### PR TITLE
profile-sync-daemon-user: init at 4d067f2 and add package option to profile-sync-daemon

### DIFF
--- a/nixos/modules/services/desktops/profile-sync-daemon.nix
+++ b/nixos/modules/services/desktops/profile-sync-daemon.nix
@@ -13,6 +13,14 @@ in {
         Whether to enable the Profile Sync daemon.
       '';
     };
+    package = mkOption {
+      type = package;
+      default = pkgs.profile-sync-daemon;
+      example = literalExpression "pkgs.profile-sync-daemon-user";
+      description = ''
+        Profile Sync daemon package to use.
+      '';
+    };
     resyncTimer = mkOption {
       type = str;
       default = "1h";
@@ -36,15 +44,15 @@ in {
             description = "Profile Sync daemon";
             wants = [ "psd-resync.service" ];
             wantedBy = [ "default.target" ];
-            path = with pkgs; [ rsync kmod gawk nettools util-linux profile-sync-daemon ];
+            path = with pkgs; [ rsync kmod gawk nettools util-linux cfg.package ];
             unitConfig = {
               RequiresMountsFor = [ "/home/" ];
             };
             serviceConfig = {
               Type = "oneshot";
               RemainAfterExit = "yes";
-              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon sync";
-              ExecStop = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon unsync";
+              ExecStart = "${cfg.package}/bin/profile-sync-daemon sync";
+              ExecStop = "${cfg.package}/bin/profile-sync-daemon unsync";
             };
           };
 
@@ -58,7 +66,7 @@ in {
             path = with pkgs; [ rsync kmod gawk nettools util-linux profile-sync-daemon ];
             serviceConfig = {
               Type = "oneshot";
-              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon resync";
+              ExecStart = "${cfg.package}/bin/profile-sync-daemon resync";
             };
           };
         };

--- a/pkgs/tools/misc/profile-sync-daemon-user/default.nix
+++ b/pkgs/tools/misc/profile-sync-daemon-user/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitHub, util-linux, coreutils }:
+
+stdenv.mkDerivation rec {
+  name = "profile-sync-daemon-user";
+
+  src = fetchFromGitHub {
+    owner = "Xervon";
+    repo = "profile-sync-daemon";
+    rev = "4d067f2";
+    sha256 = "1nslw3qqg1m6cpfv08ijpz1hnlmsd8i75pqws6lr1hpjqllz3ad4";
+  };
+
+  installPhase = ''
+    PREFIX=\"\" DESTDIR=$out make install
+    substituteInPlace $out/bin/profile-sync-daemon \
+      --replace "/usr/" "$out/" \
+      --replace "sudo " "/run/wrappers/bin/sudo "
+    # $HOME detection fails (and is unnecessary)
+    sed -i '/^HOME/d' $out/bin/profile-sync-daemon
+    substituteInPlace $out/bin/psd-overlay-helper \
+      --replace "PATH=/usr/bin:/bin" "PATH=${util-linux.bin}/bin:${coreutils}/bin" \
+      --replace "sudo " "/run/wrappers/bin/sudo "
+  '';
+
+  meta = with lib; {
+    description = "Syncs browser profile dirs to RAM";
+    longDescription = ''
+      Profile-sync-daemon (psd) is a tiny pseudo-daemon designed to manage your
+      browser's profile in tmpfs and to periodically sync it back to your
+      physical disc (HDD/SSD). This is accomplished via a symlinking step and
+      an innovative use of rsync to maintain back-up and synchronization
+      between the two. One of the major design goals of psd is a completely
+      transparent user experience.
+    '';
+    homepage = "https://github.com/Xervon/profile-sync-daemon";
+    downloadPage = "https://github.com/Xervon/profile-sync-daemon/releases";
+    license = licenses.mit;
+    maintainers = [ maintainers.grburst ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9145,6 +9145,8 @@ with pkgs;
 
   profile-sync-daemon = callPackage ../tools/misc/profile-sync-daemon { };
 
+  profile-sync-daemon-user = callPackage ../tools/misc/profile-sync-daemon-user { };
+
   projectlibre = callPackage ../applications/misc/projectlibre {
     jre = jre8;
     jdk = jdk8;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
