### PR TITLE
ocamlPackages.brisk-reconciler: init unstable-2020-12-02

### DIFF
--- a/pkgs/development/ocaml-modules/brisk-reconciler/default.nix
+++ b/pkgs/development/ocaml-modules/brisk-reconciler/default.nix
@@ -1,0 +1,33 @@
+{ buildDunePackage, fetchFromGitHub, lib, reason, ppxlib }:
+
+buildDunePackage rec {
+  pname = "brisk-reconciler";
+  version = "unstable-2020-12-02";
+
+  src = fetchFromGitHub {
+    owner = "briskml";
+    repo = "brisk-reconciler";
+    rev = "c9d5c4cf5dd17ff2da994de2c3b0f34c72778f70";
+    sha256 = "sha256-AAB4ZzBnwfwFXOAqX/sIT6imOl70F0YNMt96SWOOE9w=";
+  };
+
+  nativeBuildInputs = [ reason ];
+
+  buildInputs = [
+    ppxlib
+  ];
+
+  meta = with lib; {
+    description = "React.js-like reconciler implemented in OCaml/Reason";
+    longDescription = ''
+      Easily model any `tree-shaped state` with simple `stateful functions`.
+
+      Definitions:
+      * tree-shaped state: Any tree shaped-state like the DOM tree, app navigation state, or even rich text document!
+      * stateful functions: Functions that maintain state over time. Imagine that you can take any variable in your function and manage its value over the function's invocation. Now, imagine that any function invocation really creates its own "instance" of the function which will track this state separately from other invocations of this function.
+    '';
+    homepage = "https://github.com/briskml/brisk-reconciler";
+    maintainers = with maintainers; [ superherointj ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -87,6 +87,8 @@ let
 
     bos = callPackage ../development/ocaml-modules/bos { };
 
+    brisk-reconciler = callPackage ../development/ocaml-modules/brisk-reconciler { };
+
     bz2 = callPackage ../development/ocaml-modules/bz2 { };
 
     ca-certs = callPackage ../development/ocaml-modules/ca-certs { };


### PR DESCRIPTION
ocamlPackages.brisk-reconciler: init unstable-2020-12-02

```
$ cat ./result/lib/ocaml/4.13.1/site-lib/brisk-reconciler/META 
version = "1.0.0-alpha.0"
description = ""
requires = ""
archive(byte) = "brisk_reconciler.cma"
archive(native) = "brisk_reconciler.cmxa"
plugin(byte) = "brisk_reconciler.cma"
plugin(native) = "brisk_reconciler.cmxs"
package "ppx" (
  directory = "ppx"
  version = "1.0.0-alpha.0"
  description = ""
  requires(ppx_driver) = "ppxlib ppxlib.ast"
  archive(ppx_driver,byte) = "brisk_ppx.cma"
  archive(ppx_driver,native) = "brisk_ppx.cmxa"
  plugin(ppx_driver,byte) = "brisk_ppx.cma"
  plugin(ppx_driver,native) = "brisk_ppx.cmxs"
  # This line makes things transparent for people mixing preprocessors
  # and normal dependencies
  requires(-ppx_driver) = ""
  ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
  library_kind = "ppx_rewriter"
```

I always struggle to properly define the `propagatedBuildInputs`. As there is:
`requires(ppx_driver) = "ppxlib ppxlib.ast"`
Should `ppxlib` be propagated?