### PR TITLE
python310Packages.pkgconfig: execute tests, adopt

### DIFF
--- a/pkgs/development/python-modules/pkgconfig/default.nix
+++ b/pkgs/development/python-modules/pkgconfig/default.nix
@@ -1,8 +1,15 @@
-{ lib, buildPythonPackage, fetchPypi, pkg-config }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pkg-config
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pkgconfig";
   version = "1.5.5";
+  format = "pyproject";
 
   inherit (pkg-config)
     setupHooks
@@ -10,22 +17,32 @@ buildPythonPackage rec {
     suffixSalt
     targetPrefix
     baseBinName
-  ;
+    ;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899";
+  src = fetchFromGitHub {
+    owner = "matze";
+    repo = "pkgconfig";
+    rev = "v${version}";
+    sha256 = "sha256-uuLUGRNLCR3NS9g6OPCI+qG7tPWsLhI3OE5WmSI3vm8=";
   };
 
+  patches = [ ./executable.patch ];
+
+  postPatch = ''
+    rm pkgconfig/pkgconfig.py.orig
+    substituteInPlace pkgconfig/pkgconfig.py \
+      --replace 'PKG_CONFIG_EXE = "pkg-config"' 'PKG_CONFIG_EXE = "${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config"'
+
+    # those pc files are missing and pkg-config validates that they exist
+    substituteInPlace data/fake-openssl.pc \
+      --replace "Requires: libssl libcrypto" ""
+  '';
+
+  nativeBuildInputs = [ poetry-core ];
 
   propagatedNativeBuildInputs = [ pkg-config ];
 
-  doCheck = false;
-
-  patches = [ ./executable.patch ];
-  postPatch = ''
-    substituteInPlace pkgconfig/pkgconfig.py --replace 'PKG_CONFIG_EXE = "pkg-config"' 'PKG_CONFIG_EXE = "${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config"'
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "pkgconfig" ];
 
@@ -33,5 +50,6 @@ buildPythonPackage rec {
     description = "Interface Python with pkg-config";
     homepage = "https://github.com/matze/pkgconfig";
     license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
