### PR TITLE
Remove ktosiek from the maintainers list

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6834,12 +6834,6 @@
     githubId = 99639;
     name = "Pawel Kruszewski";
   };
-  ktosiek = {
-    email = "tomasz.kontusz@gmail.com";
-    github = "ktosiek";
-    githubId = 278013;
-    name = "Tomasz Kontusz";
-  };
   kubukoz = {
     email = "kubukoz@gmail.com";
     github = "kubukoz";

--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -89,6 +89,5 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://wiki.gnome.org/Apps/DFeet";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ktosiek ];
   };
 }

--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -89,5 +89,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://wiki.gnome.org/Apps/DFeet";
     platforms = platforms.linux;
     license = licenses.gpl2;
+    maintainers = teams.gnome.members;
   };
 }

--- a/pkgs/tools/networking/sstp/default.nix
+++ b/pkgs/tools/networking/sstp/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     description = "SSTP client for Linux";
     homepage = "http://sstp-client.sourceforge.net/";
     platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
     license = licenses.gpl2Plus;
   };
 }

--- a/pkgs/tools/networking/sstp/default.nix
+++ b/pkgs/tools/networking/sstp/default.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
     description = "SSTP client for Linux";
     homepage = "http://sstp-client.sourceforge.net/";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ktosiek ];
     license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
###### Description of changes

Removing myself from maintainers. I haven't used nixpkgs in a while, and I'm not maintaining d-feet or sstpc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
