### PR TITLE
notepad-next: init at 0.5.1

### DIFF
--- a/pkgs/applications/editors/notepad-next/default.nix
+++ b/pkgs/applications/editors/notepad-next/default.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, lib, fetchFromGitHub, qmake, libsForQt5 }:
+
+mkDerivation rec {
+  pname = "notepad-next";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "dail8859";
+    repo = "NotepadNext";
+    rev = "v${version}";
+    sha256 = "sha256-J7Ngt6YtAAZsza2lN0d1lX3T8gNJHp60sCwwaLMGBHQ=";
+    # External dependencies - https://github.com/dail8859/NotepadNext/issues/135
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ qmake libsForQt5.qt5.qttools ];
+  qmakeFlags = [ "src/NotepadNext.pro" ];
+
+  # References
+  #  https://github.com/dail8859/NotepadNext/blob/master/doc/Building.md
+  #  https://github.com/dail8859/NotepadNext/pull/124
+  postPatch = ''
+    substituteInPlace ./src/NotepadNext/NotepadNext.pro --replace /usr $out
+  '';
+
+  # Upstream suggestion: https://github.com/dail8859/NotepadNext/issues/135
+  CXXFLAGS = "-std=gnu++1z";
+
+  meta = with lib; {
+    homepage = "https://github.com/dail8859/NotepadNext";
+    description = "Notepad++-like editor for the Linux desktop";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sebtm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28599,6 +28599,8 @@ with pkgs;
 
   nomacs = libsForQt5.callPackage ../applications/graphics/nomacs { };
 
+  notepad-next = libsForQt5.callPackage ../applications/editors/notepad-next { };
+
   notepadqq = libsForQt514.callPackage ../applications/editors/notepadqq { };
 
   notmuch = callPackage ../applications/networking/mailreaders/notmuch {


### PR DESCRIPTION
###### Description of changes

Add NotepadNext at v0.5

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
