### PR TITLE
zn_poly: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/development/libraries/science/math/zn_poly/default.nix
+++ b/pkgs/development/libraries/science/math/zn_poly/default.nix
@@ -3,12 +3,12 @@
 , fetchFromGitLab
 , fetchpatch
 , gmp
-, python2
+, python3
 , tune ? false # tune to hardware, impure
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.1";
+  version = "0.9.2";
   pname = "zn_poly";
 
   # sage has picked up the maintenance (bug fixes and building, not development)
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "sagemath";
     repo = "zn_poly";
     rev = version;
-    sha256 = "0ra5vy585bqq7g3317iw6fp44iqgqvds3j0l1va6mswimypq4vxb";
+    hash = "sha256-QBItcrrpOGj22/ShTDdfZjm63bGW2xY4c71R1q8abPE=";
   };
 
   buildInputs = [
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    python2 # needed by ./configure to create the makefile
+    python3 # needed by ./configure to create the makefile
   ];
 
   # name of library file ("libzn_poly.so")
@@ -42,16 +42,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optionals (!tune) [
     "--disable-tuning"
-  ];
-
-  patches = [
-    # fix format-security by not passing variables directly to printf
-    # https://gitlab.com/sagemath/zn_poly/merge_requests/1
-    (fetchpatch {
-      name = "format-security.patch";
-      url = "https://gitlab.com/timokau/zn_poly/commit/1950900a80ec898d342b8bcafa148c8027649766.patch";
-      sha256 = "1gks9chvsfpc6sg5h3nqqfia4cgvph7jmj9dw67k7dk7kv9y0rk1";
-    })
   ];
 
   # `make install` fails to install some header files and the lib file.


### PR DESCRIPTION
###### Description of changes


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
