### PR TITLE
faucet: init at 1.10.3

### DIFF
--- a/pkgs/development/python-modules/beka/default.nix
+++ b/pkgs/development/python-modules/beka/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pbr
+, eventlet
+, pytest-cov
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "beka";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "faucetsdn";
+    repo = "beka";
+    rev = version;
+    sha256 = "sha256-rvZjeSmgTG2CxSPHhv1QFM6hVm77v6kIRQiW1TmNlJo=";
+  };
+
+  # We are installing from a tarball, so pbr will not be able to derive versioning.
+  PBR_VERSION = version;
+
+  propagatedBuildInputs = [
+    pbr
+    eventlet
+  ];
+
+  checkInputs = [ pytestCheckHook pytest-cov ];
+
+  meta = with lib; {
+    description = "Basic BGP speaker Python module, can send/receive unicast routes in IPv(4|6)";
+    homepage = "https://github.com/faucetsdn/beka";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/chewie/default.nix
+++ b/pkgs/development/python-modules/chewie/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pbr
+, eventlet
+, transitions
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "chewie";
+  version = "0.0.24";
+
+  src = fetchFromGitHub {
+    owner = "faucetsdn";
+    repo = "chewie";
+    rev = version;
+    sha256 = "sha256-ppv72wA2LvbnrJNRuOA7eZMqXjrZx4nbP+Gn02IwL9U=";
+  };
+
+  # We are installing from a tarball, so pbr will not be able to derive versioning.
+  PBR_VERSION = version;
+
+  propagatedBuildInputs = [
+    pbr
+    eventlet
+    transitions
+  ];
+
+  pytestFlagsArray = [
+    "--ignore=test/integration"
+    "--ignore=test/fuzzer"
+  ];
+
+  /*
+  Flaky tests due to state machine issues, ref https://github.com/faucetsdn/chewie/blob/master/test/unit/test_chewie.py#L27-L29
+
+        > =========================== short test summary info ============================
+       > FAILED test/unit/test_chewie.py::ChewieTestCase::test_logoff_dot1x - Assertio...
+       > FAILED test/unit/test_chewie.py::ChewieTestCase::test_success_dot1x - Asserti...
+       > ======================== 2 failed, 104 passed in 39.43s ========================
+  */
+
+  disabledTests = [
+    "test_logoff_dot1x"
+    "test_success_dot1x"
+  ];
+
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "EAPOL/802.1x implementation in Python, designed to serve as a library for the Faucet SDN project.";
+    homepage = "https://github.com/faucetsdn/chewie";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/os-ken/default.nix
+++ b/pkgs/development/python-modules/os-ken/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pbr
+, eventlet
+, msgpack
+, netaddr
+, oslo-config
+, oslotest
+, six
+, webob
+, routes
+, ovs
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "os-ken";
+  version = "2.3.1";
+
+  # opendev.org mirror
+  src = fetchFromGitHub {
+    owner = "openstack";
+    repo = "os-ken";
+    rev = version;
+    sha256 = "sha256-nZYo2yrds7U6tEFIkOt2ENjZITBPlOQ214fowVBNSeU=";
+  };
+
+  # We are installing from a tarball, so pbr will not be able to derive versioning.
+  PBR_VERSION = version;
+
+  propagatedBuildInputs = [
+    pbr
+    eventlet
+    msgpack
+    netaddr
+    oslo-config
+    six
+    routes
+    webob
+    ovs
+  ];
+
+  checkInputs = [ pytestCheckHook oslotest ];
+
+  pytestFlagsArray = [
+    "--ignore=os_ken/tests/integrated"
+    "--ignore=os_ken/tests/mininet"
+    "--ignore=os_ken/tests/switch"
+  ];
+  /*
+  =========================== short test summary info ============================
+  FAILED os_ken/tests/unit/packet/test_igmp.py::Test_igmpv3_report_group::test_aux_len_larger_than_aux
+  FAILED os_ken/tests/unit/packet/test_igmp.py::Test_igmpv3_report_group::test_aux_len_smaller_than_aux
+  FAILED os_ken/tests/unit/packet/test_igmp.py::Test_igmpv3_report_group::test_num_larger_than_srcs
+  FAILED os_ken/tests/unit/packet/test_igmp.py::Test_igmpv3_report_group::test_num_smaller_than_srcs
+  =========== 4 failed, 121132 passed, 1 warning in 408.38s (0:06:48) ============
+  */
+
+  disabledTests = [
+    "test_aux_len_smaller_than_aux"
+    "test_aux_len_larger_than_aux"
+    "test_num_smaller_than_srcs"
+    "test_num_larger_than_srcs"
+  ];
+
+  meta = with lib; {
+    description = "Software-defined networking framework for OpenStack Neutron, fork of the Ryu library";
+    homepage = "https://github.com/openstack/os-ken";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/ovs/default.nix
+++ b/pkgs/development/python-modules/ovs/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pytest
+, sortedcontainers
+, openvswitch
+}:
+
+buildPythonPackage rec {
+  pname = "ovs";
+  inherit (openvswitch) version src;
+  sourceRoot = "${openvswitch.name}/python";
+
+  # Fix up version generation / directories generation for binaries and stuff by Makefile.
+  # We do not need it here.
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace 'exec(open("ovs/version.py").read())' 'VERSION = "${version}"' \
+      --replace 'open("ovs/dirs.py")' 'pass'
+  '';
+
+  buildInputs = [ pytest openvswitch ];
+
+  propagatedBuildInputs = [ sortedcontainers ];
+
+  doCheck = false; # TODO: test only ovstest
+
+  meta = with lib; {
+    description = "Open vSwitch library for Python.";
+    homepage = "https://github.com/openvswitch/ovs";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/servers/faucet/default.nix
+++ b/pkgs/servers/faucet/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, nixosTests
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "faucet";
+  version = "1.10.3";
+
+  src = fetchFromGitHub {
+    owner = "faucetsdn";
+    repo = "faucet";
+    rev = version;
+    sha256 = "sha256-sG7YvEr5/SoEmghdw+7bKWR/Ci8ktUhDnnyhHQbI2GY=";
+  };
+
+  # We are installing from a tarball, so pbr will not be able to derive versioning.
+  PBR_VERSION = version;
+
+  propagatedBuildInputs = with python3Packages; [
+    pbr
+    pytricia
+    ruamel-yaml
+    prometheus-client
+    networkx
+    influxdb
+    beka
+    chewie
+    os-ken
+  ];
+
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+    bitstring
+    mininet-python
+    netifaces
+  ];
+
+  pytestFlagsArray = [
+    "--ignore=tests/integration"
+    "--ignore=tests/generative/integration"
+    "--ignore=tests/generative/fuzzer"
+    "--ignore=tests/unit/packaging/test_packaging.py"
+    "--ignore=clib/"
+    "--ignore=adapters/vendors/rabbitmq/test_rabbit.py"
+    "--ignore=tests/unit/gauge/test_main.py"
+  ];
+
+  # passthru.tests.faucet = nixosTests.faucet;
+
+  meta = with lib; {
+    description = "OpenFlow controller for multi-table OpenFlow ≥ 1.3 switches";
+    longDescription = "OpenFlow controller for multi-table OpenFlow ≥ 1.3 switches that supports L2 switching, VLANs ACLs, L3 IPv(4|6) routing: static and via BGP.";
+    homepage = "https://github.com/faucetsdn/faucet";
+    license = licenses.asl20;
+    changelog = "https://github.com/faucetsdn/faucet/releases/tag/${version}";
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3153,6 +3153,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  faucet = python3Packages.callPackage ../servers/faucet { };
+
   faudio = callPackage ../development/libraries/faudio { };
 
   fd = callPackage ../tools/misc/fd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5919,6 +5919,8 @@ in {
 
   ovoenergy = callPackage ../development/python-modules/ovoenergy { };
 
+  ovs = callPackage ../development/python-modules/ovs { };
+
   owslib = callPackage ../development/python-modules/owslib { };
 
   oyaml = callPackage ../development/python-modules/oyaml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5877,6 +5877,8 @@ in {
 
   orvibo = callPackage ../development/python-modules/orvibo { };
 
+  os-ken = callPackage ../development/python-modules/os-ken { };
+
   os-service-types = callPackage ../development/python-modules/os-service-types { };
 
   osc = callPackage ../development/python-modules/osc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1189,6 +1189,8 @@ in {
 
   behave = callPackage ../development/python-modules/behave { };
 
+  beka = callPackage ../development/python-modules/beka { };
+
   bellows = callPackage ../development/python-modules/bellows { };
 
   beniget = callPackage ../development/python-modules/beniget { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1607,6 +1607,8 @@ in {
 
   chevron = callPackage ../development/python-modules/chevron { };
 
+  chewie = callPackage ../development/python-modules/chewie { };
+
   chex = callPackage ../development/python-modules/chex { };
 
   chiabip158 = callPackage ../development/python-modules/chiabip158 { };


### PR DESCRIPTION
###### Description of changes

Adds http://faucet.nz/, a software-defined network controller, supporting OpenFlow ≥ 1.3 and its many dependencies, e.g. chewie (EAPOL/802.1x implementation in Python), os-ken (OpenStack fork of Ryu library for SDN), ovs (Open vSwitch Python library), beka (BGP Speaker in Python).

Here's my TODO list:

- [x] Faucet tests are very slow, investigate why
- [ ] NixOS tests are very much necessary for some dependencies and Faucet itself
- [ ] Cleanup styling, double-check licenses
- [ ] Expose binaries for some Python packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
