### PR TITLE
ocamlPackages.caqti: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/default.nix
+++ b/pkgs/development/ocaml-modules/alcotest/default.nix
@@ -1,17 +1,19 @@
 { lib, buildDunePackage, fetchurl
-, astring, cmdliner, fmt, uuidm, re, stdlib-shims, uutf
+, astring, cmdliner, fmt, uuidm, re, stdlib-shims, uutf, ocaml-syntax-shims
 }:
 
 buildDunePackage rec {
   pname = "alcotest";
-  version = "1.4.0";
+  version = "1.5.0";
 
   useDune2 = true;
 
   src = fetchurl {
-    url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-mirage-${version}.tbz";
-    sha256 = "sha256:1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
+    url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-js-${version}.tbz";
+    sha256 = "sha256-VCgZB+AteJld8kbcLhDtGCgoKUrSBZNHoeOhM1SEj2w=";
   };
+
+  nativeBuildInputs = [ ocaml-syntax-shims ];
 
   propagatedBuildInputs = [ astring cmdliner fmt uuidm re stdlib-shims uutf ];
 

--- a/pkgs/development/ocaml-modules/caqti/default.nix
+++ b/pkgs/development/ocaml-modules/caqti/default.nix
@@ -1,8 +1,10 @@
-{ lib, fetchFromGitHub, buildDunePackage, cppo, logs, ptime, uri }:
+{ lib, fetchFromGitHub, buildDunePackage
+, cppo, logs, ptime, uri, bigstringaf
+, re, cmdliner, alcotest }:
 
 buildDunePackage rec {
   pname = "caqti";
-  version = "1.7.0";
+  version = "1.8.0";
   useDune2 = true;
 
   minimumOCamlVersion = "4.04";
@@ -11,11 +13,14 @@ buildDunePackage rec {
     owner = "paurkedal";
     repo = "ocaml-${pname}";
     rev = "v${version}";
-    sha256 = "sha256-NGK38so6ZVCRbtV3ww1u31EFAjkHgDdsFfFUwc8ldm4=";
+    sha256 = "sha256-8uKlrq9j1Z3QzkCyoRIn2j6wCdGyo7BY7XlbFHN1xVE=";
   };
 
   nativeBuildInputs = [ cppo ];
-  propagatedBuildInputs = [ logs ptime uri ];
+  propagatedBuildInputs = [ logs ptime uri bigstringaf ];
+  checkInputs = [ re cmdliner alcotest ];
+
+  doCheck = true;
 
   meta = {
     description = "Unified interface to relational database libraries";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update caqti to latest release, fixes regression from #165614 cc @vbgl 

Added `doCheck = true;` which needed `alcotest@1.5.0` so I upgraded that as well. Running `nixpkgs-review` currently, it should be posted shortly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
