### PR TITLE
hwi: 2.0.2 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/hwi/default.nix
+++ b/pkgs/development/python-modules/hwi/default.nix
@@ -2,45 +2,48 @@
 , buildPythonPackage
 , fetchFromGitHub
 , bitbox02
+, cbor
 , ecdsa
 , hidapi
 , libusb1
 , mnemonic
 , pyaes
+, pyserial
 , typing-extensions
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "hwi";
-  version = "2.0.2";
+  version = "2.1.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "HWI";
     rev = version;
-    sha256 = "sha256-s0pKYqesZjHE6YndqsMwCuqLK7eE82oRiSXxBdUtEX4=";
+    sha256 = "sha256-ih4k58OdH5taf/7fvqLeWLrMzR38uPpDSGE4KU8sEAk=";
   };
 
   propagatedBuildInputs = [
     bitbox02
+    cbor
     ecdsa
     hidapi
     libusb1
     mnemonic
     pyaes
+    pyserial
     typing-extensions
   ];
 
-  # make compatible with libusb1 2.x
+  # relax required dependencies:
+  # libusb1           - https://github.com/bitcoin-core/HWI/issues/579
+  # typing-extensions - https://github.com/bitcoin-core/HWI/issues/572
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'libusb1>=1.7,<2.0' 'libusb1>=1.7' \
-      --replace "'python_requires': '>=3.6,<3.10'," "'python_requires': '>=3.6,<4'," \
-      --replace 'typing-extensions>=3.7,<4.0' 'typing-extensions>=3.7'
+      --replace 'libusb1>=1.7,<3' 'libusb1>=1.7,<4' \
+      --replace 'typing-extensions>=3.7,<4.0' 'typing-extensions>=3.7,<5.0'
   '';
 
   # tests require to clone quite a few firmwares


### PR DESCRIPTION
###### Description of changes

- new version: https://github.com/bitcoin-core/HWI/releases/tag/2.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
