### PR TITLE
prosody: 0.11.13 -> 0.12.0

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -64,6 +64,7 @@ luasocket,,,,,,
 luasql-sqlite3,,,,,,vyp
 luassert,,,,,,
 luasystem,,,,,,
+luaunbound,,,,,
 luautf8,,,,,,pstn
 luazip,,,,,,
 lua-yajl,,,,,,pstn

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -820,6 +820,7 @@ in
         '') cfg.muc}
 
       ${ lib.optionalString (cfg.uploadHttp != null) ''
+        -- TODO: think about migrating this to mod-http_file_share instead.
         Component ${toLua cfg.uploadHttp.domain} "http_upload"
             http_upload_file_size_limit = ${cfg.uploadHttp.uploadFileSizeLimit}
             http_upload_expire_after = ${cfg.uploadHttp.uploadExpireAfter}

--- a/nixos/tests/xmpp/xmpp-sendmessage.nix
+++ b/nixos/tests/xmpp/xmpp-sendmessage.nix
@@ -51,11 +51,8 @@ class CthonTest(ClientXMPP):
         log.info('Message sent')
 
         # Test http upload (XEP_0363)
-        def timeout_callback(arg):
-            log.error("ERROR: Cannot upload file. XEP_0363 seems broken")
-            sys.exit(1)
         try:
-            url = await self['xep_0363'].upload_file("${dummyFile}",timeout=10, timeout_callback=timeout_callback)
+            url = await self['xep_0363'].upload_file("${dummyFile}",timeout=10)
         except:
             log.error("ERROR: Cannot run upload command. XEP_0363 seems broken")
             sys.exit(1)

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1944,6 +1944,31 @@ buildLuarocksPackage {
   };
 }) {};
 
+luaunbound = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
+  pname = "luaunbound";
+  version = "1.0.0-1";
+  knownRockspec = (fetchurl {
+    url    = "https://luarocks.org/luaunbound-1.0.0-1.rockspec";
+    sha256 = "1zlkibdwrj5p97nhs33cz8xx0323z3kiq5x7v0h3i7v6j0h8ppvn";
+  }).outPath;
+  src = fetchurl {
+    url    = "https://code.zash.se/dl/luaunbound/luaunbound-1.0.0.tar.gz";
+    sha256 = "1lsh0ylp5xskygxl5qdv6mhkm1x8xp0vfd5prk5hxkr19jk5mr3d";
+  };
+
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
+  propagatedBuildInputs = [ lua ];
+
+  meta = {
+    homepage = "https://www.zash.se/luaunbound.html";
+    description = "A binding to libunbound";
+    license.fullName = "MIT";
+  };
+}) {};
+
 luautf8 = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
 , fetchurl, lua
 }:

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -257,6 +257,12 @@ with prev;
     ];
   });
 
+  luaunbound = prev.lib.overrideLuarocks prev.luaunbound(drv: {
+    externalDeps = [
+      { name = "libunbound"; dep = pkgs.unbound; }
+    ];
+  });
+
   luuid = (prev.lib.overrideLuarocks prev.luuid (drv: {
     externalDeps = [
       { name = "LIBUUID"; dep = pkgs.libuuid; }

--- a/pkgs/development/python-modules/slixmpp/0001-xep_0030-allow-extra-args-in-get_info_from_domain.patch
+++ b/pkgs/development/python-modules/slixmpp/0001-xep_0030-allow-extra-args-in-get_info_from_domain.patch
@@ -1,0 +1,36 @@
+From 7b5ac168892dedc5bd6be4244b18dc32d37d00fd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?F=C3=A9lix=20Baylac-Jacqu=C3=A9?= <felix@alternativebit.fr>
+Date: Fri, 22 Apr 2022 15:26:05 +0200
+Subject: [PATCH] xep_0030: allow extra args in get_info_from_domain
+
+Aftermath of ea2d851a.
+
+http_upload from xep_0363 is now forwarding all its extra input args
+to get_info_from_domain. Sadly for us, get_info_from_domain won't
+accept any extra args passed that way and will yield a "got an
+unexpected keyword argument".
+
+Modifying get_info_from_domain to accept these extra args.
+
+I hit this bug by passing a timeout_callback argument to http_upload.
+Adding this scenario to the relevant integration test.
+---
+ itests/test_httpupload.py         | 1 +
+ slixmpp/plugins/xep_0030/disco.py | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/slixmpp/plugins/xep_0030/disco.py b/slixmpp/plugins/xep_0030/disco.py
+index 37d453aa..9f9a45f2 100644
+--- a/slixmpp/plugins/xep_0030/disco.py
++++ b/slixmpp/plugins/xep_0030/disco.py
+@@ -307,7 +307,7 @@ class XEP_0030(BasePlugin):
+         return self.api['has_identity'](jid, node, ifrom, data)
+
+     async def get_info_from_domain(self, domain=None, timeout=None,
+-                                   cached=True, callback=None):
++                                   cached=True, callback=None, **iqkwargs):
+         """Fetch disco#info of specified domain and one disco#items level below
+         """
+
+--
+2.35.1

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -39,6 +39,8 @@ buildPythonPackage rec {
       src = ./hardcode-gnupg-path.patch;
       inherit gnupg;
     })
+    # Upstream MR: https://lab.louiz.org/poezio/slixmpp/-/merge_requests/198
+    ./0001-xep_0030-allow-extra-args-in-get_info_from_domain.patch
   ];
 
   disabledTestPaths = [

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -82,6 +82,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     homepage = "https://prosody.im";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz globin ninjatrappeur ];
+    maintainers = with maintainers; [ fpletz globin ];
   };
 }

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, lib, libidn, openssl, makeWrapper, fetchhg
+, icu
 , lua
 , nixosTests
 , withLibevent ? true
