### PR TITLE
[21.11] Pantheon 6.1 backports 2022-04-18

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -226,6 +226,7 @@ in
       # Settings from elementary-default-settings
       environment.etc."gtk-3.0/settings.ini".source = "${pkgs.pantheon.elementary-default-settings}/etc/gtk-3.0/settings.ini";
 
+      xdg.portal.enable = true;
       xdg.portal.extraPortals = with pkgs; [
         pantheon.elementary-files
         pantheon.elementary-settings-daemon

--- a/pkgs/desktops/pantheon/apps/elementary-code/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-code/default.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-code";
-  version = "6.1.0";
+  version = "6.2.0";
 
   repoName = "code";
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-AXmMcPj2hf33G5v3TUg+eZwaKOdVlRvoVXglMJFHRjw=";
+    sha256 = "sha256-QhJNRhYgGbPMd7B1X3kG+pnC/lGUoF7gc7O1PdG49LI=";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
@@ -68,6 +68,14 @@ stdenv.mkDerivation rec {
     pango
   ];
 
+  postInstall = ''
+    # elementary/dock/master is missing a Meson post
+    # install script that does this. This has been
+    # resolved after the dock rewrite (the `main` branch).
+    # https://github.com/elementary/default-settings/issues/267
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
   meta = with lib; {
     description = "Elegant, simple, clean dock";
     homepage = "https://github.com/elementary/dock";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-about";
-  version = "6.0.1";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0c075ac7iqz4hqbp2ph0cwyhiq0jn6c1g1jjfhygjbssv3vvd268";
+    sha256 = "sha256-/8K3xSbzlagOT0zHdXNwEERJP88C+H2I6qJHXwdlTS4=";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-keyboard";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Bl0T+8upTdBnLs03UIimcAg0LO40KwuMZRNSM+y/3Hc=";
+    sha256 = "sha256-ge87rctbd7iR9x9Xq4sMIC09DiPHbpbWBgMZUuJNWbw=";
   };
 
   patches = [

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-onlineaccounts";
-  version = "6.3.0";
+  version = "6.4.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-aRh2zbKqcGOH4Qw5gdJw07hod8a/QGWUcJo/2R9erQs=";
+    sha256 = "sha256-Fppl/IvdlW8lZ6YKEHaHNticv3FFFKEKTPPVnz4u9b4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-sound";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-yHuboDpIcioZPNgpmnrM6J2eUCJpoNDdvgu27YuN65I=";
+    sha256 = "sha256-hyBmo9P68XSXRUuLw+baEAetba2QdqOwUti64geH6xc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/desktop/gala/default.nix
+++ b/pkgs/desktops/pantheon/desktop/gala/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -27,29 +26,19 @@
 
 stdenv.mkDerivation rec {
   pname = "gala";
-  version = "6.3.0";
+  version = "6.3.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-f/WDm9/+lXgplg9tGpct4f+1cOhKgdypwiDRBhewRGw=";
+    sha256 = "sha256-7RZt6gA3wyp1cxIWBYFK+fYFSZDbjHcwYa2snOmDw1Y=";
   };
 
   patches = [
+    # We look for plugins in `/run/current-system/sw/lib/` because
+    # there are multiple plugin providers (e.g. gala and wingpanel).
     ./plugins-dir.patch
-    # Session crashes when switching windows with Alt+Tab
-    # https://github.com/elementary/gala/issues/1312
-    (fetchpatch {
-      url = "https://github.com/elementary/gala/commit/cc83db8fe398feae9f3e4caa8352b65f0c8c96d4.patch";
-      sha256 = "sha256-CPO3EHIzqHAV6ZLHngivCdsD8je8CK/NHznfxSEkhzc=";
-    })
-    # WindowSwitcher: Clear indicator background
-    # https://github.com/elementary/gala/pull/1318
-    (fetchpatch {
-      url = "https://github.com/elementary/gala/commit/cce53acffecba795b6cc48916d4621a47996d2c9.patch";
-      sha256 = "sha256-5aTZE6poo4sQMTLfk9Nhw4G4BW8i9dvpWktizRIS58Q=";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-notifications";
-  version = "6.0.0";
+  version = "6.0.1";
 
   repoName = "notifications";
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "0jfppafbc8jwhhnillylicz4zfds789d8b31ifsx0qijlxa7kji9";
+    sha256 = "sha256-AEcZVQPAQLa202/Yvq0GihY8BfMEH46iXeQ5u3QvuXg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

I expect this is the last backport pull request for 21.11, sorry I mostly live on unstable so I cannot really test 21.11 stuff frequently.

- Backports #163960
- Backports #166812
- Backports #167265
- Backports #167617
- Backports #167698

###### Previous stable channel backport pull request

- #161642

###### How to test on NixOS

> For flakes enabled system, you can also try [bobby285271/test-pantheon](https://github.com/bobby285271/test-pantheon).

1. Clone the `NixOS/nixpkgs` repository and checkout to this PR, you can use the GitHub CLI tool `gh`.
```
$ gh repo clone NixOS/nixpkgs
$ cd nixpkgs
$ gh pr checkout 169141
```

2. Save the following NixOS configuration file as `configuration.nix`, you can save the file to any directory.

```nix
{ modulesPath, pkgs, config, ... }: {
  imports = [
    "${modulesPath}/virtualisation/qemu-vm.nix"
  ];

  environment.enableDebugInfo = true;
  services.xserver = {
    enable = true;
    layout = "us";
    desktopManager.pantheon.enable = true;
    desktopManager.pantheon.debug = true;
  };

  users.mutableUsers = false;

  users.extraUsers.test = {
    isNormalUser = true;
    uid = 1000;
    extraGroups = [ "wheel" "networkmanager" ];
    password = "test";
  };
  nixpkgs.config.allowAliases = false;

  virtualisation.qemu.options = [ "-device intel-hda -device hda-duplex" ];
  virtualisation.memorySize = 2048;
  virtualisation.diskSize = 8192;
}
```

3. Run the following command to build the packages and create a virtual machine with the above configuration. Do not forget to adjust the path to the `nixpkgs` checkout (`/path/to/nixpkgs`) and the configuration (`/path/to/configuration.nix`). It will take some time to build the packages, so grab some coffee while waiting.

```
$ env NIX_PATH=nixpkgs=/path/to/nixpkgs:nixos-config=/path/to/configuration.nix nixos-rebuild build-vm
```

4. You should see a message like this, run the command provided by the output:
```
Done. The virtual machine can be started by running /nix/store/...-nixos-vm/bin/run-nixos-vm
```

5. A QEMU virtual machine will be launched, wait for LightDM to start and login with the password `test`.

6. Test the upgrade and if you find anything wrong, please also try reproduce the issue on `master` then comment here with your findings so we can handle that properly (i.e. we will drop the commit here that introduces major regressions).


###### Things done

Still testing this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
