### PR TITLE
emacsWrapper: preload autoloads

### DIFF
--- a/pkgs/build-support/emacs/wrapper.sh
+++ b/pkgs/build-support/emacs/wrapper.sh
@@ -44,4 +44,4 @@ export emacsWithPackages_siteLisp=@wrapperSiteLisp@
 export EMACSNATIVELOADPATH="${newNativeLoadPath[*]}"
 export emacsWithPackages_siteLispNative=@wrapperSiteLispNative@
 
-exec @prog@ "$@"
+exec @prog@ -l cl-loaddefs -l nix-generated-autoload "$@"


### PR DESCRIPTION
###### Description of changes

This commits changes the wrapper, that is being constructed for Emacs, when built with additional packages, to preload all autoload definitions. The list of all definitions is generated at build-time. Packages do not need to be `(require)`d for them to work.

With this commit it is now possible to do:

```sh
nix-shell -I "nixpkgs=$PWD" -p "emacs.pkgs.withPackages(e:[e.magit])" \
          --run "emacs -Q -nw -f magit"
```

Magit opens.  Without this commit:

```sh
nix-shell -p "emacs.pkgs.withPackages(e:[e.magit])" \
          --run "emacs -Q -nw -f magit"
```

> Error: "Symbol’s function definition is void: magit"

On a slight downside, this commit adds 10ms to the startup of Emacs.

Before:
```sh
$ nix-shell -p "emacs.pkgs.withPackages(e:[])" \
            --run "time emacs -Q --batch -f kill-emacs"

real	0m0.069s
user	0m0.045s
sys	0m0.024s
```

After:
```sh
$ nix-shell -I nixpkgs=$PWD -p "emacs.pkgs.withPackages(e:[])" \
            --run "time emacs -Q --batch -f kill-emacs"
real	0m0.078s
user	0m0.055s
sys	0m0.023s
```

More information on autoloading:
https://www.gnu.org/software/emacs/manual/html_node/eintr/Autoload.html

@adisbladis @AndersonTorres What do you think?

@ParetoOptimalDev This may also address the issue https://github.com/nix-community/emacs-overlay/issues/212 that you opened.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

