### PR TITLE
keylight-controller-mschneider82: init 0.1.0

### DIFF
--- a/pkgs/applications/misc/keylight-controller-mschneider82/default.nix
+++ b/pkgs/applications/misc/keylight-controller-mschneider82/default.nix
@@ -1,0 +1,53 @@
+{ buildGoModule, fetchFromGitHub, lib, libGL, nssmdns, pkg-config, xorg }:
+
+buildGoModule rec {
+  pname = "keylight-controller-mschneider82";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mschneider82";
+    repo = "keylight-control";
+    rev = "v${version}";
+    sha256 = "sha256-UZfbGihCgFBQE1oExuzCexoNgpVGwNoA9orjZ9fh4gA=";
+  };
+
+  vendorSha256 = "sha256-nFttVJbEAAGsrAglMphuw0wJ2Kf8sWB4HrpVqfHO76o=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libGL
+    nssmdns
+  ] ++ (with xorg; [
+    libX11
+    libX11.dev
+    libXcursor
+    libXext
+    libXi
+    libXinerama
+    libXrandr
+    libXxf86vm
+    xinput
+  ]);
+
+  meta = with lib; {
+    description = "A desktop application to control Elgato Keylights";
+    longDescription = ''
+      Requires having:
+      * Elgato's Keylight paired to local wifi network.
+      * Service avahi with nssmdns enabled.
+    '';
+    license = licenses.mit;
+    homepage = "https://github.com/mschneider82/keylight-control";
+    maintainers = with maintainers; [ superherointj ];
+  };
+}
+
+# Note: Application errors on first executions but works on re-runs.
+
+# Troubleshooting
+# 1. Keylight lists at: `avahi-browse --all --resolve --ignore-local`
+# 2. Ping Keylight's IP
+# 3. Resolve Keylight's hostname: `getent hosts elgato-key-light-XXXX.local`

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26584,6 +26584,8 @@ with pkgs;
 
   jackline = callPackage ../applications/networking/instant-messengers/jackline { };
 
+  keylight-controller-mschneider82 = callPackage ../applications/misc/keylight-controller-mschneider82 { };
+
   leftwm = callPackage ../applications/window-managers/leftwm { };
 
   levant = callPackage ../applications/networking/cluster/levant { };


### PR DESCRIPTION
keylight-controller-mschneider82: init 0.1.0

[Controller for Elgato Keylights](https://github.com/mschneider82/keylight-control)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
