### PR TITLE
kroki-server: init at 0.17.0

### DIFF
--- a/pkgs/tools/graphics/kroki-server/default.nix
+++ b/pkgs/tools/graphics/kroki-server/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, writeShellScript
+, jre
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kroki-server";
+  version = "0.17.0";
+
+  src = fetchurl {
+    url = "https://github.com/yuzutech/kroki/releases/download/v${version}/kroki-server-v${version}.jar";
+    hash = "sha256-s+wLhKsdC5U/YQpzHRY9PdLsU94HxzkZU9ke3XJYQ6g=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/kroki-server \
+      --add-flags "-jar ${src}"
+  '';
+
+  meta = with lib; {
+    description = "Creates diagrams from textual descriptions";
+    homepage = "https://github.com/yuzutech/kroki";
+    license = licenses.mit;
+    maintainers = with teams; iog.members;
+    inherit (jre.meta) platforms;
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3730,6 +3730,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  kroki-server = callPackage ../tools/graphics/kroki-server/default.nix { };
+
   lapce = callPackage ../applications/editors/lapce { };
 
   lcdproc = callPackage ../servers/monitoring/lcdproc { };


### PR DESCRIPTION
###### Description of changes
Could make an argument that this should be called `kroki`, however, there's many different client applications which are popular which interact with kroki, so `kroki-server` is just to differentiate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
