### PR TITLE
book-summary: init at 0.2.1

### DIFF
--- a/pkgs/tools/text/book-summary/default.nix
+++ b/pkgs/tools/text/book-summary/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, fetchpatch
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "book-summary";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "dvogt23";
+    repo = pname;
+    rev = version;
+    sha256 = "1dawddkpyasy22biqz35c912xqmwcx6ihpqp6cnikbdzv8ni8adr";
+  };
+
+  cargoPatches = [
+    # add Cargo.lock
+    # can be removed after https://github.com/dvogt23/book-summary/pull/23 gets merged
+    (fetchpatch {
+      url = "https://github.com/dvogt23/book-summary/commit/9d941a57db5cd2fd0e9813230d69eb1d166a48f8.patch";
+      sha256 = "sha256-91dwJKdaLukxVZHA3RH1rxj45U/+mabFTflBaLd2rK8=";
+    })
+  ];
+
+  cargoSha256 = "sha256-chuEzYUfZC/ZdWIUEmAXJAnXG2s8mCcNs6cuq8Lh5PQ=";
+
+  meta = with lib; {
+    description = "Book auto-summary for gitbook and mdBook";
+    homepage = "https://github.com/dvogt23/book-summary";
+    license = licenses.mit;
+    maintainers = with teams; iog.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2686,6 +2686,8 @@ with pkgs;
 
   boringtun = callPackage ../tools/networking/boringtun { };
 
+  book-summary = callPackage ../tools/text/book-summary { };
+
   bookstack = callPackage ../servers/web-apps/bookstack { };
 
   # Upstream recommends qt5.12 and it doesn't build with qt5.15


### PR DESCRIPTION
###### Description of changes

Add utility for auto-generating SUMMARY.md in a mdbook repo.

https://github.com/dvogt23/book-summary

cc @blaggacao 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
