### PR TITLE
debian-goodies: init at 0.87

### DIFF
--- a/pkgs/applications/misc/debian-goodies/default.nix
+++ b/pkgs/applications/misc/debian-goodies/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, curl
+, dialog
+, installShellFiles
+, perl
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "debian-goodies";
+  version = "0.87";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "debian-goodies";
+    rev = "debian/${version}";
+    sha256 = "sha256-7O2AY7tWYiOIy4ImFBxWu6S+ljc3VmqS/j4KyEzVVIA=";
+  };
+
+  postPatch = ''
+    substituteInPlace debmany/debmany \
+      --replace "/usr/bin/dialog" "${dialog}/bin/dialog" \
+      --replace "/usr/bin/whiptail" "${python3.pkgs.snack}/bin/whiptail"
+
+    substituteInPlace dman \
+      --replace "curl" "${curl}/bin/curl"
+  '';
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = [
+    perl
+    python3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # see https://salsa.debian.org/debian/debian-goodies/-/blob/master/debian/install
+    for bin in checkrestart dgrep dglob debget dpigs debman dman popbugs which-pkg-broke which-pkg-broke-build dhomepage debmany/debmany check-enhancements find-dbgsym-packages; do
+      install -Dm755 $bin -t $out/bin
+    done
+
+    install -Dm644 find-dbgsym-packages-templates/* -t $out/share/debian-goodies/find-dbgsym-packages-templates/
+
+    installShellCompletion --bash \
+      debmany/bash_completion/debmany \
+      debian/bash-completion
+
+    installManPage \
+      *.1 \
+      debmany/man/*.1 \
+      *.8
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Small toolbox-style utilities for Debian systems";
+    homepage = "https://salsa.debian.org/debian/debian-goodies";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4737,6 +4737,8 @@ with pkgs;
 
   debian-devscripts = callPackage ../tools/misc/debian-devscripts { };
 
+  debian-goodies = callPackage ../applications/misc/debian-goodies { };
+
   debootstrap = callPackage ../tools/misc/debootstrap { };
 
   debugedit = callPackage ../development/tools/misc/debugedit { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
