### PR TITLE
python3Packages.grip: 4.5.2 -> 4.6.1

### DIFF
--- a/pkgs/development/python-modules/grip/default.nix
+++ b/pkgs/development/python-modules/grip/default.nix
@@ -1,45 +1,41 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 # Python bits:
 , buildPythonPackage
 , pytest
 , responses
+, flake8
 , docopt
 , flask
 , markdown
 , path-and-address
 , pygments
 , requests
-, tabulate
+, werkzeug
 }:
 
 buildPythonPackage rec {
   pname = "grip";
-  version = "4.5.2";
+  version = "4.6.1";
 
   src = fetchFromGitHub {
     owner = "joeyespo";
     repo = "grip";
     rev = "v${version}";
-    sha256 = "0hphplnyi903jx7ghfxplg1qlj2kpcav1frr2js7p45pbh5ib9rm";
+    sha256 = "0vhimd99zw7s1fihwr6yfij6ywahv9gdrfcf5qljvzh75mvzcwh8";
   };
 
-  patches = [
-    # Render "front matter", used in our RFC template and elsewhere
-    (fetchpatch {
-      url = "https://github.com/joeyespo/grip/pull/249.patch";
-      sha256 = "07za5iymfv647dfrvi6hhj54a96hgjyarys51zbi08c51shqyzpg";
-    })
-  ];
+  checkInputs = [ pytest responses flake8 ];
 
-  checkInputs = [ pytest responses ];
-
-  propagatedBuildInputs = [ docopt flask markdown path-and-address pygments requests tabulate ];
+  propagatedBuildInputs = [ docopt flask markdown path-and-address pygments requests werkzeug ];
 
   checkPhase = ''
-      export PATH="$PATH:$out/bin"
-      py.test -xm "not assumption"
+    runHook preCheck
+
+    export PATH="$PATH:$out/bin"
+    py.test -xm "not assumption"
+
+    runHook postCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

I have removed the patch we were applying since it does not work anymore, and I don't think we should change behavior from upstream and even the PR author closed it: https://github.com/joeyespo/grip/pull/249#issuecomment-513524843

Ping @dtzWill who added the patch in case he still uses it.  

Changelog: 
- https://github.com/joeyespo/grip/blob/3c3f852703933bc716afdcd9151c2ec5787b0940/CHANGES.md#version-461-2022-03-30

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
