### PR TITLE
Add Korean Nanum fonts

### DIFF
--- a/pkgs/data/fonts/nanum/default.nix
+++ b/pkgs/data/fonts/nanum/default.nix
@@ -1,0 +1,27 @@
+{ fetchzip, lib }:
+
+let
+  version = "20170925";
+in
+fetchzip {
+  name = "nanum-${version}";
+  url = "mirror://ubuntu/pool/universe/f/fonts-nanum/fonts-nanum_${version}.orig.tar.xz";
+  sha256 = "sha256-lSTeQEuMmlQxiQqrx9tNScifE8nMOUDJF3lCfoAFIJk=";
+
+  postFetch = ''
+    unpackDir="$TMPDIR/unpack"
+    mkdir "$unpackDir"
+    cd "$unpackDir"
+    tar xf "$downloadedFile" --strip-components=1
+    mkdir -p $out/share/fonts
+    cp *.ttf $out/share/fonts
+  '';
+
+  meta = with lib; {
+    description = "Nanum Korean font set";
+    homepage = "https://hangeul.naver.com/font";
+    license = licenses.ofl;
+    maintainers = with lib.maintainers; [ serge ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24450,6 +24450,8 @@ with pkgs;
 
   nafees = callPackage ../data/fonts/nafees { };
 
+  nanum = callPackage ../data/fonts/nanum {  };
+
   nanum-gothic-coding = callPackage ../data/fonts/nanum-gothic-coding {  };
 
   national-park-typeface = callPackage ../data/fonts/national-park { };


### PR DESCRIPTION
###### Description of changes

Add Korean Nanum fonts: 

- Nanum Gothic
- Nanum Barun Gothic
- Nanum Barunpen
- Nanum Brush
- Nanum Myengjo
- Nanum Pen
- Nanum Square
- Nanum Square Round

The PR closes #169697 

###### Things done

- Built on platform(s)
  - [ ]  x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

