### PR TITLE
pure-maps: 2.9.2 -> 3.0.0

### DIFF
--- a/pkgs/applications/misc/pure-maps/default.nix
+++ b/pkgs/applications/misc/pure-maps/default.nix
@@ -6,13 +6,13 @@
 
 mkDerivation rec {
   pname = "pure-maps";
-  version = "2.9.2";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "rinigus";
     repo = "pure-maps";
     rev = version;
-    hash = "sha256-pMPjY6OXR6THiSQZ4mw9Kz+tAXJaOwzJEcpPOyZ+YKI=";
+    hash = "sha256-r36/Vpt4ZIWV1+VhqRBuo4uT7nmEGiFGIt3QGG3ijjs=";
     fetchSubmodules = true;
   };
 
@@ -37,6 +37,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "Display vector and raster maps, places, routes, and provide navigation instructions with a flexible selection of data and service providers";
     homepage = "https://github.com/rinigus/pure-maps";
+    changelog = "https://github.com/rinigus/pure-maps/blob/${src.rev}/NEWS.md";
     license = licenses.gpl3Only;
     maintainers = [ maintainers.Thra11 ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/mapbox-gl-qml/default.nix
+++ b/pkgs/development/libraries/mapbox-gl-qml/default.nix
@@ -6,30 +6,27 @@
 , curl
 , qtbase
 , qtlocation
-, mapbox-gl-native
+, maplibre-gl-native
 }:
 
 mkDerivation rec {
   pname = "mapbox-gl-qml";
-  version = "1.7.7.1";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "rinigus";
     repo = "mapbox-gl-qml";
     rev = version;
-    hash = "sha256-lmL9nawMY8rNNBV4zNF4N1gn9XZzIZ9Cw2ZRs9bjBaI=";
+    hash = "sha256-EVZbQXV8pI0QTqFDTTynVglsqX1O5oK0Pl5Y/wp+/q0=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ curl qtlocation mapbox-gl-native ];
+  buildInputs = [ curl qtlocation maplibre-gl-native ];
 
   postPatch = ''
     substituteInPlace src/CMakeLists.txt \
       --replace ' ''${QT_INSTALL_QML}' " $out/${qtbase.qtQmlPrefix}"
   '';
-
-  # Package expects qt5 subdirectory of mapbox-gl-native to be in the include path
-  NIX_CFLAGS_COMPILE = "-I${mapbox-gl-native}/include/qt5";
 
   meta = with lib; {
     description = "Unofficial Mapbox GL Native bindings for Qt QML";

--- a/pkgs/development/libraries/maplibre-gl-native/default.nix
+++ b/pkgs/development/libraries/maplibre-gl-native/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, qtbase
+, curl
+, libuv
+, glfw3
+, rapidjson
+}:
+
+mkDerivation rec {
+  pname = "maplibre-gl-native";
+  version = "unstable-2022-04-07";
+
+  src = fetchFromGitHub {
+    owner = "maplibre";
+    repo = "maplibre-gl-native";
+    rev = "225f8a4bfe7ad30fd59d693c1fb3ca0ba70d2806";
+    fetchSubmodules = true;
+    hash = "sha256-NLtpi+bDLTHlnzMZ4YFQyF5B1xt9lzHyZPvEQLlBAnY=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "skip-license-check.patch";
+      url = "https://git.alpinelinux.org/aports/plain/testing/mapbox-gl-native/0002-skip-license-check.patch?id=6751a93dca26b0b3ceec9eb151272253a2fe497e";
+      sha256 = "1yybwzxbvn0lqb1br1fyg7763p2h117s6mkmywkl4l7qg9daa7ba";
+    })
+  ];
+
+  postPatch = ''
+    # don't use vendored rapidjson
+    rm -r vendor/mapbox-base/extras/rapidjson
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    libuv
+    glfw3
+    qtbase
+    rapidjson
+  ];
+
+  cmakeFlags = [
+    "-DMBGL_WITH_QT=ON"
+    "-DMBGL_WITH_QT_LIB_ONLY=ON"
+    "-DMBGL_WITH_QT_HEADLESS=OFF"
+  ];
+
+  meta = with lib; {
+    description = "Open-source alternative to Mapbox GL Native";
+    homepage = "https://maplibre.org/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dotlambda ];
+    platforms = platforms.linux;
+    broken = lib.versionOlder qtbase.version "5.15";
+  };
+}

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -142,6 +142,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   mapbox-gl-qml = libsForQt5.callPackage ../development/libraries/mapbox-gl-qml { };
 
+  maplibre-gl-native = callPackage ../development/libraries/maplibre-gl-native { };
+
   mauikit = callPackage ../development/libraries/mauikit { };
 
   mauikit-filebrowsing = callPackage ../development/libraries/mauikit-filebrowsing { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Should we make mapbox-gl-native an alias of maplibre-gl-native?