### PR TITLE
man-db: revert using absolute paths for deps

### DIFF
--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -41,12 +41,6 @@ stdenv.mkDerivation rec {
 
     # Add mandb locations for the above
     echo "MANDB_MAP	/nix/var/nix/profiles/default/share/man	/var/cache/man/nixpkgs" >> src/man_db.conf.in
-
-    # use absolute paths to reference programs, otherwise artifacts will have undeclared dependencies
-    for f in configure.ac m4/man-check-progs.m4 m4/man-po4a.m4; do
-      substituteInPlace $f \
-        --replace AC_CHECK_PROGS AC_PATH_PROGS
-    done
   '';
 
   configureFlags = [
@@ -72,7 +66,9 @@ stdenv.mkDerivation rec {
     # (multi-call binary). `apropos` is actually just a symlink to whatis. So we need to
     # make sure that we don't wrap symlinks (since that changes argv[0] to the -wrapped name)
     find "$out/bin" -type f | while read file; do
-      wrapProgram "$file" --prefix PATH : "${groff}/bin"
+      wrapProgram "$file" \
+        --prefix PATH : "${groff}/bin" \
+        --prefix PATH : "${zstd}/bin"
     done
   '';
 


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/pull/121147#issuecomment-1101755621

When man calls other programs like gzip or xz for decompressing man pages, that was usually done dynamically relying on the called program being in `PATH`.
With the introduction of zstd via https://github.com/NixOS/nixpkgs/pull/121147, I included a patch to make dependencies explicit.
But this led to issues with cross compiling, as for some reason a native `groff`was referenced from the man binary instead of the target system's.

###### Done

- Revert replacing `AC_CHECK_PROGS` with `AC_PATH_PROGS` and rely on dependencies being in PATH instead again.
- Add zstd runtime dependency via wrapper

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
