### PR TITLE
update browserpass from 3.0.6 to 3.0.10

### DIFF
--- a/pkgs/tools/security/browserpass/default.nix
+++ b/pkgs/tools/security/browserpass/default.nix
@@ -1,18 +1,18 @@
 { lib, buildGoModule, fetchFromGitHub, makeWrapper, gnupg }:
 buildGoModule rec {
   pname = "browserpass";
-  version = "3.0.6";
+  version = "3.0.10";
 
   src = fetchFromGitHub {
     owner = "browserpass";
     repo = "browserpass-native";
     rev = version;
-    sha256 = "0q3bsla07zjl6i69nj1axbkg2ia89pvh0jg6nlqgbm2kpzzbn0pz";
+    sha256 = "8eAwUwcRTnhVDkQc3HsvTP0TqC4LfVrUelxdbJxe9t0=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  vendorSha256 = "1wcbn0ip596f2dp68y6jmxgv20l0dgrcxg5cwclkawigj05416zj";
+  vendorSha256 = "gWXcYyIp86b/Pn6vj7qBj/VZS9rTr4weVw0YWmg+36c=";
 
   doCheck = false;
 
@@ -21,8 +21,8 @@ buildGoModule rec {
     # variables to be valid by default
     substituteInPlace Makefile \
       --replace "PREFIX ?= /usr" ""
-    sed -i -e 's/SED :=.*/SED := sed/' Makefile
-    sed -i -e 's/INSTALL :=.*/INSTALL := install/' Makefile
+    sed -i -e 's/SED =.*/SED = sed/' Makefile
+    sed -i -e 's/INSTALL =.*/INSTALL = install/' Makefile
   '';
 
   DESTDIR = placeholder "out";


### PR DESCRIPTION
###### Description of changes

Here is the changelog: https://github.com/browserpass/browserpass-native/releases/tag/3.0.10

This package was at version 3.0.6 which was released in April 2019. A new version has been published today.

###### Things done

The patch that was applied in `postPatch` for the Makefile did not work anymore because the variables changed to be assigned using simply `=` instead of `:=`. I updated this accordingly.

I also added `CGO_ENABLED = 0;` to build the package without cgo. The maintainer explains that since version 3.0.9, they build `browserpass` without cgo for all other package managers. So it could be more consistent to have nix also build it without cgo.

https://github.com/browserpass/browserpass-native/pull/119#issuecomment-1107851161

I tested the resulted binary on my machine, and the connection with the browserpass chromium extension works correctly.

ping @rvolosatovs @infinisil 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).