### PR TITLE
obs-vkcapture: init at 1.1.3

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -9,4 +9,5 @@
   wlrobs = callPackage ./wlrobs.nix {};
   looking-glass-obs = callPackage ./looking-glass-obs.nix {};
   obs-nvfbc = callPackage ./obs-nvfbc.nix {};
+  obs-vkcapture = callPackage ./obs-vkcapture.nix {};
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, wayland
+, obs-studio
+, libX11
+, vulkan-headers
+, vulkan-loader
+, libGL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-vkcapture";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "nowrep";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-iIV9ke2yPEt2Lf4bwiEHFip4tLhMS4raWGyCWpao74w=";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ libGL libX11 obs-studio vulkan-headers vulkan-loader wayland ];
+
+  meta = with lib; {
+    description = "OBS Linux Vulkan/OpenGL game capture";
+    homepage = "https://github.com/nowrep/obs-vkcapture";
+    maintainers = with maintainers; [ atila ];
+    license = licenses.gpl2Only;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Obs-vkcapture](https://github.com/nowrep/obs-vkcapture) is an OBS Studio plugin that allows to directly capture the game from the Vulkan / OpenGL buffer, sending them to OBS through DMA-BUF.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
