### PR TITLE
gnome.gnome-maps: 42.0 → 42.1

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-maps/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , gettext
@@ -31,21 +30,12 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-maps";
-  version = "42.0";
+  version = "42.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-BUSG03dAc3BqdqmBQXl40VG+O3Ik1yN3W74xbvoked8=";
+    sha256 = "sha256-CC+ElBAf080xvU8a6YgXEOMqUz+y3belcSJ5bJRm0q4=";
   };
-
-  patches = [
-    # Do not pin to GWeather 3.0, the used API did not change in 4.0.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-maps/-/commit/759d3087b70341b2c5f1af575ce44338d926690e.patch";
-      sha256 = "Qp9Hta00TLf2lOb9+g9vnPoK17mP3eHpCG2i1ewaw+w=";
-      revert = true;
-    })
-  ];
 
   doCheck = true;
 
@@ -66,7 +56,6 @@ stdenv.mkDerivation rec {
     geocode-glib
     gjs
     gnome-online-accounts
-    gnome.adwaita-icon-theme
     gobject-introspection
     gsettings-desktop-schemas
     gtk3


### PR DESCRIPTION


###### Description of changes

https://gitlab.gnome.org/GNOME/gnome-maps/-/compare/v42.0...v42.1

 - Update GWeather dependency to version 4
 - Update the Resrobot public transit plugin to use the v2.1 API
 - Don't optimize away keep left/right instructions for turn-by-turn routes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
