### PR TITLE
GCC11 Fixes

### DIFF
--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchurl
 , boost
 , cmake
 , fftw
@@ -20,24 +19,16 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vigra";
-  version = "1.11.1";
+  version = "unstable-2022-01-11";
 
   src = fetchFromGitHub {
     owner = "ukoethe";
     repo = "vigra";
-    rev = "Version-${lib.replaceChars ["."] ["-"] version}";
-    sha256 = "sha256-tD6tdoT4mWBtzkn4Xv3nNIkBQmeqNqzI1AVxUbP76Mk=";
+    rev = "093d57d15c8c237adf1704d96daa6393158ce299";
+    sha256 = "sha256-pFANoT00Wkh1/Dyd2x75IVTfyaoVA7S86tafUSr29Og=";
   };
 
   NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR";
-
-  # Fixes compilation with clang (on darwin) see https://github.com/ukoethe/vigra/issues/414
-  patches =
-    let clangPatch = fetchurl {
-      url = "https://github.com/ukoethe/vigra/commit/81958d302494e137f98a8b1d7869841532f90388.patch";
-      sha256 = "1i1w6smijgb5z8bg9jaq84ccy00k2sxm87s37lgjpyix901gjlgi";
-    };
-    in [ clangPatch ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -58,9 +49,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DWITH_OPENEXR=1" ]
     ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux")
     [ "-DCMAKE_CXX_FLAGS=-fPIC" "-DCMAKE_C_FLAGS=-fPIC" ];
-
-  # fails with "./test_watersheds3d: error while loading shared libraries: libvigraimpex.so.11: cannot open shared object file: No such file or directory"
-  doCheck = false;
 
   meta = with lib; {
     description = "Novel computer vision C++ library with customizable algorithms and data structures";

--- a/pkgs/tools/graphics/enblend-enfuse/default.nix
+++ b/pkgs/tools/graphics/enblend-enfuse/default.nix
@@ -1,25 +1,38 @@
-{ lib, stdenv, fetchurl
-, boost, freeglut, glew, gsl, lcms2, libpng, libtiff, libGLU, libGL, vigra
-, help2man, pkg-config, perl, texlive }:
+{ lib, stdenv, fetchzip
+, autoreconfHook
+, boost
+, freeglut
+, glew
+, gsl
+, lcms2
+, libpng
+, libtiff
+, libGLU
+, libGL
+, vigra
+, help2man
+, pkg-config
+, perl
+, texlive
+}:
 
 stdenv.mkDerivation rec {
   pname = "enblend-enfuse";
-  version = "4.2";
+  version = "unstable-2022-03-06";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/enblend/${pname}-${version}.tar.gz";
-    sha256 = "0j5x011ilalb47ssah50ag0a4phgh1b0wdgxdbbp1gcyjcjf60w7";
+  src = fetchzip {
+    url = "https://sourceforge.net/code-snapshots/hg/e/en/enblend/code/enblend-code-0f423c72e51872698fe2985ca3bd453961ffe4e0.zip";
+    sha256 = "sha256-0gCUSdg3HR3YeIbOByEBCZh2zGlYur6DeCOzUM53fdc=";
+    stripRoot = true;
   };
 
   buildInputs = [ boost freeglut glew gsl lcms2 libpng libtiff libGLU libGL vigra ];
 
-  nativeBuildInputs = [ help2man perl pkg-config texlive.combined.scheme-small ];
+  nativeBuildInputs = [ autoreconfHook help2man perl pkg-config texlive.combined.scheme-small ];
 
   preConfigure = ''
     patchShebangs src/embrace
   '';
-
-  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "http://enblend.sourceforge.net/";


### PR DESCRIPTION
###### Description of changes

enblend-enfuse: 4.2 (2016) → unstable-2022-03-06
vigra: 1.11.1 (2017) → unstable-2022-01-11

No tagged releases in about 5 years, this bump fixes compilation with gcc11 of both packages.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
