### PR TITLE
lingua-franca: 0.1.0-alpha -> 0.1.0-beta

### DIFF
--- a/pkgs/development/compilers/lingua-franca/default.nix
+++ b/pkgs/development/compilers/lingua-franca/default.nix
@@ -1,24 +1,22 @@
-{ lib, pkgs, stdenv, fetchFromGitHub, jdk11_headless }:
+{ lib, pkgs, stdenv, fetchzip, jdk17_headless }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "lfc";
-  version = "0.1.0";
+  version = "0.2.0";
 
-  src = fetchFromGitHub {
-    owner = "revol-xut";
-    repo = "lingua-franca-nix-releases";
-    rev = "d37bbfa530f0189c3e86ce0191134cdf42c6aec7";
-    sha256 = "/qMBOjffvShCPcbh9rJ7aVgdgZQ1hilHakjLyEhSmgs=";
+  src = fetchzip {
+    url = "https://github.com/lf-lang/lingua-franca/releases/download/v${version}/lfc_${version}.zip";
+    sha256 = "rBx7UnPLufZBO7lG0In5upHqYCyRtI4kQv0V83CZHew=";
   };
 
-  buildInputs = [ jdk11_headless ];
+  buildInputs = [ jdk17_headless ];
 
-  _JAVA_HOME = "${jdk11_headless}/";
+  _JAVA_HOME = "${jdk17_headless}/";
 
   postPatch = ''
     substituteInPlace bin/lfc \
       --replace 'base=`dirname $(dirname ''${abs_path})`' "base='$out'" \
-      --replace "run_lfc_with_args" "${jdk11_headless}/bin/java -jar $out/lib/jars/org.lflang.lfc-0.1.0-SNAPSHOT-all.jar"
+      --replace "run_lfc_with_args" "${jdk17_headless}/bin/java -jar $out/lib/jars/org.lflang.lfc-${version}-SNAPSHOT-all.jar"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes

Bumped Version from 0.1.0-alpha to 0.1.0-beta and now using official tarball.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
