### PR TITLE
`lib.types.submoduleWith`: Avoid `_key` collisions after `extendModules` (issue #168767)

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -113,6 +113,10 @@ rec {
                   args ? {}
                 , # This would be remove in the future, Prefer _module.check option instead.
                   check ? true
+                  # Internal variable to avoid `_key` collisions regardless
+                  # of `extendModules`. Used in `submoduleWith`.
+                  # Test case: lib/tests/modules, "168767"
+                , extensionOffset ? 0
                 }:
     let
       withWarnings = x:
@@ -338,15 +342,17 @@ rec {
         modules ? [],
         specialArgs ? {},
         prefix ? [],
+        extensionOffset ? length modules,
         }:
           evalModules (evalModulesArgs // {
             modules = regularModules ++ modules;
             specialArgs = evalModulesArgs.specialArgs or {} // specialArgs;
             prefix = extendArgs.prefix or evalModulesArgs.prefix;
+            inherit extensionOffset;
           });
 
       type = lib.types.submoduleWith {
-        inherit modules specialArgs;
+        inherit modules specialArgs extensionOffset;
       };
 
       result = withWarnings {

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -293,7 +293,7 @@ checkConfigOutput '^"a c"$' config.result ./functionTo/merging-attrs.nix
 
 # moduleType
 checkConfigOutput '^"a b"$' config.resultFoo ./declare-variants.nix ./define-variant.nix
-checkConfigOutput '^"a y z"$' config.resultFooBar ./declare-variants.nix ./define-variant.nix
+checkConfigOutput '^"a b y z"$' config.resultFooBar ./declare-variants.nix ./define-variant.nix
 checkConfigOutput '^"a b c"$' config.resultFooFoo ./declare-variants.nix ./define-variant.nix
 
 ## emptyValue's
@@ -326,6 +326,10 @@ checkConfigError 'The option .theOption.nested. in .other.nix. is already declar
 
 # Test that types.optionType leaves types untouched as long as they don't need to be merged
 checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survives-type-merge.nix
+
+# Anonymous submodules don't get nixed by import resolution/deduplication
+# because of an `extendModules` bug, issue 168767.
+checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/extendModules-168767-imports.nix
+++ b/lib/tests/modules/extendModules-168767-imports.nix
@@ -1,0 +1,41 @@
+{ lib
+, extendModules
+, ...
+}:
+with lib;
+{
+  imports = [
+
+    {
+      options.sub = mkOption {
+        default = { };
+        type = types.submodule (
+          { config
+          , extendModules
+          , ...
+          }:
+          {
+            options.value = mkOption {
+              type = types.int;
+            };
+
+            options.specialisation = mkOption {
+              default = { };
+              inherit
+                (extendModules {
+                  modules = [{
+                    specialisation = mkOverride 0 { };
+                  }];
+                })
+                type;
+            };
+          }
+        );
+      };
+    }
+
+    { config.sub.value = 1; }
+
+
+  ];
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -568,6 +568,11 @@ rec {
       { modules
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false
+
+        # Internal variable to avoid `_key` collisions regardless
+        # of `extendModules`. Wired through by `evalModules`.
+        # Test case: lib/tests/modules, "168767"
+      , extensionOffset ? 0
       }@attrs:
       let
         inherit (lib.modules) evalModules;
@@ -579,11 +584,11 @@ rec {
         allModules = defs: imap1 (n: { value, file }:
           if isFunction value
           then setFunctionArgs
-                (args: lib.modules.unifyModuleSyntax file "${toString file}-${toString n}" (value args))
+                (args: lib.modules.unifyModuleSyntax file "${toString file}-${toString (n + extensionOffset)}" (value args))
                 (functionArgs value)
           else if isAttrs value
           then
-            lib.modules.unifyModuleSyntax file "${toString file}-${toString n}" (shorthandToModule value)
+            lib.modules.unifyModuleSyntax file "${toString file}-${toString (n + extensionOffset)}" (shorthandToModule value)
           else value
         ) defs;
 
@@ -620,6 +625,7 @@ rec {
           (base.extendModules {
             modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
             prefix = loc;
+            extensionOffset = extensionOffset + length defs;
           }).config;
         emptyValue = { value = {}; };
         getSubOptions = prefix: (base.extendModules


### PR DESCRIPTION
This fixes module key collisions induced by extendModules
when using anonymous modules.

TODO
 - [x] clean up
 - [x] ~consider more elegant solution, like calling unifyModuleSyntax in evalModules instead of in submoduleWith~
    - too big a change to evalModules semantics

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
