### PR TITLE
luajit: 2.0.5-2021-10-02, 2.1.0-2021-10-27 -> 2.0.5-2022-03-13, 2.1.0-2022-04-05

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -1,10 +1,10 @@
 { self, callPackage, lib }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.0.5-2021-10-02";
-  rev = "d3294fa63b344173db68dd612c6d3801631e28d4";
+  version = "2.0.5-2022-03-13";
+  rev = "93a65d3cc263aef2d2feb3d7ff2206aca3bee17e";
   isStable = true;
-  sha256 = "0ja6x7bv3iqnf6m8xk6qp1dgan2b7mys0ff86dw671fqqrfw28fn";
+  hash = "sha256-Gp7OdfxBGkW59zxWUml2ugPABLUv2SezMiDblA/FZ7g=";
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build
     platforms = with lib; filter (p: !hasPrefix "aarch64-" p)
       (platforms.linux ++ platforms.darwin);

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,8 +1,8 @@
 { self, callPackage }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.1.0-2021-10-27";
-  rev = "b4b2dce9fc3ffaaaede39b36d06415311e2aa516";
+  version = "2.1.0-2022-04-05";
+  rev = "5e3c45c43bb0e0f1f2917d432e9d2dba12c42a6e";
   isStable = false;
-  sha256 = "185s071aa0yffz8npgdxj7l98cs987vddb2l5pzfcdqfj41gn55q";
+  hash = "sha256-Q+34hJDgyCqmtThHbxR16Nn7zhq4Ql142No2rO57HL0=";
 }

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -4,7 +4,7 @@
 , buildPackages
 , name ? "luajit-${version}"
 , isStable
-, sha256
+, hash
 , rev
 , version
 , extraMeta ? { }
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    inherit sha256 rev;
+    inherit hash rev;
   };
 
   luaversion = "5.1";


### PR DESCRIPTION
Various bugfixes.

*luajit_2_0*
https://github.com/LuaJIT/LuaJIT/compare/d3294fa63b344173db68dd612c6d3801631e28d4...93a65d3cc263aef2d2feb3d7ff2206aca3bee17e

*luajit_2_1*
https://github.com/LuaJIT/LuaJIT/compare/b4b2dce9fc3ffaaaede39b36d06415311e2aa516...5e3c45c43bb0e0f1f2917d432e9d2dba12c42a6e

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
