### PR TITLE
treewide: fix updateScripts for all packages using gitUpdater

### DIFF
--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -138,7 +138,7 @@ python3Packages.buildPythonApplication rec {
   passthru.updateScript = writeScript "update.sh" ''
     #!/usr/bin/env nix-shell
     #!nix-shell -i bash -p curl common-updater-scripts
-    version=$(list-git-tags https://gitlab.gnome.org/World/OpenPaperwork/paperwork.git | sed 's/^v//' | sort -V | tail -n1)
+    version=$(list-git-tags | sed 's/^v//' | sort -V | tail -n1)
     update-source-version paperwork "$version" --file=pkgs/applications/office/paperwork/src.nix
     docs_version="$(curl https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/raw/$version/paperwork-gtk/src/paperwork_gtk/model/help/screenshot.sh | grep TEST_DOCS_TAG= | cut -d'"' -f2)"
     update-source-version paperwork.sample_docs "$docs_version" --file=pkgs/applications/office/paperwork/src.nix --version-key=rev

--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, common-updater-scripts
-, genericUpdater
+, gitUpdater
 , writers
 , makeWrapper
 , bash
@@ -130,8 +129,7 @@ let
       inherit
         pname
         version
-        common-updater-scripts
-        genericUpdater
+        gitUpdater
         writers
         jq
         yq;

--- a/pkgs/applications/video/epgstation/update.nix
+++ b/pkgs/applications/video/epgstation/update.nix
@@ -2,19 +2,17 @@
 , version
 , homepage
 , lib
-, common-updater-scripts
-, genericUpdater
+, gitUpdater
 , writers
 , jq
 , yq
 }:
 
 let
-  updater = genericUpdater {
+  updater = gitUpdater {
     inherit pname version;
     attrPath = lib.toLower pname;
     rev-prefix = "v";
-    versionLister = "${common-updater-scripts}/bin/list-git-tags --url=${homepage}";
   };
   updateScript = builtins.elemAt updater 0;
   updateArgs = map (lib.escapeShellArg) (builtins.tail updater);

--- a/pkgs/applications/video/mirakurun/default.nix
+++ b/pkgs/applications/video/mirakurun/default.nix
@@ -6,9 +6,8 @@
 { lib
 , stdenvNoCC
 , bash
-, common-updater-scripts
 , fetchFromGitHub
-, genericUpdater
+, gitUpdater
 , jq
 , makeWrapper
 , mkYarnPackage
@@ -80,8 +79,7 @@ stdenvNoCC.mkDerivation rec {
     inherit
       pname
       version
-      common-updater-scripts
-      genericUpdater
+      gitUpdater
       writers
       jq
       yarn

--- a/pkgs/applications/video/mirakurun/update.nix
+++ b/pkgs/applications/video/mirakurun/update.nix
@@ -2,8 +2,7 @@
 , version
 , homepage
 , lib
-, common-updater-scripts
-, genericUpdater
+, gitUpdater
 , writers
 , jq
 , yarn
@@ -11,15 +10,12 @@
 }:
 
 let
-  updater = genericUpdater {
+  updater = gitUpdater {
     inherit pname version;
     attrPath = lib.toLower pname;
 
     # exclude prerelease versions
-    versionLister = writers.writeBash "list-mirakurun-versions" ''
-      ${common-updater-scripts}/bin/list-git-tags --url=${homepage} \
-        | grep '^[0-9]\+\.[0-9]\+\.[0-9]\+$'
-    '';
+    ignoredVersions = "-";
   };
   updateScript = builtins.elemAt updater 0;
   updateArgs = map (lib.escapeShellArg) (builtins.tail updater);

--- a/pkgs/common-updater/git-updater.nix
+++ b/pkgs/common-updater/git-updater.nix
@@ -10,8 +10,8 @@
 , rev-prefix ? ""
 , odd-unstable ? false
 , patchlevel-unstable ? false
-# explicit url is useful when git protocol is used only for tags listing
-# while actual release is referred by tarball
+# an explicit url is needed when src.meta.homepage or src.url don't
+# point to a git repo (eg. when using fetchurl, fetchzip, ...)
 , url ? null
 }:
 

--- a/pkgs/common-updater/scripts/list-git-tags
+++ b/pkgs/common-updater/scripts/list-git-tags
@@ -31,7 +31,7 @@ done
 # By default we set url to src.url or src.meta.homepage
 if [[ -z "$url" ]]; then
     url="$(nix-instantiate $systemArg --eval -E \
-               "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.url or $UPDATE_NIX_ATTR_PATH.src.meta.homepage" \
+               "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.meta.homepage or $UPDATE_NIX_ATTR_PATH.src.url" \
         | tr -d '"')"
 fi
 

--- a/pkgs/development/beam-modules/elvis-erlang/default.nix
+++ b/pkgs/development/beam-modules/elvis-erlang/default.nix
@@ -24,7 +24,7 @@ in rebar3Relx rec {
 
     set -euo pipefail
 
-    latest=$(list-git-tags --url=https://github.com/${owner}/${repo}.git | sort -V | tail -1)
+    latest=$(list-git-tags | sort -V | tail -1)
     if [ "$latest" != "${version}" ]; then
       nixpkgs="$(git rev-parse --show-toplevel)"
       nix_path="$nixpkgs/pkgs/development/beam-modules/elvis-erlang"

--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -51,7 +51,7 @@ rebar3Relx {
     #! nix-shell -i bash -p common-updater-scripts coreutils git gnused gnutar gzip "rebar3WithPlugins { globalPlugins = [ beamPackages.rebar3-nix ]; }"
 
     set -ox errexit
-    latest=$(list-git-tags --url=https://github.com/${owner}/${repo}.git | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
+    latest=$(list-git-tags | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
     if [[ "$latest" != "${version}" ]]; then
       nixpkgs="$(git rev-parse --show-toplevel)"
       nix_path="$nixpkgs/pkgs/development/beam-modules/erlang-ls"

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -71,6 +71,7 @@ mkDerivation rec {
 
   passthru.updateScript = gitUpdater {
     inherit pname version;
+    attrPath = "libsForQt5.mlt";
     rev-prefix = "v";
   };
 

--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -81,7 +81,7 @@ let
           (rebar3WithPlugins { globalPlugins = [rebar3-nix]; })
         ]
       }
-      latest=$(list-git-tags --url=https://github.com/${owner}/${pname}.git | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
+      latest=$(list-git-tags | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
       if [ "$latest" != "${version}" ]; then
         nixpkgs="$(git rev-parse --show-toplevel)"
         nix_path="$nixpkgs/pkgs/development/tools/build-managers/rebar3"


### PR DESCRIPTION
###### Description of changes

I noticed that https://github.com/NixOS/nixpkgs/pull/161144 broke my `updateScript` for `git-review`, and realized it also broke the `updateScript` for every other package now using `gitUpdater` except for `bamf` and `iproute`.

The problem is that `url` defaults to `src.url`, so packages using `fetchFromGitHub`, `fetchFromGitLab`, `fetchFromGitea`... stopped working, because those fetchers grab tarballs by default.

I was originally going to explicitly add the urls back to each of these packages, but then realized it would probably be better to prioritize `src.meta.homepage` over `src.url` in `list-git-tags` to avoid this in general.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).