### PR TITLE
pass-secret-service: unstable-2020-04-12 -> unstable-2022-03-21

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -326,6 +326,15 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>pass-secret-service</literal> package now
+          includes systemd units from upstream, so adding it to the
+          NixOS <literal>services.dbus.packages</literal> option will
+          make it start automatically as a systemd user service when an
+          application tries to talk to the libsecret D-Bus API.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           There is a new module for the <literal>thunar</literal>
           program (the Xfce file manager), which depends on the
           <literal>xfconf</literal> dbus service, and also has a dbus

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -121,6 +121,8 @@ Use `configure.packages` instead.
 
 - Add udev rules for the Teensy family of microcontrollers.
 
+- The `pass-secret-service` package now includes systemd units from upstream, so adding it to the NixOS `services.dbus.packages` option will make it start automatically as a systemd user service when an application tries to talk to the libsecret D-Bus API.
+
 - There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.
 
 - There is a new module for the `xfconf` program (the Xfce configuration storage system), which has a dbus service.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1001,6 +1001,7 @@
   ./services/security/oauth2_proxy.nix
   ./services/security/oauth2_proxy_nginx.nix
   ./services/security/opensnitch.nix
+  ./services/security/pass-secret-service.nix
   ./services/security/privacyidea.nix
   ./services/security/physlock.nix
   ./services/security/shibboleth-sp.nix

--- a/nixos/modules/services/security/pass-secret-service.nix
+++ b/nixos/modules/services/security/pass-secret-service.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.passSecretService;
+in
+{
+  options.services.passSecretService = {
+    enable = mkEnableOption "pass secret service";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.pass-secret-service;
+      defaultText = literalExpression "pkgs.pass-secret-service";
+      description = "Which pass-secret-service package to use.";
+      example = literalExpression "pkgs.pass-secret-service.override { python3 = pkgs.python310 }";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+  };
+
+  meta.maintainers = with maintainers; [ aidalgol ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -412,6 +412,7 @@ in {
   pam-oath-login = handleTest ./pam/pam-oath-login.nix {};
   pam-u2f = handleTest ./pam/pam-u2f.nix {};
   pam-ussh = handleTest ./pam/pam-ussh.nix {};
+  pass-secret-service = handleTest ./pass-secret-service.nix {};
   pantalaimon = handleTest ./matrix/pantalaimon.nix {};
   pantheon = handleTest ./pantheon.nix {};
   paperless = handleTest ./paperless.nix {};

--- a/nixos/tests/pass-secret-service.nix
+++ b/nixos/tests/pass-secret-service.nix
@@ -1,0 +1,69 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "pass-secret-service";
+  meta.maintainers = with lib; [ aidalgol ];
+
+  nodes.machine = { nodes, pkgs, ... }:
+    {
+      imports = [ ./common/user-account.nix ];
+
+      services.passSecretService.enable = true;
+
+      environment.systemPackages = [
+        # Create a script that tries to make a request to the D-Bus secrets API.
+        (pkgs.writers.writePython3Bin "secrets-dbus-init"
+          {
+            libraries = [ pkgs.python3Packages.secretstorage ];
+          } ''
+          import secretstorage
+          print("Initializing dbus connection...")
+          connection = secretstorage.dbus_init()
+          print("Requesting default collection...")
+          collection = secretstorage.get_default_collection(connection)
+          print("Done!  dbus-org.freedesktop.secrets should now be active.")
+        '')
+        pkgs.pass
+      ];
+
+      programs.gnupg = {
+        agent.enable = true;
+        agent.pinentryFlavor = "tty";
+        dirmngr.enable = true;
+      };
+    };
+
+  # Some of the commands are run via a virtual console because they need to be
+  # run under a real login session, with D-Bus running in the environment.
+  testScript = { nodes, ... }:
+    let
+      user = nodes.machine.config.users.users.alice;
+      gpg-uid = "alice@example.net";
+      gpg-pw = "foobar9000";
+      ready-file = "/tmp/secrets-dbus-init.done";
+    in
+    ''
+      # Initialise the pass(1) storage.
+      machine.succeed("""
+        sudo -u alice gpg --pinentry-mode loopback --batch --passphrase ${gpg-pw} \
+        --quick-gen-key ${gpg-uid} \
+      """)
+      machine.succeed("sudo -u alice pass init ${gpg-uid}")
+
+      with subtest("Service is not running on login"):
+          machine.wait_until_tty_matches("1", "login: ")
+          machine.send_chars("alice\n")
+          machine.wait_until_tty_matches("1", "login: alice")
+          machine.wait_until_succeeds("pgrep login")
+          machine.wait_until_tty_matches("1", "Password: ")
+          machine.send_chars("${user.password}\n")
+          machine.wait_until_succeeds("pgrep -u alice bash")
+
+          _, output = machine.systemctl("status dbus-org.freedesktop.secrets --no-pager", "alice")
+          assert "Active: inactive (dead)" in output
+
+      with subtest("Service starts after a client tries to talk to the D-Bus API"):
+          machine.send_chars("secrets-dbus-init; touch ${ready-file}\n")
+          machine.wait_for_file("${ready-file}")
+          _, output = machine.systemctl("status dbus-org.freedesktop.secrets --no-pager", "alice")
+          assert "Active: active (running)" in output
+    '';
+})

--- a/pkgs/applications/misc/pass-secret-service/default.nix
+++ b/pkgs/applications/misc/pass-secret-service/default.nix
@@ -1,26 +1,50 @@
-{ lib, fetchFromGitHub, python3, dbus, gnupg }:
+{ lib
+, fetchFromGitHub
+, python3
+, dbus
+, gnupg
+, coreutils
+, nixosTests
+}:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "pass-secret-service";
   # PyPI has old alpha version. Since then the project has switched from using a
   # seemingly abandoned D-Bus package pydbus and started using maintained
   # dbus-next. So let's use latest from GitHub.
-  version = "unstable-2020-04-12";
+  version = "unstable-2022-03-21";
 
   src = fetchFromGitHub {
     owner = "mdellweg";
     repo = "pass_secret_service";
-    rev = "f6fbca6ac3ccd16bfec407d845ed9257adf74dfa";
-    sha256 = "0rm4pbx1fiwds1v7f99khhh7x3inv9yniclwd95mrbgljk3cc6a4";
+    rev = "149f8557e07098eee2f46561eea61e83255ac59b";
+    sha256 = "sha256-+/pFi6+K8rl0Ihm6cp/emUQVtau6+Apl8/VEr9AI0Xs=";
   };
 
+  patches = [
+    # Only needed until https://github.com/mdellweg/pass_secret_service/pull/30
+    # is merged.
+    ./int_from_bytes-deprecation-fix.patch
+  ];
 
   # Need to specify session.conf file for tests because it won't be found under
   # /etc/ in check phase.
   postPatch = ''
     substituteInPlace Makefile \
       --replace "dbus-run-session" "dbus-run-session --config-file=${dbus}/share/dbus-1/session.conf" \
-      --replace '-p $(relpassstore)' '-p $(PASSWORD_STORE_DIR)'
+      --replace '-p $(relpassstore)' '-p $(PASSWORD_STORE_DIR)' \
+      --replace 'pytest-3' 'pytest'
+
+    substituteInPlace systemd/org.freedesktop.secrets.service \
+      --replace "/bin/false" "${coreutils}/bin/false"
+    substituteInPlace systemd/dbus-org.freedesktop.secrets.service \
+      --replace "/usr/local" "$out"
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share/dbus-1/services/" "$out/lib/systemd/user/"
+    cp systemd/org.freedesktop.secrets.service "$out/share/dbus-1/services/"
+    cp systemd/dbus-org.freedesktop.secrets.service "$out/lib/systemd/user/"
   '';
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -44,17 +68,15 @@ python3.pkgs.buildPythonApplication rec {
       ps.pypass
     ];
 
-  checkPhase = ''
-    runHook preCheck
-    make test
-    runHook postCheck
-  '';
+  checkTarget = "test";
+
+  passthru.tests.pass-secret-service = nixosTests.pass-secret-service;
 
   meta = {
     description = "Libsecret D-Bus API with pass as the backend";
     homepage = "https://github.com/mdellweg/pass_secret_service/";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ jluttine ];
+    maintainers = with lib.maintainers; [ jluttine aidalgol ];
   };
 }

