### PR TITLE
kabeljau: init at 1.0.1

### DIFF
--- a/pkgs/games/kabeljau/default.nix
+++ b/pkgs/games/kabeljau/default.nix
@@ -22,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
 
     mkdir -p $out/bin
     cp ${pname}.sh $out/bin/${pname}
-    wrapProgram $out/bin/${pname} --prefix PATH : ${
+    wrapProgram $out/bin/${pname} --suffix PATH : ${
       lib.makeBinPath [ bash dialog ]
     }
 

--- a/pkgs/games/kabeljau/default.nix
+++ b/pkgs/games/kabeljau/default.nix
@@ -1,0 +1,38 @@
+{ stdenvNoCC, lib, fetchFromGitea, bash, dialog, makeWrapper }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "kabeljau";
+  version = "1.0.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "papojari";
+    repo = "kabeljau";
+    rev = "v${version}";
+    sha256 = "sha256-LOvr5fgSUTXnYhbVmynCCjo0W098jKWQnFULtIprE3M=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  postPatch = ''
+    patchShebangs --host ${pname}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ${pname}.sh $out/bin/${pname}
+    wrapProgram $out/bin/${pname} --prefix PATH : ${
+      lib.makeBinPath [ bash dialog ]
+    }
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Survive as a stray cat in an ncurses game";
+    homepage = "https://codeberg.org/papojari/kabeljau";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ papojari ];
+  };
+}

--- a/pkgs/games/kabeljau/default.nix
+++ b/pkgs/games/kabeljau/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out/bin
     cp ${pname}.sh $out/bin/${pname}
     wrapProgram $out/bin/${pname} --suffix PATH : ${
-      lib.makeBinPath [ bash dialog ]
+      lib.makeBinPath [ dialog ]
     }
 
     runHook postInstall

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2729,6 +2729,8 @@ with pkgs;
 
   clipman = callPackage ../tools/wayland/clipman { };
 
+  kabeljau = callPackage ../games/kabeljau { };
+
   kanshi = callPackage ../tools/wayland/kanshi { };
 
   oguri = callPackage  ../tools/wayland/oguri { };


### PR DESCRIPTION
###### Description of changes

Add the kabeljau package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
