### PR TITLE
pyrseas: 0.8.0 -> 0.9.1

### DIFF
--- a/pkgs/development/tools/database/pyrseas/default.nix
+++ b/pkgs/development/tools/database/pyrseas/default.nix
@@ -1,39 +1,39 @@
-{ lib, python2Packages, fetchFromGitHub }:
+{ lib, python3Packages, fetchFromGitHub }:
 
 let
-  pgdbconn = python2Packages.buildPythonPackage rec {
+  pgdbconn = python3Packages.buildPythonPackage rec {
     pname = "pgdbconn";
     version = "0.8.0";
     src = fetchFromGitHub {
       owner = "perseas";
       repo = "pgdbconn";
       rev = "v${version}";
-      sha256 = "09r4idk5kmqi3yig7ip61r6js8blnmac5n4q32cdcbp1rcwzdn6z";
+      hash = "sha256-39j2OcvhLtaYGJjYwlS1dCEtTQ7mxvOiHxHXWWaLJCc=";
     };
     # The tests are impure (they try to access a PostgreSQL server)
     doCheck = false;
     propagatedBuildInputs = [
-      python2Packages.psycopg2
-      python2Packages.pytest
+      python3Packages.psycopg2
+      python3Packages.pytest
     ];
   };
 in
 
-python2Packages.buildPythonApplication {
+python3Packages.buildPythonApplication rec {
   pname = "pyrseas";
-  version = "0.8.0";
+  version = "0.9.1";
   src = fetchFromGitHub {
     owner = "perseas";
     repo = "Pyrseas";
-    rev = "2e9be763e61168cf20d28bd69010dc5875bd7b97";
-    sha256 = "1h9vahplqh0rzqjsdq64qqar6hj1bpbc6nl1pqwwgca56385br8r";
+    rev = version;
+    hash = "sha256-+MxnxvbLMxK1Ak+qKpKe3GHbzzC+XHO0eR7rl4ON9H4=";
   };
   # The tests are impure (they try to access a PostgreSQL server)
   doCheck = false;
   propagatedBuildInputs = [
-    python2Packages.psycopg2
-    python2Packages.pytest
-    python2Packages.pyyaml
+    python3Packages.psycopg2
+    python3Packages.pytest
+    python3Packages.pyyaml
     pgdbconn
   ];
   meta = {


### PR DESCRIPTION
###### Description of changes
Say goodbye to more python2.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
