### PR TITLE
gnome-firmware: 3.34.0 → 42.1

### DIFF
--- a/pkgs/applications/misc/gnome-firmware/default.nix
+++ b/pkgs/applications/misc/gnome-firmware/default.nix
@@ -18,13 +18,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-firmware-updater";
+  pname = "gnome-firmware";
   version = "3.34.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
-    owner = "hughsie";
-    repo = "gnome-firmware-updater";
+    owner = "World";
+    repo = "gnome-firmware";
     rev = version;
     sha256 = "04pll0fzf4nr276kfw89r0524s6ppmls5rz4vq2j8c8gb50g0b6l";
   };
@@ -32,11 +32,11 @@ stdenv.mkDerivation rec {
   patches = [
     # Fixes manual build
     (fetchpatch {
-      url = "https://gitlab.gnome.org/hughsie/gnome-firmware-updater/commit/006b64dcb401d8c81a33222bc4be8274c23f3c9c.patch";
+      url = "https://gitlab.gnome.org/World/gnome-firmware/commit/006b64dcb401d8c81a33222bc4be8274c23f3c9c.patch";
       sha256 = "02303ip4ri5pv1bls8c0njb00qhn0jd0d8rmvsrig0fmacwfvc06";
     })
     (fetchpatch {
-      url = "https://gitlab.gnome.org/hughsie/gnome-firmware-updater/commit/c4f076f2c902080618e0c27dec924fd0019f68a3.patch";
+      url = "https://gitlab.gnome.org/World/gnome-firmware/commit/c4f076f2c902080618e0c27dec924fd0019f68a3.patch";
       sha256 = "1yfxd7qsg3gwpamg0m2sbcfrgks59w70r9728arrc4pwx1hia2q1";
     })
   ];
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://gitlab.gnome.org/hughsie/gnome-firmware-updater";
+    homepage = "https://gitlab.gnome.org/World/gnome-firmware";
     description = "Tool for installing firmware on devices";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;

--- a/pkgs/applications/misc/gnome-firmware/default.nix
+++ b/pkgs/applications/misc/gnome-firmware/default.nix
@@ -1,45 +1,33 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitLab
-, fetchpatch
 , appstream-glib
 , desktop-file-utils
 , fwupd
 , gettext
 , glib
-, gtk3
-, libsoup
+, gtk4
+, libadwaita
 , libxmlb
 , meson
 , ninja
 , pkg-config
 , systemd
 , help2man
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-firmware";
-  version = "3.34.0";
+  version = "42.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "gnome-firmware";
     rev = version;
-    sha256 = "04pll0fzf4nr276kfw89r0524s6ppmls5rz4vq2j8c8gb50g0b6l";
+    sha256 = "9QZ98EElENWsME/jXoj9YJl2e+ipyLm0g4grQUwmnuE=";
   };
-
-  patches = [
-    # Fixes manual build
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/World/gnome-firmware/commit/006b64dcb401d8c81a33222bc4be8274c23f3c9c.patch";
-      sha256 = "02303ip4ri5pv1bls8c0njb00qhn0jd0d8rmvsrig0fmacwfvc06";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/World/gnome-firmware/commit/c4f076f2c902080618e0c27dec924fd0019f68a3.patch";
-      sha256 = "1yfxd7qsg3gwpamg0m2sbcfrgks59w70r9728arrc4pwx1hia2q1";
-    })
-  ];
 
   nativeBuildInputs = [
     appstream-glib # for ITS rules
@@ -49,14 +37,14 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
     fwupd
     glib
-    gtk3
-    libsoup
+    gtk4
+    libadwaita
     libxmlb
     systemd
   ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -446,6 +446,7 @@ mapAliases ({
   gmic_krita_qt = gmic-qt-krita; # Added 2019-09-07
   gmvault = throw "gmvault has been removed because it is unmaintained, mostly broken, and insecure"; # Added 2021-03-08
   gnash = throw "gnash has been removed; broken and abandoned upstream"; # added 2022-02-06
+  gnome-firmware-updater = gnome-firmware; # added 2022-04-14
   gnome-passwordsafe = gnome-secrets; # added 2022-01-30
   gnome-mpv = celluloid; # Added 2019-08-22
   gnome-sharp = throw "gnome-sharp has been removed from nixpkgs"; # Added 2022-01-15

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15126,7 +15126,7 @@ with pkgs;
 
   gnome-desktop-testing = callPackage ../development/tools/gnome-desktop-testing {};
 
-  gnome-firmware-updater = callPackage ../applications/misc/gnome-firmware-updater {};
+  gnome-firmware = callPackage ../applications/misc/gnome-firmware {};
 
   gnome-usage = callPackage ../applications/misc/gnome-usage {};
 


### PR DESCRIPTION
###### Description of changes

The package is added in https://github.com/NixOS/nixpkgs/commit/08fc2fc7497470336a9018d8c0f57c8019e32bc9, Not sure why 3.36 and 41 are skipped (maybe a project rename happened and repology did not merge these projects? or am I missing something?)

Easier to review commit by commit.

---

https://gitlab.gnome.org/World/gnome-firmware/-/compare/3.34.0...3.36.0

<ul>
          <li>Dynamically show verify and releases buttons</li>
          <li>Show device and progress when doing updates</li>
          <li>Show the release issues if supplied in the metadata</li>
        </ul>



---

https://gitlab.gnome.org/World/gnome-firmware/-/compare/3.36.0...41.0


<ul>
          <li>Add support for showing the update message</li>
          <li>Add support for switching branch</li>
          <li>Send the client features at startup</li>
          <li>Show a FDE warning when required</li>
          <li>Show composite devices clearly</li>
          <li>Use libhandy to make UI responsive</li>
          <li>Use the new API from fwupd to avoid blocking the main  thread</li>
        </ul>


---

https://gitlab.gnome.org/World/gnome-firmware/-/compare/41.0...42.1


42~beta:

<ul>
          <li>Correctly print release flags</li>
          <li>Enable releases leaflet gestures to be more adaptable</li>
          <li>Hide the back button when folded</li>
        </ul>

42.0:


<ul>
          <li>Port to GTK4</li>
          <li>Add the device branch to the device page</li>
          <li>Allow installing firmware with the AFFECTS_FDE flag</li>
        </ul>

42.1:

<ul>
          <li>Do not create duplicate request events</li>
          <li>Mark the application as adaptive for mobile</li>
          <li>Do not show crazy remaining time values</li>
          <li>Show how GUIDs are constructed in the UI</li>
          <li>Show the 'No Releases Available' in more cases</li>
          <li>Update the progressbar text for every percentage changed event</li>
        </ul>





###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
