### PR TITLE
vis: add tre to buildInputs

### DIFF
--- a/pkgs/applications/editors/vis/default.nix
+++ b/pkgs/applications/editors/vis/default.nix
@@ -1,6 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, makeWrapper, makeDesktopItem
-, ncurses, libtermkey, lua
-, acl ? null, libselinux ? null
+{ lib, stdenv, fetchFromGitHub, pkg-config, makeWrapper
+, copyDesktopItems, makeDesktopItem
+, ncurses, libtermkey, lua, tre
+, acl, libselinux
 }:
 
 let
@@ -17,12 +18,13 @@ stdenv.mkDerivation rec {
     owner = "martanne";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
+  nativeBuildInputs = [ pkg-config makeWrapper copyDesktopItems ];
 
   buildInputs = [
     ncurses
     libtermkey
     luaEnv
+    tre
   ] ++ lib.optionals stdenv.isLinux [
     acl
     libselinux
@@ -33,28 +35,27 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    mkdir -p "$out/share/applications"
-    cp $desktopItem/share/applications/* $out/share/applications
-    echo wrapping $out/bin/vis with runtime environment
     wrapProgram $out/bin/vis \
       --prefix LUA_CPATH ';' "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \
       --prefix LUA_PATH ';' "${luaEnv}/share/lua/${lua.luaversion}/?.lua" \
       --prefix VIS_PATH : "\$HOME/.config:$out/share/vis"
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "vis";
-    exec = "vis %U";
-    type = "Application";
-    icon = "accessories-text-editor";
-    comment = meta.description;
-    desktopName = "vis";
-    genericName = "Text editor";
-    categories = [ "Application" "Development" "IDE" ];
-    mimeTypes = [ "text/plain" "application/octet-stream" ];
-    startupNotify = false;
-    terminal = true;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vis";
+      exec = "vis %U";
+      type = "Application";
+      icon = "accessories-text-editor";
+      comment = meta.description;
+      desktopName = "vis";
+      genericName = "Text editor";
+      categories = [ "Application" "Development" "IDE" ];
+      mimeTypes = [ "text/plain" "application/octet-stream" ];
+      startupNotify = false;
+      terminal = true;
+    })
+  ];
 
   meta = with lib; {
     description = "A vim like editor";


### PR DESCRIPTION
###### Description of changes
* [TRE](http://laurikari.net/tre/) is optional dependency for more memory efficient regex search:
```
result/bin/vis -v
vis v0.7 +curses +lua +tre +acl +selinux
```
* ~don't install `.desktop` file on darwin~

Wanted: Nix lexer https://github.com/martanne/vis/issues/880

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
