### PR TITLE
bump: enable tests

### DIFF
--- a/pkgs/development/tools/github/bump/default.nix
+++ b/pkgs/development/tools/github/bump/default.nix
@@ -13,11 +13,14 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-ZeKokW6jMiKrXLfnxwEBF+wLuFQufnPUnA/EnuhvrwI=";
 
-  doCheck = false;
-
   ldflags = [
     "-X main.buildVersion=${version}" "-X main.buildCommit=${version}" "-X main.buildDate=1970-01-01"
   ];
+
+  preCheck = ''
+    # git_test.go:55: repository does not exist
+    substituteInPlace git_test.go --replace "Test_githubRepoDetect" "Skip_githubRepoDetect"
+  '';
 
   meta = with lib; {
     license = licenses.mit;


### PR DESCRIPTION
bump: enable tests

WAIT this figuring out this.

If I create a sample git repository. Errors as:
`  git_test.go:55: remote not found`
--- FAIL: Test_githubRepoDetect (

Test failing:
```
func Test_githubRepoDetect(t *testing.T) {
	owner, repo, err := githubRepoDetect(".")
	if err != nil {
		t.Fatal(err)
	}
	expect := "mroth/bump"
	actual := owner + "/" + repo
	if expect != actual {
		t.Errorf("want %v got %v", expect, actual)
	}
}
```

Passings tests:
```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   Test_parseGithubRemote
=== RUN   Test_parseGithubRemote/GitHub_HTTPS
=== RUN   Test_parseGithubRemote/GitHub_HTTPS_noExtension
=== RUN   Test_parseGithubRemote/GitHub_SSH
--- PASS: Test_parseGithubRemote (0.00s)
    --- PASS: Test_parseGithubRemote/GitHub_HTTPS (0.00s)
    --- PASS: Test_parseGithubRemote/GitHub_HTTPS_noExtension (0.00s)
    --- PASS: Test_parseGithubRemote/GitHub_SSH (0.00s)
=== RUN   TestOptionsPrecedence
=== RUN   TestOptionsPrecedence/just_--verbose_arg
=== RUN   TestOptionsPrecedence/just_-v_arg
=== RUN   TestOptionsPrecedence/just_--no-open_arg
=== RUN   TestOptionsPrecedence/multiple_args
=== RUN   TestOptionsPrecedence/env_arg_bool_true_format
=== RUN   TestOptionsPrecedence/env_arg_bool_TRUE_format
=== RUN   TestOptionsPrecedence/env_arg_bool_1_format
=== RUN   TestOptionsPrecedence/env_arg_bool_yes_format
=== RUN   TestOptionsPrecedence/flags_beat_env_if_disagree
--- PASS: TestOptionsPrecedence (0.00s)
    --- PASS: TestOptionsPrecedence/just_--verbose_arg (0.00s)
    --- PASS: TestOptionsPrecedence/just_-v_arg (0.00s)
    --- PASS: TestOptionsPrecedence/just_--no-open_arg (0.00s)
    --- PASS: TestOptionsPrecedence/multiple_args (0.00s)
    --- PASS: TestOptionsPrecedence/env_arg_bool_true_format (0.00s)
    --- PASS: TestOptionsPrecedence/env_arg_bool_TRUE_format (0.00s)
    --- PASS: TestOptionsPrecedence/env_arg_bool_1_format (0.00s)
    --- PASS: TestOptionsPrecedence/env_arg_bool_yes_format (0.00s)
    --- PASS: TestOptionsPrecedence/flags_beat_env_if_disagree (0.00s)
PASS
ok      github.com/mroth/bump   0.003s
```


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
