### PR TITLE
fenics: use normal pytest

### DIFF
--- a/pkgs/development/python-modules/fenics/default.nix
+++ b/pkgs/development/python-modules/fenics/default.nix
@@ -1,44 +1,36 @@
 { lib, stdenv
 , fetchurl
 , fetchpatch
+, blas
 , boost
 , cmake
 , doxygen
 , eigen
+, gtest
+, hdf5
+, lapack
+, mpi
 , mpi4py
 , numpy
 , pkg-config
+, ply
 , pybind11
 , pytest
-, pythonPackages
-, six
-, sympy
-, gtest
-, hdf5
-, mpi
-, ply
 , python
+, pythonPackages
 , scotch
 , setuptools
+, six
 , sphinx
 , suitesparse
 , swig
+, sympy
 , zlib
-, blas
-, lapack
 , nixosTests
 }:
+
 let
   version = "2019.1.0";
-
-  # TODO: test with newer pytest
-  pytest = pythonPackages.callPackage
-    ../../../../python2-modules/pytest {
-      # hypothesis tests require pytest that causes dependency cycle
-      hypothesis = pythonPackages.hypothesis.override {
-        doCheck = false;
-      };
-    };
 
   dijitso = pythonPackages.buildPythonPackage {
     pname = "dijitso";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2877,7 +2877,7 @@ in {
 
   feedparser = callPackage ../development/python-modules/feedparser { };
 
-  fenics = callPackage ../development/libraries/science/math/fenics {
+  fenics = callPackage ../development/python-modules/fenics {
     hdf5 = pkgs.hdf5_1_10;
     boost = pkgs.boost169;
   };


### PR DESCRIPTION
###### Description of changes
Seems to test fine with the normal pytest so this should remove another python2 bit.
NB: The noise at the top is due to a sort.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
