### PR TITLE
breitbandmessung: fix build and OS detection workaround

### DIFF
--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -1,51 +1,18 @@
 { lib
 , stdenv
-, alsa-lib
-, at-spi2-atk
-, at-spi2-core
-, atk
-, autoPatchelfHook
-, cairo
-, cups
-, dbus
-, dpkg
-, expat
 , fetchurl
-, gdk-pixbuf
-, glib
-, gtk3
-, libdrm
-, libxkbcommon
+, dpkg
+, electron_16
 , makeWrapper
-, mesa
 , nixosTests
-, nspr
-, nss
-, pango
-, pciutils
-, systemd
+, nodePackages
 , undmg
-, writeShellScriptBin
-, xorg
 }:
 
 let
   inherit (stdenv.hostPlatform) system;
 
   version = "3.1.0";
-
-  # At first start, the program checks for supported operating systems by calling `lsb_release -a`
-  # and only runs when it finds Debian/Ubuntu. So we present us as Debian an make it happy.
-  fake-lsb-release = writeShellScriptBin "lsb_release" ''
-    echo "Distributor ID: Debian"
-    echo "Description:    Debian GNU/Linux 10 (buster)"
-    echo "Release:        10"
-    echo "Codename:       buster"
-  '';
-
-  binPath = lib.makeBinPath [
-    fake-lsb-release
-  ];
 
   systemArgs = rec {
     x86_64-linux = rec {
@@ -54,68 +21,41 @@ let
         sha256 = "sha256-jSP+H9ej9Wd+swBZSy9uMi2ExSTZ191FGZhqaocTl7w=";
       };
 
-      dontUnpack = true;
-
       nativeBuildInputs = [
-        autoPatchelfHook
         dpkg
         makeWrapper
+        nodePackages.asar
       ];
 
-      buildInputs = runtimeDependencies;
-
-      runtimeDependencies = [
-        alsa-lib
-        at-spi2-atk
-        at-spi2-core
-        atk
-        cairo
-        cups
-        dbus
-        expat
-        gdk-pixbuf
-        glib
-        gtk3
-        libdrm
-        libxkbcommon
-        mesa
-        nspr
-        nss
-        pango
-        pciutils
-        systemd
-        xorg.libX11
-        xorg.libXcomposite
-        xorg.libXdamage
-        xorg.libXext
-        xorg.libXfixes
-        xorg.libXrandr
-        xorg.libxcb
-        xorg.libxshmfence
-      ];
+      unpackPhase = "dpkg-deb -x $src .";
 
       installPhase = ''
-        dpkg-deb -x $src $out
         mkdir -p $out/bin
+        mv usr/share $out/share
+        mkdir -p $out/share/breitbandmessung/resources
 
-        chmod -R g-w $out
+        asar e opt/Breitbandmessung/resources/app.asar $out/share/breitbandmessung/resources
 
-        addAutoPatchelfSearchPath --no-recurse $out/opt/Breitbandmessung
-        autoPatchelfFile $out/opt/Breitbandmessung/breitbandmessung
+        # At first start, the program checks for supported operating systems by using the `bizzby-lsb-release`
+        # module and only runs when it finds Debian/Ubuntu. So we present us as Debian and make it happy.
+        cat <<EOF > $out/share/breitbandmessung/resources/node_modules/bizzby-lsb-release/lib/lsb-release.js
+        module.exports = function release() {
+          return {
+            distributorID: "Debian",
+            description: "Debian GNU/Linux 10 (buster)",
+            release: "10",
+            codename: "buster"
+          }
+        }
+        EOF
 
-        makeWrapper $out/opt/Breitbandmessung/breitbandmessung $out/bin/breitbandmessung \
-          --prefix PATH : ${binPath}
-
-        mv $out/usr/share $out/share
-        rmdir $out/usr
+        makeWrapper ${electron_16}/bin/electron $out/bin/breitbandmessung \
+          --add-flags $out/share/breitbandmessung/resources/build/electron.js
 
         # Fix the desktop link
         substituteInPlace $out/share/applications/breitbandmessung.desktop \
           --replace /opt/Breitbandmessung $out/bin
       '';
-
-      dontAutoPatchelf = true;
-      dontPatchELF = true;
     };
 
     x86_64-darwin = {


### PR DESCRIPTION
###### Description of changes

This fixes two issues for the `breitbandmessung` build:
- a build time issue introduced by 7b9fd5d1c9802131ca0a01ff08a3ff64379d2df4, see #166086
- a runtime issue introduced by bae181d3f0f453d9a23cf5e899c2cb0f96e91fef, see #166132

The build time problem is avoided by ignoring the bundled Electron binary and using the nixpkgs build. This reduces the dependencies of this derivation a lot and avoids the manual ELF patching of selective files.
To use the nixpkgs Electron version I needed to `patchelf` the `chrome_crashpad_handler` binary, which is used by `breitbandmessung` for crash reporting. Otherwise the binary would fail to execute and Electron would crash:

```log
FATAL:double_fork_and_exec.cc(131) execv /nix/store/v7awas2rkilb4i9y5xwy378ddzdpp12i-electron-16.2.1/lib/electron/chrome_crashpad_handler: No such file or directory (2)
traps: .electron-wrapp[1015] trap int3 ip:558abe532ec3 sp:7ffce4247a90 error:0 in .electron-wrapped[558abb619000+6a13000]
systemd[1]: Created slice Slice /system/systemd-coredump.
systemd[1]: Started Process Core Dump (PID 1016/UID 0).
systemd-coredump[1017]: Process 1015 (.electron-wrapp) of user 1000 dumped core.
```

While not strictly necessary, I also used `patchelf` to fix the `chrome-sandbox` interpreter. The binary itself is pretty useless, because without `suid` or `root` privileges it does nothing, but at least it can now be executed.

The OS detection is workaround is fixed by moving the fake data into the used Node module itself, as there is no other way to influence the output of the used module (`bizzby-lsb-release`).

Fixes #166086
Fixes #166132
See also #166118

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
    `breitbandmessung.tests`
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
