### PR TITLE
bitmask-vpn: install the app's icon

### DIFF
--- a/pkgs/tools/networking/bitmask-vpn/default.nix
+++ b/pkgs/tools/networking/bitmask-vpn/default.nix
@@ -79,7 +79,7 @@ buildGoModule rec {
       --replace "provider = riseup" "provider = ${provider}"
 
     substituteInPlace branding/templates/debian/app.desktop-template \
-      --replace "Icon=icon" "Icon=${provider}-vpn"
+      --replace "Icon=icon" "Icon=${pname}"
 
     patchShebangs gui/build.sh
     wrapPythonProgramsIn branding/scripts
@@ -133,12 +133,12 @@ buildGoModule rec {
   '';
 
   postInstall = ''
-    install -m 755 -D -t $out/bin build/qt/release/${provider}-vpn
+    install -m 755 -D -t $out/bin build/qt/release/${pname}
 
     VERSION=${version} VENDOR_PATH=providers branding/scripts/generate-debian branding/templates/debian/data.json
     (cd branding/templates/debian && ${python3Packages.python}/bin/python3 generate.py)
-    install -m 444 -D branding/templates/debian/app.desktop $out/share/applications/${provider}-vpn.desktop
-    install -m 444 -D providers/${provider}/assets/icon.svg $out/share/icons/hicolor/scalable/apps/${provider}-vpn.svg
+    install -m 444 -D branding/templates/debian/app.desktop $out/share/applications/${pname}.desktop
+    install -m 444 -D providers/${provider}/assets/icon.svg $out/share/icons/hicolor/scalable/apps/${pname}.svg
   '' + lib.optionalString stdenv.isLinux ''
     install -m 444 -D -t $out/share/polkit-1/actions ${bitmask-root}/share/polkit-1/actions/se.leap.bitmask.policy
   '';
@@ -158,7 +158,7 @@ buildGoModule rec {
       a variety of trusted service provider all from one app.
       Current providers include Riseup Networks
       and The Calyx Institute, where the former is default.
-      The <literal>${provider}-vpn</literal> executable should appear
+      The <literal>${pname}</literal> executable should appear
       in your desktop manager's XDG menu or could be launch in a terminal
       to get an execution log. A new icon should then appear in your systray
       to control the VPN and configure some options.

--- a/pkgs/tools/networking/bitmask-vpn/default.nix
+++ b/pkgs/tools/networking/bitmask-vpn/default.nix
@@ -78,6 +78,9 @@ buildGoModule rec {
     substituteInPlace providers/vendor.conf \
       --replace "provider = riseup" "provider = ${provider}"
 
+    substituteInPlace $out/share/applications/${provider}-vpn.desktop \
+      --replace icon ${provider}-vpn
+
     patchShebangs gui/build.sh
     wrapPythonProgramsIn branding/scripts
   '' + lib.optionalString stdenv.isLinux ''
@@ -135,6 +138,7 @@ buildGoModule rec {
     VERSION=${version} VENDOR_PATH=providers branding/scripts/generate-debian branding/templates/debian/data.json
     (cd branding/templates/debian && ${python3Packages.python}/bin/python3 generate.py)
     install -m 444 -D branding/templates/debian/app.desktop $out/share/applications/${provider}-vpn.desktop
+    install -m 444 -D providers/${provider}/assets/icon.svg $out/share/icons/hicolor/scalable/apps/${provider}-vpn.svg
   '' + lib.optionalString stdenv.isLinux ''
     install -m 444 -D -t $out/share/polkit-1/actions ${bitmask-root}/share/polkit-1/actions/se.leap.bitmask.policy
   '';

--- a/pkgs/tools/networking/bitmask-vpn/default.nix
+++ b/pkgs/tools/networking/bitmask-vpn/default.nix
@@ -78,8 +78,8 @@ buildGoModule rec {
     substituteInPlace providers/vendor.conf \
       --replace "provider = riseup" "provider = ${provider}"
 
-    substituteInPlace $out/share/applications/${provider}-vpn.desktop \
-      --replace icon ${provider}-vpn
+    substituteInPlace branding/templates/debian/app.desktop-template \
+      --replace "Icon=icon" "Icon=${provider}-vpn"
 
     patchShebangs gui/build.sh
     wrapPythonProgramsIn branding/scripts


### PR DESCRIPTION
###### Description of changes

Just an aesthetics thing; currently the apps are installed onto graphical interfaces with the default icon.
This does not change the build process, merely installs an additional file during postInstall.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
