### PR TITLE
uxplay: init at 1.50

### DIFF
--- a/pkgs/servers/uxplay/default.nix
+++ b/pkgs/servers/uxplay/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, pkg-config
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, wrapGAppsHook
+, avahi
+, avahi-compat
+, openssl
+, gst_all_1
+, libplist
+}:
+
+stdenv.mkDerivation rec {
+  pname = "uxplay";
+  version = "1.50";
+
+  src = fetchFromGitHub {
+    owner = "FDH2";
+    repo = "UxPlay";
+    rev = "v${version}";
+    sha256 = "sha256-43BCpYh0XtsnI064/ddcz2/Imj399g+bxLlT0BpqLMI=";
+  };
+
+  patches = [
+    # https://github.com/FDH2/UxPlay/issues/91
+    (fetchpatch {
+      url = "https://github.com/FDH2/UxPlay/commit/f373fb2edcfb1f4c279e5796cf21e4a865800a71.patch";
+      sha256 = "sha256-ENT/sMyPjDdZ4gdxiatYJ/UxuCl+ekk0iQOn8ELDAKQ=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    openssl
+    libplist
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    avahi
+    avahi-compat
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/FDH2/UxPlay";
+    description = "AirPlay Unix mirroring server";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ azuwis ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22518,6 +22518,8 @@ with pkgs;
 
   urserver = callPackage ../servers/urserver { };
 
+  uxplay = callPackage ../servers/uxplay { };
+
   vouch-proxy = callPackage ../servers/vouch-proxy {
     buildGoModule = buildGo116Module;
   };


### PR DESCRIPTION
###### Description of changes

Add `uxplay` package, AirPlay Unix mirroring server, homepage https://github.com/FDH2/UxPlay

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
