### PR TITLE
python3Packages.bottleneck: unbreak package

### DIFF
--- a/pkgs/development/python-modules/bottleneck/default.nix
+++ b/pkgs/development/python-modules/bottleneck/default.nix
@@ -21,8 +21,12 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [ pytest nose ];
+  # test_make_c_files expect a missing test data file, therefore, the test fails.
   checkPhase = ''
-    py.test -p no:warnings $out/${python.sitePackages}
+    py.test \
+      -p no:warnings \
+      -k 'not test_make_c_files' \
+      $out/${python.sitePackages}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

This disables the `test_make_c_files`, which fails with the following trace:
```
E           FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/5jhaxfpn8cwjs8zrpw35b3g9mids4ncn-python3.9-Bottleneck-1.3.4/lib/python3.9/site-packages/bottleneck/tests/data/template_test/test_template.c'

/nix/store/5jhaxfpn8cwjs8zrpw35b3g9mids4ncn-python3.9-Bottleneck-1.3.4/lib/python3.9/site-packages/bottleneck/src/bn_template.py:26: FileNotFoundError
```
Call site being: `/nix/store/5jhaxfpn8cwjs8zrpw35b3g9mids4ncn-python3.9-Bottleneck-1.3.4/lib/python3.9/site-packages/bottleneck/tests/test_template.py:14:`

It seems like a test data file is not installed over `$out`, it might be related to a missing `package_data` directive in the `setup.py`, this test is quite simple and can be fixed in the future with extra efforts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).