### PR TITLE
python3Packages.glad: init 0.1.36

### DIFF
--- a/pkgs/development/python-modules/glad/default.nix
+++ b/pkgs/development/python-modules/glad/default.nix
@@ -1,0 +1,18 @@
+{ buildPythonPackage, fetchPypi, lib }:
+
+buildPythonPackage rec {
+  pname = "glad";
+  version = "0.1.36";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-P7ANv+x65t2+ugTiFUf2fzzPx5X8NFYkUM8/K7Gf28c=";
+  };
+
+  meta = with lib; {
+    description = "Multi-Language Vulkan/GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs";
+    homepage = "https://github.com/Dav1dde/glad";
+    license = licenses.mit;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3375,6 +3375,8 @@ in {
 
   git-sweep = callPackage ../development/python-modules/git-sweep { };
 
+  glad =  callPackage ../development/python-modules/glad { };
+
   glances-api = callPackage ../development/python-modules/glances-api { };
 
   glasgow = callPackage ../development/python-modules/glasgow { };


### PR DESCRIPTION
python3Packages.glad: init 0.1.36

To test generator, try: `glad --generator c --out-path someFolder`

Running `glad` will trigger a network request, works locally when connection is available.