### PR TITLE
qpid-cpp: switch to python3

### DIFF
--- a/pkgs/servers/amqp/qpid-cpp/default.nix
+++ b/pkgs/servers/amqp/qpid-cpp/default.nix
@@ -1,14 +1,46 @@
-{ lib, stdenv, fetchurl, cmake, python2, boost, libuuid, ruby, buildEnv, buildPythonPackage, qpid-python }:
+{ lib, stdenv
+, fetchpatch
+, fetchurl
+, boost
+, cmake
+, libuuid
+, python3
+, ruby
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "qpid-cpp";
-  name = "${pname}-${version}";
   version = "1.39.0";
 
   src = fetchurl {
-    url = "mirror://apache/qpid/cpp/${version}/${name}.tar.gz";
-    sha256 = "088dx1l6myrksbhpr15bs09j6qm8vdliqwjp2ja5amym47md103r";
+    url = "mirror://apache/qpid/cpp/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-eYDQ6iHVV1WUFFdyHGnbqGIjE9CrhHzh0jP7amjoDSE=";
   };
+
+  nativeBuildInputs = [ cmake python3 ];
+  buildInputs = [ boost libuuid ruby ];
+
+  patches = [
+    (fetchpatch {
+      name = "python3-managementgen";
+      url = "https://github.com/apache/qpid-cpp/commit/0e558866e90ef3d5becbd2f6d5630a6a6dc43a5d.patch";
+      hash = "sha256-pV6xx8Nrys/ZxIO0Z/fARH0ELqcSdTXLPsVXYUd3f70=";
+    })
+  ];
+
+  # the subdir managementgen wants to install python stuff in ${python} and
+  # the installation tries to create some folders in /var
+  postPatch = ''
+    sed -i '/managementgen/d' CMakeLists.txt
+    sed -i '/ENV/d' src/CMakeLists.txt
+    sed -i '/management/d' CMakeLists.txt
+  '';
+
+  NIX_CFLAGS_COMPILE = toString ([
+    "-Wno-error=maybe-uninitialized"
+  ] ++ lib.optionals stdenv.cc.isGNU [
+    "-Wno-error=deprecated-copy"
+  ]);
 
   meta = with lib; {
     homepage = "https://qpid.apache.org";
@@ -17,41 +49,4 @@ let
     platforms = platforms.linux;
     maintainers = with maintainers; [ cpages ];
   };
-
-  qpid-cpp = stdenv.mkDerivation {
-    inherit src meta pname version;
-
-    nativeBuildInputs = [ cmake ];
-    buildInputs = [ boost libuuid ruby python2 ];
-
-    # the subdir managementgen wants to install python stuff in ${python} and
-    # the installation tries to create some folders in /var
-    postPatch = ''
-      sed -i '/managementgen/d' CMakeLists.txt
-      sed -i '/ENV/d' src/CMakeLists.txt
-      sed -i '/management/d' CMakeLists.txt
-    '';
-
-    NIX_CFLAGS_COMPILE = toString ([
-      "-Wno-error=deprecated-declarations"
-      "-Wno-error=int-in-bool-context"
-      "-Wno-error=maybe-uninitialized"
-      "-Wno-error=unused-function"
-      "-Wno-error=ignored-qualifiers"
-      "-Wno-error=catch-value"
-    ] ++ lib.optionals stdenv.cc.isGNU [
-      "-Wno-error=deprecated-copy"
-    ]);
-  };
-
-  python-frontend = buildPythonPackage {
-    inherit pname version meta src;
-
-    sourceRoot = "${name}/management/python";
-
-    propagatedBuildInputs = [ qpid-python ];
-  };
-in buildEnv {
-  name = "${name}-env";
-  paths = [ qpid-cpp python-frontend ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22318,10 +22318,7 @@ with pkgs;
 
   pypolicyd-spf = python3.pkgs.callPackage ../servers/mail/pypolicyd-spf { };
 
-  qpid-cpp = callPackage ../servers/amqp/qpid-cpp {
-    boost = boost155;
-    inherit (python2Packages) buildPythonPackage qpid-python;
-  };
+  qpid-cpp = callPackage ../servers/amqp/qpid-cpp { };
 
   qremotecontrol-server = callPackage ../servers/misc/qremotecontrol-server { };
 


### PR DESCRIPTION
qpid-cpp only supports python2 bindings, so they've been removed. #148779
(Also, the current derivation on master doesn't build; this one does)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
