### PR TITLE
chntpw: Fix build on macos

### DIFF
--- a/pkgs/tools/security/chntpw/00-chntpw-build-arch-autodetect.patch
+++ b/pkgs/tools/security/chntpw/00-chntpw-build-arch-autodetect.patch
@@ -1,10 +1,15 @@
-diff -urN chntpw-140201.orig/Makefile chntpw-140201/Makefile
---- chntpw-140201.orig/Makefile	2014-02-01 20:54:37.000000000 +0400
-+++ chntpw-140201/Makefile	2014-08-03 20:26:56.497161881 +0400
-@@ -12,14 +12,13 @@
+--- chntpw-140201.orig/Makefile	2014-02-01 17:54:37.000000000 +0100
++++ chntpw-140201/Makefile	2022-04-21 00:14:45.000000000 +0200
+@@ -6,24 +6,7 @@
+ # See INSTALL for more info.
+ #
  
- CC=gcc
- 
+-#SSLPATH=/usr/local/ssl
+-OSSLPATH=/usr
+-OSSLINC=$(OSSLPATH)/include
+-
+-CC=gcc
+-
 -# Force 32 bit
 -CFLAGS= -DUSEOPENSSL -g -I. -I$(OSSLINC) -Wall -m32 
 -OSSLLIB=$(OSSLPATH)/lib
@@ -13,13 +18,11 @@ diff -urN chntpw-140201.orig/Makefile chntpw-140201/Makefile
 -#CFLAGS= -DUSEOPENSSL -g -I. -I$(OSSLINC) -Wall
 -#OSSLLIB=$(OSSLPATH)/lib64
 -
-+ifeq      '$(shell gcc -dumpmachine)' 'x86_64-unknown-linux-gnu'
-+  CFLAGS= -DUSEOPENSSL -g -I. -I$(OSSLINC) -Wall
-+  OSSLLIB=$(OSSLPATH)/lib64
-+else ifeq '$(shell gcc -dumpmachine)' 'i686-unknown-linux-gnu'
-+  CFLAGS= -DUSEOPENSSL -g -I. -I$(OSSLINC) -Wall -m32 
-+  OSSLLIB=$(OSSLPATH)/lib
-+endif
+-
+-# This is to link with whatever we have, SSL crypto lib we put in static
+-#LIBS=-L$(OSSLLIB) $(OSSLLIB)/libcrypto.a
+-LIBS=-L$(OSSLLIB)
++CFLAGS= -DUSEOPENSSL -g -I. -Wall
  
- # This is to link with whatever we have, SSL crypto lib we put in static
- #LIBS=-L$(OSSLLIB) $(OSSLLIB)/libcrypto.a
+ 
+ all: chntpw chntpw.static cpnt reged reged.static samusrgrp samusrgrp.static sampasswd sampasswd.static

--- a/pkgs/tools/security/chntpw/01-chntpw-install-target.patch
+++ b/pkgs/tools/security/chntpw/01-chntpw-install-target.patch
@@ -1,20 +1,14 @@
-diff -urN chntpw-140201.orig/Makefile chntpw-140201/Makefile
---- chntpw-140201.orig/Makefile	2014-08-03 20:26:56.497161881 +0400
-+++ chntpw-140201/Makefile	2014-08-04 12:57:16.563818342 +0400
-@@ -10,6 +10,8 @@
- OSSLPATH=/usr
- OSSLINC=$(OSSLPATH)/include
+--- chntpw-140201/Makefile	2022-04-21 00:14:45.000000000 +0200
++++ chntpw-140201.new/Makefile	2022-04-21 09:15:42.000000000 +0200
+@@ -6,10 +6,16 @@
+ # See INSTALL for more info.
+ #
  
 +PREFIX ?= /usr
 +
- CC=gcc
+ CFLAGS= -DUSEOPENSSL -g -I. -Wall
  
- ifeq      '$(shell gcc -dumpmachine)' 'x86_64-unknown-linux-gnu'
-@@ -24,8 +26,12 @@
- #LIBS=-L$(OSSLLIB) $(OSSLLIB)/libcrypto.a
- LIBS=-L$(OSSLLIB)
- 
-+BINARIES := chntpw chntpw.static cpnt reged reged.static samusrgrp samusrgrp.static sampasswd sampasswd.static
++BINARIES := chntpw cpnt reged samusrgrp sampasswd
  
 -all: chntpw chntpw.static cpnt reged reged.static samusrgrp samusrgrp.static sampasswd sampasswd.static
 +all: $(BINARIES)

--- a/pkgs/tools/security/chntpw/default.nix
+++ b/pkgs/tools/security/chntpw/default.nix
@@ -11,7 +11,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ unzip ];
-  buildInputs = lib.optionals stdenv.isLinux [ stdenv.glibc.out stdenv.glibc.static ];
 
   patches = [
     ./00-chntpw-build-arch-autodetect.patch
@@ -27,6 +26,6 @@ stdenv.mkDerivation rec {
     description = "An utility to reset the password of any user that has a valid local account on a Windows system";
     maintainers = with lib.maintainers; [ deepfire ];
     license = licenses.gpl2;
-    platforms = with lib.platforms; linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/security/chntpw/default.nix
+++ b/pkgs/tools/security/chntpw/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ lib, stdenv, fetchurl, unzip, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "chntpw";
@@ -15,6 +15,43 @@ stdenv.mkDerivation rec {
   patches = [
     ./00-chntpw-build-arch-autodetect.patch
     ./01-chntpw-install-target.patch
+    # Import various bug fixes from debian
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/04_get_abs_path";
+      sha256 = "17h0gaczqd5b792481synr1ny72frwslb779lm417pyrz6kh9q8n";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/06_correct_test_open_syscall";
+      sha256 = "00lg83bimbki988n71w54mmhjp9529r0ngm40d7fdmnc2dlpj3hd";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/07_detect_failure_to_write_key";
+      sha256 = "0pk6xnprh2pqyx4n4lw3836z6fqsw3mclkzppl5rhjaahriwxw4l";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/08_no_deref_null";
+      sha256 = "1g7pfmjaj0c2sm64s3api2kglj7jbgddjjd3r4drw6phwdkah0zs";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/09_improve_robustness";
+      sha256 = "1nszkdy01ixnain7cwdmfbhjngphw1300ifagc1wgl9wvghzviaa";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/11_improve_documentation";
+      sha256 = "0yql6hj72q7cq69rrspsjkpiipdhcwb0b9w5j8nhq40cnx9mgqgg";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/12_readonly_filesystem";
+      sha256 = "1kxcy7f2pl6fqgmjg8bnl3pl5wgiw5xnbyx12arinmqkkggp4fa4";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/13_write_to_hive";
+      sha256 = "1638lcyxjkrkmbr3n28byixny0qrxvkciw1xd97x48mj6bnwqrkv";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/14_improve_description";
+      sha256 = "11y5kc4dh4zv24nkb0jw2zwlifx6nzsd4jbizn63l6dbpqgb25rs";
+    })
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes

This fixes the macos build by patching the makefile to remove the
explicit calls to gcc, letting it use whatever CC is the default.

It further removes the static builds entirely. This is technically a
breaking change, but I doubt it'll have a practical impact to any users.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
