### PR TITLE
burpsuit-pro: init at 2022.3.4

### DIFF
--- a/pkgs/tools/networking/burpsuite/pro.nix
+++ b/pkgs/tools/networking/burpsuite/pro.nix
@@ -1,0 +1,52 @@
+{ lib, stdenv, fetchurl, jdk11, runtimeShell, unzip, chromium }:
+
+stdenv.mkDerivation rec {
+  pname = "burpsuite-pro";
+  version = "2022.3.4";
+
+  src = fetchurl {
+    name = "burpsuite.jar";
+    urls = [
+      "https://portswigger-cdn.net/burp/releases/download?product=pro&version=${version}&type=Jar"
+    ];
+    sha256 = "sha256:0p9cmaqfaqycvpvl7jbdgshlc4wg6b6wvpja4wnw8349bbcbx4np";
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    echo '#!${runtimeShell}
+    eval "$(${unzip}/bin/unzip -p ${src} chromium.properties)"
+    mkdir -p "$HOME/.BurpSuite/burpbrowser/$linux64"
+    ln -sf "${chromium}/bin/chromium" "$HOME/.BurpSuite/burpbrowser/$linux64/chrome"
+    exec ${jdk11}/bin/java -jar ${src} "$@"' > $out/bin/burpsuite
+    chmod +x $out/bin/burpsuite
+
+    runHook postInstall
+  '';
+
+  preferLocalBuild = true;
+
+  meta = with lib; {
+    description = "An integrated platform for performing security testing of web applications";
+    longDescription = ''
+      Burp Suite is an integrated platform for performing security testing of web applications.
+      Its various tools work seamlessly together to support the entire testing process, from
+      initial mapping and analysis of an application's attack surface, through to finding and
+      exploiting security vulnerabilities.
+
+      Note that you need to get a trial key or a subscription on burpsuite to use this package.
+      Eg: https://portswigger.net/burp/pro/trial
+      It gives the active scan option.
+    '';
+    homepage = "https://portswigger.net/burp/pro";
+    downloadPage = "https://portswigger.net/burp/releases";
+    license = licenses.unfree;
+    platforms = jdk11.meta.platforms;
+    hydraPlatforms = [];
+    maintainers = with maintainers; [ jappie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2510,6 +2510,7 @@ with pkgs;
   bukubrow = callPackage ../tools/networking/bukubrow { };
 
   burpsuite = callPackage ../tools/networking/burpsuite {};
+  burpsuite-pro = callPackage ../tools/networking/burpsuite/pro.nix {};
 
   bs-platform = callPackage ../development/compilers/bs-platform {};
 


### PR DESCRIPTION
there was already a community edition.
But this doesn't include the active scan which I needed.
The build succeed and runs, but the program needs a license key

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
