### PR TITLE
assaultcube: 1.2.0.2 -> 1.3.0.2

### DIFF
--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -1,42 +1,67 @@
-{ fetchFromGitHub, lib, stdenv, makeDesktopItem, openal, pkg-config, libogg,
-  libvorbis, SDL, SDL_image, makeWrapper, zlib, file,
-  client ? true, server ? true }:
-
-with lib;
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, openal
+, pkg-config
+, libogg
+, libvorbis
+, SDL2
+, SDL2_image
+, makeWrapper
+, zlib
+, file
+, client ? true, server ? true
+}:
 
 stdenv.mkDerivation rec {
-
-  # master branch has legacy (1.2.0.2) protocol 1201 and gcc 6 fix.
   pname = "assaultcube";
-  version = "unstable-2018-05-20";
+  version = "1.3.0.2";
 
   src = fetchFromGitHub {
     owner = "assaultcube";
     repo  = "AC";
-    rev = "f58ea22b46b5013a520520670434b3c235212371";
-    sha256 = "1vfn3d55vmmipdykrcfvgk6dddi9y95vlclsliirm7jdp20f15hd";
+    rev = "v${version}";
+    sha256 = "0qv339zw9q5q1y7bghca03gw7z4v89sl4lbr6h3b7siy08mcwiz9";
   };
 
-  nativeBuildInputs = [ makeWrapper pkg-config ];
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+    copyDesktopItems
+  ];
 
-  buildInputs = [ file zlib ] ++ optionals client [ openal SDL SDL_image libogg libvorbis ];
+  buildInputs = [
+    file
+    zlib
+  ] ++ lib.optionals client [
+    openal
+    SDL2
+    SDL2_image
+    libogg
+    libvorbis
+  ];
 
-  targets = (optionalString server "server") + (optionalString client " client");
+  targets = (lib.optionalString server "server") + (lib.optionalString client " client");
   makeFlags = [ "-C source/src" "CXX=${stdenv.cc.targetPrefix}c++" targets ];
 
-  desktop = makeDesktopItem {
-    name = "AssaultCube";
-    desktopName = "AssaultCube";
-    comment = "A multiplayer, first-person shooter game, based on the CUBE engine. Fast, arcade gameplay.";
-    genericName = "First-person shooter";
-    categories = [ "Game" "ActionGame" "Shooter" ];
-    icon = "assaultcube.png";
-    exec = pname;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "AssaultCube";
+      comment = "A multiplayer, first-person shooter game, based on the CUBE engine. Fast, arcade gameplay.";
+      genericName = "First-person shooter";
+      categories = [ "Game" "ActionGame" "Shooter" ];
+      icon = "assaultcube";
+      exec = pname;
+    })
+  ];
 
   gamedatadir = "/share/games/${pname}";
 
   installPhase = ''
+    runHook preInstall
 
     bindir=$out/bin
 
@@ -47,7 +72,6 @@ stdenv.mkDerivation rec {
     if (test -e source/src/ac_client) then
       cp source/src/ac_client $bindir
       mkdir -p $out/share/applications
-      cp ${desktop}/share/applications/* $out/share/applications
       install -Dpm644 packages/misc/icon.png $out/share/icons/assaultcube.png
       install -Dpm644 packages/misc/icon.png $out/share/pixmaps/assaultcube.png
 
@@ -60,13 +84,15 @@ stdenv.mkDerivation rec {
       makeWrapper $out/bin/ac_server $out/bin/${pname}-server \
         --chdir "$out/$gamedatadir" --add-flags "-Cconfig/servercmdline.txt"
     fi
-    '';
 
-  meta = {
+    runHook postInstall
+  '';
+
+  meta = with lib; {
     description = "Fast and fun first-person-shooter based on the Cube fps";
     homepage = "https://assault.cubers.net";
-    maintainers = [ ];
     platforms = platforms.linux; # should work on darwin with a little effort.
-    license = lib.licenses.unfree;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ darkonion0 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Update assaultcube from 1.2.0.2 to 1.3.0.2 (the latest version)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
