### PR TITLE
libsForQt5.qt5-qca_2_3_2: add as darwin-compatible alternative for qt5-qca

### DIFF
--- a/pkgs/development/libraries/qca-qt5/2.3.2.nix
+++ b/pkgs/development/libraries/qca-qt5/2.3.2.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchurl, cmake, openssl, pkg-config, qtbase }:
+
+stdenv.mkDerivation rec {
+  pname = "qca-qt5";
+  version = "2.3.2";
+
+  src = fetchurl {
+    url = "http://download.kde.org/stable/qca/${version}/qca-${version}.tar.xz";
+    sha256 = "sha256-RpdgAjfEvDqXnofSzIBiTyewYoDmNfXZDsfdTSqfYG0=";
+  };
+
+  buildInputs = [ openssl qtbase ];
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  dontWrapQtApps = true;
+
+  # tells CMake to use this CA bundle file if it is accessible
+  preConfigure = "export QC_CERTSTORE_PATH=/etc/ssl/certs/ca-certificates.crt";
+
+  # tricks CMake into using this CA bundle file if it is not accessible (in a sandbox)
+  cmakeFlags = [ "-Dqca_CERTSTORE=/etc/ssl/certs/ca-certificates.crt" ];
+
+  meta = with lib; {
+    description = "Qt 5 Cryptographic Architecture";
+    homepage = "http://delta.affinix.com/qca";
+    maintainers = with maintainers; [ ttuegel ];
+    license = licenses.lgpl21Plus;
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/development/libraries/qca-qt5/default.nix
+++ b/pkgs/development/libraries/qca-qt5/default.nix
@@ -26,5 +26,8 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ttuegel ];
     license = licenses.lgpl21Plus;
     platforms = with platforms; unix;
+    # until macOS SDK supports Qt 5.15, 2.3.2 is the highest version of qca-qt5
+    # that works on darwin
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -176,6 +176,9 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
+  # Until macOS SDK allows for Qt 5.15, darwin is limited to 2.3.2
+  qca-qt5_2_3_2 = callPackage ../development/libraries/qca-qt5/2.3.2.nix { };
+
   qcoro = callPackage ../development/libraries/qcoro { };
 
   qcsxcad = callPackage ../development/libraries/science/electronics/qcsxcad { };


### PR DESCRIPTION
###### Description of changes

Noticed after #168159, `qt5-qca` 2.3.4 depends on Qt 5.15, which doesn't work on darwin.
Introduce a new `qt5-qca_2_3_2`, which still works on Qt 5.12 (and, therefore, still works on darwin), providing a path to enable Qt apps on darwin pending #101229, which will be needed before fixing Qt 5.15 on darwin.

@ttuegel

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
