### PR TITLE
python3Packages: fix pytest-mpl and update panel

### DIFF
--- a/pkgs/development/python-modules/panel/default.nix
+++ b/pkgs/development/python-modules/panel/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "panel";
-  version = "0.12.7";
+  version = "0.13.0";
 
   format = "wheel";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   # tries to fetch even more artifacts
   src = fetchPypi {
     inherit pname version format;
-    hash = "sha256-VcoMGYT48WduyuyTB/4KJybT/pBKV0hB1pSpZGagAeA=";
+    hash = "sha256-Iv1Lb45n2XUHSluZzdF2Bf/hXZmgs++9/av26rHgePc=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pytest-mpl/default.nix
+++ b/pkgs/development/python-modules/pytest-mpl/default.nix
@@ -1,7 +1,9 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools-scm
 , pytest
+, jinja2
 , matplotlib
 , nose
 , pillow
@@ -17,11 +19,18 @@ buildPythonPackage rec {
     sha256 = "sha256-iE4HjS1TgK9WQzhOIzw1jpZZgl+y2X/9r48YXENMjYk=";
   };
 
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
   buildInputs = [
     pytest
   ];
 
+  SETUPTOOLS_SCM_PRETEND_VERSION=version;
+
   propagatedBuildInputs = [
+    jinja2
     matplotlib
     nose
     pillow
@@ -31,10 +40,16 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  # Broken since b6e98f18950c2b5dbdc725c1181df2ad1be19fee
+
   disabledTests = [
+    # Broken since b6e98f18950c2b5dbdc725c1181df2ad1be19fee
     "test_hash_fails"
     "test_hash_missing"
+  ];
+
+  disabledTestPaths = [
+    # Following are broken since at least a1548780dbc79d76360580691dc1bb4af4e837f6
+    "tests/subtests/test_subtest.py"
   ];
 
   preCheck = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
