### PR TITLE
*: riscv fixes/changes

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -92,6 +92,8 @@ stdenv.mkDerivation rec {
 
   # propagation is needed for Security.framework to be available when linking
   propagatedBuildInputs = [ aws-crt-cpp ];
+  # Ensure the linker is using atomic when compiling for RISC-V, otherwise fails
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isRiscV "-latomic";
 
   cmakeFlags = [
     "-DBUILD_DEPS=OFF"

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -24,7 +24,8 @@ in stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DBuildTests=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DJSON_BuildTests=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DJSON_FastTests=ON"
     "-DJSON_MultipleHeaders=ON"
   ] ++ lib.optional finalAttrs.doCheck "-DJSON_TestDataDirectory=${testData}";
 

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -27,6 +27,7 @@ rec {
     pkgs_x86_64_linux = packageSet' { system = "x86_64-linux"; };
     pkgs_i686_linux = packageSet' { system = "i686-linux"; };
     pkgs_aarch64_linux = packageSet' { system = "aarch64-linux"; };
+    pkgs_riscv64_linux = packageSet' { system = "riscv64-linux"; };
     pkgs_aarch64_darwin = packageSet' { system = "aarch64-darwin"; };
     pkgs_armv6l_linux = packageSet' { system = "armv6l-linux"; };
     pkgs_armv7l_linux = packageSet' { system = "armv7l-linux"; };
@@ -40,6 +41,7 @@ rec {
       if system == "x86_64-linux" then pkgs_x86_64_linux
       else if system == "i686-linux" then pkgs_i686_linux
       else if system == "aarch64-linux" then pkgs_aarch64_linux
+      else if system == "riscv64-linux" then pkgs_riscv64_linux
       else if system == "aarch64-darwin" then pkgs_aarch64_darwin
       else if system == "armv6l-linux" then pkgs_armv6l_linux
       else if system == "armv7l-linux" then pkgs_armv7l_linux


### PR DESCRIPTION
###### Description of changes
Add support for the RISC-V StarFive VisionFive SoC.
Sections of this taken from https://github.com/zhaofengli/nixos-riscv64.

Current goal(s)
- Fix known upstream bugs in other issues/PRs

Past goal(s)
- Be able to build a basic NixOS system for riscv64-linux and have it run on VisionFive hardware

Past related issue(s)
- #168813
  - Fixed by #168303
- #168829
  - Fixed by #166992
- #169278
  - Fixed by #170991

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux cross to riscv64-linux
  - [ ] aarch64-linux
  - [ ] riscv64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
