### PR TITLE
pam-reattach: init at 1.2

### DIFF
--- a/pkgs/os-specific/darwin/pam-reattach/default.nix
+++ b/pkgs/os-specific/darwin/pam-reattach/default.nix
@@ -1,0 +1,31 @@
+{ fetchgit, stdenv, lib, darwin, cmake, ... }:
+
+stdenv.mkDerivation rec {
+  name = "pam-reattach";
+  version = "1.2";
+
+  src = fetchgit {
+    url = "https://github.com/fabianishere/pam_reattach";
+    rev = "24d5be4fbd27df4a3792511978fb37e0649d3527";
+    sha256 = "sha256-MhOy2GcvLGfrWM7xE5N9zD5Q7pYhiMdFPlBbfsF8HyY=";
+  };
+
+  buildInputs = [ cmake ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.MacOSX-SDK ;
+
+  configurePhase = ''
+    CMAKE_LIBRARY_PATH "${darwin.apple_sdk.MacOSX-SDK}/usr/lib" cmake \
+      -DCMAKE_INSTALL_PREFIX=$out \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DENABLE_PAM=true \
+      -DENABLE_CLI=true \
+      .
+  '';
+
+  meta = with lib; {
+    description = "Reattach to the user's GUI session on macOS during authentication (for Touch ID support in tmux)";
+    homepage = "https://github.com/fabianishere/pam_reattach";
+    licenses = licenses.mit;
+    maintainers = with maintainers; [ congee ];
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9060,6 +9060,8 @@ with pkgs;
 
   pamtester = callPackage ../tools/security/pamtester { };
 
+  pam-reattach = callPackage ../os-specific/darwin/pam-reattach {};
+
   pantheon-tweaks = callPackage ../desktops/pantheon/third-party/pantheon-tweaks { };
 
   paperless-ngx = callPackage ../applications/office/paperless-ngx { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This package adds Touch ID support in tmux on macOS. https://github.com/fabianishere/pam_reattach

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
