### PR TITLE
chia-plotter: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/applications/blockchains/chia-plotter/default.nix
+++ b/pkgs/applications/blockchains/chia-plotter/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "chia-plotter";
-  version = "1.1.7";
+  version = "1.1.8";
 
   src = fetchFromGitHub {
     owner = "madMAx43v3r";
     repo = "chia-plotter";
-    rev = "18cad340858f0dbcc8dafd0bda1ce1af0fe58c65";
-    sha256 = "sha256-lXjeqcjn3+LtnVYngdM1T3on7V7wez4oOAZ0RpKJXMM=";
+    rev = "9d7fd929919d1adde6404cb4718a665a81bcef6d";
+    sha256 = "sha256-TMAly+Qof2DHPRHqE1nZuHQaCeMo0jEd8MWy4OlXrcs=";
     fetchSubmodules = true;
   };
 
@@ -25,10 +25,17 @@ stdenv.mkDerivation {
       src = ./dont_fetch_dependencies.patch;
       pybind11_src = python3Packages.pybind11.src;
       relic_src = fetchFromGitHub {
-        owner = "relic-toolkit";
+        owner = "Chia-Network";
         repo = "relic";
-        rev = "1885ae3b681c423c72b65ce1fe70910142cf941c";
-        hash = "sha256-tsSZTcssl8t7Nqdex4BesgQ+ACPgTdtHnJFvS9josN0=";
+        rev = "1d98e5abf3ca5b14fd729bd5bcced88ea70ecfd7";
+        hash = "sha256-IfTD8DvTEXeLUoKe4Ejafb+PEJW5DV/VXRYuutwGQHU=";
+      };
+      sodium_src = fetchFromGitHub {
+        owner = "AmineKhaldi";
+        repo = "libsodium-cmake";
+        rev = "f73a3fe1afdc4e37ac5fe0ddd401bf521f6bba65"; # pinned by upstream
+        sha256 = "sha256-lGz7o6DQVAuEc7yTp8bYS2kwjzHwGaNjugDi1ruRJOA=";
+        fetchSubmodules = true;
       };
     })
   ];

--- a/pkgs/applications/blockchains/chia-plotter/dont_fetch_dependencies.patch
+++ b/pkgs/applications/blockchains/chia-plotter/dont_fetch_dependencies.patch
@@ -11,30 +11,43 @@ index 255e3bb..5f99c3a 100644
 +  SOURCE_DIR @pybind11_src@
  )
  FetchContent_MakeAvailable(pybind11 relic)
- 
-diff --git a/lib/bls-signatures/src/CMakeLists.txt b/lib/bls-signatures/src/CMakeLists.txt
-index b762b5d..e06073b 100644
---- a/lib/bls-signatures/src/CMakeLists.txt
-+++ b/lib/bls-signatures/src/CMakeLists.txt
-@@ -4,18 +4,11 @@ set (CMAKE_CXX_STANDARD 17)
- # CMake 3.14+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6922167..23d8da6 100644
+--- a/lib/bls-signatures/CMakeLists.txt
++++ b/lib/bls-signatures/CMakeLists.txt
+@@ -31,29 +31,18 @@ set(CMAKE_MODULE_PATH
  include(FetchContent)
+ 
+ FetchContent_Declare(Sodium
+-  GIT_REPOSITORY https://github.com/AmineKhaldi/libsodium-cmake.git
+-  # Latest commit at the moment this was added here
+-  # Anchored to libsodium v1.0.18
+-  GIT_TAG f73a3fe1afdc4e37ac5fe0ddd401bf521f6bba65
++  URL @sodium_src@
+ )
+ set(SODIUM_PCH "on" CACHE STRING "")
+ set(SODIUM_DISABLE_TESTS "on" CACHE STRING "")
+ set(SODIUM_CHIA_MINIMAL "on" CACHE STRING "")
+ FetchContent_MakeAvailable(Sodium)
  
 -if (DEFINED ENV{RELIC_MAIN})
 -  set(RELIC_GIT_TAG "origin/main")
 -else ()
--  set(RELIC_GIT_TAG "1885ae3b681c423c72b65ce1fe70910142cf941c")
+-  # This is currently anchored to upstream aecdcae7956f542fbee2392c1f0feb0a8ac41dc5
+-  set(RELIC_GIT_TAG "1d98e5abf3ca5b14fd729bd5bcced88ea70ecfd7")
 -endif ()
 -
  message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")
  
  FetchContent_Declare(
    relic
--  GIT_REPOSITORY https://github.com/relic-toolkit/relic.git
--  GIT_TAG        ${RELIC_GIT_TAG}
+-  GIT_REPOSITORY https://github.com/Chia-Network/relic.git
+-  GIT_TAG ${RELIC_GIT_TAG}
 +  SOURCE_DIR @relic_src@
  )
- FetchContent_MakeAvailable(relic)
+ 
+ # Relic related options
  
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 970ec74..948441a 100644


### PR DESCRIPTION
###### Description of changes

[upstream commit](https://github.com/madMAx43v3r/chia-plotter/commit/9d7fd929919d1adde6404cb4718a665a81bcef6d) (they don't tag)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
