### PR TITLE
Systemd shutdown ramfs fixup

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1266,7 +1266,7 @@
           <literal>systemd-shutdown</literal> is now properly linked on
           shutdown to unmount all filesystems and device mapper devices
           cleanly. This can be disabled using
-          <literal>boot.systemd.shutdown.enable</literal>.
+          <literal>systemd.shutdownRamfs.enable</literal>.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -500,7 +500,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `systemd-nspawn@.service` settings have been reverted to the default systemd behaviour. User namespaces are now activated by default. If you want to keep running nspawn containers without user namespaces you need to set `systemd.nspawn.<name>.execConfig.PrivateUsers = false`
 
-- `systemd-shutdown` is now properly linked on shutdown to unmount all filesystems and device mapper devices cleanly. This can be disabled using `boot.systemd.shutdown.enable`.
+- `systemd-shutdown` is now properly linked on shutdown to unmount all filesystems and device mapper devices cleanly. This can be disabled using `systemd.shutdownRamfs.enable`.
 
 - The Tor SOCKS proxy is now actually disabled if `services.tor.client.enable` is set to `false` (the default). If you are using this functionality but didn't change the setting or set it to `false`, you now need to set it to `true`.
 

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -213,6 +213,6 @@ rec {
   systemdUtils = {
     lib = import ./systemd-lib.nix { inherit lib config pkgs; };
     unitOptions = import ./systemd-unit-options.nix { inherit lib systemdUtils; };
-    types = import ./systemd-types.nix { inherit lib systemdUtils; };
+    types = import ./systemd-types.nix { inherit lib systemdUtils pkgs; };
   };
 }

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -156,37 +156,7 @@ in {
       '';
       visible = false;
       default = {};
-      type = types.attrsOf (types.submodule ({ config, options, name, ... }: {
-        options = {
-          enable = mkEnableOption "copying of this file to initrd and symlinking it" // { default = true; };
-
-          target = mkOption {
-            type = types.path;
-            description = ''
-              Path of the symlink.
-            '';
-            default = name;
-          };
-
-          text = mkOption {
-            default = null;
-            type = types.nullOr types.lines;
-            description = "Text of the file.";
-          };
-
-          source = mkOption {
-            type = types.path;
-            description = "Path of the source file.";
-          };
-        };
-
-        config = {
-          source = mkIf (config.text != null) (
-            let name' = "initrd-" + baseNameOf name;
-            in mkDerivedConfig options.text (pkgs.writeText name')
-          );
-        };
-      }));
+      type = utils.systemdUtils.types.initrdContents;
     };
 
     storePaths = mkOption {

--- a/nixos/modules/system/boot/systemd/shutdown.nix
+++ b/nixos/modules/system/boot/systemd/shutdown.nix
@@ -1,31 +1,57 @@
-{ config, lib, ... }: let
+{ config, lib, utils, pkgs, ... }: let
 
-  cfg = config.boot.systemd.shutdown;
+  cfg = config.systemd.shutdownRamfs;
+
+  ramfsContents = let
+    storePaths = map (p: "${p}\n") cfg.storePaths;
+    contents = lib.mapAttrsToList (_: v: "${v.source}\n${v.target}") (lib.filterAttrs (_: v: v.enable) cfg.contents);
+  in pkgs.writeText "shutdown-ramfs-contents" (lib.concatStringsSep "\n" (storePaths ++ contents));
 
 in {
-  options.boot.systemd.shutdown = {
+  options.systemd.shutdownRamfs = {
     enable = lib.mkEnableOption "pivoting back to an initramfs for shutdown" // { default = true; };
+    contents = lib.mkOption {
+      description = "Set of files that have to be linked into the shutdown ramfs";
+      example = lib.literalExpression ''
+        {
+          "/lib/systemd/system-shutdown/zpool-sync-shutdown".source = writeShellScript "zpool" "exec ''${zfs}/bin/zpool sync"
+        }
+      '';
+      type = utils.systemdUtils.types.initrdContents;
+    };
+
+    storePaths = lib.mkOption {
+      description = ''
+        Store paths to copy into the shutdown ramfs as well.
+      '';
+      type = lib.types.listOf lib.types.singleLineStr;
+      default = [];
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    systemd.shutdownRamfs.contents."/shutdown".source = "${config.systemd.package}/lib/systemd/systemd-shutdown";
+    systemd.shutdownRamfs.storePaths = [pkgs.runtimeShell "${pkgs.coreutils}/bin"];
+
     systemd.services.generate-shutdown-ramfs = {
       description = "Generate shutdown ramfs";
+      wantedBy = [ "shutdown.target" ];
       before = [ "shutdown.target" ];
       unitConfig = {
         DefaultDependencies = false;
         ConditionFileIsExecutable = [
           "!/run/initramfs/shutdown"
-          "/run/current-system/systemd/lib/systemd/systemd-shutdown"
         ];
       };
 
+      path = [pkgs.util-linux pkgs.makeInitrdNGTool pkgs.glibc pkgs.patchelf];
       serviceConfig.Type = "oneshot";
       script = ''
         mkdir -p /run/initramfs
         if ! mountpoint -q /run/initramfs; then
           mount -t tmpfs tmpfs /run/initramfs
         fi
-        cp /run/current-system/systemd/lib/systemd/systemd-shutdown /run/initramfs/shutdown
+        make-initrd-ng ${ramfsContents} /run/initramfs
       '';
     };
   };

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -466,6 +466,11 @@ in
         '') rootPools));
       };
 
+      systemd.shutdownRamfs.contents."/etc/systemd/system-shutdown/zpool".source = pkgs.writeShellScript "zpool-sync-shutdown" ''
+        exec ${cfgZfs.package}/bin/zpool sync
+      '';
+      systemd.shutdownRamfs.storePaths = ["${cfgZfs.package}/bin/zpool"];
+
       # TODO FIXME See https://github.com/NixOS/nixpkgs/pull/99386#issuecomment-798813567. To not break people's bootloader and as probably not everybody would read release notes that thoroughly add inSystem.
       boot.loader.grub = mkIf (inInitrd || inSystem) {
         zfsSupport = true;

--- a/nixos/tests/systemd-shutdown.nix
+++ b/nixos/tests/systemd-shutdown.nix
@@ -1,4 +1,6 @@
-import ./make-test-python.nix ({ pkgs, systemdStage1 ? false, ...} : {
+import ./make-test-python.nix ({ pkgs, systemdStage1 ? false, ...} : let
+  msg = "Shutting down NixOS";
+in {
   name = "systemd-shutdown";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ das_j ];
@@ -6,7 +8,9 @@ import ./make-test-python.nix ({ pkgs, systemdStage1 ? false, ...} : {
 
   nodes.machine = {
     imports = [ ../modules/profiles/minimal.nix ];
-    boot.initrd.systemd.enable = systemdStage1;
+    systemd.shutdownRamfs.contents."/etc/systemd/system-shutdown/shutdown-message".source = pkgs.writeShellScript "shutdown-message" ''
+      echo "${msg}"
+    '';
   };
 
   testScript = ''
@@ -14,7 +18,8 @@ import ./make-test-python.nix ({ pkgs, systemdStage1 ? false, ...} : {
     # .shutdown() would wait for the machine to power off
     machine.succeed("systemctl poweroff")
     # Message printed by systemd-shutdown
-    machine.wait_for_console_text("All filesystems, swaps, loop devices, MD devices and DM devices detached.")
+    machine.wait_for_console_text("Unmounting '/oldroot'")
+    machine.wait_for_console_text("${msg}")
     # Don't try to sync filesystems
     machine.booted = False
   '';


### PR DESCRIPTION
###### Description of changes

The shutdown ramfs wasn't actually doing anything. This fixes it and adds a convenient API for configuring it, along with an example that syncs ZFS pools on shutdown.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
