### PR TITLE
webcamoid: 8.8.0 -> 9.0.0

### DIFF
--- a/pkgs/applications/video/webcamoid/default.nix
+++ b/pkgs/applications/video/webcamoid/default.nix
@@ -1,13 +1,13 @@
-{ lib, fetchFromGitHub, pkg-config, libxcb, mkDerivation, qmake
+{ lib, fetchFromGitHub, pkg-config, libxcb, mkDerivation, cmake
 , qtbase, qtdeclarative, qtquickcontrols, qtquickcontrols2
 , ffmpeg-full, gst_all_1, libpulseaudio, alsa-lib, jack2
 , v4l-utils }:
 mkDerivation rec {
   pname = "webcamoid";
-  version = "8.8.0";
+  version = "9.0.0";
 
   src = fetchFromGitHub {
-    sha256 = "0a8M9GQ6Ea9jBCyfbORVyB6HC/O6jdcIZruQZj9Aai4=";
+    sha256 = "sha256-NV1BmG+fgy+ZcvHl+05VX5J1BAz8PxKiZ3z9BxjhMU0=";
     rev = version;
     repo = "webcamoid";
     owner = "webcamoid";
@@ -22,12 +22,7 @@ mkDerivation rec {
     v4l-utils
   ];
 
-  nativeBuildInputs = [ pkg-config qmake ];
-
-  qmakeFlags = [
-    "Webcamoid.pro"
-    "INSTALLQMLDIR=${placeholder "out"}/lib/qt/qml"
-  ];
+  nativeBuildInputs = [ pkg-config cmake ];
 
   meta = with lib; {
     description = "Webcam Capture Software";


### PR DESCRIPTION
###### Description of changes

Update Webcamoid (this fixes its build)

Will self-merge after CI

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
