### PR TITLE
ocamlPackages.ocsigen-start: 4.5.0 → 6.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, fetchFromGitHub, ppxlib }:
+
+buildDunePackage rec {
+  pname = "ocsigen-ppx-rpc";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:0qgasd89ayamgl2rfyxsipznmwa3pjllkyq9qg0g1f41h8ixpsfh";
+  };
+
+  propagatedBuildInputs = [ ppxlib ];
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Syntax for RPCs for Eliom and Ocsigen Start";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -2,13 +2,15 @@
 , cohttp-lwt-unix, eliom
 , resource-pooling
 , ocamlnet
+, ocsigen-ppx-rpc
 }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-ocsigen-start";
-  version = "4.5.0";
+  version = "6.0.1";
 
   nativeBuildInputs = [ ocaml findlib eliom ];
+  buildInputs = [ ocsigen-ppx-rpc ];
   propagatedBuildInputs = [ pgocaml_ppx safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix ocamlnet ];
 
   strictDeps = true;
@@ -19,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "ocsigen";
     repo = "ocsigen-start";
     rev = version;
-    sha256 = "sha256:1n94r8rbkzxbgcz5w135n6f2cwpc91bdvf7yslcdq4cn713rncmq";
+    sha256 = "sha256:097bjaxvb1canilmqr8ay3ihig2msq7z8mi0g0rnbciikj1jsrym";
   };
 
   preInstall = ''

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -990,6 +990,8 @@ let
 
     ocplib-simplex = callPackage ../development/ocaml-modules/ocplib-simplex { };
 
+    ocsigen-ppx-rpc = callPackage ../development/ocaml-modules/ocsigen-ppx-rpc { };
+
     ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
 
     ocsigen-start = callPackage ../development/ocaml-modules/ocsigen-start { };


### PR DESCRIPTION
###### Description of changes

Update & introduce the new `ocsigen-ppx-rpc` dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