--- a/pkgs/applications/misc/pass-secret-service/int_from_bytes-deprecation-fix.patch
+++ b/pkgs/applications/misc/pass-secret-service/int_from_bytes-deprecation-fix.patch
@@ -1,0 +1,22 @@
+--- a/pass_secret_service/interfaces/session.py
++++ b/pass_secret_service/interfaces/session.py
+@@ -4,7 +4,6 @@
+ import os
+ import hmac
+ from hashlib import sha256
+-from cryptography.utils import int_from_bytes
+ from cryptography.hazmat.backends import default_backend
+ from cryptography.hazmat.primitives.ciphers import Cipher
+ from cryptography.hazmat.primitives.ciphers.modes import CBC
+@@ -27,9 +26,9 @@ class Session(ServiceInterface, SerialMixin):
+     @classmethod
+     @run_in_executor
+     def _create_dh(cls, input):
+-        priv_key = int_from_bytes(os.urandom(0x80), "big")
++        priv_key = int.from_bytes(os.urandom(0x80), "big")
+         pub_key = pow(2, priv_key, dh_prime)
+-        shared_secret = pow(int_from_bytes(input, "big"), priv_key, dh_prime)
++        shared_secret = pow(int.from_bytes(input, "big"), priv_key, dh_prime)
+         salt = b"\x00" * 0x20
+         shared_key = hmac.new(salt, shared_secret.to_bytes(0x80, "big"), sha256).digest()
+         aes_key = hmac.new(shared_key, b"\x01", sha256).digest()[:0x10]


### PR DESCRIPTION
###### Description of changes
* Update to the latest upstream version of pass-secret-service that includes systemd service files.
* Add patch to fix use of a function that has been removed from the Python Cryptography library in NixOS 22.05
* Install systemd service files in the Nix package.
* Add NixOS test to ensure the D-Bus API activates the service unit.
* Add myself as a maintainer to the package and NixOS test.
* Use checkTarget instead of equivalent custom checkPhase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
