### PR TITLE
Add Tibetan Machine OpenType font 

### DIFF
--- a/pkgs/data/fonts/tibetan-machine/default.nix
+++ b/pkgs/data/fonts/tibetan-machine/default.nix
@@ -1,0 +1,22 @@
+{ fetchzip, lib }:
+
+let
+  version = "1.901b";
+in
+fetchzip {
+  name = "tibetan-machine-${version}";
+  url = "mirror://debian/pool/main/f/fonts-tibetan-machine/fonts-tibetan-machine_${version}.orig.tar.bz2";
+  sha256 = "sha256-A+RgpFLsP4iTzl0PMRHaNzWGbDR5Qa38lRegNJ96ULo=";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    tar xf $downloadedFile --strip-components=1 -C $out/share/fonts ttf-tmuni-${version}/TibMachUni-${version}.ttf
+  '';
+
+  meta = with lib; {
+    description = "Tibetan Machine - an OpenType Tibetan, Dzongkha and Ladakhi font";
+    license = licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ serge ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24861,6 +24861,8 @@ with pkgs;
 
   theme-vertex = callPackage ../data/themes/vertex { };
 
+  tibetan-machine = callPackage ../data/fonts/tibetan-machine { };
+
   times-newer-roman = callPackage ../data/fonts/times-newer-roman { };
 
   tipa = callPackage ../data/fonts/tipa { };


### PR DESCRIPTION
###### Description of changes

Add Tibetan Machine OpenType font for Tibetan, Dzongkha, and Ladakhi languages. The PR closes #169667

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

