### PR TITLE
piv-agent: init at 0.18.0

### DIFF
--- a/pkgs/tools/security/piv-agent/default.nix
+++ b/pkgs/tools/security/piv-agent/default.nix
@@ -1,0 +1,56 @@
+{ lib, buildGoModule, fetchFromGitHub, pkg-config, pcsclite }:
+
+buildGoModule rec {
+  pname = "piv-agent";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "smlx";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-FbA2mRNnIluUXONn3q2OUbjyh3+X50eyOglDTR39kFE=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short HEAD > $out/SHORT_COMMIT
+      # 0000-00-00T00:00:00Z
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+  vendorSha256 = "sha256-LQIQ7OZJXIVWPoxfLzMV0pJtg/UzUNOLz8kd0c6o5RY=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ pcsclite ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  # ldflags based on metadata from git and go
+  preBuild = ''
+    ldflags+=" -X main.shortCommit=$(cat SHORT_COMMIT)"
+    ldflags+=" -X \"main.goVersion=$(go version)\""
+    ldflags+=" -X main.date=$(cat SOURCE_DATE_EPOCH)"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/piv-agent --help
+    $out/bin/piv-agent version | grep "${version}"
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://smlx.github.io/piv-agent/";
+    changelog = "https://github.com/smlx/piv-agent/releases";
+    description = "SSH and GPG agent you can use with your PIV hardware security device (e.g. a Yubikey)";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -371,6 +371,10 @@ with pkgs;
 
   buildcatrust = with python3.pkgs; toPythonApplication buildcatrust;
 
+  piv-agent = callPackage ../tools/security/piv-agent {
+    buildGoModule = buildGo118Module;
+  };
+
   probe-rs-cli = callPackage ../development/tools/rust/probe-rs-cli {
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package piv-agent at `0.18.0`

https://github.com/smlx/piv-agent

![image](https://user-images.githubusercontent.com/9866621/164035390-fc26b132-6a1c-4656-9467-0fc4b7e8c237.png)

(using go 1.18 to match the repo's go.mod)

---

**Draft** until I've tested it with a yubikey or maybe solokey v2? (https://github.com/smlx/piv-agent/issues/115)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
