### PR TITLE
awscli2: use python-dateutil directly

### DIFF
--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -52,7 +52,7 @@ with py.pkgs; buildPythonApplication rec {
     rsa
     ruamel-yaml
     wcwidth
-    dateutil
+    python-dateutil
     jmespath
     urllib3
   ];


### PR DESCRIPTION
###### Description of changes

Breakage from #169441 

```
error: undefined variable 'dateutil'

       at /home/hexa/.cache/nixpkgs-review/pr-169472-1/nixpkgs/pkgs/tools/admin/awscli2/default.nix:55:5:

           54|     wcwidth
           55|     dateutil
             |     ^
           56|     jmespath

       … while evaluating 'chooseDevOutputs'

       at /home/hexa/.cache/nixpkgs-review/pr-169472-1/nixpkgs/lib/attrsets.nix:609:22:

          608|   /* Pick the outputs of packages to place in buildInputs */
          609|   chooseDevOutputs = drvs: builtins.map getDev drvs;
             |                      ^
          610|

       … from call site

       … while evaluating the attribute 'propagatedBuildInputs' of the derivation 'awscli2-2.5.6'

       at /home/hexa/.cache/nixpkgs-review/pr-169472-1/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:205:7:

          204|     // (lib.optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
          205|       name =
             |       ^
          206|         let

       … while evaluating the attribute 'out.outPath'

       at /home/hexa/.cache/nixpkgs-review/pr-169472-1/nixpkgs/lib/customisation.nix:204:13:

          203|             drvPath = assert condition; drv.${outputName}.drvPath;
          204|             outPath = assert condition; drv.${outputName}.outPath;
             |             ^
          205|           };

       … while querying the derivation named 'awscli2-2.5.6'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
