### PR TITLE
shortwave: 2.0.1 -> 3.0.0

### DIFF
--- a/pkgs/applications/audio/shortwave/default.nix
+++ b/pkgs/applications/audio/shortwave/default.nix
@@ -14,28 +14,29 @@
 , ninja
 , openssl
 , pkg-config
-, python3
 , rustPlatform
 , sqlite
-, wrapGAppsHook
+, wrapGAppsHook4
+, cmake
+, libshumate
 }:
 
 stdenv.mkDerivation rec {
   pname = "shortwave";
-  version = "2.0.1";
+  version = "3.0.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Shortwave";
     rev = version;
-    sha256 = "sha256-25qPb7qlqCwYJzl4qZxAZYx5asxSlXBlc/0dGyBdk1o=";
+    sha256 = "sha256-qwk63o9pfqpAm6l9ioj3RccacemQU8R6LF6El4yHkjQ";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-00dQXcSNmdZb2nSLG3q7jm4sugF9XR4LbH0OmcuHVxA=";
+    hash = "sha256-YrB322nv9CgZqt5//VMvVwjWA51ePlX2PI6raRJGBxA=";
   };
 
   nativeBuildInputs = [
@@ -46,11 +47,11 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    python3
     rustPlatform.rust.cargo
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
-    wrapGAppsHook
+    wrapGAppsHook4
+    cmake
   ];
 
   buildInputs = [
@@ -61,16 +62,13 @@ stdenv.mkDerivation rec {
     libadwaita
     openssl
     sqlite
+    libshumate
   ] ++ (with gst_all_1; [
     gstreamer
     gst-plugins-base
     gst-plugins-good
     gst-plugins-bad
   ]);
-
-  postPatch = ''
-    patchShebangs build-aux/meson/postinstall.py
-  '';
 
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/World/Shortwave";
@@ -80,7 +78,6 @@ stdenv.mkDerivation rec {
       desktop. It is the successor to the older Gradio application.
     '';
     maintainers = with maintainers; [ lasandell ];
-    broken = true; # incompatible with latest libadwaita
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes


**Changelog:**

> release version="3.0.0" date="2022-04-23
> Version 3.0.0 is a stable release, with the following major improvements since 2.0.1:
> 
> - Updated user interface that uses the new Adwaita design, with many improvements.
> - Support for the new GNOME 42 dark mode.
> - New option to add private stations to the library, which should not (or cannot) be available on radio-browser.info (e.g. local network or paid streams).
> - Display station bitrate information, which can also be used as a sorting option.
> - Save station data to disk so that it is still available when a station gets removed from the online database.
> - New button on the search page that allows to sort the search results.
> - Overhauled station dialog, with more clearly displayed information.
> - Update desktop notification on song change instead of generating a new separate notification for each song.
> - Shortwave can now be used normally, even if radio-browser.info is offline / unavailable.
> 
> Besides these improvements, this version also includes many changes
> under the hood changes, so many crashes and other bugs have been
> fixed. It also contains updated translations for 31 different
> languages.

https://gitlab.gnome.org/World/Shortwave/-/commit/1c698e980fd0077c68c34dcec5264e8c50c69ae8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
