### PR TITLE
frogatto: unstable-2021-05-24 -> unstable-2022-04-13

### DIFF
--- a/pkgs/games/frogatto/data.nix
+++ b/pkgs/games/frogatto/data.nix
@@ -2,14 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "frogatto-data";
-  version = "unstable-2021-05-24";
+  version = "unstable-2022-04-13";
 
   src = fetchFromGitHub {
     owner = "frogatto";
     repo = "frogatto";
-    # master branch as of 2021-11-29
-    rev = "82d3dafa0cfeaad016a427bdbc729eb9509748f1";
-    sha256 = "0fmwn584xl0vafcsh72b4xnryfqyjxk5zhmymg5i8rzp6h03n8xq";
+    rev = "655493961c4ad57ba9cccdc24d23a2ded294b5f2";
+    sha256 = "0irn7p61cs8nm7dxsx84b2c3wryf2h12k2kclywdhy6xmh53w8k1";
   };
 
   installPhase = ''

--- a/pkgs/games/frogatto/engine.nix
+++ b/pkgs/games/frogatto/engine.nix
@@ -1,18 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, which
+{ lib, stdenv, fetchFromGitHub, fetchurl, which
 , boost, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf
 , glew, zlib, icu, pkg-config, cairo, libvpx }:
 
 stdenv.mkDerivation {
   pname = "anura-engine";
-  version = "unstable-2021-11-23";
+  version = "unstable-2022-04-09";
 
   src = fetchFromGitHub {
     owner = "anura-engine";
     repo = "anura";
-    rev = "816425df31624066e2815e26a25b1c5d3d355cb4";
-    sha256 = "1k7fnfgz003gcbyygv4aakhkkz3w3z9nyz7dlwz01xa6122zqyir";
+    rev = "5ac7f6fe63114274f0da7dad4c1ed673651e6424";
+    sha256 = "1yrcbvzgxdvn893qk1qcpb53pjns366fdls5qjal7lhq71kkfc67";
     fetchSubmodules = true;
   };
+  patches = [
+    # https://github.com/anura-engine/anura/issues/321
+    (fetchurl {
+      url = "https://github.com/anura-engine/anura/commit/627d08fb5254b5c66d315f1706089905c2704059.patch";
+      sha256 = "052m58qb3lg0hnxacpnjz2sz89dk0x6b5qi2q9bkzkvg38f237rr";
+    })
+  ];
 
   nativeBuildInputs = [
     which pkg-config


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update, and fix the build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
