### PR TITLE
blackfire: 2.5.2 -> 2.8.0

### DIFF
--- a/pkgs/development/tools/misc/blackfire/default.nix
+++ b/pkgs/development/tools/misc/blackfire/default.nix
@@ -2,56 +2,96 @@
 , lib
 , fetchurl
 , dpkg
-, autoPatchelfHook
 , writeShellScript
 , curl
 , jq
 , common-updater-scripts
 }:
 
+let
+  version = "2.8.0";
+
+  sources = {
+    "x86_64-linux" = fetchurl {
+      url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_amd64.deb";
+      sha256 = "0bgd4hnpaxrqw0s0y2qiak8lbskfi2cqp147vj1kbhvm8834hwhg";
+    };
+    "i686-linux" = fetchurl {
+      url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_i386.deb";
+      sha256 = "06lf642m4imz8xvwipflmvjy1ih7k8bx8jpay0xawvilh14pqz8f";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_arm64.deb";
+      sha256 = "0rddafjgdnj3na96x83paq5z14grj46v4iv38qbkvmdllrj26a0a";
+    };
+    "aarch64-darwin" = fetchurl {
+      url = "https://packages.blackfire.io/blackfire/${version}/blackfire-darwin_arm64.pkg.tar.gz";
+      sha256 = "YWiZnYdsW7dyQ0IeKeC1U00ZIdJRnzs9keeQTEU2ozA=";
+    };
+    "x86_64-darwin" = fetchurl {
+      url = "https://packages.blackfire.io/blackfire/${version}/blackfire-darwin_amd64.pkg.tar.gz";
+      sha256 = "391b0d239b11095bb8515cb60ee95f02d5862fcb509724081f314819967206b6";
+    };
+  };
+in
 stdenv.mkDerivation rec {
   pname = "blackfire";
-  version = "2.5.2";
+  inherit version;
 
-  src = fetchurl {
-    url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_amd64.deb";
-    sha256 = "1RO5yabSNpIz5lWXngMOZ1S2vtnLEkXIj1ZoIinRrQ0=";
-  };
+  src = sources.${stdenv.hostPlatform.system};
 
-  nativeBuildInputs = [
-    dpkg
-    autoPatchelfHook
-  ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ dpkg ];
 
   dontUnpack = true;
 
   installPhase = ''
     runHook preInstall
 
-    dpkg-deb -x $src $out
-    mv $out/usr/* $out
-    rmdir $out/usr
+    if ${ lib.boolToString stdenv.isLinux }
+    then
+      dpkg-deb -x $src $out
+      mv $out/usr/* $out
+      rmdir $out/usr
 
-    # Fix ExecStart path and replace deprecated directory creation method,
-    # use dynamic user.
-    substituteInPlace "$out/lib/systemd/system/blackfire-agent.service" \
-      --replace '/usr/' "$out/" \
-      --replace 'ExecStartPre=/bin/mkdir -p /var/run/blackfire' 'RuntimeDirectory=blackfire' \
-      --replace 'ExecStartPre=/bin/chown blackfire: /var/run/blackfire' "" \
-      --replace 'User=blackfire' 'DynamicUser=yes' \
-      --replace 'PermissionsStartOnly=true' ""
+      # Fix ExecStart path and replace deprecated directory creation method,
+      # use dynamic user.
+      substituteInPlace "$out/lib/systemd/system/blackfire-agent.service" \
+        --replace '/usr/' "$out/" \
+        --replace 'ExecStartPre=/bin/mkdir -p /var/run/blackfire' 'RuntimeDirectory=blackfire' \
+        --replace 'ExecStartPre=/bin/chown blackfire: /var/run/blackfire' "" \
+        --replace 'User=blackfire' 'DynamicUser=yes' \
+        --replace 'PermissionsStartOnly=true' ""
 
-    # Modernize socket path.
-    substituteInPlace "$out/etc/blackfire/agent" \
-      --replace '/var/run' '/run'
+      # Modernize socket path.
+      substituteInPlace "$out/etc/blackfire/agent" \
+        --replace '/var/run' '/run'
+    else
+      mkdir $out
+
+      tar -zxvf $src
+
+      mv etc $out
+      mv usr/* $out
+    fi
 
     runHook postInstall
   '';
 
   passthru = {
     updateScript = writeShellScript "update-${pname}" ''
+      set -o errexit
       export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
-      update-source-version "$UPDATE_NIX_ATTR_PATH" "$(curl https://blackfire.io/api/v1/releases | jq .cli --raw-output)"
+      NEW_VERSION=$(curl -s https://blackfire.io/api/v1/releases | jq .cli --raw-output)
+
+      if [[ "${version}" = "$NEW_VERSION" ]]; then
+          echo "The new version same as the old version."
+          exit 0
+      fi
+
+      for platform in ${lib.concatStringsSep " " meta.platforms}; do
+        update-source-version "blackfire" "0" "${lib.fakeSha256}" "--system=$platform"
+        update-source-version "blackfire" "$NEW_VERSION" "--system=$platform" --ignore-same-hash
+      done
     '';
   };
 
@@ -59,7 +99,7 @@ stdenv.mkDerivation rec {
     description = "Blackfire Profiler agent and client";
     homepage = "https://blackfire.io/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ jtojnar ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jtojnar shyim ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

- Updated to Blackfire 2.8.0
- Added support for Darwin + 32bit and arm64 linux

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


