### PR TITLE
CODEOWNERS: Add layus for autoPatchelfHook

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,8 @@
 /pkgs/build-support/cc-wrapper                   @Ericson2314
 /pkgs/build-support/bintools-wrapper             @Ericson2314
 /pkgs/build-support/setup-hooks                  @Ericson2314
-/pkgs/build-support/setup-hooks/auto-patchelf.sh @aszlig
+/pkgs/build-support/setup-hooks/auto-patchelf.sh @layus
+/pkgs/build-support/setup-hooks/auto-patchelf.py @layus
 
 # Nixpkgs build-support
 /pkgs/build-support/writers @lassulus @Profpatsch


### PR DESCRIPTION
With the re-implementation in Python [merged](https://github.com/NixOS/nixpkgs/pull/149731), it no longer makes sense for me to track issues and pull requests. I did this originally because people were forgetting (rightfully so) to run tests against all that proprietary stuff we have in nixpkgs that is using `autoPatchelfHook`.

We still can't test these automatically but with me no longer being the author of the code, I hereby drop my entry in `CODEOWNERS` and instead replace it with @layus, who's the author of the rewrite.