### PR TITLE
muon: init at unstable-2022-09-24

### DIFF
--- a/pkgs/development/tools/build-managers/muon/default.nix
+++ b/pkgs/development/tools/build-managers/muon/default.nix
@@ -1,0 +1,138 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, fetchurl
+, curl
+, libarchive
+, libpkgconf
+, pkgconf
+, python3
+, samurai
+, scdoc
+, zlib
+, embedSamurai ? false
+, buildDocs ? true
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "muon"
+          + lib.optionalString embedSamurai "-embedded-samurai";
+  version = "unstable-2022-09-24";
+
+  src = fetchFromSourcehut {
+    name = "muon-src";
+    owner = "~lattis";
+    repo = "muon";
+    rev = "f385c82a6104ea3341ca34756e2812d700bc43d8";
+    hash = "sha256-Cr1r/sp6iVotU+n4bTzQiQl8Y+ShaqnnaWjL6gRW8p0=";
+  };
+
+  nativeBuildInputs = [
+    pkgconf
+    samurai
+  ]
+  ++ lib.optionals buildDocs [
+    (python3.withPackages (ps: [ ps.pyyaml ]))
+    scdoc
+  ];
+
+  buildInputs = [
+    curl
+    libarchive
+    libpkgconf
+    samurai
+    zlib
+  ];
+
+  strictDeps = true;
+
+  postUnpack = let
+    # URLs manually extracted from subprojects directory
+    meson-docs-wrap = fetchurl {
+      name = "meson-docs-wrap";
+      url = "https://mochiro.moe/wrap/meson-docs-0.63.0-116-g8a45c81cf.tar.gz";
+      hash = "sha256-fsXdhfBEXvw1mvqnPp2TgZnO5FaeHTNW3Nfd5qfTfxg=";
+    };
+
+    samurai-wrap = fetchurl {
+      name = "samurai-wrap";
+      url = "https://mochiro.moe/wrap/samurai-1.2-28-g4e3a595.tar.gz";
+      hash = "sha256-TZAEwndVgoWr/zhykfr0wcz9wM96yG44GfzM5p9TpBo=";
+  };
+  in ''
+    pushd $sourceRoot/subprojects
+    ${lib.optionalString buildDocs "tar xvf ${meson-docs-wrap}"}
+    ${lib.optionalString embedSamurai "tar xvf ${samurai-wrap}"}
+    popd
+  '';
+
+  postPatch = ''
+    patchShebangs bootstrap.sh
+  ''
+  + lib.optionalString buildDocs ''
+    patchShebangs subprojects/meson-docs/docs/genrefman.py
+  '';
+
+  # tests try to access "~"
+  postConfigure = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  buildPhase = let
+    featureFlag = feature: flag:
+      "-D${feature}=${if flag then "enabled" else "disabled"}";
+    conditionFlag = condition: flag:
+      "-D${condition}=${lib.boolToString flag}";
+    cmdlineForMuon = lib.concatStringsSep " " [
+      (conditionFlag "static" stdenv.targetPlatform.isStatic)
+      (featureFlag "docs" buildDocs)
+      (featureFlag "samurai" embedSamurai)
+    ];
+    cmdlineForSamu = "-j$NIX_BUILD_CORES";
+  in ''
+    runHook preBuild
+
+    ./bootstrap.sh stage-1
+
+    ./stage-1/muon setup ${cmdlineForMuon} stage-2
+    samu ${cmdlineForSamu} -C stage-2
+
+    stage-2/muon setup -Dprefix=$out ${cmdlineForMuon} stage-3
+    samu ${cmdlineForSamu} -C stage-3
+
+    runHook postBuild
+  '';
+
+  # tests are failing because they don't find Python
+  doCheck = false;
+
+  checkPhase = ''
+    runHook preCheck
+
+    ./stage-3/muon -C stage-3 test
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    stage-3/muon -C stage-3 install
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://muon.build/";
+    description = "An implementation of Meson build system in C99";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin; # typical `ar failure`
+  };
+})
+# TODO LIST:
+# 1. setup hook
+# 2. multiple outputs
+# 3. automate sources acquisition (especially wraps)
+# 4. tests

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17200,6 +17200,12 @@ with pkgs;
 
   samurai = callPackage ../development/tools/build-managers/samurai { };
 
+  muon = callPackage ../development/tools/build-managers/muon { };
+  muonStandalone = muon.override {
+    embedSamurai = true;
+    buildDocs = false;
+  };
+
   saleae-logic = callPackage ../development/tools/misc/saleae-logic { };
 
   saleae-logic-2 = callPackage ../development/tools/misc/saleae-logic-2 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
