### PR TITLE
python3Packages.pywebview: 3.6.1 -> 3.6.3

### DIFF
--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -2,24 +2,29 @@
 , buildPythonPackage
 , fetchFromGitHub
 , importlib-resources
+, proxy_tools
+, pygobject3
 , pyqtwebengine
 , pytest
 , pythonOlder
 , qt5
+, qtpy
+, six
 , xvfb-run
-, proxy_tools
 }:
 
 buildPythonPackage rec {
   pname = "pywebview";
-  version = "3.6.1";
+  version = "3.6.3";
+  format = "setuptools";
+
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "r0x0r";
     repo = "pywebview";
     rev = version;
-    sha256 = "sha256-9o9ghqvU9Hnmf2aj/BqX7WBgS9ilRSnicR+qd25OfjI=";
+    hash = "sha256-qOLK4MHdpmcCazCNfojncD8XH7OJB2H/pIW5XAJAlDo=";
   };
 
   nativeBuildInputs = [
@@ -29,10 +34,15 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     pyqtwebengine
     proxy_tools
-  ] ++ lib.optionals (pythonOlder "3.7") [ importlib-resources ];
+    six
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    importlib-resources
+  ];
 
   checkInputs = [
+    pygobject3
     pytest
+    qtpy
     xvfb-run
   ];
 
@@ -54,11 +64,13 @@ buildPythonPackage rec {
     popd
   '';
 
-  pythonImportsCheck = [ "webview" ];
+  pythonImportsCheck = [
+    "webview"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/r0x0r/pywebview";
     description = "Lightweight cross-platform wrapper around a webview";
+    homepage = "https://github.com/r0x0r/pywebview";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jojosch ];
   };


### PR DESCRIPTION
###### Description of changes
https://github.com/r0x0r/pywebview/releases/tag/3.6.3
https://github.com/r0x0r/pywebview/releases/tag/3.6.2

The tests are passing but with some `ValueError`s.

```bash
[...]
    gi.require_version('Gtk', '3.0')
  File "/nix/store/a0vmf32msg83gj8j4wvcp2gaavpb6i6a-python3.9-pygobject-3.42.0/lib/python3.9/site-packages/gi/__init__.py", line 126, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gtk not available
QXcbIntegration: Cannot create platform OpenGL context, neither GLX nor EGL are enabled
```

Fixes #169286

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
