### PR TITLE
bashblog: init at unstable-2022-03-26

### DIFF
--- a/pkgs/tools/text/bashblog/0001-Setting-markdown_bin.patch
+++ b/pkgs/tools/text/bashblog/0001-Setting-markdown_bin.patch
@@ -1,0 +1,25 @@
+From 1990ac93c9dbf3ada0eb2f045ef1aa95bbef7018 Mon Sep 17 00:00:00 2001
+From: "P. R. d. O" <d.ol.rod@tutanota.com>
+Date: Thu, 21 Apr 2022 07:40:30 -0600
+Subject: [PATCH] Setting markdown_bin
+
+---
+ bb.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bb.sh b/bb.sh
+index 9d8e645..40fb54d 100755
+--- a/bb.sh
++++ b/bb.sh
+@@ -160,7 +160,7 @@ global_variables() {
+ 
+     # Markdown location. Trying to autodetect by default.
+     # The invocation must support the signature 'markdown_bin in.md > out.html'
+-    [[ -f Markdown.pl ]] && markdown_bin=./Markdown.pl || markdown_bin=$(which Markdown.pl 2>/dev/null || which markdown 2>/dev/null)
++    markdown_bin=@markdown_path@
+ }
+ 
+ # Check for the validity of some variables
+-- 
+2.35.1
+

--- a/pkgs/tools/text/bashblog/default.nix
+++ b/pkgs/tools/text/bashblog/default.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, lib
+, fetchzip
+, fetchFromGitHub
+, makeWrapper
+, substituteAll
+, perlPackages
+# Flags to enable processors
+# Currently, Markdown.pl does not work
+, usePandoc ? true
+, pandoc }:
+
+let
+  inherit (perlPackages) TextMarkdown;
+  # As bashblog supports various markdown processors
+  # we can set flags to enable a certain processor
+  markdownpl_path = "${perlPackages.TextMarkdown}/bin/Markdown.pl";
+  pandoc_path = "${pandoc}/bin/pandoc";
+
+in stdenv.mkDerivation rec {
+  pname = "bashblog";
+  version = "unstable-2022-03-26";
+
+  src = fetchFromGitHub {
+    owner = "cfenollosa";
+    repo = "bashblog";
+    rev = "c3d4cc1d905560ecfefce911c319469f7a7ff8a8";
+    sha256 = "sha256-THlP/JuaZzDq9QctidwLRiUVFxRhGNhRKleWbQiqsgg=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ TextMarkdown ]
+    ++ lib.optionals usePandoc [ pandoc ];
+
+  patches = [
+    (substituteAll {
+      src = ./0001-Setting-markdown_bin.patch;
+      markdown_path = if usePandoc then pandoc_path else markdownpl_path;
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs bb.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm755 bb.sh $out/bin/bashblog
+  '';
+
+  meta = with lib; {
+    description = "A single Bash script to create blogs";
+    homepage = "https://github.com/cfenollosa/bashblog";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1853,6 +1853,8 @@ with pkgs;
 
   awless = callPackage ../tools/virtualization/awless { };
 
+  bashblog = callPackage ../tools/text/bashblog { };
+
   berglas = callPackage ../tools/admin/berglas { };
 
   betterdiscordctl = callPackage ../tools/misc/betterdiscordctl { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Originally it uses Markdown.pl, but the package `perlPackages.TextMarkdown` is failing, as stated [here](https://github.com/NixOS/nixpkgs/issues/169602). Other packages using it (like `shocco`) are also having the same issue. So I am using `pandoc` instead, which is supported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
