### PR TITLE
nixos/zookeeper: Take the same JRE we build zookeeper with by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1309,6 +1309,15 @@
       </listitem>
       <listitem>
         <para>
+          <literal>services.zookeeper</literal> has a new option
+          <literal>jre</literal> for specifying the JRE to start
+          zookeeper with. It defaults to the JRE built with
+          <literal>pkgs.zookeeper</literal> instead of
+          <literal>pkgs.jre</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>pkgs.pgadmin</literal> now refers to
           <literal>pkgs.pgadmin4</literal>. <literal>pgadmin3</literal>
           has been removed.

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1311,9 +1311,10 @@
         <para>
           <literal>services.zookeeper</literal> has a new option
           <literal>jre</literal> for specifying the JRE to start
-          zookeeper with. It defaults to the JRE built with
-          <literal>pkgs.zookeeper</literal> instead of
-          <literal>pkgs.jre</literal>.
+          zookeeper with. It defaults to the JRE that
+          <literal>pkgs.zookeeper</literal> was wrapped with, instead of
+          <literal>pkgs.jre</literal>. This changes the JRE to
+          <literal>pkgs.jdk11_headless</literal> by default.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -519,8 +519,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   commands from `otelcontribcol` to `otelcorecol` and enjoy a 7x smaller binary.
 
 - `services.zookeeper` has a new option `jre` for specifying the JRE to start
-  zookeeper with. It defaults to the JRE built with `pkgs.zookeeper` instead of
-  `pkgs.jre`.
+  zookeeper with. It defaults to the JRE that `pkgs.zookeeper` was wrapped with,
+  instead of `pkgs.jre`. This changes the JRE to `pkgs.jdk11_headless` by default.
 
 - `pkgs.pgadmin` now refers to `pkgs.pgadmin4`. `pgadmin3` has been removed.
 

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -518,6 +518,10 @@ In addition to numerous new and upgraded packages, this release has the followin
   you should change the package you refer to. If you don't need them update your
   commands from `otelcontribcol` to `otelcorecol` and enjoy a 7x smaller binary.
 
+- `services.zookeeper` has a new option `jre` for specifying the JRE to start
+  zookeeper with. It defaults to the JRE built with `pkgs.zookeeper` instead of
+  `pkgs.jre`.
+
 - `pkgs.pgadmin` now refers to `pkgs.pgadmin4`. `pgadmin3` has been removed.
 
 - `pkgs.noto-fonts-cjk` is now deprecated in favor of `pkgs.noto-fonts-cjk-sans`

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -114,6 +114,13 @@ in {
       type = types.package;
     };
 
+    jre = mkOption {
+      description = "The JRE with which to run Zookeeper";
+      default = cfg.package.passthru.jre;
+      defaultText = literalExpression "pkgs.zookeeper.passthru.jre";
+      example = literalExpression "pkgs.jre";
+      type = types.package;
+    };
   };
 
 
@@ -131,7 +138,7 @@ in {
       after = [ "network.target" ];
       serviceConfig = {
         ExecStart = ''
-          ${pkgs.jre}/bin/java \
+          ${cfg.jre}/bin/java \
             -cp "${cfg.package}/lib/*:${configDir}" \
             ${escapeShellArgs cfg.extraCmdLineOptions} \
             -Dzookeeper.datadir.autocreate=false \

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -116,8 +116,8 @@ in {
 
     jre = mkOption {
       description = "The JRE with which to run Zookeeper";
-      default = cfg.package.passthru.jre;
-      defaultText = literalExpression "pkgs.zookeeper.passthru.jre";
+      default = cfg.package.jre;
+      defaultText = literalExpression "pkgs.zookeeper.jre";
       example = literalExpression "pkgs.jre";
       type = types.package;
     };

--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -37,8 +37,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    nixos = nixosTests.zookeeper;
+  passthru = {
+    tests = {
+      nixos = nixosTests.zookeeper;
+    };
+    inherit jre;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`services.zookeeper` now takes `pkgs.jre` as its starting JRE in `ExecStart`, which is inconsistent with the `jdk11_headless` in its building nix.

This PR add a new option `services.zookeeper.jre` and make it default to the JRE it is built with. Also, users can set the option to override it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
