### PR TITLE
python3Packages.pytorch: migrate to cudaPackages

### DIFF
--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -42,6 +42,11 @@ stdenv.mkDerivation  rec {
     sed -i 's:FC="gfortran":FC=${gfortran}/bin/gfortran:' $out/bin/mpifort
   '';
 
+  passthru = {
+    cudaSupport = ch4backend.cudaSupport or false;
+    cudaPackages = ch4backend.cudaPackages or { };
+  };
+
   meta = with lib; {
     description = "Implementation of the Message Passing Interface (MPI) standard";
 

--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -72,5 +72,8 @@ in stdenv.mkDerivation {
     maintainers = with maintainers; [ tbenst ];
   };
 
-  passthru.cudatoolkit = cudatoolkit;
+  passthru = {
+    # TODO: leave just cudaPackages
+    inherit cudatoolkit cudaPackages;
+  };
 }

--- a/pkgs/development/libraries/ucx/default.nix
+++ b/pkgs/development/libraries/ucx/default.nix
@@ -1,10 +1,13 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, doxygen
 , numactl, rdma-core, libbfd, libiberty, perl, zlib, symlinkJoin
 , enableCuda ? false
-, cudatoolkit
+, cudaPackages
 }:
 
 let
+  # TODO: use the redistributable cuda packages instead
+  inherit (cudaPackages) cudatoolkit;
+
   # Needed for configure to find all libraries
   cudatoolkit' = symlinkJoin {
     inherit (cudatoolkit) name meta;
@@ -42,6 +45,11 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optional enableCuda "--with-cuda=${cudatoolkit'}";
 
   enableParallelBuilding = true;
+
+  passthru = {
+    cudaSupport = enableCuda;
+    inherit cudaPackages;
+  };
 
   meta = with lib; {
     description = "Unified Communication X library";

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -54,7 +54,7 @@ let
   inherit (cudaPackages.cudatoolkit) cc;
 
   cudatoolkit_joined = symlinkJoin {
-    name = "cudatoolkit-root";
+    name = "cudatoolkit-root-${cudaPackages.cudaVersion}";
 
     # The list of required cuda redist packages can be found e.g.
     # at https://github.com/pytorch/pytorch/blob/b09769992f83f94150eaef2ab9d03c37b36da159/cmake/Summary.cmake#L85

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -74,8 +74,8 @@ let
       libcusolver
       libcusparse
       libcurand
-      nccl.dev
-      nccl.out
+      (lib.getDev nccl)
+      nccl
     ];
 
     # ld is going to look for static archives (e.g. libcudart_static.a) in lib64

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -68,7 +68,7 @@ let
       cuda_cccl # <thrust/*>
       cuda_nvprof # <cuda_profiler_api.h>
       cuda_nvrtc
-      cuda_cudart
+      cuda_cudart # cuda_runtime.h
       libcublas
       libcufft
       libcusolver

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -54,7 +54,7 @@ let
   inherit (cudaPackages.cudatoolkit) cc;
 
   cudatoolkit_joined = symlinkJoin {
-    name = "cudatoolkit-root-${cudaPackages.cudaVersion}";
+    name = "cuda-redist-${cudaPackages.cudaVersion}";
 
     # The list of required cuda redist packages can be found e.g.
     # at https://github.com/pytorch/pytorch/blob/b09769992f83f94150eaef2ab9d03c37b36da159/cmake/Summary.cmake#L85
@@ -74,6 +74,7 @@ let
       libcusolver
       libcusparse
       libcurand
+      cuda_cupti
       (lib.getDev nccl)
       nccl
     ];

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -37,8 +37,9 @@ in
 assert cudaSupport -> (let majorIs = cudaPackages.cudaMajorVersion;
                         in majorIs == "9" || majorIs == "10" || majorIs == "11");
 
-# confirm that cudatoolkits are sync'd across dependencies
-# TODO: verify it's OK to equality-compare cudaPackages (which are attrsets, scopes, or whatever)
+# We expect referential equality of all cudaPackages used to ensure consistency
+# You can make an overlay and pass the same cudaPackages to pytorch, mpi, and magma
+# TODO: `==` is an implementation detail; move comparison logic to cudaPackages
 assert (MPISupport && cudaSupport) -> mpi.cudaPackages == cudaPackages;
 assert cudaSupport -> (magma.cudaPackages == cudaPackages);
 


### PR DESCRIPTION
Use the redistributable cuda packages, instead of runfile-based
cudatoolkit

~~Build log: https://gist.github.com/SomeoneSerge/4e5b5e9d9ee82c410eebad60d0cdc8f7~~

~~All went awry, it used cudatoolkit through cudnn. Reworking~~

EDIT later on 2022-04-15: Now it actually builds with cuda-redist! Rebased on the cudnn PR with removed propagatedBuildInputs, adjusted, and pushed

CC @NixOS/cuda-maintainers 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
