### PR TITLE
nixos/chromium: add cursor metadata patch for wayland screen-sharing

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -157,12 +157,13 @@ let
 
     patches = [
       # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed):
-      ./patches/no-build-timestamps.patch
+      #./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
-      ./patches/widevine-79.patch
+      #./patches/widevine-79.patch
       # Check whether there are any cursor metadata before trying to validate https://github.com/NixOS/nixpkgs/issues/167526 / https://webrtc-review.googlesource.com/c/src/+/255601
       ./patches/check-existence-of-cursor-metadata.patch
     ];
+    patchFlags = ["-Np1" "-d third_party/webrtc"];
 
     postPatch = ''
       # remove unused third-party

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -160,6 +160,8 @@ let
       ./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
       ./patches/widevine-79.patch
+      # Check whether there are any cursor metadata before trying to validate https://github.com/NixOS/nixpkgs/issues/167526 / https://webrtc-review.googlesource.com/c/src/+/255601
+      ./patches/check-existence-of-cursor-metadata.patch
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/patches/check-existence-of-cursor-metadata.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/check-existence-of-cursor-metadata.patch
@@ -1,3 +1,19 @@
+From c2cd814cdd8cbf8dda6ccec2266327a5321fbde8 Mon Sep 17 00:00:00 2001
+From: Jan Grulich <grulja@gmail.com>
+Date: Tue, 15 Mar 2022 14:31:55 +0100
+Subject: [PATCH] PipeWire capturer: check existence of cursor metadata
+
+Check whether there are any cursor metadata before we try to validate
+and use them, otherwise we might crash on this.
+
+Bug: webrtc:13429
+Change-Id: I365da59a189b6b974cebafc94fec49d5b942efae
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/255601
+Reviewed-by: Alexander Cooper <alcooper@chromium.org>
+Commit-Queue: Alexander Cooper <alcooper@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#36240}
+---
+
 diff --git a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
 index a8c86e2..9e81df4 100644
 --- a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc

--- a/pkgs/applications/networking/browsers/chromium/patches/check-existence-of-cursor-metadata.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/check-existence-of-cursor-metadata.patch
@@ -1,0 +1,29 @@
+From c2cd814cdd8cbf8dda6ccec2266327a5321fbde8 Mon Sep 17 00:00:00 2001
+From: Jan Grulich <grulja@gmail.com>
+Date: Tue, 15 Mar 2022 14:31:55 +0100
+Subject: [PATCH] PipeWire capturer: check existence of cursor metadata
+
+Check whether there are any cursor metadata before we try to validate
+and use them, otherwise we might crash on this.
+
+Bug: webrtc:13429
+Change-Id: I365da59a189b6b974cebafc94fec49d5b942efae
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/255601
+Reviewed-by: Alexander Cooper <alcooper@chromium.org>
+Commit-Queue: Alexander Cooper <alcooper@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#36240}
+---
+
+diff --git a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+index a8c86e2..9e81df4 100644
+--- a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
++++ b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+@@ -650,7 +650,7 @@
+     const struct spa_meta_cursor* cursor =
+         static_cast<struct spa_meta_cursor*>(spa_buffer_find_meta_data(
+             spa_buffer, SPA_META_Cursor, sizeof(*cursor)));
+-    if (spa_meta_cursor_is_valid(cursor)) {
++    if (cursor && spa_meta_cursor_is_valid(cursor)) {
+       struct spa_meta_bitmap* bitmap = nullptr;
+ 
+       if (cursor->bitmap_offset)

--- a/pkgs/applications/networking/browsers/chromium/patches/check-existence-of-cursor-metadata.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/check-existence-of-cursor-metadata.patch
@@ -1,19 +1,3 @@
-From c2cd814cdd8cbf8dda6ccec2266327a5321fbde8 Mon Sep 17 00:00:00 2001
-From: Jan Grulich <grulja@gmail.com>
-Date: Tue, 15 Mar 2022 14:31:55 +0100
-Subject: [PATCH] PipeWire capturer: check existence of cursor metadata
-
-Check whether there are any cursor metadata before we try to validate
-and use them, otherwise we might crash on this.
-
-Bug: webrtc:13429
-Change-Id: I365da59a189b6b974cebafc94fec49d5b942efae
-Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/255601
-Reviewed-by: Alexander Cooper <alcooper@chromium.org>
-Commit-Queue: Alexander Cooper <alcooper@chromium.org>
-Cr-Commit-Position: refs/heads/main@{#36240}
----
-
 diff --git a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
 index a8c86e2..9e81df4 100644
 --- a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc


### PR DESCRIPTION
Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
