### PR TITLE
python3Packages.pydicom: 2.2.2 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -11,28 +11,30 @@
 
 let
   pname = "pydicom";
-  version = "2.2.2";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
-    owner = "${pname}";
-    repo = "${pname}";
+    owner = "pydicom";
+    repo = "pydicom";
     rev = "v${version}";
-    sha256 = "sha256-p5hJAUsactv6UEvbVaF+zk4iapx98eYkC9Zo+lzFATA=";
+    hash = "sha256-CAQWaBkzecJ1VXQ5BnAUjmBMjh0I8y+gT7I4P4o2gqI=";
   };
 
   # Pydicom needs pydicom-data to run some tests. If these files aren't downloaded
   # before the package creation, it'll try to download during the checkPhase.
   test_data = fetchFromGitHub {
-    owner = "${pname}";
-    repo = "${pname}-data";
+    owner = "pydicom";
+    repo = "pydicom-data";
     rev = "bbb723879690bb77e077a6d57657930998e92bd5";
-    sha256 = "sha256-dCI1temvpNWiWJYVfQZKy/YJ4ad5B0e9hEKHJnEeqzk=";
+    hash = "sha256-dCI1temvpNWiWJYVfQZKy/YJ4ad5B0e9hEKHJnEeqzk=";
   };
 
 in
 buildPythonPackage {
   inherit pname version src;
   disabled = pythonOlder "3.6";
+
+  format = "setuptools";
 
   propagatedBuildInputs = [
     numpy
@@ -53,8 +55,8 @@ buildPythonPackage {
     ln -s ${test_data}/data_store/data $HOME/.pydicom/data
   '';
 
-  # This test try to remove a dicom inside $HOME/.pydicom/data/ and download it again.
   disabledTests = [
+    # tries to remove a dicom inside $HOME/.pydicom/data/ and download it again
     "test_fetch_data_files"
   ] ++ lib.optionals stdenv.isAarch64 [
     # https://github.com/pydicom/pydicom/issues/1386


### PR DESCRIPTION

###### Description of changes
https://pydicom.github.io/pydicom/stable/release_notes/index.html#version-2-3-0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
