### PR TITLE
pythonPackages.simple-salesforce: add zeep to propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/simple-salesforce/default.nix
+++ b/pkgs/development/python-modules/simple-salesforce/default.nix
@@ -6,6 +6,7 @@
 , nose
 , pytz
 , responses
+, zeep
 }:
 
 buildPythonPackage rec {
@@ -22,6 +23,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     authlib
     requests
+    zeep
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/simple-salesforce/default.nix
+++ b/pkgs/development/python-modules/simple-salesforce/default.nix
@@ -4,6 +4,7 @@
 , authlib
 , requests
 , nose
+, pythonOlder
 , pytz
 , responses
 , zeep
@@ -12,6 +13,9 @@
 buildPythonPackage rec {
   pname = "simple-salesforce";
   version = "1.11.6";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = pname;


### PR DESCRIPTION
Building simple-salesforce failes with

    Executing pipInstallPhase
    /build/source/dist /build/source
    Processing ./simple_salesforce-1.11.6-py2.py3-none-any.whl
    ERROR: Could not find a version that satisfies the requirement zeep (from simple-salesforce) (from versions: none)
    ERROR: No matching distribution found for zeep

This fixes the build.

cc @costrouc 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
