### PR TITLE
python3Packages.beancount-black: init at 0.1.13

### DIFF
--- a/pkgs/development/python-modules/beancount-black/default.nix
+++ b/pkgs/development/python-modules/beancount-black/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, beancount-parser
+, click
+, poetry-core
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "beancount-black";
+  version = "0.1.13";
+
+  disabled = pythonOlder "3.9";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "LaunchPlatform";
+    repo = "beancount-black";
+    rev = version;
+    sha256 = "sha256-jhcPR+5+e8d9cbcXC//xuBwmZ14xtXNlYtmH5yNSU0E=";
+  };
+
+  buildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    beancount-parser
+    click
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "beancount_black"
+  ];
+
+  meta = with lib; {
+    description = "Opinioned code formatter for Beancount";
+    homepage = "https://github.com/LaunchPlatform/beancount-black/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/development/python-modules/beancount-parser/default.nix
+++ b/pkgs/development/python-modules/beancount-parser/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, lark
+, poetry-core
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "beancount-parser";
+  version = "0.1.21";
+
+  disabled = pythonOlder "3.9";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "LaunchPlatform";
+    repo = "beancount-parser";
+    rev = version;
+    sha256 = "sha256-0uhH75OEjC9iA0XD0VX7CGoRIP/hpM4y+53JnyXgZpA=";
+  };
+
+  buildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    lark
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "beancount_parser"
+  ];
+
+  meta = with lib; {
+    description = "Standalone Lark based Beancount syntax parser";
+    homepage = "https://github.com/LaunchPlatform/beancount-parser/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33971,6 +33971,8 @@ with pkgs;
 
   beancount = with python3.pkgs; toPythonApplication beancount;
 
+  beancount-black = with python3.pkgs; toPythonApplication beancount-black;
+
   beancount-language-server = callPackage ../development/tools/beancount-language-server {};
 
   bean-add = callPackage ../applications/office/beancount/bean-add.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1188,6 +1188,8 @@ self: super: with self; {
 
   beancount = callPackage ../development/python-modules/beancount { };
 
+  beancount-parser = callPackage ../development/python-modules/beancount-parser { };
+
   beancount_docverif = callPackage ../development/python-modules/beancount_docverif { };
 
   beanstalkc = callPackage ../development/python-modules/beanstalkc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1188,6 +1188,8 @@ self: super: with self; {
 
   beancount = callPackage ../development/python-modules/beancount { };
 
+  beancount-black = callPackage ../development/python-modules/beancount-black { };
+
   beancount-parser = callPackage ../development/python-modules/beancount-parser { };
 
   beancount_docverif = callPackage ../development/python-modules/beancount_docverif { };


### PR DESCRIPTION
###### Description of changes

An opinionated `beancount` formatter.

https://github.com/LaunchPlatform/beancount-black/

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have tested the resulting executable on a simple test file taken from the repository.

I wasn't sure whether the addition of `beancount-black` to `top-level/all-packages.nix` should be in its own commit or not. I merged it with the addition to `python-packages.nix`.
