### PR TITLE
python3Packages.vivisect: unbreak on python3

### DIFF
--- a/pkgs/development/python-modules/vivisect/default.nix
+++ b/pkgs/development/python-modules/vivisect/default.nix
@@ -2,21 +2,40 @@
 , buildPythonPackage
 , isPy3k
 , fetchPypi
+, wrapQtAppsHook
+
+# propagates
 , pyasn1
 , pyasn1-modules
 , cxxfilt
 , msgpack
 , pycparser
+
+# extras: gui
+, pyqt5
+, pyqtwebengine
+
+# knobs
+, withGui ? false
 }:
+
 buildPythonPackage rec {
   pname = "vivisect";
   version = "1.0.7";
-  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "727a27ac1eb95d5a41f4430f6912e79940525551314fe68a2811fc9d51eaf2e9";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'cxxfilt>=0.2.1,<0.3.0' 'cxxfilt'
+  '';
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
 
   propagatedBuildInputs = [
     pyasn1
@@ -24,10 +43,15 @@ buildPythonPackage rec {
     cxxfilt
     msgpack
     pycparser
+  ] ++ lib.optionals (withGui) passthru.extras-require.gui;
+
+  passthru.extras-require.gui = [
+    pyqt5
+    pyqtwebengine
   ];
 
-  preBuild = ''
-    sed "s@==.*'@'@" -i setup.py
+  postFixup = ''
+    wrapQtApp $out/bin/vivbin
   '';
 
   # requires another repo for test files

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34664,6 +34664,8 @@ with pkgs;
 
   vivid = callPackage ../tools/misc/vivid { };
 
+  vivisect = with python3Packages; toPythonApplication (vivisect.override { withGui = true; });
+
   vokoscreen = libsForQt5.callPackage ../applications/video/vokoscreen { };
 
   vokoscreen-ng = libsForQt5.callPackage ../applications/video/vokoscreen-ng {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10669,7 +10669,9 @@ in {
 
   vispy = callPackage ../development/python-modules/vispy { };
 
-  vivisect = callPackage ../development/python-modules/vivisect { };
+  vivisect = callPackage ../development/python-modules/vivisect {
+    inherit (pkgs.libsForQt5) wrapQtAppsHook;
+  };
 
   viv-utils = callPackage ../development/python-modules/viv-utils { };
 


### PR DESCRIPTION
Relaxes the cxxfilt constraint to fix the build.

Implements extras handling for the GUI and create a toplevel attribute
that enables it.

Fixes: #138272

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
