### PR TITLE
protobuf: add cmake builder, protobuf3_2{0,1}: init

### DIFF
--- a/pkgs/development/libraries/protobuf/3.20.nix
+++ b/pkgs/development/libraries/protobuf/3.20.nix
@@ -1,0 +1,6 @@
+{ callPackage, abseil-cpp, ... }:
+
+callPackage ./generic-v3.nix {
+  version = "3.20.1";
+  sha256 = "sha256-pAMacD0UQetqysZHszu5slPqp0iREtDmHFv1cgcUBJA=";
+}

--- a/pkgs/development/libraries/protobuf/3.21.nix
+++ b/pkgs/development/libraries/protobuf/3.21.nix
@@ -1,0 +1,6 @@
+{ callPackage, abseil-cpp, ... }:
+
+callPackage ./generic-v3-cmake.nix {
+  version = "3.21.2";
+  sha256 = "sha256-DUv07pWiZV7jNeSA2ClDOz9DY0x/hiJynxkbSTeJOSs=";
+}

--- a/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
@@ -1,0 +1,107 @@
+# The cmake version of this build is meant to enable both cmake and .pc being exported
+# this is important because grpc exports a .cmake file which also expects for protobuf
+# to have been exported through cmake as well.
+{ lib
+, stdenv
+, abseil-cpp
+, buildPackages
+, cmake
+, fetchFromGitHub
+, fetchpatch
+, gtest
+, zlib
+, version
+, sha256
+
+# downstream dependencies
+, python3
+
+, ...
+}:
+
+let
+  self = stdenv.mkDerivation {
+    pname = "protobuf";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "protocolbuffers";
+      repo = "protobuf";
+      rev = "v${version}";
+      inherit sha256;
+    };
+
+    # re-create submodule logic
+    postPatch = ''
+      rm -rf gmock
+      cp -r ${gtest.src}/googlemock third_party/gmock
+      cp -r ${gtest.src}/googletest third_party/
+      chmod -R a+w third_party/
+
+      ln -s ../googletest third_party/gmock/gtest
+      ln -s ../gmock third_party/googletest/googlemock
+      ln -s $(pwd)/third_party/googletest third_party/googletest/googletest
+    '' + lib.optionalString stdenv.isDarwin ''
+      substituteInPlace src/google/protobuf/testing/googletest.cc \
+        --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
+    '';
+
+    patches = lib.optionals (lib.versionOlder version "3.22") [
+      # fix protobuf-targets.cmake installation paths, and allow for CMAKE_INSTALL_LIBDIR to be absolute
+      # https://github.com/protocolbuffers/protobuf/pull/10090
+      (fetchpatch {
+        url = "https://github.com/protocolbuffers/protobuf/commit/a7324f88e92bc16b57f3683403b6c993bf68070b.patch";
+        sha256 = "sha256-SmwaUjOjjZulg/wgNmR/F5b8rhYA2wkKAjHIOxjcQdQ=";
+      })
+    ];
+
+    nativeBuildInputs = let
+      protobufVersion = "${lib.versions.major version}_${lib.versions.minor version}";
+    in [
+      cmake
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      # protoc of the same version must be available for build. For non-cross builds, it's able to
+      # re-use the executable generated as part of the build
+      buildPackages."protobuf${protobufVersion}"
+    ];
+
+    buildInputs = [
+      abseil-cpp
+      zlib
+    ];
+
+    # After 3.20, CMakeLists.txt can now be found at the top-level, however
+    # a stub cmake/CMakeLists.txt still exists for compatibility with previous build assumptions
+    cmakeDir = "../cmake";
+    cmakeFlags = [
+      "-Dprotobuf_ABSL_PROVIDER=package"
+      ] ++ lib.optionals (!stdenv.targetPlatform.isStatic) [
+      "-Dprotobuf_BUILD_SHARED_LIBS=ON"
+    ];
+
+    # unfortunately the shared libraries have yet to been patched by nix, thus tests will fail
+    doCheck = false;
+
+    passthru = {
+      tests = {
+        pythonProtobuf = python3.pkgs.protobuf.override(_: {
+          protobuf = self;
+        });
+      };
+    };
+
+    meta = {
+      description = "Google's data interchange format";
+      longDescription = ''
+        Protocol Buffers are a way of encoding structured data in an efficient
+        yet extensible format. Google uses Protocol Buffers for almost all of
+        its internal RPC protocols and file formats.
+      '';
+      license = lib.licenses.bsd3;
+      platforms = lib.platforms.unix;
+      homepage = "https://developers.google.com/protocol-buffers/";
+      maintainers = with lib.maintainers; [ jonringer ];
+    };
+  };
+in
+  self

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -19,7 +19,12 @@ buildPythonPackage {
   doCheck = doCheck && !isPy27; # setuptools>=41.4 no longer collects correctly on python2
 
   propagatedBuildInputs = [ six ] ++ lib.optionals isPy27 [ google-apputils ];
-  propagatedNativeBuildInputs = [ buildPackages.protobuf ]; # For protoc.
+  propagatedNativeBuildInputs = let
+    protobufVersion = "${lib.versions.major protobuf.version}_${lib.versions.minor protobuf.version}";
+  in [
+    buildPackages."protobuf${protobufVersion}" # For protoc of the same version.
+  ];
+
   nativeBuildInputs = [ pyext ] ++ lib.optionals isPy27 [ google-apputils ];
   buildInputs = [ protobuf ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20521,6 +20521,7 @@ with pkgs;
 
   protobuf = protobuf3_19;
 
+  protobuf3_20 = callPackage ../development/libraries/protobuf/3.20.nix { };
   protobuf3_19 = callPackage ../development/libraries/protobuf/3.19.nix { };
   protobuf3_17 = callPackage ../development/libraries/protobuf/3.17.nix { };
   protobuf3_11 = callPackage ../development/libraries/protobuf/3.11.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20521,6 +20521,7 @@ with pkgs;
 
   protobuf = protobuf3_19;
 
+  protobuf3_21 = callPackage ../development/libraries/protobuf/3.21.nix { };
   protobuf3_20 = callPackage ../development/libraries/protobuf/3.20.nix { };
   protobuf3_19 = callPackage ../development/libraries/protobuf/3.19.nix { };
   protobuf3_17 = callPackage ../development/libraries/protobuf/3.17.nix { };


### PR DESCRIPTION
###### Description of changes

Add cmake protobuf builder, so that we can expose `*.cmake` and `*.pc` files.

This is important because packages such as grpc expose .cmake files, which assume that protobuf exposes cmake files as well.

3.20 changelog: https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
