### PR TITLE
hyprland: init at 0.6.0beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13682,6 +13682,12 @@
     githubId = 28888242;
     name = "WORLDofPEACE";
   };
+  wozeparrot = {
+    email = "wozeparrot@gmail.com";
+    github = "wozeparrot";
+    githubId = 25372613;
+    name = "Woze Parrot";
+  };
   wr0belj = {
     name = "Jakub Wróbel";
     email = "wrobel.jakub@protonmail.com";

--- a/pkgs/applications/window-managers/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprland/default.nix
@@ -18,14 +18,14 @@
 
 stdenv.mkDerivation rec {
   pname = "hyprland";
-  version = "0.6.0beta";
+  version = "0.6.1beta";
 
   # When updating Hyprland, the overridden wlroots commit must be bumped to match the commit upstream uses.
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-SHElAr8ZnLirEX8qd4vRyNaorUMi0lAEn/v5+GIlA5c=";
+    sha256 = "sha256-0Msqe2ErAJvnO1zHoB2k6TkDhTYnHRGkvJrfSG12dTU=";
   };
 
   nativeBuildInputs = [
@@ -50,7 +50,9 @@ stdenv.mkDerivation rec {
   # build with system wlroots
   postPatch = ''
     sed -Ei 's/"\.\.\/wlroots\/include\/([a-zA-Z0-9./_-]+)"/<\1>/g' src/includes.hpp
+  '';
 
+  preConfigure = ''
     make protocols
   '';
 

--- a/pkgs/applications/window-managers/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprland/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   pname = "hyprland";
   version = "0.6.0beta";
 
+  # When updating Hyprland, the overridden wlroots commit must be bumped to match the commit upstream uses.
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = pname;

--- a/pkgs/applications/window-managers/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprland/default.nix
@@ -47,12 +47,10 @@ stdenv.mkDerivation rec {
     xcbutilwm
   ];
 
-  # patch includes to build using nix supplied header files instead of the submodule header files
-  prePatch = ''
-    sed -Ei 's/"\.\.\/wlroots\/include\/([a-zA-Z0-9./_-]+)"/<\1>/g' src/includes.hpp
-  '';
-
+  # build with system wlroots
   postPatch = ''
+    sed -Ei 's/"\.\.\/wlroots\/include\/([a-zA-Z0-9./_-]+)"/<\1>/g' src/includes.hpp
+
     make protocols
   '';
 

--- a/pkgs/applications/window-managers/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprland/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libdrm
+, libinput
+, libxcb
+, libxkbcommon
+, mesa
+, pango
+, wayland
+, wayland-protocols
+, wayland-scanner
+, wlroots
+, xcbutilwm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hyprland";
+  version = "0.6.0beta";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-SHElAr8ZnLirEX8qd4vRyNaorUMi0lAEn/v5+GIlA5c=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    libdrm
+    libinput
+    libxcb
+    libxkbcommon
+    mesa
+    pango
+    wayland
+    wayland-protocols
+    wlroots
+    xcbutilwm
+  ];
+
+  # patch includes to build using nix supplied header files instead of the submodule header files
+  prePatch = ''
+    sed -Ei 's/"\.\.\/wlroots\/include\/([a-zA-Z0-9./_-]+)"/<\1>/g' src/includes.hpp
+  '';
+
+  postPatch = ''
+    make protocols
+  '';
+
+  postBuild = ''
+    pushd ../hyprctl
+    $CXX -std=c++20 -w ./main.cpp -o ./hyprctl
+    popd
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 ./Hyprland $out/bin
+    install -m755 ../hyprctl/hyprctl $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/vaxerski/Hyprland";
+    description = "A dynamic tiling Wayland compositor that doesn't sacrifice on its looks";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wozeparrot ];
+    mainProgram = "Hyprland";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3730,6 +3730,19 @@ with pkgs;
 
   humioctl = callPackage ../applications/logging/humioctl {};
 
+  hyprland = callPackage ../applications/window-managers/hyprland {
+    wlroots = wlroots.overrideAttrs (_: {
+      version = "unstable-2022-06-07";
+      src = fetchFromGitLab {
+        domain = "gitlab.freedesktop.org";
+        owner = "wlroots";
+        repo = "wlroots";
+        rev = "b89ed9015c3fbe8d339e9d65cf70fdca6e5645bc";
+        sha256 = "sha256-8y3u8CoigjoZOVbA2wCWBHlDNEakv0AVxU46/cOC00s=";
+      };
+    });
+  };
+
   hyx = callPackage ../tools/text/hyx { };
 
   icdiff = callPackage ../tools/text/icdiff {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [hyprland](https://github.com/vaxerski/Hyprland): A dynamic tiling Wayland compositor that doesn't sacrifice on its looks.
Since hyprland also requires wlroots-git to build, I also packaged wlroots-git.

Closes: #168392

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
