### PR TITLE
testVersion: when there is a error show the whole error

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -810,7 +810,11 @@ rec {
       command ? "${package.meta.mainProgram or package.pname or package.name} --version",
       version ? package.version,
     }: runCommand "${package.name}-test-version" { nativeBuildInputs = [ package ]; meta.timeout = 60; } ''
-      ${command} |& grep -Fw ${version}
-      touch $out
+      if output=$(${command} 2>&1); then
+        grep -Fw "${version}" - <<< "$output"
+        touch $out
+      else
+        echo "$output" >&2 && exit 1
+      fi
     '';
 }


### PR DESCRIPTION
before

$ nix build ".#whipper.tests.version"
whipper>   File "/nix/store/2iiyy58pmm1ys6dy8ycbmmmfm67iakv1-whipper-0.10.0/bin/.whipper-wrapped", line 6, in <module>
whipper>   File "/nix/store/2iiyy58pmm1ys6dy8ycbmmmfm67iakv1-whipper-0.10.0/lib/python3.9/site-packages/whipper/__init__.py", line 5, in <module>
note: keeping build directory '/tmp/nix-build-whipper-0.10.0-test-version.drv-7'

after
$ nix build ".#whipper.tests.version"
whipper> Traceback (most recent call last):
whipper>   File "/nix/store/2iiyy58pmm1ys6dy8ycbmmmfm67iakv1-whipper-0.10.0/bin/.whipper-wrapped", line 6, in <module>
whipper>     from whipper.command.main import main
whipper>   File "/nix/store/2iiyy58pmm1ys6dy8ycbmmmfm67iakv1-whipper-0.10.0/lib/python3.9/site-packages/whipper/__init__.py", line 5, in <module>
whipper>     from pkg_resources import (get_distribution,
whipper> ModuleNotFoundError: No module named 'pkg_resources'
note: keeping build directory '/tmp/nix-build-whipper-0.10.0-test-version.drv-34'
error: builder for '/nix/store/5lxjicdhwgmjcz9ddlxgq3s3gyaa6lz4-whipper-0.10.0-test-version.drv' failed with exit code 1;

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
