### PR TITLE
veracrypt: 1.24-Update7 -> 1.25.9

### DIFF
--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -18,11 +18,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "veracrypt";
-  version = "1.24-Update7";
+  version = "1.25.9";
 
   src = fetchurl {
     url = "https://launchpad.net/${pname}/trunk/${toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
-    sha256 = "0i7h44zn2mjzgh416l7kfs0dk6qc7b1bxsaxqqqcvgrpl453n7bc";
+    sha256 = "sha256-drbhgYS8IaQdKUn/Y9ch1JBUpxbO/zpL13tcNRC3lK8=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

This fixes a current build issue on master
(cae8c76a9ba9a13d4ae409617bf5b52f2f6960f7)

<details><summary>Failure log:</summary>

```
unpacking sources
unpacking source archive /nix/store/7lm8qckfq3290hjlbbfa0pgkcn0yzsws-VeraCrypt_1.24-Update7_Source.tar.bz2
source root is src
setting SOURCE_DATE_EPOCH to timestamp 1596911374 of file src/Volume/VolumeSlot.h
patching sources
applying patch /nix/store/5449fmpgmfn1h554zb38jm1p5xd2dr6n-fix-paths.patch
patching file Core/VolumeCreator.h
Hunk #1 succeeded at 76 (offset -1 lines).
configuring
no configure script, doing nothing
building
build flags: -j24 -l24 SHELL=/nix/store/fcd0m68c331j7nkdxvnnpb8ggwsaiqac-bash-5.1-p16/bin/bash
Compiling Buffer.cpp
Compiling Exception.cpp
Compiling Event.cpp
Compiling FileCommon.cpp
Compiling MemoryStream.cpp
Compiling Memory.cpp
Compiling PlatformTest.cpp
Compiling Serializable.cpp
Compiling Serializer.cpp
Compiling SerializerFactory.cpp
Compiling StringConverter.cpp
Compiling TextReader.cpp
Compiling Directory.cpp
Compiling File.cpp
Compiling FilesystemPath.cpp
Compiling Mutex.cpp
Compiling Pipe.cpp
Compiling Poller.cpp
Compiling Process.cpp
Compiling SyncEvent.cpp
Compiling SystemException.cpp
Compiling SystemInfo.cpp
Compiling SystemLog.cpp
Compiling Thread.cpp
Compiling Time.cpp
Updating library Platform.a
ar: `u' modifier ignored since `D' is the default (see `U')
Compiling Cipher.cpp
Compiling EncryptionAlgorithm.cpp
Compiling EncryptionMode.cpp
Compiling EncryptionModeXTS.cpp
Compiling EncryptionTest.cpp
Compiling EncryptionThreadPool.cpp
Compiling Hash.cpp
Compiling Keyfile.cpp
Compiling Pkcs5Kdf.cpp
Compiling Volume.cpp
Compiling VolumeException.cpp
Compiling VolumeHeader.cpp
Compiling VolumeInfo.cpp
Compiling VolumeLayout.cpp
Compiling VolumePassword.cpp
Compiling VolumePasswordCache.cpp
Assembling Aes_x64.asm
Assembling Aes_hw_cpu.asm
Compiling Twofish_x64.S
Compiling Camellia_x64.S
Compiling Camellia_aesni_x64.S
Compiling sha512-x64-nayuki.S
Assembling sha256_avx1_x64.asm
Assembling sha256_avx2_x64.asm
Assembling sha256_sse4_x64.asm
Assembling sha512_avx1_x64.asm
Assembling sha512_avx2_x64.asm
Assembling sha512_sse4_x64.asm
Compiling Aeskey.c
Compiling Aestab.c
Compiling cpu.c
Compiling Rmd160.c
Compiling SerpentFast.c
Compiling SerpentFast_simd.cpp
Compiling Sha2.c
Compiling Twofish.c
../Crypto/cpu.c:67:32: warning: argument 2 of type 'uint32[4]' {aka 'unsigned int[4]'} with mismatched bound [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Warray-parameter=-Warray-parameter=8;;]
   67 | int CpuId(uint32 input, uint32 output[4])
      |                         ~~~~~~~^~~~~~~~~
In file included from ../Crypto/cpu.c:3:
../Crypto/cpu.h:229:33: note: previously declared as 'uint32 *' {aka 'unsigned int *'}
  229 | int CpuId(uint32 input, uint32 *output);
      |                         ~~~~~~~~^~~~~~
Compiling Whirlpool.c
Compiling Camellia.c
Compiling GostCipher.c
Compiling Streebog.c
Compiling kuznyechik.c
Compiling kuznyechik_simd.c
In file included from /build/src/Common/Crypto.h:195,
                 from EncryptionThreadPool.cpp:24:
/build/src/Crypto/Aes_hw_cpu.h:27:32: error: reference to 'byte' is ambiguous
   27 | void aes_hw_cpu_decrypt (const byte *ks, byte *data);
      |                                ^~~~
In file included from /build/src/Platform/PlatformBase.h:16,
                 from /build/src/Platform/SyncEvent.h:21,
                 from EncryptionThreadPool.cpp:22:
/nix/store/19xbyxc31snlk60cil7cx6l4xw126ids-gcc-11.2.0/include/c++/11.2.0/cstddef:69:14: note: candidates are: 'enum class std::byte'
   69 |   enum class byte : unsigned char {};
      |              ^~~~
In file included from /build/src/Common/Crypto.h:32,
                 from EncryptionThreadPool.cpp:24:
/build/src/Common/Tcdefs.h:118:17: note:                 'typedef uint8_t byte'
  118 | typedef uint8_t byte;
      |                 ^~~~
In file included from /build/src/Common/Crypto.h:195,
                 from EncryptionThreadPool.cpp:24:
/build/src/Crypto/Aes_hw_cpu.h:27:42: error: reference to 'byte' is ambiguous
   27 | void aes_hw_cpu_decrypt (const byte *ks, byte *data);
      |                                          ^~~~

[..]

In file included from Hash.cpp:18:
/build/src/Crypto/Streebog.h:35:49: note:   initializing argument 2 of 'void STREEBOG_finalize(STREEBOG_CTX*, int*)'
   35 | void STREEBOG_finalize(STREEBOG_CTX *ctx, byte *out);
      |                                           ~~~~~~^~~
Hash.cpp: In member function 'virtual void VeraCrypt::Streebog::ProcessData(const VeraCrypt::ConstBufferPtr&)':
Hash.cpp:165:71: error: cannot convert 'const byte*' {aka 'const unsigned char*'} to 'const int*'
  165 |                 STREEBOG_add ((STREEBOG_CTX *) Context.Ptr(), data.Get(), (int) data.Size());
      |                                                               ~~~~~~~~^~
      |                                                                       |
      |                                                                       const byte* {aka const unsigned char*}
In file included from Hash.cpp:18:
/build/src/Crypto/Streebog.h:34:50: note:   initializing argument 2 of 'void STREEBOG_add(STREEBOG_CTX*, const int*, size_t)'
   34 | void STREEBOG_add(STREEBOG_CTX *ctx, const byte *msg, size_t len);
      |                                      ~~~~~~~~~~~~^~~
make[1]: *** [/build/src/Build/Include/Makefile.inc:29: EncryptionMode.o] Error 1
make[1]: *** [/build/src/Build/Include/Makefile.inc:28: Hash.o] Error 1
make[1]: *** [/build/src/Build/Include/Makefile.inc:28: EncryptionAlgorithm.o] Error 1
make[1]: *** [/build/src/Build/Include/Makefile.inc:28: VolumeInfo.o] Error 1
make[1]: *** [/build/src/Build/Include/Makefile.inc:28: VolumeHeader.o] Error 1
make: *** [Makefile:424: all] Error 2

```
</details>

[Release Notes](https://veracrypt.fr/en/Release%20Notes.html)



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
