### PR TITLE
libarchive: enable tests

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -37,6 +37,22 @@ stdenv.mkDerivation rec {
     hash = "sha256-G4wL5DDbX0FqaA4cnOlVLZ25ObN8dNsRtxyas29tpDA=";
   };
 
+  postPatch = ''
+    substituteInPlace Makefile.am --replace '/bin/pwd' "$(type -P pwd)"
+
+    declare -a skip_tests=(
+      # test won't work in nix sandbox
+      'test_write_disk_perms'
+      # can't be sure builder will have sparse-capable fs
+      'test_sparse_basic'
+    )
+
+    for test_name in "''${skip_tests[@]}" ; do
+      sed -i "/$test_name/d" Makefile.am
+      rm "libarchive/test/$test_name.c"
+    done
+  '';
+
   outputs = [ "out" "lib" "dev" ];
 
   nativeBuildInputs = [
@@ -60,17 +76,12 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional (!xarSupport) "--without-xml2";
 
-  postPatch = ''
-     substituteInPlace Makefile.am --replace '/bin/pwd' 'pwd'
-  '';
-
   preBuild = lib.optionalString stdenv.isCygwin ''
     echo "#include <windows.h>" >> config.h
   '';
 
-  # 484: test_write_disk_perms FAIL
-  # TODO: how to disable it? Should it be reported upstream?
-  doCheck = false;
+  # https://github.com/libarchive/libarchive/issues/1475
+  doCheck = !stdenv.hostPlatform.isMusl;
 
   preFixup = ''
     sed -i $lib/lib/libarchive.la \


### PR DESCRIPTION
###### Description of changes

Only needed a small amount of modification to enable its test discovery to work, skip a test that will never work in the nix build environment and disable the tests for musl (https://github.com/libarchive/libarchive/issues/1475)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux `pkgsMusl`
  - [x] x86_64-linux `pkgsCross.aarch64-mutiplatform`
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
