### PR TITLE
premake5: 5.0.0-alpha12 -> 5.0.0-beta2

### DIFF
--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -1,21 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, Foundation, readline }:
+{ lib, stdenv, fetchFromGitHub, libuuid, cacert, Foundation, readline }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "premake5";
-  version = "5.0.0-alpha12";
+  version = "5.0.0-beta2";
 
   src = fetchFromGitHub {
     owner = "premake";
     repo = "premake-core";
     rev = "v${version}";
-    sha256 = "1h3hr96pdz94njn4bg02ldcz0k5j1x017d8svc7fdyvl2b77nqzf";
+    sha256 = "sha256-2R5gq4jaQsp8Ny1oGuIYkef0kn2UG9jMf20vq0714oY=";
   };
 
-  buildInputs = optionals stdenv.isDarwin [ Foundation readline ];
+  buildInputs = [ libuuid ] ++ optionals stdenv.isDarwin [ Foundation readline ];
 
-  patchPhase = optional stdenv.isDarwin ''
+  patches = [ ./no-curl-ca.patch ];
+  patchPhase = ''
+    substituteInPlace contrib/curl/premake5.lua \
+      --replace "ca = nil" "ca = '${cacert}/etc/ssl/certs/ca-bundle.crt'"
+  '' + optionalString stdenv.isDarwin ''
     substituteInPlace premake5.lua \
       --replace -mmacosx-version-min=10.4 -mmacosx-version-min=10.5
   '';

--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -43,5 +43,6 @@ stdenv.mkDerivation rec {
     description = "A simple build configuration and project generation tool using lua";
     license = lib.licenses.bsd3;
     platforms = platforms.darwin ++ platforms.linux;
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/tools/misc/premake/no-curl-ca.patch
+++ b/pkgs/development/tools/misc/premake/no-curl-ca.patch
@@ -1,0 +1,36 @@
+From a26e36d55cd2447488e01b2ff4ac65e2596862cd Mon Sep 17 00:00:00 2001
+From: Ellie Hermaszewska <git@monoid.al>
+Date: Mon, 3 Oct 2022 16:50:33 +0800
+Subject: [PATCH] Do not set CURL_CA_BUNDLE
+
+---
+ contrib/curl/premake5.lua | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/contrib/curl/premake5.lua b/contrib/curl/premake5.lua
+index 474f5cfa..553bbd02 100644
+--- a/contrib/curl/premake5.lua
++++ b/contrib/curl/premake5.lua
+@@ -32,19 +32,6 @@ project "curl-lib"
+ 
+ 		-- find the location of the ca bundle
+ 		local ca = nil
+-		for _, f in ipairs {
+-			"/etc/ssl/certs/ca-certificates.crt",
+-			"/etc/pki/tls/certs/ca-bundle.crt",
+-			"/usr/share/ssl/certs/ca-bundle.crt",
+-			"/usr/local/share/certs/ca-root.crt",
+-			"/usr/local/share/certs/ca-root-nss.crt",
+-			"/etc/certs/ca-certificates.crt",
+-			"/etc/ssl/cert.pem" } do
+-			if os.isfile(f) then
+-				ca = f
+-				break
+-			end
+-		end
+ 		if ca then
+ 			defines { 'CURL_CA_BUNDLE="' .. ca .. '"' }
+ 		end
+-- 
+2.37.2
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).