### PR TITLE
openjdk: 11.0.12+7 -> 11.0.15.+10, 17.0.1+12 -> 17.0.3.+7

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -11,8 +11,8 @@
 let
   major = "11";
   minor = "0";
-  update = "12";
-  build = "7";
+  update = "15";
+  build = "10";
 
   openjdk = stdenv.mkDerivation rec {
     pname = "openjdk" + lib.optionalString headless "-headless";
@@ -22,7 +22,7 @@ let
       owner = "openjdk";
       repo = "jdk${major}u";
       rev = "jdk-${version}";
-      sha256 = "0s8g6gj5vhm7hbp05cqaxasjrkwr41fm634qim8q6slklm4pkkli";
+      sha256 = "le2JDxPJPSuga4JxLJNRZwCaodptSb2kh4TsJXumTXs=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];
@@ -40,7 +40,6 @@ let
       ./currency-date-range-jdk10.patch
       ./increase-javadoc-heap.patch
       ./fix-library-path-jdk11.patch
-      ./fix-glibc-2.34.patch
     ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk10.patch
     ];
@@ -61,13 +60,17 @@ let
       "--with-zlib=system"
       "--with-lcms=system"
       "--with-stdc++lib=dynamic"
+      "--disable-warnings-as-errors"
     ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
       ++ lib.optional headless "--enable-headless-only"
       ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
 
     separateDebugInfo = true;
 
-    NIX_CFLAGS_COMPILE = "-Wno-error";
+    # Workaround for
+    # `cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]`
+    # when building jtreg
+    NIX_CFLAGS_COMPILE = "-Wformat";
 
     NIX_LDFLAGS = toString (lib.optionals (!headless) [
       "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -11,8 +11,8 @@
 let
   version = {
     feature = "17";
-    interim = ".0.1";
-    build = "12";
+    interim = ".0.3";
+    build = "7";
   };
 
   openjdk = stdenv.mkDerivation {
@@ -23,7 +23,7 @@ let
       owner = "openjdk";
       repo = "jdk${version.feature}u";
       rev = "jdk-${version.feature}${version.interim}+${version.build}";
-      sha256 = "1l1jgbz8q7zq66npfg88r0l5xga427vrz35iys09j44b6qllrldd";
+      sha256 = "qxiKz8HCNZXFdfgfiA16q5z0S65cZE/u7e+QxLlplWo=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];

--- a/pkgs/development/compilers/openjdk/fix-library-path-jdk11.patch
+++ b/pkgs/development/compilers/openjdk/fix-library-path-jdk11.patch
@@ -1,16 +1,31 @@
+From 83f97773ea99fe2191a49e551ea43d51c9a765cd Mon Sep 17 00:00:00 2001
+Subject: [PATCH] strip some hard-coded default paths for libs and extensions
+
+---
+ src/hotspot/os/linux/os_linux.cpp | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
 diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
-index 0dbe03349e..847d56778d 100644
+index 476b1c2175..2695ed2301 100644
 --- a/src/hotspot/os/linux/os_linux.cpp
 +++ b/src/hotspot/os/linux/os_linux.cpp
-@@ -326,13 +326,13 @@ void os::init_system_properties_values() {
+@@ -417,20 +417,20 @@ void os::init_system_properties_values() {
    //        ...
    //        7: The default directories, normally /lib and /usr/lib.
  #if defined(AMD64) || (defined(_LP64) && defined(SPARC)) || defined(PPC64) || defined(S390)
 -  #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
 +  #define DEFAULT_LIBPATH ""
  #else
+ #if defined(AARCH64)
+   // Use 32-bit locations first for AARCH64 (a 64-bit architecture), since some systems
+   // might not adhere to the FHS and it would be a change in behaviour if we used
+   // DEFAULT_LIBPATH of other 64-bit architectures which prefer the 64-bit paths.
+-  #define DEFAULT_LIBPATH "/lib:/usr/lib:/usr/lib64:/lib64"
++  #define DEFAULT_LIBPATH ""
+ #else
 -  #define DEFAULT_LIBPATH "/lib:/usr/lib"
 +  #define DEFAULT_LIBPATH ""
+ #endif // AARCH64
  #endif
  
  // Base path of extensions installed on the system.
@@ -19,7 +34,7 @@ index 0dbe03349e..847d56778d 100644
  #define EXTENSIONS_DIR  "/lib/ext"
  
    // Buffer that fits several sprintfs.
-@@ -392,13 +392,13 @@ void os::init_system_properties_values() {
+@@ -490,13 +490,13 @@ void os::init_system_properties_values() {
                                                       strlen(v) + 1 +
                                                       sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1,
                                                       mtInternal);
@@ -35,3 +50,6 @@ index 0dbe03349e..847d56778d 100644
    Arguments::set_ext_dirs(buf);
  
    FREE_C_HEAP_ARRAY(char, buf);
+--
+2.35.1
+


### PR DESCRIPTION
###### Description of changes

Fixes several security vulnerabilities, see https://openjdk.java.net/groups/vulnerability/advisories/2022-04-19

Proper release notes from upstream are not out yet, but will probably be linked here eventually:
https://wiki.openjdk.java.net/display/JDKUpdates/JDK11u
https://wiki.openjdk.java.net/display/JDKUpdates/JDK+17u

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).