### PR TITLE
tomlc99: init at 0.pre+date=2022-04-04; tomlcpp: init at 0.pre+date=2022-05-01

### DIFF
--- a/pkgs/development/libraries/tomlc99/default.nix
+++ b/pkgs/development/libraries/tomlc99/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tomlc99";
+  version = "0.pre+date=2022-04-04";
+
+  src = fetchFromGitHub {
+    owner = "cktan";
+    repo = pname;
+    rev = "4e7b082ccc44316f212597ae5b09a35cf9329e69";
+    hash = "sha256-R9OBMG/aUa80Qw/zqaks63F9ybQcThfOYRsHP4t1Gv8=";
+  };
+
+  dontConfigure = true;
+
+  installFlags = [
+    "prefix=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cktan/tomlc99";
+    description = "TOML v1.0.0-compliant library written in C99";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/development/libraries/tomlcpp/0001-missing-headers.diff
+++ b/pkgs/development/libraries/tomlcpp/0001-missing-headers.diff
@@ -1,0 +1,15 @@
+diff -Naur old-source/tomlcpp.hpp new-source/tomlcpp.hpp
+--- tomlcpp/tomlcpp.hpp	1969-12-31 21:00:01.000000000 -0300
++++ tomlcpp/tomlcpp.hpp	2022-04-14 12:50:14.269775437 -0300
+@@ -25,6 +25,11 @@
+ #ifndef TOML_HPP
+ #define TOML_HPP
+ 
++#include <memory>
++#include <string>
++#include <utility>
++#include <vector>
++
+ struct toml_table_t;
+ struct toml_array_t;
+ 

--- a/pkgs/development/libraries/tomlcpp/default.nix
+++ b/pkgs/development/libraries/tomlcpp/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tomlcpp";
+  version = "0.pre+date=2022-05-01";
+
+  src = fetchFromGitHub {
+    owner = "cktan";
+    repo = pname;
+    rev = "59fcc6dc89fb3f4130a2865e41e1fa5b8c502e45";
+    hash = "sha256-Uc6R5KnGIZXY0EJgFM4Xi7Jtxcu6l8yGh5xgFZPoJDM=";
+  };
+
+  patches = [
+    # Self-explaining
+    ./0001-missing-headers.diff
+  ];
+
+  dontConfigure = true;
+
+  installFlags = [
+    "prefix=${placeholder "out"}"
+  ];
+
+  meta = with lib;{
+    homepage = "https://github.com/cktan/tomlcpp";
+    description = "No fanfare TOML C++ Library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20478,6 +20478,8 @@ with pkgs;
 
   kyotocabinet = callPackage ../development/libraries/kyotocabinet { };
 
+  tomlc99 = callPackage ../development/libraries/tomlc99 { };
+
   tokyocabinet = callPackage ../development/libraries/tokyo-cabinet { };
 
   tokyotyrant = callPackage ../development/libraries/tokyo-tyrant { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20480,6 +20480,8 @@ with pkgs;
 
   tomlc99 = callPackage ../development/libraries/tomlc99 { };
 
+  tomlcpp = callPackage ../development/libraries/tomlcpp { };
+
   tokyocabinet = callPackage ../development/libraries/tokyo-cabinet { };
 
   tokyotyrant = callPackage ../development/libraries/tokyo-tyrant { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
