### PR TITLE
segyio: init at 1.9.9

### DIFF
--- a/pkgs/development/python-modules/segyio/default.nix
+++ b/pkgs/development/python-modules/segyio/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, python
+, scikit-build
+, pytest
+, numpy
+, fetchpatch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "segyio";
+  version = "1.9.9";
+
+  patches = [
+    # PR https://github.com/equinor/segyio/pull/531
+    (fetchpatch {
+        url = "https://github.com/equinor/segyio/commit/628bc5e02d0f98b89fe70b072df9b8e677622e9e.patch";
+        sha256 = "sha256-j+vqHZNfPIh+yWBgqbGD3W04FBvFiDJKnmcC/oTk3a8=";
+    })
+  ];
+
+  postPatch = ''
+    # Removing unecessary build dependency
+    substituteInPlace python/setup.py --replace "'pytest-runner'," ""
+
+    # Fixing bug making one test fail in the python 3.10 build
+    substituteInPlace python/segyio/open.py --replace \
+    "cube_metrics = f.xfd.cube_metrics(iline, xline)" \
+    "cube_metrics = f.xfd.cube_metrics(int(iline), int(xline))"
+  '';
+
+  src = fetchFromGitHub {
+    owner = "equinor";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-L3u5BHS5tARS2aIiQbumADkuzw1Aw4Yuav8H8tRNYNg=";
+  };
+
+  nativeBuildInputs = [ cmake ninja python scikit-build ];
+
+  doCheck = true;
+  # I'm not modifying the checkPhase nor adding a pytestCheckHook because the pytest is called
+  # within the cmake test phase
+  checkInputs = [ pytest numpy ];
+
+  meta = with lib; {
+    description = "Fast Python library for SEGY files";
+    homepage = "https://github.com/equinor/segyio";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9213,6 +9213,10 @@ in {
 
   segments = callPackage ../development/python-modules/segments { };
 
+  segyio = toPythonModule (callPackage ../development/python-modules/segyio {
+    inherit (pkgs) cmake ninja;
+  });
+
   selectors2 = callPackage ../development/python-modules/selectors2 { };
 
   selenium = callPackage ../development/python-modules/selenium { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Segyio](https://github.com/equinor/segyio) is python library that handles I/O of SEGY files.
I'm packaging this for my work, since this is a geophysics library for I/O of seismic data. SEGY is the most common seismic data format out there, so this very important package for researchers working with real data.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
