### PR TITLE
binutils: fix cross compilation from darwin

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation {
     texinfo
   ]
   ++ lib.optionals targetPlatform.isiOS [ autoreconfHook ]
-  ++ lib.optionals targetPlatform.isDarwin [ autoconf269 automake gettext libtool ]
+  ++ lib.optionals buildPlatform.isDarwin [ autoconf269 automake gettext libtool ]
   ++ lib.optionals targetPlatform.isVc4 [ flex ]
   ;
 
@@ -118,7 +118,7 @@ stdenv.mkDerivation {
 
   inherit noSysDirs;
 
-  preConfigure = (lib.optionalString targetPlatform.isDarwin ''
+  preConfigure = (lib.optionalString buildPlatform.isDarwin ''
     for i in */configure.ac; do
       pushd "$(dirname "$i")"
       echo "Running autoreconf in $PWD"


### PR DESCRIPTION
The libtool patch is required to correctly invoke the linker while
building, so it should depend on the build toolchain.

###### Description of changes

Addressing breakage reported in https://github.com/NixOS/nixpkgs/pull/134917#issuecomment-1102559620

This is only part of the story. There's still a problem with glibc and `separateDebugInfo`. If I turn that off I can build `pkgsCross.aarch64-multiplatform.hello` from `x86_64-darwin` via rosetta.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (via rosetta)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
