### PR TITLE
vigra: fix build in enblend-enfuse-4.2

### DIFF
--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , fetchurl
+, fetchpatch
 , boost
 , cmake
 , fftw
@@ -31,13 +32,21 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR";
 
-  # Fixes compilation with clang (on darwin) see https://github.com/ukoethe/vigra/issues/414
-  patches =
-    let clangPatch = fetchurl {
+
+  patches = [
+    # Fixes compilation with clang (on darwin) see https://github.com/ukoethe/vigra/issues/414
+    (fetchpatch {
+      name = "clangPatch";
       url = "https://github.com/ukoethe/vigra/commit/81958d302494e137f98a8b1d7869841532f90388.patch";
-      sha256 = "1i1w6smijgb5z8bg9jaq84ccy00k2sxm87s37lgjpyix901gjlgi";
-    };
-    in [ clangPatch ];
+      hash = "sha256-UtV7cO5lMU1W7viMdcgMocHt7UWobqtA4+ivHztm8bs=";
+    })
+    #Fixes error: C++17 does not allow dynamic exception specifications
+    (fetchpatch {
+      name = "dynamicException";
+      url = "https://github.com/ukoethe/vigra/commit/dc730be49fc8def4304a651fa525e43b7754955e.patch";
+      hash = "sha256-2MFzqQCrdxWiINs4UzwSIVbfcmChawaBOJebtAW8MRA=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

Enblend-enfuse  fails to build (since the staging-next merge 95af2245a32f8e1310ad4e3bf50b76d86ddbbc0a from #168737 )  due to a C++17 deprecated method in vigra. 

Vigra still builds without issues on its own. Just when building enblend-enfuse the error gets thrown from the vigra directory. 

<details><summary>Build log</summary>

```
unpacking sources
unpacking source archive /nix/store/r6b21cj2jfcjrccp47cqdj1c2sc3kcn2-enblend-enfuse-4.2.tar.gz
source root is enblend-enfuse-4.2
setting SOURCE_DATE_EPOCH to timestamp 1459238319 of file enblend-enfuse-4.2/src/enfuse.1
patching sources
configuring
patching script interpreter paths in src/embrace
src/embrace: interpreter directive changed from "#! /usr/bin/env perl" to "/nix/store/xvacdngzsxn6hwnymncs8iv752aal4j0-perl-5.34.1/bin/perl"
configure flags: --disable-dependency-tracking --prefix=/nix/store/l407lgqsdmxalwypkddqhdqrwp9mmbi0-enblend-enfuse-4.2
checking for a BSD-compatible install... /nix/store/hgl0ydlkgs6y6hx9h7k209shw3v7z77j-coreutils-9.0/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /nix/store/hgl0ydlkgs6y6hx9h7k209shw3v7z77j-coreutils-9.0/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports nested variables... (cached) yes
checking whether the C++ compiler works... yes
checking for C++ compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking for style of include used by make... GNU
checking dependency style of g++... none
checking whether g++ supports C++11 features by default... yes
checking whether the compiler supports as_const()... yes
checking for gcc... gcc
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... none
checking for ar... ar
checking the archiver (ar) interface... ar
checking for grep that handles long lines and -e... /nix/store/bqkx3pi50phcglv0l551jhp96bq8njl0-gnugrep-3.7/bin/grep
checking for egrep... /nix/store/bqkx3pi50phcglv0l551jhp96bq8njl0-gnugrep-3.7/bin/grep -E
checking for grep that handles long lines and -e... (cached) /nix/store/bqkx3pi50phcglv0l551jhp96bq8njl0-gnugrep-3.7/bin/grep
checking for ranlib... ranlib
checking for a sed that does not truncate output... /nix/store/1442kn5q9ah0bhhqm99f8nr76diczqgm-gnused-4.8/bin/sed
checking how to run the C++ preprocessor... g++ -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking whether byte ordering is bigendian... no
checking if on-demand dynamic linking is desired... check
checking for on-demand dynamic linking... yes
checking gperftools/tcmalloc.h usability... no
checking gperftools/tcmalloc.h presence... no
checking for gperftools/tcmalloc.h... no
checking tcmalloc.h usability... no
checking tcmalloc.h presence... no
checking for tcmalloc.h... no
checking for sqrt in -lm... yes
checking for cblas_dgemm in -lgslcblas... yes
checking for gsl_blas_dgemm in -lgsl... yes
checking for gzopen in -lz... yes
checking for jpeg_finish_compress in -ljpeg... yes
checking for png_init_io in -lpng... yes
checking for TIFFOpen in -ltiff... yes
checking for cmsCreateTransform in -llcms2... yes
checking if OpenEXR is wanted... checking pkg-config is at least version 0.9.0... yes
yes
checking for OPENEXR... no
configure: WARNING: "OpenEXR support disabled: " No package 'OpenEXR' found
checking for Vigra import/export-library... yes
yes
checking if malloc debugging is wanted... no
checking dlfcn.h usability... yes
checking dlfcn.h presence... yes
checking for dlfcn.h... yes
checking for library containing dlopen... none required
checking for dirent.h that defines DIR... yes
checking for library containing opendir... none required
checking for ANSI C header files... (cached) yes
checking fenv.h usability... yes
checking fenv.h presence... yes
checking for fenv.h... yes
checking limits.h usability... yes
checking limits.h presence... yes
checking for limits.h... yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking for unistd.h... (cached) yes
checking sys/times.h usability... yes
checking sys/times.h presence... yes
checking for sys/times.h... yes
checking tiffio.h usability... yes
checking tiffio.h presence... yes
checking for tiffio.h... yes
checking jpeglib.h usability... yes
checking jpeglib.h presence... yes
checking for jpeglib.h... yes
checking png.h usability... yes
checking png.h presence... yes
checking for png.h... yes
checking vigra/basicimage.hxx usability... yes
checking vigra/basicimage.hxx presence... yes
checking for vigra/basicimage.hxx... yes
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking for boostlib >= 1.55... yes
checking boost/optional.hpp usability... yes
checking boost/optional.hpp presence... yes
checking for boost/optional.hpp... yes
checking gsl/gsl_errno.h usability... yes
checking gsl/gsl_errno.h presence... yes
checking for gsl/gsl_errno.h... yes
checking gsl/gsl_min.h usability... yes
checking gsl/gsl_min.h presence... yes
checking for gsl/gsl_min.h... yes
checking gsl/gsl_multimin.h usability... yes
checking gsl/gsl_multimin.h presence... yes
checking for gsl/gsl_multimin.h... yes
checking gsl/gsl_rng.h usability... yes
checking gsl/gsl_rng.h presence... yes
checking for gsl/gsl_rng.h... yes
checking gsl/gsl_vector.h usability... yes
checking gsl/gsl_vector.h presence... yes
checking for gsl/gsl_vector.h... yes
checking lcms2.h usability... yes
checking lcms2.h presence... yes
checking for lcms2.h... yes
checking for stdbool.h that conforms to C99... no
checking for _Bool... no
checking for an ANSI C-conforming const... yes
checking for inline... inline
checking for C/C++ restrict keyword... __restrict
checking for off_t... yes
checking for sig_atomic_t... yes
checking for size_t... yes
checking for ptrdiff_t... yes
checking whether closedir returns void... no
checking for error_at_line... yes
checking for _LARGEFILE_SOURCE value needed for large files... no
checking whether strerror_r is declared... yes
checking for strerror_r... yes
checking whether strerror_r returns char *... yes
checking for working strtod... yes
checking for atexit... yes
checking for clock_gettime... yes
checking for fesetround... yes
checking for floor... yes
checking for memset... yes
checking for mkstemp... yes
checking for select... yes
checking for pow... yes
checking for sqrt... yes
checking for sqrt... (cached) yes
checking for strchr... yes
checking for strcspn... yes
checking for strdup... yes
checking for strerror... yes
checking for strpbrk... yes
checking for strrchr... yes
checking for strtok_r... yes
checking for strtol... yes
checking for strtoul... yes
checking for lrint... yes
checking for lrintf... yes
checking for BOOST_FALLTHROUGH... no
checking for perl... /nix/store/xvacdngzsxn6hwnymncs8iv752aal4j0-perl-5.34.1/bin/perl
checking for perl module Sys::Hostname... ok
checking for perl module Time::Zone... no
configure: WARNING: missing Perl module Time::Zone
checking for latex... /nix/store/9ar47sq3vk3254z003hamnxbb0py45nz-texlive-combined-small-2021-final/bin/latex
checking for pdflatex... /nix/store/9ar47sq3vk3254z003hamnxbb0py45nz-texlive-combined-small-2021-final/bin/pdflatex
checking for latex... latex
checking for class report... yes
checking for class refrep... 
checking for amsmath in class report... yes
checking for bold-extra in class report... no
configure: WARNING: missing LaTeX package bold-extra
checking for color in class report... yes
checking for enumitem in class report... no
configure: WARNING: missing LaTeX package enumitem
checking for float in class report... yes
checking for footnote in class report... yes
checking for graphicx in class report... yes
checking for hyperref in class report... yes
checking for hyphenat in class report... no
configure: WARNING: missing LaTeX package hyphenat
checking for ifpdf in class report... yes
checking for index in class report... yes
checking for latexsym in class report... yes
checking for listings in class report... yes
checking for microtype in class report... yes
checking for ragged2e in class report... yes
checking for shorttoc in class report... no
configure: WARNING: missing LaTeX package shorttoc
checking for suffix in class report... no
configure: WARNING: missing LaTeX package suffix
checking for url in class report... yes
checking for xstring in class report... no
configure: WARNING: missing LaTeX package xstring
checking for perl module File::Basename... ok
checking for perl module FindBin... ok
checking for perl module Getopt::Long... ok
checking for perl module IO::File... ok
checking for perl module IO::Handle... ok
checking for perl module Readonly... no
configure: WARNING: missing Perl module Readonly
checking for texloganalyser... cat
configure: WARNING: cannot find texloganalyser; will substitute cat(1)
checking for makeindex... /nix/store/9ar47sq3vk3254z003hamnxbb0py45nz-texlive-combined-small-2021-final/bin/makeindex
checking for dvips... /nix/store/9ar47sq3vk3254z003hamnxbb0py45nz-texlive-combined-small-2021-final/bin/dvips
checking for convert... false
configure: WARNING: cannot find convert; will not be able to build documentation
checking whether hevea executable path has been provided... no
checking for hevea... false
configure: WARNING: cannot find LaTeX to HTML translator; will not be able to build HTML documentation
checking for hacha... false
configure: WARNING: cannot find hacha; will not be able to split HTML documentation on request
checking for gnuplot... false
configure: WARNING: cannot find gnuplot; will not be able to build documentation
checking for m4... false
configure: WARNING: cannot find m4; will not be able to build documentation
checking for dot... false
configure: WARNING: cannot find dot; will not be able to build documentation
checking for rsvg-convert... false
configure: WARNING: cannot find rsvg-convert; will not be able to build documentation
checking for ps2pdf... no
checking for ps2pdf14... no
checking for dvipdfmx... /nix/store/9ar47sq3vk3254z003hamnxbb0py45nz-texlive-combined-small-2021-final/bin/dvipdfmx
checking whether to enable debugging... no
checking whether to enable image cache... no
checking whether to compile with OpenMP... no
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating doc/Makefile
config.status: creating doc/examples/Makefile
config.status: creating doc/examples/enfuse/Makefile
config.status: creating doc/examples/enfuse/Makefile.userweight
config.status: creating Makefile
config.status: creating src/Makefile
config.status: creating src/dynamic_loader/Makefile
config.status: creating src/layer_selection/Makefile
config.status: creating src/win32helpers/Makefile
config.status: creating config.h
config.status: executing depfiles commands

 enblend-enfuse now configured for x86_64-unknown-linux-gnu
   Source directory:               .
   Installation directory:         /nix/store/l407lgqsdmxalwypkddqhdqrwp9mmbi0-enblend-enfuse-4.2
   C++ compiler:                   g++
   CFLAGS:                          -g -O2
   CXXFLAGS:                        -g -O2 -O2 -DNDEBUG
   LDFLAGS:                        -Wl,--as-needed -Wl,--no-copy-dt-needed-entries 
   LIBS:                           -lvigraimpex  -llcms2 -ltiff -lpng -ljpeg -lz -lgsl -lgslcblas -lm 
   EXTRA_LIBS (optional):          <none selected>

 can build all documentation:      no, because of missing bold-extra.sty enumitem.sty hyphenat.sty shorttoc.sty suffix.sty xstring.sty Readonly texloganalyser convert hevea gnuplot m4 dot rsvg-convert

 feature selection:
   enable debugging support:       no
   enable malloc debugging:        no
   enable dynamic loading          yes (via dl)
   OpenEXR image format            no
   use image cache:                no
   use OpenMP:                     no
   use TCMalloc:                   no

building
build flags: -j24 -l24 SHELL=/nix/store/fcd0m68c331j7nkdxvnnpb8ggwsaiqac-bash-5.1-p16/bin/bash
make  all-recursive
make[1]: Entering directory '/build/enblend-enfuse-4.2'
Making all in src
make[2]: Entering directory '/build/enblend-enfuse-4.2/src'
./embrace --format=c++ --label=distance_transform_fh_source_code distance_transform_fh.cl > distance_transform_fh.icl
./embrace --format=c++ --label=calculate_state_probabilities_source_code calculate_state_probabilities.cl > calculate_state_probabilities.icl
make  all-recursive
make[3]: Entering directory '/build/enblend-enfuse-4.2/src'
Making all in dynamic_loader
make[4]: Entering directory '/build/enblend-enfuse-4.2/src/dynamic_loader'
g++ -DHAVE_CONFIG_H -I. -I../..     -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I../../include -I../../src -I../../src/dynamic_loader -g -O2 -O2 -DNDEBUG -c -o libdynamic_loader_a-dynamic_loader.o `test -f 'dynamic_loader.cc' || echo './'`dynamic_loader.cc
g++ -DHAVE_CONFIG_H -I. -I../..     -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I../../include -I../../src -I../../src/dynamic_loader -g -O2 -O2 -DNDEBUG -c -o libdynamic_loader_a-posix_implementation.o `test -f 'posix_implementation.cc' || echo './'`posix_implementation.cc
g++ -DHAVE_CONFIG_H -I. -I../..     -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I../../include -I../../src -I../../src/dynamic_loader -g -O2 -O2 -DNDEBUG -c -o libdynamic_loader_a-dynamic_loader_implementation.o `test -f 'dynamic_loader_implementation.cc' || echo './'`dynamic_loader_implementation.cc
rm -f libdynamic_loader.a
ar cru libdynamic_loader.a libdynamic_loader_a-dynamic_loader.o libdynamic_loader_a-dynamic_loader_implementation.o libdynamic_loader_a-posix_implementation.o
ar: `u' modifier ignored since `D' is the default (see `U')
ranlib libdynamic_loader.a
make[4]: Leaving directory '/build/enblend-enfuse-4.2/src/dynamic_loader'
Making all in layer_selection
make[4]: Entering directory '/build/enblend-enfuse-4.2/src/layer_selection'
g++ -DHAVE_CONFIG_H -I. -I../..     -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I../../include -I../../src -I../../src/layer_selection -g -O2 -O2 -DNDEBUG -c -o liblayersel_a-info.o `test -f 'info.cc' || echo './'`info.cc
g++ -DHAVE_CONFIG_H -I. -I../..     -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I../../include -I../../src -I../../src/layer_selection -g -O2 -O2 -DNDEBUG -c -o liblayersel_a-selector.o `test -f 'selector.cc' || echo './'`selector.cc
In file included from selector.cc:30:
../../config.h:8: warning: "BOOST_FALLTHROUGH" redefined
    8 | #define BOOST_FALLTHROUGH ((void) 0)
      | 
In file included from include/boost/config.hpp:39,
                 from include/boost/static_assert.hpp:17,
                 from include/boost/iterator/iterator_adaptor.hpp:10,
                 from include/boost/token_iterator.hpp:22,
                 from include/boost/tokenizer.hpp:20,
                 from selector.cc:27:
include/boost/config/compiler/gcc.hpp:309: note: this is the location of the previous definition
g++ -DHAVE_CONFIG_H -I. -I../..     -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I../../include -I../../src -I../../src/layer_selection -g -O2 -O2 -DNDEBUG -c -o liblayersel_a-layer_selection.o `test -f 'layer_selection.cc' || echo './'`layer_selection.cc
rm -f liblayersel.a
ar cru liblayersel.a liblayersel_a-info.o liblayersel_a-layer_selection.o liblayersel_a-selector.o 
ar: `u' modifier ignored since `D' is the default (see `U')
ranlib liblayersel.a
make[4]: Leaving directory '/build/enblend-enfuse-4.2/src/layer_selection'
Making all in win32helpers
make[4]: Entering directory '/build/enblend-enfuse-4.2/src/win32helpers'
make[4]: Nothing to be done for 'all'.
make[4]: Leaving directory '/build/enblend-enfuse-4.2/src/win32helpers'
make[4]: Entering directory '/build/enblend-enfuse-4.2/src'
g++ -DHAVE_CONFIG_H -I. -I..    -DENBLEND_SOURCE   -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I../src/dynamic_loader -I../src/layer_selection -g -O2 -O2 -DNDEBUG -c -o enblend-enblend.o `test -f 'enblend.cc' || echo './'`enblend.cc
In file included from alternativepercentage.h:25,
                 from enblend.cc:78:
../config.h:8: warning: "BOOST_FALLTHROUGH" redefined
    8 | #define BOOST_FALLTHROUGH ((void) 0)
      | 
In file included from include/boost/config.hpp:39,
                 from include/boost/static_assert.hpp:17,
                 from include/boost/iterator/iterator_adaptor.hpp:10,
                 from include/boost/token_iterator.hpp:22,
                 from include/boost/tokenizer.hpp:20,
                 from enblend.cc:71:
include/boost/config/compiler/gcc.hpp:309: note: this is the location of the previous definition
In file included from /nix/store/7py54yf73dwqf3q7d7adrbwkwx2xjm74-vigra-1.11.1/include/vigra/stdconvolution.hxx:43,
                 from /nix/store/7py54yf73dwqf3q7d7adrbwkwx2xjm74-vigra-1.11.1/include/vigra/convolution.hxx:41,
                 from openmp_vigra.h:32,
                 from enblend.h:40,
                 from enblend.cc:191:
/nix/store/7py54yf73dwqf3q7d7adrbwkwx2xjm74-vigra-1.11.1/include/vigra/separableconvolution.hxx:1413:13: error: ISO C++17 does not allow dynamic exception specifications
 1413 |             throw(PreconditionViolation)
      |             ^~~~~
In file included from /nix/store/7py54yf73dwqf3q7d7adrbwkwx2xjm74-vigra-1.11.1/include/vigra/convolution.hxx:41,
                 from openmp_vigra.h:32,
                 from enblend.h:40,
                 from enblend.cc:191:
/nix/store/7py54yf73dwqf3q7d7adrbwkwx2xjm74-vigra-1.11.1/include/vigra/stdconvolution.hxx:796:13: error: ISO C++17 does not allow dynamic exception specifications
  796 |             throw(PreconditionViolation)
      |             ^~~~~
make[4]: *** [Makefile:659: enblend-enblend.o] Error 1
make[4]: Leaving directory '/build/enblend-enfuse-4.2/src'
make[3]: *** [Makefile:1096: all-recursive] Error 1
make[3]: Leaving directory '/build/enblend-enfuse-4.2/src'
make[2]: *** [Makefile:520: all] Error 2
make[2]: Leaving directory '/build/enblend-enfuse-4.2/src'
make[1]: *** [Makefile:432: all-recursive] Error 1
make[1]: Leaving directory '/build/enblend-enfuse-4.2'
make: *** [Makefile:372: all] Error 2
```
</details>

The interessting part is:
```
In file included from /nix/store/7py54yf73dwqf3q7d7adrbwkwx2xjm74-vigra-1.11.1/include/vigra/stdconvolution.hxx:43,
                 from /nix/store/7py54yf73dwqf3q7d7adrbwkwx2xjm74-vigra-1.11.1/include/vigra/convolution.hxx:41,
                 from openmp_vigra.h:32,
                 from enblend.h:40,
                 from enblend.cc:191:
```

So, this PR fixes vigra (which didn't have a new upstream release, but had a patch from https://github.com/ukoethe/vigra/issues/426 addressing these deprecated errors.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

