### PR TITLE
platformsh: init at v3.78.0

### DIFF
--- a/pkgs/misc/platformsh/default.nix
+++ b/pkgs/misc/platformsh/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchurl, makeWrapper, writeShellScript, lib, php, curl, jq, common-updater-scripts }:
+
+let
+  pname = "platformsh";
+  version = "v3.78.0";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://github.com/platformsh/platformsh-cli/releases/download/${version}/platform.phar";
+    sha256 = "sha256-2EasMsZIwplkl1S5PH0Y3gRymAIdpiFgVc3pNPiFg1o=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/platformsh/platform.phar
+    makeWrapper ${php}/bin/php $out/bin/platform \
+      --add-flags "$out/libexec/platformsh/platform.phar"
+    runHook postInstall
+  '';
+
+  passthru = {
+      updateScript = writeShellScript "update-${pname}" ''
+        set -o errexit
+        export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
+        NEW_VERSION=$(curl -s https://api.github.com/repos/platformsh/platformsh-cli/releases/latest | jq .tag_name --raw-output)
+
+        if [[ "${version}" = "$NEW_VERSION" ]]; then
+            echo "The new version same as the old version."
+            exit 0
+        fi
+
+        update-source-version "platformsh" "$NEW_VERSION"
+      '';
+    };
+
+  meta = with lib; {
+    description = "The unified tool for managing your Platform.sh services from the command line.";
+    license = licenses.mit;
+    homepage = "https://github.com/platformsh/platformsh-cli";
+    maintainers = with maintainers; [ shyim ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2337,6 +2337,8 @@ with pkgs;
 
   passExtensions = recurseIntoAttrs pass.extensions;
 
+  platformsh = callPackage ../misc/platformsh { };
+
   inherd-quake = callPackage ../applications/misc/inherd-quake {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };


### PR DESCRIPTION
###### Description of changes

Added platform.sh cli to nixpkgs. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
