### PR TITLE
unigine-sanctuary: init at 2.3

### DIFF
--- a/pkgs/applications/graphics/unigine-sanctuary/default.nix
+++ b/pkgs/applications/graphics/unigine-sanctuary/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, autoPatchelfHook
+, libX11
+, libXext
+, libXrandr
+, libXinerama
+, libglvnd
+, openal
+, glibc
+, makeDesktopItem
+, copyDesktopItems
+, imagemagick
+, liberation_ttf
+}:
+stdenv.mkDerivation rec{
+  pname = "unigine-sanctuary";
+  version = "2.3";
+
+  src = fetchurl {
+    url = "https://m12-assets.unigine.com/d/Unigine_Sanctuary-${version}.run";
+    sha256 = "1m9r79q33hx213zg3c2kknnc7hi8jp2h88s9qynny4k4rg8vpa18";
+  };
+
+  libPath = lib.makeLibraryPath [
+    libglvnd
+    openal
+    glibc
+  ];
+
+  installPhase = ''
+    bash $src --target ${pname}-${version}
+
+    install -D -m 0755 ${pname}-${version}/bin/libUnigine_x86.so $out/lib/unigine/sanctuary/bin/libUnigine_x86.so
+    install -D -m 0755 ${pname}-${version}/bin/Sanctuary $out/lib/unigine/sanctuary/bin/Sanctuary
+    install -D -m 0755 ${pname}-${version}/1024x768_windowed.sh $out/bin/Sanctuary
+
+    cp -R ${pname}-${version}/data $out/lib/unigine/sanctuary
+
+    wrapProgram $out/bin/Sanctuary \
+      --prefix LD_LIBRARY_PATH : ${libPath}:$out/lib/unigine/sanctuary/bin \
+      --run "cd $out/lib/unigine/sanctuary"
+
+    convert -size 256x256 xc:Transparent -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
+      -define gradient:radii="128,128" -fill radial-gradient:'rgb(164,0,0)-rgb(67,1,3)' \
+      -draw "roundRectangle 0,0 256,256 50,50" ${pname}-${version}/icon.png
+    convert ${pname}-${version}/icon.png -size 181.991x181.991 -font ${liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf \
+      -pointsize 181.991 -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
+      -define gradient:radii="46.6974,46.6974" -fill radial-gradient:'rgb(249,197,46)-rgb(218,144,31)' \
+      -stroke none -strokewidth 4.54977 -draw 'text 69.3061,194.247 "S"' ${pname}-${version}/icon.png
+
+    for RES in 16 24 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
+      convert ${pname}-${version}/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Sanctuary.png
+    done
+    convert ${pname}-${version}/icon.png -resize 128x128 $out/share/icons/Sanctuary.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Sanctuary";
+      exec = "Sanctuary";
+      genericName = "A GPU Stress test tool from the UNIGINE";
+      icon = "Sanctuary";
+      desktopName = "Sanctuary Benchmark";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    imagemagick
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc
+    libX11
+    libXext
+    libXrandr
+    libXinerama
+  ];
+
+  dontUnpack = true;
+
+  meta = {
+    description = "The Unigine Heaven GPU benchmarking tool";
+    homepage = "https://benchmark.unigine.com/sanctuary";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.BarinovMaxim ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29675,6 +29675,8 @@ with pkgs;
 
   unigine-tropics = pkgsi686Linux.callPackage ../applications/graphics/unigine-tropics { };
 
+  unigine-sanctuary = pkgsi686Linux.callPackage ../applications/graphics/unigine-sanctuary { };
+
   unigine-superposition = libsForQt5.callPackage ../applications/graphics/unigine-superposition { };
 
   unipicker = callPackage ../applications/misc/unipicker { };


### PR DESCRIPTION
###### Description of changes

I want to add another unigine benchmark package. It's unigine-sanctuary. It's a benchmarking tool from unigine. Nixos users will be able to install this package on their computers and benchmark gpu.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
