### PR TITLE
yabridge, yabridgectl: 3.8.0 → 3.8.1

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -1,7 +1,6 @@
 { lib
 , multiStdenv
 , fetchFromGitHub
-, fetchpatch
 , substituteAll
 , pkgsi686Linux
 , libnotify
@@ -49,14 +48,14 @@ let
   };
 in multiStdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.8.0";
+  version = "3.8.1";
 
   # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    sha256 = "sha256-XacJjHxsp60/l36pFPGonUyOsyFF2lmqplAaisHXZDY=";
+    sha256 = "sha256-5Mi/aIjOKbn7guTj+AKGQRv+k7w4gzfdA9Mw4ocUlOE=";
   };
 
   # Unpack subproject sources
@@ -78,14 +77,6 @@ in multiStdenv.mkDerivation rec {
       libxcb32 = pkgsi686Linux.xorg.libxcb;
       inherit libnotify wine;
     })
-    # Remove with next yabridge update
-   (fetchpatch {
-      name = "fix-for-wine-7.1.patch";
-      url = "https://github.com/robbert-vdh/yabridge/commit/de470d345ab206b08f6d4a147b6af1d285a4211f.patch";
-      sha256 = "sha256-xJx1zvxD+DIjbkm7Ovoy4RaAvjx936/j/7AYUPh/kOo=";
-      includes = [ "src/wine-host/xdnd-proxy.cpp" ];
-    })
-
   ];
 
   postPatch = ''

--- a/pkgs/tools/audio/yabridge/hardcode-dependencies.patch
+++ b/pkgs/tools/audio/yabridge/hardcode-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index 95ecb728..cb30f3af 100644
+index c71d4fdb..b3f381ba 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -201,6 +201,7 @@ if with_32bit_libraries or with_bitbridge
@@ -20,7 +20,7 @@ index 95ecb728..cb30f3af 100644
  
  # These are all headers-only libraries, and thus won't require separate 32-bit
 diff --git a/src/plugin/utils.cpp b/src/plugin/utils.cpp
-index 1a457f03..20ca1e63 100644
+index fc2c8b25..c73249e3 100644
 --- a/src/plugin/utils.cpp
 +++ b/src/plugin/utils.cpp
 @@ -107,7 +107,7 @@ std::string PluginInfo::wine_version() const {

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoSha256 = "sha256-pwy2Q2HUCihr7W81hGvDm9EiZHk9G8knSy0yxPy6hl8=";
+  cargoSha256 = "sha256-ducF55d5OvCwlNFtt2r6pG5e9VevM2AzHSvPnWvIp1Y=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using


### PR DESCRIPTION
###### Description of changes

Update to the latest version: https://github.com/robbert-vdh/yabridge/releases/tag/3.8.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).