### PR TITLE
cudaPackages.cudnn: migrate to redist cuda, fix missing zlib

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/extension.nix
+++ b/pkgs/development/libraries/science/math/cudnn/extension.nix
@@ -5,7 +5,11 @@ final: prev: let
 
   ### CuDNN
 
-  buildCuDnnPackage = args: callPackage ./generic.nix {} args;
+  buildCuDnnPackage = args:
+    let
+      useCudatoolkitRunfile = lib.versionOlder cudaVersion "11.3.999";
+    in
+    callPackage ./generic.nix { inherit useCudatoolkitRunfile; } args;
 
   toUnderscore = str: lib.replaceStrings ["."] ["_"] str;
 

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, zlib
 , cudaPackages
 , fetchurl
 , addOpenGLRunpath
@@ -49,7 +50,7 @@ in stdenv.mkDerivation {
 
     function fixRunPath {
       p=$(patchelf --print-rpath $1)
-      patchelf --set-rpath "''${p:+$p:}${lib.makeLibraryPath [ cc.cc libcublas ]}:\$ORIGIN/" $1
+      patchelf --set-rpath "''${p:+$p:}${lib.makeLibraryPath [ cc.cc libcublas zlib ]}:\$ORIGIN/" $1
     }
 
     for sofile in {lib,lib64}/lib*.so; do

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -42,7 +42,8 @@ let
     else libcublas;
 in
 stdenv.mkDerivation {
-  name = "cudatoolkit-${cudaMajorVersion}-cudnn-${version}";
+  pname = "cudatoolkit-${cudaMajorVersion}-cudnn";
+  inherit version;
 
   src = fetchurl {
     inherit url hash sha256;

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -81,13 +81,6 @@ in stdenv.mkDerivation {
     done
   '';
 
-  propagatedBuildInputs = [
-    # FIXME: we can and should decouple cudnn from runfile-based cudatoolkit
-    # ...leaving this in propagated inputs just to avoid breaking downstream
-    # derivations right now
-    cudaPackages.cudatoolkit
-  ];
-
   passthru = {
     cudatoolkit = lib.warn "cudnn.cudatoolkit passthru attribute is deprecated: use cudaPackages" cudaPackages.cudatoolkit;
     inherit cudaPackages;

--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
     eigen
   ] ++ lib.optionals (enableGPU && enableCuda) [
     cudaPackages.cudnn
+    cudaPackages.cudatoolkit
     mesa.drivers
   ] ++ lib.optionals (enableGPU && !enableCuda) [
     opencl-headers


### PR DESCRIPTION
###### Description of changes

- [x] Removes cudnn's dependency on (runfile-based) `cudatoolkit`, except for temporarily keeping it in `propagatedBuildInputs`
- [x] Adds a `checkPhase` that compares `Runpath` against `DT_NEEDED` via `ldd`
  - [x] Try and replace it with `autoPatchelfHook`?
- [x] Adds missing zlib dependency to `Runpath`

The mentioned missing dependency leads to runtime errors when evaluating jit-traced models in cuda-enabled pytorch

CC @NixOS/cuda-maintainers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
