### PR TITLE
protolint: init at 0.37.1

### DIFF
--- a/pkgs/development/tools/protolint/default.nix
+++ b/pkgs/development/tools/protolint/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "protolint";
+  version = "0.37.1";
+
+  src = fetchFromGitHub {
+    owner = "yoheimuta";
+    repo = pname;
+    rev = "6aa30515838cc0adf7c76a9461f52bdc713f2e9f";
+    sha256 = "sha256-oKGA5FZpT3E5G7oREGAojdu4Xn8JPd7IYwfueK9QA34=";
+  };
+
+  vendorSha256 = "sha256-iLQwx3B5n21ZXefWiGBBL9roa9LIFByzB8KXLywhvKs=";
+
+  # Something about the way we run tests causes issues. It doesn't happen
+  # when using "go test" directly:
+  # === RUN   TestEnumFieldNamesPrefixRule_Apply_fix/no_fix_for_a_correct_proto
+  #    util_test.go:35: open : no such file or directory
+  # === RUN   TestEnumFieldNamesPrefixRule_Apply_fix/fix_for_an_incorrect_proto
+  #    util_test.go:35: open : no such file or directory
+  excludedPackages = [ "internal" ];
+
+  ldflags = let
+    rev = builtins.substring 0 7 src.rev;
+  in [
+    "-X github.com/yoheimuta/protolint/internal/cmd.version=${version}"
+    "-X github.com/yoheimuta/protolint/internal/cmd.revision=${rev}"
+    "-X github.com/yoheimuta/protolint/internal/cmd/protocgenprotolint.version=${version}"
+    "-X github.com/yoheimuta/protolint/internal/cmd/protocgenprotolint.revision=${rev}"
+  ];
+
+  meta = with lib; {
+    description = "A pluggable linter and fixer to enforce Protocol Buffer style and conventions";
+    homepage = "https://github.com/yoheimuta/protolint";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.zane ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -409,6 +409,8 @@ with pkgs;
 
   protoc-gen-validate = callPackage ../development/tools/protoc-gen-validate { };
 
+  protolint = callPackage ../development/tools/protolint { };
+
   ptags = callPackage ../development/tools/misc/ptags { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };


### PR DESCRIPTION
###### Description of changes

Packaging protolint.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
