### PR TITLE
vulkan-tools: enable support for Darwin

### DIFF
--- a/pkgs/os-specific/darwin/moltenvk/default.nix
+++ b/pkgs/os-specific/darwin/moltenvk/default.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation rec {
     QuartzCore
   ];
 
-  outputs = [ "out" "bin" ];
+  outputs = [ "out" "bin" "dev" ];
 
   # MoltenVK requires specific versions of its dependencies.
   # Pin them here except for cereal, which is four years old and has several CVEs.
@@ -170,9 +170,10 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p "$out/lib" "$out/share/vulkan/icd.d" "$bin/bin"
+    mkdir -p "$out/lib" "$out/share/vulkan/icd.d" "$bin/bin" "$dev/include/MoltenVK"
     cp outputs/bin/MoltenVKShaderConverter "$bin/bin/"
     cp outputs/lib/libMoltenVK.dylib "$out/lib/"
+    cp MoltenVK/MoltenVK/API/* "$dev/include/MoltenVK"
     ${cctools}/bin/install_name_tool -id "$out/lib/libMoltenVK.dylib" "$out/lib/libMoltenVK.dylib"
     # FIXME: https://github.com/NixOS/nixpkgs/issues/148189
     /usr/bin/codesign -s - -f "$out/lib/libMoltenVK.dylib"

--- a/pkgs/os-specific/darwin/moltenvk/default.nix
+++ b/pkgs/os-specific/darwin/moltenvk/default.nix
@@ -178,7 +178,7 @@ stdenvNoCC.mkDerivation rec {
     /usr/bin/codesign -s - -f "$out/lib/libMoltenVK.dylib"
     install -m644 MoltenVK/icd/MoltenVK_icd.json "$out/share/vulkan/icd.d/MoltenVK_icd.json"
     substituteInPlace $out/share/vulkan/icd.d/MoltenVK_icd.json \
-      --replace ./libMoltenVK.dylib "$out/share/vulkan/icd.d/MoltenVK_icd.json"
+      --replace ./libMoltenVK.dylib "$out/lib/libMoltenVK.dylib"
   '';
 
   sandboxProfile = ''

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -14,6 +14,9 @@
 , vulkan-loader
 , wayland
 , wayland-protocols
+, moltenvk
+, AppKit
+, Cocoa
 }:
 
 stdenv.mkDerivation rec {
@@ -38,19 +41,44 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glslang
+    vulkan-headers
+    vulkan-loader
+  ] ++ lib.optionals (!stdenv.isDarwin) [
     libffi
     libX11
     libXau
     libxcb
     libXdmcp
     libXrandr
-    vulkan-headers
-    vulkan-loader
     wayland
     wayland-protocols
+  ] ++ lib.optionals stdenv.isDarwin [
+    moltenvk
+    moltenvk.dev
+    AppKit
+    Cocoa
   ];
 
   libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
+
+  patches = [
+    # Vulkan-Tools expects to find the MoltenVK ICD and `libMoltenVK.dylib` in its source repo.
+    # Patch it to use the already-built binaries and ICD in nixpkgs.
+    ./use-nix-moltenvk.patch
+  ];
+
+  # vkcube.app and vkcubepp.app require `ibtool`, but the version in `xib2nib` is not capable of
+  # building these apps. Build them using `ibtool` from Xcode, but don’t allow any other binaries
+  # into the sandbox. Note that the CLT are not supported because `ibtool` requires Xcode.
+  sandboxProfile = lib.optionalString stdenv.isDarwin ''
+    (allow process-exec
+      (literal "/usr/bin/ibtool")
+      (regex "/Xcode.app/Contents/Developer/usr/bin/ibtool")
+      (regex "/Xcode.app/Contents/Developer/usr/bin/xcodebuild"))
+    (allow file-read*)
+    (deny file-read* (subpath "/usr/local") (with no-log))
+    (allow file-write* (subpath "/private/var/folders"))
+  '';
 
   dontPatchELF = true;
 
@@ -62,6 +90,9 @@ stdenv.mkDerivation rec {
     "-DPKG_CONFIG_EXECUTABLE=${pkg-config}/bin/pkg-config"
     # Hide dev warnings that are useless for packaging
     "-Wno-dev"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DMOLTENVK_REPO_ROOT=${moltenvk}/share/vulkan/icd.d"
+    "-DIBTOOL=/usr/bin/ibtool"
   ];
 
   meta = with lib; {
@@ -72,7 +103,7 @@ stdenv.mkDerivation rec {
       use of the Vulkan API.
     '';
     homepage    = "https://github.com/KhronosGroup/Vulkan-Tools";
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
     license     = licenses.asl20;
     maintainers = [ maintainers.ralith ];
   };

--- a/pkgs/tools/graphics/vulkan-tools/use-nix-moltenvk.patch
+++ b/pkgs/tools/graphics/vulkan-tools/use-nix-moltenvk.patch
@@ -1,0 +1,155 @@
+diff --git a/cube/CMakeLists.txt b/cube/CMakeLists.txt
+index 616fbc96..d2811c8d 100644
+--- a/cube/CMakeLists.txt
++++ b/cube/CMakeLists.txt
+@@ -262,14 +262,7 @@ else()
+ endif()
+ 
+ if(APPLE)
+-    # Keep RPATH so fixup_bundle can use it to find libraries
+-    set_target_properties(vkcube PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+-    install(TARGETS vkcube BUNDLE DESTINATION "cube")
+-    # Fix up the library references to be self-contained within the bundle.
+-    install(CODE "
+-        include(BundleUtilities)
+-        fixup_bundle(\${CMAKE_INSTALL_PREFIX}/cube/vkcube.app \"\" \"${Vulkan_LIBRARY_DIR}\")
+-        ")
++    install(TARGETS vkcube BUNDLE DESTINATION "Applications")
+ else()
+     install(TARGETS vkcube RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+ endif()
+@@ -309,14 +302,7 @@ else()
+ endif()
+ 
+ if(APPLE)
+-    # Keep RPATH so fixup_bundle can use it to find libraries
+-    set_target_properties(vkcubepp PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+-    install(TARGETS vkcubepp BUNDLE DESTINATION "cube")
+-    # Fix up the library references to be self-contained within the bundle.
+-    install(CODE "
+-        include(BundleUtilities)
+-        fixup_bundle(\${CMAKE_INSTALL_PREFIX}/cube/vkcubepp.app \"\" \"${Vulkan_LIBRARY_DIR}\")
+-        ")
++    install(TARGETS vkcubepp BUNDLE DESTINATION "Applications")
+ else()
+     install(TARGETS vkcubepp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+ endif()
+diff --git a/cube/macOS/cube/cube.cmake b/cube/macOS/cube/cube.cmake
+index 9b823f95..238c3e67 100644
+--- a/cube/macOS/cube/cube.cmake
++++ b/cube/macOS/cube/cube.cmake
+@@ -72,12 +69,14 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
+ # Copy the MoltenVK lib into the bundle.
+ if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
+     add_custom_command(TARGET vkcube POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcube.app/Contents/Frameworks
++                       COMMAND ${CMAKE_COMMAND} -E create_symlink "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcube.app/Contents/Frameworks/libMoltenVK.dylib
+                        DEPENDS vulkan)
+ else()
+     add_custom_command(TARGET vkcube POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/vkcube.app/Contents/Frameworks
++                       COMMAND ${CMAKE_COMMAND} -E create_symlink "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/vkcube.app/Contents/Frameworks/libMoltenVK.dylib
+                        DEPENDS vulkan)
+ endif()
+diff --git a/cube/macOS/cubepp/cubepp.cmake b/cube/macOS/cubepp/cubepp.cmake
+index eae4de3c..0acd18f9 100644
+--- a/cube/macOS/cubepp/cubepp.cmake
++++ b/cube/macOS/cubepp/cubepp.cmake
+@@ -74,12 +71,14 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
+ # Copy the MoltenVK lib into the bundle.
+ if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
+     add_custom_command(TARGET vkcubepp POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcubepp.app/Contents/Frameworks
++                       COMMAND ${CMAKE_COMMAND} -E create_symlink "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcubepp.app/Contents/Frameworks/libMoltenVK.dylib
+                        DEPENDS vulkan)
+ else()
+     add_custom_command(TARGET vkcubepp POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/vkcubepp.app/Contents/Frameworks
++                       COMMAND ${CMAKE_COMMAND} -E create_symlink "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/vkcubepp.app/Contents/Frameworks/libMoltenVK.dylib
+                        DEPENDS vulkan)
+ endif()
+diff --git a/mac_common.cmake b/mac_common.cmake
+index bad3c414..b498906d 100644
+--- a/mac_common.cmake
++++ b/mac_common.cmake
+@@ -23,9 +23,8 @@ set(MOLTENVK_DIR ${MOLTENVK_REPO_ROOT})
+ # MoltenVK JSON File
+ 
+ execute_process(COMMAND mkdir -p ${CMAKE_BINARY_DIR}/staging-json)
+-execute_process(COMMAND sed -e "/\"library_path\":/s$:[[:space:]]*\"[[:space:]]*[\\.\\/]*$: \"..\\/..\\/..\\/Frameworks\\/$"
+-                        ${MOLTENVK_DIR}/MoltenVK/icd/MoltenVK_icd.json
+-                OUTPUT_FILE ${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json)
++execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${MOLTENVK_DIR}/MoltenVK_icd.json
++                        ${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json)
+ 
+ # ~~~
+ # Modify the ICD JSON file to adjust the library path.
+@@ -36,10 +35,9 @@ execute_process(COMMAND sed -e "/\"library_path\":/s$:[[:space:]]*\"[[:space:]]*
+ # ~~~
+ add_custom_target(MoltenVK_icd-staging-json ALL
+                   COMMAND mkdir -p ${CMAKE_BINARY_DIR}/staging-json
+-                  COMMAND sed -e "/\"library_path\":/s$:[[:space:]]*\"[[:space:]]*[\\.\\/]*$: \"..\\/..\\/..\\/Frameworks\\/$"
+-                          ${MOLTENVK_DIR}/MoltenVK/icd/MoltenVK_icd.json > ${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json
+-                  VERBATIM
+-                  DEPENDS "${MOLTENVK_DIR}/MoltenVK/icd/MoltenVK_icd.json")
++                  COMMAND ${CMAKE_COMMAND} -E create_symlink ${MOLTENVK_DIR}/MoltenVK_icd.json
++                          ${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json
++                  DEPENDS "${MOLTENVK_DIR}/MoltenVK_icd.json")
+ set_source_files_properties(${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json PROPERTIES GENERATED TRUE)
+ 
+ find_library(COCOA NAMES Cocoa)
+diff --git a/vulkaninfo/CMakeLists.txt b/vulkaninfo/CMakeLists.txt
+index fb236a5b..3c8270d4 100644
+--- a/vulkaninfo/CMakeLists.txt
++++ b/vulkaninfo/CMakeLists.txt
+@@ -139,9 +139,4 @@ elseif(APPLE)
+     add_definitions(-DVK_USE_PLATFORM_MACOS_MVK -DVK_USE_PLATFORM_METAL_EXT)
+ endif()
+ 
+-if(APPLE)
+-    install(TARGETS vulkaninfo RUNTIME DESTINATION "vulkaninfo")
+-else()
+-    install(TARGETS vulkaninfo RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-endif()
+-
++install(TARGETS vulkaninfo RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+diff --git a/vulkaninfo/macOS/vulkaninfo.cmake b/vulkaninfo/macOS/vulkaninfo.cmake
+index 9614530e..56af3b89 100644
+--- a/vulkaninfo/macOS/vulkaninfo.cmake
++++ b/vulkaninfo/macOS/vulkaninfo.cmake
+@@ -48,26 +48,4 @@ set_source_files_properties(${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json
+                             MACOSX_PACKAGE_LOCATION
+                             "Resources/vulkan/icd.d")
+ 
+-# Xcode projects need some extra help with what would be install steps.
+-if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
+-    add_custom_command(TARGET vulkaninfo-bundle POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
+-                               ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vulkaninfo.app/Contents/Frameworks/libMoltenVK.dylib
+-                       DEPENDS vulkan)
+-else()
+-    add_custom_command(TARGET vulkaninfo-bundle POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
+-                               ${CMAKE_CURRENT_BINARY_DIR}/vulkaninfo.app/Contents/Frameworks/libMoltenVK.dylib
+-                       DEPENDS vulkan)
+-endif()
+-
+-# Keep RPATH so fixup_bundle can use it to find libraries
+-set_target_properties(vulkaninfo-bundle PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+-install(TARGETS vulkaninfo-bundle BUNDLE DESTINATION "vulkaninfo")
+-# Fix up the library search path in the executable to find (loader) libraries in the bundle. When fixup_bundle() is passed a bundle
+-# in the first argument, it looks at the Info.plist file to determine the BundleExecutable. In this case, the executable is a
+-# script, which can't be fixed up. Instead pass it the explicit name of the executable.
+-install(CODE "
+-    include(BundleUtilities)
+-    fixup_bundle(\${CMAKE_INSTALL_PREFIX}/vulkaninfo/vulkaninfo.app/Contents/MacOS/vulkaninfo \"\" \"${Vulkan_LIBRARY_DIR}\")
+-    ")
++install(TARGETS vulkaninfo-bundle BUNDLE DESTINATION "Applications")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21010,7 +21010,10 @@ with pkgs;
   vulkan-extension-layer = callPackage ../tools/graphics/vulkan-extension-layer { };
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { inherit (darwin) moltenvk; };
-  vulkan-tools = callPackage ../tools/graphics/vulkan-tools { };
+  vulkan-tools = callPackage ../tools/graphics/vulkan-tools {
+    inherit (darwin) moltenvk;
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
+  };
   vulkan-tools-lunarg = callPackage ../tools/graphics/vulkan-tools-lunarg { };
   vulkan-validation-layers = callPackage ../development/tools/vulkan-validation-layers { };
 


### PR DESCRIPTION
###### Description of changes

Enable building of vulkan-tools on Darwin. Note that `sandbox = relaxed` was used for testing the `sandboxProfile`.

Also includes two changes to MoltenVK to allow it to work:

* Fix incorrect ICD definition; and
* Export MoltenVK headers in a `dev` output.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
