### PR TITLE
python3Packages.flask-security-too: 4.1.3 -> 4.1.4

### DIFF
--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -43,12 +43,12 @@
 
 buildPythonPackage rec {
   pname = "flask-security-too";
-  version = "4.1.3";
+  version = "4.1.4";
 
   src = fetchPypi {
     pname = "Flask-Security-Too";
     inherit version;
-    sha256 = "sha256-mW2NKGeJpyR4Ri7m+KE3ElSg3E+P7qbzNTTCo3cskc8=";
+    sha256 = "sha256-j6My1CD+GY2InHlN0IXPcNqfq+ytdoDD3y+5s2o3WRI=";
   };
 
   propagatedBuildInputs = [
@@ -98,28 +98,6 @@ buildPythonPackage rec {
   ++ passthru.extras-require.fsqla
   ++ passthru.extras-require.mfa;
 
-  disabledTests = [
-    # flask 2.1.0 incompatibilities https://github.com/Flask-Middleware/flask-security/issues/594
-    "test_admin_setup_reset"
-    "test_authn_freshness"
-    "test_authn_freshness_nc"
-    "test_bad_sender"
-    "test_change_invalidates_auth_token"
-    "test_change_invalidates_session"
-    "test_default_authn_bp"
-    "test_default_unauthn"
-    "test_default_unauthn_bp"
-    "test_email_not_identity"
-    "test_next"
-    "test_post_security_with_application_root"
-    "test_post_security_with_application_root_and_views"
-    "test_recover_invalidates_session"
-    "test_two_factor_flag"
-    "test_unauthorized_access_with_referrer"
-    "test_verify"
-    "test_verify_link"
-    "test_view_configuration"
-  ];
 
   pythonImportsCheck = [ "flask_security" ];
 


### PR DESCRIPTION
###### Description of changes

Update to newest version.

This is a [patch release](https://flask-security-too.readthedocs.io/en/stable/changelog.html#version-4-1-4) which makes the removal of the disabledTests possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

nixpkgs-review will throw an error due to pgadmin4 failing to build. This is unrelated and fixed in #169370 
