### PR TITLE
binutils-unwrapped-all-targets: fix libctf breakage

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -21,7 +21,7 @@ in
 , enableGold ? execFormatIsELF stdenv.targetPlatform
 , enableShared ? !stdenv.hostPlatform.isStatic
   # WARN: Enabling all targets increases output size to a multiple.
-, withAllTargets ? false, libbfd, libopcodes
+, withAllTargets ? false
 }:
 
 # WARN: configure silently disables ld.gold if it's unsupported, so we need to
@@ -183,11 +183,9 @@ stdenv.mkDerivation {
   # Fails
   doCheck = false;
 
-  postFixup = lib.optionalString (enableShared && withAllTargets) ''
-    rm "$out"/lib/lib{bfd,opcodes}-${version}.so
-    ln -s '${lib.getLib libbfd}/lib/libbfd-${version}.so' "$out/lib/"
-    ln -s '${lib.getLib libopcodes}/lib/libopcodes-${version}.so' "$out/lib/"
-  '';
+  # Remove on next bump. It's a vestige of past conditional. Stays here to avoid
+  # mass rebuild.
+  postFixup = "";
 
   # INFO: Otherwise it fails with:
   # `./sanity.sh: line 36: $out/bin/size: not found`


### PR DESCRIPTION
Before the change 'postFixup' was breaking binaries as it deleted `libctf.so`'s
dependency without fixing the links (https://hydra.nixos.org/build/173957444):

  objdump:
    symbol lookup error: ...-binutils-2.38/lib/libctf.so.0: undefined symbol: htab_eq_string

Instead of tying binutils and libbfd together let's stop replacing the
libraries and use local copies. They are not mechanically interchangeable.

Ideally binutils' upstream build system should allow linking external
`libbfd`/`libopcodes`/`libctf` but we are not there yet.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
