### PR TITLE
syncplay: Allow disabling GUI

### DIFF
--- a/nixos/modules/services/networking/syncplay.nix
+++ b/nixos/modules/services/networking/syncplay.nix
@@ -89,7 +89,7 @@ in
         ${lib.optionalString (cfg.passwordFile != null) ''
           export SYNCPLAY_PASSWORD=$(cat "''${CREDENTIALS_DIRECTORY}/password")
         ''}
-        exec ${pkgs.syncplay}/bin/syncplay-server ${escapeShellArgs cmdArgs}
+        exec ${pkgs.syncplay-nogui}/bin/syncplay-server ${escapeShellArgs cmdArgs}
       '';
     };
   };

--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonApplication, pyside2, shiboken2, twisted, certifi, qt5 }:
+{ lib, fetchFromGitHub, buildPythonApplication, pyside2, twisted, certifi, qt5, enableGUI ? true }:
 
 buildPythonApplication rec {
   pname = "syncplay";
@@ -13,12 +13,14 @@ buildPythonApplication rec {
     sha256 = "0qm3qn4a1nahhs7q81liz514n9blsi107g9s9xfw2i8pzi7v9v0v";
   };
 
-  propagatedBuildInputs = [ pyside2 shiboken2 twisted certifi ] ++ twisted.extras.tls;
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+  propagatedBuildInputs = [ twisted certifi ]
+    ++ twisted.extras.tls
+    ++ lib.optional enableGUI pyside2;
+  nativeBuildInputs = lib.optionals enableGUI [ qt5.wrapQtAppsHook ];
 
   makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
 
-  postFixup = ''
+  postFixup = lib.optionalString enableGUI ''
     wrapQtApp $out/bin/syncplay
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29309,6 +29309,8 @@ with pkgs;
 
   syncplay = python3.pkgs.callPackage ../applications/networking/syncplay { };
 
+  syncplay-nogui = syncplay.override { enableGUI = false; };
+
   syncterm = callPackage ../applications/terminal-emulators/syncterm { };
 
   inherit (callPackages ../applications/networking/syncthing { })


### PR DESCRIPTION
###### Description of changes

Introduces a no-GUI version of syncplay.

The GUI brings a huge closure size with it, about 1.64GB, or 90.5% of
the total. Turning the GUI off brings the closure size down to just
177MB, which is much nicer for small servers

I also removed the explicit `shiboken2` dependency, it's not needed.

Relevant are syncplays [`requirements.txt`](https://github.com/Syncplay/syncplay/blob/master/requirements.txt) and [`requirements_gui.txt`](https://github.com/Syncplay/syncplay/blob/master/requirements_gui.txt) files, which now match the Nix builds for the two versions.

Ping @Enzime @solson 

###### Things done

- [x] Built both versions and tested that a syncplay server without GUI works and that a syncplay client with GUI can connect to it and play a video