### PR TITLE
[21.11] re2c: add patch for CVE-2022-23901

### DIFF
--- a/pkgs/development/tools/parsing/re2c/default.nix
+++ b/pkgs/development/tools/parsing/re2c/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , autoreconfHook
 , python3
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -15,6 +16,14 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "0snfxk1cf2f4dy4hcxd1fx1grav3di0qjgqqn97k85zsf9f6ys78";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-23901.patch";
+      url = "https://github.com/skvadrik/re2c/commit/a3473fd7be829cb33907cb08612f955133c70a96.patch";
+      sha256 = "1zf6fqgz4l2aggpk6y6ax038gniqd8zsdhwqfl57f45hs0cmfgv5";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-23901
#168687

This CVE scores 9.8, but honestly I find the likelihood of people using `re2c` on untrusted input to be fairly remote.

A second commit (https://github.com/skvadrik/re2c/commit/039c18949190c5de5397eba504d2c75dad2ea9ca) is indicated in the fix, though I omitted it as it doesn't apply cleanly to 2.2 and all it really does is bail earlier with a nicer error message in some scenarios.

Patch comes with new test covering issue. Existing tests pass. Built `ninja` and `spamassassin` with this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
