### PR TITLE
init ocamlPackages.xmlplaylist, init ocamlPackages.lastfm

### DIFF
--- a/pkgs/development/ocaml-modules/lastfm/default.nix
+++ b/pkgs/development/ocaml-modules/lastfm/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+, pkg-config
+, dune-configurator
+, xmlplaylist
+, ocaml_pcre
+, ocamlnet
+}:
+
+buildDunePackage rec {
+  pname = "lastfm";
+  version = "0.3.3";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-lastfm";
+    rev = "v${version}";
+    sha256 = "1sz400ny9h7fs20k7600q475q164x49ba30ls3q9y35rhm3g2y2b";
+  };
+
+  propagatedBuildInputs = [ xmlplaylist ocaml_pcre ocamlnet ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-lastfm";
+    description = "OCaml API to lastfm radio and audioscrobbler";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/xmlplaylist/default.nix
+++ b/pkgs/development/ocaml-modules/xmlplaylist/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, xmlm }:
+
+buildDunePackage rec {
+  pname = "xmlplaylist";
+  version = "0.1.5";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-xmlplaylist";
+    rev = "v${version}";
+    sha256 = "1x5lbwkr2ip00x8vyfbl8936yy79j138vx8a16ix7g9p2j5qsfcq";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ xmlm ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-xmlplaylist";
+    description = "Module to parse various RSS playlist formats";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1455,6 +1455,8 @@ let
 
     xmlm = callPackage ../development/ocaml-modules/xmlm { };
 
+    xmlplaylist = callPackage ../development/ocaml-modules/xmlplaylist { };
+
     xml-light = callPackage ../development/ocaml-modules/xml-light { };
 
     xtmpl = callPackage ../development/ocaml-modules/xtmpl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -645,6 +645,8 @@ let
 
     lambda-term = callPackage ../development/ocaml-modules/lambda-term { };
 
+    lastfm = callPackage ../development/ocaml-modules/lastfm { };
+
     lens = callPackage ../development/ocaml-modules/lens { };
 
     letsencrypt = callPackage ../development/ocaml-modules/letsencrypt { };


### PR DESCRIPTION
###### Description of changes
Part of splitting out https://github.com/NixOS/nixpkgs/pull/140777 for easier review
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
