### PR TITLE
python3Packages.{nbclient: 0.5.11 -> 0.6.2, nbconvert: 6.4.2 -> 6.5.0, bleach: 4.1.0 -> 5.0.0}

### DIFF
--- a/pkgs/applications/networking/zerobin/default.nix
+++ b/pkgs/applications/networking/zerobin/default.nix
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
     # relax version constraints of some dependencies
     substituteInPlace setup.cfg \
       --replace "clize==4.1.1" "clize" \
-      --replace "bleach==3.1.5" "bleach>=3.1.5,<5" \
+      --replace "bleach==3.1.5" "bleach>=3.1.5,<6" \
       --replace "bottle==0.12.18" "bottle>=0.12.18,<1" \
       --replace "Paste==3.4.3" "Paste>=3.4.3,<4"
   '';

--- a/pkgs/development/python-modules/bleach/default.nix
+++ b/pkgs/development/python-modules/bleach/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "bleach";
-  version = "4.1.0";
+  version = "5.0.0";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-CQDYs366YagC7kCsAGH4wrXe4pwZJ90dIz4HXr9acdo=";
+    hash = "sha256-xtbMBUvcnIO0i4CD4jbl8A8jhChmbSzi4IPqpf1WhWU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/nbclient/default.nix
+++ b/pkgs/development/python-modules/nbclient/default.nix
@@ -6,8 +6,6 @@
 buildPythonPackage rec {
   pname = "nbclient";
   version = "0.6.2";
-  # As of version 0.6.2, there is both a setup.py and pyproject.toml. However,
-  # the pyproject.toml does not appear to be the main entry point.
   format = "setuptools";
 
   disabled = pythonOlder "3.7";

--- a/pkgs/development/python-modules/nbclient/default.nix
+++ b/pkgs/development/python-modules/nbclient/default.nix
@@ -5,12 +5,16 @@
 
 buildPythonPackage rec {
   pname = "nbclient";
-  version = "0.5.13";
+  version = "0.6.2";
+  # As of version 0.6.2, there is both a setup.py and pyproject.toml. However,
+  # the pyproject.toml does not appear to be the main entry point.
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-QMUsm148MfrsruafICs/U+ONfBxWPeD63enX7aD9r+g=";
+    hash = "sha256-i0dVPxztB3zXxFN/1dcB1G92gfJLKCdeXMHTR+fJtGs=";
   };
 
   doCheck = false; # Avoid infinite recursion

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -5,13 +5,11 @@
 , glibcLocales
 , entrypoints
 , bleach
-, beautifulsoup4
 , mistune
 , nbclient
 , jinja2
 , pygments
 , traitlets
-, testpath
 , jupyter_core
 , jupyterlab-pygments
 , nbformat
@@ -20,15 +18,18 @@
 , tornado
 , jupyter-client
 , defusedxml
+, tinycss2
+, beautifulsoup4
 }:
 
 buildPythonPackage rec {
   pname = "nbconvert";
-  version = "6.4.5";
+  version = "6.5.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-IRY6jiBzwHEJyo85iDbkXv26KqzqaNb3WopUX+8HDU4=";
+    hash = "sha256-Ij5G4nq+hZa4rtVDAfrbukM7f/6oGWpo/Xsf9Qnu6Z0=";
   };
 
   # Add $out/share/jupyter to the list of paths that are used to search for
@@ -44,9 +45,9 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook glibcLocales ];
 
   propagatedBuildInputs = [
-    entrypoints bleach mistune jinja2 pygments traitlets testpath
+    entrypoints bleach mistune jinja2 pygments traitlets
     jupyter_core nbformat ipykernel pandocfilters tornado jupyter-client
-    defusedxml beautifulsoup4
+    defusedxml tinycss2 beautifulsoup4
     nbclient
     jupyterlab-pygments
   ];


### PR DESCRIPTION
###### Description of changes

I wanted to bump nbclient, which necessitated updates to nbconvert and bleach.

[Changelog nbclient](https://github.com/jupyter/nbclient/releases/tag/v0.6.0)
[Changelog nbconvert](https://github.com/jupyter/nbconvert/releases/tag/6.5)
[Changelog bleach](https://github.com/mozilla/bleach/releases/tag/v5.0.0)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
