### PR TITLE
nixos/s3backer: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -705,6 +705,7 @@
   ./services/network-filesystems/rsyncd.nix
   ./services/network-filesystems/samba.nix
   ./services/network-filesystems/samba-wsdd.nix
+  ./services/network-filesystems/s3backer.nix
   ./services/network-filesystems/tahoe.nix
   ./services/network-filesystems/diod.nix
   ./services/network-filesystems/u9fs.nix

--- a/nixos/modules/services/network-filesystems/s3backer.nix
+++ b/nixos/modules/services/network-filesystems/s3backer.nix
@@ -1,0 +1,104 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.s3backer;
+  mountOption = { name, ... }: {
+    options = {
+      accessFile = mkOption {
+        default = null;
+        type = types.nullOr types.path;
+        description = ''
+          Specify a file containing `accessID:accessKey' pairs, one per-line.  Blank lines and lines beginning with a `#' are ignored.
+          If no --accessKey or --accessKeyEnv is specified, this file will be searched for the entry matching the access ID specified via --accessId;
+          if no --accessId is specified, the first entry in this file will be used. If not specified, $HOME/.s3backer_passwd will be used.
+        '';
+      };
+      bucketPath = mkOption {
+        type = types.str;
+        description = ''
+          Bucket and optional key within bucket to create backing file for.
+        '';
+        example = "bucket_name/subdir";
+      };
+      encrypt = mkOption {
+        default = false;
+        type = types.nullOr types.bool;
+        description = ''
+          Enable encryption and authentication of block data.
+        '';
+      };
+      passwordFile = mkOption {
+        default = null;
+        type = types.nullOr types.path;
+        description = ''
+          File containing the encryption password for the 'encrypt' option.
+        '';
+      };
+      mountPoint = mkOption {
+        default = "/var/lib/s3backer/${name}";
+        type = types.str;
+        description = "Mount point for s3backer FUSE filesystem";
+      };
+      size = mkOption {
+        type = types.str;
+        description = ''
+          Specify the size (in bytes) of the backed file to be exported by the filesystem.
+          The size may have an optional suffix 'K' for Kilobytes, 'M' for Megabytes, 'G' for Gigabytes, 'T' for Terabytes, 'E' for Exabytes, 'Z' for Zettabytes, or 'Y' for Yottabytes.
+        '';
+      };
+      filename = mkOption {
+        default = "file";
+        type = types.str;
+        description = ''
+          The name of the backed file that appears in the s3backer filesystem.
+        '';
+      };
+      extraOptions = mkOption {
+        default = null;
+        type = types.nullOr types.lines;
+        description = ''
+          Extra command-line arguments to be passed to s3backer.
+
+          Leading and trailing whitespace is trimmed from each line, and blank lines and lines starting with # are ignored.
+          Each line contains exactly one command line argument (including internal whitespace, if any).
+        '';
+      };
+    };
+  };
+in
+{
+  options.services.s3backer = {
+    package = mkPackageOption pkgs "s3backer" { };
+    mounts = mkOption {
+      default = { };
+      type = types.attrsOf (types.submodule mountOption);
+      description = ''
+        Configuration for s3backer mount points.
+      '';
+    };
+  };
+  config.systemd.services = mapAttrs'
+    (name: mount:
+      let options = [
+        (lib.optionalString (mount.accessFile != null) "--accessFile=${mount.accessFile}")
+        (lib.optionalString mount.encrypt "--encrypt")
+        (lib.optionalString (mount.passwordFile != null) "--passwordFile=${mount.passwordFile}")
+        "--size=${mount.size}"
+        "--filename=${mount.filename}"
+        "--configFile=${pkgs.writeText "s3backer-${name}-extra.conf" mount.extraOptions}"
+      ];
+      in
+      nameValuePair ("s3backer-${name}") {
+        path = [ cfg.package ];
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        restartIfChanged = true;
+        preStart = ''
+          mkdir -p ${mount.mountPoint}
+        '';
+        script = ''
+          s3backer -f ${concatStringsSep " " options} ${mount.bucketPath} ${mount.mountPoint}
+        '';
+      })
+    cfg.mounts;
+}


### PR DESCRIPTION
Add a NixOS module for `s3backer`.

Only a few of the command line arguments for s3backer have parameters, but the
'extraOptions' parameter can be used to add arbitrary other arguments.

Multiple s3backer mount points can be configured with different settings.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
