### PR TITLE
zi: init at unstable-2022-04-09

### DIFF
--- a/pkgs/shells/zsh/zi/default.nix
+++ b/pkgs/shells/zsh/zi/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, installShellFiles, stdenvNoCC }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "zi";
+  version = "unstable-2022-04-09";
+  src = fetchFromGitHub {
+    owner = "z-shell";
+    repo = pname;
+    rev = "4ca4d3276ca816c3d37a31e47d754f9a732c40b9";
+    sha256 = "sha256-KcDFT0is5Ef/zRo6zVfxYfBMOb5oVaVFT4EsUrfiMko=";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r lib zi.zsh $out
+    installManPage docs/man/zi.1
+    installShellCompletion --zsh lib/_zi
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/z-shell/zi";
+    description = "A Swiss Army Knife for Zsh - Unix Shell";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sei40kr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11453,6 +11453,8 @@ with pkgs;
 
   zplug = callPackage ../shells/zsh/zplug { };
 
+  zi = callPackage ../shells/zsh/zi {};
+
   zinit = callPackage ../shells/zsh/zinit {} ;
 
   zs-apc-spdu-ctl = callPackage ../tools/networking/zs-apc-spdu-ctl { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [zi](https://github.com/z-shell/zi), a fork of zinit, a plugin manager for Z-shell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] completion
  - [x] program
  - [x] snippet
  - [x] plugin
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
