### PR TITLE
yafetch: unstable-2021-07-18 -> unstable-2022-04-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1043,8 +1043,8 @@
     name = "Kirill Boltaev";
   };
   ashley = {
-    email = "personavinny@protonmail.com";
-    github = "paranoidcat";
+    email = "ashley@kira64.xyz";
+    github = "kira64xyz";
     githubId = 84152630;
     name = "Ashley Chiara";
   };

--- a/pkgs/tools/misc/yafetch/default.nix
+++ b/pkgs/tools/misc/yafetch/default.nix
@@ -1,29 +1,29 @@
-{ lib, stdenv, fetchFromGitLab }:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "yafetch";
-  version = "unstable-2021-07-18";
+  version = "unstable-2022-04-20";
 
-  src = fetchFromGitLab {
-    owner = "cyberkitty";
+  src = fetchFromGitHub {
+    owner = "kira64xyz";
     repo = pname;
-    rev = "f3efbca54df1ffea22cc40034114af141ccff9c1";
-    sha256 = "1cxhrjy9vzq87rzql4dcknkwca7nydysp1p1x4fh1qfw79dfdmxw";
+    rev = "a118cfc13f0b475db7c266105c10138d838788b8";
+    sha256 = "bSJlerfbJG6h5dDwWQKHnVLH6DEuvuUyqaRuJ7jvOsA=";
   };
 
   # Use the provided NixOS logo automatically
   prePatch = ''
     substituteInPlace ./config.h --replace \
-      "#include \"ascii/tux.h\"" "#include \"ascii/nixos.h\""
+      "#include \"ascii/gnu.h\"" "#include \"ascii/nixos.h\""
   '';
 
   # Fixes installation path
   PREFIX = placeholder "out";
 
   meta = with lib; {
-    homepage = "https://gitlab.com/cyberkitty/yafetch";
+    homepage = "https://github.com/kira64xyz/yafetch";
     description = "Yet another fetch clone written in C++";
-    license = licenses.gpl2Only;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ivar ashley ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes
Updated the yafetch package to a new version and changed upstream to github.com/kira64xyz/yafetch, since development moved there
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
