### PR TITLE
lshw: B.02.18 -> 02.19

### DIFF
--- a/pkgs/tools/system/lshw/default.nix
+++ b/pkgs/tools/system/lshw/default.nix
@@ -10,12 +10,15 @@
 
 stdenv.mkDerivation rec {
   pname = "lshw";
-  version = "B.02.19";
+  # Fix repology.org by not including the prefixed B, otherwise the `pname` attr
+  # gets filled as `lshw-B.XX.XX` in `nix-env --query --available --attr nixpkgs.lshw --meta`
+  # See https://github.com/NixOS/nix/pull/4463 for a definitive fix
+  version = "02.19";
 
   src = fetchFromGitHub {
     owner = "lyonel";
     repo = pname;
-    rev = version;
+    rev = "B.${version}";
     sha256 = "sha256-PzbNGc1pPiPLWWgTeWoNfAo+SsXgi1HcjnXfYXA9S0I=";
   };
 
@@ -26,7 +29,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "VERSION=${version}"
+    "VERSION=${src.rev}"
   ];
 
   buildFlags = [ "all" ] ++ lib.optional withGUI "gui";

--- a/pkgs/tools/system/lshw/default.nix
+++ b/pkgs/tools/system/lshw/default.nix
@@ -1,40 +1,33 @@
-{ stdenv, lib, fetchurl, fetchpatch
-, withGUI ? false, gtk2, pkg-config, sqlite # compile GUI
+{ stdenv
+, lib
+, fetchFromGitHub
+, hwdata
+, gtk2
+, pkg-config
+, sqlite # compile GUI
+, withGUI ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "lshw";
-  version = "B.02.18";
+  version = "B.02.19";
 
-  src = fetchurl {
-    url = "https://ezix.org/software/files/lshw-${version}.tar.gz";
-    sha256 = "0brwra4jld0d53d7jsgca415ljglmmx1l2iazpj4ndilr48yy8mf";
+  src = fetchFromGitHub {
+    owner = "lyonel";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-PzbNGc1pPiPLWWgTeWoNfAo+SsXgi1HcjnXfYXA9S0I=";
   };
-
-  patches = [
-    (fetchpatch {
-      # fix crash in scan_dmi_sysfs() when run as non-root
-      url = "https://github.com/lyonel/lshw/commit/fbdc6ab15f7eea0ddcd63da355356ef156dd0d96.patch";
-      sha256 = "147wyr5m185f8swsmb4q1ahs9r1rycapbpa2548aqbv298bbish3";
-    })
-    (fetchpatch {
-      # support cross-compilation
-      url = "https://github.com/lyonel/lshw/commit/8486d25cea9b68794504fbd9e5c6e294bac6cb07.patch";
-      sha256 = "08f0wnxsq0agvsc66bhc7lxvk564ir0pp8pg3cym6a621prb9lm0";
-    })
-  ];
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = lib.optionals withGUI [ gtk2 sqlite ];
+  buildInputs = [ hwdata ]
+    ++ lib.optionals withGUI [ gtk2 sqlite ];
 
-  # Fix version info.
-  preConfigure = ''
-    sed -e "s/return \"unknown\"/return \"${version}\"/" \
-        -i src/core/version.cc
-  '';
-
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "VERSION=${version}"
+  ];
 
   buildFlags = [ "all" ] ++ lib.optional withGUI "gui";
 
@@ -46,7 +39,7 @@ stdenv.mkDerivation rec {
     homepage = "https://ezix.org/project/wiki/HardwareLiSter";
     description = "Provide detailed information on the hardware configuration of the machine";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ thiagokokada ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

- Bump version
- Switch to `fetchFromGitHub` to get updates from @r-ryantm bot
- Remove patches (they're merged upstream)
- Update dependencies
- Fix version workaround (not necessary anymore)
- Add myself as maintainer
- Fix the version for repology.org (see commit message for details)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
