### PR TITLE
conda: 4.6.14 -> 4.11.0

### DIFF
--- a/pkgs/tools/package-management/conda/default.nix
+++ b/pkgs/tools/package-management/conda/default.nix
@@ -8,10 +8,11 @@
 , libarchive
 , libGL
 , xorg
+, zlib
 # Conda installs its packages and environments under this directory
 , installationPath ? "~/.conda"
 # Conda manages most pkgs itself, but expects a few to be on the system.
-, condaDeps ? [ stdenv.cc xorg.libSM xorg.libICE xorg.libX11 xorg.libXau xorg.libXi xorg.libXrender libselinux libGL ]
+, condaDeps ? [ stdenv.cc xorg.libSM xorg.libICE xorg.libX11 xorg.libXau xorg.libXi xorg.libXrender libselinux libGL zlib]
 # Any extra nixpkgs you'd like available in the FHS env for Conda to use
 , extraPkgs ? [ ]
 }:
@@ -30,24 +31,37 @@
 # $ conda-shell
 # $ conda install spyder
 let
-  version = "4.6.14";
+  version = "4.11.0";
   src = fetchurl {
-      url = "https://repo.continuum.io/miniconda/Miniconda3-${version}-Linux-x86_64.sh";
-      sha256 = "1gn43z1y5zw4yv93q1qajwbmmqs83wx5ls5x4i4llaciba4j6sqd";
+      url = "https://repo.continuum.io/miniconda/Miniconda3-py39_${version}-Linux-x86_64.sh";
+      sha256 = "sha256-TunDqlMynNemO0mHfAurtJsZt+WvKYB7eTp2vbHTYrQ=";
   };
+  conda = (
+    let
+      libPath = lib.makeLibraryPath [
+        zlib # libz.so.1
+      ];
+    in
+      runCommand "conda-install" { buildInputs = [ makeWrapper zlib]; }
+        # on line 10, we have 'unset LD_LIBRARY_PATH'
+        # we have to comment it out however in a way that the number of bytes in the
+        # file does not change. So we replace the 'u' in the line with a '#'
+        # The reason is that the binary payload is encoded as number
+        # of bytes from the top of the installer script
+        # and unsetting the library path prevents the zlib library from being discovered
+        ''
+          mkdir -p $out/bin
 
-  conda = runCommand "conda-install" { buildInputs = [ makeWrapper ]; }
-    ''
-      mkdir -p $out/bin
-      cp ${src} $out/bin/miniconda-installer.sh
-      chmod +x $out/bin/miniconda-installer.sh
+          sed 's/unset LD_LIBRARY_PATH/#nset LD_LIBRARY_PATH/' ${src} > $out/bin/miniconda-installer.sh
+          chmod +x $out/bin/miniconda-installer.sh
 
-      makeWrapper                            \
-        $out/bin/miniconda-installer.sh      \
-        $out/bin/conda-install               \
-        --add-flags "-p ${installationPath}" \
-        --add-flags "-b"
-    '';
+          makeWrapper                            \
+            $out/bin/miniconda-installer.sh      \
+            $out/bin/conda-install               \
+            --add-flags "-p ${installationPath}" \
+            --add-flags "-b"                     \
+            --prefix "LD_LIBRARY_PATH" : "${libPath}"
+        '');
 in
   buildFHSUserEnv {
     name = "conda-shell";


### PR DESCRIPTION
###### Description of changes

Updated conda version from 4.6.14 to 4.11.0

As described in #119832 there was an issue with a missing zlib. I debugged the issue and included the missing zlib so that conda-install now succeeds. Patching of the miniconda-installer.sh script was necessary.

###### Things done

Sorry that I tested only on x86_64 linux. I only run nix as a package manager inside Ubuntu, not as a full linux distribution. Hope this helps anyway.

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
