### PR TITLE
minecraft-servers: init snapshot at 22w15a

### DIFF
--- a/pkgs/games/minecraft-servers/versions.json
+++ b/pkgs/games/minecraft-servers/versions.json
@@ -100,5 +100,11 @@
     "sha1": "d8321edc9470e56b8ad5c67bbd16beba25843336",
     "version": "1.2.5",
     "javaVersion": null
+  },
+  "snapshot": {
+    "url": "https://launcher.mojang.com/v1/objects/2760f745a00711bcc19bf78d6056019f69318d03/server.jar",
+    "sha1": "2760f745a00711bcc19bf78d6056019f69318d03",
+    "version": "22w15a",
+    "javaVersion": 17
   }
 }

--- a/pkgs/games/minecraft-servers/versions.json
+++ b/pkgs/games/minecraft-servers/versions.json
@@ -81,25 +81,25 @@
     "url": "https://launcher.mojang.com/v1/objects/f9ae3f651319151ce99a0bfad6b34fa16eb6775f/server.jar",
     "sha1": "f9ae3f651319151ce99a0bfad6b34fa16eb6775f",
     "version": "1.5.2",
-    "javaVersion": null
+    "javaVersion": 8
   },
   "1.4": {
     "url": "https://launcher.mojang.com/v1/objects/2f0ec8efddd2f2c674c77be9ddb370b727dec676/server.jar",
     "sha1": "2f0ec8efddd2f2c674c77be9ddb370b727dec676",
     "version": "1.4.7",
-    "javaVersion": null
+    "javaVersion": 8
   },
   "1.3": {
     "url": "https://launcher.mojang.com/v1/objects/3de2ae6c488135596e073a9589842800c9f53bfe/server.jar",
     "sha1": "3de2ae6c488135596e073a9589842800c9f53bfe",
     "version": "1.3.2",
-    "javaVersion": null
+    "javaVersion": 8
   },
   "1.2": {
     "url": "https://launcher.mojang.com/v1/objects/d8321edc9470e56b8ad5c67bbd16beba25843336/server.jar",
     "sha1": "d8321edc9470e56b8ad5c67bbd16beba25843336",
     "version": "1.2.5",
-    "javaVersion": null
+    "javaVersion": 8
   },
   "snapshot": {
     "url": "https://launcher.mojang.com/v1/objects/2760f745a00711bcc19bf78d6056019f69318d03/server.jar",


### PR DESCRIPTION
###### Description of changes

Add the latest snapshot version (at the time of update.py execution) of minecraft server to minecraft-servers.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

