### PR TITLE
sonic-pi: use supercollider with sc3-plugins

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -18,7 +18,6 @@
 }:
 
 let
-
   pname = "sonic-pi";
   version = "3.3.1";
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -2,7 +2,6 @@
 , lib
 , qtbase
 , fetchFromGitHub
-, fftwSinglePrec
 , ruby
 , erlang
 , aubio
@@ -14,13 +13,11 @@
 , boost
 , bash
 , jack2
-, supercollider
+, supercollider-with-sc3-plugins
 , qwt
 }:
 
 let
-
-  supercollider_single_prec = supercollider.override {  fftw = fftwSinglePrec; };
 
   pname = "sonic-pi";
   version = "3.3.1";
@@ -62,7 +59,7 @@ mkDerivation rec {
     qwt
     ruby
     aubio
-    supercollider_single_prec
+    supercollider-with-sc3-plugins
     boost
     erlang
     alsa-lib
@@ -122,18 +119,18 @@ mkDerivation rec {
   dontWrapQtApps = true;
   preFixup = ''
     wrapQtApp "$out/bin/sonic-pi" \
-      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider erlang] }
+      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider-with-sc3-plugins erlang] }
     makeWrapper \
       $out/app/server/ruby/bin/sonic-pi-server.rb \
       $out/bin/sonic-pi-server \
-      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider erlang ] }
+      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider-with-sc3-plugins erlang ] }
   '';
 
   meta = {
     homepage = "https://sonic-pi.net/";
     description = "Free live coding synth for everyone originally designed to support computing and music lessons within schools";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ Phlogistique kamilchm c0deaddict sohalt ];
+    maintainers = with lib.maintainers; [ Phlogistique kamilchm c0deaddict sohalt lilyinstarlight ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

Some synths in Sonic Pi, such as the `:piano` synth, require sc3-plugins to be loaded in SuperCollider. This PR uses the recently merged plugin support (#147011) to have SuperCollider automatically load sc3-plugins, as Sonic Pi expects. I additionally made a drive-by change to remove the `supercollider` package override, since the package is already using `fftwSinglePrec` anyways without it

See https://github.com/sonic-pi-net/sonic-pi/blob/v3.3.1/FAQ.md#linux-there-is-no-sound-with-use_synth-piano for info about sc3-plugins requirement

Also, I've been keeping up with the development of the imminent 4.0 release of Sonic Pi and have been working toward making it friendlier for Linux packaging. Relatedly, I've been keeping a Nix package up to date with recent working dev commits that I planned to PR to nixpkgs once 4.0 is stable (see [here](https://github.com/lilyinstarlight/foosteros/blob/main/pkgs/sonic-pi-beta/default.nix)). I'm happy to add myself to the maintainer list if you'd like, since I'm involved on the Sonic Pi core team and have been working on Nix packaging for Sonic Pi


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>sonic-pi</li>
  </ul>
</details>