### PR TITLE
htmlcxx: 0.86 -> 0.87

### DIFF
--- a/pkgs/development/libraries/htmlcxx/c++17.patch
+++ b/pkgs/development/libraries/htmlcxx/c++17.patch
@@ -1,0 +1,24 @@
+diff --color -Naur a/html/CharsetConverter.cc b/html/CharsetConverter.cc
+--- a/html/CharsetConverter.cc	2018-12-29 03:13:56.000000000 +0000
++++ b/html/CharsetConverter.cc	2021-05-31 23:03:10.705334580 +0100
+@@ -7,7 +7,7 @@
+ using namespace std;
+ using namespace htmlcxx;
+ 
+-CharsetConverter::CharsetConverter(const string &from, const string &to) throw (Exception)
++CharsetConverter::CharsetConverter(const string &from, const string &to)
+ {
+ 	mIconvDescriptor = iconv_open(to.c_str(), from.c_str());
+ 	if (mIconvDescriptor == (iconv_t)(-1))
+diff --color -Naur a/html/CharsetConverter.h b/html/CharsetConverter.h
+--- a/html/CharsetConverter.h	2018-12-29 03:13:56.000000000 +0000
++++ b/html/CharsetConverter.h	2021-05-31 23:03:19.042574598 +0100
+@@ -17,7 +17,7 @@
+ 						: std::runtime_error(arg) {}
+ 			};
+ 			
+-			CharsetConverter(const std::string &from, const std::string &to) throw (Exception);
++			CharsetConverter(const std::string &from, const std::string &to);
+ 			~CharsetConverter();
+ 			
+ 			std::string convert(const std::string &input);

--- a/pkgs/development/libraries/htmlcxx/default.nix
+++ b/pkgs/development/libraries/htmlcxx/default.nix
@@ -2,15 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "htmlcxx";
-  version = "0.86";
+  version = "0.87";
 
   src = fetchurl {
-    url = "mirror://sourceforge/htmlcxx/htmlcxx/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1hgmyiad3qgbpf2dvv2jygzj6jpz4dl3n8ds4nql68a4l9g2nm07";
+    url = "mirror://sourceforge/htmlcxx/v${version}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-XTj5OM9N+aKYpTRq8nGV//q/759GD8KgIjPLz6j8dcg=";
   };
 
   buildInputs = [ libiconv ];
-  patches = [ ./ptrdiff.patch ];
+  patches = [
+    ./ptrdiff.patch
+    ./c++17.patch
+  ];
 
   meta = with lib; {
     homepage = "http://htmlcxx.sourceforge.net/";


### PR DESCRIPTION
###### Description of changes

Fixing htmlcxx build (for lgogdownloader).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

No maintainers, pinging @siraben as per `git blame`.