### PR TITLE
cudaPackages: 11.5 -> 11.6 and gcc11

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/versions.toml
+++ b/pkgs/development/compilers/cudatoolkit/versions.toml
@@ -50,7 +50,9 @@ gcc = "gcc10"
 version = "11.5.0"
 url = "https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run"
 sha256 = "sha256-rgoWk9lJfPPYHmlIlD43lGNpANtxyY1Y7v2sr38aHkw="
-gcc = "gcc10" # cuda 11.5 has problems with glibc 2.4 -> keeping gcc10
+# cuda 11.5 has problems with glibc 2.4 -> keeping gcc10
+# cf. https://forums.developer.nvidia.com/t/cuda-11-5-samples-throw-multiple-error-attribute-malloc-does-not-take-arguments/192750/15
+gcc = "gcc10"
 
 ["11.6"]
 version = "11.6.1"

--- a/pkgs/development/compilers/cudatoolkit/versions.toml
+++ b/pkgs/development/compilers/cudatoolkit/versions.toml
@@ -44,13 +44,13 @@ gcc = "gcc9"
 version = "11.4.2"
 url = "https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run"
 sha256 = "sha256-u9h8oOkT+DdFSnljZ0c1E83e9VUILk2G7Zo4ZZzIHwo="
-gcc = "gcc11"
+gcc = "gcc10"
 
 ["11.5"]
 version = "11.5.0"
 url = "https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run"
 sha256 = "sha256-rgoWk9lJfPPYHmlIlD43lGNpANtxyY1Y7v2sr38aHkw="
-gcc = "gcc11"
+gcc = "gcc10" # cuda 11.5 has problems with glibc 2.4 -> keeping gcc10
 
 ["11.6"]
 version = "11.6.1"

--- a/pkgs/development/libraries/science/math/nccl/default.nix
+++ b/pkgs/development/libraries/science/math/nccl/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "nccl-${version}-cuda-${cudatoolkit.majorVersion}";
-  version = "2.7.8-1";
+  version = "2.12.10-1";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "nccl";
     rev = "v${version}";
-    sha256 = "0xxiwaw239dc9g015fka3k1nvm5zyl00dzgxnwzkang61dys9wln";
+    sha256 = "sha256-QqORzm0gD+QG+P8rId8bQn2oZsxL5YyxCIobUVs85wE=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4882,7 +4882,7 @@ with pkgs;
   cudaPackages_11_4 = callPackage ./cuda-packages.nix { cudaVersion = "11.4"; };
   cudaPackages_11_5 = callPackage ./cuda-packages.nix { cudaVersion = "11.5"; };
   cudaPackages_11_6 = callPackage ./cuda-packages.nix { cudaVersion = "11.6"; };
-  cudaPackages_11 = cudaPackages_11_5;
+  cudaPackages_11 = cudaPackages_11_6;
   cudaPackages = recurseIntoAttrs cudaPackages_11;
 
   # TODO: move to alias

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3582,7 +3582,6 @@ with pkgs;
   gpu-burn = callPackage ../applications/misc/gpu-burn {
     # gpu-burn doesn't build on gcc11. CUDA 11.3 is the last version to use
     # pre-gcc11, in particular gcc9.
-    cudatoolkit = cudaPackages_11_3.cudatoolkit;
     stdenv = gcc9Stdenv;
   };
 
@@ -23108,7 +23107,6 @@ with pkgs;
     cudaSupport = true;
     # librealsenseWithCuda doesn't build on gcc11. CUDA 11.3 is the last version
     # to use pre-gcc11, in particular gcc9.
-    cudaPackages = cudaPackages_11_3;
     stdenv = gcc9Stdenv;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1958,11 +1958,7 @@ in {
 
   cufflinks = callPackage ../development/python-modules/cufflinks { };
 
-  cupy = callPackage ../development/python-modules/cupy {
-    # cupy doesn't build on gcc11. CUDA 11.3 is the last version to use
-    # pre-gcc11, in particular gcc9.
-    cudaPackages = pkgs.cudaPackages_11_3;
-  };
+  cupy = callPackage ../development/python-modules/cupy { };
 
   curio = callPackage ../development/python-modules/curio { };
 


### PR DESCRIPTION
###### Description of changes

Cuda has strict requirements for the compiler and libc versions, in particular `11.5` is incompatible with glibc `2.4`, but `11.6` introduces a fix for that.

This PR updates the default cudaPackages of nixpkgs from `11.5` to `11.6`, resets preferred gcc versions for cuda `11.4` and  `11.5` back to `gcc10`, and keeps `gcc11` for cuda `11.6`.

At first glance, this seems to fix the cuda-related breakages introduced in https://github.com/NixOS/nixpkgs/pull/165732.
Hopefully this would allow us to revert the `cudaPackages_11_3` fallbacks introduced in https://github.com/NixOS/nixpkgs/pull/169279 as a fix

Waiting for the builds to finish: https://hercules-ci.com/github/SomeoneSerge/nixpkgs-unfree/jobs/449 (also a [baseline](https://hercules-ci.com/github/SomeoneSerge/nixpkgs-unfree/jobs/451))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
