### PR TITLE
giac: 1.6.0-47 -> 1.9.0-5

### DIFF
--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, fetchpatch, texlive, bison, flex, lapack, blas
-, gmp, mpfr, pari, ntl, gsl, mpfi, ecm, glpk, nauty
-, readline, gettext, libpng, libao, gfortran, perl
+, autoreconfHook, gmp, mpfr, pari, ntl, gsl, mpfi, ecm, glpk, nauty
+, buildPackages, readline, gettext, libpng, libao, gfortran, perl
 , enableGUI ? false, libGL, libGLU, xorg, fltk
 , enableMicroPy ? false, python3
 }:
@@ -9,11 +9,11 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "giac${lib.optionalString enableGUI "-with-xcas"}";
-  version = "1.6.0-47"; # TODO try to remove preCheck phase on upgrade
+  version = "1.9.0-5"; # TODO try to remove preCheck phase on upgrade
 
   src = fetchurl {
     url = "https://www-fourier.ujf-grenoble.fr/~parisse/debian/dists/stable/main/source/giac_${version}.tar.gz";
-    sha256 = "sha256-c5A9/I6L/o3Y3dxEPoTKpw/fJqYMr6euLldaQ1HWT5c=";
+    sha256 = "sha256-EP8wRi8QZPrr1lfKN6da87s1FCy8AuDYbzcvsJCWyLE=";
   };
 
   patches = [
@@ -32,18 +32,21 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # 1.9.0-5's tarball contains a binary (src/mkjs) which is executed
+  # at build time. we will delete and rebuild it.
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   postPatch = ''
     for i in doc/*/Makefile* micropython*/xcas/Makefile*; do
       substituteInPlace "$i" --replace "/bin/cp" "cp";
     done;
-  '' +
-  # workaround for 1.6.0-47, should not be necessary in future versions
-  lib.optionalString (!enableMicroPy) ''
-    sed -i -e 's/micropython-[0-9.]* //' Makefile*
+    rm src/mkjs
+    substituteInPlace src/Makefile.am --replace "g++ mkjs.cc" \
+      "${buildPackages.stdenv.cc.targetPrefix}c++ mkjs.cc"
   '';
 
   nativeBuildInputs = [
-    texlive.combined.scheme-small bison flex
+    autoreconfHook texlive.combined.scheme-small bison flex
   ];
 
   # perl is only needed for patchShebangs fixup.
@@ -57,13 +60,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableGUI [
     libGL libGLU fltk xorg.libX11
   ] ++ lib.optional enableMicroPy python3;
-
-  /* fixes:
-  configure:16211: checking for main in -lntl
-  configure:16230: g++ -o conftest -g -O2   conftest.cpp -lntl  -llapack -lblas -lgfortran -ldl -lpng16 -lm -lmpfi -lmpfr -lgmp  >&5
-  /nix/store/y9c1v4x7y39j2rfbg17agjwqdzxpsn18-ntl-11.3.2/lib/libntl.so: undefined reference to `pthread_key_create'
-  */
-  NIX_CFLAGS_LINK="-lpthread";
 
   # xcas Phys and Turtle menus are broken with split outputs
   # and interactive use is likely to need docs

--- a/pkgs/applications/science/math/sage/patches/docutils-0.18.1-deprecation.patch
+++ b/pkgs/applications/science/math/sage/patches/docutils-0.18.1-deprecation.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sage/misc/sagedoc.py b/src/sage/misc/sagedoc.py
+index 4c56aea078..e51a77ae8a 100644
+--- a/src/sage/misc/sagedoc.py
++++ b/src/sage/misc/sagedoc.py
+@@ -1402,6 +1402,8 @@ class _sage_doc:
+             sage: identity_matrix.__doc__ in browse_sage_doc(identity_matrix, 'rst')
+             True
+             sage: browse_sage_doc(identity_matrix, 'html', False)             # optional - sphinx
++            ...
++            FutureWarning: The configuration setting "embed_images" will be removed in Docutils 1.2. Use "image_loading: link".
+             '...div...File:...Type:...Definition:...identity_matrix...'
+ 
+         In the 'text' version, double colons have been replaced with


### PR DESCRIPTION
###### Description of changes

Also includes a few other Sage test updates, while I'm at it. Sphinx now triggers deprecation warnings via docutils, and since it's impractical to patch Sphinx I just added the warning to the expected test output for the time being.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
