### PR TITLE
gnome-shell-pomodoro: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/desktops/gnome/misc/pomodoro/default.nix
+++ b/pkgs/desktops/gnome/misc/pomodoro/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , substituteAll
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -20,17 +19,19 @@
 , libpeas
 , gsettings-desktop-schemas
 , gettext
+, cairo
+, json-glib
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-pomodoro";
-  version = "0.20.0";
+  version = "0.21.0";
 
   src = fetchFromGitHub {
     owner = "gnome-pomodoro";
     repo = "gnome-pomodoro";
     rev = version;
-    sha256 = "sha256-USzLHoBM0QbBPtbTzJJY02cOSDtmlxPGYhMj7M1FJic=";
+    sha256 = "sha256-LJpS6eAlfeDIehRCD9jBjzd5zjlRhBn8Oc6ZREkwOkA=";
   };
 
   patches = [
@@ -39,13 +40,6 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-schema-path.patch;
       inherit pname version;
-    })
-
-    # Fix error reporting code.
-    # https://github.com/gnome-pomodoro/gnome-pomodoro/pull/591
-    (fetchpatch {
-      url = "https://github.com/gnome-pomodoro/gnome-pomodoro/commit/133bd62f15653856d9705b66188b42c20d81719e.patch";
-      sha256 = "A20K+57A6/lYH2Buri2+wrCQgz6EGBdYg2xQbHPSkYc=";
     })
   ];
 
@@ -62,6 +56,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    cairo
     glib
     gom
     gsettings-desktop-schemas
@@ -69,6 +64,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-good
     gst_all_1.gstreamer
     gtk3
+    json-glib
     libcanberra
     libpeas
     sqlite


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update gnome-shell-pomodoro 0.20.0 -> 0.21.0.

- Remove the patch from gnome-pomodoro/gnome-pomodoro/pull/591 since it had been merged to upstream.
- Add cairo, json-glib as dependencies (See [here](https://github.com/gnome-pomodoro/gnome-pomodoro/blob/b1173f4036a0a946ffa3ef890920f8b4cc8da155/NEWS#L7))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
