### PR TITLE
pngtools: init at unstable-2022-03-14

### DIFF
--- a/pkgs/tools/graphics/pngtools/default.nix
+++ b/pkgs/tools/graphics/pngtools/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, libpng12, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "pngtools";
+  version = "unstable-2022-03-14";
+
+  src = fetchFromGitHub {
+    owner = "mikalstill";
+    repo = "pngtools";
+    rev = "1ccca3a0f3f6882661bbafbfb62feb774ca195d1";
+    sha256 = "sha256-W1XofOVTyfA7IbxOnTkWdOOZ00gZ4e0GOYl7nMtLIJk=";
+  };
+
+  buildInputs = [ libpng12 ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mikalstill/pngtools";
+    description = "PNG manipulation tools";
+    maintainers = with maintainers; [ zendo ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/tools/graphics/pngtools/default.nix
+++ b/pkgs/tools/graphics/pngtools/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/mikalstill/pngtools";
     description = "PNG manipulation tools";
     maintainers = with maintainers; [ zendo ];
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
   };
 }

--- a/pkgs/tools/graphics/pngtools/default.nix
+++ b/pkgs/tools/graphics/pngtools/default.nix
@@ -18,5 +18,6 @@ stdenv.mkDerivation {
     description = "PNG manipulation tools";
     maintainers = with maintainers; [ zendo ];
     license = licenses.gpl2Only;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9330,6 +9330,8 @@ with pkgs;
     libpng = libpng12;
   };
 
+  pngtools = callPackage ../tools/graphics/pngtools { };
+
   pngpp = callPackage ../development/libraries/png++ { };
 
   pngquant = callPackage ../tools/graphics/pngquant { };


### PR DESCRIPTION
###### Description of changes
Closes #169825 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
