### PR TITLE
eva: 0.2.7 -> 0.3.0

### DIFF
--- a/pkgs/tools/misc/eva/default.nix
+++ b/pkgs/tools/misc/eva/default.nix
@@ -1,29 +1,17 @@
-{ lib, rustPlatform, fetchCrate, fetchpatch }:
+{ lib, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
   pname = "eva";
-  version = "0.2.7";
+  version = "0.3.0";
 
-  src = fetchCrate {
-    inherit pname version;
-    sha256 = "sha256-4rmFvu6G4h8Pl592NlldSCkqZBbnTcXrs98ljIJmTXo=";
+  src = fetchFromGitHub {
+    owner = "nerdypepper";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-INXKjjHW9HZ1NWx1CQOerTBUy0rYFLNJMuRgKQfQwdc=";
   };
 
-  cargoSha256 = "sha256-BG/W8lG/47kyA7assS6efEO+DRkpSFcZQhlSIozlonA=";
-
-  patches = [
-    # to fix the test suite (can be removed as soon as #33 is merged).
-    (fetchpatch {
-      url = "https://github.com/NerdyPepper/eva/commit/cacf51dbb9748b1dbe97b35f3c593a0a272bd4db.patch";
-      sha256 = "11q7dkz2x1888f3awnlr1nbbxzzfjrr46kd0kk6sgjdkyfh50cvv";
-    })
-
-    # to fix `cargo test -- --test-threads $NIX_BUILD_CORES`
-    (fetchpatch {
-      url = "https://github.com/NerdyPepper/eva/commit/ccfb3d327567dbaf03b2283c7e684477e2e84590.patch";
-      sha256 = "003yxqlyi8jna0rf05q2a006r2pkz6pcwwfl3dv8zb6p83kk1kgj";
-    })
-  ];
+  cargoSha256 = "sha256-4l9y2qmS7G1PvxF8/51F7fx/sDuYHWDkcyOin2sYHdk=";
 
   meta = with lib; {
     description = "A calculator REPL, similar to bc";


### PR DESCRIPTION

###### Description of changes
Changes: https://github.com/nerdypepper/eva/compare/v0.2.7...v0.3.0

I ha to go back to using `fetchFromGitHub` because `0.3.0` is not
published on crates.io (cc @NerdyPepper).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
