### PR TITLE
eltclsh: init at 1.18

### DIFF
--- a/pkgs/development/tools/eltclsh/default.nix
+++ b/pkgs/development/tools/eltclsh/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchgit
+, automake
+, autoconf
+, libtool
+, libedit
+, tcl
+, tk
+}:
+
+tcl.mkTclDerivation rec {
+  pname = "eltclsh";
+  version = "1.18";
+
+  src = fetchgit {
+    url = "https://git.openrobots.org/robots/eltclsh.git";
+    rev = "eltclsh-${version}";
+    hash = "sha256-C996BJxEoCSpA0x/nSnz4nnmleTIWyzm0imZp/K+Q/o=";
+  };
+
+  nativeBuildInputs = [
+    automake
+    autoconf
+    libtool
+  ];
+  buildInputs = [
+    libedit
+    tk
+  ];
+
+  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
+
+  configureFlags = [
+    "--enable-tclshrl"
+    "--enable-wishrl"
+    "--with-tk=${tk}/lib"
+    "--with-includes=${libedit.dev}/include/readline"
+    "--with-libtool=${libtool}"
+  ];
+
+  meta = with lib; {
+    description = "Interactive shell for the TCL programming language based on editline";
+    homepage = "https://homepages.laas.fr/mallet/soft/shell/eltclsh";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ iwanb ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15540,6 +15540,8 @@ with pkgs;
 
   tclreadline = callPackage ../development/interpreters/tclreadline { };
 
+  eltclsh = callPackage ../development/tools/eltclsh { };
+
   trealla = callPackage ../development/interpreters/trealla { };
 
   wapm-cli = callPackage ../tools/package-management/wapm/cli {


### PR DESCRIPTION
###### Description of changes

Added eltclsh, a REPL for Tcl based on editline, similar to tclreadline.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
