### PR TITLE
tup: generate verbose build scripts in setup hook

### DIFF
--- a/pkgs/development/tools/build-managers/tup/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/tup/setup-hook.sh
@@ -19,7 +19,7 @@ tupConfigurePhase() {
     echo "${tupConfig-}" >> tup.config
 
     tup init
-    tup generate tupBuild.sh
+    tup generate --verbose tupBuild.sh
 
     runHook postConfigure
 }
@@ -33,7 +33,7 @@ tupBuildPhase() {
     runHook preBuild
 
     pushd .
-    . tupBuild.sh
+    ./tupBuild.sh
     popd
 
     runHook postBuild


### PR DESCRIPTION
###### Description of changes

This allows the build commands to be debugged more easily when building the package under Nix (i.e. not inside a Nix shell).

Specifically, this will cause `tup` to generate a build script that starts with `#! /bin/sh -ex` instead of `#! /bin/sh -e` which, in turn, will cause all build commands to be printed when they are executed, e.g.:

```
+ clang src/io.c -c -o (...)
error: option 'cf-protection=return' cannot be specified on this target
```

Whereas before, the output would simply be:
```
error: option 'cf-protection=return' cannot be specified on this target
```

... and we would have no clue which command caused the error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @ehmry

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
