### PR TITLE
libarchive: 3.6.0 -> 3.6.1

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -1,14 +1,27 @@
-{
-  fetchFromGitHub, lib, stdenv, pkg-config, autoreconfHook,
-  acl, attr, bzip2, e2fsprogs, libxml2, lzo, openssl, sharutils, xz, zlib, zstd,
+{ lib
+, stdenv
+, fetchFromGitHub
+, acl
+, attr
+, autoreconfHook
+, bzip2
+, e2fsprogs
+, lzo
+, openssl
+, pkg-config
+, sharutils
+, xz
+, zlib
+, zstd
+# Optional but increases closure only negligibly. Also, while libxml2 builds
+# fine on windows, libarchive has trouble linking windows things it depends on
+# for some reason.
+, xarSupport ? stdenv.hostPlatform.isUnix, libxml2
 
-  # Optional but increases closure only negligibly. Also, while libxml2
-  # builds fine on windows, but libarchive has trouble linking windows
-  # things it depends on for some reason.
-  xarSupport ? stdenv.hostPlatform.isUnix,
-
-  # for passthru.tests
-  cmake, nix, samba
+# for passthru.tests
+, cmake
+, nix
+, samba
 }:
 
 assert xarSupport -> libxml2 != null;
@@ -26,11 +39,20 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" ];
 
-  nativeBuildInputs = [ pkg-config autoreconfHook ];
-  buildInputs =
-    lib.optional stdenv.hostPlatform.isUnix sharutils
-    ++ [ zlib bzip2 openssl xz lzo zstd ]
-    ++ lib.optionals stdenv.isLinux [ e2fsprogs attr acl ]
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs =  [
+    bzip2
+    lzo
+    openssl
+    xz
+    zlib
+    zstd
+  ] ++ lib.optional stdenv.hostPlatform.isUnix sharutils
+    ++ lib.optionals stdenv.isLinux [ acl attr e2fsprogs ]
     ++ lib.optional xarSupport libxml2;
 
   # Without this, pkg-config-based dependencies are unhappy
@@ -38,11 +60,17 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional (!xarSupport) "--without-xml2";
 
-  preBuild = if stdenv.isCygwin then ''
-    echo "#include <windows.h>" >> config.h
-  '' else null;
+  postPatch = ''
+     substituteInPlace Makefile.am --replace '/bin/pwd' 'pwd'
+  '';
 
-  doCheck = false; # fails
+  preBuild = lib.optionalString stdenv.isCygwin ''
+    echo "#include <windows.h>" >> config.h
+  '';
+
+  # 484: test_write_disk_perms FAIL
+  # TODO: how to disable it? Should it be reported upstream?
+  doCheck = false;
 
   preFixup = ''
     sed -i $lib/lib/libarchive.la \
@@ -52,21 +80,22 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.tests = {
-    inherit cmake nix samba;
-  };
-
-  meta = {
+  meta = with lib; {
+    homepage = "http://libarchive.org";
     description = "Multi-format archive and compression library";
     longDescription = ''
-      This library has code for detecting and reading many archive formats and
-      compressions formats including (but not limited to) tar, shar, cpio, zip, and
-      compressed with gzip, bzip2, lzma, xz, ...
+      The libarchive project develops a portable, efficient C library that can
+      read and write streaming archives in a variety of formats. It also
+      includes implementations of the common tar, cpio, and zcat command-line
+      tools that use the libarchive library.
     '';
-    homepage = "http://libarchive.org";
     changelog = "https://github.com/libarchive/libarchive/releases/tag/v${version}";
-    license = lib.licenses.bsd3;
-    platforms = with lib.platforms; all;
-    maintainers = with lib.maintainers; [ jcumming ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jcumming AndersonTorres ];
+    platforms = platforms.all;
+  };
+
+  passthru.tests = {
+    inherit cmake nix samba;
   };
 }

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -15,13 +15,13 @@ assert xarSupport -> libxml2 != null;
 
 stdenv.mkDerivation rec {
   pname = "libarchive";
-  version = "3.6.0";
+  version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "libarchive";
     repo = "libarchive";
     rev = "v${version}";
-    sha256 = "sha256-u6Zeu9yTjhx5U7KZVUkuuUsQPjWN71mE5egG4T+FGfY=";
+    hash = "sha256-G4wL5DDbX0FqaA4cnOlVLZ25ObN8dNsRtxyas29tpDA=";
   };
 
   outputs = [ "out" "lib" "dev" ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Security and rebuild-intensive update

https://github.com/libarchive/libarchive/releases/tag/v3.6.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
