### PR TITLE
argagg: init at 0.4.6

### DIFF
--- a/pkgs/development/libraries/argagg/0001-catch.diff
+++ b/pkgs/development/libraries/argagg/0001-catch.diff
@@ -1,0 +1,20 @@
+--- old/test/doctest.h	2019-03-05 18:04:06.143740733 +0300
++++ new/test/doctest.h	2019-03-05 18:04:43.577284916 +0300
+@@ -1307,7 +1307,7 @@
+                                                        __FILE__, __LINE__, #expr, #as);            \
+             try {                                                                                  \
+                 expr;                                                                              \
+-            } catch(as) {                                                                          \
++            } catch(as e) {                                                                          \
+                 _DOCTEST_RB.m_threw    = true;                                                     \
+                 _DOCTEST_RB.m_threw_as = true;                                                     \
+             } catch(...) { _DOCTEST_RB.m_threw = true; }                                           \
+@@ -1332,7 +1332,7 @@
+ #define DOCTEST_REQUIRE_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_REQUIRE_THROWS)
+ 
+ #define DOCTEST_WARN_THROWS_AS(expr, ex) DOCTEST_ASSERT_THROWS_AS(expr, ex, DT_WARN_THROWS_AS)
+-#define DOCTEST_CHECK_THROWS_AS(expr, ex) DOCTEST_ASSERT_THROWS_AS(expr, ex, DT_CHECK_THROWS_AS)
++#define DOCTEST_CHECK_THROWS_AS(expr, ex) DOCTEST_ASSERT_THROWS_AS(expr, const ex &, DT_CHECK_THROWS_AS)
+ #define DOCTEST_REQUIRE_THROWS_AS(expr, ex) DOCTEST_ASSERT_THROWS_AS(expr, ex, DT_REQUIRE_THROWS_AS)
+ 
+ #define DOCTEST_WARN_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_WARN_NOTHROW)

--- a/pkgs/development/libraries/argagg/default.nix
+++ b/pkgs/development/libraries/argagg/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "argagg";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "vietjtnguyen";
+    repo = pname;
+    rev = version;
+    hash = "sha256-MCtlAPfwdJpgfS8IH+zlcgaaxZ5AsP4hJvbZAFtOa4o=";
+  };
+
+  patches = [
+    # Fix compilation of macro catch statement
+    ./0001-catch.diff
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/vietjtnguyen/argagg";
+    description = "Argument Aggregator";
+    longDescription = ''
+      argagg is yet another C++ command line argument/option parser. It was
+      written as a simple and idiomatic alternative to other frameworks like
+      getopt, Boost program options, TCLAP, and others. The goal is to achieve
+      the majority of argument parsing needs in a simple manner with an easy to
+      use API. It operates as a single pass over all arguments, recognizing
+      flags prefixed by - (short) or -- (long) and aggregating them into easy to
+      access structures with lots of convenience functions. It defers processing
+      types until you access them, so the result structures end up just being
+      pointers into the original command line argument C-strings.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; all;
+    badPlatforms = [ "aarch64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1456,6 +1456,8 @@ with pkgs;
 
   apitrace = libsForQt514.callPackage ../applications/graphics/apitrace {};
 
+  argagg = callPackage ../development/libraries/argagg { };
+
   argtable = callPackage ../development/libraries/argtable { };
 
   arguments = callPackage ../development/libraries/arguments { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
