### PR TITLE
nginxModules.vts: fix build on gcc11

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -107,6 +107,8 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = toString ([
     "-I${libxml2.dev}/include/libxml2"
     "-Wno-error=implicit-fallthrough"
+    # fix build vts module on gcc11
+    "-Wno-error=stringop-overread"
   ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations");
 
   configurePlatforms = [];


### PR DESCRIPTION
###### Description of changes
Fix build nginx vts module on gcc11

Error build after this PR - https://github.com/NixOS/nixpkgs/pull/168797
Build error log:
```
In file included from src/core/ngx_core.h:53,
                 from /nix/store/vpcskyg0s8mc6z0p9sizd7j39zs7mfnv-vts/src/ngx_http_vhost_traffic_status_module.h:13,
                 from /nix/store/vpcskyg0s8mc6z0p9sizd7j39zs7mfnv-vts/src/ngx_http_vhost_traffic_status_dump.c:7:
In function 'ngx_write_fd',
    inlined from 'ngx_http_vhost_traffic_status_dump_node_write' at /nix/store/vpcskyg0s8mc6z0p9sizd7j39zs7mfnv-vts/src/ngx_http_vhost_traffic_status_dump.c:118:16:
src/os/unix/ngx_files.h:147:12: error: 'write' reading 3480 bytes from a region of size 1 [^[]8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overread^G-Werror=stringop-overread^[]8;;^G]
  147 |     return write(fd, buf, n);
      |            ^~~~~~~~~~~~~~~~~
In file included from src/core/ngx_core.h:49,
                 from /nix/store/vpcskyg0s8mc6z0p9sizd7j39zs7mfnv-vts/src/ngx_http_vhost_traffic_status_module.h:13,
                 from /nix/store/vpcskyg0s8mc6z0p9sizd7j39zs7mfnv-vts/src/ngx_http_vhost_traffic_status_dump.c:7:
src/os/unix/ngx_files.h: In function 'ngx_http_vhost_traffic_status_dump_node_write':
src/core/ngx_rbtree.h:27:28: note: source object 'color' of size 1
   27 |     u_char                 color;
      |                            ^~~~~
In file included from src/os/unix/ngx_linux_config.h:20,
                 from src/core/ngx_config.h:26,
                 from /nix/store/vpcskyg0s8mc6z0p9sizd7j39zs7mfnv-vts/src/ngx_http_vhost_traffic_status_module.h:12,
                 from /nix/store/vpcskyg0s8mc6z0p9sizd7j39zs7mfnv-vts/src/ngx_http_vhost_traffic_status_dump.c:7:
/nix/store/pvn23vycg674bj6nypjcfyhqbr85rqxa-glibc-2.34-115-dev/include/unistd.h:378:16: note: in a call to function 'write' declared with attribute 'access (read_only, 2, 3)'
  378 | extern ssize_t write (int __fd, const void *__buf, size_t __n) __wur
      |                ^~~~~
cc1: all warnings being treated as errors
make[1]: *** [objs/Makefile:2816: objs/addon/src/ngx_http_vhost_traffic_status_dump.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/build/nginx-1.20.2'
make: *** [Makefile:10: build] Error 2
```

cc @ajs124 @fabianhjr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
