### PR TITLE
networking.defaultGateway: add new option for preferred source address

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -151,7 +151,7 @@ let
                       "metric ${toString cfg.defaultGateway6.metric}"
                     } proto static
                   ''}
-                  ${optionalString (cfg.defaultGateway6.srcAddress != null) 
+                  ${optionalString (cfg.defaultGateway6.srcAddress != null)
                     "sleep 2s && "}ip -6 route replace default ${optionalString (cfg.defaultGateway6.metric != null)
                       "metric ${toString cfg.defaultGateway6.metric}"
                     } via "${cfg.defaultGateway6.address}" ${

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -140,7 +140,9 @@ let
                     optionalString (cfg.defaultGatewayWindowSize != null)
                       "window ${toString cfg.defaultGatewayWindowSize}"} ${
                     optionalString (cfg.defaultGateway.interface != null)
-                      "dev ${cfg.defaultGateway.interface}"} proto static
+                      "dev ${cfg.defaultGateway.interface}"} ${
+                    optionalString (cfg.defaultGateway.srcAddress != null)
+                      "src ${cfg.defaultGateway.srcAddress}"} proto static
                 ''}
                 ${optionalString (cfg.defaultGateway6 != null && cfg.defaultGateway6.address != "") ''
                   ${optionalString (cfg.defaultGateway6.interface != null) ''
@@ -154,7 +156,9 @@ let
                     optionalString (cfg.defaultGatewayWindowSize != null)
                       "window ${toString cfg.defaultGatewayWindowSize}"} ${
                     optionalString (cfg.defaultGateway6.interface != null)
-                      "dev ${cfg.defaultGateway6.interface}"} proto static
+                      "dev ${cfg.defaultGateway6.interface}"} ${
+                    optionalString (cfg.defaultGateway6.srcAddress != null)
+                      "src ${cfg.defaultGateway6.srcAddress}"} proto static
                 ''}
               '';
           };

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -144,13 +144,15 @@ let
                     optionalString (cfg.defaultGateway.srcAddress != null)
                       "src ${cfg.defaultGateway.srcAddress}"} proto static
                 ''}
+                # without 'sleep' we have 'Invalid source address' error
                 ${optionalString (cfg.defaultGateway6 != null && cfg.defaultGateway6.address != "") ''
                   ${optionalString (cfg.defaultGateway6.interface != null) ''
                     ip -6 route replace ${cfg.defaultGateway6.address} dev ${cfg.defaultGateway6.interface} ${optionalString (cfg.defaultGateway6.metric != null)
                       "metric ${toString cfg.defaultGateway6.metric}"
                     } proto static
                   ''}
-                  ip -6 route replace default ${optionalString (cfg.defaultGateway6.metric != null)
+                  ${optionalString (cfg.defaultGateway6.srcAddress != null) 
+                    "sleep 2s && "}ip -6 route replace default ${optionalString (cfg.defaultGateway6.metric != null)
                       "metric ${toString cfg.defaultGateway6.metric}"
                     } via "${cfg.defaultGateway6.address}" ${
                     optionalString (cfg.defaultGatewayWindowSize != null)

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -139,6 +139,16 @@ let
         description = "The default gateway metric/preference.";
       };
 
+      srcAddress= mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "1.1.1.1";
+        description = ''
+          If the interface has several ip addresses we can select by this option
+          which of them will be used as the source address for outgoing connections";
+        '';
+      };
+
     };
 
   };


### PR DESCRIPTION
###### Description of changes

This adds `srcAddress` option for cases when we have several ip addresses on a same interface and want to set one of them as preferable for outgoing connections. Works both for IPv4 and IPv6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
