### PR TITLE
tvheadend: add tvheadend-latest alonside tvheadend

### DIFF
--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -1,82 +1,99 @@
 { lib, stdenv, fetchFromGitHub, cmake, makeWrapper, pkg-config
-, avahi, dbus, gettext, git, gnutar, gzip, bzip2, ffmpeg_4, libiconv, openssl, python2
-, v4l-utils, which, zlib }:
+, avahi, dbus, gettext, git, gnutar, gzip, bzip2, ffmpeg_4, libdvbcsa, libiconv, libopus, libvpx, openssl, python2
+, v4l-utils, which, x264, x265, zlib }:
 
 let
-  version = "4.2.8";
-
-  dtv-scan-tables = stdenv.mkDerivation {
-    pname = "dtv-scan-tables";
-    version = "2020-05-18";
-    src = fetchFromGitHub {
-      owner = "tvheadend";
-      repo = "dtv-scan-tables";
-      rev = "e3138a506a064f6dfd0639d69f383e8e576609da";
-      sha256 = "19ac9ds3rfc2xrqcywsbd1iwcpv7vmql7gp01iikxkzcgm2g2b6w";
+  versions = {
+    tvheadend = {
+      version = "4.2.8";
+      rev = "v4.2.8";
+      sha256 = "1xq059r2bplaa0nd0wkhw80jfwd962x0h5hgd7fz2yp6largw34m";
     };
-    nativeBuildInputs = [ v4l-utils ];
-    installFlags = [ "DATADIR=$(out)" ];
+
+    tvheadend-latest = {
+      version = "master-9a51cea";
+      rev = "9a51cea492e4a5579ca3ddf9233fecfa419de078";
+      sha256 = "1n6da55i8jg90sf3x66xpzcialkwrf5b2hyllymwlv4g2wnr74av";
+    };
   };
-in stdenv.mkDerivation {
-  pname = "tvheadend";
-  inherit version;
+  common = pname: { version, rev, sha256 }:
+    let
+      dtv-scan-tables = stdenv.mkDerivation {
+        pname = "dtv-scan-tables";
+        version = "2020-05-18";
+        src = fetchFromGitHub {
+          owner = "tvheadend";
+          repo = "dtv-scan-tables";
+          rev = "e3138a506a064f6dfd0639d69f383e8e576609da";
+          sha256 = "19ac9ds3rfc2xrqcywsbd1iwcpv7vmql7gp01iikxkzcgm2g2b6w";
+        };
+        nativeBuildInputs = [ v4l-utils ];
+        installFlags = [ "DATADIR=$(out)" ];
+      };
+    in
 
-  src = fetchFromGitHub {
-    owner  = "tvheadend";
-    repo   = "tvheadend";
-    rev    = "v${version}";
-    sha256 = "1xq059r2bplaa0nd0wkhw80jfwd962x0h5hgd7fz2yp6largw34m";
-  };
+      stdenv.mkDerivation rec {
+        pname = "tvheadend";
+        inherit version;
 
-  buildInputs = [
-    avahi dbus gettext git gnutar gzip bzip2 ffmpeg_4 libiconv openssl python2
-    which zlib
-  ];
+        src = fetchFromGitHub {
+          owner  = "tvheadend";
+          repo   = "tvheadend";
+          rev    = "v${rev}";
+          sha256 = "${sha256}";
+        };
 
-  nativeBuildInputs = [ cmake makeWrapper pkg-config ];
+        buildInputs = [
+          avahi dbus gettext git gnutar gzip bzip2 ffmpeg_4 libdvbcsa libiconv libopus libvpx openssl python2
+          which x264 x265 zlib
+        ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" "-Wno-error=stringop-truncation" ];
+        nativeBuildInputs = [ cmake makeWrapper pkg-config ];
 
-  # disable dvbscan, as having it enabled causes a network download which
-  # cannot happen during build.  We now include the dtv-scan-tables ourselves
-  configureFlags = [
-    "--disable-dvbscan"
-    "--disable-bintray_cache"
-    "--disable-ffmpeg_static"
-    "--disable-hdhomerun_client"
-    "--disable-hdhomerun_static"
-  ];
+        NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" "-Wno-error=stringop-truncation" ];
 
-  dontUseCmakeConfigure = true;
+        # disable dvbscan, as having it enabled causes a network download which
+        # cannot happen during build.  We now include the dtv-scan-tables ourselves
+        configureFlags = [
+          "--disable-dvbscan"
+          "--disable-bintray_cache"
+          "--disable-ffmpeg_static"
+          "--disable-hdhomerun_client"
+          "--disable-hdhomerun_static"
+        ];
 
-  preConfigure = ''
-    patchShebangs ./configure
+        dontUseCmakeConfigure = true;
 
-    substituteInPlace src/config.c \
-      --replace /usr/bin/tar ${gnutar}/bin/tar
+        preConfigure = ''
+          patchShebangs ./configure
 
-    substituteInPlace src/input/mpegts/scanfile.c \
-      --replace /usr/share/dvb ${dtv-scan-tables}/dvbv5
+          substituteInPlace src/config.c \
+            --replace /usr/bin/tar ${gnutar}/bin/tar
 
-    # the version detection script `support/version` reads this file if it
-    # exists, so let's just use that
-    echo ${version} > rpm/version
-  '';
+          substituteInPlace src/input/mpegts/scanfile.c \
+            --replace /usr/share/dvb ${dtv-scan-tables}/dvbv5
 
-  postInstall = ''
-    wrapProgram $out/bin/tvheadend \
-      --prefix PATH : ${lib.makeBinPath [ bzip2 ]}
-  '';
+          # the version detection script `support/version` reads this file if it
+          # exists, so let's just use that
+          echo ${version} > rpm/version
+        '';
 
-  meta = with lib; {
-    description = "TV streaming server";
-    longDescription = ''
-        Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android
-        supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV, SAT>IP and HDHomeRun as input sources.
-        Tvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP streaming.'';
-    homepage = "https://tvheadend.org";
-    license = licenses.gpl3;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ simonvandel ];
-  };
-}
+        postInstall = ''
+          wrapProgram $out/bin/tvheadend \
+            --prefix PATH : ${lib.makeBinPath [ bzip2 ]}
+        '';
+
+        meta = with lib; {
+          description = "TV streaming server";
+          longDescription = ''
+              Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android
+              supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV, SAT>IP and HDHomeRun as input sources.
+              Tvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP streaming.'';
+          homepage = "https://tvheadend.org";
+          license = licenses.gpl3;
+          platforms = platforms.unix;
+          maintainers = with maintainers; [ simonvandel melias122 ];
+        };
+      };
+in
+lib.mapAttrs common versions

--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -20,12 +20,12 @@ let
     let
       dtv-scan-tables = stdenv.mkDerivation {
         pname = "dtv-scan-tables";
-        version = "2020-05-18";
+        version = "2022-03-14";
         src = fetchFromGitHub {
           owner = "tvheadend";
           repo = "dtv-scan-tables";
-          rev = "e3138a506a064f6dfd0639d69f383e8e576609da";
-          sha256 = "19ac9ds3rfc2xrqcywsbd1iwcpv7vmql7gp01iikxkzcgm2g2b6w";
+          rev = "1cbadfff235047ff255730da0cebeea225602461";
+          sha256 = "11nlqpmp5vin3i8y30zniq3ysf4ny5gjbr2rwcjnyva5vxyjmzxv";
         };
         nativeBuildInputs = [ v4l-utils ];
         installFlags = [ "DATADIR=$(out)" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34471,7 +34471,9 @@ with pkgs;
 
   tvbrowser-bin = callPackage ../applications/misc/tvbrowser/bin.nix { };
 
-  tvheadend = callPackage ../servers/tvheadend { };
+  inherit (callPackages ../servers/tvheadend {})
+    tvheadend
+    tvheadend-latest;
 
   ums = callPackage ../servers/ums { };
 


### PR DESCRIPTION
###### Description of changes

This commit is inspired by/copy of matomo/default.nix. It also updates
dtv-scan-tables to latest commit.

###### Things done
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
