### PR TITLE
nextcloud-client: build dolphin plugin, man pages, fix vfs support

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -28,6 +28,8 @@ mkDerivation rec {
   pname = "nextcloud-client";
   version = "3.4.4";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "nextcloud";
     repo = "desktop";

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -2,6 +2,7 @@
 , mkDerivation
 , fetchFromGitHub
 , cmake
+, extra-cmake-modules
 , inotify-tools
 , libcloudproviders
 , libsecret
@@ -15,6 +16,7 @@
 , qtwebsockets
 , qtquickcontrols2
 , qtgraphicaleffects
+, plasma5Packages
 , sqlite
 , inkscape
 , xdg-utils
@@ -40,6 +42,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     cmake
+    extra-cmake-modules
     inkscape
   ];
 
@@ -49,6 +52,7 @@ mkDerivation rec {
     libsecret
     openssl
     pcre
+    plasma5Packages.kio
     qtbase
     qtkeychain
     qttools

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -41,6 +41,13 @@ mkDerivation rec {
     ./0001-When-creating-the-autostart-entry-do-not-use-an-abso.patch
   ];
 
+  postPatch = ''
+    for file in src/libsync/vfs/*/CMakeLists.txt; do
+      substituteInPlace $file \
+        --replace "PLUGINDIR" "KDE_INSTALL_PLUGINDIR"
+    done
+  '';
+
   nativeBuildInputs = [
     pkg-config
     cmake

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , extra-cmake-modules
 , inotify-tools
+, installShellFiles
 , libcloudproviders
 , libsecret
 , openssl
@@ -17,6 +18,7 @@
 , qtquickcontrols2
 , qtgraphicaleffects
 , plasma5Packages
+, sphinx
 , sqlite
 , inkscape
 , xdg-utils
@@ -44,6 +46,7 @@ mkDerivation rec {
     cmake
     extra-cmake-modules
     inkscape
+    sphinx
   ];
 
   buildInputs = [
@@ -74,6 +77,10 @@ mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
     "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
   ];
+
+  postBuild = ''
+    make doc-man
+  '';
 
   meta = with lib; {
     description = "Nextcloud themed desktop client";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
