### PR TITLE
gnomeExtensions: improve update script

### DIFF
--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -10,6 +10,7 @@ import urllib.error
 import urllib.request
 import zipfile
 from operator import itemgetter
+from pathlib import Path
 from typing import List, Dict, Optional, Any, Tuple
 
 # We don't want all those deprecated legacy extensions
@@ -34,6 +35,8 @@ ExtensionVersion = int
 package_name_registry: Dict[ShellVersion, Dict[PackageName, List[Uuid]]] = {}
 for shell_version in supported_versions.keys():
     package_name_registry[shell_version] = {}
+
+updater_dir_path = Path(__file__).resolve().parent
 
 
 def fetch_extension_data(uuid: str, version: str) -> Tuple[str, str]:
@@ -271,7 +274,7 @@ if __name__ == "__main__":
         f"Done. Writing results to extensions.json ({len(processed_extensions)} extensions in total)"
     )
 
-    with open("extensions.json", "w") as out:
+    with open(updater_dir_path / "extensions.json", "w") as out:
         # Manually pretty-print the outer level, but then do one compact line per extension
         # This allows for the diffs to be manageable (one line of change per extension) despite their quantity
         for index, extension in enumerate(processed_extensions):
@@ -283,14 +286,14 @@ if __name__ == "__main__":
             out.write("\n")
         out.write("]\n")
 
-    with open("extensions.json", "r") as out:
+    with open(updater_dir_path / "extensions.json", "r") as out:
         # Check that the generated file actually is valid JSON, just to be sure
         json.load(out)
 
     logging.info(
         "Done. Writing name collisions to collisions.json (please check manually)"
     )
