### PR TITLE
mplus-outline-font: Add warning and fallback for deleted attribute

### DIFF
--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip, fetchFromGitHub }:
 
 let pname = "mplus-outline-fonts";
-in {
+in rec {
   osdnRelease = fetchzip {
     name = "${pname}-osdn";
     url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-063a.tar.xz";
@@ -42,4 +42,6 @@ in {
       license = licenses.ofl;
     };
   };
+
+  __toString = _: builtins.trace "'mplus-outline-fonts' is deprecated. Please pick either the legacy 'mplus-outline-fonts.osdnRelease' or the reworked and backward-incompatible 'mplus-outline-fonts.githubRelease'." osdnRelease.outPath; # Added 2022-04-20
 }


### PR DESCRIPTION
###### Description of changes

Added a __toString attribute that restores backward compatibility for users of 
the old mplus-outline-font. This makes the attribute a valid "types.path" value 
for nixos, and allows to use it, with a warning, as a font package.

An issue I could not fix is that the warning is printed four times with my 
nixos config, albeit being used at only one place. I still consider that better 
than a bare `throw`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

- [X] tested on my config
- [X] tested that it does not alter the list of packages generated by ofborg
- [X] tested that it doe snot alter the packages reported by search.nixos.org

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
