### PR TITLE
cmdpack: init at 1.03

### DIFF
--- a/pkgs/tools/misc/cmdpack/default.nix
+++ b/pkgs/tools/misc/cmdpack/default.nix
@@ -1,0 +1,136 @@
+{ stdenv, lib, fetchurl }:
+let
+  mkCmdPackDerivation = { pname, postInstall ? "", description }: stdenv.mkDerivation {
+    inherit pname postInstall;
+
+    version = "1.03";
+
+    src = fetchurl {
+      url = "https://web.archive.org/web/20140330233023/http://www.neillcorlett.com/downloads/cmdpack-1.03-src.tar.gz";
+      sha256 = "0v0a9rpv59w8lsp1cs8f65568qj65kd9qp7854z1ivfxfpq0da2n";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+
+      gcc -o ${pname} src/${pname}.c
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      cp ${pname} $out/bin
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      inherit description;
+
+      homepage = "https://web.archive.org/web/20140330233023/http://www.neillcorlett.com/cmdpack/";
+      platforms = platforms.all;
+      license = licenses.gpl3Plus;
+      maintainers = with maintainers; [ zane ];
+    };
+  };
+in
+{
+  bin2iso = mkCmdPackDerivation {
+    pname = "bin2iso";
+    description = "Convert CD .BIN to .ISO";
+  };
+
+  bincomp = mkCmdPackDerivation {
+    pname = "bincomp";
+    description = "Compare binary files";
+  };
+
+  brrrip = mkCmdPackDerivation {
+    pname = "brrrip";
+    description = "Rip SNES BRR sound samples";
+  };
+
+  byteshuf = mkCmdPackDerivation {
+    pname = "byteshuf";
+    description = "Shuffle or unshuffle bytes in a file";
+  };
+
+  byteswap = mkCmdPackDerivation {
+    pname = "byteswap";
+    description = "Swap byte order of files";
+  };
+
+  cdpatch = mkCmdPackDerivation {
+    pname = "cdpatch";
+    description = "CD-XA image insert/extract utility";
+  };
+
+  ecm = mkCmdPackDerivation {
+    pname = "ecm";
+    postInstall = "ln $out/bin/ecm $out/bin/unecm";
+    description = "Encoder/decoder for Error Code Modeler format";
+  };
+
+  fakecrc = mkCmdPackDerivation {
+    pname = "fakecrc";
+    description = "Fake the CRC32 of a file";
+  };
+
+  hax65816 = mkCmdPackDerivation {
+    pname = "hax65816";
+    description = "Simple 65816 disassembler";
+  };
+
+  id3point = mkCmdPackDerivation {
+    pname = "id3point";
+    description = "Pointless ID3v1 Tagger";
+  };
+
+  pecompat = mkCmdPackDerivation {
+    pname = "pecompat";
+    description = "Maximize compatibility of a Win32 PE file";
+  };
+
+  rels = mkCmdPackDerivation {
+    pname = "rels";
+    description = "Relative Searcher";
+  };
+
+  screamf = mkCmdPackDerivation {
+    pname = "screamf";
+    description = ".AMF to .S3M converter";
+  };
+
+  subfile = mkCmdPackDerivation {
+    pname = "subfile";
+    description = "Extract a portion of a file";
+  };
+
+  uips = mkCmdPackDerivation {
+    pname = "uips";
+    description = "Universal IPS patch create/apply utility";
+  };
+
+  usfv = mkCmdPackDerivation {
+    pname = "usfv";
+    description = "Universal SFV create/verify utility";
+  };
+
+  vb2rip = mkCmdPackDerivation {
+    pname = "vb2rip";
+    description = "VB2 sound format ripping utility";
+  };
+
+  wordadd = mkCmdPackDerivation {
+    pname = "wordadd";
+    description = "Addition word puzzle solver";
+  };
+
+  zerofill = mkCmdPackDerivation {
+    pname = "zerofill";
+    description = "Create a large, empty file";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4558,6 +4558,8 @@ with pkgs;
 
   cloudlist = callPackage ../tools/security/cloudlist { };
 
+  cmdpack = callPackages ../tools/misc/cmdpack { };
+
   cobalt = callPackage ../applications/misc/cobalt {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Description of changes

Packaging the old cmdpack utilities.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
