### PR TITLE
python3Packages.geopandas: fix tests

### DIFF
--- a/pkgs/development/python-modules/geopandas/default.nix
+++ b/pkgs/development/python-modules/geopandas/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch, pythonOlder
 , pandas, shapely, fiona, pyproj
 , pytestCheckHook, Rtree }:
 
@@ -13,6 +13,19 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "14azl3gppqn90k8h4hpjilsivj92k6p1jh7mdr6p4grbww1b7sdq";
   };
+
+  patches = [
+    # Fixes a test, will be included in the next release after 0.10.2
+    (fetchpatch {
+      url = "https://github.com/geopandas/geopandas/pull/2219/commits/ac67515c9df745b672cca1669adf05eaf5cb0f3b.patch";
+      sha256 = "sha256-XcaoFhD6Rq0nfEpMbOJiAWPbaPDrMwFwoyppayq8NHc=";
+    })
+    # 5 commits from post 0.10.2 that fix the test suite compatibility with pandas >=1.4
+    (fetchpatch {
+      url = "https://github.com/geopandas/geopandas/pull/2289.patch";
+      sha256 = "sha256-BcZVdaO/DdpZoVGUWaw9etFvvgwizAgrkaBISEOhV4A=";
+    })
+  ];
 
   propagatedBuildInputs = [
     pandas


### PR DESCRIPTION
###### Description of changes
This package is failing to build on master. (https://hydra.nixos.org/build/174558912). I fixed the tests by pulling in two patches from upstream.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
