### PR TITLE
sdrangel: 6.18.1 -> 6.20.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -536,6 +536,12 @@
     githubId = 782180;
     name = "Alex Vorobiev";
   };
+  alexwinter = {
+    email = "git@alexwinter.net";
+    github = "lxwntr";
+    githubId = 50754358;
+    name = "Alex Winter";
+  };
   alexeyre = {
     email = "A.Eyre@sms.ed.ac.uk";
     github = "alexeyre";

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , codec2
 , fetchFromGitHub
+, fetchpatch
 , fftwFloat
 , glew
 , hackrf
@@ -24,6 +25,7 @@
 , qtmultimedia
 , qtserialport
 , qtspeech
+, qtwebengine
 , qtwebsockets
 , rtl-sdr
 , serialdv
@@ -33,15 +35,24 @@
 
 mkDerivation rec {
   pname = "sdrangel";
-  version = "6.18.1";
+  version = "6.20.2";
 
   src = fetchFromGitHub {
     owner = "f4exb";
     repo = "sdrangel";
     rev = "v${version}";
-    sha256 = "sha256-gf+RUOcki0pi3UH4NHFsmbTV04HUG16UC4jcUjyeip4=";
+    sha256 = "sha256-4RvOXC4I0njkMQqYiQODtJB2bYfw6Kt6z3Ek63BOVYg=";
     fetchSubmodules = false;
   };
+
+  patches = [
+    # Fixes a core dump bug when unloading DATV or DSD decoder, backport from v7 branch
+    # Should be removed if v7 is released or backported upstream
+    (fetchpatch {
+      url = "https://github.com/f4exb/sdrangel/commit/98a3a76ca111652a7e6714e9231e6c42bb212a0b.patch";
+      sha256 = "sha256-Fgs4u6rSUyhvYJ66ywH6PTBrj9fSWWtR9QGFb8dEEdY=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 
@@ -66,6 +77,7 @@ mkDerivation rec {
     qtmultimedia
     qtserialport
     qtspeech
+    qtwebengine
     qtwebsockets
     rtl-sdr
     serialdv
@@ -74,6 +86,8 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [
+    "-DDEBUG_OUTPUT=ON"
+    "-DRX_SAMPLE_24BIT=ON"
     "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"
     "-DLIMESUITE_INCLUDE_DIR:PATH=${limesuite}/include"
     "-DLIMESUITE_LIBRARY:FILEPATH=${limesuite}/lib/libLimeSuite.so"

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -5,6 +5,7 @@
 , cmake
 , codec2
 , dab_lib
+, dsdcc
 , faad2
 , fetchFromGitHub
 , fetchpatch
@@ -69,6 +70,7 @@ mkDerivation rec {
     cm256cc
     codec2
     dab_lib
+    dsdcc
     faad2
     ffmpeg
     fftwFloat

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -37,6 +37,7 @@
 , rtl-sdr
 , sdrplay_source ? false, sdrplay
 , serialdv
+, sgp4
 , soapysdr-with-plugins
 , uhd
 }:
@@ -96,6 +97,7 @@ mkDerivation rec {
     qtwebsockets
     rtl-sdr
     serialdv
+    sgp4
     soapysdr-with-plugins
     uhd
   ]
@@ -109,6 +111,7 @@ mkDerivation rec {
     "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"
     "-DLIMESUITE_INCLUDE_DIR:PATH=${limesuite}/include"
     "-DLIMESUITE_LIBRARY:FILEPATH=${limesuite}/lib/libLimeSuite.so"
+    "-DSGP4_DIR=${sgp4}"
     "-DSOAPYSDR_DIR=${soapysdr-with-plugins}"
   ];
 

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -28,6 +28,7 @@
 , qtwebengine
 , qtwebsockets
 , rtl-sdr
+, sdrplay_source ? false, sdrplay
 , serialdv
 , soapysdr-with-plugins
 , uhd
@@ -83,7 +84,8 @@ mkDerivation rec {
     serialdv
     soapysdr-with-plugins
     uhd
-  ];
+  ]
+    ++ lib.optional sdrplay_source sdrplay;
 
   cmakeFlags = [
     "-DDEBUG_OUTPUT=ON"

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -45,13 +45,13 @@
 
 mkDerivation rec {
   pname = "sdrangel";
-  version = "6.20.2";
+  version = "6.20.3";
 
   src = fetchFromGitHub {
     owner = "f4exb";
     repo = "sdrangel";
     rev = "v${version}";
-    sha256 = "sha256-4RvOXC4I0njkMQqYiQODtJB2bYfw6Kt6z3Ek63BOVYg=";
+    sha256 = "sha256-Ma1XB1F+0TcDy9/NhiaBajewFCn/7yMRhgx9GI1+VWk=";
     fetchSubmodules = false;
   };
 

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -1,5 +1,6 @@
 { airspy
 , airspyhf
+, aptdec
 , boost
 , cm256cc
 , cmake
@@ -66,6 +67,7 @@ mkDerivation rec {
   buildInputs = [
     airspy
     airspyhf
+    aptdec
     boost
     cm256cc
     codec2
@@ -102,6 +104,7 @@ mkDerivation rec {
   cmakeFlags = [
     "-DDEBUG_OUTPUT=ON"
     "-DRX_SAMPLE_24BIT=ON"
+    "-DAPT_DIR=${aptdec}"
     "-DDAB_DIR=${dab_lib}"
     "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"
     "-DLIMESUITE_INCLUDE_DIR:PATH=${limesuite}/include"

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -1,13 +1,16 @@
 { airspy
+, airspyhf
 , boost
 , cm256cc
 , cmake
 , codec2
+, faad2
 , fetchFromGitHub
 , fetchpatch
 , fftwFloat
 , glew
 , hackrf
+, hidapi
 , lib
 , ffmpeg
 , libiio
@@ -16,6 +19,7 @@
 , libusb1
 , limesuite
 , libbladeRF
+, mbelib
 , mkDerivation
 , ocl-icd
 , opencv3
@@ -59,19 +63,23 @@ mkDerivation rec {
 
   buildInputs = [
     airspy
+    airspyhf
     boost
     cm256cc
     codec2
+    faad2
     ffmpeg
     fftwFloat
     glew
     hackrf
+    hidapi
     libbladeRF
     libiio
     libopus
     libpulseaudio
     libusb1
     limesuite
+    mbelib
     opencv3
     qtcharts
     qtlocation

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -4,6 +4,7 @@
 , cm256cc
 , cmake
 , codec2
+, dab_lib
 , faad2
 , fetchFromGitHub
 , fetchpatch
@@ -67,6 +68,7 @@ mkDerivation rec {
     boost
     cm256cc
     codec2
+    dab_lib
     faad2
     ffmpeg
     fftwFloat
@@ -98,6 +100,7 @@ mkDerivation rec {
   cmakeFlags = [
     "-DDEBUG_OUTPUT=ON"
     "-DRX_SAMPLE_24BIT=ON"
+    "-DDAB_DIR=${dab_lib}"
     "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"
     "-DLIMESUITE_INCLUDE_DIR:PATH=${limesuite}/include"
     "-DLIMESUITE_LIBRARY:FILEPATH=${limesuite}/lib/libLimeSuite.so"

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -17,6 +17,7 @@
 , lib
 , ffmpeg
 , libiio
+, libmirisdr-4
 , libopus
 , libpulseaudio
 , libusb1
@@ -82,6 +83,7 @@ mkDerivation rec {
     hidapi
     libbladeRF
     libiio
+    libmirisdr-4
     libopus
     libpulseaudio
     libusb1

--- a/pkgs/development/libraries/aptdec/default.nix
+++ b/pkgs/development/libraries/aptdec/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, libpng, libsndfile
+} :
+
+stdenv.mkDerivation {
+  pname = "aptdec";
+  version = "20220518";
+
+  src = fetchFromGitHub {
+    owner = "Xerbo";
+    repo = "aptdec";
+    rev = "b1cc7480732349a7c772124f984b58f4c734c91b";
+    sha256 = "sha256-Fi9IkZcvqxpmHzqucpCr++37bmTtMy18P4LPznoaYIY=";
+  };
+
+  # fixes https://github.com/Xerbo/aptdec/issues/15
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace "-Werror" ""
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libpng libsndfile ];
+
+  meta = with lib; {
+    description = "NOAA APT satellite imagery decoding library";
+    homepage = "https://github.com/Xerbo/aptdec";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ alexwinter ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/dab_lib/default.nix
+++ b/pkgs/development/libraries/dab_lib/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, faad2, fftwFloat, zlib
+} :
+
+stdenv.mkDerivation {
+  pname = "dab_lib";
+  version = "20211228";
+
+  src = fetchFromGitHub {
+    owner = "JvanKatwijk";
+    repo = "dab-cmdline";
+    rev = "d23adb3616bb11d98a909aceecb5a3b9507a674c";
+    sha256 = "sha256-n/mgsldgXEOLHZEL1cmsqXgFXByWoMeNXNoDWqPpipA=";
+  };
+
+  sourceRoot = "source/library/";
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ faad2 fftwFloat zlib ];
+
+  meta = with lib; {
+    description = "DAB/DAB+ decoding library";
+    homepage = "https://github.com/JvanKatwijk/dab-cmdline";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ alexwinter ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/dsdcc/default.nix
+++ b/pkgs/development/libraries/dsdcc/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, mbelib, serialdv
+} :
+
+stdenv.mkDerivation rec {
+  pname = "dsdcc";
+  version = "1.9.3";
+
+  src = fetchFromGitHub {
+    owner = "f4exb";
+    repo = "dsdcc";
+    rev = "v${version}";
+    sha256 = "sha256-8lO2c4fkQCaVO8IM05+Rdpo6oMxoEIObBm0y08i+/0k=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ mbelib serialdv ];
+
+  cmakeFlags = [
+    "-DUSE_MBELIB=ON"
+  ];
+
+  meta = with lib; {
+    description = "Digital Speech Decoder (DSD) rewritten as a C++ library";
+    homepage = "https://github.com/f4exb/dsdcc";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ alexwinter ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libmirisdr-4/default.nix
+++ b/pkgs/development/libraries/libmirisdr-4/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, libusb1
+} :
+
+stdenv.mkDerivation rec {
+  pname = "libmirisdr-4";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "f4exb";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "sha256-woqWZOlmPmye5fSANCns7KTLTnxNB3nH/v95sCXO1F4=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libusb1 ];
+
+  cmakeFlags = [
+    "-DDETACH_KERNEL_DRIVER=ON"
+  ];
+
+  meta = with lib; {
+    description = "Mirics MSi001 + MSi2500 SDR device library";
+    homepage = "https://github.com/f4exb/libmirisdr-4";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ alexwinter ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/sgp4/default.nix
+++ b/pkgs/development/libraries/sgp4/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config } :
+
+stdenv.mkDerivation {
+  pname = "sgp4";
+  version = "20210111";
+
+  src = fetchFromGitHub {
+    owner = "dnwrnr";
+    repo = "sgp4";
+    rev = "ca9d4d97af4ee62461de6f13e0c85d1dc6000040";
+    sha256 = "sha256-56It/71R10U+Hnhw2tC16e5fZdyfQ8DLx6LVq65Rjvc=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ ];
+
+  meta = with lib; {
+    description = "Simplified perturbations models library";
+    homepage = "https://github.com/dnwrnr/sgp4";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ alexwinter ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7574,6 +7574,8 @@ with pkgs;
     gtk3 = if stdenv.isDarwin then gtk3-x11 else gtk3;
   };
 
+  libmirisdr-4 = callPackage ../development/libraries/libmirisdr-4 { };
+
   libshumate = callPackage ../development/libraries/libshumate { };
 
   libsmartcols = callPackage ../development/libraries/libsmartcols { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3369,6 +3369,8 @@ with pkgs;
 
   dpic = callPackage ../tools/graphics/dpic { };
 
+  dsdcc = callPackage ../development/libraries/dsdcc {};
+
   dstp = callPackage ../development/tools/dstp { };
 
   dsvpn = callPackage ../applications/networking/dsvpn { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3209,6 +3209,8 @@ with pkgs;
 
   cucumber = callPackage ../development/tools/cucumber {};
 
+  dab_lib = callPackage ../development/libraries/dab_lib {};
+
   dabet = callPackage ../tools/misc/dabet { };
 
   dabtools = callPackage ../applications/radio/dabtools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4201,6 +4201,8 @@ with pkgs;
 
   s2png = callPackage ../tools/graphics/s2png { };
 
+  sgp4 = callPackage ../development/libraries/sgp4 {};
+
   shab = callPackage ../tools/text/shab { };
 
   shell-hist = callPackage ../tools/misc/shell-hist { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2545,6 +2545,8 @@ with pkgs;
 
   apprise = with python3Packages; toPythonApplication apprise;
 
+  aptdec = callPackage ../development/libraries/aptdec {};
+
   aria2 = callPackage ../tools/networking/aria2 {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

- Updated SDRangel to latest version: https://github.com/f4exb/sdrangel/releases
- Added newly required dependency: qtwebengine (enables 3D maps)
- Updated cmake flags to match upstream build documentation (RX sample rate)

Additional changes, each in its own commit:

- Added optional support for (unfree) sdrplay (better gain control than using soapysdr)
- Added all upstream-documented (optional) dependencies that are already packaged
- Added package: dab_lib for DAB/DAB+ radio decoding
- Added package: dsdcc for decoding of various digital voice modes (DMR, D-Star, etc.)
- Added package: aptdec for decoding of NOAA satellite imagery
- Added package: sgp4 for calculation of satellite orbits
- Added package: libmirisdr-4 for full open-source support of SDRPlay RSP1, RSP1A and RSP2

Not added:
- Additional (optional) QT dependencies for 2D maps because [they cause SDRangel to hang](https://github.com/f4exb/sdrangel/issues/1169)
- These are: qtgraphicaleffects, qtquickcontrols2
- Note: this is not new, maps are not working in the current nixpkgs version

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

