### PR TITLE
wasmtime: 0.35.2 -> 0.36.0

### DIFF
--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wasmtime";
-  version = "0.35.2";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-4oZglk7MInLIsvbeCfs4InAcmSmzZp16XL5+8eoYXJk=";
+    sha256 = "sha256-nSA78eQRbJ5JTDquaRqRgFU0V8RVCzvWUONgHxGj+Mc=";
     fetchSubmodules = true;
   };
 
-  cargoSha256 = "sha256-IqFOw9bGdM3IEoMeqDlxKfLnZvR80PSnwP9kr1tI/h0=";
+  cargoSha256 = "sha256-/+uioJRXiugsV7SUwsDNHGaPxrxrhscQUGyXOzzwG/g=";
 
   # This environment variable is required so that when wasmtime tries
   # to run tests by using the rusty_v8 crate, it does not try to


### PR DESCRIPTION
wasmtime 0.36.0 does not yet include https://github.com/bytecodealliance/wasmtime/pull/4022/commits/b1dfe5835a74662f46bb57e656648df79061e0fa, so darwin as a full platform cannot be enabled yet.