### PR TITLE
x16: 38 -> 40

### DIFF
--- a/pkgs/applications/emulators/commanderx16/emulator.nix
+++ b/pkgs/applications/emulators/commanderx16/emulator.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "x16-emulator";
-  version = "38";
+  version = "40";
 
   src = fetchFromGitHub {
     owner = "commanderx16";
     repo = pname;
     rev = "r${version}";
-    sha256 = "WNRq/m97NpOBWIk6mtxBAKmkxCGWacWjXeOvIhBrkYE=";
+    hash = "sha256-7ZzVd2NJCFNAFrS2cj6bxcq/AzO5VakoFX9o1Ac9egg=";
   };
 
   dontConfigure = true;
@@ -21,8 +21,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    install -D --mode 755 --target-directory $out/bin/ x16emu
-    install -D --mode 444 --target-directory $out/share/doc/${pname} README.md
+
+    install -Dm 755 -t $out/bin/ x16emu
+    install -Dm 444 -t $out/share/doc/${pname} README.md
+
     runHook postInstall
   '';
 
@@ -31,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "The official emulator of CommanderX16 8-bit computer";
     license = licenses.bsd2;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = SDL2.meta.platforms;
+    inherit (SDL2.meta) platforms;
   };
 
   passthru = {

--- a/pkgs/applications/emulators/commanderx16/rom.nix
+++ b/pkgs/applications/emulators/commanderx16/rom.nix
@@ -2,20 +2,24 @@
 , lib
 , fetchFromGitHub
 , cc65
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "x16-rom";
-  version = "38";
+  version = "40";
 
   src = fetchFromGitHub {
     owner = "commanderx16";
     repo = pname;
     rev = "r${version}";
-    sha256 = "xaqF0ppB7I7ST8Uh3jPbC14uRAb/WH21tHlNeTvYpoI=";
+    hash = "sha256-5oqttuTJiJOUENncOJipAar22OsI1uG3G69m+eYoSh0=";
   };
 
-  nativeBuildInputs = [ cc65 ];
+  nativeBuildInputs = [
+    cc65
+    python3
+  ];
 
   postPatch = ''
     patchShebangs scripts/
@@ -25,8 +29,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    install -D --mode 444 --target-directory $out/share/${pname} build/x16/rom.bin
-    install -D --mode 444 --target-directory $out/share/doc/${pname} README.md
+
+    install -Dm 444 -t $out/share/${pname} build/x16/rom.bin
+    install -Dm 444 -t $out/share/doc/${pname} README.md
+
     runHook postInstall
   '';
 
@@ -35,7 +41,7 @@ stdenv.mkDerivation rec {
     description = "ROM file for CommanderX16 8-bit computer";
     license = licenses.bsd2;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = cc65.meta.platforms;
+    inherit (cc65.meta) platforms;
   };
 
   passthru = {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
