### PR TITLE
mruby: add patch for CVE-2022-1212

### DIFF
--- a/pkgs/development/compilers/mruby/default.nix
+++ b/pkgs/development/compilers/mruby/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, ruby, bison, rake, fetchFromGitHub }:
+{ lib, stdenv, ruby, bison, rake, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "mruby";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev     = version;
     sha256  = "sha256-C3K7ZooaOMa+V2HjxwiKxrrMb7ffl4QAgPsftRtb60c=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-1212.patch";
+      url = "https://github.com/mruby/mruby/commit/3cf291f72224715942beaf8553e42ba8891ab3c6.patch";
+      sha256  = "1bl8wm6v7v18zgxqvm4kbn8g97a75phzrdah279xqw1qvplbd2w7";
+    })
+  ];
 
   nativeBuildInputs = [ ruby bison rake ];
 


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-1212

Tested provided poc, checked the patch resolves it.

As far as the other vulnerabilities in #168676 go, it looks like 3.0.0 is not vulnerable to them:

 - The fix for CVE-2022-1106 basically reverts a couple of lines to the state they were in in 3.0.0. Checked poc doesn't trigger asan.
 - The troublesome dereference in CVE-2022-1201 doesn't exist in 3.0.0. Checked poc doesn't produce a segfault.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
