### PR TITLE
python3Packages.brother: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/brother/default.nix
+++ b/pkgs/development/python-modules/brother/default.nix
@@ -1,37 +1,29 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pysnmp
+, pysnmplib
 , pytest-asyncio
 , pytest-error-for-skips
-, pytest-runner
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "brother";
-  version = "1.1.0";
+  version = "1.2.0";
+  format = "setuptools";
+
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ZDQIpzdr3XkYrSUgrBDZsUwUZRQCdJdvmniMezvJxzU=";
+    hash = "sha256-hKOZ5pTDwhM0lOXoatXXVvEVxiTfxIpBRe3fFcUfzwE=";
   };
 
-  nativeBuildInputs = [
-    pytest-runner
-  ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "--cov --cov-report term-missing " ""
-  '';
-
   propagatedBuildInputs = [
-    pysnmp
+    pysnmplib
   ];
 
   checkInputs = [
@@ -40,7 +32,16 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "brother" ];
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov --cov-report term-missing " ""
+    substituteInPlace setup.py \
+      --replace '"pytest-runner"' ""
+  '';
+
+  pythonImportsCheck = [
+    "brother"
+  ];
 
   meta = with lib; {
     description = "Python wrapper for getting data from Brother laser and inkjet printers via SNMP";

--- a/pkgs/development/python-modules/pysnmp-pyasn1/default.nix
+++ b/pkgs/development/python-modules/pysnmp-pyasn1/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pysnmp-pyasn1";
+  version = "1.1.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pysnmp";
+    repo = "pyasn1";
+    rev = "v${version}";
+    hash = "sha256-R4reMwVcJBTfTEHUk6sSUugsEPuKIziH1WbjMakP/dA=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyasn1"
+  ];
+
+  meta = with lib; {
+    description = "Python ASN.1 encoder and decoder";
+    homepage = "https://github.com/pysnmp/pyasn1";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pysnmp-pysmi/default.nix
+++ b/pkgs/development/python-modules/pysnmp-pysmi/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, ply
+, poetry-core
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pysnmp-pysmi";
+  version = "1.1.8";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pysnmp";
+    repo = "pysmi";
+    rev = "v${version}";
+    hash = "sha256-nsIEZPD7bfbePZukkudP0ZH/m8Be88QkVDM5PdjNHVk=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    ply
+    requests
+  ];
+
+  # Circular dependency with pysnmplib
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pysmi"
+  ];
+
+  meta = with lib; {
+    description = "SNMP MIB parser";
+    homepage = "https://github.com/pysnmp/pysmi";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pysnmplib/default.nix
+++ b/pkgs/development/python-modules/pysnmplib/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pycryptodomex
+, pysnmp-pyasn1
+, pysnmp-pysmi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pysnmplib";
+  version = "5.0.10";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "pysnmp";
+    repo = "pysnmp";
+    rev = "v${version}";
+    hash = "sha256-PsfsOVzeHCVdd1Bi+FYYi68Wzn1MI8dZUbRr/tmT+cA=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    pysnmp-pysmi
+    pysnmp-pyasn1
+    pycryptodomex
+  ];
+
+  # Module has no test, examples are used for testing
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pysnmp"
+  ];
+
+  meta = with lib; {
+    description = "Implementation of v1/v2c/v3 SNMP engine";
+    homepage = "https://github.com/pysnmp/pysnmp";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7765,6 +7765,8 @@ in {
 
   pysnmp = callPackage ../development/python-modules/pysnmp { };
 
+  pysnmp-pyasn1 = callPackage ../development/python-modules/pysnmp-pyasn1 { };
+
   pysnooper = callPackage ../development/python-modules/pysnooper { };
 
   pysnow = callPackage ../development/python-modules/pysnow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7767,6 +7767,8 @@ in {
 
   pysnmp-pyasn1 = callPackage ../development/python-modules/pysnmp-pyasn1 { };
 
+  pysnmp-pysmi = callPackage ../development/python-modules/pysnmp-pysmi { };
+
   pysnooper = callPackage ../development/python-modules/pysnooper { };
 
   pysnow = callPackage ../development/python-modules/pysnow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7769,6 +7769,8 @@ in {
 
   pysnmp-pysmi = callPackage ../development/python-modules/pysnmp-pysmi { };
 
+  pysnmplib = callPackage ../development/python-modules/pysnmplib { };
+
   pysnooper = callPackage ../development/python-modules/pysnooper { };
 
   pysnow = callPackage ../development/python-modules/pysnow { };


### PR DESCRIPTION
###### Description of changes
https://github.com/bieniu/brother/releases/tag/1.2.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
