### PR TITLE
gfs-fonts: init at unstable-2022-04-14

### DIFF
--- a/pkgs/data/fonts/gfs-fonts/default.nix
+++ b/pkgs/data/fonts/gfs-fonts/default.nix
@@ -1,0 +1,53 @@
+{
+  fetchzip,
+  symlinkJoin,
+  lib,
+}: let
+  gfs-font = name: sha256:
+    fetchzip {
+      inherit name sha256;
+      url = "http://www.greekfontsociety-gfs.gr/_assets/fonts/${name}.zip";
+      postFetch = ''
+        mkdir -p $out/share/fonts
+        unzip -j -o $downloadedFile "*.otf" -d $out/share/fonts/opentype
+        unzip -j -o $downloadedFile "**/*.otf" -d $out/share/fonts/opentype
+      '';
+    };
+  version = "unstable-2022-04-14";
+in
+  symlinkJoin {
+    name = "gfs-fonts-${version}";
+
+    paths = lib.mapAttrsToList gfs-font {
+      GFS_Artemisia = "1q39086pr2jhv118fjfv6l1li6japv4pdjnhh1scqw06mqrmydf4";
+      GFS_Baskerville = "07gx5b9b43zv74d2lay37sajd4ba2wqn3b7xzvyhn265ds9x7cxk";
+      GFS_Bodoni = "0jhl0728ikzha1krm01sk52nz3jzibidwmyvgidg61d87l8nbf2p";
+      GFS_Bodoni_Classic = "06jw2irskn75s50mgwkx08rzwqi82gpc6lgjsimsi8p81566gfrh";
+      GFS_Complutum = "1q7dxs2z3yrgchd2pz9h72mjrk62kdc2mmqw8kg9q76k28f8n3p0"; # -> GFSPolyglot.otf
+      GFS_Decker = "016v1j5n9ph4i2cpmlk26pcxhp3q2fjwlaryppd5akl84dfkpncl";
+      GFS_Didot = "0ysvrp527wm0wxfp6wmlgmxfx7ysr5mwpmjmqp1h605cy44jblfm";
+      GFS_Didot_Classic = "0n5awqksvday3l3d85yhwmbmfj9bcpxivy4wpd4zrkgl7b85af2c";
+      GFS_Didot_Display = "0n2di2zyc76w6f8mc6hfilc2ir6igks7ldjp9fkw1gjp06330fi7";
+      GFS_Elpis = "02l7wd3nbn1kpv7ghxh19k4dbvd49ijyxd6gq83gcr9vlmxcq2s2";
+      GFS_Gazis = "0x9iwj6pinaykrds0iw6552hf256d0dr41sipdb1jnnlr2d3bf9w";
+      GFS_Goschen = "1jvbn33wzq2yj0aygwy9pd2msg3wkmdp0npjzazadrmfjpnpkcy9";
+      GFS_NeoHellenic = "1ixm2frdc6i5lbn9h0h4gdsvsw2k4hny75q8ig4kgs28ac3dbzq3";
+      GFS_Olga = "1qaxaw3ngnbr1gb1xyk5f2z647zklg6sl3bqwi28l47j9mp0f8aj";
+      GFS_Orpheus = "18n6fag4pyr8jdwnsz0vixf47jz4ym8mjmppc1w3k7v27cg1z9dz";
+      GFS_Orpheus_Classic = "1rqy1kf7slw56zfhbv264yzarjisnqbqydj4f7hghiknhnmdakps";
+      GFS_Orpheus_Sans = "02rh7z8c3h3xyfi52rn47z4finizx636d05bg5g23v0l0mqs6nkg";
+      GFS_Philostratos = "0zh3d0cn6b2fjbwnvmg379z20zh7w626w2bnj19xcazjvqkwhzx1";
+      GFS_Porson = "0c2axagkm6wxv8na2q11k6c5dmgkwx5hn9sh9qy82gbips9blnda";
+      GFS_Pyrsos = "0y0dv7y3n01bbhhnczflx1zcc7by56cffmr2xqixj2rd1nvchx0j";
+      GFS_Solomos = "1mpx9mw566awvfjdfx5sbz3wz5gbnjjw56gz30mk1lw06vxf0dxz";
+      GFS_Theokritos = "0haasx819x8c8yvna6pqywgi4060av2570jm34cddnz1fgnhv1b8";
+    };
+
+    meta = with lib; {
+      homepage = "http://www.greekfontsociety-gfs.gr";
+      descriptions = "Fonts by the Greek Font Society (GFS)";
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.kmein ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23833,6 +23833,8 @@ with pkgs;
 
   geolite-legacy = callPackage ../data/misc/geolite-legacy { };
 
+  gfs-fonts = callPackage ../data/fonts/gfs-fonts {};
+
   gohufont = callPackage ../data/fonts/gohufont
     { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
