### PR TITLE
richgo: enable tests

### DIFF
--- a/pkgs/development/tools/richgo/default.nix
+++ b/pkgs/development/tools/richgo/default.nix
@@ -13,10 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-O63QEo0/+m9cYktMg4+RloLuUfAlCG0eGkxpHPFg/Cw=";
 
-  doCheck = false;
-
-  subPackages = [ "." ];
-
   meta = with lib; {
     description = "Enrich `go test` outputs with text decorations";
     homepage = "https://github.com/kyoh86/richgo";


### PR DESCRIPTION
richgo: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
?   	github.com/kyoh86/richgo	[no test files]
?   	github.com/kyoh86/richgo	[no test files]
=== RUN   TestMarshalYAML
--- PASS: TestMarshalYAML (0.00s)
=== RUN   TestMarshalJSON
--- PASS: TestMarshalJSON (0.00s)
=== RUN   TestUnmarshalYAML
--- PASS: TestUnmarshalYAML (0.00s)
=== RUN   TestUnmarshalJSON
--- PASS: TestUnmarshalJSON (0.00s)
=== RUN   TestB
--- PASS: TestB (0.00s)
=== RUN   TestF
--- PASS: TestF (0.00s)
=== RUN   TestConcatConfig
--- PASS: TestConcatConfig (0.00s)
=== RUN   TestActualConfig
=== RUN   TestActualConfig/initial_actual_config
=== RUN   TestActualConfig/actual_config_will_save_a_value
--- PASS: TestActualConfig (0.00s)
    --- PASS: TestActualConfig/initial_actual_config (0.00s)
    --- PASS: TestActualConfig/actual_config_will_save_a_value (0.00s)
=== RUN   TestConcatColor
--- PASS: TestConcatColor (0.00s)
=== RUN   TestActualColor
--- PASS: TestActualColor (0.00s)
=== RUN   TestConcatLabelType
--- PASS: TestConcatLabelType (0.00s)
=== RUN   TestActualLabelType
--- PASS: TestActualLabelType (0.00s)
=== RUN   TestConcatStyle
--- PASS: TestConcatStyle (0.00s)
=== RUN   TestConcatInt
--- PASS: TestConcatInt (0.00s)
=== RUN   TestActualInt
--- PASS: TestActualInt (0.00s)
=== RUN   TestConcatBool
--- PASS: TestConcatBool (0.00s)
=== RUN   TestActualBool
--- PASS: TestActualBool (0.00s)
=== RUN   TestLabelTypeMarshaling
--- PASS: TestLabelTypeMarshaling (0.00s)
=== RUN   TestInGlobal
--- PASS: TestInGlobal (0.00s)
=== RUN   TestInGlobalWithNotCoveredEnv
--- PASS: TestInGlobalWithNotCoveredEnv (0.00s)
=== RUN   TestInLocal
--- PASS: TestInLocal (0.00s)
=== RUN   TestLoad
=== RUN   TestLoad/no_trick
=== RUN   TestLoad/with_valid_files
=== RUN   TestLoad/with_invalid_file
=== RUN   TestLoad/with_invalid_yaml
--- PASS: TestLoad (0.00s)
    --- PASS: TestLoad/no_trick (0.00s)
    --- PASS: TestLoad/with_valid_files (0.00s)
    --- PASS: TestLoad/with_invalid_file (0.00s)
    --- PASS: TestLoad/with_invalid_yaml (0.00s)
=== RUN   TestApply
--- PASS: TestApply (0.00s)
PASS
ok  	github.com/kyoh86/richgo/config	0.028s
=== RUN   TestWriter
=== RUN   TestWriter/valid_editor_and_writer
=== RUN   TestWriter/invalid_editor
--- PASS: TestWriter (0.00s)
    --- PASS: TestWriter/valid_editor_and_writer (0.00s)
    --- PASS: TestWriter/invalid_editor (0.00s)
=== RUN   TestParrot
--- PASS: TestParrot (0.00s)
=== RUN   TestReplaces
--- PASS: TestReplaces (0.00s)
=== RUN   TestFormattable
--- PASS: TestFormattable (0.00s)
PASS
ok  	github.com/kyoh86/richgo/editor	0.018s
=== RUN   TestE2E
--- PASS: TestE2E (0.03s)
PASS
ok  	github.com/kyoh86/richgo/editor/test	0.049s
?   	github.com/kyoh86/richgo/editor/test/statik	[no test files]
```

###### Description of changes

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
