### PR TITLE
tdesktop: fix build with kwayland 5.94

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -82,6 +82,14 @@ env.mkDerivation rec {
     sha256 = "0zcjm08nfdlxrsv0fi6dqg3lk52bcvsxnsf6jm5fv6gf5v9ia3hq";
   };
 
+  patches = [
+    # fix build with KWayland 5.94+
+    # cf. https://invent.kde.org/frameworks/kwayland/-/commit/de442e4a94e249a29cf2e005db8e0a5e4a6a13ed
+    # upstream bug: https://github.com/telegramdesktop/tdesktop/issues/24375
+    # FIXME remove when no longer necessary
+    ./kf594.diff
+  ];
+
   postPatch = ''
     substituteInPlace Telegram/CMakeLists.txt \
       --replace '"''${TDESKTOP_LAUNCHER_BASENAME}.appdata.xml"' '"''${TDESKTOP_LAUNCHER_BASENAME}.metainfo.xml"'

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/kf594.diff
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/kf594.diff
@@ -1,0 +1,57 @@
+diff --git a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
+index 7641579aa..3c195e397 100644
+--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
++++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
+@@ -9,10 +9,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ 
+ #include "base/platform/base_platform_info.h"
+ 
+-#include <connection_thread.h>
+-#include <registry.h>
+-#include <surface.h>
+-#include <plasmashell.h>
++#include <KWayland/Client/connection_thread.h>
++#include <KWayland/Client/registry.h>
++#include <KWayland/Client/surface.h>
++#include <KWayland/Client/plasmashell.h>
+ 
+ using namespace KWayland::Client;
+ 
+Submodule Telegram/lib_base contains modified content
+diff --git a/Telegram/lib_base/base/platform/linux/base_linux_wayland_integration.cpp b/Telegram/lib_base/base/platform/linux/base_linux_wayland_integration.cpp
+index 32f0de6..30a087f 100644
+--- a/Telegram/lib_base/base/platform/linux/base_linux_wayland_integration.cpp
++++ b/Telegram/lib_base/base/platform/linux/base_linux_wayland_integration.cpp
+@@ -13,11 +13,11 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include <QtCore/QPointer>
+ #include <QtGui/QWindow>
+ 
+-#include <connection_thread.h>
+-#include <registry.h>
+-#include <surface.h>
+-#include <xdgforeign.h>
+-#include <idleinhibit.h>
++#include <KWayland/Client/connection_thread.h>
++#include <KWayland/Client/registry.h>
++#include <KWayland/Client/surface.h>
++#include <KWayland/Client/xdgforeign.h>
++#include <KWayland/Client/idleinhibit.h>
+ 
+ using namespace KWayland::Client;
+ 
+Submodule Telegram/lib_ui contains modified content
+diff --git a/Telegram/lib_ui/ui/platform/linux/ui_linux_wayland_integration.cpp b/Telegram/lib_ui/ui/platform/linux/ui_linux_wayland_integration.cpp
+index 01f1e80..163cb6a 100644
+--- a/Telegram/lib_ui/ui/platform/linux/ui_linux_wayland_integration.cpp
++++ b/Telegram/lib_ui/ui/platform/linux/ui_linux_wayland_integration.cpp
+@@ -24,8 +24,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include <private/qwaylandwindow_p.h>
+ #include <private/qwaylandshellsurface_p.h>
+ 
+-#include <connection_thread.h>
+-#include <registry.h>
++#include <KWayland/Client/connection_thread.h>
++#include <KWayland/Client/registry.h>
+ 
+ Q_DECLARE_METATYPE(QMargins);
+ 


### PR DESCRIPTION
Hopefully a temporary hack until upstream fixes this (or nixpkgs ships qt6).
###### Description of changes

Added a patch to look for headers in correct places instead of mostly-happened-to-work-due-to-KDE4-compat-horrors places.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
