### PR TITLE
Init bloomrpc at 1.5.3

### DIFF
--- a/pkgs/tools/networking/bloomrpc/default.nix
+++ b/pkgs/tools/networking/bloomrpc/default.nix
@@ -1,0 +1,49 @@
+with import <nixpkgs>{};
+
+let
+  version = "1.5.3";
+  pname = "bloomrpc";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/bloomrpc/bloomrpc/releases/download/1.5.3/BloomRPC-${version}.AppImage";
+    sha256 = "9fba03507d78342b9eb045bed256864bb5bfa1247d3374dd396d66b996fa5f2b";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  profile = ''
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  extraPkgs = pkgs: with pkgs; [
+    gsettings-desktop-schemas
+  ];
+
+  extraInstallCommands = ''
+    mv $out/bin/{${name},${pname}}
+    install -m 444 -D ${appimageContents}/bloomrpc.desktop $out/share/applications/bloomrpc.desktop
+    install -m 444 -D ${appimageContents}/bloomrpc.png $out/share/icons/hicolor/512x512/apps/bloomrpc.png
+    substituteInPlace $out/share/applications/bloomrpc.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "The missing GUI Client for GRPC services.";
+    longDescription = ''
+      Inspired by Postman and GraphQL Playground
+      BloomRPC aims to provide the simplest and most efficient developer experience for exploring and querying your GRPC services.
+
+      Install the client, select your protobuf files and start making requests!
+      No extra steps or configuration needed.'';
+    homepage = "https://github.com/bloomrpc/bloomrpc";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mwdomino ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35010,3 +35010,4 @@ with pkgs;
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
 
   bloomrpc = callPackage ../tools/networking/bloomrpc { };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35008,4 +35008,5 @@ with pkgs;
   honeytail = callPackage ../servers/tracing/honeycomb/honeytail { };
 
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
-}
+
+  bloomrpc = callPackage ../tools/networking/bloomrpc { };


### PR DESCRIPTION
###### Description of changes

This includes a new package `bloomrpc`, a GUI for sending gRPC requests
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
