### PR TITLE
uasm: 2.53 -> 2.55; _7zz: build with useUasm in more platforms

### DIFF
--- a/pkgs/development/compilers/uasm/default.nix
+++ b/pkgs/development/compilers/uasm/default.nix
@@ -2,30 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "uasm";
-  version = "2.53";
+  version = "2.55";
 
   src = fetchFromGitHub {
     owner = "Terraspace";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-Aohwrcb/KTKUFFpfmqVDPNjJh1dMYSNnBJ2eFaP20pM=";
+    # Specifying only the tag results in the following error during download:
+    # the given path has multiple possibilities: #<Git::Ref:0x00007f618689c378>, #<Git::Ref:0x00007f618689c1e8>
+    # Probably because upstream has both a tag and a branch with the same name
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-CIbHPKJa60SyJeFgF1Tux7RfJZBChhUVXR7HGa+gCtQ=";
   };
-
-  # https://github.com/Terraspace/UASM/pull/154
-  patches = [
-    # fix `invalid operands to binary - (have 'char *' and 'uint_8 *' {aka 'unsigned char *'})`
-    (fetchpatch {
-      name = "fix_pointers_compare.patch";
-      url = "https://github.com/clouds56/UASM/commit/9cd3a400990e230571e06d4c758bd3bd35f90ab6.patch";
-      sha256 = "sha256-8mY36dn+g2QNJ1JbWt/y4p0Ha9RSABnOE3vlWANuhsA=";
-    })
-    # fix `dbgcv.c:*:*: fatal error: direct.h: No such file or directory`
-    (fetchpatch {
-      name = "fix_build_dbgcv_c_on_unix.patch";
-      url = "https://github.com/clouds56/UASM/commit/806d54cf778246c96dcbe61a4649bf0aebcb0eba.patch";
-      sha256 = "sha256-uc1LaizdYEh1Ry55Cq+6wrCa1OeBPFo74H5iBpmteAE=";
-    })
-  ];
 
   enableParallelBuilding = true;
 
@@ -43,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.terraspace.co.uk/uasm.html";
     description = "A free MASM-compatible assembler based on JWasm";
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
     maintainers = with maintainers; [ thiagokokada ];
     license = licenses.watcom;
   };

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 
 , uasm
-, useUasm ? stdenv.isx86_64
+, useUasm ? stdenv.isLinux
 
   # RAR code is under non-free unRAR license
   # see the meta.license section below for more details
@@ -13,11 +13,12 @@
 let
   inherit (stdenv.hostPlatform) system;
   platformSuffix =
-    if useUasm then
-      {
-        x86_64-linux = "_x64";
-      }.${system} or (throw "`useUasm` is not supported for system ${system}")
-    else "";
+    lib.optionalString useUasm {
+      aarch64-linux = "_arm64";
+      i686-linux = "_x86";
+      x86_64-linux = "_x64";
+    }.${system} or
+      (builtins.trace "7zz's ASM optimizations not available for `${system}`. Building without optimizations." "");
 in
 stdenv.mkDerivation rec {
   pname = "7zz";


### PR DESCRIPTION
###### Description of changes

New version of `uasm`, including the older patches that we used. Also, I tested in some additional Linux platforms (`aarch64-linux`, `i686-linux`) and it also works fine.

This also allow us to enable ASM optimizations in more platforms in `7zz`. So this PR also enables them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
