### PR TITLE
python310Packages.xml2rfc: 3.12.3 -> 3.12.4

### DIFF
--- a/pkgs/development/python-modules/xml2rfc/default.nix
+++ b/pkgs/development/python-modules/xml2rfc/default.nix
@@ -1,6 +1,6 @@
 { lib
-, fetchPypi
 , buildPythonPackage
+, fetchFromGitHub
 , pythonOlder
 , intervaltree
 , pyflakes
@@ -18,18 +18,36 @@
 , jinja2
 , configargparse
 , appdirs
+, decorator
+, pycairo
+, pytestCheckHook
+, python-fontconfig
 }:
 
 buildPythonPackage rec {
   pname = "xml2rfc";
-  version = "3.12.3";
+  version = "3.12.4";
 
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-YUrcD3Q1fkDW+nwf6k2T/aBL8+W9iWkPYW/TqdTiuA0=";
+  src = fetchFromGitHub {
+    owner = "ietf-tools";
+    repo = "xml2rfc";
+    rev = "v${version}";
+    sha256 = "sha256-TAu2Ls553t7wJ/Jhgu+Ff+H4P6az0Du8OL00JjZyCDs=";
   };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "SHELL := /bin/bash" "SHELL := bash" \
+      --replace "test flaketest" "test" \
+      --replace "python setup.py --quiet install" ""
+    substituteInPlace setup.py \
+      --replace "'tox'," ""
+    substituteInPlace requirements.txt \
+      --replace "jinja2>=2.11,<3.0" "jinja2" \
+      --replace "markupsafe==2.0.1" "markupsafe"
+  '';
 
   propagatedBuildInputs = [
     intervaltree
@@ -50,23 +68,25 @@ buildPythonPackage rec {
     appdirs
   ];
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "jinja2>=2.11,<3.0" "jinja2>=2.11"
-  '';
+  checkInputs = [
+    decorator
+    pycairo
+    pytestCheckHook
+    python-fontconfig
+  ];
 
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
-
-  # lxml tries to fetch from the internet
+   # requires Noto Serif and Roboto Mono font
   doCheck = false;
+
+  checkPhase = ''
+    make tests-no-network
+  '';
 
   pythonImportsCheck = [ "xml2rfc" ];
 
   meta = with lib; {
     description = "Tool generating IETF RFCs and drafts from XML sources";
-    homepage = "https://tools.ietf.org/tools/xml2rfc/trac/";
+    homepage = "https://github.com/ietf-tools/xml2rfc";
     # Well, parts might be considered unfree, if being strict; see:
     # http://metadata.ftp-master.debian.org/changelogs/non-free/x/xml2rfc/xml2rfc_2.9.6-1_copyright
     license = licenses.bsd3;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
