### PR TITLE
libinjection: 3.10.0 -> unstable-2021-04-09

### DIFF
--- a/pkgs/development/libraries/libinjection/default.nix
+++ b/pkgs/development/libraries/libinjection/default.nix
@@ -1,19 +1,19 @@
 { lib, stdenv, fetchFromGitHub
-, python2
+, python3
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname   = "libinjection";
-  version = "3.10.0";
+  version = "unstable-2021-04-09";
 
   src = fetchFromGitHub {
-    owner  = "client9";
-    repo   = pname;
-    rev    = "refs/tags/v${version}";
-    sha256 = "0chsgam5dqr9vjfhdcp8cgk7la6nf3lq44zs6z6si98cq743550g";
+    owner = "libinjection";
+    repo  = "libinjection";
+    rev   = "49904c42a6e68dc8f16c022c693e897e4010a06c";
+    hash  = "sha256-Y6ZPxjJUBn2P5UdejJdUuBvrSHaUoIs3lZo14gCB16Y=";
   };
 
-  nativeBuildInputs = [ python2 ];
+  nativeBuildInputs = [ python3 ];
 
   strictDeps = true;
 


### PR DESCRIPTION
###### Description of changes
3.10.0 was released in 2017. Upstream looks to have stagnated and this bump is being performed for #148779 as Python 3 is now supported (for building).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
