### PR TITLE
nixos/pdns-recursor: update default values

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -481,6 +481,31 @@
       </listitem>
       <listitem>
         <para>
+          In the PowerDNS Recursor module
+          (<literal>services.pdns-recursor</literal>), default values of
+          several IP address-related NixOS options have been updated to
+          match the default upstream behavior. In particular, Recursor
+          by default will:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              listen on (and allows connections from) both IPv4 and IPv6
+              addresses
+              (<literal>services.pdns-recursor.dns.address</literal>,
+              <literal>services.pdns-recursor.dns.allowFrom</literal>);
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              allow only local connections to the REST API server
+              (<literal>services.pdns-recursor.api.allowFrom</literal>).
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
           <literal>openssh</literal> has been update to 8.9p1, changing
           the FIDO security key middleware interface.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -154,6 +154,12 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `services.kubernetes.scheduler.{port,address}` now set `--secure-port` and `--bind-address` instead of `--port` and `--address`, since the former have been deprecated and are no longer functional in kubernetes>=1.23. Ensure that you are not relying on the insecure behaviour before upgrading.
 
+- In the PowerDNS Recursor module (`services.pdns-recursor`), default values of several IP address-related NixOS options have been updated to match the default upstream behavior.
+  In particular, Recursor by default will:
+    - listen on (and allows connections from) both IPv4 and IPv6 addresses
+      (`services.pdns-recursor.dns.address`, `services.pdns-recursor.dns.allowFrom`);
+    - allow only local connections to the REST API server (`services.pdns-recursor.api.allowFrom`).
+
 - `openssh` has been update to 8.9p1, changing the FIDO security key middleware interface.
 
 - `services.k3s.enable` no longer implies `systemd.enableUnifiedCgroupHierarchy = false`, and will default to the 'systemd' cgroup driver when using `services.k3s.docker = true`.

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -30,10 +30,10 @@ in {
     enable = mkEnableOption "PowerDNS Recursor, a recursive DNS server";
 
     dns.address = mkOption {
-      type = types.str;
-      default = "0.0.0.0";
+      type = oneOrMore types.str;
+      default = [ "::" "0.0.0.0" ];
       description = ''
-        IP address Recursor DNS server will bind to.
+        IP addresses Recursor DNS server will bind to.
       '';
     };
 
@@ -47,8 +47,12 @@ in {
 
     dns.allowFrom = mkOption {
       type = types.listOf types.str;
-      default = [ "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" ];
-      example = [ "0.0.0.0/0" ];
+      default = [
+        "127.0.0.0/8" "10.0.0.0/8" "100.64.0.0/10"
+        "169.254.0.0/16" "192.168.0.0/16" "172.16.0.0/12"
+        "::1/128" "fc00::/7" "fe80::/10"
+      ];
+      example = [ "0.0.0.0/0" "::/0" ];
       description = ''
         IP address ranges of clients allowed to make DNS queries.
       '';
@@ -72,7 +76,8 @@ in {
 
     api.allowFrom = mkOption {
       type = types.listOf types.str;
-      default = [ "0.0.0.0/0" ];
+      default = [ "127.0.0.1" "::1" ];
+      example = [ "0.0.0.0/0" "::/0" ];
       description = ''
         IP address ranges of clients allowed to make API requests.
       '';
@@ -96,7 +101,7 @@ in {
 
     forwardZonesRecurse = mkOption {
       type = types.attrs;
-      example = { eth = "127.0.0.1:5353"; };
+      example = { eth = "[::1]:5353"; };
       default = {};
       description = ''
         DNS zones to be forwarded to other recursive servers.

--- a/nixos/tests/pdns-recursor.nix
+++ b/nixos/tests/pdns-recursor.nix
@@ -1,12 +1,15 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
-  name = "powerdns";
+  name = "powerdns-recursor";
 
   nodes.server = { ... }: {
     services.pdns-recursor.enable = true;
+    services.pdns-recursor.exportHosts= true;
+    networking.hosts."192.0.2.1" = [ "example.com" ];
   };
 
   testScript = ''
     server.wait_for_unit("pdns-recursor")
     server.wait_for_open_port("53")
+    assert "192.0.2.1" in server.succeed("host example.com localhost")
   '';
 })


### PR DESCRIPTION
###### Description of changes

Some changes to keep NixOS in line with upstream and improving IPv6 support.

###### Things done

- [x] Tested `nixosTests.pdns-recursor`
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).