### PR TITLE
blas,lapack with mkl: amend libblas, libcblas, liblapack, liblapacke for darwin

### DIFF
--- a/pkgs/build-support/alternatives/blas/default.nix
+++ b/pkgs/build-support/alternatives/blas/default.nix
@@ -65,7 +65,11 @@ stdenv.mkDerivation {
   installPhase = (''
   mkdir -p $out/lib $dev/include $dev/lib/pkgconfig
 
-  libblas="${lib.getLib blasProvider'}/lib/libblas${canonicalExtension}"
+  if [ -n "${builtins.toString stdenv.hostPlatform.isDarwin}" ] && [ "${blasImplementation}" == "mkl" ]; then
+    libblas="${lib.getLib blasProvider'}/lib/libmkl_rt${canonicalExtension}"
+  else
+    libblas="${lib.getLib blasProvider'}/lib/libblas${canonicalExtension}"
+  fi
 
   if ! [ -e "$libblas" ]; then
     echo "$libblas does not exist, ${blasProvider'.name} does not provide libblas."
@@ -102,7 +106,11 @@ Libs: -L$out/lib -lblas
 Cflags: -I$dev/include
 EOF
 
-  libcblas="${lib.getLib blasProvider'}/lib/libcblas${canonicalExtension}"
+  if [ -n "${builtins.toString stdenv.hostPlatform.isDarwin}" ] && [ "${blasImplementation}" == "mkl" ]; then
+    libcblas="${lib.getLib blasProvider'}/lib/libmkl_rt${canonicalExtension}"
+  else
+    libcblas="${lib.getLib blasProvider'}/lib/libcblas${canonicalExtension}"
+  fi
 
   if ! [ -e "$libcblas" ]; then
     echo "$libcblas does not exist, ${blasProvider'.name} does not provide libcblas."

--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -44,7 +44,11 @@ stdenv.mkDerivation {
   installPhase = (''
   mkdir -p $out/lib $dev/include $dev/lib/pkgconfig
 
-  liblapack="${lib.getLib lapackProvider'}/lib/liblapack${canonicalExtension}"
+  if [ -n "${builtins.toString stdenv.hostPlatform.isDarwin}" ] && [ "${lapackImplementation}" == "mkl" ]; then
+    liblapack="${lib.getLib lapackProvider'}/lib/libmkl_rt${canonicalExtension}"
+  else
+    liblapack="${lib.getLib lapackProvider'}/lib/liblapack${canonicalExtension}"
+  fi
 
   if ! [ -e "$liblapack" ]; then
     echo "$liblapack does not exist, ${lapackProvider'.name} does not provide liblapack."
@@ -73,7 +77,11 @@ Cflags: -I$dev/include
 Libs: -L$out/lib -llapack
 EOF
 
-  liblapacke="${lib.getLib lapackProvider'}/lib/liblapacke${canonicalExtension}"
+  if [ -n "${builtins.toString stdenv.hostPlatform.isDarwin}" ] && [ "${lapackImplementation}" == "mkl" ]; then
+    liblapacke="${lib.getLib lapackProvider'}/lib/libmkl_rt${canonicalExtension}"
+  else
+    liblapacke="${lib.getLib lapackProvider'}/lib/liblapacke${canonicalExtension}"
+  fi
 
   if ! [ -e "$liblapacke" ]; then
     echo "$liblapacke does not exist, ${lapackProvider'.name} does not provide liblapacke."


### PR DESCRIPTION
###### Description of changes

When `blasProvider` and `lapackProvider` are assigned to be `mkl`(iMac 2014 Big Sur),
`${lib.get Lib blasProvider'}/lib/libblas.dylib`, `${lib.get Lib blasProvider'}/lib/libcblas.dylib`, `${lib.get Lib lapackProvider'}/lib/liblapack.dylib`, `${lib.get Lib lapackProvider'}/lib/liblapacke.dylib` don't exist.


###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've tested with iMac 2014 Big Sur. 20000 by 20000 matrix norm was calculated which took about 76 seconds.
