### PR TITLE
python3Packages.platformdirs: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/development/python-modules/hatch-vcs/default.nix
+++ b/pkgs/development/python-modules/hatch-vcs/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+, git
+, hatchling
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "hatch-vcs";
+  version = "0.2.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "hatch_vcs";
+    inherit version;
+    sha256 = "sha256-mRPXM7NO7JuwNF0GJsoyFlpK0t4V0c5kPDbQnKkIq/8=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    hatchling
+    setuptools-scm
+  ];
+
+  checkInputs = [
+    git
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "hatch_vcs"
+  ];
+
+  meta = with lib; {
+    description = "A plugin for Hatch that uses your preferred version control system (like Git) to determine project versions";
+    homepage = "https://github.com/ofek/hatch-vcs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/development/python-modules/platformdirs/default.nix
+++ b/pkgs/development/python-modules/platformdirs/default.nix
@@ -1,32 +1,29 @@
 { lib
 , appdirs
 , buildPythonPackage
-, fetchFromGitHub
-, platformdirs
+, fetchPypi
 , pytest-mock
 , pytestCheckHook
 , pythonOlder
-, setuptools-scm
+, hatchling
+, hatch-vcs
 }:
 
 buildPythonPackage rec {
   pname = "platformdirs";
-  version = "2.5.1";
-  format = "setuptools";
+  version = "2.5.2";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-z6WIwTWLlc/chNRxt3dqqa/IxYj1BBTcQ6OcfliHrvA=";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-WMirsH3LRB5u5LEdjfCshWA4+USrmLe+ayeyo8f+7xk=";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   nativeBuildInputs = [
-    setuptools-scm
+    hatchling
+    hatch-vcs
   ];
 
   checkInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3747,6 +3747,8 @@ in {
 
   hatchling = callPackage ../development/python-modules/hatchling { };
 
+  hatch-vcs = callPackage ../development/python-modules/hatch-vcs { };
+
   haversine = callPackage ../development/python-modules/haversine { };
 
   hawkauthlib = callPackage ../development/python-modules/hawkauthlib { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump `platformdirs` from 2.5.1 to 2.5.2, add necessary new build dependency `hatch-vcs` to `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
