### PR TITLE
wraith-master: init at 1.2.1

### DIFF
--- a/pkgs/applications/misc/wraith-master/default.nix
+++ b/pkgs/applications/misc/wraith-master/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gtk3
+, libusb1
+, gradle
+, jdk
+, kotlin
+, scdoc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wraith-master";
+  version = "1.2.1";
+
+  src = fetchFromGitLab {
+    owner = "serebit";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-zuvNR9yTFqBPTN58jN63Iv0bkc6M6yZwTGOjWdnYaRk=";
+  };
+
+  nativeBuildInputs = [
+    scdoc
+    gradle
+  ];
+
+  buildInputs = [
+    gtk3
+    jdk
+    kotlin
+    libusb1
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace ./gradlew gradle
+  '';
+
+  meta = with lib; {
+    description = "A Wraith Prism RGB control application for Linux, built with GTK+ and Kotlin/Native";
+    homepage = "https://gitlab.com/serebit/wraith-master";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ papojari ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34628,6 +34628,8 @@ with pkgs;
 
   wraith = callPackage ../applications/networking/irc/wraith { };
 
+  wraith-master = callPackage ../applications/misc/wraith-master { };
+
   wxsqlite3 = callPackage ../development/libraries/wxsqlite3 {
     wxGTK = wxGTK30;
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
###### Description of changes

Taking on #131519. Add the wraith-master package with cli and gtk frontend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
