### PR TITLE
grafana: add update-script, (no-op) update 8.4.5 -> 8.4.6

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -66,7 +66,10 @@ buildGoModule rec {
     cp ./conf/defaults.ini $out/share/grafana/conf/
   '';
 
-  passthru.tests = { inherit (nixosTests) grafana; };
+  passthru = {
+    tests = { inherit (nixosTests) grafana; };
+    updateScript = ./update.sh;
+  };
 
   meta = with lib; {
     description = "Gorgeous metric viz, dashboards & editors for Graphite, InfluxDB & OpenTSDB";

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "grafana";
-  version = "8.4.5";
+  version = "8.4.6";
 
   excludedPackages = [ "alert_webhook_listener" "clean-swagger" "release_publisher" "slow_proxy" "slow_proxy_mac" "macaron" ];
 
@@ -10,12 +10,12 @@ buildGoModule rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "sha256-CdGg979c7XD5V3jZbVeHUGylAarGc+cR+bFi5FngKtU=";
+    sha256 = "sha256-BXAvsHP6bDMrSk5jMCJmvrS1w/d+Mmym+OMCqO2YozY=";
   };
 
   srcStatic = fetchurl {
     url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "sha256-PjDTEmzjDmT1WQGqF3GwojJ6mG2whBoPK0KWfXI8AB4=";
+    sha256 = "1af0277kb2msjqjv2kxajpxia4q4y2bslf009fx13h2c0grv8j7f";
   };
 
   vendorSha256 = "sha256-iOJEy7dCZGRTaOuL/09wcMlNDHjRi9SIr9bialdcKi4=";

--- a/pkgs/servers/monitoring/grafana/update.sh
+++ b/pkgs/servers/monitoring/grafana/update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts jq nix nix-prefetch-scripts moreutils
+
+set -euxo pipefail
+
+FILE="$(nix-instantiate --eval -E 'with import ./. {}; (builtins.unsafeGetAttrPos "version" grafana).file' | tr -d '"')"
+replaceHash() {
+  old="${1?old hash missing}"
+  new="${2?new hash missing}"
+  awk -v OLD="$old" -v NEW="$new" '{
+    if (i=index($0, OLD)) {
+      $0 = substr($0, 1, i-1) NEW substr($0, i+length(OLD));
+    }
+    print $0;
+  }' "$FILE" | sponge "$FILE"
+}
+extractVendorHash() {
+  original="${1?original hash missing}"
+  result="$(nix-build -A grafana.go-modules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+  [ -z "$result" ] && { echo "$original"; } || { echo "$result"; }
+}
+
+oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion grafana" | tr -d '"')"
+latest="$(curl https://api.github.com/repos/grafana/grafana/releases/latest | jq '.tag_name' -r | tr -d 'v')"
+
+targetVersion="${1:-$latest}"
+if [ ! "${oldVersion}" = "${targetVersion}" ]; then
+  update-source-version grafana "${targetVersion#v}"
+  oldStaticHash="$(nix-instantiate --eval -A grafana.srcStatic.outputHash | tr -d '"')"
+  newStaticHash="$(nix-prefetch-url "https://dl.grafana.com/oss/release/grafana-${targetVersion#v}.linux-amd64.tar.gz")"
+  replaceHash "$oldStaticHash" "$newStaticHash"
+  goHash="$(nix-instantiate --eval -A grafana.vendorSha256 | tr -d '"')"
+  emptyHash="$(nix-instantiate --eval -A lib.fakeSha256 | tr -d '"')"
+  replaceHash "$goHash" "$emptyHash"
+  replaceHash "$emptyHash" "$(extractVendorHash "$goHash")"
+  nix-build -A grafana
+else
+  echo "grafana is already up-to-date"
+fi


### PR DESCRIPTION
###### Description of changes

Adds an update script because I'm too lazy to always update three hashes manually when updating the package.

The update to 8.4.6 is just a no-op, but I did it to test the script :-) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
