### PR TITLE
nixos/ncdns: listen on IPv6 by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -506,6 +506,13 @@
       </listitem>
       <listitem>
         <para>
+          In the ncdns module, the default value of
+          <literal>services.ncdns.address</literal> has been changed to
+          the IPv6 loopback address (<literal>::1</literal>).
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>openssh</literal> has been update to 8.9p1, changing
           the FIDO security key middleware interface.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -160,6 +160,8 @@ In addition to numerous new and upgraded packages, this release has the followin
       (`services.pdns-recursor.dns.address`, `services.pdns-recursor.dns.allowFrom`);
     - allow only local connections to the REST API server (`services.pdns-recursor.api.allowFrom`).
 
+- In the ncdns module, the default value of `services.ncdns.address` has been changed to the IPv6 loopback address (`::1`).
+
 - `openssh` has been update to 8.9p1, changing the FIDO security key middleware interface.
 
 - `services.k3s.enable` no longer implies `systemd.enableUnifiedCgroupHierarchy = false`, and will default to the 'systemd' cgroup driver when using `services.k3s.docker = true`.

--- a/nixos/modules/services/networking/ncdns.nix
+++ b/nixos/modules/services/networking/ncdns.nix
@@ -58,7 +58,7 @@ in
 
       address = mkOption {
         type = types.str;
-        default = "127.0.0.1";
+        default = "[::1]";
         description = ''
           The IP address the ncdns resolver will bind to.  Leave this unchanged
           if you do not wish to directly expose the resolver.
@@ -202,7 +202,7 @@ in
   config = mkIf cfg.enable {
 
     services.pdns-recursor = mkIf cfgs.pdns-recursor.resolveNamecoin {
-      forwardZonesRecurse.bit = "127.0.0.1:${toString cfg.port}";
+      forwardZonesRecurse.bit = "${cfg.address}:${toString cfg.port}";
       luaConfig =
         if cfg.dnssec.enable
           then ''readTrustAnchorsFromFile("${cfg.dnssec.keys.public}")''

--- a/nixos/tests/ncdns.nix
+++ b/nixos/tests/ncdns.nix
@@ -29,10 +29,10 @@ in
   };
 
   nodes.server = { ... }: {
-    networking.nameservers = [ "127.0.0.1" ];
+    networking.nameservers = [ "::1" ];
 
     services.namecoind.rpc = {
-      address = "127.0.0.1";
+      address = "::1";
       user = "namecoin";
       password = "secret";
       port = 8332;
@@ -45,7 +45,7 @@ in
       script = ''
         while true; do
           echo -e "HTTP/1.1 200 OK\n\n $(<${fakeReply})\n" \
-            | ${pkgs.netcat}/bin/nc -N -l 127.0.0.1 8332
+            | ${pkgs.netcat}/bin/nc -N -l ::1 8332
         done
       '';
     };
@@ -58,14 +58,10 @@ in
       identity.address    = "1.0.0.1";
     };
 
-    services.pdns-recursor = {
-      enable = true;
-      dns.allowFrom = [ "127.0.0.0/8" ];
-      resolveNamecoin = true;
-    };
+    services.pdns-recursor.enable = true;
+    services.pdns-recursor.resolveNamecoin = true;
 
     environment.systemPackages = [ pkgs.dnsutils ];
-
   };
 
   testScript =
@@ -91,6 +87,7 @@ in
           assert "example.com" in server.succeed("dig SOA @localhost -p 5333 bit")
 
       with subtest("bit. zone forwarding works"):
+          server.wait_for_unit("pdns-recursor")
           assert "1.2.3.4" in server.succeed("host test.bit")
     '';
 })


### PR DESCRIPTION
###### Description of changes

One small step towards deprecating IPv4

###### Things done

- [x] Tested `nixosTests.ncdns`
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
