### PR TITLE
metal-cli: 0.7.3 -> 0.7.4

### DIFF
--- a/pkgs/development/tools/metal-cli/default.nix
+++ b/pkgs/development/tools/metal-cli/default.nix
@@ -2,22 +2,28 @@
 
 buildGoModule rec {
   pname = "metal-cli";
-  version = "0.7.3";
+  version = "0.7.4";
 
   src = fetchFromGitHub {
     owner = "equinix";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-PsTQuEbo1ReWwZV4D14mEGsU99j49kleiL/6Xyk+g9s=";
+    sha256 = "sha256-muhHBUb5Ttj4n6fJzIJMqics5rKupeSBZAd4JxZUe64=";
   };
-
-  ldflags = [
-    "-X github.com/equinix/metal-cli/cmd.Version=${version}"
-  ];
 
   vendorSha256 = "sha256-F8d5i9jvjY11Pv6w0ZXI3jr0Wix++B/w9oRTuJGpQfE=";
 
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/equinix/metal-cli/cmd.Version=${version}"
+  ];
+
   doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+      $out/bin/metal --version | grep ${version}
+  '';
 
   meta = with lib; {
     description = "Official Equinix Metal CLI";


### PR DESCRIPTION
metal-cli: 0.7.3 -> 0.7.4


---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
