### PR TITLE
qt5: use 5.15 LTS for certain packages

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7725,7 +7725,7 @@ with pkgs;
 
   ninka = callPackage ../development/tools/misc/ninka { };
 
-  nixnote2 = libsForQt514.callPackage ../applications/misc/nixnote2 { };
+  nixnote2 = libsForQt5.callPackage ../applications/misc/nixnote2 { };
 
   nodenv = callPackage ../development/tools/nodenv { };
 
@@ -8663,7 +8663,7 @@ with pkgs;
 
   nmap-formatter = callPackage ../tools/security/nmap-formatter { };
 
-  nmapsi4 = libsForQt514.callPackage ../tools/security/nmap/qt.nix { };
+  nmapsi4 = libsForQt5.callPackage ../tools/security/nmap/qt.nix { };
 
   nnn = callPackage ../applications/misc/nnn { };
 
@@ -12186,7 +12186,7 @@ with pkgs;
 
   colm = callPackage ../development/compilers/colm { };
 
-  colmap = libsForQt514.callPackage ../applications/science/misc/colmap { };
+  colmap = libsForQt5.callPackage ../applications/science/misc/colmap { };
   colmapWithCuda = colmap.override { cudaSupport = true; cudatoolkit = cudatoolkit_11; };
 
   chickenPackages_4 = callPackage ../development/compilers/chicken/4 { };
@@ -27552,7 +27552,7 @@ with pkgs;
 
   libowlevelzs = callPackage ../development/libraries/libowlevelzs { };
 
-  librecad = libsForQt514.callPackage ../applications/misc/librecad {
+  librecad = libsForQt5.callPackage ../applications/misc/librecad {
     boost = boost175;
   };
 
@@ -27833,8 +27833,7 @@ with pkgs;
 
   meme-suite = callPackage ../applications/science/biology/meme-suite { };
 
-  # Needs qtwebkit which is broken on qt5.15
-  mendeley = libsForQt514.callPackage ../applications/office/mendeley {
+  mendeley = libsForQt5.callPackage ../applications/office/mendeley {
     gconf = gnome2.GConf;
   };
 
@@ -28945,7 +28944,7 @@ with pkgs;
 
   qimgv = libsForQt5.callPackage ../applications/graphics/qimgv { };
 
-  qlandkartegt = libsForQt514.callPackage ../applications/misc/qlandkartegt {
+  qlandkartegt = libsForQt5.callPackage ../applications/misc/qlandkartegt {
     gdal = gdal.override {
       libgeotiff = libgeotiff.override { proj = proj_7; };
       libspatialite = libspatialite.override { proj = proj_7; };
@@ -30119,7 +30118,7 @@ with pkgs;
 
   virtual-ans = callPackage ../applications/audio/virtual-ans {};
 
-  virtualbox = libsForQt514.callPackage ../applications/virtualization/virtualbox {
+  virtualbox = libsForQt5.callPackage ../applications/virtualization/virtualbox {
     stdenv = stdenv_32bit;
     inherit (gnome2) libIDL;
     jdk = openjdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
@@ -30402,7 +30401,7 @@ with pkgs;
 
   worldengine-cli = python3Packages.worldengine;
 
-  wpsoffice = libsForQt514.callPackage ../applications/office/wpsoffice {};
+  wpsoffice = libsForQt5.callPackage ../applications/office/wpsoffice {};
 
   wrapFirefox = callPackage ../applications/networking/browsers/firefox/wrapper.nix { };
 
@@ -34867,7 +34866,7 @@ with pkgs;
     inherit pkgs lib stdenv;
   };
 
-  golden-cheetah = libsForQt514.callPackage ../applications/misc/golden-cheetah {};
+  golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah {};
 
   linkchecker = callPackage ../tools/networking/linkchecker { };
 


### PR DESCRIPTION
###### Description of changes

Use qt5.15 LTS instead of qt5.14 for packages currently not building due to broken qtwebengine 5.14
(see https://github.com/NixOS/nixpkgs/issues/169996)

packages were checked on hydra and if broken, tried to build with qt 5.15. If this succeeded, they were upgraded here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This is a semi-automatic executed nixpkgs-review with nixpkgs-review-checks extension. It is checked by a human on a best effort basis and does not build all packages (e.g. lumo, tensorflow or pytorch).

Result of nixpkgs-review run on x86_64-linux 1

<details>
<summary>3 packages failed to build and already failed to build on hydra master:</summary>
  <ul>
<li>linuxKernel.packages.linux_4_14_hardened.virtualbox: log was empty</li>
<li>linuxKernel.packages.linux_4_19_hardened.virtualbox: log was empty</li>
<li>linuxKernel.packages.linux_5_4_hardened.virtualbox: log was empty</li>
  </ul>
</details>
<details>
<summary>1 package failed to build and are new build failure:</summary>
  <ul>
<li>colmapWithCuda: log was empty</li>
  </ul>
</details>
<details>
<summary>
29 packages built:
</summary>
<ul>
<li>colmap</li>
<li>digitalbitbox</li>
<li>golden-cheetah</li>
<li>librecad</li>
<li>linuxKernel.packages.linux_4_14.virtualbox</li>
<li>linuxKernel.packages.linux_4_19.virtualbox</li>
<li>linuxKernel.packages.linux_4_9.virtualbox</li>
<li>linuxKernel.packages.linux_5_10.virtualbox</li>
<li>linuxKernel.packages.linux_5_10_hardened.virtualbox</li>
<li>linuxKernel.packages.linux_5_15.virtualbox</li>
<li>linuxKernel.packages.linux_hardened.virtualbox (linuxKernel.packages.linux_5_15_hardened.virtualbox)</li>
<li>linuxKernel.packages.linux_5_16.virtualbox</li>
<li>linuxKernel.packages.linux_5_17.virtualbox</li>
<li>linuxKernel.packages.linux_5_4.virtualbox</li>
<li>linuxKernel.packages.linux_latest_libre.virtualbox</li>
<li>linuxKernel.packages.linux_libre.virtualbox</li>
<li>linuxKernel.packages.linux_lqx.virtualbox</li>
<li>linuxKernel.packages.linux_testing_bcachefs.virtualbox</li>
<li>linuxKernel.packages.linux_xanmod.virtualbox</li>
<li>linuxKernel.packages.linux_xanmod_latest.virtualbox</li>
<li>linuxKernel.packages.linux_zen.virtualbox</li>
<li>mendeley</li>
<li>nixnote2</li>
<li>nmapsi4</li>
<li>qlandkartegt</li>
<li>virtualbox</li>
<li>virtualboxHardened</li>
<li>virtualboxWithExtpack</li>
<li>wpsoffice</li>
</ul>
</details>