### PR TITLE
uasm: fix compilation on darwin; _7zz: cross-compilation fixes

### DIFF
--- a/pkgs/development/compilers/uasm/default.nix
+++ b/pkgs/development/compilers/uasm/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, testVersion
+, uasm
+}:
 
 stdenv.mkDerivation rec {
   pname = "uasm";
@@ -40,6 +46,12 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests.version = testVersion {
+    package = uasm;
+    command = "uasm -h";
+    version = "v${version}";
+  };
 
   meta = with lib; {
     homepage = "http://www.terraspace.co.uk/uasm.html";

--- a/pkgs/development/compilers/uasm/default.nix
+++ b/pkgs/development/compilers/uasm/default.nix
@@ -14,9 +14,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-CIbHPKJa60SyJeFgF1Tux7RfJZBChhUVXR7HGa+gCtQ=";
   };
 
+  patches = lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "fix-v2_55-compilation-on-macos.patch";
+      url = "https://github.com/Terraspace/UASM/commit/b50c430cc3083c7f32e288a9f64fe1cafb03091d.patch";
+      sha256 = "sha256-FGFB282LSEKtGD1cIRH+Qi5bye5Gx4xb0Ty4J03xjCU";
+    })
+  ];
+
   enableParallelBuilding = true;
 
-  makefile = "gccLinux64.mak";
+  makefile =
+    if stdenv.isDarwin then
+      "ClangOSX64.mak"
+    else
+      "gccLinux64.mak";
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     runHook preInstall
@@ -30,7 +44,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.terraspace.co.uk/uasm.html";
     description = "A free MASM-compatible assembler based on JWasm";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ thiagokokada ];
     license = licenses.watcom;
   };

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -50,6 +50,10 @@ stdenv.mkDerivation rec {
   sourceRoot = "CPP/7zip/Bundles/Alone2";
 
   makeFlags =
+    [
+      "CC=${stdenv.cc.targetPrefix}cc"
+      "CXX=${stdenv.cc.targetPrefix}c++"
+    ] ++
     lib.optionals useUasm [ "MY_ASM=uasm" ] ++
     # it's the compression code with the restriction, see DOC/License.txt
     lib.optionals (!enableUnfree) [ "DISABLE_RAR_COMPRESS=true" ];


### PR DESCRIPTION
###### Description of changes

Got `uasm` to build in `x86_64-darwin` by pulling this fix: https://github.com/Terraspace/UASM/pull/165

Also fixes `7zz` cross-compilation by setting `CC` and `CXX` flags correctly.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
