### PR TITLE
python310Packages.ffcv: fix build

### DIFF
--- a/pkgs/development/python-modules/ffcv/default.nix
+++ b/pkgs/development/python-modules/ffcv/default.nix
@@ -5,7 +5,7 @@
 , numba
 , opencv4
 , pandas
-, pkgconfig
+, pkg-config
 , pytorch-pfn-extras
 , terminaltables
 , tqdm
@@ -35,7 +35,7 @@ buildPythonPackage rec {
       --replace "'webdataset'," ""
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libjpeg ];
   propagatedBuildInputs = [ opencv4 numba pandas pytorch-pfn-extras terminaltables tqdm ];
 

--- a/pkgs/development/python-modules/onnx/default.nix
+++ b/pkgs/development/python-modules/onnx/default.nix
@@ -55,6 +55,11 @@ buildPythonPackage rec {
     export MAX_JOBS=$NIX_BUILD_CORES
   '';
 
+  disabledTestPaths = [
+    # Unexpected output fields from running code: {'stderr'}
+    "onnx/examples/np_array_tensorproto.ipynb"
+  ];
+
   # The executables are just utility scripts that aren't too important
   postInstall = ''
     rm -r $out/bin

--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -3,8 +3,10 @@
 , lib
 , numpy
 , onnx
+, packaging
 , pytestCheckHook
 , pytorch
+, torchvision
 , typing-extensions
 }:
 
@@ -19,15 +21,28 @@ buildPythonPackage rec {
     sha256 = "sha256-gB575ZKXZRAy5K5CkBtfG6KG1yQ9WDREIobsy43CEOc=";
   };
 
-  propagatedBuildInputs = [ numpy pytorch typing-extensions ];
+  propagatedBuildInputs = [ numpy packaging pytorch typing-extensions ];
 
-  checkInputs = [ onnx pytestCheckHook ];
+  checkInputs = [ onnx pytestCheckHook torchvision ];
+
+  preCheck = ''
+    # ignore all pytest warnings
+    rm pytest.ini
+  '';
 
   pythonImportsCheck = [ "pytorch_pfn_extras" ];
 
   disabledTestPaths = [
     # Requires optuna which is currently (2022-02-16) marked as broken.
     "tests/pytorch_pfn_extras_tests/test_config_types.py"
+
+    # requires onnxruntime which was removed because of poor maintainability
+    "tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py"
+    "tests/pytorch_pfn_extras_tests/onnx_tests/test_torchvision.py"
+    "tests/pytorch_pfn_extras_tests/onnx_tests/utils.py"
+
+    # RuntimeError: No Op registered for Gradient with domain_version of 9
+    "tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py"
 
     # Requires CUDA access which is not possible in the nix environment.
     "tests/pytorch_pfn_extras_tests/cuda_tests/test_allocator.py"

--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
     "tests/pytorch_pfn_extras_tests/test_config_types.py"
 
     # requires onnxruntime which was removed because of poor maintainability
+    # See https://github.com/NixOS/nixpkgs/pull/105951 https://github.com/NixOS/nixpkgs/pull/155058
     "tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py"
     "tests/pytorch_pfn_extras_tests/onnx_tests/test_torchvision.py"
     "tests/pytorch_pfn_extras_tests/onnx_tests/utils.py"

--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -25,8 +25,8 @@ buildPythonPackage rec {
 
   checkInputs = [ onnx pytestCheckHook torchvision ];
 
+  # ignore all pytest warnings
   preCheck = ''
-    # ignore all pytest warnings
     rm pytest.ini
   '';
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
