### PR TITLE
ripes: init at 2.2.4

### DIFF
--- a/pkgs/applications/emulators/ripes/default.nix
+++ b/pkgs/applications/emulators/ripes/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, pkg-config
+, qtbase
+, qtsvg
+, qtcharts
+, wrapQtAppsHook
+, cmake
+, python3
+}:
+
+mkDerivation rec {
+  pname = "ripes";
+  version = "2.2.4";
+
+  src = fetchFromGitHub {
+    owner = "mortbopet";
+    repo = "Ripes";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-Aal2A4xypzaY7Oa+boIrXk7ITNKnh5OZIP7DkJjcGu4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtsvg
+    qtcharts
+  ];
+
+  installPhase = ''
+    install -D Ripes $out/bin/Ripes
+    cp -r ${src}/appdir/usr/share $out/share
+  '';
+
+  meta = with lib; {
+    description = "A graphical processor simulator and assembly editor for the RISC-V ISA";
+    homepage = "https://github.com/mortbopet/Ripes";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rewine ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1343,6 +1343,8 @@ with pkgs;
 
   retrofe = callPackage ../applications/emulators/retrofe { };
 
+  ripes = libsForQt5.callPackage ../applications/emulators/ripes { };
+
   rpcs3 = libsForQt5.callPackage ../applications/emulators/rpcs3 { };
 
   ruffle = callPackage ../applications/emulators/ruffle { };


### PR DESCRIPTION
###### Description of changes
Ripes is a graphical processor simulator and assembly code editor built for the [RISC-V instruction set architecture](https://content.riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf), suitable for teaching how assembly level code is executed on various microarchitectures.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
