### PR TITLE
mg,oed,oksh: fix cross-compilation

### DIFF
--- a/pkgs/applications/editors/mg/default.nix
+++ b/pkgs/applications/editors/mg/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-qnb0yB/NNJV257dsLmP84brajoRG03U+Ja1ACYbBvbE=";
   };
 
+  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    substituteInPlace configure --replace "./conftest" "echo"
+  '';
+
   enableParallelBuilding = true;
 
   makeFlags = [ "PKG_CONFIG=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config" ];

--- a/pkgs/applications/editors/oed/default.nix
+++ b/pkgs/applications/editors/oed/default.nix
@@ -14,6 +14,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-Z8B1RIFve3UPj+9G/WJX0BNc2ynG/qtoGfoesarYGz8=";
   };
 
+  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    substituteInPlace configure --replace "./conftest" "echo"
+  '';
+
+  installPhase = ''
+    install -m755 -Dt $out/bin ed
+    install -m644 -Dt $out/share/man/man1 ed.1
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/ibara/oed";
     description = "Portable ed editor from OpenBSD";

--- a/pkgs/shells/oksh/default.nix
+++ b/pkgs/shells/oksh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub, buildPackages }:
 
 stdenv.mkDerivation rec {
   pname = "oksh";
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
     rev = "${pname}-${version}";
     sha256 = "sha256-076nD0aPps6n5qkR3LQJ6Kn2g3mkov+/M0qSvxNLZ6o=";
   };
+
+  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    substituteInPlace configure --replace "./conftest" "echo"
+  '';
+
+  configureFlags = [ "--no-strip" ];
 
   meta = with lib; {
     description = "Portable OpenBSD ksh, based on the Public Domain Korn Shell (pdksh)";


### PR DESCRIPTION
###### Description of changes
Fix cross-compilation:
```
mg-aarch64-unknown-linux-gnu> checking for C compiler... ./conftest: line 0: : not found
mg-aarch64-unknown-linux-gnu> ./conftest: line 0: B@9�5����: not found
mg-aarch64-unknown-linux-gnu> ./conftest: line 1: ELF��@@�g@8: not found
mg-aarch64-unknown-linux-gnu> ./conftest: line 0: can't open A,����D����0X����@: no such file
mg-aarch64-unknown-linux-gnu> �@���o�@p@@: not found
mg-aarch64-unknown-linux-gnu> ./conftest: line 1: �
                                                   �AH�@x: not found
mg-aarch64-unknown-linux-gnu> ./conftest: line 28: D������������p0����: not found
mg-aarch64-unknown-linux-gnu> ./conftest: line 29: 7G: not found
mg-aarch64-unknown-linux-gnu> ./conftest: line 30: syntax error: unexpected "("
mg-aarch64-unknown-linux-gnu> could not build working executables
mg-aarch64-unknown-linux-gnu> Please ensure your C compiler is a native compiler
```
Caused by:
https://github.com/ibara/mg/blob/053f809ca2d7711d477c0116957f31e38b983ff7/configure#L13
https://github.com/ibara/mg/blob/053f809ca2d7711d477c0116957f31e38b983ff7/configure#L36

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
