### PR TITLE
Small fix: removed redundant "lib." namespace prefix because "with lib;" is already …

### DIFF
--- a/nixos/modules/profiles/headless.nix
+++ b/nixos/modules/profiles/headless.nix
@@ -9,7 +9,7 @@ with lib;
   boot.vesa = false;
 
   # Don't start a tty on the serial consoles.
-  systemd.services."serial-getty@ttyS0".enable = lib.mkDefault false;
+  systemd.services."serial-getty@ttyS0".enable = mkDefault false;
   systemd.services."serial-getty@hvc0".enable = false;
   systemd.services."getty@tty1".enable = false;
   systemd.services."autovt@".enable = false;


### PR DESCRIPTION
Small fix. Removed "lib." prefix from mkDefault because "with lib;" is already specified above.