### PR TITLE
python3Packages.xxhash: fix version with setuptools-scm

### DIFF
--- a/pkgs/development/python-modules/xxhash/default.nix
+++ b/pkgs/development/python-modules/xxhash/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
@@ -11,6 +12,10 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-MLLZeq8R+xIgI/a0TruXxpVengDXRhqWQVygMLXOucc=";
   };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/ifduyue/python-xxhash";


### PR DESCRIPTION
###### Description of changes

Right now anything that depends on `xxhash` will fail to compile, for example:
```
python3.9-botw-utils> ERROR: Could not find a version that satisfies the requirement xxhash>=1.4 (from botw-utils) (from versions: none)
python3.9-botw-utils> ERROR: No matching distribution found for xxhash>=1.4
python3.9-botw-utils> 
error: builder for '/nix/store/s2bw1y30a2qi7vb4bfp3nwkq66zcbi2s-python3.9-botw-utils-0.2.3.drv' failed with exit code 1;
       last 10 log lines:
       > removing build/bdist.linux-x86_64/wheel
       > Finished executing setuptoolsBuildPhase
       > installing
       > Executing pipInstallPhase
       > /build/source/dist /build/source
       > Processing ./botw_utils-0.2.3-py3-none-any.whl
       > Requirement already satisfied: oead>=1.0.0 in /nix/store/b80lzyj7hfzmvws20p765280pncs1sp4-python3.9-oead-1.2.3/lib/python3.9/site-packages (from botw-utils==0.2.3) (1.2.3)
       > ERROR: Could not find a version that satisfies the requirement xxhash>=1.4 (from botw-utils) (from versions: none)
       > ERROR: No matching distribution found for xxhash>=1.4
       >
       For full logs, run 'nix log /nix/store/s2bw1y30a2qi7vb4bfp3nwkq66zcbi2s-python3.9-botw-utils-0.2.3.drv'.
```

Since v3.0.0, `python-xxhash` now uses `setuptools-scm` to manage its version: https://github.com/ifduyue/python-xxhash/commit/57ba2797db188e78e37db9c94addf3be0e36dc6e

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  No binary files
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).