### PR TITLE
nearcore: init at 1.25.0

### DIFF
--- a/pkgs/applications/blockchains/nearcore/default.nix
+++ b/pkgs/applications/blockchains/nearcore/default.nix
@@ -1,0 +1,42 @@
+{ rustPlatform, lib, fetchFromGitHub
+, zlib, elfutils, openssl
+, cmake, python3, pkg-config, protobuf, perl, llvmPackages
+}:
+rustPlatform.buildRustPackage rec {
+  #https://github.com/near/nearcore
+  pname = "nearcore";
+  version = "1.25.0";
+  src = fetchFromGitHub {
+    owner = "near";
+    repo = "nearcore";
+    # there is also a branch for this version number, so we need to be explicit
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-7hiBqJLGIf+kNKJvMQ7KtGZm/SWLY3pT7YDlwbm3HDM=";
+  };
+
+  cargoSha256 = "sha256-EGv4CibSHL9oTAdWK7d/SOzZWPcEB16hTWlWHjKU4wc=";
+
+  # don't build SDK samples that require wasm-enabled rust
+  cargoBuildFlags = [ "-p" "neard" ];
+  doCheck = false; # needs network
+
+  buildInputs = [ zlib elfutils openssl ];
+  nativeBuildInputs = [
+    cmake
+    python3
+    pkg-config
+    protobuf
+    perl
+  ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion llvmPackages.clang}/include";
+
+  meta = with lib; {
+    description = "Reference client for NEAR Protocol";
+    homepage = "https://github.com/near/nearcore";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8154,6 +8154,8 @@ with pkgs;
 
   ndppd = callPackage ../applications/networking/ndppd { };
 
+  nearcore = callPackage ../applications/blockchains/nearcore { };
+
   nebula = callPackage ../tools/networking/nebula { };
 
   nemiver = callPackage ../development/tools/nemiver { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
