### PR TITLE
ocamlPackages.rebez: init unstable-2019-06-20

### DIFF
--- a/pkgs/development/ocaml-modules/rebez/default.nix
+++ b/pkgs/development/ocaml-modules/rebez/default.nix
@@ -1,0 +1,22 @@
+{ buildDunePackage, fetchFromGitHub, lib, reason }:
+
+buildDunePackage rec {
+  pname = "rebez";
+  version = "unstable-2019-06-20";
+
+  src = fetchFromGitHub {
+    owner = "jchavarri";
+    repo = "rebez";
+    rev = "03fa3b707abb28fdd710eb9e57ba40d9cd6ae163";
+    sha256 = "sha256-khZSwtwW+mP/EvAvIZMQyOb6FgNR+gmzpBZoD9ZPkpY=";
+  };
+
+  nativeBuildInputs = [ reason ];
+
+  meta = with lib; {
+    description = "Cubic bezier implementation in Reason / OCaml";
+    homepage = "https://github.com/jchavarri/rebez/";
+    maintainers = with maintainers; [ superherointj ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1260,6 +1260,8 @@ let
 
     reason-native = lib.recurseIntoAttrs (callPackage ../development/ocaml-modules/reason-native { });
 
+    rebez = callPackage ../development/ocaml-modules/rebez { };
+
     rfc7748 = callPackage ../development/ocaml-modules/rfc7748 { };
 
     ezresto = callPackage ../development/ocaml-modules/resto/ezresto.nix { };


### PR DESCRIPTION
ocamlPackages.rebez: init unstable-2019-06-20

Cubic bezier implementation in Reason / OCaml

Question:
* Since last Dune version change. Which dune version to use? None = Default?