### PR TITLE
wormhole-william: enable tests

### DIFF
--- a/pkgs/tools/networking/wormhole-william/default.nix
+++ b/pkgs/tools/networking/wormhole-william/default.nix
@@ -13,7 +13,12 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-J6iht3cagcwFekydShgaYJtkNLfEvSDqonkC7+frldM=";
 
-  doCheck = false;
+  preCheck = ''
+    # wormhole_test.go:692: failed to establish connection
+    substituteInPlace wormhole/wormhole_test.go \
+      --replace "TestWormholeDirectoryTransportSendRecvDirect" \
+                "SkipWormholeDirectoryTransportSendRecvDirect"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/psanford/wormhole-william";


### PR DESCRIPTION
wormhole-william: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
package github.com/psanford/wormhole-william/ci: build constraints exclude all Go files in /build/source/ci
=== RUN   TestBasicClient
--- PASS: TestBasicClient (0.00s)
=== RUN   TestCustomUserAgent
--- PASS: TestCustomUserAgent (0.00s)
PASS
ok      github.com/psanford/wormhole-william/rendezvous 0.004s
=== RUN   TestStructTags
--- PASS: TestStructTags (0.00s)
PASS
ok      github.com/psanford/wormhole-william/rendezvous/internal/msgs   0.001s
?       github.com/psanford/wormhole-william/rendezvous/rendezvousservertest    [no test files]
=== RUN   TestWormholeSendRecvText
--- PASS: TestWormholeSendRecvText (0.03s)
=== RUN   TestVerifierAbort
--- PASS: TestVerifierAbort (0.01s)
=== RUN   TestWormholeFileReject
--- PASS: TestWormholeFileReject (0.01s)
=== RUN   TestWormholeFileTransportSendRecvViaRelayServer
--- PASS: TestWormholeFileTransportSendRecvViaRelayServer (0.01s)
=== RUN   TestWormholeBigFileTransportSendRecvViaRelayServer
--- PASS: TestWormholeBigFileTransportSendRecvViaRelayServer (0.01s)
=== RUN   TestWormholeFileTransportRecvMidStreamCancel
--- PASS: TestWormholeFileTransportRecvMidStreamCancel (0.01s)
=== RUN   TestWormholeFileTransportSendMidStreamCancel
--- PASS: TestWormholeFileTransportSendMidStreamCancel (0.01s)
=== RUN   TestPendingSendCancelable
--- PASS: TestPendingSendCancelable (0.00s)
=== RUN   TestPendingRecvCancelable
--- PASS: TestPendingRecvCancelable (0.01s)
PASS
ok      github.com/psanford/wormhole-william/wormhole   0.105s
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
