### PR TITLE
kotatogram-desktop: update tg_owt, fix build on Darwin & screensharing on Wayland

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/kotato-10.12-sdk.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/kotato-10.12-sdk.patch
@@ -1,8 +1,8 @@
 diff --git a/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm b/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm
-index 337055443..09604b117 100644
+index 9e9a1744b..ae55f873f 100644
 --- a/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm
 +++ b/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm
-@@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+@@ -14,6 +14,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
  
  #include <Cocoa/Cocoa.h>
  #include <CoreFoundation/CFURL.h>
@@ -11,10 +11,10 @@ index 337055443..09604b117 100644
  namespace Platform {
  namespace {
 diff --git a/Telegram/SourceFiles/platform/mac/specific_mac.mm b/Telegram/SourceFiles/platform/mac/specific_mac.mm
-index 3b4395ae3..7f8ee401f 100644
+index 1d68457bb..ac8c4e0ab 100644
 --- a/Telegram/SourceFiles/platform/mac/specific_mac.mm
 +++ b/Telegram/SourceFiles/platform/mac/specific_mac.mm
-@@ -119,6 +119,7 @@ PermissionStatus GetPermissionStatus(PermissionType type) {
+@@ -118,6 +118,7 @@ PermissionStatus GetPermissionStatus(PermissionType type) {
  	switch (type) {
  	case PermissionType::Microphone:
  	case PermissionType::Camera:
@@ -22,7 +22,7 @@ index 3b4395ae3..7f8ee401f 100644
  		const auto nativeType = (type == PermissionType::Microphone)
  			? AVMediaTypeAudio
  			: AVMediaTypeVideo;
-@@ -133,6 +134,7 @@ PermissionStatus GetPermissionStatus(PermissionType type) {
+@@ -132,6 +133,7 @@ PermissionStatus GetPermissionStatus(PermissionType type) {
  					return PermissionStatus::Denied;
  			}
  		}
@@ -30,7 +30,7 @@ index 3b4395ae3..7f8ee401f 100644
  		break;
  	}
  	return PermissionStatus::Granted;
-@@ -142,6 +144,7 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
+@@ -141,6 +143,7 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
  	switch (type) {
  	case PermissionType::Microphone:
  	case PermissionType::Camera:
@@ -38,7 +38,7 @@ index 3b4395ae3..7f8ee401f 100644
  		const auto nativeType = (type == PermissionType::Microphone)
  			? AVMediaTypeAudio
  			: AVMediaTypeVideo;
-@@ -152,6 +155,7 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
+@@ -151,6 +154,7 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
  				});
  			}];
  		}
@@ -217,7 +217,7 @@ index 464f87c9c..9a008c75e 100644
  	controller:(not_null<Window::Controller*>)controller
 Submodule Telegram/ThirdParty/tgcalls contains modified content
 diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm
-index 8a4417b..2d9794e 100644
+index b280c1b..a1ed0d2 100644
 --- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm
 +++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm
 @@ -71,7 +71,7 @@
@@ -239,10 +239,10 @@ index 8a4417b..2d9794e 100644
      if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
        return [[TGRTCVideoDecoderH265 alloc] init];
 diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm
-index 2901417..ac9ec2a 100644
+index 9960607..f3659b3 100644
 --- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm
 +++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm
-@@ -76,7 +76,7 @@
+@@ -89,7 +89,7 @@
        [result addObject:h265Info];
      }
    }
@@ -251,7 +251,7 @@ index 2901417..ac9ec2a 100644
    if (@available(macOS 10.13, *)) {
      if ([[AVAssetExportSession allExportPresets] containsObject:AVAssetExportPresetHEVCHighestQuality]) {
        [result addObject:h265Info];
-@@ -112,7 +112,7 @@
+@@ -129,7 +129,7 @@
        return [[TGRTCVideoEncoderH265 alloc] initWithCodecInfo:info];
      }
    }
@@ -261,7 +261,7 @@ index 2901417..ac9ec2a 100644
      if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
        return [[TGRTCVideoEncoderH265 alloc] initWithCodecInfo:info];
 diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm
-index de92427..9a5b20d 100644
+index bf99063..b717645 100644
 --- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm
 +++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm
 @@ -507,8 +507,7 @@ static tgcalls::DarwinVideoTrackSource *getObjCVideoSource(const rtc::scoped_ref
@@ -274,11 +274,20 @@ index de92427..9a5b20d 100644
    RTCLogError(@"Dropped sample buffer. Reason: %@", droppedReason);
  }
  
