### PR TITLE
python3Packages.pyvis: unstable-2021-04-29 -> 0.2.1

### DIFF
--- a/pkgs/development/python-modules/pyvis/default.nix
+++ b/pkgs/development/python-modules/pyvis/default.nix
@@ -6,25 +6,25 @@
 , jinja2
 , ipython
 , jsonpickle
-, numpy }:
+, numpy
+}:
 
 buildPythonPackage rec {
   pname = "pyvis";
-  version = "unstable-2021-04-29";
+  version = "0.2.1";
 
-  # We use unstable, as test are failing for 0.1.9
   src = fetchFromGitHub {
     owner = "WestHealth";
     repo = pname;
-    rev = "4c521302abf9725dcbe7f59962baf85360b2718d";
-    sha256 = "sha256-DYbHQpxtSfiLbzmBGclym/ChM0WLBzSEC/3phDTtGY8=";
+    rev = "v${version}";
+    sha256 = "sha256-cER5XYxnURzRLtrisWBu2kxtOiRqgaRTJYyaCMh2qqE=";
   };
 
   patches = [
-    # Remove when https://github.com/WestHealth/pyvis/pull/101 is merged.
+    # Fix test: https://github.com/WestHealth/pyvis/issues/138
     (fetchpatch {
-      url = "https://github.com/WestHealth/pyvis/commit/158a34de45f970b17ffd746c6e705b89128e2445.patch";
-      sha256 = "sha256-zK72nrnn5YLGNW6PKYUyHry5ORCdt1T1oH6n1X64DKg=";
+      url = "https://github.com/WestHealth/pyvis/commit/eaa24b882401e2e74353efa78bf4e71a880cfc47.patch";
+      sha256 = "sha256-hyDypavoCM36SiuQda1U4FLUPdAjTIMtaeZ0KqfHKzI=";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
