### PR TITLE
hw-probe: init at 1.6.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10948,6 +10948,12 @@
     githubId = 7226587;
     name = "Théophane Hufschmitt";
   };
+  rehno-lindeque = {
+    email = "rehno.lindeque+code@gmail.com";
+    github = "rehno-lindeque";
+    githubId = 337811;
+    name = "Rehno Lindeque";
+  };
   relrod = {
     email = "ricky@elrod.me";
     github = "relrod";

--- a/pkgs/tools/system/hw-probe/default.nix
+++ b/pkgs/tools/system/hw-probe/default.nix
@@ -1,0 +1,140 @@
+{ config
+, stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, makePerlPath
+
+# Perl libraries
+, LWP
+, LWPProtocolHttps
+, HTTPMessage
+, HTTPDate
+, URI
+, TryTiny
+
+# Required
+, coreutils
+, curl # Preferred to using the Perl HTTP libs - according to hw-probe.
+, dmidecode
+, edid-decode
+, gnugrep
+, gnutar
+, hwinfo
+, iproute2
+, kmod
+, pciutils
+, perl
+, smartmontools
+, usbutils
+, xz
+
+# Conditionally recommended
+, systemdSupport ? stdenv.isLinux
+, systemd
+
+# Recommended
+, withRecommended ? true # Install recommended tools
+, mcelog
+, hdparm
+, acpica-tools
+, drm_info
+, mesa-demos
+, memtester
+, sysstat
+, cpuid
+, util-linuxMinimal
+, xinput
+, libva-utils
+, inxi
+, vulkan-utils
+, i2c-tools
+, opensc
+
+# Suggested
+, withSuggested ? false # Install (most) suggested tools
+, hplip
+, sane-backends
+# , pnputils # pnputils (lspnp) isn't currently in nixpkgs and appears to be poorly maintained
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hw-probe";
+  version = "1.6.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxhw";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:028wnhrbn10lfxwmcpzdbz67ygldimv7z1k1bm64ggclykvg5aim";
+  };
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ perl ];
+
+  makeWrapperArgs =
+    let
+      requiredPrograms = [
+        hwinfo
+        dmidecode
+        smartmontools
+        pciutils
+        usbutils
+        edid-decode
+        iproute2 # (ip)
+        coreutils # (sort)
+        gnugrep
+        curl
+        gnutar
+        xz
+        kmod # (lsmod)
+      ];
+      recommendedPrograms = [
+        mcelog
+        hdparm
+        acpica-tools
+        drm_info
+        mesa-demos
+        memtester
+        sysstat # (iostat)
+        cpuid
+        util-linuxMinimal # (rfkill)
+        xinput
+        libva-utils # (vainfo)
+        inxi
+        vulkan-utils
+        i2c-tools
+        opensc
+      ];
+      conditionallyRecommendedPrograms = lib.optional systemdSupport systemd; # (systemd-analyze)
+      suggestedPrograms = [
+        hplip # (hp-probe)
+        sane-backends # (sane-find-scanner)
+        # pnputils # (lspnp)
+      ];
+      programs =
+        requiredPrograms
+        ++ conditionallyRecommendedPrograms
+        ++ lib.optionals withRecommended recommendedPrograms
+        ++ lib.optionals withSuggested suggestedPrograms;
+    in [
+      "--set" "PERL5LIB" "${makePerlPath [ LWP LWPProtocolHttps HTTPMessage URI HTTPDate TryTiny ]}"
+      "--prefix" "PATH" ":" "${lib.makeBinPath programs}"
+    ];
+
+  postInstall = ''
+    wrapProgram $out/bin/hw-probe \
+      $makeWrapperArgs
+  '';
+
+  meta = with lib; {
+    description = "Probe for hardware, check operability and find drivers";
+    homepage = "https://github.com/linuxhw/hw-probe";
+    platforms = with platforms; (linux ++ freebsd ++ netbsd ++ openbsd);
+    license = with licenses; [ lgpl21 bsdOriginal ];
+    maintainers = with maintainers; [ rehno-lindeque  ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7462,6 +7462,10 @@ with pkgs;
 
   hwinfo = callPackage ../tools/system/hwinfo { };
 
+  hw-probe = perlPackages.callPackage ../tools/system/hw-probe {
+    vulkan-utils = haskell.lib.compose.justStaticExecutables haskellPackages.vulkan-utils;
+  };
+
   hybridreverb2 = callPackage ../applications/audio/hybridreverb2 {
     stdenv = gcc8Stdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7462,9 +7462,7 @@ with pkgs;
 
   hwinfo = callPackage ../tools/system/hwinfo { };
 
-  hw-probe = perlPackages.callPackage ../tools/system/hw-probe {
-    vulkan-utils = haskell.lib.compose.justStaticExecutables haskellPackages.vulkan-utils;
-  };
+  hw-probe = perlPackages.callPackage ../tools/system/hw-probe { };
 
   hybridreverb2 = callPackage ../applications/audio/hybridreverb2 {
     stdenv = gcc8Stdenv;
@@ -21876,6 +21874,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
   };
   vulkan-tools-lunarg = callPackage ../tools/graphics/vulkan-tools-lunarg { };
+  vulkan-utils = haskell.lib.compose.justStaticExecutables haskellPackages.vulkan-utils;
   vulkan-validation-layers = callPackage ../development/tools/vulkan-validation-layers { };
 
   vxl = callPackage ../development/libraries/vxl { };


### PR DESCRIPTION
###### Description of changes

A tool to probe for hardware, check operability and find drivers with the help of Linux hardware database.

Results can be uploaded to the database used by https://linux-hardware.org/ (or https://bsd-hardware.info/)

hw-probe was previously [mentioned on /r/NixOS](https://www.reddit.com/r/NixOS/comments/ta7rov/list_of_tested_hardware_user_statistics_for_nixos/): People appear to use docker to run it on NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
