### PR TITLE
packagekit: fix build with Nix 2.8

### DIFF
--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -11,7 +11,6 @@
 , vala
 , gtk-doc
 , nix
-, nlohmann_json ? null
 , boost
 , meson
 , ninja
@@ -27,12 +26,6 @@
 , enableSystemd ? stdenv.isLinux
 , systemd
 }:
-let
-  nix_version = lib.removeSuffix nix.VERSION_SUFFIX nix.version;
-  useNlohmann = lib.versionAtLeast "2.7" nix_version;
-in
-
-assert useNlohmann -> nlohmann_json != null;
 
 stdenv.mkDerivation rec {
   pname = "packagekit";
@@ -43,8 +36,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "PackageKit";
     repo = "PackageKit";
-    rev = "33b847c49b4a42499e3c0f10fef62830c874e086";
-    sha256 = "UDpMswf0EBwcoHTqoWiztXnIAwM69nM+S9MPsR24amw=";
+    rev = "30bb82da8d4161330a6d7a20c9989149303421a1";
+    sha256 = "k2osc2v0OuGrNjwxdqn785RsbHEJP3p79PG9YqnVE3U=";
   };
 
   buildInputs = [
@@ -59,7 +52,6 @@ stdenv.mkDerivation rec {
     nix
     boost
   ] ++ lib.optional enableSystemd systemd
-  ++ lib.optional useNlohmann nlohmann_json
   ++ lib.optional enableBashCompletion bash-completion;
   nativeBuildInputs = [
     vala

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9028,7 +9028,7 @@ with pkgs;
 
   p7zip = callPackage ../tools/archivers/p7zip { };
 
-  packagekit = callPackage ../tools/package-management/packagekit { nix = nixVersions.nix_2_6; };
+  packagekit = callPackage ../tools/package-management/packagekit { nix = nixVersions.nix_2_8; };
 
   packetdrill = callPackage ../tools/networking/packetdrill { };
 


### PR DESCRIPTION


###### Description of changes

https://github.com/PackageKit/PackageKit/compare/33b847c...30bb82d

`nlohmann_json` is propagated by nix https://github.com/NixOS/nixpkgs/commit/eeab10bd54e2f6a25c27059290e7e7f2b3fd1cf0 and we are requiring nix 2.8 now so I dropped related stuff.

I am not removing the `nix = nixVersions.nix_2_8;` pin because I expect breaking API changes happens on every nix release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
