### PR TITLE
libstrangle: 0.1.1 -> unstable-202202022

### DIFF
--- a/pkgs/tools/X11/libstrangle/default.nix
+++ b/pkgs/tools/X11/libstrangle/default.nix
@@ -2,20 +2,22 @@
 
 stdenv.mkDerivation rec {
   pname = "libstrangle";
-  version = "0.1.1";
+  version = "unstable-202202022";
 
   buildInputs = [ libGL libX11 ];
 
   src = fetchFromGitLab {
     owner = "torkel104";
     repo = pname;
-    rev = version;
-    sha256 = "135icr544w5ynlxfnxqgjn794bsm9i703rh9jfnracjb7jgnha4w";
+    rev = "0273e318e3b0cc759155db8729ad74266b74cb9b";
+    sha256 = "sha256-h10QA7m7hIQHq1g/vCYuZsFR2NVbtWBB46V6OWP5wgM=";
   };
 
   makeFlags = [ "prefix=" "DESTDIR=$(out)" ];
 
-  patches = [ ./nixos.patch ];
+  patches = [
+      ./nixos.patch
+  ];
 
   postPatch = ''
     substituteAllInPlace src/strangle.sh

--- a/pkgs/tools/X11/libstrangle/nixos.patch
+++ b/pkgs/tools/X11/libstrangle/nixos.patch
@@ -7,7 +7,7 @@ diff --git a/makefile b/makefile
  
 -install-ld: ld
 -	install -m 0644 -D -T $(BUILDDIR)/libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/libstrangle.conf
--	ldconfig
+-	if [ -z "$(DESTDIR)" ]; then ldconfig; fi
 -
  install-32: 32-bit
  	install -m 0755 -D -T $(BUILDDIR)/libstrangle32.so $(DESTDIR)$(LIB32_PATH)/libstrangle.so


### PR DESCRIPTION
###### Description of changes

it fixes issue #169034

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
