### PR TITLE
qtmultimedia: restrict libpulseaudio to linux

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -15,8 +15,9 @@ qtModule {
   pname = "qtmultimedia";
   qtInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ gstreamer gst-plugins-base libpulseaudio ]
-    ++ lib.optional (stdenv.isLinux) alsa-lib
+  buildInputs = [ gstreamer gst-plugins-base ]
+    # https://github.com/NixOS/nixpkgs/pull/169336 regarding libpulseaudio
+    ++ lib.optionals stdenv.isLinux [ libpulseaudio alsa-lib ]
     ++ lib.optional (lib.versionAtLeast qtbase.version "5.14.0" && stdenv.isLinux) wayland;
   outputs = [ "bin" "dev" "out" ];
   qmakeFlags = [ "GST_VERSION=1.0" ];


### PR DESCRIPTION
libpulseaudio doesn't currently build on darwin after a recent
upgrade (#160097). When looking closely at the darwin build, it
appeared that it wasn't being used at all.

```
❯ nix log $(nix-build --no-out-link  channel:nixpkgs-unstable --argstr system x86_64-darwin -A qt512.qtmultimedia) | grep PulseAudio
Checking for PulseAudio >= 0.9.10... no
  PulseAudio ............................. no

❯ nix log $(nix-build --no-out-link  channel:nixpkgs-unstable --argstr system x86_64-darwin -A qt514.qtmultimedia) | grep PulseAudio
Checking for PulseAudio >= 0.9.10... no
  PulseAudio ............................. no

❯ nix log $(nix-build --no-out-link  channel:nixpkgs-unstable --argstr system x86_64-darwin -A qt515.qtmultimedia) | grep PulseAudio
Checking for PulseAudio >= 0.9.10... no
  PulseAudio ............................. no
```

###### Description of changes

So far as I can tell, the requirement for pulseaudio support in qtmultimedia is the pkg-config expression `libpulse >= 0.9.10 libpulse-mainloop-glib`, which requires pulseaudio to be configured with glib on darwin. Once libpulseaudio is working again, it's a fairly straightforward change to make. I don't know if there are wider consequences to using glib though.

I must confess I'm tying to keep nixpkgs-unstable unblocked more than I'm trying to fix pulseaudio.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (via rosetta)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
