### PR TITLE
jasmin-compiler: init at 21.0

### DIFF
--- a/pkgs/development/compilers/jasmin-compiler/default.nix
+++ b/pkgs/development/compilers/jasmin-compiler/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchurl, ocamlPackages, mpfr, ppl }:
+
+stdenv.mkDerivation rec {
+  pname = "jasmin-compiler";
+  version = "21.0";
+
+  src = fetchurl {
+    url = "https://github.com/jasmin-lang/jasmin/releases/download/v${version}/jasmin-compiler-v${version}.tar.bz2";
+    sha256 = "sha256:1px17fpc00gca5ayfcr4k008srkyw120c25rnyf7cgzfs1gpylj2";
+  };
+
+  sourceRoot = "jasmin-compiler-v${version}/compiler";
+
+  nativeBuildInputs = with ocamlPackages; [ ocaml findlib ocamlbuild menhir camlidl ];
+
+  buildInputs = [
+    mpfr
+    ppl
+  ] ++ (with ocamlPackages; [
+    apron
+    batteries
+    menhirLib
+    yojson
+    zarith
+  ]);
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp jasminc.native $out/bin/jasminc
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A workbench for high-assurance and high-speed cryptography";
+    homepage = "https://github.com/jasmin-lang/jasmin/";
+    platforms = lib.platforms.all;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7121,6 +7121,8 @@ with pkgs;
 
   jamesdsp = libsForQt5.callPackage ../applications/audio/jamesdsp { };
 
+  jasmin-compiler = callPackage ../development/compilers/jasmin-compiler { };
+
   jazzy = callPackage ../development/tools/jazzy { };
 
   jc = with python3Packages; toPythonApplication jc;


### PR DESCRIPTION
###### Description of changes

Adds the Jasmin compiler.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
