### PR TITLE
nixos/test-driver: highlight driver log lines

### DIFF
--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -86,7 +86,7 @@ class Driver:
 
     def subtest(self, name: str) -> Iterator[None]:
         """Group logs under a given test name"""
-        with rootlog.nested(name):
+        with rootlog.nested("subtest: " + name):
             try:
                 yield
                 return True

--- a/nixos/lib/test-driver/test_driver/logger.py
+++ b/nixos/lib/test-driver/test_driver/logger.py
@@ -1,4 +1,4 @@
-from colorama import Style
+from colorama import Style, Fore
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator
 from queue import Queue, Empty
@@ -81,7 +81,11 @@ class Logger:
 
     @contextmanager
     def nested(self, message: str, attributes: Dict[str, str] = {}) -> Iterator[None]:
-        self._eprint(self.maybe_prefix(message, attributes))
+        self._eprint(
+            self.maybe_prefix(
+                Style.BRIGHT + Fore.GREEN + message + Style.RESET_ALL, attributes
+            )
+        )
 
         self.xml.startElement("nest", attrs={})
         self.xml.startElement("head", attributes)


### PR DESCRIPTION
###### Description of changes

There is a whole lot of noise in a NixOS test log due to journal,
commands, and test driver messages all being mixing together.
With this commit the test driver messages are highlighted so you don't
have to squint too much to see where a subtest starts and ends or what
was the last command being run.

Here's an excerpt from a highlighted log:

![log](https://user-images.githubusercontent.com/2817565/163364416-c48458da-d231-42ff-a129-bc95915d50a9.png)


###### Things done

- [x] Built test driver
- [x] Run a couple of NixOS tests
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).