### PR TITLE
WIP testWaylandHeadless

### DIFF
--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -24,6 +24,9 @@
 , foot
 , llvmPackages
 , llvmPackages_latest
+# tests
+, testWaylandHeadless
+, sway
 }:
 
 let
@@ -198,6 +201,11 @@ stdenv.mkDerivation rec {
     stimulus-script-is-current = stimulusGenerator.src.overrideAttrs (_: {
       name = "generate-alt-random-writes-${version}.py";
     });
+
+    headless = testWaylandHeadless {
+      package = foot;
+      command = "foot -d error sh -c 'exit'";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -102,7 +102,7 @@ let
     import ../build-support/trivial-builders.nix {
       inherit lib;
       inherit (self) runtimeShell stdenv stdenvNoCC;
-      inherit (self.pkgsBuildHost) shellcheck;
+      inherit (self.pkgsBuildHost) shellcheck sway dbus makeFontsConf;
       inherit (self.pkgsBuildHost.xorg) lndir;
     };
 


### PR DESCRIPTION
i'll move these testing functions to a new file

currently works

```
$ nix build ".#foot.tests.headless"
foot> 00:00:00.000 [wlr] [render/wlr_renderer.c:322] drmGetDevices2 failed: No such file or directory
foot> 00:00:00.000 [wlr] [types/wlr_drm_lease_v1.c:705] No DRM backend supplied, failed tocreate wlr_drm_lease_v1_manager
foot> 00:00:00.000 [common/ipc-client.c:87] Unable to receive IPC response
*exit code 0*
```