### PR TITLE
john: add gcc11 patch

### DIFF
--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, openssl, nss, nspr, libkrb5, gmp, zlib, libpcap, re2
-, gcc, python3Packages, perl, perlPackages, makeWrapper
+, gcc, python3Packages, perl, perlPackages, makeWrapper, fetchpatch
 }:
 
 with lib;
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
     url = "http://www.openwall.com/john/k/${pname}-${version}.tar.xz";
     sha256 = "0fvz3v41hnaiv1ggpxanfykyfjq79cwp9qcqqn63vic357w27lgm";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-gcc-11-struct-allignment-incompatibility.patch";
+      url = "https://github.com/openwall/john/commit/154ee1156d62dd207aff0052b04c61796a1fde3b.patch";
+      sha256 = "sha256-3rfS2tu/TF+KW2MQiR+bh4w/FVECciTooDQNTHNw31A=";
+    })
+  ];
 
   postPatch = ''
     sed -ri -e '

--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openssl, nss, nspr, libkrb5, gmp, zlib, libpcap, re2
+{ lib, stdenv, fetchFromGitHub, openssl, nss, nspr, libkrb5, gmp, zlib, libpcap, re2
 , gcc, python3Packages, perl, perlPackages, makeWrapper, fetchpatch
 }:
 
@@ -8,9 +8,11 @@ stdenv.mkDerivation rec {
   pname = "john";
   version = "1.9.0-jumbo-1";
 
-  src = fetchurl {
-    url = "http://www.openwall.com/john/k/${pname}-${version}.tar.xz";
-    sha256 = "0fvz3v41hnaiv1ggpxanfykyfjq79cwp9qcqqn63vic357w27lgm";
+  src = fetchFromGitHub {
+    owner = "openwall";
+    repo = pname;
+    rev = "1.9.0-Jumbo-1";
+    sha256 = "sha256-O1iPh5QTMjZ78sKvGbvSpaHFbBuVc1z49UKTbMa24Rs=";
   };
 
   patches = [
@@ -77,8 +79,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "John the Ripper password cracker";
-    license = licenses.gpl2;
-    homepage = "https://github.com/magnumripper/JohnTheRipper/";
+    license = licenses.gpl2Plus;
+    homepage = "https://github.com/openwall/john/";
     maintainers = with maintainers; [ offline matthewbauer ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Description of changes

JohnTheRipper cannot build with GCC 11 due to struct/array alignment issues.

See <https://github.com/openwall/john/issues/4604>.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
