### PR TITLE
pubs: 0.8.3 -> 0.9.0

### DIFF
--- a/pkgs/tools/misc/pubs/default.nix
+++ b/pkgs/tools/misc/pubs/default.nix
@@ -1,34 +1,54 @@
-{ lib, fetchFromGitHub, python3Packages }:
+{ lib
+, fetchFromGitHub
+, python3
+}:
 
-python3Packages.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "pubs";
-  version = "0.8.3";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "pubs";
     repo = "pubs";
     rev = "v${version}";
-    sha256 = "0npgsyxj7kby5laznk5ilkrychs3i68y57gphwk48w8k9fvnl3zc";
+    hash = "sha256-U/9MLqfXrzYVGttFSafw4pYDy26WgdsJMCxciZzO1pw=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    argcomplete python-dateutil configobj feedparser bibtexparser pyyaml requests six
+  propagatedBuildInputs = with python3.pkgs; [
+    pyyaml
+    bibtexparser
+    python-dateutil
+    six
+    requests
+    configobj
     beautifulsoup4
+    feedparser
+    argcomplete
   ];
 
-  checkInputs = with python3Packages; [ pyfakefs mock ddt ];
+  checkInputs = with python3.pkgs; [
+    pyfakefs
+    mock
+    ddt
+    pytestCheckHook
+  ];
 
-  # Disabling git tests because they expect git to be preconfigured
-  # with the user's details. See
-  # https://github.com/NixOS/nixpkgs/issues/94663
-  preCheck = ''
-    rm tests/test_git.py
-    '';
+  disabledTestPaths = [
+    # Disabling git tests because they expect git to be preconfigured
+    # with the user's details. See
+    # https://github.com/NixOS/nixpkgs/issues/94663
+    "tests/test_git.py"
+  ];
+
+  disabledTests = [
+    # https://github.com/pubs/pubs/issues/276
+    "test_readme"
+  ];
 
   meta = with lib; {
     description = "Command-line bibliography manager";
     homepage = "https://github.com/pubs/pubs";
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [ gebner ];
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ gebner dotlambda ];
   };
 }


### PR DESCRIPTION

###### Description of changes
https://github.com/pubs/pubs/blob/v0.9.0/changelog.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
