### PR TITLE
python3Packages.sentry-sdk: disable tests

### DIFF
--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -137,10 +137,10 @@ buildPythonPackage rec {
     "tests/integrations/pyramid/test_pyramid.py"
   ]
   # test crashes on aarch64
-  ++ (if stdenv.buildPlatform != "x86_64-linux" then [
+  ++ lib.optionals (stdenv.buildPlatform != "x86_64-linux") [
     "tests/test_transport.py"
     "tests/integrations/threading/test_threading.py"
-  ] else [ ]);
+  ];
 
   pythonImportsCheck = [
     "sentry_sdk"

--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -112,6 +112,8 @@ buildPythonPackage rec {
     "test_auto_session_tracking_with_aggregates"
     # Network requests to public web
     "test_crumb_capture"
+    # TypeError: cannot unpack non-iterable TestResponse object
+    "test_rpc_error_page"
   ];
 
   disabledTestPaths = [
@@ -128,7 +130,17 @@ buildPythonPackage rec {
     "tests/integrations/rq/"
     # broken since pytest 7.0.1; AssertionError: previous item was not torn down properly
     "tests/utils/test_contextvars.py"
-  ];
+    # broken since Flask and Werkzeug update to 2.1.0 (different error messages)
+    "tests/integrations/flask/test_flask.py"
+    "tests/integrations/bottle/test_bottle.py"
+    "tests/integrations/django/test_basic.py"
+    "tests/integrations/pyramid/test_pyramid.py"
+  ]
+  # test crashes on aarch64
+  ++ (if stdenv.buildPlatform != "x86_64-linux" then [
+    "tests/test_transport.py"
+    "tests/integrations/threading/test_threading.py"
+  ] else [ ]);
 
   pythonImportsCheck = [
     "sentry_sdk"


### PR DESCRIPTION
###### Description of changes

disable tests in the wake of Flask and Werkzeug update. Also disable failing tests on non-x86_64-linux architecture.

Fixes #169130

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This is a semi-automatic executed nixpkgs-review with nixpkgs-review-checks extension. It is checked by a human on a best effort basis and does not build all packages (e.g. lumo, tensorflow or pytorch).

Result of nixpkgs-review run on x86_64-linux 1

<details>
<summary>
3 packages marked as broken and skipped:
</summary>
<ul>
<li>python39Packages.spacy</li>
<li>python39Packages.spacy-transformers</li>
<li>python39Packages.textacy</li>
</ul>
</details>
<details>
<summary>3 packages failed to build and already failed to build on hydra master:</summary>
  <ul>
<li>alerta-server: log was empty</li>
<li>gns3-gui: log was empty</li>
<li>gns3-server: log was empty</li>
  </ul>
</details>
<details>
<summary>
11 packages built:
</summary>
<ul>
<li>cura</li>
<li>home-assistant-component-tests.sentry</li>
<li>moodle-dl</li>
<li>moz-phab</li>
<li>netbox</li>
<li>openai (python39Packages.openai)</li>
<li>python39Packages.django-rq</li>
<li>python39Packages.sentry-sdk</li>
<li>python39Packages.spacy-loggers</li>
<li>python39Packages.wandb</li>
<li>tribler</li>
</ul>
</details>
