### PR TITLE
[21.11] libarchive: add patch for CVE-2022-26280

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -1,6 +1,7 @@
 {
   fetchFromGitHub, lib, stdenv, pkg-config, autoreconfHook,
   acl, attr, bzip2, e2fsprogs, libxml2, lzo, openssl, sharutils, xz, zlib, zstd,
+  fetchpatch,
 
   # Optional but increases closure only negligibly. Also, while libxml2
   # builds fine on windows, but libarchive has trouble linking windows
@@ -23,6 +24,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1q4ij55yirrbrk5iwnh3r90ayq92n02shxc4qkyf73h8zqlfrcj7";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-26280.patch";
+      url = "https://github.com/libarchive/libarchive/commit/cfaa28168a07ea4a53276b63068f94fce37d6aff.patch";
+      sha256 = "1xvgpj6l4a5i6sy5wvq7v9n7am43mcbgbfsvgzmpmrlkr148kn3g";
+    })
+    (fetchpatch {
+      name = "oss-fuzz-38764-fix.patch";
+      url = "https://github.com/libarchive/libarchive/commit/9ad5f077491b9536f01dadca1724385c39cd7613.patch";
+      sha256 = "0106gc5vsp57yg2p7y2lyddradzgsbnmnbbj1g9pw6daypj3czhd";
+    })
+  ];
 
   outputs = [ "out" "lib" "dev" ];
 


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-26280

Also included the fix for OSS Fuzz issue 38764, which looks like it has the potential for just the same severity, except nobody has assigned a CVE for it (yet?).

Tested on indicated platforms with the test enablement from #169051 retrofitted. All pass, so I have quite a bit of confidence in this.

Issues fixed in `master` through using 3.6.1. A number of the potentially-security-related issues fixed in 3.6.1 were only *introduced* in 3.6.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
