### PR TITLE
SIL fonts

### DIFF
--- a/pkgs/data/fonts/annapurna-sil/default.nix
+++ b/pkgs/data/fonts/annapurna-sil/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchzip }:
+
+let
+  version = "1.204";
+in
+  fetchzip rec {
+    name = "annapurna-sil-${version}";
+
+    url = "https://software.sil.org/downloads/r/annapurna/AnnapurnaSIL-${version}.zip";
+
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+
+    sha256 = "sha256-kVeP9ZX8H+Wn6jzmH1UQvUKY6vJjadMTdEusS7LodFM=";
+
+    meta = with lib; {
+      homepage = "https://software.sil.org/annapurna";
+      description = "Unicode-based font family with broad support for writing systems that use the Devanagari script";
+      longDescription = ''
+        Annapurna SIL is a Unicode-based font family with broad support for writing systems that use the Devanagari script. Inspired by traditional calligraphic forms, the design is intended to be highly readable, reasonably compact, and visually attractive.
+      '';
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.kmein ];
+    };
+  }

--- a/pkgs/data/fonts/ezra-sil/default.nix
+++ b/pkgs/data/fonts/ezra-sil/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchzip }:
+
+let
+  version = "2.51";
+in
+  fetchzip rec {
+    name = "ezra-sil-${version}";
+
+    url = "https://software.sil.org/downloads/r/ezra/EzraSIL-${version}.zip";
+
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+
+    sha256 = "sha256-1LGw/RPFeNtEvcBWFWZf8+dABvWye2RfZ/jt8rwQewM=";
+
+    meta = with lib; {
+      homepage = "https://software.sil.org/ezra";
+      description = "Typeface fashioned after the square letter forms of the typography of the Biblia Hebraica Stuttgartensia (BHS)";
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.kmein ];
+    };
+  }

--- a/pkgs/data/fonts/galatia-sil/default.nix
+++ b/pkgs/data/fonts/galatia-sil/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchzip }:
+
+let
+  version = "2.1";
+in
+  fetchzip rec {
+    name = "galatia-sil-${version}";
+
+    url = "https://software.sil.org/downloads/r/galatia/GalatiaSIL-${version}.zip";
+
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+
+    sha256 = "sha256-zLL/7LMcJul2LilhEafpvm+tiYlgv1y1jj85VvG+wiI=";
+
+    meta = with lib; {
+      homepage = "https://software.sil.org/galatia";
+      description = "Font designed to support Biblical Polytonic Greek";
+      longDescription = ''
+        Galatia SIL, designed to support Biblical Polytonic Greek, is a Unicode 3.1 font released under the SIL Open Font License. The font supports precomposed characters rather than decomposed characters. Thus, you must use a keyboard that outputs NFC encoding (precomposed).
+      '';
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.kmein ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23829,6 +23829,8 @@ with pkgs;
 
   g15daemon = callPackage ../os-specific/linux/g15daemon {};
 
+  galatia-sil = callPackage ../data/fonts/galatia-sil { };
+
   gentium = callPackage ../data/fonts/gentium {};
 
   gentium-book-basic = callPackage ../data/fonts/gentium-book-basic {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23802,6 +23802,8 @@ with pkgs;
 
   execline-man-pages = skawarePackages.execline-man-pages;
 
+  ezra-sil = callPackage ../data/fonts/ezra-sil { };
+
   fantasque-sans-mono = callPackage ../data/fonts/fantasque-sans-mono {};
 
   fira = callPackage ../data/fonts/fira { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23588,6 +23588,8 @@ with pkgs;
   ankacoder = callPackage ../data/fonts/ankacoder { };
   ankacoder-condensed = callPackage ../data/fonts/ankacoder/condensed.nix { };
 
+  annapurna-sil = callPackage ../data/fonts/annapurna-sil { };
+
   anonymousPro = callPackage ../data/fonts/anonymous-pro { };
 
   ant-theme = callPackage ../data/themes/ant-theme/ant.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
