### PR TITLE
pythonPackages.wifi: init 0.3.5

### DIFF
--- a/pkgs/development/python-modules/wifi/default.nix
+++ b/pkgs/development/python-modules/wifi/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pbkdf2
+, pytestCheckHook
+, pythonOlder
+, substituteAll
+, wirelesstools
+}:
+
+buildPythonPackage rec {
+  pname = "wifi";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "rockymeza";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-scg/DvApvyQZtzDgkHFJzf9gCRfJgBvZ64CG/c2Cx8E=";
+  };
+
+  disabled = pythonOlder "2.6";
+
+  postPatch = ''
+    substituteInPlace wifi/scan.py \
+      --replace "/sbin/iwlist" "${wirelesstools}/bin/iwlist"
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    pbkdf2
+  ];
+
+  pythonImportsCheck = [ "wifi" ];
+
+  meta = with lib; {
+    description = "Provides a command line wrapper for iwlist and /etc/network/interfaces";
+    homepage = "https://github.com/rockymeza/wifi";
+    maintainers = with maintainers; [ rhoriguchi ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10781,6 +10781,8 @@ in {
 
   wiffi = callPackage ../development/python-modules/wiffi { };
 
+  wifi = callPackage ../development/python-modules/wifi { };
+
   willow = callPackage ../development/python-modules/willow { };
 
   winacl = callPackage ../development/python-modules/winacl { };


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
