### PR TITLE
[WIP] Properly order numeric sysctl settings

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -909,6 +909,15 @@ rec {
       inherit priority content;
     };
 
+  # The priority range from 801 to 899 is reserved for ordering of numbers.
+  # Nothing bad will happen if these priorities are used for other purposes as well.
+  # For example: boot.kernel.sysctl."net.core.rmem_max"
+  # Where higher numbers are supposed to "win" by having a lower priority,
+  # use this formula for calculating a good priority for a given number:
+  # 900-(log(number)-1)*10
+  # I chose this formula because it seems to give somewhat reasonable outputs for all values in Nixpkgs.
+  # If it doesn't fit, just make up your own priorities
+
   mkOptionDefault = mkOverride 1500; # priority of option defaults
   mkDefault = mkOverride 1000; # used in config sections of non-user modules to set a default
   mkImageMediaOverride = mkOverride 60; # image media profiles can be derived by inclusion into host config, hence needing to override host config, but do allow user to mkForce

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -210,7 +210,7 @@ in
     environment.variables.IPFS_PATH = cfg.dataDir;
 
     # https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size
-    boot.kernel.sysctl."net.core.rmem_max" = mkDefault 2500000;
+    boot.kernel.sysctl."net.core.rmem_max" = mkOverride 846 2500000;
 
     programs.fuse = mkIf cfg.autoMount {
       userAllowOther = true;

--- a/nixos/modules/services/networking/jitsi-videobridge.nix
+++ b/nixos/modules/services/networking/jitsi-videobridge.nix
@@ -270,8 +270,10 @@ in
 
     # (from videobridge2 .deb)
     # this sets the max, so that we can bump the JVB UDP single port buffer size.
-    boot.kernel.sysctl."net.core.rmem_max" = mkDefault 10485760;
-    boot.kernel.sysctl."net.core.netdev_max_backlog" = mkDefault 100000;
+    boot.kernel.sysctl = {
+      "net.core.rmem_max" = mkOverride 840 10485760;
+      "net.core.netdev_max_backlog" = mkOverride 860 100000;
+    };
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall
       [ jvbConfig.videobridge.ice.tcp.port ];

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -423,8 +423,8 @@ in
       # https://trac.transmissionbt.com/browser/trunk/libtransmission/tr-udp.c?rev=11956.
       # at least up to the values hardcoded here:
       (mkIf cfg.settings.utp-enabled {
-        "net.core.rmem_max" = mkDefault "4194304"; # 4MB
-        "net.core.wmem_max" = mkDefault "1048576"; # 1MB
+        "net.core.rmem_max" = mkOverride 844 "4194304"; # 4MB
+        "net.core.wmem_max" = mkOverride 850 "1048576"; # 1MB
       })
       (mkIf cfg.performanceNetParameters {
         # Increase the number of available source (local) TCP and UDP ports to 49151.


### PR DESCRIPTION
###### Description of changes
I'm marking this as a draft as I'd like to get some feedback first and I still need to add a commit message.
See https://github.com/NixOS/nixpkgs/pull/135850#issuecomment-907600197 for my motivation.
TLDR: enabling `services.transmission` and `services.ipfs` might cause `boot.kernel.sysctl."net.core.rmem_max"` to be set to the lower value of the two as both modules set it via `mkDefault` and it is not clearly defined, which module should win.
This PR makes the ordering explicit, so that the highest value always wins. At the moment the priorities need to be defined manually. Is it possible to use `mkOverride` with a floating point number? In that case it might be possible to automate this with a function that calculates the priorities with the formula I outlined in the comment. I can probably come up with a better function to use in that case.
Does the priority range 801 to 899 have some other uses?
Any other suggestions for improvements? Any objections?

Cc @happysalada

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).