### PR TITLE
[21.11] gnome.epiphany: 41.2 → 41.4

### DIFF
--- a/pkgs/desktops/gnome/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome/core/epiphany/default.nix
@@ -41,11 +41,11 @@
 
 stdenv.mkDerivation rec {
   pname = "epiphany";
-  version = "41.2";
+  version = "41.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "Ud5KGB+nxKEs3DDMsWQ2ElwaFt+av44/pTP8gb8Q60w=";
+    sha256 = "ugEmjuVPMY39rC4B66OKP8lpQMHL9kDtJhOuKfi8ua0=";
   };
 
   patches = lib.optionals withPantheon [

--- a/pkgs/desktops/gnome/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome/core/epiphany/default.nix
@@ -41,11 +41,11 @@
 
 stdenv.mkDerivation rec {
   pname = "epiphany";
-  version = "41.3";
+  version = "41.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "ugEmjuVPMY39rC4B66OKP8lpQMHL9kDtJhOuKfi8ua0=";
+    sha256 = "5jX6EIIyMawDeD6BSyj5CIny0gSI8UyfjzVApkU6+w0=";
   };
 
   patches = lib.optionals withPantheon [


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/epiphany/-/compare/41.2...41.3
https://gitlab.gnome.org/GNOME/epiphany/-/compare/41.3...41.4

Fixes: CVE-2022-29536

See https://github.com/NixOS/nixpkgs/pull/169695 for nixos-unstable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

<img src="https://user-images.githubusercontent.com/20080233/164614709-e6936a15-9316-4c08-a5b2-55cc5fd91742.png" width=70%>

