### PR TITLE
lvm2: fix static compilation;  mesa: disable withValgrind if valgrind-light is marked as broken

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -9,7 +9,7 @@
 , vulkanDrivers ? ["auto"]
 , eglPlatforms ? [ "x11" ] ++ lib.optionals stdenv.isLinux [ "wayland" ]
 , OpenGL, Xplugin
-, withValgrind ? !stdenv.isDarwin && lib.meta.availableOn stdenv.hostPlatform valgrind-light, valgrind-light
+, withValgrind ? lib.meta.availableOn stdenv.hostPlatform valgrind-light && !valgrind-light.meta.broken, valgrind-light
 , enableGalliumNine ? stdenv.isLinux
 , enableOSMesa ? stdenv.isLinux
 , enableOpenCL ? stdenv.isLinux && stdenv.isx86_64

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -4,18 +4,19 @@
 , fetchpatch
 , fetchurl
 , pkg-config
-, util-linux
 , coreutils
 , libuuid
 , libaio
 , substituteAll
 , enableCmdlib ? false
 , enableDmeventd ? false
-, udevSupport ? !stdenv.hostPlatform.isStatic, udev ? null
+, udevSupport ? !stdenv.hostPlatform.isStatic, udev
 , onlyLib ? stdenv.hostPlatform.isStatic
-, enableVDO ? false, vdo ? null
-, enableMdadm ? false, mdadm ? null
-, enableMultipath ? false, multipath-tools ? null
+  # Otherwise we have a infinity recursion during static compilation
+, enableUtilLinux ? !stdenv.hostPlatform.isStatic, util-linux
+, enableVDO ? false, vdo
+, enableMdadm ? false, mdadm
+, enableMultipath ? false, multipath-tools
 , nixosTests
 }:
 
@@ -102,7 +103,7 @@ stdenv.mkDerivation rec {
     in {
       src = ./fix-blkdeactivate.patch;
       inherit coreutils;
-      util_linux = util-linux;
+      util_linux = optionalTool enableUtilLinux util-linux;
       mdadm = optionalTool enableMdadm mdadm;
       multipath_tools = optionalTool enableMultipath multipath-tools;
       vdo = optionalTool enableVDO vdo;

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -96,8 +96,9 @@ stdenv.mkDerivation rec {
     sed -i 's|^#define LVM_CONFIGURE_LINE.*$|#define LVM_CONFIGURE_LINE "<removed>"|g' ./include/configure.h
   '';
 
-  patches = [
+  patches = lib.optionals (lib.versionAtLeast version "2.03.15") [
     # fixes paths to and checks for tools
+    # TODO: needs backport to LVM 2.02 used by static/musl
     (substituteAll (let
       optionalTool = cond: pkg: if cond then pkg else "/run/current-system/sw";
     in {


### PR DESCRIPTION
###### Description of changes

This should avoid a infinity recursion issue during static compilation, by making util-linux not a dependency of the `fix-blkdeactivate.patch`.

Thanks @symphorien for the help with this issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
