### PR TITLE
[21.11] webkitgtk: disable hardware acceleration

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -82,6 +82,10 @@ stdenv.mkDerivation rec {
       inherit (addOpenGLRunpath) driverLink;
     })
     ./libglvnd-headers.patch
+
+    # The upgrade to 2.36 has enabled hardware acceleration by
+    # default. This causes problems. See #168645.
+    ./disable-compositing.patch
   ];
 
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''

--- a/pkgs/development/libraries/webkitgtk/disable-compositing.patch
+++ b/pkgs/development/libraries/webkitgtk/disable-compositing.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp b/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
+index 8f10c7e611b7..9c827a4d6d75 100644
+--- a/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
++++ b/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
+@@ -38,7 +38,7 @@ HardwareAccelerationManager& HardwareAccelerationManager::singleton()
+ }
+ 
+ HardwareAccelerationManager::HardwareAccelerationManager()
+-    : m_canUseHardwareAcceleration(true)
++    : m_canUseHardwareAcceleration(false)
+     , m_forceHardwareAcceleration(false)
+ {
+ #if !ENABLE(WEBGL)


### PR DESCRIPTION
###### Description of changes

Since the update to webkitgtk 2.36 in #167920, webkitgtk enables hardware acceleration by default. This fully breaks GNOME Evolution for me, because the email compose window becomes unusable.

There is a workaround by setting `WEBKIT_DISABLE_COMPOSITING_MODE=1`, but I assume that other apps that use webkit are also affected. So this PR reverts webkit back to its 2.34 behavior of not using hardware acceleration by default.

Fixes #168645. Relates to #168532.

Marked as draft until my builds complete.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

@NixOS/gnome

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
