### PR TITLE
jesec-libtorrent: patch test to pass with glibc 2.34

### DIFF
--- a/pkgs/tools/networking/p2p/jesec-rtorrent/libtorrent-glibc-2.34.patch
+++ b/pkgs/tools/networking/p2p/jesec-rtorrent/libtorrent-glibc-2.34.patch
@@ -1,0 +1,13 @@
+diff --git a/test/net/test_address_info.cc b/test/net/test_address_info.cc
+index ef104c96..59e0f56f 100644
+--- a/test/net/test_address_info.cc
++++ b/test/net/test_address_info.cc
+@@ -58,7 +58,7 @@ TEST_F(test_address_info, test_basic) {
+                                               nullptr,
+                                               nullptr,
+                                               std::placeholders::_1),
+-                                    EAI_NONAME));
++                                    EAI_AGAIN));
+   ASSERT_TRUE(test_valid_ai_ref_err(std::bind(torrent::ai_get_addrinfo,
+                                               "2001:db8:a::22123",
+                                               nullptr,

--- a/pkgs/tools/networking/p2p/jesec-rtorrent/libtorrent.nix
+++ b/pkgs/tools/networking/p2p/jesec-rtorrent/libtorrent.nix
@@ -18,9 +18,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-S3DOKzXkvU+ZJxfrxwLXCVBnepzmiZ+3iiQqz084BEk=";
   };
 
+  patches = [ ./libtorrent-glibc-2.34.patch ];
+
   nativeBuildInputs = [
     cmake
   ];
+
   buildInputs = [
     openssl
     zlib
@@ -30,6 +33,7 @@ stdenv.mkDerivation rec {
   preCheck = ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
   '';
+
   checkInputs = [
     gtest
   ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes #167854.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
