### PR TITLE
epub-thumbnailer: init unstable-2022-02-10

### DIFF
--- a/pkgs/tools/graphics/epub-thumbnailer/default.nix
+++ b/pkgs/tools/graphics/epub-thumbnailer/default.nix
@@ -1,0 +1,34 @@
+{ lib, python3Packages, fetchFromGitHub, pillow }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "epub-thumbnailer";
+  version = "unstable-2022-02-10";
+
+  src = fetchFromGitHub {
+    owner = "marianosimone";
+    repo = pname;
+    rev = "486111b27d192c27011229dc696e9179f59b0eab";
+    sha256 = "0mv0zd74g4xfi2pvl8k0z6qvf1987lwk47ia8cyr51capk95p4rp";
+  };
+
+  # The installer is a simple python script, so no tests nor build steps are necessary
+  dontBuild = true;
+  doCheck = false;
+
+  propagatedBuildInputs = [ pillow ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/epub-thumbnailer.py $out/bin/epub-thumbnailer
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/marianosimone/epub-thumbnailer";
+    description = "Script to extract the cover of an epub book and create a thumbnail for it";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5295,6 +5295,8 @@ with pkgs;
 
   epubcheck = callPackage ../tools/text/epubcheck { };
 
+  epub-thumbnailer = python3Packages.callPackage ../tools/graphics/epub-thumbnailer { };
+
   evil-winrm = callPackage ../tools/security/evil-winrm { };
 
   luckybackup = libsForQt5.callPackage ../tools/backup/luckybackup {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer) is a small python application is able to creating png thumbnails out of epub files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
