### PR TITLE
didyoumean: init at 1.1.0

### DIFF
--- a/pkgs/tools/misc/didyoumean/default.nix
+++ b/pkgs/tools/misc/didyoumean/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, libxcb
+# Darwin dependencies
+, AppKit
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "didyoumean";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hisbaan";
+    repo = "didyoumean";
+    rev = "v${version}";
+    sha256 = "sha256-t2bmvz05vWIxQhC474q/9uky1kAQoFN8Z+qflw5Vj68=";
+  };
+
+  cargoSha256 = "sha256-4DbziI9enib4pm9/P4WEu15glIxtejaV2GCqbzuxxyw=";
+
+  buildInputs = lib.optional stdenv.isLinux [ libxcb ]
+    ++ lib.optionals stdenv.isDarwin [ AppKit ];
+
+  meta = with lib; {
+    description = "A CLI spelling corrector for when you're unsure";
+    homepage = "https://github.com/hisbaan/didyoumean";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -433,6 +433,10 @@ with pkgs;
 
   devour = callPackage ../tools/X11/devour {};
 
+  didyoumean = callPackage ../tools/misc/didyoumean {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
+
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;


### PR DESCRIPTION
###### Description of changes
Initialize didyoumean at 1.1.0
Links: [GitHub](https://github.com/hisbaan/didyoumean), [crates.io](https://crates.io/crates/didyoumean), [Reddit](https://reddit.com/r/rust/comments/u5mryq/media_didyoumean_a_cli_spelling_corrector_written/)

![9FF93034-FA5B-4F38-B7E6-7822AF84AEE8](https://user-images.githubusercontent.com/1847524/163741904-7c45e23f-bfd9-473f-b594-0712b99dc233.jpeg)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