-    with open("collisions.json", "w") as out:
+    with open(updater_dir_path / "collisions.json", "w") as out:
         # Filter out those that are not duplicates
         package_name_registry_filtered: Dict[ShellVersion, Dict[PackageName, List[Uuid]]] = {
             # The outer level keys are shell versions

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -51,14 +51,7 @@ def fetch_extension_data(uuid: str, version: str) -> Tuple[str, str]:
     if url == 'https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension.zip':
         url = 'https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension_v1BI2FB.zip'
 
-    # Yes, we download that file two times:
-
-    # The first time is for the maintainer, so they may have a personal backup to fix potential issues
-    # subprocess.run(
-    #     ["wget", url], capture_output=True, text=True
-    # )
-
-    # The second time, we add the file to store
+    # Download extension and add the zip content to nix-store
     process = subprocess.run(
         ["nix-prefetch-url", "--unpack", "--print-path", url], capture_output=True, text=True
     )

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -I nixpkgs=../../../.. -i python3 -p python3
 
-import json
-import urllib.request
-import urllib.error
-from typing import List, Dict, Optional, Any, Tuple
-import logging
-from operator import itemgetter
-import subprocess
-import zipfile
-import io
 import base64
+import io
+import json
+import logging
+import subprocess
+import urllib.error
+import urllib.request
+import zipfile
+from operator import itemgetter
+from typing import List, Dict, Optional, Any, Tuple
 
 # We don't want all those deprecated legacy extensions
 # Group extensions by GNOME "major" version for compatibility reasons
@@ -21,13 +21,11 @@ supported_versions = {
     "42": "42",
 }
 
-
 # Some type alias to increase readility of complex compound types
 PackageName = str
 ShellVersion = str
 Uuid = str
 ExtensionVersion = int
-
 
 # Keep track of all names that have been used till now to detect collisions.
 # This works because we deterministically process all extensions in historical order
@@ -69,7 +67,7 @@ def fetch_extension_data(uuid: str, version: str) -> Tuple[str, str]:
 
 
 def generate_extension_versions(
-    extension_version_map: Dict[ShellVersion, ExtensionVersion], uuid: str
+        extension_version_map: Dict[ShellVersion, ExtensionVersion], uuid: str
 ) -> Dict[ShellVersion, Dict[str, str]]:
     """
     Takes in a mapping from shell versions to extension versions and transforms it the way we need it:
@@ -127,7 +125,7 @@ def pname_from_url(url: str) -> Tuple[str, str]:
     """
 
     url = url.split("/")  # type: ignore
-    return (url[3], url[2])
+    return url[3], url[2]
 
 
 def process_extension(extension: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -225,7 +223,7 @@ def scrape_extensions_index() -> List[Dict[str, Any]]:
         logging.info("Scraping page " + str(page))
         try:
             with urllib.request.urlopen(
-                f"https://extensions.gnome.org/extension-query/?n_per_page=25&page={page}"
+                    f"https://extensions.gnome.org/extension-query/?n_per_page=25&page={page}"
             ) as response:
                 data = json.loads(response.read().decode())["extensions"]
                 responseLength = len(data)

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -238,13 +238,13 @@ def scrape_extensions_index() -> List[Dict[str, Any]]:
                     f"https://extensions.gnome.org/extension-query/?n_per_page=25&page={page}"
             ) as response:
                 data = json.loads(response.read().decode())["extensions"]
-                responseLength = len(data)
+                response_length = len(data)
 
                 for extension in data:
                     extensions.append(extension)
 
                 # If our page isn't "full", it must have been the last one
-                if responseLength < 25:
+                if response_length < 25:
                     logging.debug(
                         f"\tThis page only has {responseLength} entries, so it must be the last one."
                     )

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -198,7 +198,7 @@ def process_extension(extension: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 
     for shell_version in shell_version_map.keys():
         if pname in package_name_registry[shell_version]:
-            logging.warning(f"Package name '{pname}' is colliding.")
+            logging.warning(f"Package name '{pname}' for GNOME '{shell_version}' is colliding.")
             package_name_registry[shell_version][pname].append(uuid)
         else:
             package_name_registry[shell_version][pname] = [uuid]

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -46,6 +46,10 @@ def fetch_extension_data(uuid: str, version: str) -> Tuple[str, str]:
     uuid = uuid.replace("@", "")
     url: str = f"https://extensions.gnome.org/extension-data/{uuid}.v{version}.shell-extension.zip"
 
+    # TODO remove when Vitals@CoreCoding.com version != 53, this extension has a missing manifest.json
+    if url == 'https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension.zip':
+        url = 'https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension_v1BI2FB.zip'
+
     # Yes, we download that file three times:
 
     # The first time is for the maintainter, so they may have a personal backup to fix potential issues

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -275,10 +275,6 @@ if __name__ == "__main__":
             processed_extensions.append(processed_extension)
             logging.debug(f"Processed {num + 1} / {len(raw_extensions)}")
 
-    logging.info(
-        f"Done. Writing results to extensions.json ({len(processed_extensions)} extensions in total)"
-    )
-
     with open(updater_dir_path / "extensions.json", "w") as out:
         # Manually pretty-print the outer level, but then do one compact line per extension
         # This allows for the diffs to be manageable (one line of change per extension) despite their quantity
@@ -291,13 +287,14 @@ if __name__ == "__main__":
             out.write("\n")
         out.write("]\n")
 
+    logging.info(
+        f"Done. Writing results to extensions.json ({len(processed_extensions)} extensions in total)"
+    )
+
     with open(updater_dir_path / "extensions.json", "r") as out:
         # Check that the generated file actually is valid JSON, just to be sure
         json.load(out)
 
-    logging.info(
-        "Done. Writing name collisions to collisions.json (please check manually)"
-    )
     with open(updater_dir_path / "collisions.json", "w") as out:
         # Filter out those that are not duplicates
         package_name_registry_filtered: Dict[ShellVersion, Dict[PackageName, List[Uuid]]] = {
@@ -309,3 +306,7 @@ if __name__ == "__main__":
         }
         json.dump(package_name_registry_filtered, out, indent=2, ensure_ascii=False)
         out.write("\n")
+
+    logging.info(
+        "Done. Writing name collisions to collisions.json (please check manually)"
+    )

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -21,7 +21,7 @@ supported_versions = {
     "42": "42",
 }
 
-# Some type alias to increase readility of complex compound types
+# Some type alias to increase readability of complex compound types
 PackageName = str
 ShellVersion = str
 Uuid = str
@@ -52,7 +52,7 @@ def fetch_extension_data(uuid: str, version: str) -> Tuple[str, str]:
 
     # Yes, we download that file three times:
 
-    # The first time is for the maintainter, so they may have a personal backup to fix potential issues
+    # The first time is for the maintainer, so they may have a personal backup to fix potential issues
     # subprocess.run(
     #     ["wget", url], capture_output=True, text=True
     # )
@@ -116,7 +116,7 @@ def generate_extension_versions(
             "version": str(extension_version),
             "sha256": sha256,
             # The downloads are impure, their metadata.json may change at any time.
-            # Thus, be back it up / pin it to remain deterministic
+            # Thus, we back it up / pin it to remain deterministic
             # Upstream issue: https://gitlab.gnome.org/Infrastructure/extensions-web/-/issues/137
             "metadata": metadata,
         }
@@ -153,7 +153,7 @@ def process_extension(extension: Dict[str, Any]) -> Optional[Dict[str, Any]]:
                    Don't make any assumptions on it, and treat it like an opaque string!
             "link" follows the following schema: "/extension/$number/$string/"
                    The number is monotonically increasing and unique to every extension.
-                   The string is usually derived from the extensions's name (but shortened, kebab-cased and URL friendly).
+                   The string is usually derived from the extension name (but shortened, kebab-cased and URL friendly).
                    It may diverge from the actual name.
             The keys of "shell_version_map" are GNOME Shell version numbers.
 


### PR DESCRIPTION
###### Description of changes

- Fix some typos
- Script can be called from any location, `collisions.json` and  `extensions.json` will be created next to it
- Get `metadata.json` from nix store, so it only has to be downloaded once
- Fix upstream bug where `metadata.json` missing

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

This extension (<https://extensions.gnome.org/extension/1460/vitals>) version `53` has no `metadata.json`. If you download it throught the web page it has one...

Webpage link: <https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension_v1BI2FB.zip>
Generated link: <https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension.zip>

```
INFO:root:Processing 'Vitals@CoreCoding.com'
DEBUG:root:[Vitals@CoreCoding.com] Downloading v53
Traceback (most recent call last):
  File "/home/rhoriguchi/Git/nixpkgs/pkgs/desktops/gnome/extensions/update-extensions.py", line 268, in <module>
    processed_extension = process_extension(raw_extension)
  File "/home/rhoriguchi/Git/nixpkgs/pkgs/desktops/gnome/extensions/update-extensions.py", line 193, in process_extension
    shell_version_map: Dict[ShellVersion, Dict[str, str]] = generate_extension_versions(shell_version_map, uuid)  # type: ignore
  File "/home/rhoriguchi/Git/nixpkgs/pkgs/desktops/gnome/extensions/update-extensions.py", line 111, in generate_extension_versions
    fetch_extension_data(uuid, str(extension_version))
  File "/home/rhoriguchi/Git/nixpkgs/pkgs/desktops/gnome/extensions/update-extensions.py", line 70, in fetch_extension_data
    with open(os.path.join(path, "metadata.json"), "r") as out:
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/g9naba5wqzj19alkizj7ah01hmx43y2n-VitalsCoreCoding.com.v53.shell-extension.zip/metadata.json'
```

How should that edge case be handled? @jtojnar @piegamesde