### PR TITLE
xonotic: fix compiling with GCC11

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchzip, makeWrapper, runCommand, makeDesktopItem
+{ lib, stdenv, fetchurl, fetchpatch, fetchzip, makeWrapper, runCommand, makeDesktopItem
 , xonotic-data, copyDesktopItems
 , # required for both
   unzip, libjpeg, zlib, libvorbis, curl
@@ -63,6 +63,15 @@ let
       url = "https://dl.xonotic.org/xonotic-${version}-source.zip";
       sha256 = "0axxw04fyz6jlfqd0kp7hdrqa0li31sx1pbipf2j5qp9wvqicsay";
     };
+
+    patches = [
+      # Fix to make darkplaces compile under GCC 11
+      (fetchpatch {
+        name = "fix-darkplaces-gcc11";
+        url = "https://gitlab.com/xonotic/darkplaces/-/commit/5e9e998c1759bc0085c3273fc39f9ea6f72a7dc8.patch";
+        sha256 = "sha256-s0JettSg0AYr8V2mXKJ2QU125bBcX1BAu/yDciTWC5o=";
+      })
+    ];
 
     nativeBuildInputs = [ unzip ];
     buildInputs = [ libjpeg zlib libvorbis curl gmp ]


### PR DESCRIPTION
###### Description of changes
Xonotic currently [fails to build](https://hydra.nixos.org/build/174120780) with GCC11. This pulls an upstream patch to Darkplaces (Xonotic's engine) to make it build.

* Upstream issue: https://gitlab.com/xonotic/darkplaces/-/issues/361
* Commit: https://gitlab.com/xonotic/darkplaces/-/commit/5e9e998c1759bc0085c3273fc39f9ea6f72a7dc8
* Ultimate patch origin: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=bc2ba1cd6fdc5a7ad7d161efb21652b73c6b207e

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
