### PR TITLE
gh: Avoid absoloute executable paths in gitconfig

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gh/avoid-absoloute-executable-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/gh/avoid-absoloute-executable-path.patch
@@ -1,0 +1,11 @@
+--- a/pkg/cmd/auth/shared/git_credential.go
++++ b/pkg/cmd/auth/shared/git_credential.go
+@@ -93,7 +93,7 @@ func (flow *GitCredentialFlow) gitCredentialSetup(hostname, username, password s
+ 			configureCmd, err := git.GitCommand(
+ 				"config", "--global", "--add",
+ 				credHelperKey,
+-				fmt.Sprintf("!%s auth git-credential", shellQuote(flow.Executable)),
++				"!gh auth git-credential",
+ 			)
+ 			if err != nil {
+ 				configErr = err

--- a/pkgs/applications/version-management/git-and-tools/gh/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gh/default.nix
@@ -11,6 +11,10 @@ buildGoModule rec {
     sha256 = "sha256-oPLnc3Fv8oGbfQMujcVIwKJrQ3vCV9yIB4rUtjeVOV0=";
   };
 
+  patches = [
+    ./avoid-absoloute-executable-path.patch
+  ];
+
   vendorSha256 = "sha256-YLkNua0Pz0gVIYnWOzOlV5RuLBaoZ4l7l1Pf4QIfUVQ=";
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
`gh auth login` may install credential helpers using absoloute store
paths (see cli/cli@98f1f5ec0d570a1b89cfe249cc6fff37dc6d7ab1 introducing
this behaviour).

Replace the path with "gh" to rely on `PATH` lookup instead and thus
keep working across `gh` nix updates.

Fixes #169115.