### PR TITLE
lxpanel: switch to gtk3

### DIFF
--- a/pkgs/desktops/lxde/core/lxpanel/default.nix
+++ b/pkgs/desktops/lxde/core/lxpanel/default.nix
@@ -1,25 +1,25 @@
 { lib
 , stdenv
-, fetchurl
-, pkg-config
-, gettext
-, m4
-, intltool
-, libxmlxx
-, keybinder
-, gtk2
-, libX11
-, libfm
-, libwnck2
-, libXmu
-, libXpm
+, autoreconfHook
+, fetchFromGitHub
 , cairo
+, curl
 , gdk-pixbuf
 , gdk-pixbuf-xlib
-, menu-cache
+, gettext
+, gtk3
+, intltool
+, keybinder3
+, libX11
+, libXmu
+, libXpm
+, libfm
+, libwnck
+, libxmlxx
 , lxmenu-data
+, menu-cache
+, pkg-config
 , wirelesstools
-, curl
 , supportAlsa ? false, alsa-lib
 }:
 
@@ -27,36 +27,41 @@ stdenv.mkDerivation rec {
   pname = "lxpanel";
   version = "0.10.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/lxde/${pname}-${version}.tar.xz";
-    sha256 = "sha256-HjGPV9fja2HCOlBNA9JDDHja0ULBgERRBh8bPqVEHug=";
+  src = fetchFromGitHub {
+    owner = "lxde";
+    repo = "lxpanel";
+    rev = version;
+    hash = "sha256-YUoDFO+Ip6uWjXMP+PTJqcfiGPAE4EfjQz8F4M0FxZM=";
   };
 
-  nativeBuildInputs = [ pkg-config gettext m4 intltool libxmlxx ];
+  nativeBuildInputs = [
+    autoreconfHook
+    gettext
+    intltool
+    libxmlxx
+    pkg-config
+  ];
+
   buildInputs = [
-    keybinder
-    gtk2
-    libX11
-    libfm
-    libwnck2
-    libXmu
-    libXpm
     cairo
+    curl
     gdk-pixbuf
     gdk-pixbuf-xlib.dev
-    menu-cache
+    gtk3
+    keybinder3
+    libX11
+    libXmu
+    libXpm
+    libfm
+    libwnck
     lxmenu-data
-    m4
+    menu-cache
     wirelesstools
-    curl
   ] ++ lib.optional supportAlsa alsa-lib;
 
-  postPatch = ''
-    substituteInPlace src/Makefile.in \
-      --replace "@PACKAGE_CFLAGS@" "@PACKAGE_CFLAGS@ -I${gdk-pixbuf-xlib.dev}/include/gdk-pixbuf-2.0"
-    substituteInPlace plugins/Makefile.in \
-      --replace "@PACKAGE_CFLAGS@" "@PACKAGE_CFLAGS@ -I${gdk-pixbuf-xlib.dev}/include/gdk-pixbuf-2.0"
-  '';
+  configureFlags = [
+    "--enable-gtk3"
+  ];
 
   meta = with lib; {
     description = "Lightweight X11 desktop panel for LXDE";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14116,9 +14116,7 @@ with pkgs;
 
   lxmenu-data = callPackage ../desktops/lxde/core/lxmenu-data.nix { };
 
-  lxpanel = callPackage ../desktops/lxde/core/lxpanel {
-    gtk2 = gtk2-x11;
-  };
+  lxpanel = callPackage ../desktops/lxde/core/lxpanel { };
 
   lxtask = callPackage ../desktops/lxde/core/lxtask { };
 
@@ -18344,7 +18342,9 @@ with pkgs;
 
   libfishsound = callPackage ../development/libraries/libfishsound { };
 
-  libfm = callPackage ../development/libraries/libfm { };
+  libfm = callPackage ../development/libraries/libfm {
+    withGtk3 = true;
+  };
   libfm-extra = libfm.override {
     extraOnly = true;
   };


### PR DESCRIPTION
###### Description of changes
gtk2 is unmaintained and lxpanel is the only reason we still need keybinder so we can remove that as well afterwards.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