+@@ -682,7 +681,7 @@ static tgcalls::DarwinVideoTrackSource *getObjCVideoSource(const rtc::scoped_ref
+             int closest = -1;
+             CMTime result;
+             for (int i = 0; i < format.videoSupportedFrameRateRanges.count; i++) {
+-                const auto rateRange = format.videoSupportedFrameRateRanges[i];
++                const AVFrameRateRange *rateRange = format.videoSupportedFrameRateRanges[i];
+                 int gap = abs(rateRange.minFrameRate - target);
+                 if (gap <= closest || closest == -1) {
+                     closest = gap;
 diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm
-index bcabcf7..de7b6c7 100644
+index 4ef8630..3fc753c 100644
 --- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm
 +++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm
-@@ -245,9 +245,11 @@ private:
+@@ -243,9 +243,11 @@ private:
      layer.framebufferOnly = true;
      layer.opaque = false;
  //    layer.cornerRadius = 4;
@@ -290,7 +299,7 @@ index bcabcf7..de7b6c7 100644
  //    layer.presentsWithTransaction = YES;
      layer.backgroundColor = [NSColor clearColor].CGColor;
      layer.contentsGravity = kCAGravityResizeAspectFill;
-@@ -334,9 +336,7 @@ private:
+@@ -332,9 +334,7 @@ private:
  - (RTCVideoRotation)rtcFrameRotation {
      if (_rotationOverride) {
          RTCVideoRotation rotation;
@@ -323,10 +332,10 @@ index 5491702..32befc6 100644
  }
  
 diff --git a/Telegram/lib_base/base/platform/mac/base_info_mac.mm b/Telegram/lib_base/base/platform/mac/base_info_mac.mm
-index 29e368f..ea1f65f 100644
+index f1f259a..6629eb6 100644
 --- a/Telegram/lib_base/base/platform/mac/base_info_mac.mm
 +++ b/Telegram/lib_base/base/platform/mac/base_info_mac.mm
-@@ -203,16 +203,20 @@ void Finish() {
+@@ -226,16 +226,20 @@ void Finish() {
  }
  
  void OpenInputMonitoringPrivacySettings() {
@@ -348,10 +357,10 @@ index 29e368f..ea1f65f 100644
  }
  
 diff --git a/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm b/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm
-index c86ac77..b081162 100644
+index 6102705..8981239 100644
 --- a/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm
 +++ b/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm
-@@ -271,6 +271,7 @@ void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
+@@ -277,6 +277,7 @@ void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
  	if (thumbnail.isNull()) {
  		return;
  	}
@@ -359,7 +368,7 @@ index c86ac77..b081162 100644
  	if (@available(macOS 10.13.2, *)) {
  		const auto copy = thumbnail;
  		[_private->info
-@@ -284,6 +285,7 @@ void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
+@@ -290,6 +291,7 @@ void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
  			forKey:MPMediaItemPropertyArtwork];
  		updateDisplay();
  	}
@@ -367,7 +376,7 @@ index c86ac77..b081162 100644
  }
  
  void SystemMediaControls::setDuration(int duration) {
-@@ -302,10 +304,12 @@ void SystemMediaControls::setVolume(float64 volume) {
+@@ -308,10 +310,12 @@ void SystemMediaControls::setVolume(float64 volume) {
  }
  
  void SystemMediaControls::clearThumbnail() {
@@ -380,7 +389,7 @@ index c86ac77..b081162 100644
  }
  
  void SystemMediaControls::clearMetadata() {
-@@ -367,9 +371,11 @@ bool SystemMediaControls::volumeSupported() const {
+@@ -373,9 +377,11 @@ bool SystemMediaControls::volumeSupported() const {
  }
  
  bool SystemMediaControls::Supported() {

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt-10.12-sdk.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt-10.12-sdk.patch
@@ -1,3 +1,16 @@
+diff --git a/src/rtc_base/async_resolver.cc b/src/rtc_base/async_resolver.cc
+index ad1598f2..fe9c3832 100644
+--- a/src/rtc_base/async_resolver.cc
++++ b/src/rtc_base/async_resolver.cc
+@@ -57,7 +57,7 @@ void GlobalGcdRunTask(void* context) {
+ 
+ // Post a task into the system-defined global concurrent queue.
+ void PostTaskToGlobalQueue(std::unique_ptr<webrtc::QueuedTask> task) {
+-  dispatch_queue_global_t global_queue =
++  dispatch_queue_t global_queue =
+       dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+   webrtc::QueuedTask* context = task.release();
+   dispatch_async_f(global_queue, context, &GlobalGcdRunTask);
 diff --git a/src/rtc_base/system/gcd_helpers.m b/src/rtc_base/system/gcd_helpers.m
 index fd9a361f..3a63be6d 100644
 --- a/src/rtc_base/system/gcd_helpers.m
@@ -13,10 +26,10 @@ index fd9a361f..3a63be6d 100644
    dispatch_set_target_queue(queue, target);
    return queue;
 diff --git a/src/sdk/objc/components/video_codec/nalu_rewriter.cc b/src/sdk/objc/components/video_codec/nalu_rewriter.cc
-index 61c1e7d6..b19f3f91 100644
+index 1121c921..f21926b0 100644
 --- a/src/sdk/objc/components/video_codec/nalu_rewriter.cc
 +++ b/src/sdk/objc/components/video_codec/nalu_rewriter.cc
-@@ -245,10 +245,7 @@ bool H265CMSampleBufferToAnnexBBuffer(
+@@ -242,10 +242,7 @@ bool H265CMSampleBufferToAnnexBBuffer(
    int nalu_header_size = 0;
    size_t param_set_count = 0;
    OSStatus status = noErr;
@@ -28,7 +41,7 @@ index 61c1e7d6..b19f3f91 100644
      RTC_LOG(LS_ERROR) << "Not supported.";
      return false;
    }
-@@ -271,10 +268,7 @@ bool H265CMSampleBufferToAnnexBBuffer(
+@@ -268,10 +265,7 @@ bool H265CMSampleBufferToAnnexBBuffer(
      size_t param_set_size = 0;
      const uint8_t* param_set = nullptr;
      for (size_t i = 0; i < param_set_count; ++i) {
@@ -40,7 +53,7 @@ index 61c1e7d6..b19f3f91 100644
          RTC_LOG(LS_ERROR) << "Not supported.";
          return false;
        }
-@@ -514,11 +508,7 @@ CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
+@@ -501,11 +495,7 @@ CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
    // Parse the SPS and PPS into a CMVideoFormatDescription.
    CMVideoFormatDescriptionRef description = nullptr;
    OSStatus status = noErr;

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -26,7 +26,6 @@
 , pipewire
 , mesa
 , libglvnd
-, libepoxy
 , Cocoa
 , AppKit
 , IOKit
@@ -46,13 +45,13 @@
 
 stdenv.mkDerivation {
   pname = "tg_owt";
-  version = "unstable-2022-02-26";
+  version = "unstable-2022-04-13";
 
   src = fetchFromGitHub {
     owner = "desktop-app";
     repo = "tg_owt";
-    rev = "a264028ec71d9096e0aa629113c49c25db89d260";
-    sha256 = "sha256-JR+M+4w0QsQLfIunZ/7W+5Knn+gX+RR3DBrpOz7q44I=";
+    rev = "63a934db1ed212ebf8aaaa20f0010dd7b0d7b396";
+    sha256 = "sha256-WddSsQ9KW1zYyYckzdUOvfFZArYAbyvXmABQNMtK6cM=";
     fetchSubmodules = true;
   };
 
@@ -87,7 +86,6 @@ stdenv.mkDerivation {
     glib
     pipewire
     mesa
-    libepoxy
     libglvnd
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -25,7 +25,8 @@
 , abseil-cpp
 , pipewire
 , mesa
-, libglvnd
+, libdrm
+, libGL
 , Cocoa
 , AppKit
 , IOKit
@@ -60,6 +61,17 @@ stdenv.mkDerivation {
     ./tg_owt-10.12-sdk.patch
   ];
 
+  postPatch = lib.optionalString stdenv.isLinux ''
+    substituteInPlace src/modules/desktop_capture/linux/egl_dmabuf.cc \
+      --replace '"libEGL.so.1"' '"${libGL}/lib/libEGL.so.1"'
+    substituteInPlace src/modules/desktop_capture/linux/egl_dmabuf.cc \
+      --replace '"libGL.so.1"' '"${libGL}/lib/libGL.so.1"'
+    substituteInPlace src/modules/desktop_capture/linux/egl_dmabuf.cc \
+      --replace '"libgbm.so.1"' '"${mesa}/lib/libgbm.so.1"'
+    substituteInPlace src/modules/desktop_capture/linux/egl_dmabuf.cc \
+      --replace '"libdrm.so.2"' '"${libdrm}/lib/libdrm.so.2"'
+  '';
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkg-config cmake ninja yasm ];
@@ -86,7 +98,8 @@ stdenv.mkDerivation {
     glib
     pipewire
     mesa
-    libglvnd
+    libdrm
+    libGL
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa
     AppKit

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27082,13 +27082,13 @@ with pkgs;
 
     # C++20 is required, darwin has Clang 7 by default, aarch64 has gcc 9 by default
     stdenv = if stdenv.isDarwin
-      then llvmPackages_12.libcxxStdenv
+      then clang12Stdenv
       else if stdenv.isAarch64 then gcc10Stdenv else stdenv;
 
     # tdesktop has random crashes when jemalloc is built with gcc.
     # Apparently, it triggers some bug due to usage of gcc's builtin
     # functions like __builtin_ffsl by jemalloc when it's built with gcc.
-    jemalloc = (jemalloc.override { stdenv = llvmPackages.stdenv; }).overrideAttrs(_: {
+    jemalloc = (jemalloc.override { stdenv = clangStdenv; }).overrideAttrs(_: {
       # no idea how to fix the tests :(
       doCheck = false;
     });


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (with GH actions)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (only on Linux though)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
