### PR TITLE
sigi: 3.0.3 -> 3.2.1

### DIFF
--- a/pkgs/applications/misc/sigi/default.nix
+++ b/pkgs/applications/misc/sigi/default.nix
@@ -2,25 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sigi";
-  version = "3.0.2";
+  version = "3.2.1";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-N+8DdokiYW5mHIQJisdTja8xMVGip37X6c/xBYnQaRU=";
+    sha256 = "sha256-1eZ6i0CvjNyYlWb7c0OPlGtvVSFpi8hiOl/7qeeE9wA=";
   };
 
+  cargoSha256 = "sha256-Tyrcu/BYt9k4igiEIiZ2I7VIGiBZ3D2i6XfT/XGlU+U=";
   nativeBuildInputs = [ installShellFiles ];
 
-  # As part of its tests, sigi hard-codes a location to BATS based on git
-  # submodules. The tests are recommeded to skip for Linux packaging. They'll
-  # move to Rust after this issue: https://github.com/hiljusti/sigi/issues/19
-  checkFlags = [ "SKIP_BATS_TESTS=1" ];
+  # In case anything goes wrong.
+  checkFlags = [ "RUST_BACKTRACE=1" ];
 
   postInstall = ''
     installManPage sigi.1
   '';
-
-  cargoSha256 = "sha256-vO9ocTDcGt/T/sLCP+tCHXihV1H2liFDjI7OhhmPd3I=";
 
   passthru.tests.version = testVersion { package = sigi; };
 


### PR DESCRIPTION
###### Description of changes

Backporting https://github.com/NixOS/nixpkgs/pull/166389

This includes changes from [3.1.0](https://github.com/hiljusti/sigi/releases/tag/v3.1.0) and [3.1.1](https://github.com/hiljusti/sigi/releases/tag/v3.1.1).

This is fully backwards-compatible. There is one new subcommand (list-stacks) added to the CLI, all other changes are to internals, testing, and documentation.

The https://github.com/hiljusti/sigi/issues/19 is complete, so testing now happens with no skips at all.

https://github.com/hiljusti/sigi/compare/v3.0.3...v3.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
