### PR TITLE
ocamlPackages.gd4o: init at 1.0a5

### DIFF
--- a/pkgs/development/ocaml-modules/gd4o/default.nix
+++ b/pkgs/development/ocaml-modules/gd4o/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl, ocaml, gd, freetype, findlib, zlib, libpng, libjpeg }:
+
+stdenv.mkDerivation rec {
+  pname = "gd4o";
+  version = "1.0a5";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/gd4o/gd4o/1.0%20Alpha%205/gd4o-1.0a5.tar.gz";
+    sha256 = "1vbyakz7byvxmqf3hj68rw15b4kb94ppcnhvmjv38rsyg05bc47s";
+  };
+
+  buildInputs = [ ocaml findlib libjpeg libpng ];
+  propagatedBuildInputs = [ gd zlib freetype ];
+
+
+  preInstall = ''
+    mkdir -p $OCAMLFIND_DESTDIR/stublibs
+  '';
+
+  buildFlags = [ "all" "opt" ];
+
+  checkPhase = ''
+    runHook preCheck
+    make test.opt
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://sourceforge.net/projects/gd4o/";
+    description = "OCaml wrapper for the GD graphics library";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/gd4o/default.nix
+++ b/pkgs/development/ocaml-modules/gd4o/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, ocaml, gd, freetype, findlib, zlib, libpng, libjpeg }:
 
 stdenv.mkDerivation rec {
-  pname = "gd4o";
+  pname = "ocaml${ocaml.version}-gd4o";
   version = "1.0a5";
 
   src = fetchurl {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -435,6 +435,8 @@ let
 
     functory = callPackage ../development/ocaml-modules/functory { };
 
+    gd4o = callPackage ../development/ocaml-modules/gd4o { };
+
     gen = callPackage ../development/ocaml-modules/gen { };
 
     genspio = callPackage ../development/ocaml-modules/genspio { };


### PR DESCRIPTION
###### Description of changes
Part of splitting out https://github.com/NixOS/nixpkgs/pull/140777 for easier review

This thing is pretty weird, I tried to build it with and without libjpeg, and it does change something in the output of the ocaml files. But doesn't seem to be directly used or referred to by path in any of the output when using nix why-depends so I put them in normal buildInputs

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
