### PR TITLE
python3Packages.tpm2-pytss: fix build 1.1.0

### DIFF
--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, python3, python3Packages
 , pkg-config, swig
 , tpm2-tss
 , cryptography, ibm-sw-tpm2
@@ -7,22 +7,17 @@
 buildPythonPackage rec {
   pname = "tpm2-pytss";
 
-  # Last version on github is 0.2.4, but it looks
-  # like a mistake (it's missing commits from 0.1.9)
   version = "1.1.0";
   disabled = pythonOlder "3.5";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-O0d1b99/V8b3embg8veerTrJGSVb/prlPVb7qSHErdQ=";
   };
-  postPatch = ''
-    substituteInPlace tpm2_pytss/config.py --replace \
-      'SYSCONFDIR = CONFIG.get("sysconfdir", "/etc")' \
-      'SYSCONFDIR = "${tpm2-tss}/etc"'
-  '';
 
-  nativeBuildInputs = [ pkg-config swig ];
+  buildInputs = with python3.pkgs; [ pkgconfig asn1crypto ];
+  nativeBuildInputs = [ swig ];
   # The TCTI is dynamically loaded from tpm2-tss, we have to provide the library to the end-user
   propagatedBuildInputs = [ tpm2-tss ];
 

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -1,5 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, python3, python3Packages
-, pkg-config, swig
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, pkgconfig, asn1crypto, swig
 , tpm2-tss
 , cryptography, ibm-sw-tpm2
 }:
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "sha256-O0d1b99/V8b3embg8veerTrJGSVb/prlPVb7qSHErdQ=";
   };
 
-  buildInputs = with python3.pkgs; [ pkgconfig asn1crypto ];
+  buildInputs = [ pkgconfig asn1crypto ];
   nativeBuildInputs = [ swig ];
   # The TCTI is dynamically loaded from tpm2-tss, we have to provide the library to the end-user
   propagatedBuildInputs = [ tpm2-tss ];

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -6,7 +6,6 @@
 
 buildPythonPackage rec {
   pname = "tpm2-pytss";
-
   version = "1.1.0";
   disabled = pythonOlder "3.5";
   format = "pyproject";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10218,7 +10218,9 @@ in {
 
   tox = callPackage ../development/python-modules/tox { };
 
-  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss { };
+  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss {
+    inherit asn1crypto pkgconfig;
+  };
 
   tqdm = callPackage ../development/python-modules/tqdm { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10218,9 +10218,7 @@ in {
 
   tox = callPackage ../development/python-modules/tox { };
 
-  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss {
-    inherit asn1crypto pkgconfig;
-  };
+  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss { };
 
   tqdm = callPackage ../development/python-modules/tqdm { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The upstream switched from setuptools to pyproject in 1.1.0 which caused a build failure that is fixed in this commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