@@ -13,7 +14,7 @@ with lib;
 
 let
   luaEnv = lua.withPackages(p: with p; [
-      luasocket luasec luaexpat luafilesystem luabitop luadbi-sqlite3
+      luasocket luasec luaexpat luafilesystem luabitop luadbi-sqlite3 luaunbound
     ]
     ++ lib.optional withLibevent p.luaevent
     ++ lib.optional withDBI p.luadbi
@@ -21,21 +22,19 @@ let
   );
 in
 stdenv.mkDerivation rec {
-  version = "0.11.13"; # also update communityModules
+  version = "0.12.0"; # also update communityModules
   pname = "prosody";
   # The following community modules are necessary for the nixos module
   # prosody module to comply with XEP-0423 and provide a working
   # default setup.
   nixosModuleDeps = [
-    "bookmarks"
     "cloud_notify"
     "vcard_muc"
-    "smacks"
     "http_upload"
   ];
   src = fetchurl {
     url = "https://prosody.im/downloads/source/${pname}-${version}.tar.gz";
-    sha256 = "sha256-OcYbNGoJtRJbYEy5aeFCBsu8uGyBFW/8a6LWJSfPBDI=";
+    sha256 = "sha256-dS/zIBXaxWX8NBfCGWryaJccNY7gZuUfXZEkE1gNiJo=";
   };
 
   # A note to all those merging automated updates: Please also update this
@@ -43,13 +42,13 @@ stdenv.mkDerivation rec {
   # version.
   communityModules = fetchhg {
     url = "https://hg.prosody.im/prosody-modules";
-    rev = "54fa2116bbf3";
-    sha256 = "sha256-OKZ7tD75q8/GMXruUQ+r9l0BxzdbPHNf41fZ3fHVQVw=";
+    rev = "65438e4ba563";
+    sha256 = "sha256-zHOrMzcgHOdBl7nObM+OauifbcmKEOfAuj81MDSoLMk=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [
-    luaEnv libidn openssl
+    luaEnv libidn openssl icu
   ]
   ++ withExtraLibs;
 
@@ -63,26 +62,14 @@ stdenv.mkDerivation rec {
     make -C tools/migration
   '';
 
-  luaEnvPath = lua.pkgs.lib.genLuaPathAbsStr luaEnv;
-  luaEnvCPath = lua.pkgs.lib.genLuaCPathAbsStr luaEnv;
-
   # the wrapping should go away once lua hook is fixed
   postInstall = ''
       ${concatMapStringsSep "\n" (module: ''
         cp -r $communityModules/mod_${module} $out/lib/prosody/modules/
       '') (lib.lists.unique(nixosModuleDeps ++ withCommunityModules ++ withOnlyInstalledCommunityModules))}
-      wrapProgram $out/bin/prosody \
-        --prefix LUA_PATH ';' "$luaEnvPath" \
-        --prefix LUA_CPATH ';' "$luaEnvCPath"
       wrapProgram $out/bin/prosodyctl \
-        --add-flags '--config "/etc/prosody/prosody.cfg.lua"' \
-        --prefix LUA_PATH ';' "$luaEnvPath" \
-        --prefix LUA_CPATH ';' "$luaEnvCPath"
-
+        --add-flags '--config "/etc/prosody/prosody.cfg.lua"'
       make -C tools/migration install
-      wrapProgram $out/bin/prosody-migrator \
-        --prefix LUA_PATH ';' "$luaEnvPath" \
-        --prefix LUA_CPATH ';' "$luaEnvCPath"
     '';
 
   passthru = {


### PR DESCRIPTION
It's been quite a journey...

Prosody 0.12 requires luaunbound, we package it on https://github.com/NixOS/nixpkgs/commit/811f95f000d9610bd85cca1cf78ae9a069464d87. See commit message for more details.  Cc @teto, you seem to be the one maintaining most of this packageset. 

The last Slixmpp bump revealed a upstream bug. Fixing it on https://github.com/NixOS/nixpkgs/commit/0e630462da8c2e83b6d04eb935353d1e34549c32 to unbreak the prosody test. See commit message for more details. Cc @fabaff, you seem to be relying on slixmpp as well.

We finally update prosody on https://github.com/NixOS/nixpkgs/commit/2585ca317fa51a0005b04cac01f70b1f68f71674. We remove the recently introduced wrappers in the process. I don't really get why they aren't necessary anymore. Cc @arcnmx

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
