### PR TITLE
keyd: init at 2.2.7-beta

### DIFF
--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "keyd";
+  version = "2.2.7-beta";
+
+  src = fetchFromGitHub {
+    owner = "rvaiya";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-G84NbhG0EjEPCZSbgCKzc2VJ+YcW7QWlniRWqOULemU=";
+  };
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" "PREFIX=" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/rvaiya/keyd";
+    description = "A key remapping daemon for linux";
+    longDescription = ''
+      Keyd has several unique features many of which are traditionally
+      only found in custom keyboard firmware like QMK as well as some
+      which are unique to keyd.
+      It expects a configuration file at /etc/keyd/default.conf. For
+      more details check out the homepage.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ taha ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4394,6 +4394,8 @@ with pkgs;
 
   gebaar-libinput = callPackage ../tools/inputmethods/gebaar-libinput { };
 
+  keyd = callPackage ../tools/inputmethods/keyd { };
+
   kime = callPackage ../tools/inputmethods/kime { };
 
   libpinyin = callPackage ../development/libraries/libpinyin { };


### PR DESCRIPTION
###### Description of changes

Added https://github.com/rvaiya/keyd

>Impetus: Linux lacks a good key remapping solution. In order to achieve satisfactory results a medley of tools need to be employed (e.g xcape, xmodmap) with the end result often being tethered to a specified environment (X11). keyd attempts to solve this problem by providing a flexible system wide daemon which remaps keys using kernel level input primitives (evdev, uinput).

The author of this derivation was originally https://github.com/NixOS/nixpkgs/pull/158489 but it seemed the author closed the pull request so I only bumped up the version number and I am resubmitting the same derivation. https://github.com/NixOS/nixpkgs/pull/158793 was created to add a module but it seems to have been overlooked so I am submitting the derivation only, so that is easier to merge.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
