### PR TITLE
seehecht: init at 3.0.2

### DIFF
--- a/pkgs/tools/text/seehecht/default.nix
+++ b/pkgs/tools/text/seehecht/default.nix
@@ -1,0 +1,27 @@
+{ lib, rustPlatform, fetchFromGitea }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "seehecht";
+  version = "3.0.2";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "papojari";
+    repo = "seehecht";
+    rev = "v${version}";
+    sha256 = "sha256-x5zZEDaBmWpyvY+sKuiK4L+hc85prxCueWYUNMi9ty0=";
+  };
+
+  cargoSha256 = "sha256-mWGmMtUYeM97SM+/jtOzkAe1usuZT4yOI6PAbiGKe7M=";
+
+  postInstall = ''
+    ln -s $out/bin/seh $out/bin/seehecht
+  '';
+
+  meta = with lib; {
+    description = "A tool to quickly open a markdown document with already filled out frontmatter";
+    license = licenses.lgpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ papojari ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10018,6 +10018,8 @@ with pkgs;
 
   securefs = callPackage ../tools/filesystems/securefs { };
 
+  seehecht = callPackage ../tools/text/seehecht { };
+
   seexpr = callPackage ../development/compilers/seexpr { };
 
   setroot = callPackage  ../tools/X11/setroot { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
