### PR TITLE
graalvmXX-ce: add sourcesPath parameter

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/default.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/default.nix
@@ -49,7 +49,6 @@ in
     };
     defaultVersion = graalvm11-ce-release-version;
     javaVersion = "11";
-    platforms = builtins.attrNames config;
   };
 
   graalvm17-ce = mkGraal rec {
@@ -74,6 +73,5 @@ in
     };
     defaultVersion = graalvm17-ce-release-version;
     javaVersion = "17";
-    platforms = builtins.attrNames config;
   };
 }

--- a/pkgs/development/compilers/graalvm/community-edition/default.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/default.nix
@@ -15,8 +15,8 @@ let
   */
   graalvm11-ce-release-version = "22.0.0.2";
   graalvm17-ce-release-version = "22.0.0.2";
-  graalvm11-ce-dev-version = "22.2.0-dev-20220401_1942";
-  graalvm17-ce-dev-version = "22.2.0-dev-20220401_1942";
+  graalvm11-ce-dev-version = "22.2.0-dev-20220415_1945";
+  graalvm17-ce-dev-version = "22.2.0-dev-20220415_1945";
 
   products = [
     "graalvm-ce"

--- a/pkgs/development/compilers/graalvm/community-edition/graalvm11-ce-sources.json
+++ b/pkgs/development/compilers/graalvm/community-edition/graalvm11-ce-sources.json
@@ -1,12 +1,12 @@
 {
   "darwin-aarch64": {
-    "graalvm-ce|java11|22.2.0-dev-20220414_2112": {
-      "sha256": "7d1d39a7cc2579112e745943fa5b557405b501f5c3c3fde441f9a31c7627d18d",
-      "url": "https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/22.2.0-dev-20220414_2112/graalvm-ce-java11-darwin-aarch64-dev.tar.gz"
+    "graalvm-ce|java11|22.2.0-dev-20220415_1945": {
+      "sha256": "ab81b00177124d746a3871b6e48ce7611e93dd3b4f6dee45d77300ef214fbab8",
+      "url": "https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/22.2.0-dev-20220415_1945/graalvm-ce-java11-darwin-aarch64-dev.tar.gz"
     },
-    "native-image-installable-svm|java11|22.2.0-dev-20220414_2112": {
-      "sha256": "5ec82588bf493c38656ca7c31fff276342ce1cbadee41309ae7a3486f56f7ba7",
-      "url": "https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/22.2.0-dev-20220414_2112/native-image-installable-svm-java11-darwin-aarch64-dev.jar"
+    "native-image-installable-svm|java11|22.2.0-dev-20220415_1945": {
+      "sha256": "9d3753736fe71f55f3fb3bcbdf43271dd96dda0c4b731d11f3f890d5bddf3bbb",
+      "url": "https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/22.2.0-dev-20220415_1945/native-image-installable-svm-java11-darwin-aarch64-dev.jar"
     }
   },
   "darwin-amd64": {

--- a/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
@@ -1,9 +1,36 @@
-{ config
+{
+  # An attrset describing each platform configuration. All values are extract
+  # from the GraalVM releases available on
+  # https://github.com/graalvm/graalvm-ce-builds/releases
+  # Example:
+  # config = {
+  #   x86_64-linux = {
+  #     # List of products that will be included in the GraalVM derivation
+  #     # See `with{NativeImage,Ruby,Python,WASM,*}Svm` variables for the
+  #     # available values
+  #     products = [ "graalvm-ce" "native-image-installable-svm" ];
+  #     # GraalVM arch, not to be confused with the nix platform
+  #     arch = "linux-amd64";
+  #     # GraalVM version
+  #     version = "22.0.0.2";
+  #   };
+  # }
+  config
+  # GraalVM version that will be used unless overriden by `config.<platform>.version`
 , defaultVersion
+  # Java version used by GraalVM
 , javaVersion
-, platforms
+  # Platforms were GraalVM will be allowed to build (i.e. `meta.platforms`)
+, platforms ? builtins.attrNames config
+  # If set to true, update script will (re-)generate the sources file even if
+  # there are no updates available
 , forceUpdate ? false
+  # Path for the sources file that will be used
+  # See `update.nix` file for a description on how this file works
 , sourcesPath ? ./. + "/graalvm${javaVersion}-ce-sources.json"
+  # Use musl instead of glibc to allow true static builds in GraalVM's
+  # Native Image (i.e.: `--static --libc=musl`). This will cause glibc builds
+  # to fail, so it should be used with care
 , useMusl ? false
 }:
 

--- a/pkgs/development/compilers/graalvm/community-edition/update.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/update.nix
@@ -1,14 +1,14 @@
-{ javaVersion
-, graalVersion
+{ config
 , defaultVersion
-, config
-, sourcesFilename
-, name
-, lib
-, writeShellScript
-, jq
+, forceUpdate
 , gnused
-, forceUpdate ? false
+, graalVersion
+, javaVersion
+, jq
+, lib
+, name
+, sourcesPath
+, writeShellScript
 }:
 
 /*
@@ -185,7 +185,7 @@ let
 
   newVersion = getLatestVersion graalVersion;
   sourcesJson = genSources javaVersion defaultVersion config;
-  sourcesJsonPath = lib.strings.escapeShellArg ./. + "/${sourcesFilename}";
+  sourcesJsonPath = lib.strings.escapeShellArg sourcesPath;
 
   # versionKeyInDefaultNix String -> String
   versionKeyInDefaultNix = graalVersion:


### PR DESCRIPTION
In #168816, we removed support for Python/Ruby/WASM to reduce the support burden of GraalVM languages that, arguably, are not really being used.

However, the way that `pkgs.graalvmCEPackages.mkGraal` function works right now doesn't allow passing a custom sources file, that would allow someone to compile GraalVM with the additional products (e.g.: Python). This PR adds this possibility.

So if someone wants to create a custom graalvm11-ce derivation with Python support, for example, they can do something like this:

```nix
let
   graalvm11-ce-custom = pkgs.graalvmCEPackages.mkGraal {
      config = {
         x86_64-linux = {
            products = [ "graalvm-ce" "python-installable-svm" ];
            arch = "linux-amd64";
         };
      };
      defaultVersion = "22.0.0.2";
      javaVersion = "11";
      sourcesPath = /home/someone/graalvm11-ce-sources.json;
   };
in
{
   environment.systemPackages = [ graalvm11-ce-custom ];
}
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
