### PR TITLE
datadog-agent: make systemd optional

### DIFF
--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -1,4 +1,15 @@
-{ lib, buildGoModule, makeWrapper, fetchFromGitHub, pythonPackages, pkg-config, systemd, hostname, extraTags ? [] }:
+{ lib
+, stdenv
+, buildGoModule
+, makeWrapper
+, fetchFromGitHub
+, pythonPackages
+, pkg-config
+, systemd
+, hostname
+, withSystemd ? stdenv.isLinux
+, extraTags ? [ ]
+}:
 
 let
   # keep this in sync with github.com/DataDog/agent-payload dependency
@@ -30,19 +41,28 @@ in buildGoModule rec {
 
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [ systemd ];
+  buildInputs = lib.optionals withSystemd [ systemd ];
   PKG_CONFIG_PATH = "${python}/lib/pkgconfig";
 
-  preBuild = let
-    ldFlags = lib.concatStringsSep " " [
-      "-X ${goPackagePath}/pkg/version.Commit=${src.rev}"
-      "-X ${goPackagePath}/pkg/version.AgentVersion=${version}"
-      "-X ${goPackagePath}/pkg/serializer.AgentPayloadVersion=${payloadVersion}"
-      "-X ${goPackagePath}/pkg/collector/py.pythonHome=${python}"
-      "-r ${python}/lib"
-    ];
-  in ''
-    buildFlagsArray=( "-tags" "ec2 systemd cpython process log secrets ${lib.concatStringsSep " " extraTags}" "-ldflags" "${ldFlags}")
+  tags = [
+    "ec2"
+    "cpython"
+    "process"
+    "log"
+    "secrets"
+  ]
+  ++ lib.optionals withSystemd [ "systemd" ]
+  ++ extraTags;
+
+  ldflags = [
+    "-X ${goPackagePath}/pkg/version.Commit=${src.rev}"
+    "-X ${goPackagePath}/pkg/version.AgentVersion=${version}"
+    "-X ${goPackagePath}/pkg/serializer.AgentPayloadVersion=${payloadVersion}"
+    "-X ${goPackagePath}/pkg/collector/py.pythonHome=${python}"
+    "-r ${python}/lib"
+  ];
+
+  preBuild = ''
     # Keep directories to generate in sync with tasks/go.py
     go generate ./pkg/status ./cmd/agent/gui
   '';
@@ -66,7 +86,7 @@ in buildGoModule rec {
     cp -R $src/pkg/status/templates $out/share/datadog-agent
 
     wrapProgram "$out/bin/agent" \
-      --set PYTHONPATH "$out/${python.sitePackages}" \
+      --set PYTHONPATH "$out/${python.sitePackages}"'' + lib.optionalString withSystemd '' \
       --prefix LD_LIBRARY_PATH : ${lib.getLib systemd}/lib
   '';
 
@@ -77,6 +97,6 @@ in buildGoModule rec {
     '';
     homepage    = "https://www.datadoghq.com";
     license     = licenses.bsd3;
-    maintainers = with maintainers; [ thoughtpolice domenkozar rvl ];
+    maintainers = with maintainers; [ thoughtpolice domenkozar rvl viraptor ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Allow compiling without systemd support and disable that by default on
non-Linux platforms. This allows compiling the agent on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
