### PR TITLE
python310Packages.tpm2-pytss: fix build, cleanup, prepare executing t…

### DIFF
--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -1,36 +1,57 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
-, pkg-config, swig
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, asn1crypto
+, cffi
+, cryptography
+, ibm-sw-tpm2
+, pkg-config
+, pkgconfig
+, pycparser
+, pytestCheckHook
+, python
+, setuptools-scm
 , tpm2-tss
-, cryptography, ibm-sw-tpm2
 }:
 
 buildPythonPackage rec {
   pname = "tpm2-pytss";
-
-  # Last version on github is 0.2.4, but it looks
-  # like a mistake (it's missing commits from 0.1.9)
   version = "1.1.0";
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-O0d1b99/V8b3embg8veerTrJGSVb/prlPVb7qSHErdQ=";
   };
-  postPatch = ''
-    substituteInPlace tpm2_pytss/config.py --replace \
-      'SYSCONFDIR = CONFIG.get("sysconfdir", "/etc")' \
-      'SYSCONFDIR = "${tpm2-tss}/etc"'
-  '';
 
-  nativeBuildInputs = [ pkg-config swig ];
-  # The TCTI is dynamically loaded from tpm2-tss, we have to provide the library to the end-user
-  propagatedBuildInputs = [ tpm2-tss ];
+  nativeBuildInputs = [
+    cffi
+    pkgconfig
+    # somehow propagating from pkgconfig does not work
+    pkg-config
+    setuptools-scm
+  ];
+
+  buildInputs = [
+    tpm2-tss
+  ];
+
+  propagatedBuildInputs = [
+    cffi
+    asn1crypto
+    cryptography
+  ];
+
+  # https://github.com/tpm2-software/tpm2-pytss/issues/341
+  doCheck = false;
 
   checkInputs = [
-    cryptography
-    # provide tpm_server used as simulator for the tests
     ibm-sw-tpm2
+    pytestCheckHook
   ];
+
+  pythonImportsCheck = [ "tpm2_pytss" ];
 
   meta = with lib; {
     homepage = "https://github.com/tpm2-software/tpm2-pytss";


### PR DESCRIPTION
…ests

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
