### PR TITLE
patchSourcetimePath(Bash|Csh|Fish|Posix): init; root: fix thisroot.* setxrd.*

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -43,7 +43,7 @@
 let
 
   _llvm_9 = llvm_9.overrideAttrs (prev: {
-    patches = (prev.patches or []) ++ [
+    patches = (prev.patches or [ ]) ++ [
       (fetchpatch {
         url = "https://github.com/root-project/root/commit/a9c961cf4613ff1f0ea50f188e4a4b0eb749b17d.diff";
         stripLen = 3;

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -8,6 +8,8 @@
 , ftgl
 , gl2ps
 , glew
+, gnugrep
+, gnused
 , gsl
 , lapack
 , libX11
@@ -20,11 +22,14 @@
 , llvm_9
 , lz4
 , xz
+, man
 , openblas
 , pcre
 , nlohmann_json
 , pkg-config
+, procps
 , python
+, which
 , xxHash
 , zlib
 , zstd
@@ -33,6 +38,9 @@
 , libjpeg
 , libtiff
 , libpng
+, patchSourcetimePathCsh
+, patchSourcetimePathFish
+, patchSourcetimePathPosix
 , tbb
 , Cocoa
 , CoreSymbolication
@@ -85,6 +93,9 @@ stdenv.mkDerivation rec {
     libtiff
     libpng
     nlohmann_json
+    patchSourcetimePathCsh
+    patchSourcetimePathFish
+    patchSourcetimePathPosix
     python.pkgs.numpy
     tbb
   ]
@@ -185,6 +196,15 @@ stdenv.mkDerivation rec {
         --set PYTHONPATH "$out/lib" \
         --set ${lib.optionalString stdenv.isDarwin "DY"}LD_LIBRARY_PATH "$out/lib"
     done
+
+    # Make ldd and sed available to the ROOT executable
+    wrapProgram "$out/bin/root" --prefix PATH : "${lib.makeBinPath [ gnused stdenv.cc.libc ]}"
+
+    # Patch thisroot.{sh,csh,fish} setxrd.{sh,csh}
+    patchSourcetimePathPosix "$out/bin/thisroot.sh" "${lib.makeBinPath [ gnugrep gnused man procps which ]}"
+    patchSourcetimePathCsh "$out/bin/thisroot.csh" "${lib.makeBinPath [ gnugrep gnused man which ]}"
+    patchSourcetimePathFish "$out/bin/thisroot.fish" "${lib.makeBinPath [ man which]}"
+    patchSourcetimePathPosix "$out/bin/setxrd.sh" "${lib.makeBinPath [ gnused man which ]}"
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/default.nix
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, callPackage
+, makeSetupHook
+, gnused
+}:
+let
+  tests = import ./test { inherit callPackage; };
+in
+{
+  patchSourcetimePathBash = makeSetupHook
+    {
+      name = "patch-sourcetime-path-bash";
+      passthru.tests = {
+        inherit (tests) test-bash;
+      };
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a Bash/Ksh/Zsh script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-sourcetime-path-bash.sh;
+  patchSourcetimePathCsh = makeSetupHook
+    {
+      name = "patch-sourcetime-path-csh";
+      substitutions = {
+        sed = "${gnused}/bin/sed";
+      };
+      passthru.tests = {
+        inherit (tests) test-csh;
+      };
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a Csh script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-sourcetime-path-csh.sh;
+  patchSourcetimePathFish = makeSetupHook
+    {
+      name = "patch-sourcetime-path-fish";
+      passthru.tests = {
+        inherit (tests) test-fish;
+      };
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a Fish script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-sourcetime-path-fish.sh;
+  patchSourcetimePathPosix = makeSetupHook
+    {
+      name = "patch-sourcetime-path-posix";
+      substitutions = {
+        sed = "${gnused}/bin/sed";
+      };
+      passthru.tests = {
+        inherit (tests) test-posix;
+      };
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a POSIX shell script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-sourcetime-path-posix.sh;
+}

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-bash.sh
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-bash.sh
@@ -1,0 +1,49 @@
+patchSourcetimePathBash(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if [[ -n "\${NIXPKGS_SOURCETIME_PATH-}" ]]; then
+    NIXPKGS_SOURCETIME_PATH_OLD="\$NIXPKGS_SOURCETIME_PATH;\${NIXPKGS_SOURCETIME_PATH_OLD-}"
+fi
+NIXPKGS_SOURCETIME_PATH="$SOURCETIME_PATH"
+if [[ -n "\${PATH-}" ]]; then
+    PATH=":\$PATH"
+fi
+PATH="\$NIXPKGS_SOURCETIME_PATH\$PATH"
+export PATH
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if [[ -n "\${PATH-}" ]]; then
+    # Remove the inserted section
+    PATH="\${PATH/\$NIXPKGS_SOURCETIME_PATH}"
+    # Remove the duplicated colons
+    PATH="\${PATH//::/:}"
+    # Remove the prefixing colon
+    if [[ -n "\$PATH" && "\${PATH:0:1}" == ":" ]]; then
+        PATH="\${PATH:1}"
+    fi
+    # Remove the trailing colon
+    if [[ -n "\$PATH" && "\${PATH:\${#PATH}-1}" == ":" ]]; then
+        PATH="\${PATH::}"
+    fi
+    export PATH
+fi
+if [[ -n "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]]; then
+    IFS="" read -r -d ";" NIXPKGS_SOURCETIME_PATH <<< "\$NIXPKGS_SOURCETIME_PATH_OLD"
+    NIXPKGS_SOURCETIME_PATH_OLD="\${NIXPKGS_SOURCETIME_PATH_OLD:\${#NIXPKGS_SOURCETIME_PATH}+1}"
+else
+    unset NIXPKGS_SOURCETIME_PATH
+fi
+if [[ -z "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]]; then
+    unset NIXPKGS_SOURCETIME_PATH_OLD
+fi
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-csh.sh
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-csh.sh
@@ -1,0 +1,57 @@
+patchSourcetimePathCsh(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if (\$?NIXPKGS_SOURCETIME_PATH) then
+    if ("\$NIXPKGS_SOURCETIME_PATH" != "") then
+        if (! \$?NIXPKGS_SOURCETIME_PATH_OLD) then
+            if ("\$NIXPKGS_SOURCETIME_PATH_OLD" != "")
+                set NIXPKGS_SOURCETIME_PATH_OLD = (\$NIXPKGS_SOURCETIME_PATH \$NIXPKGS_SOURCETIME_PATH_OLD)
+            else
+                set NIXPKGS_SOURCETIME_PATH_OLD = \$NIXPKGS_SOURCETIME_PATH
+            endif
+        else
+            set NIXPKGS_SOURCETIME_PATH_OLD = \$NIXPKGS_SOURCETIME_PATH
+        endif
+    endif
+endif
+set NIXPKGS_SOURCETIME_PATH = "$SOURCETIME_PATH"
+if (! \$?PATH) then
+    setenv PATH ""
+endif
+if ("\$PATH" != "") then
+    setenv PATH "\${NIXPKGS_SOURCETIME_PATH}:\$PATH"
+else
+    setenv PATH "\$NIXPKGS_SOURCETIME_PATH"
+endif
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if (\$?PATH) then
+    if ("\$PATH" != "") then
+        # Remove the inserted section, the duplicated colons, and the leading and trailing colon
+        setenv PATH \`echo "\$PATH" | @sed@ "s#\${NIXPKGS_SOURCETIME_PATH}##" | @sed@ "s#::#:#g" | @sed@ "s#^:##" | @sed@ 's#:\$##'\`
+    endif
+endif
+if (\$?NIXPKGS_SOURCETIME_PATH_OLD) then
+    if ("\$NIXPKGS_SOURCETIME_PATH_OLD" != "") then
+        set NIXPKGS_SOURCETIME_PATH = \$NIXPKGS_SOURCETIME_PATH_OLD[1]
+        set NIXPKGS_SOURCETIME_PATH_OLD = \$NIXPKGS_SOURCETIME_PATH_OLD[2-]
+    else
+        unset NIXPKGS_SOURCETIME_PATH
+    endif
+    if (NIXPKGS_SOURCETIME_PATH_OLD == "") then
+        unset NIXPKGS_SOURCETIME_PATH_OLD
+    endif
+else
+    unset NIXPKGS_SOURCETIME_PATH
+endif
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-fish.sh
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-fish.sh
@@ -1,0 +1,50 @@
+patchSourcetimePathFish(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if set -q NIXPKGS_SOURCETIME_PATH && test (count \$NIXPKGS_SOURCETIME_PATH) -gt 0
+    set --unpath NIXPKGS_SOURCETIME_PATH_OLD "\$NIXPKGS_SOURCETIME_PATH" \$NIXPKGS_SOURCETIME_PATH_OLD
+end
+set --path NIXPKGS_SOURCETIME_PATH $SOURCETIME_PATH
+set -g --path PATH \$NIXPKGS_SOURCETIME_PATH \$PATH
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if set -q PATH && test "\$PATH" != "" && test (count \$PATH) -ge (count \$NIXPKGS_SOURCETIME_PATH)
+    # Remove the inserted section
+    for i in (seq 0 (math (count \$PATH) - (count \$NIXPKGS_SOURCETIME_PATH)))
+        for j in (seq 1 (count \$NIXPKGS_SOURCETIME_PATH))
+            if test \$PATH[(math \$i + \$j)] != \$NIXPKGS_SOURCETIME_PATH[\$j]
+                set i -1
+                break
+            end
+        end
+        if test \$i -eq -1
+            continue
+        end
+        if test \$i -eq 0
+            set -g --path PATH \$PATH[(math (count \$NIXPKGS_SOURCETIME_PATH) + 1)..]
+        else
+            set -g --path PATH \$PATH[..\$i] \$PATH[(math (count \$NIXPKGS_SOURCETIME_PATH) + 1 + \$i)..]
+        end
+        break
+    end
+end
+if set -q NIXPKGS_SOURCETIME_PATH_OLD && test (count \$NIXPKGS_SOURCETIME_PATH_OLD) -gt 0
+    set --path NIXPKGS_SOURCETIME_PATH \$NIXPKGS_SOURCETIME_PATH_OLD[1]
+    set --unpath NIXPKGS_SOURCETIME_PATH_OLD \$NIXPKGS_SOURCETIME_PATH_OLD[2..]
+else
+    set -e NIXPKGS_SOURCETIME_PATH
+end
+if set -q NIXPKGS_SOURCETIME_PATH_OLD && test (count \$NIXPKGS_SOURCETIME_PATH_OLD) -eq 0
+    set -e NIXPKGS_SOURCETIME_PATH_OLD
+end
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-posix.sh
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/patch-sourcetime-path-posix.sh
@@ -1,0 +1,38 @@
+patchSourcetimePathPosix(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if [ -n "\${NIXPKGS_SOURCETIME_PATH-}" ]; then
+    NIXPKGS_SOURCETIME_PATH_OLD="\$NIXPKGS_SOURCETIME_PATH;\${NIXPKGS_SOURCETIME_PATH_OLD-}"
+fi
+NIXPKGS_SOURCETIME_PATH="$SOURCETIME_PATH"
+if [ -n "\${PATH-}" ]; then
+    PATH=":\$PATH"
+fi
+PATH="\$NIXPKGS_SOURCETIME_PATH\$PATH"
+export PATH
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if [ -n "\${PATH-}" ]; then
+    PATH="\$(echo "\$PATH" | @sed@ "s#\$NIXPKGS_SOURCETIME_PATH##" | @sed@ "s#::#:#g" | @sed@ "s#^:##" | @sed@ "s#:\\\$##")"
+    export PATH
+fi
+if [ -n "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]; then
+    NIXPKGS_SOURCETIME_PATH="\$(echo "\$NIXPKGS_SOURCETIME_PATH_OLD" | @sed@ "s#\\([^;]\\);.*#\\1#")"
+    NIXPKGS_SOURCETIME_PATH_OLD="\$(echo "\$NIXPKGS_SOURCETIME_PATH_OLD" | @sed@ "s#[^;];\\(.*\\)#\\1#")"
+else
+    unset NIXPKGS_SOURCETIME_PATH
+fi
+if [ -z "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]; then
+    unset NIXPKGS_SOURCETIME_PATH_OLD
+fi
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/default.nix
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/default.nix
@@ -1,0 +1,216 @@
+{ callPackage }:
+{
+  test-bash = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , bash
+      , ksh
+      , patchSourcetimePathBash
+      , shellcheck
+      , zsh
+      }:
+      runCommandLocal "patch-sourcetime-path-bash-test"
+        {
+          nativeBuildInputs = [
+            bash
+            ksh
+            patchSourcetimePathBash
+            shellcheck
+            zsh
+          ];
+        } ''
+        set -eu -o pipefail
+        echo "Running shellcheck against ${./test-sourcing-bash}"
+        shellcheck -s bash --exclude SC1090 ${./test-sourcing-bash}
+        touch blank.bash
+        cp blank.bash blank_patched.bash
+        echo "Generating blank_patched.bash from blank.bash"
+        patchSourcetimePathBash blank_patched.bash "$PWD/delta:$PWD/foxtrot"
+        echo "Running shellcheck against blank_patched.bash"
+        shellcheck -s bash blank_patched.bash
+        echo "Testing in Bash if blank.bash and blank_patched.bash modifies PATH the same way"
+        bash ${./test-sourcing-bash} blank.bash blank_patched.bash
+        echo "Testing in Ksh if blank.bash and blank_patched.bash modifies PATH the same way"
+        ksh ${./test-sourcing-bash} "$PWD/blank.bash" "$PWD/blank_patched.bash"
+        echo "Testing in Zsh if blank.bash and blank_patched.bash modifies PATH the same way"
+        zsh ${./test-sourcing-bash} ./blank.bash ./blank_patched.bash
+        echo "Running shellcheck against sample_source.bash"
+        shellcheck -s bash ${./sample_source.bash}
+        cp ${./sample_source.bash} sample_source_patched.bash
+        chmod u+w sample_source_patched.bash
+        echo "Generating sample_source_patched.bash from ./sample_source.bash"
+        patchSourcetimePathBash sample_source_patched.bash "$PWD/delta:$PWD/foxtrot"
+        echo "Running shellcheck against sample_source_patched.bash"
+        shellcheck -s bash sample_source_patched.bash
+        echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        bash ${./test-sourcing-bash} ${./sample_source.bash} sample_source_patched.bash
+        echo "Testing in Ksh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        ksh ${./test-sourcing-bash} ${./sample_source.bash} "$PWD/sample_source_patched.bash"
+        echo "Testing in Zsh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        zsh ${./test-sourcing-bash} ${./sample_source.bash} ./sample_source_patched.bash
+        echo "Patching sample_source_patched.bash the second time"
+        patchSourcetimePathBash blank_patched.bash "$PWD/delta:$PWD/golf"
+        echo "Running shellcheck against sample_source_patched.bash"
+        shellcheck -s bash sample_source_patched.bash
+        echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        bash ${./test-sourcing-bash} ${./sample_source.bash} sample_source_patched.bash
+        echo "Testing in Ksh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        ksh ${./test-sourcing-bash} ${./sample_source.bash} "$PWD/sample_source_patched.bash"
+        echo "Testing in Zsh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        zsh ${./test-sourcing-bash} ${./sample_source.bash} ./sample_source_patched.bash
+        touch "$out"
+      ''
+    )
+    { };
+  test-csh = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , gnused
+      , patchSourcetimePathCsh
+      , tcsh
+      }:
+      runCommandLocal "patch-sourcetime-path-csh-test"
+        {
+          nativeBuildInputs = [
+            patchSourcetimePathCsh
+            tcsh
+          ];
+        } ''
+        set -eu -o pipefail
+        touch blank.csh
+        cp blank.csh blank_patched.csh
+        echo "Generating blank_patched.csh from blank.csh"
+        patchSourcetimePathCsh blank_patched.csh "$PWD/delta:$PWD/foxtrot"
+        echo "Testing in Csh if blank.csh and blank_patched.csh modifies PATH the same way"
+        tcsh ${./test-sourcing-csh} blank.csh blank_patched.csh
+        substitute ${./sample_source.csh.in} sample_source.csh --replace @sed@ ${gnused}/bin/sed
+        chmod u+rw sample_source.csh
+        cp sample_source.csh sample_source_patched.csh
+        chmod u+w sample_source_patched.csh
+        echo "Generating sample_source_patched.csh from sample_source.csh"
+        patchSourcetimePathCsh sample_source_patched.csh "$PWD/delta:$PWD/foxtrot"
+        echo "Testing in Csh if sample_source.csh and sample_source_patched.csh modifies PATH the same way"
+        tcsh ${./test-sourcing-csh} sample_source.csh sample_source_patched.csh
+        echo "Patching sample_source_patched.csh the second time"
+        patchSourcetimePathCsh sample_source_patched.csh "$PWD/delta:$PWD/golf"
+        echo "Testing in Csh if sample_source.csh and sample_source_patched.csh modifies PATH the same way"
+        tcsh ${./test-sourcing-csh} sample_source.csh sample_source_patched.csh
+        touch "$out"
+      ''
+    )
+    { };
+  test-fish = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , fish
+      , patchSourcetimePathFish
+      }:
+      runCommandLocal "patch-sourcetime-path-fish-test"
+        {
+          nativeBuildInputs = [
+            fish
+            patchSourcetimePathFish
+          ];
+        } ''
+        set -eu -o pipefail
+        touch blank.fish
+        cp blank.fish blank_patched.fish
+        echo "Generating blank_patched.fish from blank.fish"
+        patchSourcetimePathFish blank_patched.fish "$PWD/delta:$PWD/foxtrot"
+        echo "Testing in Fish if blank.fish and blank_patched.fish modifies PATH the same way"
+        HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+        HOME="$HOME_TEMP" fish ${./test-sourcing-fish} blank.fish blank_patched.fish
+        rm -r "$HOME_TEMP"
+        cp ${./sample_source.fish} sample_source_patched.fish
+        chmod u+w sample_source_patched.fish
+        echo "Generating sample_source_patched.fish from ${./sample_source.fish}"
+        patchSourcetimePathFish sample_source_patched.fish "$PWD/delta:$PWD/foxtrot"
+        echo "Testing in Fish if sample_source.fish and sample_source_patched.fish modifies PATH the same way"
+        HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+        HOME="$HOME_TEMP" fish ${./test-sourcing-fish} ${./sample_source.fish} sample_source_patched.fish
+        rm -r "$HOME_TEMP"
+        echo "Patching sample_source_patched.fish the second time"
+        patchSourcetimePathFish sample_source_patched.fish "$PWD/delta:$PWD/golf"
+        echo "Testing in Fish if sample_source.fish and sample_source_patched.fish modifies PATH the same way"
+        HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+        HOME="$HOME_TEMP" fish ${./test-sourcing-fish} ${./sample_source.fish} sample_source_patched.fish
+        rm -r "$HOME_TEMP"
+        touch "$out"
+      ''
+    )
+    { };
+  test-posix = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , bash
+      , dash
+      , gnused
+      , ksh
+      , patchSourcetimePathPosix
+      , shellcheck
+      }:
+      runCommandLocal "patch-sourcetime-path-posix-test"
+        {
+          nativeBuildInputs = [
+            bash
+            dash
+            ksh
+            patchSourcetimePathPosix
+            shellcheck
+          ];
+        } ''
+        set -eu -o pipefail
+        echo "Running shellcheck against ${./test-sourcing-posix}"
+        shellcheck -s sh --exclude SC1090 ${./test-sourcing-posix}
+        shellcheck -s dash --exclude SC1090 ${./test-sourcing-posix}
+        touch blank.sh
+        cp blank.sh blank_patched.sh
+        echo "Generating blank_patched.sh from blank.sh"
+        patchSourcetimePathPosix blank_patched.sh "$PWD/delta:$PWD/foxtrot"
+        echo "Running shellcheck against blank_patched.sh"
+        shellcheck -s sh blank_patched.sh
+        shellcheck -s dash blank_patched.sh
+        echo "Testing in Bash if blank.sh and blank_patched.sh modifies PATH the same way"
+        bash --posix ${./test-sourcing-posix} ./blank.sh ./blank_patched.sh
+        echo "Testing in Dash if blank.sh and blank_patched.sh modifies PATH the same way"
+        dash ${./test-sourcing-posix} ./blank.sh ./blank_patched.sh
+        echo "Testing in Ksh if ./blank.sh and ./blank_patched.sh modifies PATH the same way"
+        ksh ${./test-sourcing-posix} "$PWD/blank.sh" "$PWD/blank_patched.sh"
+        substitute ${./sample_source.sh.in} sample_source.sh --replace @sed@ ${gnused}/bin/sed
+        chmod u+rw sample_source.sh
+        echo "Running shellcheck against sample_source.sh"
+        shellcheck -s sh sample_source.sh
+        shellcheck -s dash sample_source.sh
+        cp sample_source.sh sample_source_patched.sh
+        chmod u+w sample_source_patched.sh
+        echo "Generating sample_source_patched.sh from sample_source.sh"
+        patchSourcetimePathPosix sample_source_patched.sh "$PWD/delta:$PWD/foxtrot"
+        echo "Running shellcheck against sample_source_patched.sh"
+        shellcheck -s sh sample_source_patched.sh
+        shellcheck -s dash sample_source_patched.sh
+        echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        bash --posix ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+        echo "Testing in Dash if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+        dash ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+        echo "Testing in Ksh if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+        ksh ${./test-sourcing-posix} "$PWD/sample_source.sh" "$PWD/sample_source_patched.sh"
+        echo "Patching sample_source_patched.sh the second time"
+        patchSourcetimePathPosix sample_source_patched.sh "$PWD/delta:$PWD/golf"
+        echo "Running shellcheck against sample_source_patched.sh"
+        shellcheck -s sh sample_source_patched.sh
+        shellcheck -s dash sample_source_patched.sh
+        echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+        bash --posix ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+        echo "Testing in Dash if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+        dash ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+        echo "Testing in Ksh if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+        ksh ${./test-sourcing-posix} "$PWD/sample_source.sh" "$PWD/sample_source_patched.sh"
+        touch "$out"
+      ''
+    )
+    { };
+}

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.bash
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.bash
@@ -1,0 +1,2 @@
+PATH="$PWD/charlie:${PATH/:$PWD\/bravo}"
+export PATH

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.csh.in
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.csh.in
@@ -1,0 +1,1 @@
+setenv PATH=$PWD/charlie:`echo "$PATH" | @sed@ "s#:$PWD/bravo##"`

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.fish
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.fish
@@ -1,0 +1,9 @@
+begin
+    for p in $PATH
+        if test $p != "$PWD/bravo"
+            set TEMPORARY_PATH $TEMPORARY_PATH $p
+        end
+    end
+    set -g PATH $TEMPORARY_PATH
+end
+set PATH "$PWD/charlie" $PATH

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.sh.in
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/sample_source.sh.in
@@ -1,0 +1,2 @@
+PATH="$PWD/charlie:$(echo "$PATH" | @sed@ "s#:$PWD/bravo##")"
+export PATH

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-bash
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+UNPATCHED_SOURCE_FILE="$1"
+PATCHED_SOURCE_FILE="$2"
+ORIG_PATH="$PWD/alfa:$PWD/bravo"
+RESULT_PATH_FROM_UNPATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$UNPATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+RESULT_PATH_FROM_PATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$PATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+if [[ "$RESULT_PATH_FROM_UNPATCHED" != "$RESULT_PATH_FROM_PATCHED" ]]; then
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" >&2
+    exit 1
+fi

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-csh
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-csh
@@ -1,0 +1,13 @@
+#/usr/bin/env tcsh
+
+set UNPATCHED_SOURCE_FILE = "$1"
+set PATCHED_SOURCE_FILE = "$2"
+set ORIG_PATH = "${PWD}/alfa:${PWD}/bravo"
+
+set RESULT_PATH_FROM_UNPATCHED = `setenv PATH "$ORIG_PATH"; source $UNPATCHED_SOURCE_FILE; echo $PATH`
+set RESULT_PATH_FROM_PATCHED = `setenv PATH "$ORIG_PATH"; source $PATCHED_SOURCE_FILE; echo $PATH`
+
+if ($RESULT_PATH_FROM_UNPATCHED != $RESULT_PATH_FROM_PATCHED) then
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" > /dev/stderr
+    exit 1
+endif

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-fish
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-fish
@@ -1,0 +1,13 @@
+#/usr/bin/env fish
+
+set UNPATCHED_SOURCE_FILE $argv[1]
+set PATCHED_SOURCE_FILE $argv[2]
+set ORIG_PATH "$PWD/alfa:$PWD/bravo"
+
+set RESULT_PATH_FROM_UNPATCHED (fish -c "set -g PATH \"$ORIG_PATH\"; source $UNPATCHED_SOURCE_FILE; echo \"\$PATH\"")
+set RESULT_PATH_FROM_PATCHED (fish -c "set -g PATH \"$ORIG_PATH\"; source $PATCHED_SOURCE_FILE; echo \"\$PATH\"")
+
+if test "$RESULT_PATH_FROM_UNPATCHED" != "$RESULT_PATH_FROM_PATCHED"
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" >&2
+    exit 1
+end

--- a/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-posix
+++ b/pkgs/build-support/setup-hooks/patch-sourcetime-path-hooks/test/test-sourcing-posix
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+UNPATCHED_SOURCE_FILE="$1"
+PATCHED_SOURCE_FILE="$2"
+ORIG_PATH="$PWD/alfa:$PWD/bravo"
+RESULT_PATH_FROM_UNPATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$UNPATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+RESULT_PATH_FROM_PATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$PATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+if [ "$RESULT_PATH_FROM_UNPATCHED" != "$RESULT_PATH_FROM_PATCHED" ]; then
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" > /dev/stderr
+    exit 1
+fi

--- a/pkgs/build-support/setup-hooks/postgresql-test-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/postgresql-test-hook/default.nix
@@ -1,9 +1,8 @@
 { callPackage, makeSetupHook }:
 
-(makeSetupHook {
+makeSetupHook {
   name = "postgresql-test-hook";
-} ./postgresql-test-hook.sh).overrideAttrs (o: {
   passthru.tests = {
     simple = callPackage ./test.nix { };
   };
-})
+} ./postgresql-test-hook.sh

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -523,12 +523,22 @@ rec {
    *                 substitutions = { bash = "${pkgs.bash}/bin/bash"; };
    *                 meta.platforms = lib.platforms.linux;
    *               } ./myscript.sh;
+   *
+   * # setup hook with a package test
+   * myhellohookTested = makeSetupHook {
+   *                 deps = [ hello ];
+   *                 substitutions = { bash = "${pkgs.bash}/bin/bash"; };
+   *                 meta.platforms = lib.platforms.linux;
+   *                 passthru.tests.greeting = callPackage ./test { };
+   *               } ./myscript.sh;
    */
-  makeSetupHook = { name ? "hook", deps ? [], substitutions ? {}, meta ? {} }: script:
+  makeSetupHook = { name ? "hook", deps ? [], substitutions ? {}, meta ? {}, passthru ? null }: script:
     runCommand name
       (substitutions // {
         inherit meta;
         strictDeps = true;
+      } // lib.optionalAttrs (passthru != null) {
+        inherit passthru;
       })
       (''
         mkdir -p $out/nix-support

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -894,6 +894,10 @@ with pkgs;
   octant-desktop = callPackage ../applications/networking/cluster/octant/desktop.nix { };
   starboard-octant-plugin = callPackage ../applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix { };
 
+  inherit (
+    callPackages ../build-support/setup-hooks/patch-sourcetime-path-hooks { }
+  ) patchSourcetimePathBash patchSourcetimePathCsh patchSourcetimePathFish patchSourcetimePathPosix;
+
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;
 
   pruneLibtoolFiles = makeSetupHook { name = "prune-libtool-files"; }


### PR DESCRIPTION
###### Description of changes
*   Add setup hook `patchSourcetimePath(Bash|Csh|Fish|Posix)` to add extra bin paths to `PATH` during the time the script is sourced, and clean them up afterward. Several test cases are also added to ensure that those hooks do their jobs.

*   Use the above setup hooks to patch thisrooot.* and setxrd.* for ROOT, so that the builder won't complain about command not found when sourcing thisroot.sh and building packages that depends on ROOT. Most of the files added are part of the test cases of the hooks.

*   Require #186323 (will rebase this PR when that one gets merged)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
