### PR TITLE
roccat-tools: Fix udev rules

### DIFF
--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, stdenv, fetchurl, cmake, pkg-config, gettext
+{ lib, stdenv, fetchurl, cmake, pkg-config, gettext
 , dbus, dbus-glib, libgaminggear, libgudev, lua
 , harfbuzz, runtimeShell, coreutils, kmod
 }:

--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config gettext ];
   buildInputs = [ dbus dbus-glib libgaminggear libgudev lua ];
-  runtimeDeps = [ coreutils kmod ];
 
   cmakeFlags = [
     "-DUDEVDIR=\${out}/lib/udev/rules.d"

--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config, gettext
+{ lib, pkgs, stdenv, fetchurl, cmake, pkg-config, gettext
 , dbus, dbus-glib, libgaminggear, libgudev, lua
-, harfbuzz
+, harfbuzz, runtimeShell, coreutils, kmod
 }:
 
 stdenv.mkDerivation rec {
@@ -19,10 +19,16 @@ stdenv.mkDerivation rec {
       /return/c \
         return g_build_path("/", g_get_user_data_dir(), "roccat", NULL);
     }' libroccat/roccat_helper.c
+
+    substituteInPlace udev/90-roccat-kone.rules \
+      --replace "/bin/sh" "${runtimeShell}" \
+      --replace "/sbin/modprobe" "${kmod}/bin/modprobe" \
+      --replace "/bin/echo" "${coreutils}/bin/echo"
   '';
 
   nativeBuildInputs = [ cmake pkg-config gettext ];
   buildInputs = [ dbus dbus-glib libgaminggear libgudev lua ];
+  runtimeDeps = [ coreutils kmod ];
 
   cmakeFlags = [
     "-DUDEVDIR=\${out}/lib/udev/rules.d"


### PR DESCRIPTION
###### Description of changes

The file 90-roccat-kone.rules contains references to /bin/sh, /sbin/modprobe, and /bin/echo, so these need to be corrected to point to the nix store, otherwise nixos-rebuild refuses to allow this package to be in `services.udev.packages`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
I have tested these changes on my system by adding this package to `services.udev.packages` and rebuilding my configuration.  I have a Roccat Kone Pure Optical instead of a Roccat Kone, so I cannot test the changed udev rules, but, as mentioned at the top of this PR, this fix makes it possible to install the udev rules from this package, and I have confirmed that they are, indeed, being applied, as I no longer need to run the tools as root to let them communicate with my device.