### PR TITLE
python3Packages.flask-appbuilder: 3.4.4 -> 4.0.0

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "3.4.4";
+  version = "4.0.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -35,14 +35,10 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "Flask-AppBuilder";
     inherit version;
-    sha256 = "sha256-uZzuvNusqMzAS/vmg3CuZ+D442J4LbFwsBboVIx/srE=";
+    hash = "sha256-g+iHUL83PokXPGu7HJ8ffLocQr0uGpMqS5MbfIlZZ2E=";
   };
 
-  # See here: https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch
-  #           https://github.com/dpgaspar/Flask-AppBuilder/pull/1610
-  # The patch from the PR doesn't apply cleanly so I edited it manually.
   patches = [
-    ./upgrade-to-flask_jwt_extended-4.patch
     (fetchpatch {
       # https://github.com/dpgaspar/Flask-AppBuilder/pull/1734
       name = "flask-appbuilder-wtf3.patch";
@@ -82,16 +78,11 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "apispec[yaml]>=3.3, <4" "apispec[yaml] >=3.3" \
-      --replace "Flask>=0.12, <2" "Flask" \
-      --replace "Flask-Login>=0.3, <0.5" "Flask-Login >=0.3, <0.6" \
-      --replace "Flask-Babel>=1, <2" "Flask-Babel >=1, <3" \
+      --replace "Flask-Login>=0.3, <0.5" "Flask-Login >=0.3" \
       --replace "Flask-WTF>=0.14.2, <0.15.0" "Flask-WTF" \
       --replace "WTForms<3.0.0" "WTForms" \
       --replace "marshmallow-sqlalchemy>=0.22.0, <0.27.0" "marshmallow-sqlalchemy" \
-      --replace "Flask-JWT-Extended>=3.18, <4" "Flask-JWT-Extended>=4.1.0" \
-      --replace "PyJWT>=1.7.1, <2.0.0" "PyJWT>=2.0.1" \
-      --replace "prison>=0.2.1, <1.0.0" "prison" \
-      --replace "SQLAlchemy<1.4.0" "SQLAlchemy"
+      --replace "prison>=0.2.1, <1.0.0" "prison"
   '';
 
   # Majority of tests require network access or mongo


### PR DESCRIPTION
###### Description of changes
https://github.com/dpgaspar/Flask-AppBuilder/releases/tag/v4.0.0


FIx build (https://hydra.nixos.org/build/174136814)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
