### PR TITLE
mle: fix on darwin

### DIFF
--- a/pkgs/applications/editors/mle/default.nix
+++ b/pkgs/applications/editors/mle/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, termbox, pcre, uthash, lua5_3 }:
+{ lib, stdenv, fetchFromGitHub, termbox, pcre, uthash, lua5_3, makeWrapper, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "mle";
@@ -18,11 +18,21 @@ stdenv.mkDerivation rec {
     patchShebangs tests/*
   '';
 
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
   buildInputs = [ termbox pcre uthash lua5_3 ];
 
   doCheck = true;
 
   installFlags = [ "prefix=${placeholder "out"}" ];
+
+  postInstall = ''
+    installManPage mle.1
+  '';
+
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    wrapProgram $out/bin/mle --prefix DYLD_LIBRARY_PATH : ${termbox}/lib
+  '';
 
   meta = with lib; {
     description = "Small, flexible terminal-based text editor";


### PR DESCRIPTION
###### Description of changes
* fix on darwin, see https://github.com/NixOS/nixpkgs/pull/80131#issuecomment-899122362
* install man page

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
