### PR TITLE
openmw: enable with glibc fix

### DIFF
--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -1,6 +1,7 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , pkg-config
 , wrapQtAppsHook
@@ -55,6 +56,13 @@ mkDerivation rec {
     sha256 = "sha256-Xq9hDUTCQr79Zzjk0CsiXclVTHK6nrSowukIQqVdrKY=";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.com/OpenMW/openmw/-/merge_requests/1239.diff";
+      sha256 = "sha256-RhbIGeE6GyqnipisiMTwWjcFnIiR055hUPL8IkjPgZw=";
+    })
+  ];
+
   nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
 
   buildInputs = [
@@ -83,10 +91,5 @@ mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ abbradar marius851000 ];
     platforms = platforms.linux;
-
-    # 2021-10-13, doesn't compile with glibc-2.34, maintainers prefer a fix on glibc's end.
-    # Can be marked as un-broken as soon as https://gitlab.com/OpenMW/openmw/-/merge_requests/1239
-    # is resolved and a patch is appliable here.
-    broken = true;
   };
 }

--- a/pkgs/games/openmw/tes3mp.nix
+++ b/pkgs/games/openmw/tes3mp.nix
@@ -87,7 +87,7 @@ let
     '';
 
     # https://github.com/TES3MP/openmw-tes3mp/issues/552
-    patches = [ ./tes3mp.patch ];
+    patches = oldAttrs.patches ++ [ ./tes3mp.patch ];
 
     NIX_CFLAGS_COMPILE = "-fpermissive";
 
@@ -108,6 +108,7 @@ let
       license = licenses.gpl3Only;
       maintainers = with maintainers; [ peterhoeg ];
       platforms = [ "x86_64-linux" "i686-linux" ];
+      broken = true;
     };
   });
 


### PR DESCRIPTION
###### Description of changes

Apply a patch to fix compilation with new glibc versions.

Fixed also some problems with tes3mp.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
