### PR TITLE
Bump pocketsphinx/sphinxbase

### DIFF
--- a/pkgs/development/libraries/pocketsphinx/default.nix
+++ b/pkgs/development/libraries/pocketsphinx/default.nix
@@ -1,28 +1,33 @@
 { lib, stdenv
-, fetchurl
+, fetchFromGitHub
 , sphinxbase
 , pkg-config
-, python27 # >= 2.6
+, python3
 , swig2 # 2.0
+, autoreconfHook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pocketsphinx";
-  version = "5prealpha";
+  version = "unstable-2022-02-22";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/cmusphinx/pocketsphinx-${version}.tar.gz";
-    sha256 = "1n9yazzdgvpqgnfzsbl96ch9cirayh74jmpjf7svs4i7grabanzg";
+  src = fetchFromGitHub {
+    owner = "cmusphinx";
+    repo = "pocketsphinx";
+    rev = "5da71f0a05350c923676b02a69423d1291825d5b";
+    hash = "sha256-YZwuVYg8Uqt1gOYXeYC8laRj+IObbuO9f/BjcQKRwkY=";
   };
 
   propagatedBuildInputs = [ sphinxbase ];
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ python27 swig2 ];
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [ python3 swig2 ];
+
+  preBuild = "gcc --version";
 
   meta = {
     description = "Voice recognition library written in C";
-    homepage = "http://cmusphinx.sourceforge.net";
+    homepage = "https://cmusphinx.github.io";
     license = lib.licenses.free;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/development/libraries/sphinxbase/default.nix
+++ b/pkgs/development/libraries/sphinxbase/default.nix
@@ -8,7 +8,7 @@
 , multipleOutputs ? false #Uses incomplete features of nix!
 }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation {
   pname = "sphinxbase";
   version = "unstable-2022-02-21";
 
@@ -40,4 +40,4 @@ stdenv.mkDerivation (rec {
     mkdir -p $headers
     cp -av $out/include $headers
   '';
-}))
+})

--- a/pkgs/development/libraries/sphinxbase/default.nix
+++ b/pkgs/development/libraries/sphinxbase/default.nix
@@ -1,27 +1,30 @@
 { lib, stdenv
-, fetchurl
+, autoreconfHook
+, fetchFromGitHub
 , bison
 , pkg-config
-, python27 # >= 2.6
+, python3
 , swig2 # 2.0
 , multipleOutputs ? false #Uses incomplete features of nix!
 }:
 
 stdenv.mkDerivation (rec {
   pname = "sphinxbase";
-  version = "5prealpha";
+  version = "unstable-2022-02-21";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/cmusphinx/sphinxbase-${version}.tar.gz";
-    sha256 = "0vr4k8pv5a8nvq9yja7kl13b5lh0f9vha8fc8znqnm8bwmcxnazp";
+  src = fetchFromGitHub {
+    owner = "cmusphinx";
+    repo = "sphinxbase";
+    rev = "3612ab4e8de9172e2b7e2401f4ca1ad122c29fde";
+    hash = "sha256-O/Olx7S+g4DftN/ahVXr2dQUtoQe4hxQUsz8Z7We0RI=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ swig2 python27 bison ];
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [ swig2 python3 bison ];
 
   meta = {
     description = "Support Library for Pocketsphinx";
-    homepage = "http://cmusphinx.sourceforge.net";
+    homepage = "https://cmusphinx.github.io";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ ];


### PR DESCRIPTION
###### Description of changes
Pocketsphinx was last updated [>5 years ago](https://github.com/NixOS/nixpkgs/commit/ca3f41d44bd701efd1b252ea7d717a2031ece332) in nixpkgs. Though upstream has yet to put out a tagged release, this update should rid us of more Python 2 dependencies (#148779).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
