### PR TITLE
nixos/manual: re-generate

### DIFF
--- a/nixos/doc/manual/from_md/administration/cleaning-store.chapter.xml
+++ b/nixos/doc/manual/from_md/administration/cleaning-store.chapter.xml
@@ -23,7 +23,7 @@ $ nix-collect-garbage
     this unit automatically at certain points in time, for instance,
     every night at 03:15:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 nix.gc.automatic = true;
 nix.gc.dates = &quot;03:15&quot;;
 </programlisting>

--- a/nixos/doc/manual/from_md/administration/container-networking.section.xml
+++ b/nixos/doc/manual/from_md/administration/container-networking.section.xml
@@ -31,7 +31,7 @@ $ ping -c1 10.233.4.2
     address. This can be accomplished using the following configuration
     on the host:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.nat.enable = true;
 networking.nat.internalInterfaces = [&quot;ve-+&quot;];
 networking.nat.externalInterface = &quot;eth0&quot;;
@@ -45,7 +45,7 @@ networking.nat.externalInterface = &quot;eth0&quot;;
     If you are using Network Manager, you need to explicitly prevent it
     from managing container interfaces:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.networkmanager.unmanaged = [ &quot;interface-name:ve-*&quot; ];
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/administration/control-groups.chapter.xml
+++ b/nixos/doc/manual/from_md/administration/control-groups.chapter.xml
@@ -42,7 +42,7 @@ $ systemd-cgls
     process would get 1/1001 of the cgroup’s CPU time.) You can limit a
     service’s CPU share in <literal>configuration.nix</literal>:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 systemd.services.httpd.serviceConfig.CPUShares = 512;
 </programlisting>
   <para>
@@ -57,7 +57,7 @@ systemd.services.httpd.serviceConfig.CPUShares = 512;
     <literal>configuration.nix</literal>; for instance, to limit
     <literal>httpd.service</literal> to 512 MiB of RAM (excluding swap):
   </para>
