### PR TITLE
edid-decode: unstable-2018-12-06 -> unstable-2022-04-06

### DIFF
--- a/pkgs/tools/misc/edid-decode/default.nix
+++ b/pkgs/tools/misc/edid-decode/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
-  pname = "edid-decode-unstable";
-  version = "unstable-2018-12-06";
+  pname = "edid-decode";
+  version = "unstable-2022-04-06";
 
   src = fetchgit {
     url = "git://linuxtv.org/edid-decode.git";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "EDID decoder and conformance tester";
-    homepage = "https://cgit.freedesktop.org/xorg/app/edid-decode/";
+    homepage = "https://git.linuxtv.org/edid-decode.git";
     license = licenses.mit;
     maintainers = with maintainers; [ Madouura ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
###### Description of changes
Update.
Looks like the project has [moved](https://cgit.freedesktop.org/xorg/app/edid-decode/commit/?id=e6d15fd33e2e81b483921cb23642dbd8f05e08d2) to https://git.linuxtv.org/edid-decode.git.
Related: #169096

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
