### PR TITLE
peazip: init at 9.9.0

### DIFF
--- a/pkgs/tools/archivers/peazip/default.nix
+++ b/pkgs/tools/archivers/peazip/default.nix
@@ -1,0 +1,98 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, wrapQtAppsHook
+, fpc
+, lazarus
+, xorg
+, libqt5pas
+, _7zz
+, archiver
+, brotli
+, upx
+, zpaq
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "peazip";
+  version = "9.9.0";
+
+  src = fetchFromGitHub {
+    owner = "peazip";
+    repo = pname;
+    rev = version;
+    hash = "sha256-1UavigwVp/Gna2BOUECQrn/VQjov8wDw5EdPWX3mpvM=";
+  };
+  sourceRoot = "${src.name}/peazip-sources";
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    lazarus
+    fpc
+  ];
+
+  buildInputs = [
+    xorg.libX11
+    libqt5pas
+  ];
+
+  NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
+
+  buildPhase = ''
+    export HOME=$(mktemp -d)
+    cd dev
+    lazbuild --lazarusdir=${lazarus}/share/lazarus --widgetset=qt5 --build-all project_pea.lpi && [ -f pea ]
+    lazbuild --lazarusdir=${lazarus}/share/lazarus --widgetset=qt5 --build-all project_peach.lpi && [ -f peazip ]
+    cd ..
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Executables
+    ## Main programs
+    install -D dev/{pea,peazip} -t $out/lib/peazip
+    mkdir -p $out/bin
+    ln -s $out/lib/peazip/{pea,peazip} $out/bin/
+
+    ## Symlink the available compression algorithm programs.
+    mkdir -p $out/lib/peazip/res/bin/7z
+    ln -s ${_7zz}/bin/7zz $out/lib/peazip/res/bin/7z/7z
+    mkdir -p $out/lib/peazip/res/bin/arc
+    ln -s ${archiver}/bin/arc $out/lib/peazip/res/bin/arc/
+    mkdir -p $out/lib/peazip/res/bin/brotli
+    ln -s ${brotli}/bin/brotli $out/lib/peazip/res/bin/brotli/
+    mkdir -p $out/lib/peazip/res/bin/upx
+    ln -s ${upx}/bin/upx $out/lib/peazip/res/bin/upx/
+    mkdir -p $out/lib/peazip/res/bin/zpaq
+    ln -s ${zpaq}/bin/zpaq $out/lib/peazip/res/bin/zpaq/
+    mkdir -p $out/lib/peazip/res/bin/zstd
+    ln -s ${zstd}/bin/zstd $out/lib/peazip/res/bin/zstd/
+
+    mkdir -p $out/share/peazip
+    ln -s $out/share/peazip $out/lib/peazip/res/share
+    cp -r res/share/{icons,lang,themes,presets} $out/share/peazip/
+    install -D res/share/batch/freedesktop_integration/peazip.png -t "$out/share/icons/hicolor/256x256/apps"
+    install -D res/share/icons/peazip_{7z,rar,zip}.png -t "$out/share/icons/hicolor/256x256/mimetypes"
+    install -D res/share/batch/freedesktop_integration/peazip_{add,extract}.png -t "$out/share/icons/hicolor/256x256/actions"
+    install -D res/share/batch/freedesktop_integration/*.desktop -t "$out/share/applications"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform file and archive manager";
+    longDescription = ''
+      Free Zip / Unzip software and Rar file extractor. Cross-platform file and archive manager.
+
+      Features volume spanning, compression, authenticated encryption.
+
+      Supports 7Z, 7-Zip sfx, ACE, ARJ, Brotli, BZ2, CAB, CHM, CPIO, DEB, GZ, ISO, JAR, LHA/LZH, NSIS, OOo, PEA, RAR, RPM, split, TAR, Z, ZIP, ZIPX, Zstandard.
+    '';
+    license = licenses.gpl3Only;
+    homepage = "https://peazip.github.io";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ annaaurora ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34495,6 +34495,8 @@ with pkgs;
     stdenv = gccStdenv;
   };
 
+  peazip = libsForQt5.callPackage ../tools/archivers/peazip { };
+
   peek = callPackage ../applications/video/peek { };
 
   peertube = callPackage ../servers/peertube {


### PR DESCRIPTION
###### Description of changes

Taking on #167707. Add the peazip package.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
