### PR TITLE
napari: fix after the transition to pyproject.toml

### DIFF
--- a/pkgs/development/python-modules/magicgui/default.nix
+++ b/pkgs/development/python-modules/magicgui/default.nix
@@ -9,20 +9,29 @@
 , pyside2
 , psygnal
 , docstring-parser
+, napari # a reverse-dependency, for tests
 }: buildPythonPackage rec {
   pname = "magicgui";
   version = "0.3.7";
+
+  format = "pyproject";
+
   src = fetchFromGitHub {
     owner = "napari";
     repo = "magicgui";
     rev = "v${version}";
     sha256 = "sha256-LYXNNr5lS3ibQk2NIopZkB8kzC7j3yY8moGMk0Gr+hU=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
   nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ typing-extensions qtpy pyside2 psygnal docstring-parser ];
   checkInputs = [ pytestCheckHook pytest-mypy-plugins ];
+
   doCheck = false; # Reports "Fatal Python error"
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  passthru.tests = { inherit napari; };
 
   meta = with lib; {
     description = "Build GUIs from python functions, using magic.  (napari/magicgui)";

--- a/pkgs/development/python-modules/napari-npe2/default.nix
+++ b/pkgs/development/python-modules/napari-npe2/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, appdirs
+, pyyaml
+, pytomlpp
+, pydantic
+, magicgui
+, typer
+, setuptools-scm
+, napari # reverse dependency, for tests
+}:
+
+let
+  pname = "napari-npe2";
+  version = "0.3.0";
+in
+buildPythonPackage {
+  inherit pname version;
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "napari";
+    repo = "npe2";
+    rev = "v${version}";
+    hash = "sha256-IyDUeztWQ8JWXDo//76iHzAlWWaZP6/0lwCh0eZAZsM=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    # npe2 *can* build without it,
+    # but then setuptools refuses to acknowledge it when building napari
+    setuptools-scm
+  ];
+  propagatedBuildInputs = [
+    appdirs
+    pyyaml
+    pytomlpp
+    pydantic
+    magicgui
+    typer
+  ];
+
+  passthru.tests = { inherit napari; };
+
+  meta = with lib; {
+    description = "Yet another plugin system for napari (the image visualizer)";
+    homepage = "https://github.com/napari/npe2";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -6,7 +6,7 @@
 , superqt
 , typing-extensions
 , tifffile
-, napari-plugin-engine
+, napari-npe2
 , pint
 , pyyaml
 , numpydoc
@@ -29,15 +29,24 @@
 }: mkDerivationWith buildPythonPackage rec {
   pname = "napari";
   version = "0.4.14";
+
+  format = "pyproject";
+
   src = fetchFromGitHub {
     owner = "napari";
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-uDDj5dzsT4tRVV0Y+CYegiCpLM77XFaXEXEZXTnX808=";
   };
-  nativeBuildInputs = [ setuptools-scm wrapQtAppsHook ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+    wrapQtAppsHook
+  ];
   propagatedBuildInputs = [
-    napari-plugin-engine
+    napari-npe2
     cachey
     napari-svg
     napari-console
@@ -60,7 +69,7 @@
     jsonschema
     scipy
   ];
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
   dontUseSetuptoolsCheck = true;
   postFixup = ''
     wrapQtApp $out/bin/napari

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation {
     license = with licenses; [ gpl2 lgpl21 ];
     homepage = "https://wiki.qt.io/Qt_for_Python";
     maintainers = with maintainers; [ gebner ];
-    broken = stdenv.isDarwin;
+    broken = stdenv.isDarwin || python.isPy310;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5429,6 +5429,8 @@ in {
 
   napari-console = callPackage ../development/python-modules/napari-console { };
 
+  napari-npe2 = callPackage ../development/python-modules/napari-npe2 { };
+
   napari-plugin-engine = callPackage ../development/python-modules/napari-plugin-engine { };
 
   napari-svg = callPackage ../development/python-modules/napari-svg { };


### PR DESCRIPTION
###### Description of changes

Napari (the image visualizer) has moved from `setup.py` to `pyproject.toml` (with the `setuptools` back-end) and invented a new plugin system ("npe2"). This PR changes the "format" of those derivations that have already transitioned to the new system and introduces a new expression, the plugin engine: `python3Packages.napari-npe2`

I'm also marking `shiboken2` as broken for python 3.10 - shiboken2 is a reverse-dependency for napari.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC @Artturin :)