### PR TITLE
[staging-21.11] libinput: 1.19.1 → 1.19.4

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -44,13 +44,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libinput";
-  version = "1.19.3";
+  version = "1.19.4";
 
   outputs = [ "bin" "out" "dev" ];
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libinput/libinput-${version}.tar.xz";
-    sha256 = "sha256-PK54zN4Z19Dzh+WLxzTU0Xq19kJvVKnotyjJCxe6oGg=";
+    sha256 = "sha256-/zOlcLWpNsgebAg4moWBwmZTEdAmzj0iXIjQnEn5tEA=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -1,47 +1,70 @@
-{ lib, stdenv, fetchurl, pkg-config, meson, ninja
-, libevdev, mtdev, udev, libwacom
-, documentationSupport ? false, doxygen, graphviz # Documentation
-, eventGUISupport ? false, cairo, glib, gtk3 # GUI event viewer support
-, testsSupport ? false, check, valgrind, python3
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, meson
+, ninja
+, libevdev
+, mtdev
+, udev
+, libwacom
+, documentationSupport ? false
+, doxygen
+, graphviz
+, eventGUISupport ? false
+, cairo
+, glib
+, gtk3
+, testsSupport ? false
+, check
+, valgrind
+, python3
 , nixosTests
 }:
 
 let
   mkFlag = optSet: flag: "-D${flag}=${lib.boolToString optSet}";
 
-  sphinx-build = if documentationSupport then
-    python3.pkgs.sphinx.overrideAttrs (super: {
-      propagatedBuildInputs = super.propagatedBuildInputs ++ (with python3.pkgs; [ recommonmark sphinx_rtd_theme ]);
+  sphinx-build =
+    python3.pkgs.sphinx.overrideAttrs (attrs: {
+      propagatedBuildInputs =
+        attrs.propagatedBuildInputs
+        ++ (with python3.pkgs; [
+          recommonmark
+          sphinx_rtd_theme
+        ]);
 
-      postFixup = super.postFixup or "" + ''
+      postFixup = attrs.postFixup or "" + ''
         # Do not propagate Python
         rm $out/nix-support/propagated-build-inputs
       '';
-    })
-  else null;
+    });
 in
 
 stdenv.mkDerivation rec {
   pname = "libinput";
   version = "1.19.3";
 
+  outputs = [ "bin" "out" "dev" ];
+
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libinput/libinput-${version}.tar.xz";
     sha256 = "sha256-PK54zN4Z19Dzh+WLxzTU0Xq19kJvVKnotyjJCxe6oGg=";
   };
 
-  outputs = [ "bin" "out" "dev" ];
-
-  mesonFlags = [
-    (mkFlag documentationSupport "documentation")
-    (mkFlag eventGUISupport "debug-gui")
-    (mkFlag testsSupport "tests")
-    "--sysconfdir=/etc"
-    "--libexecdir=${placeholder "bin"}/libexec"
+  patches = [
+    ./udev-absolute-path.patch
   ];
 
-  nativeBuildInputs = [ pkg-config meson ninja ]
-    ++ lib.optionals documentationSupport [ doxygen graphviz sphinx-build ];
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ] ++ lib.optionals documentationSupport [
+    doxygen
+    graphviz
+    sphinx-build
+  ];
 
   buildInputs = [
     libevdev
@@ -53,20 +76,34 @@ stdenv.mkDerivation rec {
       pyyaml
       setuptools
     ]))
-  ] ++ lib.optionals eventGUISupport [ cairo glib gtk3 ];
+  ] ++ lib.optionals eventGUISupport [
+    # GUI event viewer
+    cairo
+    glib
+    gtk3
+  ];
+
+  propagatedBuildInputs = [
+    udev
+  ];
 
   checkInputs = [
     check
     valgrind
   ];
 
-  propagatedBuildInputs = [ udev ];
+  mesonFlags = [
+    (mkFlag documentationSupport "documentation")
+    (mkFlag eventGUISupport "debug-gui")
+    (mkFlag testsSupport "tests")
+    "--sysconfdir=/etc"
+    "--libexecdir=${placeholder "bin"}/libexec"
+  ];
 
-  patches = [ ./udev-absolute-path.patch ];
+  doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;
 
   postPatch = ''
     patchShebangs \
-      tools/helper-copy-and-exec-from-tmp.sh \
       test/symbols-leak-test \
       test/check-leftover-udev-rules.sh \
       test/helper-copy-and-exec-from-tmp.sh
@@ -75,17 +112,15 @@ stdenv.mkDerivation rec {
     sed -i "/install_subdir('libinput', install_dir : dir_etc)/d" meson.build
   '';
 
-  doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;
-
   passthru.tests = {
     libinput-module = nixosTests.libinput;
   };
 
   meta = with lib; {
     description = "Handles input devices in Wayland compositors and provides a generic X.Org input driver";
-    homepage    = "https://www.freedesktop.org/wiki/Software/libinput/";
-    license     = licenses.mit;
-    platforms   = platforms.unix;
+    homepage = "https://www.freedesktop.org/wiki/Software/libinput/";
+    license = licenses.mit;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ codyopel ];
   };
 }

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -121,6 +121,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.freedesktop.org/wiki/Software/libinput/";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ codyopel ];
+    maintainers = with maintainers; [ codyopel ] ++ teams.freedesktop.members;
   };
 }

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -23,11 +23,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libinput";
-  version = "1.19.1";
+  version = "1.19.3";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libinput/libinput-${version}.tar.xz";
-    sha256 = "sha256-C9z1sXg7c3hUt68coi32e8Nqb+fJz6cfAekUn5IgRG0=";
+    sha256 = "sha256-PK54zN4Z19Dzh+WLxzTU0Xq19kJvVKnotyjJCxe6oGg=";
   };
 
   outputs = [ "bin" "out" "dev" ];


### PR DESCRIPTION
###### Description of changes

Backport of #150019 plus 1.19.3 -> 1.19.4 update, fixes CVE-2022-1215

https://gitlab.freedesktop.org/libinput/libinput/-/compare/1.19.3...1.19.4
https://lists.x.org/archives/wayland-devel/2022-April/042161.html

See https://github.com/NixOS/nixpkgs/pull/169399 for nixos-unstable

(Feel free to force push or close this PR if I am not responding in time)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] [Run the sway test using ofborg](https://github.com/NixOS/nixpkgs/runs/6090517402)
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
