### PR TITLE
Add Japanese Takao fonts

### DIFF
--- a/pkgs/data/fonts/takao/default.nix
+++ b/pkgs/data/fonts/takao/default.nix
@@ -1,0 +1,27 @@
+{ fetchzip, lib }:
+
+let
+  version = "00303.01";
+in
+fetchzip {
+  name = "takao-${version}";
+  url = "mirror://ubuntu/pool/universe/f/fonts-takao/fonts-takao_${version}.orig.tar.gz";
+  sha256 = "sha256-TlPq3iIv8vHlxYu5dkX/Lf6ediYKQaQ5uMbFvypQM/w=";
+
+  postFetch = ''
+    unpackDir="$TMPDIR/unpack"
+    mkdir "$unpackDir"
+    cd "$unpackDir"
+    tar xf "$downloadedFile" --strip-components=1
+    mkdir -p $out/share/fonts
+    cp *.ttf $out/share/fonts
+  '';
+
+  meta = with lib; {
+    description = "Japanese TrueType Gothic, P Gothic, Mincho, P Mincho fonts";
+    homepage = "https://launchpad.net/takao-fonts";
+    license = licenses.ipa;
+    maintainers = with lib.maintainers; [ serge ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24746,6 +24746,8 @@ with pkgs;
 
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;
 
+  takao = callPackage ../data/fonts/takao { };
+
   taskspooler = callPackage ../tools/system/taskspooler { };
 
   tamsyn = callPackage ../data/fonts/tamsyn { inherit (buildPackages.xorg) mkfontscale; };


### PR DESCRIPTION
###### Description of changes

Add Japanese Takao fonts (Gothic, Mincho, P Gothic, P Mincho). The PR closes #169674 

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

