### PR TITLE
Fix pytest-testmon

### DIFF
--- a/pkgs/development/python-modules/pytest-testmon/default.nix
+++ b/pkgs/development/python-modules/pytest-testmon/default.nix
@@ -16,16 +16,11 @@ buildPythonPackage rec {
     sha256 = "sha256-6gWWCtm/GHknhjLyRdVf42koeaSKzk5/V0173DELmj0=";
   };
 
-  propagatedBuildInputs = [ coverage ];
+  propagatedBuildInputs = [ pytest coverage ];
 
-  checkInputs = [ pytest ];
-
-  # avoid tests which try to import unittest_mixins
-  # unittest_mixins doesn't seem to be very active
-  checkPhase = ''
-    cd test
-    pytest test_{core,process_code,pytest_assumptions}.py
-  '';
+  # The project does not include tests since version 1.3.0
+  doCheck = false;
+  pythonImportsCheck = [ "testmon" ];
 
   meta = with lib; {
     homepage = "https://github.com/tarpas/pytest-testmon/";


### PR DESCRIPTION
The tests have been removed upstream in late january:
https://github.com/tarpas/pytest-testmon/commit/decb4f4fdefeea875f4c66ff56bea29ae222b872

which means this package has been broken since 1.3.0 on March 2nd

###### Before

```
> nix build nixpkgs#legacyPackages.x86_64-linux.python310Packages.pytest-testmon
error: builder for '/nix/store/rafmz9pah4zlfy11acfdn8hhysfqxywx-python3.10-pytest-testmon-1.3.0.drv' failed with exit code 1;
       last 10 log lines:
       > post-installation fixup
       > shrinking RPATHs of ELF executables and libraries in /nix/store/bpj2r8g45pq4j6jhsd0z3a2m5dva86i4-python3.10-pytest-testmon-1.3.0
       > strip is /nix/store/4ybkncn05qbhgbdxg9sxdgpm1jpdx76w-gcc-wrapper-10.3.0/bin/strip
       > stripping (with command strip and flags -S) in /nix/store/bpj2r8g45pq4j6jhsd0z3a2m5dva86i4-python3.10-pytest-testmon-1.3.0/lib
       > patching script interpreter paths in /nix/store/bpj2r8g45pq4j6jhsd0z3a2m5dva86i4-python3.10-pytest-testmon-1.3.0
       > checking for references to /build/ in /nix/store/bpj2r8g45pq4j6jhsd0z3a2m5dva86i4-python3.10-pytest-testmon-1.3.0...
       > Executing pythonRemoveTestsDir
       > Finished executing pythonRemoveTestsDir
       > running install tests
       > /nix/store/83l8wwrx7xs3mh9sbbj6whmyx8y4cz36-stdenv-linux/setup: line 1354: cd: test: No such file or directory
       For full logs, run 'nix log /nix/store/rafmz9pah4zlfy11acfdn8hhysfqxywx-python3.10-pytest-testmon-1.3.0.drv'.
```
###### After

```
> nix build github:voidus/nixpkgs/fix-pytest-testmon#legacyPackages.x86_64-linux.python310Packages.pytest-testmon
nix build   1,98s user 1,52s system 35% cpu 9,751 total
```