### PR TITLE
gnome-builder: 42.0 → 42.1

### DIFF
--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -5,7 +5,6 @@
 , appstream-glib
 , desktop-file-utils
 , fetchurl
-, fetchpatch
 , flatpak
 , gnome
 , libgit2-glib
@@ -41,22 +40,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-builder";
-  version = "42.0";
+  version = "42.1";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "Uu/SltaLL/GCNBwEgdz9cGVMQIvbZ5/Ot225cDwiQo8=";
+    sha256 = "XU1RtwKGW0gBcgHwxgfiSifXIDGo9ciNT86HW1VFZwo=";
   };
-
-  patches = [
-    # Fix appstream validation
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-builder/-/commit/d7151679e0c925d27216256dc32fe67fb298d059.patch";
-      sha256 = "vdNJawkqSBaFGRZvxzvjOryQpBL4jcN7tr1t3ihD7LA=";
-    })
-  ];
 
   nativeBuildInputs = [
     appstream-glib
@@ -115,8 +106,6 @@ stdenv.mkDerivation rec {
     "-Dnetwork_tests=false"
   ];
 
-  # Some tests fail due to being unable to find the Vte typelib, and I don't
-  # understand why. Somebody should look into fixing this.
   doCheck = true;
 
   postPatch = ''


### PR DESCRIPTION

###### Description of changes

https://gitlab.gnome.org/GNOME/gnome-builder/-/compare/42.0...42.1

> - Meson templates updates
> - Fix failure to load project under certain symlink situations
> - Fix restore-cursor plugin
> - Improve newline handling with git diffs
> - Updated GJS snippets
> - Fixes for podman integration
> - Language Server Protocol enhancements
> - Translation updates


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
