### PR TITLE
pdfdiff: 0.92 -> 0.93

### DIFF
--- a/pkgs/applications/misc/pdfdiff/default.nix
+++ b/pkgs/applications/misc/pdfdiff/default.nix
@@ -1,37 +1,40 @@
-{ lib, python2Packages, fetchurl, xpdf }:
+{ lib
+, fetchFromGitHub
+, python3Packages
+, xpdf
+}:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "pdfdiff";
-  version = "0.92";
+  version = "0.93";
 
-  src = fetchurl {
-    url = "https://www.cs.ox.ac.uk/people/cas.cremers/downloads/software/pdfdiff.py";
-    sha256 = "0zxwjjbklz87wkbhkmsvhc7xmv5php7m2a9vm6ydhmhlxsybf836";
+  src = fetchFromGitHub {
+    owner = "cascremers";
+    repo = "pdfdiff";
+    rev = version;
+    hash = "sha256-NPki/PFm0b71Ksak1mimR4w6J2a0jBCbQDTMQR4uZFI=";
   };
 
-  buildInputs = [  python2Packages.wrapPython ];
+  format = "other";
 
   dontConfigure = true;
   dontBuild = true;
   doCheck = false;
 
-  unpackPhase = "cp $src pdfdiff.py";
-
   postPatch = ''
-    sed -i -r 's|pdftotextProgram = "pdftotext"|pdftotextProgram = "${xpdf}/bin/pdftotext"|' pdfdiff.py
-    sed -i -r 's|progName = "pdfdiff.py"|progName = "pdfdiff"|' pdfdiff.py
+    substituteInPlace pdfdiff.py \
+      --replace 'pdftotextProgram = "pdftotext"' 'pdftotextProgram = "${xpdf}/bin/pdftotext"' \
+      --replace 'progName = "pdfdiff.py"' 'progName = "pdfdiff"'
     '';
 
   installPhase = ''
     mkdir -p $out/bin
     cp pdfdiff.py $out/bin/pdfdiff
     chmod +x $out/bin/pdfdiff
-
-    substituteInPlace $out/bin/pdfdiff --replace "#!/usr/bin/python" "#!${python2Packages.python.interpreter}"
     '';
 
   meta = with lib; {
-    homepage = "http://www.cs.ox.ac.uk/people/cas.cremers/misc/pdfdiff.html";
+    homepage = "https://github.com/cascremers/pdfdiff";
     description = "Tool to view the difference between two PDF or PS files";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes
Appears to have a new home: https://github.com/cascremers/pdfdiff
Bonus: python2 -> python3
NB: This depends on https://github.com/NixOS/nixpkgs/pull/170179 since xpdf doesn't host older versions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
