### PR TITLE
umoria: init at 5.7.15

### DIFF
--- a/pkgs/games/umoria/default.nix
+++ b/pkgs/games/umoria/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, gcc9Stdenv
+, fetchFromGitHub
+, autoreconfHook
+, cmake
+, ncurses6
+, runtimeShell
+}:
+
+let
+  savesDir = "~/.umoria/";
+in
+gcc9Stdenv.mkDerivation rec {
+  pname = "umoria";
+  version = "5.7.15";
+
+  src = fetchFromGitHub {
+    owner = "dungeons-of-moria";
+    repo = "umoria";
+    rev = "v${version}";
+    sha256 = "sha256-1j4QkE33UcTzM06qAjk1/PyK5uNA7E/kyDe3bZcFKUM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ncurses6 ];
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/data $out/bin
+    cp -r umoria/data/* $out/data
+    cp umoria/umoria $out/.umoria-unwrapped
+
+    mkdir -p $out/bin
+    cat <<EOF >$out/bin/umoria
+    #! ${runtimeShell} -e
+
+    RUNDIR=\$(mktemp -d)
+
+    cleanup() {
+      rm -rf \$RUNDIR
+    }
+
+    trap cleanup EXIT
+
+    cd \$RUNDIR
+    mkdir data
+
+    for i in $out/data/*; do
+      ln -s \$i "data/\$(basename \$i)"
+    done
+
+    mkdir -p ${savesDir}
+    [[ ! -f ${savesDir}/scores.dat ]] && touch ${savesDir}/scores.dat
+    ln -s ${savesDir}/scores.dat scores.dat
+
+    $out/.umoria-unwrapped
+    EOF
+
+    chmod +x $out/bin/umoria
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://umoria.org/";
+    description = "The Dungeons of Moria - the original roguelike";
+    longDescription = ''
+      The Dungeons of Moria is a single player dungeon simulation originally written
+      by Robert Alan Koeneke, with its first public release in 1983.
+      The game was originally developed using VMS Pascal before being ported to the C
+      language by James E. Wilson in 1988, and released a Umoria.
+    '';
+    platforms = platforms.unix;
+    badPlatforms = [ "aarch64-darwin" ];
+    maintainers = [ maintainers.aciceri ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31910,6 +31910,8 @@ with pkgs;
 
   ultrastardx = callPackage ../games/ultrastardx { };
 
+  umoria = callPackage ../games/umoria { };
+
   unciv = callPackage ../games/unciv { };
 
   unnethack = callPackage ../games/unnethack { };


### PR DESCRIPTION
Added [umoria](https://github.com/dungeons-of-moria/umoria) game. The binary is being wrapped with a script that runs it in a temporary directory with the needed data files linked from the store and creating a savefile in `~/.umoria` if needed.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
