### PR TITLE
konsave: init at 2.1.2

### DIFF
--- a/pkgs/applications/misc/konsave/default.nix
+++ b/pkgs/applications/misc/konsave/default.nix
@@ -1,0 +1,27 @@
+{ lib, python3Packages, fetchPypi }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "konsave";
+  version = "2.2.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Konsave";
+    hash = "sha256-tWarqT2jFgCuSsa2NwMHRaR3/wj0khiRHidvRNMwM8M=";
+  };
+
+  nativeBuildInputs = with python3Packages; [ setuptools-scm ];
+  propagatedBuildInputs = with python3Packages; [ pyyaml setuptools ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "Save Linux Customization";
+    maintainers = with maintainers; [ MoritzBoehme ];
+    homepage = "https://github.com/Prayag2/konsave";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5778,6 +5778,8 @@ with pkgs;
 
   komorebi = callPackage ../applications/graphics/komorebi { };
 
+  konsave = callPackage ../applications/misc/konsave { };
+
   krapslog = callPackage ../tools/misc/krapslog { };
 
   krelay = callPackage ../applications/networking/cluster/krelay { };


### PR DESCRIPTION
###### Description of changes

Init konsave at `2.1.2` at the request of @zendo and thereby closes #168296.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

TLDR: this problem is now resolved.

Original Problem:
Package can currently not be built, because konsave pins PyYaml to `5.4.1` as mentioned in following issue https://github.com/Prayag2/konsave/issues/55.
Trying to pin to that version manually did not work, because building PyYaml at `5.4.1` failed with a SyntaxError.
I will continue packaging this as soon as https://github.com/Prayag2/konsave/pull/56 is merged.