### PR TITLE
kompute: init at 0.8.1

### DIFF
--- a/pkgs/development/libraries/kompute/default.nix
+++ b/pkgs/development/libraries/kompute/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, vulkan-headers
+, vulkan-loader
+, fmt
+, glslang
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kompute";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "KomputeProject";
+    repo = "kompute";
+    rev = "v${version}";
+    sha256 = "sha256-OkVGYh8QrD7JNqWFBLrDTYlk6IYHdvt4i7UtC4sQTzo=";
+  };
+
+  cmakeFlags = [
+    "-DKOMPUTE_OPT_INSTALL=1"
+    "-DRELEASE=1"
+    "-DKOMPUTE_ENABLE_SPDLOG=1"
+  ];
+
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ fmt ];
+  propagatedBuildInputs = [ glslang vulkan-headers vulkan-loader ];
+
+  meta = with lib; {
+    description = "General purpose GPU compute framework built on Vulkan";
+    longDescription = ''
+      General purpose GPU compute framework built on Vulkan to
+      support 1000s of cross vendor graphics cards (AMD,
+      Qualcomm, NVIDIA & friends). Blazing fast, mobile-enabled,
+      asynchronous and optimized for advanced GPU data
+      processing usecases. Backed by the Linux Foundation"
+    '';
+    homepage = "https://kompute.cc/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ atila ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33985,6 +33985,8 @@ with pkgs;
 
   kompose = callPackage ../applications/networking/cluster/kompose { };
 
+  kompute = callPackage ../development/libraries/kompute { };
+
   kontemplate = callPackage ../applications/networking/cluster/kontemplate { };
 
   # In general we only want keep the last three minor versions around that


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Kompute](https://kompute.cc/) is a vulkan GPGPU framework that allows developers to create applications that support practically every available GPU, including mobile gpus. It even can run on cpu using the Swiftshader shader. 

This derivation packages this library, but only the C++ version. There is also a python module available, but I will need some more studying to make it work within the same derivation, I kindly ask for your help in that regard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
