### PR TITLE
python3Packages.meteofrance-api: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/meteofrance-api/default.nix
+++ b/pkgs/development/python-modules/meteofrance-api/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry
+, pytestCheckHook
+, pythonOlder
+, pytz
+, requests
+, requests-mock
+, typing-extensions
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "meteofrance-api";
+  version = "1.0.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "hacf-fr";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-X8f0z9ZPXH7Wc3GqHmPptxpNxbHeezdOzw4gZCprumU=";
+  };
+
+  nativeBuildInputs = [
+    # Doesn't work with poetry-core at the moment
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    pytz
+    requests
+    urllib3
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    typing-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  pythonImportsCheck = [
+    "meteofrance_api"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_currentphenomenons"
+    "test_forecast"
+    "test_full_with_coastal_bulletint"
+    "test_fulls"
+    "test_no_rain_expected"
+    "test_picture_of_the_day"
+    "test_places"
+    "test_rain"
+    "test_session"
+    "test_workflow"
+  ];
+
+  meta = with lib; {
+    description = "Module to access information from the Meteo-France API";
+    homepage = "https://github.com/hacf-fr/meteofrance-api";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1534,7 +1534,8 @@
       pymeteireann
     ];
     "meteo_france" = ps: with ps; [
-    ]; # missing inputs: meteofrance-api
+      meteofrance-api
+    ];
     "meteoalarm" = ps: with ps; [
       meteoalertapi
     ];
@@ -3416,6 +3417,7 @@
     "meraki"
     "met"
     "met_eireann"
+    "meteo_france"
     "meteoclimatic"
     "microsoft_face"
     "microsoft_face_detect"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5140,6 +5140,8 @@ in {
 
   meteoalertapi = callPackage ../development/python-modules/meteoalertapi { };
 
+  meteofrance-api = callPackage ../development/python-modules/meteofrance-api { };
+
   mezzanine = callPackage ../development/python-modules/mezzanine { };
 
   micawber = callPackage ../development/python-modules/micawber { };


### PR DESCRIPTION
###### Description of changes
Module to accesse information from the Meteo-France API

https://github.com/hacf-fr/meteofrance-api

This is a Home Assistant dependency.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
