### PR TITLE
firefox-devedition-bin-unwrapped: 99.0b6 -> 100.0b5

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "99.0b6";
+  version = "100.0b5";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ach/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ach/firefox-100.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "0bb4605a97661502cb23fe2ebfdb1a31831f8ca015349b3105d1245fcaa5eb69";
+      sha256 = "fb1b570f098ca5d80f41f14ada1f7ad6dc43e5e1c6984e1fca29cfd275dabded";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/af/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/af/firefox-100.0b5.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "564fd8895c6fa6aecebd5a7250bd73df45a6e51f90845d9597e59cd9175b6c2c";
+      sha256 = "31322e6c45045322977b5d240350e0e4740f9c48174b719553410fea3212f475";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/an/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/an/firefox-100.0b5.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "76035e42b93995e6cda0de737981760a0025013bc3330142b95ba7329d54153b";
+      sha256 = "137eb68b647af950362682646f7edf754bfb51a03b20f59b777f877b3ef003c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ar/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ar/firefox-100.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "31abbbdf4378559e6b612fd3b0167bbaad332edc47d6ff67e8d9aa7e01130808";
+      sha256 = "22d24c6bad9ce2ded7634449fbc5d0bcdd4972aac15f60e04cf963ab0ee252bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ast/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ast/firefox-100.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "1c4a2c370c3f566823c722082a3a9f149050cb7a891f3a1f21b7ca8ec899ca92";
+      sha256 = "e8a2e7ea146efe41105d84a667568662d029a9773855ae31768ba9c14abbdde7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/az/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/az/firefox-100.0b5.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "b1d0effa84614c985001705630da49b70f09e91be3715795fc18d926303b6b95";
+      sha256 = "34d76711bdc45cc45650cb4c94e553f67579be3f406c391c9878cb6de1c39bb5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/be/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/be/firefox-100.0b5.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d0ace001eff838f8dcb80090a193307e143a5c1f3b1dac143ded5af3fecbdfda";
+      sha256 = "fdd4d1cea3b71f54b58230a30c744d2ff7b0237869fd14e617ba3322c2d59f6f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bg/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bg/firefox-100.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "784d6029972a843829783581796263899371c777cf669f0e4f6978f35a8d6199";
+      sha256 = "e63e65a92f73a31d2adac6a0c1b6dc45f38425ed8596039332108565de43daa6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bn/firefox-100.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "7cdc3a6f35c2a56b87a58eaf3112148c51b2d2d0fe5d9afc5deccfb2d2269b2e";
+      sha256 = "29fbffaeb7bd8750cf1fb543692855d427200d7df6e9ca92224bd96103b06b35";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/br/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/br/firefox-100.0b5.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "abbe12c9d887ea98d85479105bf2640bdbe3d295def41b626d3d8feef3627b36";
+      sha256 = "3c1bc8cace7f4d2c7522fc9dd994c42707ca4d54b74ead88726c8e83862c3757";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bs/firefox-100.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "fc1076c2eda5623869a3af5c850fb51cf8611501f51984c85f690b4c545cc93b";
+      sha256 = "3e6c94efea22c4bd2620225e8a339689e3e4f642d474f4580092a85d7c4a4950";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ca-valencia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ca-valencia/firefox-100.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d328055c61c96c92dd05989c23a3f8f49b36cb755f72118c21331f986ba3b44d";
+      sha256 = "485b33fe034acd03412b3407338cd246077209fc1ccd566f2ac9d347c8da6308";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ca/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ca/firefox-100.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6a020e56c5f4136deff38f07d94b516971af1a31a804384a50396dbf6241877e";
+      sha256 = "a0b2780c0a634c85a9dbdc00b6952c81b503c3173d2c2cb9df5d9c5958ab640c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cak/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cak/firefox-100.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "c6298bdeba82a637bb3903aaf73b9de9f0a3ce4ec22637b1ee1340273b7e36af";
+      sha256 = "360abc1da779874423792e63b545343aaeb3984201193c687c3c8b67b67cecb1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cs/firefox-100.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "1facd79fe087052af58205d2a0a9acce68a1d9bc58d1a3bd3e49b740f6e51647";
+      sha256 = "1dc722b7931908a38f43254aa1c1c78fb77ee30868c15455c0448927e658613d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cy/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cy/firefox-100.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e7305badc55114c4a39edc317202338b3e61feba9844fc2cd8edc1518486736a";
+      sha256 = "55eba066d11752cbf973312d55568e51b720f21e66bf590adadbe93be386e989";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/da/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/da/firefox-100.0b5.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "6b1d2403e1e74c97c763476a128c56079d546967c87f1b225ac790d9acb6940d";
+      sha256 = "cc3fa0c0ef8a1af9f8bb78e7196c5cc7a6c6df2d9f25c5fe8d79f47879354331";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/de/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/de/firefox-100.0b5.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c8d01b9a1bbcdeb1fa0fa63ff553209d095280ebad4eb03efa47e029505b8204";
+      sha256 = "b745aa34eca890302b701be19bdd3affcba37e7b1af388e4844ce61c3a1244fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/dsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/dsb/firefox-100.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "bea09c23f3099c85e415bb05916ab9e3374f78e897e2b8549fb9f67895b7c052";
+      sha256 = "e7a4c1390919cfd01fe13f5a81ce35fbdf0868c725783d603c7d2e210e3ba368";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/el/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/el/firefox-100.0b5.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "bd740ab9aaad78e4b16e42d610ea1b914db95e2f8396f0e9c4803e38c9810f20";
+      sha256 = "6f0b80919e22ec67f80c7c034fdd9e290cf2ec442ae828a706e780df2ec54d90";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-CA/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-CA/firefox-100.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "acf5c9da684d5f7bb5b25e5fbd62d5dfafb1a5f33bd6c7baa385a37967e516a1";
+      sha256 = "0184e33ff9582a77a5f9d61f1904f3cd097feda7576aaa276480eff92dfcb4de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-GB/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-GB/firefox-100.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "76cfab3fb29274bcec47ce72e88f783668653d3f8ea4ad00637bdd7ad5d32364";
+      sha256 = "b5affd31a9004c9161d6a55cb713999932b18f1340ce67d0e7f77b0c805ca785";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-US/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-US/firefox-100.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "798f68125a37ac1e60d72dff3a773cd167075a58d523d7d9659cd5fb511e2dcb";
+      sha256 = "635c5b79c514b9b7717c903cdabc2f6bf3f19cb9689354dc33f21cc8eed3d540";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/eo/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/eo/firefox-100.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0b65dc59679b42a298484d3901f3f47d6073f08e260a792a6e80d9c5a0e6ad0b";
+      sha256 = "9e4a718c0932688ece8883fd2fa2d175c3483d73ac16075d8efa0e6758f4cf61";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-AR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-AR/firefox-100.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3a894741998ee1a2adb6def1c8d548b2c5fcab8fbea655a013dbeef9a29ab228";
+      sha256 = "3bc0ce89dc3ab79108bf527fccc9aa9663f61e6578b2561fc7e1950dcaaed1db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-CL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-CL/firefox-100.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "1964534e196d426a9d6dbe664dc16790f010214cfba85e98f5df728e110e0a74";
+      sha256 = "966db10e384f875272ffcdb743c472a78a75a95e0990a32fb16fe2b8d5a70761";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-ES/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-ES/firefox-100.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "32b21ccb56fbe2e46aba0e21c417e2a7d3404a0a3487186c75d042fd84c5033a";
+      sha256 = "8b23f6957fb0825b973c4ab59c80ffdfeb8370a72a291ebec6ae7abff1ca3392";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-MX/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-MX/firefox-100.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "d70ff15a4cced1028433e603151af021be98d1026322203f0412605685611e5d";
+      sha256 = "75102ce28fbb425fb0c13dccfdbc5095c1c92c4dd83e14140bd672fe60547603";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/et/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/et/firefox-100.0b5.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "df844133edc74d396a2fe66b0a71efda2c4797ca7110a12c4c7e620cbacbfe8d";
+      sha256 = "ab7d6e1294e49e83307bac9541b15163263bc15693fd0845c335e523e5420623";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/eu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/eu/firefox-100.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "1ca8ba1a7ba29a0c21d7bdf5cbb046fa0e145a9bdad5debd93d121b512a060a4";
+      sha256 = "6defedc5c4faacc9765a1d26352d9d8f30f895a6ec5bad1c3ed7c3d98ec42e16";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fa/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fa/firefox-100.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "a4c223f683bf75c96650d939c56aa17bfeca975ba8863e44dd5ce0449b436b3e";
+      sha256 = "0fe1b25b3b970e04980ca729a6630648b0923b98fd00bc81a4553235d741a6c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ff/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ff/firefox-100.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "6b165789213fc3f9c3f46457a04974e3c718b2c0aebd44c57c7bf8f41c73687b";
+      sha256 = "e8ad5c7403928bfa5e34c6bbb8958730dba8dcc6d799c9a7676d82440b8f1ab8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fi/firefox-100.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "eea67a8d94f324a9ab74caae5a7755f9505781ff690760a06a62ad034ba76bd5";
+      sha256 = "37e8619971dffc7c6caa43cf72f5870c5d5d1ed489bf8a3596215f285f17fa1a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fr/firefox-100.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "d4cc1a70f8d020870ccac0b023574b9c0f39fd44bbbcfd8a35f6c688183f2a9a";
+      sha256 = "90c21cec994d7fa1c4ffa6512c448a4948be5eb5d318a0f6c4ae6d6b6f801780";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fy-NL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fy-NL/firefox-100.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "df49ee1a9db407819fcc7baa9c6bc9c6fc9ab2c2b57b08d85c9478f1b0aaf6c0";
+      sha256 = "c12a1b475b4d611d4083bb11d7384573817aef22796e91c7df968b7d6d726133";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ga-IE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ga-IE/firefox-100.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e7e846a95ba695a8a3edf233ad31117f4d35d4942784c5f6c5a1ebed7f2f8e4a";
+      sha256 = "fcdf90dbd66c1c87e7f8b25d820c5c866f0d905bbe424a8b6d8c27e7cbef5677";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gd/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gd/firefox-100.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "48ef5fa12ec7415ad23a5a40f2f882147e03ecc074b33b173f413e53cc0cdde6";
+      sha256 = "bfbeca59a046bffa5156621946c397884998fbd383085fab5159ae775db9cc9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gl/firefox-100.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "b44500b87f3b2219ba10e06bd937ba06784fc00085be12a16f69fe26f7733317";
+      sha256 = "c0f1de5a454ae0f8df7407d08394f73cf8e09f39342288d6670d4c0b8adf2e77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gn/firefox-100.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "0e521a61d44d1058ceb566ae58272e41f0aab7f2267555781bb3235ff5e3a59c";
+      sha256 = "5e177db13df6f5195603d8d2acb92dccdf2989fdb721e6ef6b758120f2efff75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gu-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gu-IN/firefox-100.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "2179c82d7763294f5adedb8c905ed5e009a4d3d176fae58c7503404015214c51";
+      sha256 = "748aedc09ffe44b4f8223456afbfb43901b492ff401c6ff39127ff4267ce6123";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/he/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/he/firefox-100.0b5.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "69383070d17f2ae68363e8a29efc53e2748b8f784137c854162ec0132295a9e1";
+      sha256 = "91c1abfed2e942c076c6b0068edd2dca02e496321fbd79fdd39c7c2dbe7c5c2a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hi-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hi-IN/firefox-100.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "71e57a59cfc523d5c1c73c9b5547b3247170865a95022e5bd3098967c3e6002c";
+      sha256 = "4e13080d458b980cac72cdda1f40a786db926b494fc905eab71cf3535f5383ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hr/firefox-100.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "9ea82b192336e83c7ac450dc7068f2730c031f43633a87b7fa554651cf64a912";
+      sha256 = "583c5a5f6aa0e328c57c303ba97d1bdfc0a2a959485560d27aa2e906a0deeb8e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hsb/firefox-100.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e3814f823f3bde2812751e9dd6a2b51a8861952eb04cb845d543a9252501dbba";
+      sha256 = "d8c10888b1e3735fce5d1213322f62732b030919ff4b5df70d12d934d348e91c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hu/firefox-100.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "e647f86de2e7687e23320aa0f36d96743f5da2cf43b2d83444a41506d13face9";
+      sha256 = "4133206571188244ddf17b96d287d5683fbfeffe2cdd5b2c8ee63fb7db56e3c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hy-AM/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hy-AM/firefox-100.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "21cc172fad6136a17df0a6ae4c6e90ec72a02db744cfcb5252cedcf48223e543";
+      sha256 = "7326ae0a0d0a0afc40f6aa8b0b1506dbe7ead006c641eed4812e63bbb58bdb82";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ia/firefox-100.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "5f0c85a36ec40ef57cfa2bbbc1a4663ce10c8659e0d6ecad67ea993186c9cbb6";
+      sha256 = "e61cc178ec2a648c0bb229e5145d8755343427388911bc6386fae77a5ecfae5e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/id/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/id/firefox-100.0b5.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "e6671d2ac6b63ea4f2a84d1d0e89038ef1030d85e84d6b47c5b878ddc8d96b60";
+      sha256 = "0ac90236941c9a0a5f17e2e5e96ee14c0ef6d5e5645566bc09cb9023359db882";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/is/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/is/firefox-100.0b5.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5bcafb210fa3aa06d56f17972d94c17faaaa2937948890b993bbc6c9bfbeecad";
+      sha256 = "b1efef91567c6b1d52b5fcccf9fbb3c3f81b05929242ebc68168c4712e47c3b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/it/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/it/firefox-100.0b5.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3c14104a82a312324c1d42644eca6f80b7375f946a42edcb0a23f8a824bd0eb7";
+      sha256 = "33e8282f6b1b3a9e404374f93eb6207c3110177fdc11c831469fa721c6669d93";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ja/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ja/firefox-100.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "00713bc8710add3312294aa755c881701ebbb2d00e1f5f242ca12d102ab6f19b";
+      sha256 = "ad13269606214cc9fa7d05037db3c6ecb192a5bcc06872aa487b023c2823862d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ka/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ka/firefox-100.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "ba6985797ef85bdccb1f81053456baddbe2cfd9e1097e42b20617270f681c1ad";
+      sha256 = "42b97eab01d92ad491e744890fe6984af4f435ce96595c5dd7bed02f6f5ff369";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kab/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kab/firefox-100.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "8be17598d305e257005ba0f9ef2f7053ee7e79bf3c1b4caade77c8e5a7e8a57c";
+      sha256 = "64c9abf3921fcf698ed5cda9724884f2e3c1ad8651cbdf9a9fbebf2d8ca930fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kk/firefox-100.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "7e142151f26355256d2923b183fa1d225e3ed26026cbedf9abcebef301dc1045";
+      sha256 = "9f4546b31322c74e76b13e4557bc412d5d75adddbba16f4e0b0ca8badc81f83f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/km/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/km/firefox-100.0b5.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "0df166d5a55e52ad60f8873afff5c1c43816ef99b56e1d817b4d4c29f173def5";
+      sha256 = "daac53a85b255ad6b491efa2c4d021c0aa91f927e3a5f0fb0d1462ae473a9daf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kn/firefox-100.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "193c7b709c03212ba91ea99da00c6b1c53edebbc9390d7321bd9815e5ced8233";
+      sha256 = "20b8072ddf8fc07f5095ad97464fe0b84b10215fa02bdd9a31254a92c12541a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ko/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ko/firefox-100.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "d265a984bcc6a381f715eff5e2501acde0c8793b111e15877f7d4e9086ddcf10";
+      sha256 = "29be35485bf287596145f26602aac5a520d7e980f3012b564a297e13b83bf489";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lij/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lij/firefox-100.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "4a8327447982439a2f9e5ecff39b77ddd2bfdcb081d9b6f89848f2c93db3b3ca";
+      sha256 = "7023d002cc4a7081eccbd5f061bbfe295f1856ed39724be4228e727119bc0a57";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lt/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lt/firefox-100.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "cb2a9545762247192f909c1600097b1198fbddfed1c383adf5dfa9666ddc0e80";
+      sha256 = "d121af78fa8bddf3825a89e751d37f12ea7c7513f331e015b0a951efedd80609";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lv/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lv/firefox-100.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "6ed249ade30c7d2d5ff290c4b65d3eaf3df4e49e112412cb3153da15bcf23fcd";
+      sha256 = "3f4a005f6ba7b09766f9a9d0186c0d5c82049be965e40f58eaa9c0474fb9d5e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/mk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/mk/firefox-100.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "56af16c66d20eaae2d6b487c3bec4f438d21effd3e3b1582579bb9c1836956d0";
+      sha256 = "d1e7703d77584b93261676bb4e5e15a9df0953012392cc52636bafad697bfda8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/mr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/mr/firefox-100.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "fa6f5e496fdac7eda06220a423683f608d6c49b0e3caada52b9fd903b5ebcbe9";
+      sha256 = "e7dcd45869323e949baed0e6e561a3051439e190ab3927d59af1008973e58f9b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ms/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ms/firefox-100.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0820d7fcdeb7226d067f920e7cb8a0bb3bfd98ea931d468ae58ed54e074dd1f7";
+      sha256 = "bb605564c51282e7c5c48150fa61196374b77c2de48c394f4c887c2bd0456f11";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/my/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/my/firefox-100.0b5.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "20ab8faa3a4aa4b4f94f6c057d4fc9602201a55482d492bc6dd7acc5173364a7";
+      sha256 = "9c0bec027eaad1ce4e2e6abeb35e62276805fd49ef818ddc67fd826c8a95f93e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nb-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nb-NO/firefox-100.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "77bf24610d6ad64859c83125909b70b3dd768e90e563971461f2c18fa2cd7693";
+      sha256 = "141aec935cb203578e819481b9548e29212c29c94a6c60dd79bad0f676633cd9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ne-NP/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ne-NP/firefox-100.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "fe5477509d83a14875e0409f99e2336abba237da75d1e56d753e27b7d1016c9c";
+      sha256 = "5d3e083b078496ca6fa34960a3e480baa69b582bb737fbcded6a119c9216c0b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nl/firefox-100.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "3b67159e8d34c836d5367a2e17b54bd2aa274e1f602ae42649afc2ba2fa1429f";
+      sha256 = "f7a8257d2c2cd266e46db87b6ebd8a7530a486d503760baee3d7ab655dc5e7d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nn-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nn-NO/firefox-100.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "4faf2904a8b9a0c315c222d7e810d2fb3e24947dda1e006ddd1f727d2f9f967a";
+      sha256 = "30ec48d85ebccfc9314cb642a8171d5ce98dbd0ab102f6ec00cbff2d26163d0e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/oc/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/oc/firefox-100.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "1dfa10fd1d9f958d487023144b7fad8ca8d1e528954f11e28509b7e22e48a341";
+      sha256 = "4d580c477ef3dab1f217114b24486d29df4ce022fa444b013a296603c3ff5936";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pa-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pa-IN/firefox-100.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "e6e4cc03a47ab8ff0546457b2ee0b55b8702463ed5666c15c0d2d98716fa84d2";
+      sha256 = "02953120d3becd386ce8551fd4f97e1da930b7778906096fda8d79340e53230f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pl/firefox-100.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "525023c756ff0a0eae303c02ef9b7155fdad5f0f41bc4e539be5ca21d1af0ceb";
+      sha256 = "362c1d650bf4613e46384ba5837daa80a790b504fedc254c8af7cc146127fe1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pt-BR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pt-BR/firefox-100.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "1a8070c38035f97ed771b02e59b3c2b0ef0073560c8ba285be9779fd4e99b61f";
+      sha256 = "38ec5f6aeb156437f2925df9f1e5135bfa9d85e55d570548c56770334fe09bb1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pt-PT/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pt-PT/firefox-100.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ea356edfa8b398ea16719993cf05e65b5c63b4d2c4e589a9a26814ae275e4be2";
+      sha256 = "9cfcd7212cd3531ee0694cc58653a53acd211494705f1d3040bbf03b4bb537f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/rm/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/rm/firefox-100.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "f07ca7d4233860a6271eaa972358bd05b834c7f56c4b64d45eb9af72bcf2dd9f";
+      sha256 = "ffce43f1c388618b53abaec130e288210cdb1361af512eedf0780d591e7ccffe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ro/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ro/firefox-100.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "fccb8f523251dba30a73f6ec9259113142514b6d4657f63b88f5b9d9e8a01923";
+      sha256 = "62bbfeb4a6692c25a1a2a0eb5e790e262e0141dcb74056cb55dc5e7e4a958954";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ru/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ru/firefox-100.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "d87928af8f4a0b28abdcd0386755a3f4f70d7e17e455fe5913b1e177c3edff2c";
+      sha256 = "0acf8d6c81c1704a67c9b7b9542ac6f1bd0b929cd0f0814b84cf64a46cc38107";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sco/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sco/firefox-100.0b5.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "de3bda2032217c56213f64b31332e8e6ea9598c7f31f3dce1a7b136c40c3153d";
+      sha256 = "fc172346729982645acf975a7fba8e045eb81755540faf3eea9699a7474e4ab5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/si/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/si/firefox-100.0b5.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "22dbdccec8073bd1d83cc236fc563aa97a3607a92e9b3908d4c8c0307dca8b08";
+      sha256 = "64ef404110234acc639faefe93499578b88506e287d0e75ec2fc36be625e7025";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sk/firefox-100.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d5f73c93ef57cd600a2c4269a99a498896b580ec99b549db8b0ee1537a644bb1";
+      sha256 = "6fdeb9de76bc3d7d7b5907340368adcd69d28b0db7a46bf96ee54ab731821952";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sl/firefox-100.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "12459b203b0de94241b243b07b9f54e7ae612f7887581c5cd3ac7ca2a08a54d9";
+      sha256 = "259b7c2467220ed58a725006b70b1610d7b1589892e75b0eda1ed5a97ea8d65d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/son/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/son/firefox-100.0b5.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "2d44c84feaa5c5e3595055289f84f320b447664d01c653b0a3b50f1da24b1a78";
+      sha256 = "56f4d79d2e4c3df1ea6903c230d790aa2e40adb704358c6d225fcb2103122cdd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sq/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sq/firefox-100.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "fa3f9724380818a71d895252631b354ffb692f35679eb9b8ffa5b2beede8ab61";
+      sha256 = "73490c2374b06cb4a8fdcf5c1ed32484581b62f380aef5d8d6da8c1319caa0b2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sr/firefox-100.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c2e5ad218b8cbadfda7c455266e018a6eaf9b450a905e8a73b01d02b7efed608";
+      sha256 = "06070996a689d5cac3f97348af762834d0a9e56446b8b58ceba11235f49f17cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sv-SE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sv-SE/firefox-100.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "12060ac843f03a7544db8631c7f53bcd0cc6fb15d62cd997b02a83f0560722aa";
+      sha256 = "bc2b8826c8635d5e96b596aa5add0a6f6146fd9b70195323b6fac588ad4e0a88";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/szl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/szl/firefox-100.0b5.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "71ace92d020f3fbd1d5e223dfaa01e3a53ac625ba5ecf074153aad8ccb640ede";
+      sha256 = "40eb80afc5f91513f4ee96dddd842b7b424b4caa2b41cbb0542b6a9c009b2099";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ta/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ta/firefox-100.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "6ace267aab85845babad8b11b68e154e1128b920ed16b8b8d011d53f6dced16c";
+      sha256 = "79132eab776f5e3eba46368a837297be38123ac7036ab550c82d60037e8bc594";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/te/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/te/firefox-100.0b5.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "e381faff48999b63b4981695e7c80bb946b44503ab5275344f12b7005ed49ef3";
+      sha256 = "b2062d708ca2964fe0d046da13c6e763dcc6702dbffc4bb32ace4301e2653941";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/th/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/th/firefox-100.0b5.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "6c2ddea1c0ccf0521b9b647827569b78ac2143163895e67476051f8496011b66";
+      sha256 = "4e1ce1968f16403268a69ab85abb33422eb52cb0f36c854a16dda87d5abd941d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/tl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/tl/firefox-100.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "9d949c9c61922756d0f2dbcff76906191d438d161c74fbe7d702c7372c11b5d0";
+      sha256 = "c1ee82d1b14be9bf7c634029884a7eb59c051f26663e00ea0bf6e5f74ef9e04c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/tr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/tr/firefox-100.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "88763e4847b865603a7d953d54b86e6a053d2476209b4046bcb09149275690f8";
+      sha256 = "0c58541768c627cb4d556b34ed8523f3bccfdaa757cdcde37d1fe7d19c934562";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/trs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/trs/firefox-100.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b6e7aa724a06f85e4eaae7e1c55e3ed1ec9a6b5664150745a257bd3f63310d53";
+      sha256 = "139f2a1abb08dc5ef684d51226fbe64c41e08ad4f183a8b15ff155c5fe51e922";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/uk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/uk/firefox-100.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "69b200c0c4c92430f188ea12bf5e60aae18203a76e61cc163738d46c3627b137";
+      sha256 = "633fa83f990bc1e8a791a0486bf9034f5b4709fd3e2d868f42895b66c5476ca7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ur/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ur/firefox-100.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "330bb00cc0c0882a1e8aa06fdf7d283eaeef04500a9bfccef50f7b2ab8becf81";
+      sha256 = "25d7518b88be9d1cbf504a8c214049f265f74a0def26bf5a1c60d562d999a5e8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/uz/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/uz/firefox-100.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "a9b7087c1deec3aedcc2c279b135b113e79739a28e31ba6cd090541505e5d9e5";
+      sha256 = "39f6c200dc56585bf527e8daa59f460d9193f7d5e7194efb7b1bfbf2d4f92e4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/vi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/vi/firefox-100.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "76b034ed53b8c99cf7909a6a5651627fcd9cdebd7f8ccdbd3d2286cb19dc7eaa";
+      sha256 = "e4d0a5838b837d7020da1595cf77093d53aa5d7f765fcc98da20c11c0e853874";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/xh/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/xh/firefox-100.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a1c9ec73200bea835c46879d8196b380a3157c98404e6a009fbdb24b1662ddde";
+      sha256 = "679180e00ca70e112d5053c72cabc0ca5eb92f2f16915c556aefc861188d0318";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/zh-CN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/zh-CN/firefox-100.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "74fd44c26c503014d0fc3a32dbb726feefd572ce52697879a392996243b5811d";
+      sha256 = "c280eef16ab855db69e975f8cac93a2987e125236d7df34a5a336cc837cfd901";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/zh-TW/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/zh-TW/firefox-100.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a9d86ddb8f5388370a28ac643e3d21a411625b7098aca9c399551f8e2c125da9";
+      sha256 = "2b6d0a74fd53d907a6e0f6e28be41e9cfa62e61c42dbc132d16c39f87980ad49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ach/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ach/firefox-100.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "67b0501117e5d93046031860df5dc6eef3fc3126f0b10240cc13b83f6f1cfdb9";
+      sha256 = "579452bc9bf650c9664775a5ec438be6cf4276b807840a38e30a0c08237a777d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/af/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/af/firefox-100.0b5.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "43b9b1107fb13b97f6b955b3abaa4f1d590bbb1747859e54bb306c9578fbdfe6";
+      sha256 = "a9828b2f4954f63b8b4b37722da0a50f1b9e6230aa981f51597718bf05e52b54";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/an/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/an/firefox-100.0b5.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "da752ce8f7a9a0769c93f6f1817649354f892c440cdd48f0dd75739baedcff40";
+      sha256 = "0d7083b1feef4c8cde1be64ff26c37afdba36454802266c28b1916f760881de4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ar/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ar/firefox-100.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e67fc64daef74e78eee12a1e5d4c1ef5a89a8278d19187d9e0c67ac5ea350623";
+      sha256 = "57e5e2863caf348c475daaa6949dabe013aab0b3e63db61b3a9b9ef4049e62e9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ast/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ast/firefox-100.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "115cb0605bfb7629b854d242634cd2797b5072f735c840a6611325faf7bc3f77";
+      sha256 = "e954fde4dcca82fdfd8605bcd43930f0b85117c1b2dc9edeba75b435b77b121e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/az/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/az/firefox-100.0b5.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "c839a19dc4f5d938fe7a5426a8abd7b228c89a262201c019b4b53953211aea78";
+      sha256 = "a893f228de842c6bdd0c41df3db328c737b57a945a55e1e56f3672a7beffbe5b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/be/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/be/firefox-100.0b5.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "94c8e688578059f8c4f7fd2a65a8fd77280b4047e845efd6ea66e34f5320d119";
+      sha256 = "8cb4ca15ee69f9bb74cd13de82697526d6e64c6968881489b7ddbe4ad9266c54";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bg/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bg/firefox-100.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "9f7acb26e7cd9193e9e435da3e2f4e9d9ee82195cc18e8de8295cba2446da1f0";
+      sha256 = "2d8a566a4619f549bf6b68a2d1b0fad51843de0257da54039050affbc21de948";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bn/firefox-100.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "93f31b395a9a42386b0de322db1f675810a3db106a0e8c583f18ad4dd0c56488";
+      sha256 = "e75c5aecf6b0bd0d60423bb66980c085957b1acd1549426a44a4a7991d1f2db3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/br/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/br/firefox-100.0b5.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "a04a2b2f2b70f33bfe288d9907291aa61f2daa64d0d6802c784d7b4f44b38326";
+      sha256 = "bb8794c3069989e0f06f0dbd0b7fee638bcf9e6e3d24d28ce41db3a182a83a60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bs/firefox-100.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "154456c3aeefe93d6891306fe295342aa02c294bf64693fe93943ae836fc796d";
+      sha256 = "db964f0e1eb920cac95cd0dc14175f5e20a1ec32f56a3b43554f22cc67dce752";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ca-valencia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ca-valencia/firefox-100.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "c00ab86f77e5113f85feb8eb14b74c2c144e9c7e08c4442b06b749ffccde2cf1";
+      sha256 = "ca124cd11585fc521b4e2d1c4bc0c2407056abffbb2b36e46ec568c6490b28d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ca/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ca/firefox-100.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "07de1d9c72f9d5487b9ff57ec609a2b6ce37a8b09fc81200a6cc6610a7e66b9f";
+      sha256 = "6ca6e8c905b44c09c4d061656fe2cace22d261ea4efd04917fc2aa2ce13a1cb6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cak/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cak/firefox-100.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "ee05ba6ce42f873ab79032553302caae28069d84c5105192623f1261d2d3d609";
+      sha256 = "44bfca1c2cac5eea67f68891da93604edbdf6e0eda92fd1686d83512feff2089";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cs/firefox-100.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "9b2af581c1c70b72cbf82cf656f94e65058063f0fd6807d99760dfe9b68af808";
+      sha256 = "491a9c7a2471fc1a06751282340f1b6bd00118a8ea11d54420985822c0e9a19e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cy/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cy/firefox-100.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f638faf94045b5e739736926e4b3e173f8830542287d46aed70337d9ac3a4495";
+      sha256 = "b9e55860c0f14afcd2d2cf87e5ca7d4b853fce667f93a6b493323423c16f8adc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/da/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/da/firefox-100.0b5.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "3dad188b310fef15b704ca788b320d502a0a6ee59538296176fb17d2b440163a";
+      sha256 = "899a53b667b4f64e953b7d1cf430eea8e67de747b28c93435cf33f008dc464eb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/de/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/de/firefox-100.0b5.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "1bdb5b60bdf16126de86ba1413eb5ac4184f727b3e57a36d424dfe39647f53be";
+      sha256 = "efecb119d1becf00b34babaf42cae5f5c586dc8cc2a29c71d410b68b7aa00cc5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/dsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/dsb/firefox-100.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "b306d40607d73314c0e3e87bb1bce65369846be3e370943088a8e7e9731098fc";
+      sha256 = "b47d0bed633a6c8608c600d6b1c8c49bfe40e4b1df6f72bb7dd49e722084cf81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/el/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/el/firefox-100.0b5.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "45202f79f9cbf2a44bfefa9ce50bd0a6b88485207105db4df1f26f547c1f556b";
+      sha256 = "07b34038828ea049ea6c1bba71d27bada83ec514d8d58be92f9005ff01cd6853";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-CA/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-CA/firefox-100.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "78020bb6fa9395fc4e2cf40645e127d0f6d6dfca4044e5c00f63a90e24824add";
+      sha256 = "fe1dfeca3de53837003d93aecf5fa971a51e8a585cbe9a1c44f338d8d1d7788c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-GB/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-GB/firefox-100.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "647947c0b765d1142947d3cb35ceb308946090e928ecbd4cf8c3eba4b57afa47";
+      sha256 = "fe4baa77504d9ed1f789726db85599d5cc634765ae19cb4604234ccf7a43b97d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-US/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-US/firefox-100.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "4249f742c2918d66af2e7defe1c6b34870f258fe047ae7b38f91b0394b453cbe";
+      sha256 = "6ca97f006b90f98676efae14423c8707527182e118f4d3020e51eddcb14cf8d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/eo/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/eo/firefox-100.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "1726df9605c7deafd6963c18c4b8dbd4bbbed86814fa9932367fd04f6ef609fc";
+      sha256 = "e9fb1b7b6752629891df490ff625897ae5d929c435c824cb6c5dce18340e3273";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-AR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-AR/firefox-100.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "c3820a35047f21efc721889fa0003d8e74e13858aad4d3aea038c01b5cd6c657";
+      sha256 = "b18a2fb101d28d1dae1b4a33d63906a7c6720ddf5e4418eecf8f6df0be58e017";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-CL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-CL/firefox-100.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "b1f5bf697007d8b6ac9f1fa057f292bcfb860d71229a7d0ad6d611ab02991211";
+      sha256 = "37a54082b8bb69c925894718eefcb1229ad661cfe31aa95906da163a213ea4b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-ES/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-ES/firefox-100.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "de33571140d165d0422b2e4543893bab6435b6626333a05bfef39682ef759db0";
+      sha256 = "bb38bb93c74878646f31c09d524eaadf18a1e2f6ace957abfabd05e1e63898e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-MX/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-MX/firefox-100.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f681be5b92c8959e0e8c90cf4c7f6cd9197e11be1828797e853310a49dc76698";
+      sha256 = "6c75d42e34b6fde9e8b3ad31ad3574af87dfab2f5eef71b457fbdb9ca6dbe12e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/et/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/et/firefox-100.0b5.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "476a0ccde58372bffea3ebfb0d88795b31db2ec622f9c1b99df51287aa8ba69b";
+      sha256 = "e25b97ff49fcfaef9906cee48f0f342272d2b9807a6221aa6b4fa5939bfba70e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/eu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/eu/firefox-100.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "d465a6a4a01853724894fd81e31b63b80e830cee268298d6e037e6877ae77661";
+      sha256 = "f929034c74b057e32db4408ca25b9e9aff9b26d487db29cbb0c0fa0ade96748a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fa/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fa/firefox-100.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "cf8ac9c8d667ccb0066db1d20a9f43af807e40d1746931e001ec900b34fbbc02";
+      sha256 = "2fd4af491c79dbceee3de7e04fef413535757c0588072ece7e5ebcf252815782";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ff/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ff/firefox-100.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "86dcb3f9e1d899973eaccd3caf401471b36ff70f4a4693fa9f857083e8641a2e";
+      sha256 = "7b0f38144eef79ead877a352a03abb3d50631031b051750d3d9ab84dd8afe319";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fi/firefox-100.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "ca0b830aa6ec724aa31f957e7c84156726c26fa0a74ace80ecdea899a8091f82";
+      sha256 = "fefaec6affe3be2d963967397aa6b0c7495570d0fb437820d87ef6289654fd80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fr/firefox-100.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "e94a7a54ba806e2b4baa0159d2f8cb96e79abc9c01e2526821cac8253c6ad495";
+      sha256 = "1dcb22611d288ea566f1d319b4fa8f6ec7057e05d39a1be794ae12f343e29809";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fy-NL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fy-NL/firefox-100.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "cae5c9c607c0dc99e4645f756befce2c9c4ae83b7edc39cf12af81781b33a7b9";
+      sha256 = "fe15fecf740bdc9f9476366f394a10f2f919d7c84f64844025faafbf28fef05f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ga-IE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ga-IE/firefox-100.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "b9b1cb2a48cd17179d5e3a8a3fca9ac25c3367ff6281f632d826cd6a9bb4a633";
+      sha256 = "06c5708ca8cf4ded0cbc7b52e0772bc4fb86ae55d822ff09088af5c35e60d917";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gd/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gd/firefox-100.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "b5454de81ba2fee053e98dcb37d3703b5385a51561e45fa32f6872494cfc047b";
+      sha256 = "fdbf7f54a4120dee131687fc81e972e4df52347de4e8473a152ca0b98d7bef92";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gl/firefox-100.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "be3b3decd8e75740a317f105bfa2e4c919ad7f31e391845fb60b299fae7bea7c";
+      sha256 = "807d0deda34da90207a6ddac26649f38eded1a6b2337d9cb73ed28c55bd316b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gn/firefox-100.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "394562b739f81ec43a954f7393c5177f87d3d5b36d404d97e2e483f3000bb615";
+      sha256 = "a70ec6595f9ff5cfcc8ae0185d4ece632a17ff49817b98052bee8981dbd63d58";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gu-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gu-IN/firefox-100.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "d2e36f37146b48cbc710af7663ad8b4f7770dbb5f6a557e3f54d637e7061ad90";
+      sha256 = "44e9a22d946e4405db84069d329b66293b0d789b59d98bed4570d98dd19b6c0f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/he/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/he/firefox-100.0b5.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "17bbbd7768ff852dc1f27b224b77dfdaaebabaf531028c71a371bf302a9dd92d";
+      sha256 = "1855cfb19d6bd857a14950399e238c30768e23c08d21a1db38b49dcedf2302bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hi-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hi-IN/firefox-100.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "2f431a3e50ac0b74a2bda65652a5aa45c0e1b44ef0837645ec49e30c6d0d7fbc";
+      sha256 = "47fc9f90b3d52e353594bef6c84bf408ef3e37fa2d0eefe17997bab546b2f9b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hr/firefox-100.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e57e5fe2cb59c25002e9c06cd3298d9cb75c4437ddc9556590d6c56a1eac57bb";
+      sha256 = "bcbe511cd9bf09605f1e6bdb3b65e9f8eff6c6e8cbdb904987941d2edbd10b42";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hsb/firefox-100.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "7c1eefa455afacf5b3b1ee1d04b6e793e2db210912dae58910093c70a21a73f5";
+      sha256 = "5a5b5063eaeeeec63d13f138ba43280ea6cde0aeb03bcf18c6f5ed0c7ab575d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hu/firefox-100.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "d2b02034ce6686e0743af6444acc2a23ed657124bd7bb6ddfaf6d24cf11730b6";
+      sha256 = "7828ea71f5ecf9afcc52fad0047789ece2c8be5c7ba8d390d98a24daffebc0c1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hy-AM/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hy-AM/firefox-100.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "75589d2abd9488269693c0a0440d6359bafb354b1b5ee91b90306871903eda0b";
+      sha256 = "c76b2e07e5085caf56c8c94848f7d7dc4b40c5000a792921bce762ed55b73f4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ia/firefox-100.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "b26efd6320a41a558383e22db49cbcdd930161fb48ad0032d24e44b57b01f0c6";
+      sha256 = "de9ace36727f9fb070138d30bb854bf28ad57b7a9895cff492d48231826044cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/id/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/id/firefox-100.0b5.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d50fff8b0ff7ae5546ad3f25e485ef51280bd022708e3d0aae97d99f79788f0a";
+      sha256 = "01dcade8b0d7dd4f4ec9a408291c643bbfbcb922ba0b2cd84645799c22c46082";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/is/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/is/firefox-100.0b5.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "4cf7fbadac8084b8e134f6110ee07076ddd93cf00a10b6ef3d6276df9080bdc1";
+      sha256 = "a8aa5de061a5414e55f45c61bece3f4471662f36e3e30163daef028cbc62a675";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/it/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/it/firefox-100.0b5.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "6fabf495a730600869f6d1e2d9382120361f5061e3a893321f68a6378f7eeddc";
+      sha256 = "4610c04780fc075cb49a09e0815671dcd8f3b625a5b30913c8ff5be81cfd13cb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ja/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ja/firefox-100.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "95a537b3306ae1f6bfe9c4076042d6c29c6478c0f32e5aa4a01e800c1d2a75a5";
+      sha256 = "7ca93bd2ab0a1e0e0aa1a41df7331c65f27747b3d511527c557e613272a736ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ka/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ka/firefox-100.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "e73b2b555f7318650ca1ea20f9d8c1fbc933d230eba3eaeb5e5a47dac24797b1";
+      sha256 = "55cf179d73cfafc5526e5701de3560e4bf9c1d02c28c77cc66801b828fa9e33f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kab/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kab/firefox-100.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "cd55879a883ac4e4efef972d6200284d6839dc786e7dad4c3a81fd88b89b18ab";
+      sha256 = "c7930dbea998892979a16d3e60b19db62cbbe8388e68a2ea59a11e234e8f94b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kk/firefox-100.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "cf2dd9ae9cd6347eaf976cdcf4a6cce81abb741b0cc273063cbe1274d271e05b";
+      sha256 = "771eb9217226b36cb04719555a82c3b11e783059183ebc9c295677ea06d69321";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/km/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/km/firefox-100.0b5.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "f0f3982e7d838841a01b24c330ed3e74416073c40470293447551aacb5411506";
+      sha256 = "970daaec6f449ab1d6dc8688ee9f41b95d295523ed57ec14c5f34fc98ee18dee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kn/firefox-100.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "3e2953e55e3bc7fa76ff77aac08f79b20bbf2be52683c08b3d54a323a1754ed7";
+      sha256 = "fae2d5a9a428ddba10cdafb6fce6e0d591b5ba8353d2cf88ed423602fd150576";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ko/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ko/firefox-100.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "5c5bec8a40dbea26674eb2d4b7160c1c2f3ef37f68d67c24a7ca6a2cf77eac85";
+      sha256 = "4a66e9cec2224382645d962908218bb89fe4a499b9138c83966dd70d9d25b172";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lij/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lij/firefox-100.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "7cc492c5eff065cc3cbceb292d18d833e9f2bf76ace0d5ca960256290f049f94";
+      sha256 = "85ef4a63c9dc97f9b482382a83f5a7a6880c5df87acce7e142506c2d449e4f69";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lt/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lt/firefox-100.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "b4b56e01e65ffe4f7232daf661df178d4af1d813e1c8122c4ba56aada0b2ef52";
+      sha256 = "da3ccc7021eb4b62c35c716089599f714cfef218856063e083c3547d64271b4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lv/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lv/firefox-100.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "b13ac2b90f13813b8252c5eb817d0f55f770a58e05f8a98b1a08fdf59fc9191a";
+      sha256 = "6aa1d5453d938f16330e0ed54d63bc59c5b57e7da5ddbc41a05c2f75dea68e73";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/mk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/mk/firefox-100.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "6b1d2598350feb901e86f332598688853b607c7c14c13ac228610d16e89eeda3";
+      sha256 = "e0cc100f8be06fd97cb029837a054e60d136272a9f6b78eaef692d3bc5d8a669";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/mr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/mr/firefox-100.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "9a6a47fc20500b4421b12381374f0a8ecfa9a0929a54a6f6dba73e1c2e5a6c81";
+      sha256 = "d3a3d72bebefc51cd8eb1a1ebc1431a9845d15af6321b76e2982a0d210397409";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ms/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ms/firefox-100.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "e79c4f88952ec9061b4d90f8ca5970be8b5c19cbc1df8d9970b9b23c801103a1";
+      sha256 = "c59362f1817f98ec80ea275b39f50bed7a0ee1154d6a6ea3ad6dbe8f2eb1bf79";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/my/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/my/firefox-100.0b5.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "f8ce25b87b639843fa6fab4651326719f229f91a4d6b3a6ef17d0e9f4035b1f3";
+      sha256 = "ec1d06208223422633c2ca495bb17ca946e379d361a2e00f94ed08588b6b2263";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nb-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nb-NO/firefox-100.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "03f5550bf0c0f33c3cf252cbad1650204e008d852e6db46a6f7fb6f6b5ac10ed";
+      sha256 = "2e31732057bda76dd2d74d8e2b3e6c38a2035bf163234fd82fc867b544d34dc1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ne-NP/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ne-NP/firefox-100.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "5d94d2dbdbdadf6abb7250772e6e046b9ce03cbf5e4c920ef7e8b5cae69359b7";
+      sha256 = "eba3a80cb0b761b68d5e318d5f8110a7d19da1261868cbc1f1a39eb47c08c018";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nl/firefox-100.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "3045ce321c102e2c114a48a46526572a2c52d228b44ab35d8241d92bd65dd9fa";
+      sha256 = "1f7ae0dc78d5b30741e8d645471aa1875c2de144742383eb5c24cc2deda79f77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nn-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nn-NO/firefox-100.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "a16aa9b6de0ac4213492ca117eb47fbd4994824c0f080001baa9136231fb69cf";
+      sha256 = "acd635ad253a878043ec4121984da468901c49d4fb511ec9cfad478980ecf647";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/oc/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/oc/firefox-100.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "70bf39cd4c3fc4ef772dd71d97f71fdc92324ce2caf9d359cc1d3f3d1557c3a5";
+      sha256 = "2721c54a1bee621d9c7cf2f5c657dc48a7d9406d80c5aeb9963bf7b128c17629";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pa-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pa-IN/firefox-100.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "951263906c05aa6f60a65d77e917a95ce10e8ae31f156acac7f47ab4ec36deab";
+      sha256 = "97c435e09c0b56bd9bf66d50e90034a502e9af6cc1984d5acdd2d948f7556273";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pl/firefox-100.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "476ca14396dd7ee636ed1e74a20d9d0ff3b0c452e5b5f61eae6f0594ba060f3e";
+      sha256 = "36e81c101b8cb68be0f69339c47ff4e5839397096775cf9ea46f0ff1efe5353a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pt-BR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pt-BR/firefox-100.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "33ea09c993bddcc36621ae633713e758ac33349847604995e05fce0d26be398f";
+      sha256 = "fb90a3a2a303f945bc34e2a6ec397f0116ac77f02062e7a7c8dcd382606dfec0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pt-PT/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pt-PT/firefox-100.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "fd4b924d8afa163ec40a2f5ca6ae0b89e1a22a8be8b8fbf9f43012159d0b7172";
+      sha256 = "8797c65c277cc0f46a8d8b2cafc370be55c57eccc8e9fc88d3053e2969f9de58";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/rm/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/rm/firefox-100.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "97ce5f4af9e8ed2af039255e284ce1b55b6a3ac0eacf4c40be82b635b1df0f2b";
+      sha256 = "b8cd7b28f31d4e1ee874f1073065897444eb9503e207b924a875a8c3a0b21509";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ro/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ro/firefox-100.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a959d39333b98c5a479e6975dfa82a4c2b3efe5d69d2d99fddc8d2aabdbe95ce";
+      sha256 = "3907d9aa29f56fbf97008e65f83ae25719f4156961ff3e976661a2012f16fafd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ru/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ru/firefox-100.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e4f65bbf839054b7009e01461cf4a0b943e1373df054e9b40797b5d233654aac";
+      sha256 = "4913bf6de1f5b14d005f20bbc0d2ef97227903d296851034735e872e28b3f065";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sco/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sco/firefox-100.0b5.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "fac16861dbc011655c3b36b31d5e0816a09e1f88e34032d247d09f691c097ddd";
+      sha256 = "ac4fb9005a71ca5bd25120946b65ebc0f437d8c86b9dcdc11e9b874ade8b4dbb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/si/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/si/firefox-100.0b5.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "93423cb2cccf166f374fb4b8779f337fa1cfdff67f0f2c463a398a35ecd251bf";
+      sha256 = "8fdac92f650f10a9dc9322f817f1bb6f60b5a9fe97942cc1ca5ae694aad71523";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sk/firefox-100.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "e63c2240f7b791b01c94084dbb28d74ddd6528a7bd1e62bb74ee9271d0fd81f6";
+      sha256 = "57987896b0e1b8846911b878dc360d139002401ed57a9b95fe47f2801c983848";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sl/firefox-100.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "87064873e57431bb9cfd3e231df07753c8f644e218ea0318b3731baa05b16c1e";
+      sha256 = "3097cfb125f9b275270955c454577b7aa5ffe68b5ee0917cf6b3e0c31d9c5b25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/son/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/son/firefox-100.0b5.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "6ecdf2061f0787fc9adcd27465211446df45751d103e279aa50f278361061728";
+      sha256 = "8588038e834177672a47530e8e86c202123606ef6f1a5d9a4d5c40cac8cb9aec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sq/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sq/firefox-100.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "47783d01b35119b158c746c5ccede7e4832d15317958030306035d1b448b77dc";
+      sha256 = "cc229e95ce396fc37fd7103e70acae2414de501823beb04e71c702cc65c430f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sr/firefox-100.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "4aa1908894de6eb3640b497361d5245ed3379d29ffe6e10401540cc1c10cb965";
+      sha256 = "9c134f28f92311c8c8764df4d37727134fecab10197cbbaae01d26773e2897a3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sv-SE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sv-SE/firefox-100.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "2334fb5859711a4471f06a9eb81907d0b41ba52a8fce05b7cec320a0d31a4167";
+      sha256 = "40c8f4af652dae7a3eb1b1cab01f032ecb526600cbeea0dd5ccc4319b0d50310";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/szl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/szl/firefox-100.0b5.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "39ad1c9f4da42278f2a1b3c125aa7e2a8005376a6f458a03851d42f85d116dee";
+      sha256 = "d71882b04563f7f89a4c0bd2431e6b33e2af010b40b1dd50304f9daf0ca66525";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ta/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ta/firefox-100.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "24055aedcf23fcde0dc519bc2124a8d42c82ddd74dda46b694a20d25ff76d2ce";
+      sha256 = "a473f9123d53de141e0592e03e8c9dd6ce8f057c57f89f55957c1436d139582f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/te/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/te/firefox-100.0b5.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "18a90860a6428ab31229c975927b264d75b2e2f186f83ef270262f7598053d48";
+      sha256 = "042aae2c4d10d2b7407b3252a39600217ab8ac0c9e34045c31e70cd8e792968f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/th/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/th/firefox-100.0b5.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b965a21a0585cc07714c39ba33afc5ce757294d595c7617ba5b330a0d1d8cf0b";
+      sha256 = "6455ef37c941c978b1380f6ff3de41c0b7f8348d498d154e78c9c7b6e8992187";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/tl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/tl/firefox-100.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "cd1fb6553daf6b123e6545cf0553038b2f16c12ae4a21425e253c68124a8ce42";
+      sha256 = "b41d0029729bb4fa1e8d8c596232272c1e238d8bbdb675d31e42250faed54396";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/tr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/tr/firefox-100.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "2a2c6abfa119022520e8a3ab4c430c282a7a3f7d5e72d2a67d070a64398b2bb9";
+      sha256 = "e0345c71199784d40fa159617371a72e3f3e05d2aadc041d14c6b3e450304afd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/trs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/trs/firefox-100.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "aae079859fcf211c1e465a00a6a07514397a9f715bc02d704daf062e3d75220a";
+      sha256 = "4a6afcbbb3d05bf6f3abe3194a21aa6ea6d2f76cc5429ef4ca0a433ab1d97f76";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/uk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/uk/firefox-100.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "04ebb332d79d0a9aef5d2e93b2aa8dae0ded8d4e4c639d192ac969e8033ffa24";
+      sha256 = "97709ab7965f859da2ce93cd4c22b875a0a94af8b8b7acabd1578d5ae82d6d85";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ur/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ur/firefox-100.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "8a8d6d6503657665882ccea44a56b324253adc8d98eba20696ecfd096311821f";
+      sha256 = "7c69d7f588540d0a72d9942671d40ab59f066b9798279dbe1b0b0980cfa13a06";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/uz/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/uz/firefox-100.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "e2990d6a4c3bfb5547bdac49a2499c7dd958d0b8e665b636e0ffd6e9aebaab58";
+      sha256 = "53c450eeb1223c2794b9270d257fdeec50bb4deece5bf5d7d05a5819f54989c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/vi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/vi/firefox-100.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b7c2a4d8c1c400f44fcad7e91572134328097d183c76b8e22d5eaa0a4959d35f";
+      sha256 = "395e8ffa9c6a0145f6fdd005df0b73fd4d59410ba780818232cde2f3fc257d50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/xh/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/xh/firefox-100.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "e3dc9942f397812564b5d7728bb4857f0c217183300ac0ab28590921f56bda34";
+      sha256 = "22359e92de488a24709445de54499c9ad49e841e4ef6ba45296b44fac089121c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/zh-CN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/zh-CN/firefox-100.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "11ff62d8f465b9ce17591177f1fc98d6dcbbd819332f65bcffd685d43b5aa285";
+      sha256 = "7f5d0d771c546d41e835ce7842ee7659ec4a69cd78176b0c679b4b056e8d5499";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/zh-TW/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/zh-TW/firefox-100.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "406200aceeae06ce5ae2d736d8ff42713e2275b5f369682cd49946326c5cf21d";
+      sha256 = "8bd0dbb9bf1a3682ea39e43da3819a4f12bc147484528d869a252d2ad000f95a";
     }
     ];
 }


### PR DESCRIPTION
###### Description of changes

#166355 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
