### PR TITLE
python3Packages.pytorch-lightning: fix build, add deps

### DIFF
--- a/pkgs/development/python-modules/pydeprecate/default.nix
+++ b/pkgs/development/python-modules/pydeprecate/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pydeprecate";
+  version = "0.3.1";
+  src = fetchPypi {
+    inherit version;
+    pname = "pyDeprecate";
+    sha256 = "+iaHCSTTR1Yhw0QEXCwBoWugNBE6kCYAx451s/rF9yw=";
+  };
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Simple tooling for marking deprecated functions or classes and re-routing to the new successors’ instance.";
+    homepage = "https://borda.github.io/pyDeprecate/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cfhammill ];
+  };
+
+}

--- a/pkgs/development/python-modules/pytorch-lightning/default.nix
+++ b/pkgs/development/python-modules/pytorch-lightning/default.nix
@@ -7,7 +7,11 @@
 , pytorch
 , pyyaml
 , tensorboard
-, tqdm }:
+, tqdm
+, pydeprecate
+, torchmetrics
+, fsspec
+}:
 
 buildPythonPackage rec {
   pname = "pytorch-lightning";
@@ -28,6 +32,9 @@ buildPythonPackage rec {
     pyyaml
     tensorboard
     tqdm
+    pydeprecate
+    torchmetrics
+    fsspec
   ];
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/torchmetrics/default.nix
+++ b/pkgs/development/python-modules/torchmetrics/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, pytorch
+, pydeprecate
+, pytest
+, pytest-doctestplus
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "torchmetrics";
+  version = "0.7.3";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "h150Sm22PIh1cmDWPLgJGdA5hzSn9Fb46kGBuy25V9g=";
+  };
+  propagatedBuildInputs = [ numpy pytorch pydeprecate ];
+  checkInputs = [ pytest pytest-doctestplus pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Machine learning metrics for distributed, scalable PyTorch applications.";
+    homepage = "https://github.com/PyTorchLightning/metrics";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cfhammill ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6299,6 +6299,8 @@ in {
 
   pycoolmasternet-async = callPackage ../development/python-modules/pycoolmasternet-async { };
 
+  pydeprecate = callPackage ../development/python-modules/pydeprecate { };
+
   pyfireservicerota = callPackage ../development/python-modules/pyfireservicerota { };
 
   pyflexit = callPackage ../development/python-modules/pyflexit { };
@@ -10198,6 +10200,8 @@ in {
   torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
 
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };
+
+  torchmetrics = callPackage ../development/python-modules/torchmetrics { };
 
   torchinfo = callPackage ../development/python-modules/torchinfo { };
 


### PR DESCRIPTION
###### Description of changes

adds missing propagatedBuildInputs
pydeprecate: init at 0.3.1
torchmetrics: init at 0.7.3

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