-  <programlisting language="bash">
+  <programlisting>
 systemd.services.httpd.serviceConfig.MemoryLimit = &quot;512M&quot;;
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/administration/declarative-containers.section.xml
+++ b/nixos/doc/manual/from_md/administration/declarative-containers.section.xml
@@ -6,7 +6,7 @@
     following specifies that there shall be a container named
     <literal>database</literal> running PostgreSQL:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 containers.database =
   { config =
       { config, pkgs, ... }:
@@ -29,7 +29,7 @@ containers.database =
     However, they cannot change the network configuration. You can give
     a container its own network as follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 containers.database = {
   privateNetwork = true;
   hostAddress = &quot;192.168.100.10&quot;;

--- a/nixos/doc/manual/from_md/administration/service-mgmt.chapter.xml
+++ b/nixos/doc/manual/from_md/administration/service-mgmt.chapter.xml
@@ -91,7 +91,7 @@ Jan 07 15:55:57 hagbard systemd[1]: Started PostgreSQL Server.
       In order to enable a systemd <emphasis>system</emphasis> service
       with provided upstream package, use (e.g):
     </para>
-    <programlisting language="bash">
+    <programlisting>
 systemd.packages = [ pkgs.packagekit ];
 </programlisting>
     <para>

--- a/nixos/doc/manual/from_md/configuration/abstractions.section.xml
+++ b/nixos/doc/manual/from_md/configuration/abstractions.section.xml
@@ -4,7 +4,7 @@
     If you find yourself repeating yourself over and over, it’s time to
     abstract. Take, for instance, this Apache HTTP Server configuration:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 {
   services.httpd.virtualHosts =
     { &quot;blog.example.org&quot; = {
@@ -29,7 +29,7 @@
     the only difference is the document root directories. To prevent
     this duplication, we can use a <literal>let</literal>:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 let
   commonConfig =
     { adminAddr = &quot;alice@example.org&quot;;
@@ -55,7 +55,7 @@ in
     You can write a <literal>let</literal> wherever an expression is
     allowed. Thus, you also could have written:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 {
   services.httpd.virtualHosts =
     let commonConfig = ...; in
@@ -74,7 +74,7 @@ in
     of different virtual hosts, all with identical configuration except
     for the document root. This can be done as follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 {
   services.httpd.virtualHosts =
     let

--- a/nixos/doc/manual/from_md/configuration/ad-hoc-network-config.section.xml
+++ b/nixos/doc/manual/from_md/configuration/ad-hoc-network-config.section.xml
@@ -7,7 +7,7 @@
     network configuration not covered by the existing NixOS modules. For
     instance, to statically configure an IPv6 address:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.localCommands =
   ''
     ip -6 addr add 2001:610:685:1::1/64 dev eth0

--- a/nixos/doc/manual/from_md/configuration/adding-custom-packages.section.xml
+++ b/nixos/doc/manual/from_md/configuration/adding-custom-packages.section.xml
@@ -18,7 +18,7 @@ $ cd nixpkgs
     manual. Finally, you add it to
     <xref linkend="opt-environment.systemPackages" />, e.g.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 environment.systemPackages = [ pkgs.my-package ];
 </programlisting>
   <para>
@@ -35,7 +35,7 @@ environment.systemPackages = [ pkgs.my-package ];
     Hello</link> package directly in
     <literal>configuration.nix</literal>:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 environment.systemPackages =
   let
     my-hello = with pkgs; stdenv.mkDerivation rec {
@@ -52,13 +52,13 @@ environment.systemPackages =
     Of course, you can also move the definition of
     <literal>my-hello</literal> into a separate Nix expression, e.g.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 environment.systemPackages = [ (import ./my-hello.nix) ];
 </programlisting>
   <para>
     where <literal>my-hello.nix</literal> contains:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 with import &lt;nixpkgs&gt; {}; # bring all of Nixpkgs into scope
 
 stdenv.mkDerivation rec {

--- a/nixos/doc/manual/from_md/configuration/config-file.section.xml
+++ b/nixos/doc/manual/from_md/configuration/config-file.section.xml
@@ -3,7 +3,7 @@
   <para>
     The NixOS configuration file generally looks like this:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 { option definitions
@@ -21,7 +21,7 @@
     the name of an option and <literal>value</literal> is its value. For
     example,
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 { services.httpd.enable = true;
@@ -44,7 +44,7 @@
     <literal>true</literal>. This means that the example above can also
     be written as:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 { services = {
@@ -96,7 +96,7 @@ The option value `services.httpd.enable' in `/etc/nixos/configuration.nix' is no
         <para>
           Strings are enclosed in double quotes, e.g.
         </para>
-        <programlisting language="bash">
+        <programlisting>
 networking.hostName = &quot;dexter&quot;;
 </programlisting>
         <para>
@@ -107,7 +107,7 @@ networking.hostName = &quot;dexter&quot;;
           Multi-line strings can be enclosed in <emphasis>double single
           quotes</emphasis>, e.g.
         </para>
-        <programlisting language="bash">
+        <programlisting>
 networking.extraHosts =
   ''
     127.0.0.2 other-localhost
@@ -135,7 +135,7 @@ networking.extraHosts =
           These can be <literal>true</literal> or
           <literal>false</literal>, e.g.
         </para>
-        <programlisting language="bash">
+        <programlisting>
 networking.firewall.enable = true;
 networking.firewall.allowPing = false;
 </programlisting>
@@ -149,7 +149,7 @@ networking.firewall.allowPing = false;
         <para>
           For example,
         </para>
-        <programlisting language="bash">
+        <programlisting>
 boot.kernel.sysctl.&quot;net.ipv4.tcp_keepalive_time&quot; = 60;
 </programlisting>
         <para>
@@ -171,7 +171,7 @@ boot.kernel.sysctl.&quot;net.ipv4.tcp_keepalive_time&quot; = 60;
           Sets were introduced above. They are name/value pairs enclosed
           in braces, as in the option definition
         </para>
-        <programlisting language="bash">
+        <programlisting>
 fileSystems.&quot;/boot&quot; =
   { device = &quot;/dev/sda1&quot;;
     fsType = &quot;ext4&quot;;
@@ -189,13 +189,13 @@ fileSystems.&quot;/boot&quot; =
           The important thing to note about lists is that list elements
           are separated by whitespace, like this:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 boot.kernelModules = [ &quot;fuse&quot; &quot;kvm-intel&quot; &quot;coretemp&quot; ];
 </programlisting>
         <para>
           List elements can be any other type, e.g. sets:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 swapDevices = [ { device = &quot;/dev/disk/by-label/swap&quot;; } ];
 </programlisting>
       </listitem>
@@ -211,7 +211,7 @@ swapDevices = [ { device = &quot;/dev/disk/by-label/swap&quot;; } ];
           through the function argument <literal>pkgs</literal>. Typical
           uses:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 environment.systemPackages =
   [ pkgs.thunderbird
     pkgs.emacs

--- a/nixos/doc/manual/from_md/configuration/customizing-packages.section.xml
+++ b/nixos/doc/manual/from_md/configuration/customizing-packages.section.xml
@@ -22,7 +22,7 @@
     a dependency on GTK 2. If you want to build it against GTK 3, you
     can specify that as follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];
 </programlisting>
   <para>
@@ -46,7 +46,7 @@ environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];
     the package, such as the source code. For instance, if you want to
     override the source code of Emacs, you can say:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 environment.systemPackages = [
   (pkgs.emacs.overrideAttrs (oldAttrs: {
     name = &quot;emacs-25.0-pre&quot;;
@@ -72,7 +72,7 @@ environment.systemPackages = [
     everything depend on your customised instance, you can apply a
     <emphasis>global</emphasis> override as follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 nixpkgs.config.packageOverrides = pkgs:
   { emacs = pkgs.emacs.override { gtk = pkgs.gtk3; };
   };

--- a/nixos/doc/manual/from_md/configuration/declarative-packages.section.xml
+++ b/nixos/doc/manual/from_md/configuration/declarative-packages.section.xml
@@ -7,7 +7,7 @@
     adding the following line to <literal>configuration.nix</literal>
     enables the Mozilla Thunderbird email application:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 environment.systemPackages = [ pkgs.thunderbird ];
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/configuration/file-systems.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/file-systems.chapter.xml
@@ -7,7 +7,7 @@
     <literal>/dev/disk/by-label/data</literal> onto the mount point
     <literal>/data</literal>:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 fileSystems.&quot;/data&quot; =
   { device = &quot;/dev/disk/by-label/data&quot;;
     fsType = &quot;ext4&quot;;

--- a/nixos/doc/manual/from_md/configuration/firewall.section.xml
+++ b/nixos/doc/manual/from_md/configuration/firewall.section.xml
@@ -6,14 +6,14 @@
     both IPv4 and IPv6 traffic. It is enabled by default. It can be
     disabled as follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.firewall.enable = false;
 </programlisting>
   <para>
     If the firewall is enabled, you can open specific TCP ports to the
     outside world:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.firewall.allowedTCPPorts = [ 80 443 ];
 </programlisting>
   <para>
@@ -26,7 +26,7 @@ networking.firewall.allowedTCPPorts = [ 80 443 ];
   <para>
     To open ranges of TCP ports:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.firewall.allowedTCPPortRanges = [
   { from = 4000; to = 4007; }
   { from = 8000; to = 8010; }

--- a/nixos/doc/manual/from_md/configuration/gpu-accel.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/gpu-accel.chapter.xml
@@ -62,7 +62,7 @@ Platform Vendor      Advanced Micro Devices, Inc.
         <xref linkend="opt-hardware.opengl.extraPackages" /> enables
         OpenCL support:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 hardware.opengl.extraPackages = [
   rocm-opencl-icd
 ];
@@ -85,7 +85,7 @@ hardware.opengl.extraPackages = [
         enable OpenCL support. For example, for Gen8 and later GPUs, the
         following configuration can be used:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 hardware.opengl.extraPackages = [
   intel-compute-runtime
 ];
@@ -162,7 +162,7 @@ GPU1:
         makes amdvlk the default driver and hides radv and lavapipe from
         the device list. A specific driver can be forced as follows:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 hardware.opengl.extraPackages = [
   pkgs.amdvlk
 ];

--- a/nixos/doc/manual/from_md/configuration/ipv4-config.section.xml
+++ b/nixos/doc/manual/from_md/configuration/ipv4-config.section.xml
@@ -6,7 +6,7 @@
     interfaces. However, you can configure an interface manually as
     follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.interfaces.eth0.ipv4.addresses = [ {
   address = &quot;192.168.1.2&quot;;
   prefixLength = 24;
@@ -16,7 +16,7 @@ networking.interfaces.eth0.ipv4.addresses = [ {
     Typically you’ll also want to set a default gateway and set of name
     servers:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.defaultGateway = &quot;192.168.1.1&quot;;
 networking.nameservers = [ &quot;8.8.8.8&quot; ];
 </programlisting>
@@ -32,7 +32,7 @@ networking.nameservers = [ &quot;8.8.8.8&quot; ];
     The host name is set using
     <xref linkend="opt-networking.hostName" />:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.hostName = &quot;cartman&quot;;
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/configuration/ipv6-config.section.xml
+++ b/nixos/doc/manual/from_md/configuration/ipv6-config.section.xml
@@ -10,21 +10,21 @@
     <xref linkend="opt-networking.interfaces._name_.tempAddress" />. You
     can disable IPv6 support globally by setting:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.enableIPv6 = false;
 </programlisting>
   <para>
     You can disable IPv6 on a single interface using a normal sysctl (in
     this example, we use interface <literal>eth0</literal>):
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.kernel.sysctl.&quot;net.ipv6.conf.eth0.disable_ipv6&quot; = true;
 </programlisting>
   <para>
     As with IPv4 networking interfaces are automatically configured via
     DHCPv6. You can configure an interface manually:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.interfaces.eth0.ipv6.addresses = [ {
   address = &quot;fe00:aa:bb:cc::2&quot;;
   prefixLength = 64;
@@ -34,7 +34,7 @@ networking.interfaces.eth0.ipv6.addresses = [ {
     For configuring a gateway, optionally with explicitly specified
     interface:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.defaultGateway6 = {
   address = &quot;fe00::1&quot;;
   interface = &quot;enp0s3&quot;;

--- a/nixos/doc/manual/from_md/configuration/kubernetes.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/kubernetes.chapter.xml
@@ -10,7 +10,7 @@
     way is to enable and configure cluster components appropriately by
     hand:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.kubernetes = {
   apiserver.enable = true;
   controllerManager.enable = true;
@@ -25,20 +25,20 @@ services.kubernetes = {
     &quot;node&quot;) to the host. This enables apiserver,
     controllerManager, scheduler, addonManager, kube-proxy and etcd:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.kubernetes.roles = [ &quot;master&quot; ];
 </programlisting>
   <para>
     While this will enable the kubelet and kube-proxy only:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.kubernetes.roles = [ &quot;node&quot; ];
 </programlisting>
   <para>
     Assigning both the master and node roles is usable if you want a
     single node Kubernetes cluster for dev or testing purposes:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.kubernetes.roles = [ &quot;master&quot; &quot;node&quot; ];
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/configuration/linux-kernel.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/linux-kernel.chapter.xml
@@ -5,7 +5,7 @@
     option <literal>boot.kernelPackages</literal>. For instance, this
     selects the Linux 3.10 kernel:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.kernelPackages = pkgs.linuxKernel.packages.linux_3_10;
 </programlisting>
   <para>
@@ -35,7 +35,7 @@ zcat /proc/config.gz
     <xref linkend="sec-customising-packages" />). For instance, to
     enable support for the kernel debugger KGDB:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 nixpkgs.config.packageOverrides = pkgs: pkgs.lib.recursiveUpdate pkgs {
   linuxKernel.kernels.linux_5_10 = pkgs.linuxKernel.kernels.linux_5_10.override {
     extraConfig = ''
@@ -56,7 +56,7 @@ nixpkgs.config.packageOverrides = pkgs: pkgs.lib.recursiveUpdate pkgs {
     automatically by <literal>udev</literal>. You can force a module to
     be loaded via <xref linkend="opt-boot.kernelModules" />, e.g.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.kernelModules = [ &quot;fuse&quot; &quot;kvm-intel&quot; &quot;coretemp&quot; ];
 </programlisting>
   <para>
@@ -64,7 +64,7 @@ boot.kernelModules = [ &quot;fuse&quot; &quot;kvm-intel&quot; &quot;coretemp&quo
     root file system), you can use
     <xref linkend="opt-boot.initrd.kernelModules" />:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.initrd.kernelModules = [ &quot;cifs&quot; ];
 </programlisting>
   <para>
@@ -75,7 +75,7 @@ boot.initrd.kernelModules = [ &quot;cifs&quot; ];
     Kernel runtime parameters can be set through
     <xref linkend="opt-boot.kernel.sysctl" />, e.g.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.kernel.sysctl.&quot;net.ipv4.tcp_keepalive_time&quot; = 120;
 </programlisting>
   <para>
@@ -90,7 +90,7 @@ boot.kernel.sysctl.&quot;net.ipv4.tcp_keepalive_time&quot; = 120;
       pass your own config via the <literal>configfile</literal> setting
       of <literal>linuxKernel.manualConfig</literal>:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 custom-kernel = let base_kernel = linuxKernel.kernels.linux_4_9;
   in super.linuxKernel.manualConfig {
     inherit (super) stdenv hostPlatform;
@@ -118,7 +118,7 @@ nix-shell -E 'with import &lt;nixpkgs&gt; {}; kernelToOverride.overrideAttrs (o:
       (which you can influence by overriding
       <literal>extraConfig, autoModules, modDirVersion, preferBuiltin, extraConfig</literal>).
     </para>
-    <programlisting language="bash">
+    <programlisting>
 mptcp93.override ({
   name=&quot;mptcp-local&quot;;
 

--- a/nixos/doc/manual/from_md/configuration/luks-file-systems.section.xml
+++ b/nixos/doc/manual/from_md/configuration/luks-file-systems.section.xml
@@ -30,7 +30,7 @@ Enter passphrase for /dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d: ***
     at boot time as <literal>/</literal>, add the following to
     <literal>configuration.nix</literal>:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.initrd.luks.devices.crypted.device = &quot;/dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d&quot;;
 fileSystems.&quot;/&quot;.device = &quot;/dev/mapper/crypted&quot;;
 </programlisting>
@@ -39,7 +39,7 @@ fileSystems.&quot;/&quot;.device = &quot;/dev/mapper/crypted&quot;;
     located on an encrypted partition, it is necessary to add the
     following grub option:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.loader.grub.enableCryptodisk = true;
 </programlisting>
   <section xml:id="sec-luks-file-systems-fido2">
@@ -67,7 +67,7 @@ Added to key to device /dev/sda2, slot: 2
       compatible key, add the following to
       <literal>configuration.nix</literal>:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 boot.initrd.luks.fido2Support = true;
 boot.initrd.luks.devices.&quot;/dev/sda2&quot;.fido2.credential = &quot;f1d00200108b9d6e849a8b388da457688e3dd653b4e53770012d8f28e5d3b269865038c346802f36f3da7278b13ad6a3bb6a1452e24ebeeaa24ba40eef559b1b287d2a2f80b7&quot;;
 </programlisting>
@@ -77,7 +77,7 @@ boot.initrd.luks.devices.&quot;/dev/sda2&quot;.fido2.credential = &quot;f1d00200
       protected, such as
       <link xlink:href="https://trezor.io/">Trezor</link>.
     </para>
-    <programlisting language="bash">
+    <programlisting>
 boot.initrd.luks.devices.&quot;/dev/sda2&quot;.fido2.passwordLess = true;
 </programlisting>
   </section>

--- a/nixos/doc/manual/from_md/configuration/modularity.section.xml
+++ b/nixos/doc/manual/from_md/configuration/modularity.section.xml
@@ -14,7 +14,7 @@
     other modules by including them from
     <literal>configuration.nix</literal>, e.g.:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 { imports = [ ./vpn.nix ./kde.nix ];
@@ -28,7 +28,7 @@
     <literal>vpn.nix</literal> and <literal>kde.nix</literal>. The
     latter might look like this:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 { services.xserver.enable = true;
@@ -50,7 +50,7 @@
     you want it to appear first, you can use
     <literal>mkBefore</literal>:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.kernelModules = mkBefore [ &quot;kvm-intel&quot; ];
 </programlisting>
   <para>
@@ -70,7 +70,7 @@ The unique option `services.httpd.adminAddr' is defined multiple times, in `/etc
     When that happens, it’s possible to force one definition take
     precedence over the others:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.httpd.adminAddr = pkgs.lib.mkForce &quot;bob@example.org&quot;;
 </programlisting>
   <para>
@@ -93,7 +93,7 @@ services.httpd.adminAddr = pkgs.lib.mkForce &quot;bob@example.org&quot;;
     <xref linkend="opt-services.xserver.enable" /> is set to
     <literal>true</literal> somewhere else:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 { environment.systemPackages =
@@ -137,7 +137,7 @@ nix-repl&gt; map (x: x.hostName) config.services.httpd.virtualHosts
     below would have the same effect as importing a file which sets
     those options.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 let netConfig = hostName: {

--- a/nixos/doc/manual/from_md/configuration/network-manager.section.xml
+++ b/nixos/doc/manual/from_md/configuration/network-manager.section.xml
@@ -4,7 +4,7 @@
     To facilitate network configuration, some desktop environments use
     NetworkManager. You can enable NetworkManager by setting:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.networkmanager.enable = true;
 </programlisting>
   <para>
@@ -15,7 +15,7 @@ networking.networkmanager.enable = true;
     All users that should have permission to change network settings
     must belong to the <literal>networkmanager</literal> group:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 users.users.alice.extraGroups = [ &quot;networkmanager&quot; ];
 </programlisting>
   <para>
@@ -36,7 +36,7 @@ users.users.alice.extraGroups = [ &quot;networkmanager&quot; ];
       used together if desired. To do this you need to instruct
       NetworkManager to ignore those interfaces like:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 networking.networkmanager.unmanaged = [
    &quot;*&quot; &quot;except:type:wwan&quot; &quot;except:type:gsm&quot;
 ];

--- a/nixos/doc/manual/from_md/configuration/profiles.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/profiles.chapter.xml
@@ -9,7 +9,7 @@
     to say, expected usage is to add them to the imports list of your
     <literal>/etc/configuration.nix</literal> as such:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 imports = [
   &lt;nixpkgs/nixos/modules/profiles/profile-name.nix&gt;
 ];

--- a/nixos/doc/manual/from_md/configuration/renaming-interfaces.section.xml
+++ b/nixos/doc/manual/from_md/configuration/renaming-interfaces.section.xml
@@ -30,7 +30,7 @@
       the interface with MAC address
       <literal>52:54:00:12:01:01</literal> using a netword link unit:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 systemd.network.links.&quot;10-wan&quot; = {
   matchConfig.PermanentMACAddress = &quot;52:54:00:12:01:01&quot;;
   linkConfig.Name = &quot;wan&quot;;
@@ -43,7 +43,7 @@ systemd.network.links.&quot;10-wan&quot; = {
     <para>
       Alternatively, we can use a plain old udev rule:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.udev.initrdRules = ''
   SUBSYSTEM==&quot;net&quot;, ACTION==&quot;add&quot;, DRIVERS==&quot;?*&quot;, \
   ATTR{address}==&quot;52:54:00:12:01:01&quot;, KERNEL==&quot;eth*&quot;, NAME=&quot;wan&quot;

--- a/nixos/doc/manual/from_md/configuration/ssh.section.xml
+++ b/nixos/doc/manual/from_md/configuration/ssh.section.xml
@@ -3,7 +3,7 @@
   <para>
     Secure shell (SSH) access to your machine can be enabled by setting:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.openssh.enable = true;
 </programlisting>
   <para>
@@ -16,7 +16,7 @@ services.openssh.enable = true;
     You can declaratively specify authorised RSA/DSA public keys for a
     user as follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 users.users.alice.openssh.authorizedKeys.keys =
   [ &quot;ssh-dss AAAAB3NzaC1kc3MAAACBAPIkGWVEt4...&quot; ];
 </programlisting>

--- a/nixos/doc/manual/from_md/configuration/sshfs-file-systems.section.xml
+++ b/nixos/doc/manual/from_md/configuration/sshfs-file-systems.section.xml
@@ -54,7 +54,7 @@ SHA256:yjxl3UbTn31fLWeyLYTAKYJPRmzknjQZoyG8gSNEoIE my-user@workstation
       <link linkend="opt-fileSystems">fileSystems</link> option. Here’s
       a typical setup:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 {
   system.fsPackages = [ pkgs.sshfs ];
 
@@ -80,7 +80,7 @@ SHA256:yjxl3UbTn31fLWeyLYTAKYJPRmzknjQZoyG8gSNEoIE my-user@workstation
       well, for example you can change the default SSH port or specify a
       jump proxy:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 {
   options =
     [ &quot;ProxyJump=bastion@example.com&quot;
@@ -92,7 +92,7 @@ SHA256:yjxl3UbTn31fLWeyLYTAKYJPRmzknjQZoyG8gSNEoIE my-user@workstation
       It’s also possible to change the <literal>ssh</literal> command
       used by SSHFS to connect to the server. For example:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 {
   options =
     [ (builtins.replaceStrings [&quot; &quot;] [&quot;\\040&quot;]

--- a/nixos/doc/manual/from_md/configuration/subversion.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/subversion.chapter.xml
@@ -25,7 +25,7 @@
       Apache HTTP, setting
       <xref linkend="opt-services.httpd.adminAddr" /> appropriately:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.httpd.enable = true;
 services.httpd.adminAddr = ...;
 networking.firewall.allowedTCPPorts = [ 80 443 ];
@@ -40,7 +40,7 @@ networking.firewall.allowedTCPPorts = [ 80 443 ];
       <literal>.authz</literal> file describing access permission, and
       <literal>AuthUserFile</literal> to the password file.
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.httpd.extraModules = [
     # note that order is *super* important here
     { name = &quot;dav_svn&quot;; path = &quot;${pkgs.apacheHttpdPackages.subversion}/modules/mod_dav_svn.so&quot;; }
@@ -106,7 +106,7 @@ $ htpasswd -s PASSWORD_FILE USER_NAME
       <literal>ACCESS_FILE</literal> will look something like the
       following:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 [/]
 * = r
 

--- a/nixos/doc/manual/from_md/configuration/user-mgmt.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/user-mgmt.chapter.xml
@@ -7,7 +7,7 @@
     states that a user account named <literal>alice</literal> shall
     exist:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 users.users.alice = {
   isNormalUser = true;
   home = &quot;/home/alice&quot;;
@@ -45,7 +45,7 @@ users.users.alice = {
     A user ID (uid) is assigned automatically. You can also specify a
     uid manually by adding
   </para>
-  <programlisting language="bash">
+  <programlisting>
 uid = 1000;
 </programlisting>
   <para>
@@ -55,7 +55,7 @@ uid = 1000;
     Groups can be specified similarly. The following states that a group
     named <literal>students</literal> shall exist:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 users.groups.students.gid = 1000;
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/configuration/wayland.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/wayland.chapter.xml
@@ -9,7 +9,7 @@
     means it is sufficient to install a Wayland Compositor such as sway
     without separately enabling a Wayland server:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 programs.sway.enable = true;
 </programlisting>
   <para>
@@ -21,7 +21,7 @@ programs.sway.enable = true;
     be able to share your screen, you might want to activate this
     option:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 xdg.portal.wlr.enable = true;
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/configuration/wireless.section.xml
+++ b/nixos/doc/manual/from_md/configuration/wireless.section.xml
@@ -9,13 +9,13 @@
   <para>
     NixOS will start wpa_supplicant for you if you enable this setting:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.wireless.enable = true;
 </programlisting>
   <para>
     NixOS lets you specify networks for wpa_supplicant declaratively:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 networking.wireless.networks = {
   echelon = {                # SSID with no spaces or special characters
     psk = &quot;abcdefgh&quot;;
@@ -49,7 +49,7 @@ network={
         psk=dca6d6ed41f4ab5a984c9f55f6f66d4efdc720ebf66959810f4329bb391c5435
 }
 </programlisting>
-  <programlisting language="bash">
+  <programlisting>
 networking.wireless.networks = {
   echelon = {
     pskRaw = &quot;dca6d6ed41f4ab5a984c9f55f6f66d4efdc720ebf66959810f4329bb391c5435&quot;;

--- a/nixos/doc/manual/from_md/configuration/x-windows.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/x-windows.chapter.xml
@@ -4,7 +4,7 @@
     The X Window System (X11) provides the basis of NixOS’ graphical
     user interface. It can be enabled as follows:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.xserver.enable = true;
 </programlisting>
   <para>
@@ -13,7 +13,7 @@ services.xserver.enable = true;
     and <literal>intel</literal>). You can also specify a driver
     manually, e.g.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.xserver.videoDrivers = [ &quot;r128&quot; ];
 </programlisting>
   <para>
@@ -25,7 +25,7 @@ services.xserver.videoDrivers = [ &quot;r128&quot; ];
     <literal>xterm</literal> window. Thus you should pick one or more of
     the following lines:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.xserver.desktopManager.plasma5.enable = true;
 services.xserver.desktopManager.xfce.enable = true;
 services.xserver.desktopManager.gnome.enable = true;
@@ -42,14 +42,14 @@ services.xserver.windowManager.herbstluftwm.enable = true;
     LightDM. You can select an alternative one by picking one of the
     following lines:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.xserver.displayManager.sddm.enable = true;
 services.xserver.displayManager.gdm.enable = true;
 </programlisting>
   <para>
     You can set the keyboard layout (and optionally the layout variant):
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.xserver.layout = &quot;de&quot;;
 services.xserver.xkbVariant = &quot;neo&quot;;
 </programlisting>
@@ -57,7 +57,7 @@ services.xserver.xkbVariant = &quot;neo&quot;;
     The X server is started automatically at boot time. If you don’t
     want this to happen, you can set:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.xserver.autorun = false;
 </programlisting>
   <para>
@@ -70,7 +70,7 @@ services.xserver.autorun = false;
     On 64-bit systems, if you want OpenGL for 32-bit programs such as in
     Wine, you should also set the following:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 hardware.opengl.driSupport32Bit = true;
 </programlisting>
   <section xml:id="sec-x11-auto-login">
@@ -90,14 +90,14 @@ hardware.opengl.driSupport32Bit = true;
       manager and desktop environment. If you wanted no desktop
       environment and i3 as your your window manager, you'd define:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.displayManager.defaultSession = &quot;none+i3&quot;;
 </programlisting>
     <para>
       Every display manager in NixOS supports auto-login, here is an
       example using lightdm for a user <literal>alice</literal>:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.displayManager.lightdm.enable = true;
 services.xserver.displayManager.autoLogin.enable = true;
 services.xserver.displayManager.autoLogin.user = &quot;alice&quot;;
@@ -131,7 +131,7 @@ services.xserver.displayManager.autoLogin.user = &quot;alice&quot;;
       <xref linkend="opt-services.xserver.videoDrivers" /> to set one.
       The recommended configuration for modern systems is:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.videoDrivers = [ &quot;modesetting&quot; ];
 services.xserver.useGlamor = true;
 </programlisting>
@@ -139,7 +139,7 @@ services.xserver.useGlamor = true;
       If you experience screen tearing no matter what, this
       configuration was reported to resolve the issue:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.videoDrivers = [ &quot;intel&quot; ];
 services.xserver.deviceSection = ''
   Option &quot;DRI&quot; &quot;2&quot;
@@ -160,14 +160,14 @@ services.xserver.deviceSection = ''
       enabled by default because it’s not free software. You can enable
       it as follows:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.videoDrivers = [ &quot;nvidia&quot; ];
 </programlisting>
     <para>
       Or if you have an older card, you may have to use one of the
       legacy drivers:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.videoDrivers = [ &quot;nvidiaLegacy390&quot; ];
 services.xserver.videoDrivers = [ &quot;nvidiaLegacy340&quot; ];
 services.xserver.videoDrivers = [ &quot;nvidiaLegacy304&quot; ];
@@ -186,7 +186,7 @@ services.xserver.videoDrivers = [ &quot;nvidiaLegacy304&quot; ];
       features or performance. If you still want to use it anyway, you
       need to explicitly set:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.videoDrivers = [ &quot;amdgpu-pro&quot; ];
 </programlisting>
     <para>
@@ -200,14 +200,14 @@ services.xserver.videoDrivers = [ &quot;amdgpu-pro&quot; ];
       Support for Synaptics touchpads (found in many laptops such as the
       Dell Latitude series) can be enabled as follows:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.libinput.enable = true;
 </programlisting>
     <para>
       The driver has many options (see <xref linkend="ch-options" />).
       For instance, the following disables tap-to-click behavior:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.libinput.touchpad.tapping = false;
 </programlisting>
     <para>
@@ -223,7 +223,7 @@ services.xserver.libinput.touchpad.tapping = false;
       applications look similar to GTK ones, you can use the following
       configuration:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 qt5.enable = true;
 qt5.platformTheme = &quot;gtk2&quot;;
 qt5.style = &quot;gtk2&quot;;
@@ -248,7 +248,7 @@ qt5.style = &quot;gtk2&quot;;
       <literal>symbols</literal>; it's an XKB peculiarity that will help
       with testing):
     </para>
-    <programlisting language="bash">
+    <programlisting>
 xkb_symbols &quot;us-greek&quot;
 {
   include &quot;us(basic)&quot;            // includes the base US keys
@@ -264,7 +264,7 @@ xkb_symbols &quot;us-greek&quot;
     <para>
       A minimal layout specification must include the following:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.extraLayouts.us-greek = {
   description = &quot;US layout with alt-gr greek&quot;;
   languages   = [ &quot;eng&quot; ];
@@ -313,7 +313,7 @@ $ echo &quot;$(nix-build --no-out-link '&lt;nixpkgs&gt;' -A xorg.xkeyboardconfig
       interest, then create a <literal>media-key</literal> file to hold
       the keycodes definitions
     </para>
-    <programlisting language="bash">
+    <programlisting>
 xkb_keycodes &quot;media&quot;
 {
  &lt;volUp&gt;   = 123;
@@ -323,7 +323,7 @@ xkb_keycodes &quot;media&quot;
     <para>
       Now use the newly define keycodes in <literal>media-sym</literal>:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 xkb_symbols &quot;media&quot;
 {
  key.type = &quot;ONE_LEVEL&quot;;
@@ -334,7 +334,7 @@ xkb_symbols &quot;media&quot;
     <para>
       As before, to install the layout do
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.extraLayouts.media = {
   description  = &quot;Multimedia keys remapping&quot;;
   languages    = [ &quot;eng&quot; ];
@@ -358,7 +358,7 @@ services.xserver.extraLayouts.media = {
       default. As a workaround, you can set the keymap using
       <literal>setxkbmap</literal> at the start of the session with:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.xserver.displayManager.sessionCommands = &quot;setxkbmap -keycodes media&quot;;
 </programlisting>
     <para>

--- a/nixos/doc/manual/from_md/configuration/xfce.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/xfce.chapter.xml
@@ -3,7 +3,7 @@
   <para>
     To enable the Xfce Desktop Environment, set
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.xserver.desktopManager.xfce.enable = true;
 services.xserver.displayManager.defaultSession = &quot;xfce&quot;;
 </programlisting>
@@ -11,7 +11,7 @@ services.xserver.displayManager.defaultSession = &quot;xfce&quot;;
     Optionally, <emphasis>picom</emphasis> can be enabled for nice
     graphical effects, some example settings:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 services.picom = {
   enable = true;
   fade = true;

--- a/nixos/doc/manual/from_md/development/activation-script.section.xml
+++ b/nixos/doc/manual/from_md/development/activation-script.section.xml
@@ -22,7 +22,7 @@
     these dependencies into account and order the snippets accordingly.
     As a simple example:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 system.activationScripts.my-activation-script = {
   deps = [ &quot;etc&quot; ];
   # supportsDryActivation = true;

--- a/nixos/doc/manual/from_md/development/assertions.section.xml
+++ b/nixos/doc/manual/from_md/development/assertions.section.xml
@@ -18,7 +18,7 @@
     <para>
       This is an example of using <literal>warnings</literal>.
     </para>
-    <programlisting language="bash">
+    <programlisting>
 { config, lib, ... }:
 {
   config = lib.mkIf config.services.foo.enable {
@@ -42,7 +42,7 @@
       assertion is useful to prevent such a broken system from being
       built.
     </para>
-    <programlisting language="bash">
+    <programlisting>
 { config, lib, ... }:
 {
   config = lib.mkIf config.services.syslogd.enable {

--- a/nixos/doc/manual/from_md/development/freeform-modules.section.xml
+++ b/nixos/doc/manual/from_md/development/freeform-modules.section.xml
@@ -30,7 +30,7 @@
     type-checked <literal>settings</literal> attribute</link> for a more
     complete example.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { lib, config, ... }: {
 
   options.settings = lib.mkOption {
@@ -52,7 +52,7 @@
   <para>
     And the following shows what such a module then allows
   </para>
-  <programlisting language="bash">
+  <programlisting>
 {
   # Not a declared option, but the freeform type allows this
   settings.logLevel = &quot;debug&quot;;
@@ -72,7 +72,7 @@
       Freeform attributes cannot depend on other attributes of the same
       set without infinite recursion:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 {
   # This throws infinite recursion encountered
   settings.logLevel = lib.mkIf (config.settings.port == 80) &quot;debug&quot;;

--- a/nixos/doc/manual/from_md/development/importing-modules.section.xml
+++ b/nixos/doc/manual/from_md/development/importing-modules.section.xml
@@ -4,7 +4,7 @@
     Sometimes NixOS modules need to be used in configuration but exist
     outside of Nixpkgs. These modules can be imported:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, lib, pkgs, ... }:
 
 {
@@ -23,18 +23,18 @@
     Nixpkgs NixOS modules. Like any NixOS module, this module can import
     additional modules:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 # ./module-list/default.nix
 [
   ./example-module1
   ./example-module2
 ]
 </programlisting>
-  <programlisting language="bash">
+  <programlisting>
 # ./extra-module/default.nix
 { imports = import ./module-list.nix; }
 </programlisting>
-  <programlisting language="bash">
+  <programlisting>
 # NIXOS_EXTRA_MODULE_PATH=/absolute/path/to/extra-module
 { config, lib, pkgs, ... }:
 

--- a/nixos/doc/manual/from_md/development/meta-attributes.section.xml
+++ b/nixos/doc/manual/from_md/development/meta-attributes.section.xml
@@ -15,7 +15,7 @@
     Each of the meta-attributes must be defined at most once per module
     file.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, lib, pkgs, ... }:
 {
   options = {

--- a/nixos/doc/manual/from_md/development/option-declarations.section.xml
+++ b/nixos/doc/manual/from_md/development/option-declarations.section.xml
@@ -6,7 +6,7 @@
     hasn’t been declared in any module. An option declaration generally
     looks like this:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 options = {
   name = mkOption {
     type = type specification;
@@ -119,7 +119,7 @@ options = {
         For example:
       </para>
       <anchor xml:id="ex-options-declarations-util-mkEnableOption-magic" />
-      <programlisting language="bash">
+      <programlisting>
 lib.mkEnableOption &quot;magic&quot;
 # is like
 lib.mkOption {
@@ -134,7 +134,7 @@ lib.mkOption {
         <para>
           Usage:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 mkPackageOption pkgs &quot;name&quot; { default = [ &quot;path&quot; &quot;in&quot; &quot;pkgs&quot; ]; example = &quot;literal example&quot;; }
 </programlisting>
         <para>
@@ -169,7 +169,7 @@ mkPackageOption pkgs &quot;name&quot; { default = [ &quot;path&quot; &quot;in&qu
           Examples:
         </para>
         <anchor xml:id="ex-options-declarations-util-mkPackageOption-hello" />
-        <programlisting language="bash">
+        <programlisting>
 lib.mkPackageOption pkgs &quot;hello&quot; { }
 # is like
 lib.mkOption {
@@ -180,7 +180,7 @@ lib.mkOption {
 }
 </programlisting>
         <anchor xml:id="ex-options-declarations-util-mkPackageOption-ghc" />
-        <programlisting language="bash">
+        <programlisting>
 lib.mkPackageOption pkgs &quot;GHC&quot; {
   default = [ &quot;ghc&quot; ];
   example = &quot;pkgs.haskell.package.ghc922.ghc.withPackages (hkgs: [ hkgs.primes ])&quot;;
@@ -279,7 +279,7 @@ lib.mkOption {
             <emphasis role="strong">Example: Extensible type placeholder
             in the service module</emphasis>
           </para>
-          <programlisting language="bash">
+          <programlisting>
 services.xserver.displayManager.enable = mkOption {
   description = &quot;Display manager to use&quot;;
   type = with types; nullOr (enum [ ]);
@@ -291,7 +291,7 @@ services.xserver.displayManager.enable = mkOption {
             <literal>services.xserver.displayManager.enable</literal> in
             the <literal>gdm</literal> module</emphasis>
           </para>
-          <programlisting language="bash">
+          <programlisting>
 services.xserver.displayManager.enable = mkOption {
   type = with types; nullOr (enum [ &quot;gdm&quot; ]);
 };
@@ -302,7 +302,7 @@ services.xserver.displayManager.enable = mkOption {
             <literal>services.xserver.displayManager.enable</literal> in
             the <literal>sddm</literal> module</emphasis>
           </para>
-          <programlisting language="bash">
+          <programlisting>
 services.xserver.displayManager.enable = mkOption {
   type = with types; nullOr (enum [ &quot;sddm&quot; ]);
 };

--- a/nixos/doc/manual/from_md/development/option-def.section.xml
+++ b/nixos/doc/manual/from_md/development/option-def.section.xml
@@ -4,7 +4,7 @@
     Option definitions are generally straight-forward bindings of values
     to option names, like
   </para>
-  <programlisting language="bash">
+  <programlisting>
 config = {
   services.httpd.enable = true;
 };
@@ -21,7 +21,7 @@ config = {
       another option, you may need to use <literal>mkIf</literal>.
       Consider, for instance:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 config = if config.services.httpd.enable then {
   environment.systemPackages = [ ... ];
   ...
@@ -34,7 +34,7 @@ config = if config.services.httpd.enable then {
       value being constructed here. After all, you could also write the
       clearly circular and contradictory:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 config = if config.services.httpd.enable then {
   services.httpd.enable = false;
 } else {
@@ -44,7 +44,7 @@ config = if config.services.httpd.enable then {
     <para>
       The solution is to write:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 config = mkIf config.services.httpd.enable {
   environment.systemPackages = [ ... ];
   ...
@@ -55,7 +55,7 @@ config = mkIf config.services.httpd.enable {
       of the conditional to be <quote>pushed down</quote> into the
       individual definitions, as if you had written:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 config = {
   environment.systemPackages = if config.services.httpd.enable then [ ... ] else [];
   ...
@@ -72,7 +72,7 @@ config = {
       can specify an explicit priority by using
       <literal>mkOverride</literal>, e.g.
     </para>
-    <programlisting language="bash">
+    <programlisting>
 services.openssh.enable = mkOverride 10 false;
 </programlisting>
     <para>
@@ -89,7 +89,7 @@ services.openssh.enable = mkOverride 10 false;
       to be merged together as if they were declared in separate
       modules. This can be done using <literal>mkMerge</literal>:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 config = mkMerge
   [ # Unconditional stuff.
     { environment.systemPackages = [ ... ];

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -67,14 +67,14 @@
           <para>
             Two definitions of this type like
           </para>
-          <programlisting language="bash">
+          <programlisting>
 {
   str = lib.mkDefault &quot;foo&quot;;
   pkg.hello = pkgs.hello;
   fun.fun = x: x + 1;
 }
 </programlisting>
-          <programlisting language="bash">
+          <programlisting>
 {
   str = lib.mkIf true &quot;bar&quot;;
   pkg.gcc = pkgs.gcc;
@@ -84,7 +84,7 @@
           <para>
             will get merged to
           </para>
-          <programlisting language="bash">
+          <programlisting>
 {
   str = &quot;bar&quot;;
   pkg.gcc = pkgs.gcc;
@@ -622,7 +622,7 @@
       <emphasis role="strong">Example: Directly defined
       submodule</emphasis>
     </para>
-    <programlisting language="bash">
+    <programlisting>
 options.mod = mkOption {
   description = &quot;submodule example&quot;;
   type = with types; submodule {
@@ -642,7 +642,7 @@ options.mod = mkOption {
       <emphasis role="strong">Example: Submodule defined as a
       reference</emphasis>
     </para>
-    <programlisting language="bash">
+    <programlisting>
 let
   modOptions = {
     options = {
@@ -677,7 +677,7 @@ options.mod = mkOption {
       <emphasis role="strong">Example: Declaration of a list of
       submodules</emphasis>
     </para>
-    <programlisting language="bash">
+    <programlisting>
 options.mod = mkOption {
   description = &quot;submodule example&quot;;
   type = with types; listOf (submodule {
@@ -697,7 +697,7 @@ options.mod = mkOption {
       <emphasis role="strong">Example: Definition of a list of
       submodules</emphasis>
     </para>
-    <programlisting language="bash">
+    <programlisting>
 config.mod = [
   { foo = 1; bar = &quot;one&quot;; }
   { foo = 2; bar = &quot;two&quot;; }
@@ -717,7 +717,7 @@ config.mod = [
       <emphasis role="strong">Example: Declaration of attribute sets of
       submodules</emphasis>
     </para>
-    <programlisting language="bash">
+    <programlisting>
 options.mod = mkOption {
   description = &quot;submodule example&quot;;
   type = with types; attrsOf (submodule {
@@ -737,7 +737,7 @@ options.mod = mkOption {
       <emphasis role="strong">Example: Definition of attribute sets of
       submodules</emphasis>
     </para>
-    <programlisting language="bash">
+    <programlisting>
 config.mod.one = { foo = 1; bar = &quot;one&quot;; };
 config.mod.two = { foo = 2; bar = &quot;two&quot;; };
 </programlisting>
@@ -768,7 +768,7 @@ config.mod.two = { foo = 2; bar = &quot;two&quot;; };
             <emphasis role="strong">Example: Adding a type
             check</emphasis>
           </para>
-          <programlisting language="bash">
+          <programlisting>
 byte = mkOption {
   description = &quot;An integer between 0 and 255.&quot;;
   type = types.addCheck types.int (x: x &gt;= 0 &amp;&amp; x &lt;= 255);
@@ -779,7 +779,7 @@ byte = mkOption {
             <emphasis role="strong">Example: Overriding a type
             check</emphasis>
           </para>
-          <programlisting language="bash">
+          <programlisting>
 nixThings = mkOption {
   description = &quot;words that start with 'nix'&quot;;
   type = types.str // {

--- a/nixos/doc/manual/from_md/development/replace-modules.section.xml
+++ b/nixos/doc/manual/from_md/development/replace-modules.section.xml
@@ -22,7 +22,7 @@
     only overrides the module definition, this won't use postgresql from
     nixos-unstable unless explicitly configured to do so.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, lib, pkgs, ... }:
 
 {
@@ -42,7 +42,7 @@
     for an existing module. Importing this module will disable the
     original module without having to know it's implementation details.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, lib, pkgs, ... }:
 
 with lib;

--- a/nixos/doc/manual/from_md/development/settings-options.section.xml
+++ b/nixos/doc/manual/from_md/development/settings-options.section.xml
@@ -318,7 +318,7 @@
       used, along with some other related best practices. See the
       comments for explanations.
     </para>
-    <programlisting language="bash">
+    <programlisting>
 { options, config, lib, pkgs, ... }:
 let
   cfg = config.services.foo;
@@ -391,7 +391,7 @@ in {
         <emphasis role="strong">Example: Declaring a type-checked
         <literal>settings</literal> attribute</emphasis>
       </para>
-      <programlisting language="bash">
+      <programlisting>
 settings = lib.mkOption {
   type = lib.types.submodule {
 

--- a/nixos/doc/manual/from_md/development/writing-modules.chapter.xml
+++ b/nixos/doc/manual/from_md/development/writing-modules.chapter.xml
@@ -32,7 +32,7 @@
     In <xref linkend="sec-configuration-syntax" />, we saw the following
     structure of NixOS modules:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 { option definitions
@@ -50,7 +50,7 @@
     <emphasis role="strong">Example: Structure of NixOS
     Modules</emphasis>
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ... }:
 
 {
@@ -146,7 +146,7 @@
     <emphasis role="strong">Example: NixOS Module for the
     <quote>locate</quote> Service</emphasis>
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, lib, pkgs, ... }:
 
 with lib;
@@ -208,7 +208,7 @@ in {
     <emphasis role="strong">Example: Escaping in Exec
     directives</emphasis>
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, lib, pkgs, utils, ... }:
 
 with lib;

--- a/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
+++ b/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
@@ -3,7 +3,7 @@
   <para>
     A NixOS test is a Nix expression that has the following structure:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 import ./make-test-python.nix {
 
   # One or more machines:
@@ -544,7 +544,7 @@ machine.wait_for_unit(&quot;xautolock.service&quot;, &quot;x-session-user&quot;)
       For faster dev cycles it's also possible to disable the
       code-linters (this shouldn't be commited though):
     </para>
-    <programlisting language="bash">
+    <programlisting>
 import ./make-test-python.nix {
   skipLint = true;
   nodes.machine =
@@ -564,7 +564,7 @@ import ./make-test-python.nix {
       disable the Black linter directly (again, don't commit this within
       the Nixpkgs repository):
     </para>
-    <programlisting language="bash">
+    <programlisting>
   testScript =
     ''
       # fmt: off

--- a/nixos/doc/manual/from_md/installation/changing-config.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/changing-config.chapter.xml
@@ -94,7 +94,7 @@ $ ./result/bin/run-*-vm
     unless you have set <literal>mutableUsers = false</literal>. Another
     way is to temporarily add the following to your configuration:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 users.users.your-user.initialHashedPassword = &quot;test&quot;;
 </programlisting>
   <para>

--- a/nixos/doc/manual/from_md/installation/installing-behind-a-proxy.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-behind-a-proxy.section.xml
@@ -11,7 +11,7 @@
         <literal>/mnt/etc/nixos/configuration.nix</literal> to keep the
         internet accessible after reboot.
       </para>
-      <programlisting language="bash">
+      <programlisting>
 networking.proxy.default = &quot;http://user:password@proxy:port/&quot;;
 networking.proxy.noProxy = &quot;127.0.0.1,localhost,internal.domain&quot;;
 </programlisting>

--- a/nixos/doc/manual/from_md/installation/installing-from-other-distro.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-from-other-distro.section.xml
@@ -129,7 +129,7 @@ $ sudo `which nixos-generate-config` --root /mnt
         Ubuntu, you may want to add something like this to your
         <literal>configuration.nix</literal>:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 boot.loader.grub.extraEntries = ''
   menuentry &quot;Ubuntu&quot; {
     search --set=ubuntu --fs-uuid 3cc3e652-0c1f-4800-8451-033754f68e6e
@@ -229,7 +229,7 @@ $ sudo `which nixos-generate-config` --root /
         account with <literal>sudo passwd -l root</literal> if you use
         <literal>sudo</literal>)
       </para>
-      <programlisting language="bash">
+      <programlisting>
 users.users.root.initialHashedPassword = &quot;&quot;;
 </programlisting>
     </listitem>

--- a/nixos/doc/manual/from_md/installation/installing-virtualbox-guest.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-virtualbox-guest.section.xml
@@ -58,14 +58,14 @@
     There are a few modifications you should make in configuration.nix.
     Enable booting:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.loader.grub.device = &quot;/dev/sda&quot;;
 </programlisting>
   <para>
     Also remove the fsck that runs at startup. It will always fail to
     run, stopping your boot until you press <literal>*</literal>.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 boot.initrd.checkJournalingFS = false;
 </programlisting>
   <para>
@@ -76,7 +76,7 @@ boot.initrd.checkJournalingFS = false;
     If you do not add <literal>&quot;nofail&quot;</literal>, the system
     will not boot properly.
   </para>
-  <programlisting language="bash">
+  <programlisting>
 { config, pkgs, ...} :
 {
   fileSystems.&quot;/virtualboxshare&quot; = {

--- a/nixos/doc/manual/from_md/installation/upgrading.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/upgrading.chapter.xml
@@ -128,7 +128,7 @@ nixos https://nixos.org/channels/nixos-unstable
       You can keep a NixOS system up-to-date automatically by adding the
       following to <literal>configuration.nix</literal>:
     </para>
-    <programlisting language="bash">
+    <programlisting>
 system.autoUpgrade.enable = true;
 system.autoUpgrade.allowReboot = true;
 </programlisting>
@@ -145,7 +145,7 @@ system.autoUpgrade.allowReboot = true;
       contains a different kernel, initrd or kernel modules. You can
       also specify a channel explicitly, e.g.
     </para>
-    <programlisting language="bash">
+    <programlisting>
 system.autoUpgrade.channel = https://nixos.org/channels/nixos-21.11;
 </programlisting>
   </section>

--- a/nixos/doc/manual/from_md/release-notes/rl-1404.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1404.section.xml
@@ -79,7 +79,7 @@
         the NixOS configuration. For instance, if a package
         <literal>foo</literal> provides systemd units, you can say:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   systemd.packages = [ pkgs.foo ];
 }
@@ -88,7 +88,7 @@
         to enable those units. You can then set or override unit options
         in the usual way, e.g.
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   systemd.services.foo.wantedBy = [ &quot;multi-user.target&quot; ];
   systemd.services.foo.serviceConfig.MemoryLimit = &quot;512M&quot;;
@@ -105,7 +105,7 @@
         NixOS configuration requires unfree packages from Nixpkgs, you
         need to enable support for them explicitly by setting:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   nixpkgs.config.allowUnfree = true;
 }
@@ -123,7 +123,7 @@
         The Adobe Flash player is no longer enabled by default in the
         Firefox and Chromium wrappers. To enable it, you must set:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   nixpkgs.config.allowUnfree = true;
   nixpkgs.config.firefox.enableAdobeFlash = true; # for Firefox
@@ -136,7 +136,7 @@
         The firewall is now enabled by default. If you don’t want this,
         you need to disable it explicitly:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   networking.firewall.enable = false;
 }

--- a/nixos/doc/manual/from_md/release-notes/rl-1412.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1412.section.xml
@@ -370,7 +370,7 @@
         documentation</link> for details. If you wish to continue to use
         httpd 2.2, add the following line to your NixOS configuration:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   services.httpd.package = pkgs.apacheHttpd_2_2;
 }

--- a/nixos/doc/manual/from_md/release-notes/rl-1509.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1509.section.xml
@@ -42,7 +42,7 @@
       </para>
     </listitem>
   </itemizedlist>
-  <programlisting language="bash">
+  <programlisting>
 {
   system.autoUpgrade.enable = true;
 }
@@ -432,7 +432,7 @@
       </para>
     </listitem>
   </itemizedlist>
-  <programlisting language="bash">
+  <programlisting>
 {
   system.stateVersion = &quot;14.12&quot;;
 }
@@ -523,7 +523,7 @@
       </para>
     </listitem>
   </itemizedlist>
-  <programlisting language="bash">
+  <programlisting>
 {
   fileSystems.&quot;/shiny&quot; = {
     device = &quot;myshinysharedfolder&quot;;
@@ -662,7 +662,7 @@ infinite recursion encountered
         <literal>lib</literal>, after adding it as argument of the
         module. The following module
       </para>
-      <programlisting language="bash">
+      <programlisting>
 { config, pkgs, ... }:
 
 with pkgs.lib;
@@ -677,7 +677,7 @@ with pkgs.lib;
       <para>
         should be modified to look like:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 { config, pkgs, lib, ... }:
 
 with lib;
@@ -695,7 +695,7 @@ with lib;
         replaced by <literal>(import &lt;nixpkgs&gt; {})</literal>. The
         following module
       </para>
-      <programlisting language="bash">
+      <programlisting>
 { config, pkgs, ... }:
 
 let
@@ -712,7 +712,7 @@ in
       <para>
         should be modified to look like:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 { config, pkgs, ... }:
 
 let

--- a/nixos/doc/manual/from_md/release-notes/rl-1603.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1603.section.xml
@@ -378,7 +378,7 @@
         You will need to add an import statement to your NixOS
         configuration in order to use it, e.g.
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   imports = [ &lt;nixpkgs/nixos/modules/services/misc/gitit.nix&gt; ];
 }
@@ -395,7 +395,7 @@
         to be built in. All modules now reside in
         <literal>nginxModules</literal> set. Example configuration:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 nginx.override {
   modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
 }
@@ -468,7 +468,7 @@ nginx.override {
         continue to work, but print a warning, until the 16.09 release.
         An example of the new style:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   fileSystems.&quot;/example&quot; = {
     device = &quot;/dev/sdc&quot;;
@@ -524,7 +524,7 @@ nginx.override {
         used input method name, <literal>&quot;ibus&quot;</literal> for
         ibus. An example of the new style:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   i18n.inputMethod.enabled = &quot;ibus&quot;;
   i18n.inputMethod.ibus.engines = with pkgs.ibus-engines; [ anthy mozc ];
@@ -533,7 +533,7 @@ nginx.override {
       <para>
         That is equivalent to the old version:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   programs.ibus.enable = true;
   programs.ibus.plugins = with pkgs; [ ibus-anthy mozc ];
@@ -587,7 +587,7 @@ $TTL 1800
         point to exact folder where syncthing is writing to. Example
         configuration should look something like:
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   services.syncthing = {
       enable = true;

--- a/nixos/doc/manual/from_md/release-notes/rl-1609.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1609.section.xml
@@ -192,7 +192,7 @@
         interface has been streamlined. Desktop users should be able to
         simply set
       </para>
-      <programlisting language="bash">
+      <programlisting>
 {
   security.grsecurity.enable = true;
 }

--- a/nixos/doc/manual/from_md/release-notes/rl-1703.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1703.section.xml
@@ -581,7 +581,7 @@
           <literal>service.nylon</literal> is now declared using named
           instances. As an example:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.nylon = {
     enable = true;
@@ -594,7 +594,7 @@
         <para>
           should be replaced with:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.nylon.myvpn = {
     enable = true;
@@ -615,7 +615,7 @@
           <link xlink:href="https://nixos.org/nixpkgs/manual/#sec-overlays-install">
           overlays</link>. For example, the following code:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 let
   pkgs = import &lt;nixpkgs&gt; {};
 in
@@ -624,7 +624,7 @@ in
         <para>
           should be replaced by:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 let
   pkgs = import &lt;nixpkgs&gt; {};
 in

--- a/nixos/doc/manual/from_md/release-notes/rl-1709.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1709.section.xml
@@ -29,7 +29,7 @@
           head. Apart from that, it's now possible to also set
           additional options by using an attribute set, for example:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 { services.xserver.xrandrHeads = [
     &quot;HDMI-0&quot;
     {

--- a/nixos/doc/manual/from_md/release-notes/rl-1803.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1803.section.xml
@@ -830,7 +830,7 @@
         <para>
           In order to have the previous default configuration add
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.xserver.displayManager.lightdm.greeters.gtk.indicators = [
     &quot;~host&quot; &quot;~spacer&quot;

--- a/nixos/doc/manual/from_md/release-notes/rl-1809.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1809.section.xml
@@ -54,7 +54,7 @@
         <para>
           For example
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   programs.firejail = {
     enable = true;
@@ -695,7 +695,7 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
           A NixOS system can now be constructed more easily based on a
           preexisting invocation of Nixpkgs. For example:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   inherit (pkgs.nixos {
     boot.loader.grub.enable = false;
@@ -791,7 +791,7 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
           <para>
             An example usage of this would be:
           </para>
-          <programlisting language="bash">
+          <programlisting>
 { config, ... }:
 
 {

--- a/nixos/doc/manual/from_md/release-notes/rl-1903.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-1903.section.xml
@@ -374,7 +374,7 @@
           setting the <literal>services.nscd.config</literal> option
           with the desired caching parameters.
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.nscd.config =
   ''

--- a/nixos/doc/manual/from_md/release-notes/rl-2003.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2003.section.xml
@@ -133,7 +133,7 @@
           option to improve support for upstream session files. If you
           used something like:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.xserver.desktopManager.default = &quot;xfce&quot;;
   services.xserver.windowManager.default = &quot;icewm&quot;;
@@ -142,7 +142,7 @@
         <para>
           you should change it to:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.xserver.displayManager.defaultSession = &quot;xfce+icewm&quot;;
 }
@@ -821,7 +821,7 @@ See https://github.com/NixOS/nixpkgs/pull/71684 for details.
           is a <literal>loaOf</literal> option that is commonly used as
           follows:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   users.users =
     [ { name = &quot;me&quot;;
@@ -836,7 +836,7 @@ See https://github.com/NixOS/nixpkgs/pull/71684 for details.
           value of <literal>name</literal> as the name of the attribute
           set:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   users.users.me =
     { description = &quot;My personal user.&quot;;
@@ -940,7 +940,7 @@ See https://github.com/NixOS/nixpkgs/pull/71684 for details.
           because it permitted root auto-login you can override the
           lightdm-autologin pam module like:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   security.pam.services.lightdm-autologin.text = lib.mkForce ''
       auth     requisite pam_nologin.so
@@ -1004,7 +1004,7 @@ auth required pam_succeed_if.so quiet
               Additionally, some Postfix configuration must now be set
               manually instead of automatically by the Mailman module:
             </para>
-            <programlisting language="bash">
+            <programlisting>
 {
   services.postfix.relayDomains = [ &quot;hash:/var/lib/mailman/data/postfix_domains&quot; ];
   services.postfix.config.transport_maps = [ &quot;hash:/var/lib/mailman/data/postfix_lmtp&quot; ];
@@ -1066,7 +1066,7 @@ auth required pam_succeed_if.so quiet
           or by passing a TOML configuration file via
           <link xlink:href="options.html#opt-services.dnscrypt-proxy2.configFile">services.dnscrypt-proxy2.configFile</link>.
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   # Example configuration:
   services.dnscrypt-proxy2.enable = true;
@@ -1229,7 +1229,7 @@ auth required pam_succeed_if.so quiet
               when upgrading. Otherwise, the package can be deployed
               using the following config:
             </para>
-            <programlisting language="bash">
+            <programlisting>
 { pkgs, ... }: {
   services.hydra.package = pkgs.hydra-migration;
 }
@@ -1319,7 +1319,7 @@ $ hydra-backfill-ids
         <para>
           To continue to use the old approach, you can configure:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.nginx.appendConfig = let cfg = config.services.nginx; in ''user ${cfg.user} ${cfg.group};'';
   systemd.services.nginx.serviceConfig.User = lib.mkForce &quot;root&quot;;
@@ -1432,7 +1432,7 @@ $ hydra-backfill-ids
               older, you simply need to enable postgresql-support
               explicitly:
             </para>
-            <programlisting language="bash">
+            <programlisting>
 { ... }: {
   services.matrix-synapse = {
     enable = true;

--- a/nixos/doc/manual/from_md/release-notes/rl-2009.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2009.section.xml
@@ -730,7 +730,7 @@
           traditional mysql_native_password plugin method, one must run
           the following:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
 services.mysql.initialScript = pkgs.writeText &quot;mariadb-init.sql&quot; ''
   ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD(&quot;verysecret&quot;);
@@ -755,7 +755,7 @@ services.mysql.initialScript = pkgs.writeText &quot;mariadb-init.sql&quot; ''
           allow MySQL to read from /home and /tmp directories when using
           <literal>LOAD DATA INFILE</literal>
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   systemd.services.mysql.serviceConfig.ProtectHome = lib.mkForce &quot;read-only&quot;;
 }
@@ -766,7 +766,7 @@ services.mysql.initialScript = pkgs.writeText &quot;mariadb-init.sql&quot; ''
           <literal>SELECT * INTO OUTFILE</literal>, assuming the mysql
           user has write access to <literal>/var/data</literal>
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   systemd.services.mysql.serviceConfig.ReadWritePaths = [ &quot;/var/data&quot; ];
 }
@@ -885,7 +885,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
           <literal>phantomJsSupport = true</literal> to the package
           instantiation:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.grafana.package = pkgs.grafana.overrideAttrs (oldAttrs: rec {
     phantomJsSupport = true;
@@ -958,7 +958,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
           <literal>opcache</literal>, <literal>pdo</literal> and
           <literal>pdo_mysql</literal> loaded:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   environment.systemPackages = [
     (pkgs.php.withExtensions
@@ -997,7 +997,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
           The remaining configuration flags can now be set directly on
           the <literal>php</literal> attribute. For example, instead of
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   php.override {
     config.php.embed = true;
@@ -1008,7 +1008,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
         <para>
           you should now write
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   php.override {
     embedSupport = true;
@@ -1062,7 +1062,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
           writing to other folders, use
           <literal>systemd.services.nginx.serviceConfig.ReadWritePaths</literal>
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   systemd.services.nginx.serviceConfig.ReadWritePaths = [ &quot;/var/www&quot; ];
 }
@@ -1076,7 +1076,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
           docs</link> for details). If you require serving files from
           home directories, you may choose to set e.g.
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   systemd.services.nginx.serviceConfig.ProtectHome = &quot;read-only&quot;;
 }
@@ -1093,7 +1093,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
         <para>
           Replace a <literal>nesting.clone</literal> entry with:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   specialisation.example-sub-configuration = {
     configuration = {
@@ -1104,7 +1104,7 @@ WHERE table_schema = &quot;zabbix&quot; AND COLLATION_NAME = &quot;utf8_general_
         <para>
           Replace a <literal>nesting.children</literal> entry with:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   specialisation.example-sub-configuration = {
     inheritParentConfig = false;
@@ -1385,7 +1385,7 @@ $ sudo /run/current-system/fine-tune/child-1/bin/switch-to-configuration test
           multi-instance config with an existing bitcoind data directory
           and user, you have to adjust the original config, e.g.:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.bitcoind = {
     enable = true;
@@ -1397,7 +1397,7 @@ $ sudo /run/current-system/fine-tune/child-1/bin/switch-to-configuration test
         <para>
           To something similar:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.bitcoind.mainnet = {
     enable = true;
@@ -1447,7 +1447,7 @@ $ sudo /run/current-system/fine-tune/child-1/bin/switch-to-configuration test
           the original SSL settings, you have to adjust the original
           config, e.g.:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.dokuwiki = {
     enable = true;
@@ -1458,7 +1458,7 @@ $ sudo /run/current-system/fine-tune/child-1/bin/switch-to-configuration test
         <para>
           To something similar:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.dokuwiki.&quot;mywiki&quot; = {
     enable = true;
@@ -1492,7 +1492,7 @@ $ sudo /run/current-system/fine-tune/child-1/bin/switch-to-configuration test
           option is (<literal>/var/db/postgresql</literal>) and then
           explicitly set this value to maintain compatibility:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.postgresql.dataDir = &quot;/var/db/postgresql&quot;;
 }
@@ -1825,7 +1825,7 @@ CREATE ROLE postgres LOGIN SUPERUSER;
           you must include those directories into the
           <literal>BindPaths</literal> of the service:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   systemd.services.transmission.serviceConfig.BindPaths = [ &quot;/path/to/alternative/download-dir&quot; ];
 }
@@ -1835,7 +1835,7 @@ CREATE ROLE postgres LOGIN SUPERUSER;
           <literal>transmission-daemon</literal> is now only available
           on the local network interface by default. Use:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.transmission.settings.rpc-bind-address = &quot;0.0.0.0&quot;;
 }
@@ -1900,7 +1900,7 @@ CREATE ROLE postgres LOGIN SUPERUSER;
         <para>
           This means that a configuration like this
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.dovecot2.mailboxes = [
     { name = &quot;Junk&quot;;
@@ -1912,7 +1912,7 @@ CREATE ROLE postgres LOGIN SUPERUSER;
         <para>
           should now look like this:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.dovecot2.mailboxes = {
     Junk.auto = &quot;create&quot;;

--- a/nixos/doc/manual/from_md/release-notes/rl-2105.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2105.section.xml
@@ -330,7 +330,7 @@
           <literal>mediatomb</literal> package. If you want to keep the
           old behavior, you must declare it with:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.mediatomb.package = pkgs.mediatomb;
 }
@@ -341,7 +341,7 @@
           service declaration to add the firewall rules itself before,
           you should now declare it with:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.mediatomb.openFirewall = true;
 }
@@ -368,7 +368,7 @@
           <link xlink:href="options.html#opt-services.uwsgi.capabilities">services.uwsgi.capabilities</link>.
           The previous behaviour can be restored by setting:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.uwsgi.user = &quot;root&quot;;
   services.uwsgi.group = &quot;root&quot;;
@@ -552,7 +552,7 @@ $ slapcat -F $TMPDIR -n0 -H 'ldap:///???(!(objectClass=olcSchemaConfig))'
           has been removed. To enable Privoxy, and to configure it to
           use Tor's faster port, use the following configuration:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   opt-services.privoxy.enable = true;
   opt-services.privoxy.enableTor = true;
@@ -689,7 +689,7 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
           <literal>mpich</literal> instead of the default
           <literal>openmpi</literal> can now be achived like this:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 self: super:
 {
   mpi = super.mpich;
@@ -850,7 +850,7 @@ self: super:
           kodiPackages.inputstream-adaptive and kodiPackages.vfs-sftp
           addons:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   environment.systemPackages = [
     pkgs.kodi
@@ -867,7 +867,7 @@ self: super:
           and as a result the above configuration should now be written
           as:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   environment.systemPackages = [
     (pkgs.kodi.withPackages (p: with p; [
@@ -1158,7 +1158,7 @@ self: super:
           users to declare autoscan media directories from their nixos
           configuration:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.mediatomb.mediaDirectories = [
     { path = &quot;/var/lib/mediatomb/pictures&quot;; recursive = false; hidden-files = false; }
@@ -1518,7 +1518,7 @@ self: super:
           been dropped. Users that still want it should add the
           following to their system configuration:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.gvfs.package = pkgs.gvfs.override { samba = null; };
 }

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -633,7 +633,7 @@
             </para>
           </listitem>
         </itemizedlist>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.paperless-ng.extraConfig = {
     # Provide languages as ISO 639-2 codes
@@ -728,7 +728,7 @@ Superuser created successfully.
           insecure. Out-of-tree modules are likely to require
           adaptation: instead of
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   users.users.foo = {
     isSystemUser = true;
@@ -738,7 +738,7 @@ Superuser created successfully.
         <para>
           also create a group for your user:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   users.users.foo = {
     isSystemUser = true;

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -507,7 +507,7 @@
           <literal>config.nixpkgs.config.allowUnfree</literal> are
           enabled. If you still want these fonts, use:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   fonts.fonts = [
     pkgs.xorg.fontbhlucidatypewriter100dpi
@@ -595,7 +595,7 @@
         <para>
           Before:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.matrix-synapse = {
     enable = true;
@@ -630,7 +630,7 @@
         <para>
           After:
         </para>
-        <programlisting language="bash">
+        <programlisting>
 {
   services.matrix-synapse = {
     enable = true;


### PR DESCRIPTION
Somewhere between cd67b4fcbb81d07477746a138d6dbb9d01a81450 and b0c612766821c65eaa9a9f296547acef9a63755e, there were changes to the generated NixOS manual which have not yet been committed.

This creates noise in other issues updating the manual, ie. https://github.com/NixOS/nixpkgs/pull/162550.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
