### PR TITLE
[21.11] neomutt: apply patch for CVE-2022-1328

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -32,6 +32,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/neomutt/neomutt/commit/4242a31313e0b600693215c01047bbda8a6dd25a.patch";
       sha256 = "sha256-fcuNeBkPjqln5QA9VFcfXCQD/VrUoSEMSxQ//Xj+yxY=";
     })
+
+    # CVE-2022-1328, https://github.com/advisories/GHSA-qfrq-pp74-gpff
+    (fetchpatch {
+      name = "CVE-2022-1328.patch";
+      url = "https://github.com/neomutt/neomutt/commit/ee7cb4e461c1cdf0ac14817b03687d5908b85f84.patch";
+      sha256 = "sha256-PQMXPko/UPlhzmOTsUWjrhVtUQCv22ppmi/u8Xof5d8=";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION

###### Description of changes

This fixes a buffer overflow in NeoMutt, to quote the original
report[1]:

> Hello, In mutt_decode_uuencoded(), the line length is read from the
> untrusted uuencoded part without validation. This could result in
> including private memory in message parts, for example fragments of
> other messages, passphrases or keys in replys.

Security advistory for the corresponding CVE-2022-1328 is on GitHub[2].

Applying the entire release 20220415 is IMHO too risky because too much
has changed, but applying the patch only works fine as well here.

In NeoMutt 20220415 / Mutt 2.2.3 there's also a fix for an integer
overflow[3] of a `strlen()` for very large messages which is however not
exploitable for NeoMutt according to the upstream maintainers[4], so I
won't backport this patch as well.

Related to https://github.com/NixOS/nixpkgs/pull/168800.

[1] https://gitlab.com/muttmua/mutt/-/issues/404
[2] https://github.com/advisories/GHSA-qfrq-pp74-gpff
[3] https://gitlab.com/muttmua/mutt/-/issues/405
[4] https://github.com/neomutt/neomutt/commit/2bedc9762e2be679a24c8af9c56d16d670aef958:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
