### PR TITLE
nvtop: 1.2.2 -> 2.0.1

### DIFF
--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -1,34 +1,62 @@
-{ lib, stdenv, fetchFromGitHub, cmake, cudatoolkit, ncurses, addOpenGLRunpath }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, cudatoolkit
+, libdrm
+, ncurses
+, addOpenGLRunpath
+, amd ? true
+, nvidia ? true
+}:
 
+let
+  pname-suffix = if amd && nvidia then "" else if amd then "-amd" else "-nvidia";
+  nvidia-postFixup = "addOpenGLRunpath $out/bin/nvtop";
+  libPath = lib.makeLibraryPath [ libdrm ncurses ];
+  amd-postFixup = ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      $out/bin/nvtop
+  '';
+in
 stdenv.mkDerivation rec {
-  pname = "nvtop";
-  version = "1.2.2";
+  pname = "nvtop" + pname-suffix;
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "Syllo";
     repo = "nvtop";
     rev = version;
-    sha256 = "sha256-B/SRTOMp3VYShjSGxnF1ll58ijddJG7w/7nPK1fMltk=";
+    sha256 = "sha256-4Alc5pBXb38PUhTRhdKZMiW+P3daDB0q3jiVL8qqEe4=";
   };
 
-  cmakeFlags = [
-    "-DNVML_INCLUDE_DIRS=${cudatoolkit}/include"
-    "-DNVML_LIBRARIES=${cudatoolkit}/targets/x86_64-linux/lib/stubs/libnvidia-ml.so"
+  cmakeFlags = with lib; [
     "-DCMAKE_BUILD_TYPE=Release"
-  ];
+  ] ++ optional nvidia "-DNVML_INCLUDE_DIRS=${cudatoolkit}/include"
+  ++ optional nvidia "-DNVML_LIBRARIES=${cudatoolkit}/targets/x86_64-linux/lib/stubs/libnvidia-ml.so"
+  ++ optional (!amd) "-DAMDGPU_SUPPORT=OFF"
+  ++ optional (!nvidia) "-DNVIDIA_SUPPORT=OFF"
+  ++ optional amd "-DLibdrm_INCLUDE_DIRS=${libdrm}/lib/stubs/libdrm.so.2"
+  ;
+  nativeBuildInputs = [ cmake] ++ lib.optional nvidia addOpenGLRunpath;
+  buildInputs = with lib; [ ncurses ]
+    ++ optional nvidia cudatoolkit
+    ++ optional amd libdrm
+  ;
 
-  nativeBuildInputs = [ cmake addOpenGLRunpath ];
-  buildInputs = [ ncurses cudatoolkit ];
-
-  postFixup = ''
-    addOpenGLRunpath $out/bin/nvtop
-  '';
+  # ordering of fixups is important
+  postFixup = (lib.optionalString amd amd-postFixup) + (lib.optionalString nvidia nvidia-postFixup);
 
   meta = with lib; {
-    description = "A (h)top like task monitor for NVIDIA GPUs";
+    description = "A (h)top like task monitor for AMD and NVIDIA GPUs";
+    longDescription = ''
+      Nvtop stands for Neat Videocard TOP, a (h)top like task monitor for AMD and NVIDIA GPUs. It can handle multiple GPUs and print information about them in a htop familiar way.
+  '';
     homepage = "https://github.com/Syllo/nvtop";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ willibutz ];
+    maintainers = with maintainers; [ willibutz gbtb ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19670,6 +19670,8 @@ with pkgs;
   nvidia-optical-flow-sdk = callPackage ../development/libraries/nvidia-optical-flow-sdk { };
 
   nvtop = callPackage ../tools/system/nvtop { };
+  nvtop-nvidia = callPackage ../tools/system/nvtop { amd = false; };
+  nvtop-amd = callPackage ../tools/system/nvtop { nvidia = false; };
 
   ocl-icd = callPackage ../development/libraries/ocl-icd { };
 


### PR DESCRIPTION
###### Description of changes
Recent update 2.0.0 of nvtop added support for AMD GPU's https://github.com/Syllo/nvtop/releases. Aside from bumping version of nvtop package I've decided to create two separate packages built with only Nvidia or AMD GPU support, because they are relying on different dependencies. I've got an AMD GPU so I have no use for installing CUDA toolkit into my system.
BTW if you think that splitting and conditional compilation should be done differently, feel free to point me to a good example of such packages.

I've tested nvtop-amd and nvtop packages with my single amd gpu, so obviously it would be nice if someone with nvidia GPU or even multiple GPUs tested this update as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
