### PR TITLE
hopper: 4.5.29 -> 5.5.3; libffi_3_3: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -947,6 +947,12 @@
     githubId = 1118815;
     name = "Vikram Narayanan";
   };
+  armeenm = {
+    email = "mahdianarmeen@gmail.com";
+    github = "armeenm";
+    githubId = 29145250;
+    name = "Armeen Mahdian";
+  };
   armijnhemel = {
     email = "armijn@tjaldur.nl";
     github = "armijnhemel";

--- a/pkgs/development/libraries/libffi/3.3.nix
+++ b/pkgs/development/libraries/libffi/3.3.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv, fetchurl, fetchpatch
+, autoreconfHook
+
+, doCheck ? true # test suite depends on dejagnu which cannot be used during bootstrapping
+, dejagnu
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libffi";
+  version = "3.3";
+
+  src = fetchurl {
+    url = "https://github.com/libffi/libffi/releases/download/v${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-cvunkicD3fp6Ao1ROsFahcjVTI1n9V+lpIAohdxlIFY=";
+  };
+
+  patches = [];
+
+  outputs = [ "out" "dev" "man" "info" ];
+
+  configureFlags = [
+    "--with-gcc-arch=generic" # no detection of -march= or -mtune=
+    "--enable-pax_emutramp"
+
+    # Causes issues in downstream packages which misuse ffi_closure_alloc
+    # Reenable once these issues are fixed and merged:
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6155
+    # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
+    "--disable-exec-static-tramp"
+  ];
+
+  preCheck = ''
+    # The tests use -O0 which is not compatible with -D_FORTIFY_SOURCE.
+    NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
+  '';
+
+  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+
+  inherit doCheck;
+
+  checkInputs = [ dejagnu ];
+
+  meta = with lib; {
+    description = "A foreign function call interface library";
+    longDescription = ''
+      The libffi library provides a portable, high level programming
+      interface to various calling conventions.  This allows a
+      programmer to call any function specified by a call interface
+      description at run-time.
+
+      FFI stands for Foreign Function Interface.  A foreign function
+      interface is the popular name for the interface that allows code
+      written in one language to call code written in another
+      language.  The libffi library really only provides the lowest,
+      machine dependent layer of a fully featured foreign function
+      interface.  A layer must exist above libffi that handles type
+      conversions for values passed between the two languages.
+    '';
+    homepage = "http://sourceware.org/libffi/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ armeenm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -3,36 +3,35 @@
 , lib
 , autoPatchelfHook
 , wrapQtAppsHook
-, libbsd
-, python27
 , gmpxx
-, ncurses5
 , gnustep
-, libffi
+, libbsd
+, libffi_3_3
+, ncurses6
 }:
+
 stdenv.mkDerivation rec {
   pname = "hopper";
-  version = "4.5.29";
-  rev = "v${lib.versions.major version}";
+  version = "5.5.3";
+  rev = "v4";
 
   src = fetchurl {
-    url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux.pkg.tar.xz";
-    sha256 = "1v1pff5fiv41khvrnlpdks2vddjnvziyn14qqj6v26snyhwi86zh";
+    url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux-demo.pkg.tar.xz";
+    hash = "sha256-xq9ZVg1leHm/tq6LYyQLa8p5dDwBd64Jt92uMoE0z58=";
   };
 
   sourceRoot = ".";
 
   nativeBuildInputs = [
-    wrapQtAppsHook
     autoPatchelfHook
+    wrapQtAppsHook
   ];
 
   buildInputs = [
-    libbsd
-    python27
-    gmpxx
-    ncurses5
     gnustep.libobjc
+    libbsd
+    libffi_3_3
+    ncurses6
   ];
 
   installPhase = ''
@@ -53,9 +52,6 @@ stdenv.mkDerivation rec {
       $sourceRoot/opt/hopper-${rev}/lib/libobjcxx.so* \
       $sourceRoot/opt/hopper-${rev}/lib/libpthread_workqueue.so* \
       $out/lib
-
-    # we already ship libffi.so.7
-    ln -s ${lib.getLib libffi}/lib/libffi.so $out/lib/libffi.so.6
 
     cp -r $sourceRoot/usr/share $out
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18482,6 +18482,7 @@ with pkgs;
   libffcall = callPackage ../development/libraries/libffcall { };
 
   libffi = callPackage ../development/libraries/libffi { };
+  libffi_3_3 = callPackage ../development/libraries/libffi/3.3.nix { };
   libffiBoot = libffi.override {
     doCheck = false;
   };


### PR DESCRIPTION
###### Description of changes
Hopper 5.5.3 requires libffi.so.7 which is provided by libffi 3.3. This PR inits a package libffi7 akin to [Ubuntu's](https://packages.ubuntu.com/focal/libffi7) for the purpose of bumping Hopper to 5.5.3 as 4.5.29 relies on python2 (#148779).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
