### PR TITLE
cross-compilation fixes

### DIFF
--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "doc" ];
   outputMan = "out"; # users will want `man man` to work
 
+  strictDeps = true;
   nativeBuildInputs = [ autoreconfHook groff makeWrapper pkg-config zstd ];
   buildInputs = [ libpipeline db groff ]; # (Yes, 'groff' is both native and build input)
   checkInputs = [ libiconv /* for 'iconv' binary */ ];
@@ -41,12 +42,6 @@ stdenv.mkDerivation rec {
 
     # Add mandb locations for the above
     echo "MANDB_MAP	/nix/var/nix/profiles/default/share/man	/var/cache/man/nixpkgs" >> src/man_db.conf.in
-
-    # use absolute paths to reference programs, otherwise artifacts will have undeclared dependencies
-    for f in configure.ac m4/man-check-progs.m4 m4/man-po4a.m4; do
-      substituteInPlace $f \
-        --replace AC_CHECK_PROGS AC_PATH_PROGS
-    done
   '';
 
   configureFlags = [
@@ -72,21 +67,15 @@ stdenv.mkDerivation rec {
     # (multi-call binary). `apropos` is actually just a symlink to whatis. So we need to
     # make sure that we don't wrap symlinks (since that changes argv[0] to the -wrapped name)
     find "$out/bin" -type f | while read file; do
-      wrapProgram "$file" --prefix PATH : "${groff}/bin"
+      wrapProgram "$file" \
+        --prefix PATH : "${lib.getBin groff}/bin" \
+        --prefix PATH : "${lib.getBin zstd}/bin"
     done
   '';
 
-  postFixup = lib.optionalString (buildPackages.groff != groff) ''
-    # Check to make sure none of the outputs depend on build-time-only groff:
-    for outName in $outputs; do
-      out=''${!outName}
-      echo "Checking $outName(=$out) for references to build-time groff..."
-      if grep -r '${buildPackages.groff}' $out; then
-        echo "Found an erroneous dependency on groff ^^^" >&2
-        exit 1
-      fi
-    done
-  '';
+  disallowedReferences = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    buildPackages.groff
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -5,6 +5,7 @@
 , autoreconfHook
 , pkg-config
 , texinfo
+, bash
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +32,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = lib.optionalString (psutils != null) ''
+  postPatch = ''
+    # BASH_PROG gets replaced with a path to the build bash which doesn't get automatically patched by patchShebangs
+    substituteInPlace contrib/gdiffmk/gdiffmk.sh \
+      --replace "@BASH_PROG@" "/bin/sh"
+  '' + lib.optionalString (psutils != null) ''
     substituteInPlace src/preproc/html/pre-html.cpp \
       --replace "psselect" "${psutils}/bin/psselect"
   '' + lib.optionalString (netpbm != null) ''
@@ -45,7 +50,8 @@ stdenv.mkDerivation rec {
       --replace "@PNMTOPS_NOSETPAGE@" "${lib.getBin netpbm}/bin/pnmtops -nosetpage"
   '';
 
-  buildInputs = [ ghostscript psutils netpbm perl ];
+  strictDeps = true;
+  buildInputs = [ ghostscript psutils netpbm perl bash ];
   nativeBuildInputs = [ autoreconfHook pkg-config texinfo ];
 
   # Builds running without a chroot environment may detect the presence

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" "doc" "info" "perl" ];
 
-  enableParallelBuilding = false;
+  enableParallelBuilding = true;
 
   patches = [
     ./0001-Fix-cross-compilation-by-looking-for-ar.patch


### PR DESCRIPTION
See commit messages

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux and to cross aarch64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
