### PR TITLE
codeql: 2.8.2 -> 2.8.5

### DIFF
--- a/pkgs/development/tools/analysis/codeql/default.nix
+++ b/pkgs/development/tools/analysis/codeql/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   # needed until codeql/csharp/tools/linux64/libcoreclrtraceptprovider.so updates its liblttng-ust dependency from liblttng-ust.so.0 to liblttng-ust.so.1
-  autoPatchelfIgnoreMissingDeps=true;
+  autoPatchelfIgnoreMissingDeps = true;
 
   nativeBuildInputs = [
     zlib

--- a/pkgs/development/tools/analysis/codeql/default.nix
+++ b/pkgs/development/tools/analysis/codeql/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   # needed until codeql/csharp/tools/linux64/libcoreclrtraceptprovider.so updates its liblttng-ust dependency from liblttng-ust.so.0 to liblttng-ust.so.1
   autoPatchelfIgnoreMissingDeps=true;
-  
+
   nativeBuildInputs = [
     zlib
     xorg.libX11
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     # resolve java home, so to be able to create databases, we want to make
     # sure that they point somewhere sane/usable since we can not autopatch
     # the codeql packaged java dist, but we DO want to patch the extractors
-    # as well as the builders which are ELF binaries for the most particle
+    # as well as the builders which are ELF binaries for the most part
 
     rm -rf $out/codeql/tools/linux64/java
     ln -s ${jdk11} $out/codeql/tools/linux64/java

--- a/pkgs/development/tools/analysis/codeql/default.nix
+++ b/pkgs/development/tools/analysis/codeql/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, zlib, xorg, freetype, jdk11, curl, lttng-ust, autoPatchelfHook }:
+{ lib, stdenv, fetchzip, zlib, xorg, freetype, jdk11, curl, autoPatchelfHook }:
 
 stdenv.mkDerivation rec {
   pname = "codeql";
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     jdk11
     stdenv.cc.cc.lib
     curl
-    lttng-ust
     autoPatchelfHook
   ];
 

--- a/pkgs/development/tools/analysis/codeql/default.nix
+++ b/pkgs/development/tools/analysis/codeql/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     ln -s ${jdk11} $out/codeql/tools/linux64/java
 
     ln -s $out/codeql/codeql $out/bin/
-    '';
+  '';
 
   meta = with lib; {
     description = "Semantic code analysis engine";

--- a/pkgs/development/tools/analysis/codeql/default.nix
+++ b/pkgs/development/tools/analysis/codeql/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, zlib, xorg, freetype, jdk11, curl, autoPatchelfHook }:
+{ lib, stdenv, fetchzip, zlib, xorg, freetype, jdk11, curl, lttng-ust, autoPatchelfHook }:
 
 stdenv.mkDerivation rec {
   pname = "codeql";
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     jdk11
     stdenv.cc.cc.lib
     curl
+    lttng-ust
     autoPatchelfHook
   ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- update: v2.8.2 to v2.8.5
- bugfix: support codeql database creation on nixos linux64 by swapping out the binary packaged java distribution for the nixos jdk11 distribution

The existing nixpkgs codeql package performs a sed operation to set a static path to nixpkgs jdk11 for the main codeql executable. However there are many other executables that need to be able to resolve a functioning java home inside the codeql binary distribution, including database extractors and autobuilders and they also depend on CODEQL_DIST and CODEQL_PLATFORM to resolve java home.

This update swaps out the codeql java distribution in its entirety by symlinking against nixpkgs jdk11 as well as enabling the autopatchElfhook such that all database extractors and autobuilders actually function on nixos. This means CODEQL_DIST and  CODEQL_PLATFORM are consistently correct for all binary dependencies inside the codeql distribution.

Prior to this update you could only use codeql main commands, i.e. run queries. This version of the package also enables you to create new databases.

Known issues: 

The csharp extractor depends on an old version of libttng-ust (.so.0), nixpkgs currently ships a more modern version (.so.1), which makes autopatchElf fail against the csharp extractor. This means csharp extraction currently does not work on nixpkgs codeql.  This update ignores this dependency failure. All other extractors and autobuilders patch and function correctly. Once the codeql csharp extractor updates to a more recent libttng-ust dependency in a future release, this will automatically resolve itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
