### PR TITLE
[WIP] slithin: init 1.0.13.0

### DIFF
--- a/pkgs/applications/misc/remarkable/slithin/default.nix
+++ b/pkgs/applications/misc/remarkable/slithin/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, dpkg
+, fetchurl
+, icu
+, remarkable2-toolchain
+, fontconfig
+, vscode-extensions
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation rec {
+    pname = "slithin";
+	version = "1.0.13.0";
+    src = fetchurl {
+      url = "https://github.com/furesoft/Slithin/releases/download/${version}/Slithin.${version}.linux-x64.deb";
+      sha512 = "14g32h3b8vk1qlxm2jvy68w3hbcgbwas027kx0pklcdp407kq54gid0spmn0c2cg9q6bqlbkg6kzfq300pq4lf7qd6b2xmfm9ykg8p0";
+    };
+
+	nativeBuildInputs = [
+	autoPatchelfHook
+	];
+
+	unpackCmd = ''
+    mkdir ./unpack
+    ${dpkg}/bin/dpkg-deb -x $curSrc ./unpack
+	'';
+
+	buildInputs = [
+    stdenv.cc.cc.lib
+	fontconfig.lib
+	vscode-extensions.ms-python.python.out
+  	];
+
+	runtimeDependencies = [
+	icu
+	];
+
+	installPhase = ''
+    mkdir -p $out
+    mv usr $out/usr
+	'';
+
+	meta = {
+    homepage = "https://github.com/furesoft/Slithin/";
+    description = "Slithin is a forever free, cross-platform managenment tool for Remarkable Devices.";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.gpl3;
+  	};
+}


### PR DESCRIPTION
###### Description of changes

Management tool for Remarkable tables which allows you to manage backups, notebooks, templates and screens. 

So far the basic package structure was created, but I would like to ask for help as I'm not able to include the last missing dependency successfully (liblttng-ust.so.0).

nix-locate returned vscode-extensions.ms-python.python.out as an usable source but I think I included it wrong.
Does someone has an idea?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
