### PR TITLE
gnome.gnome-music: 42.0 → 42.1

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-music/default.nix
@@ -8,7 +8,7 @@
 , libxml2
 , python3
 , libnotify
-, wrapGAppsHook
+, wrapGAppsHook4
 , libmediaart
 , gobject-introspection
 , gnome-online-accounts
@@ -30,13 +30,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "42.0";
+  version = "42.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "nWgZj5hSveD4NFhLlqgSiX0xDLcXKLak8Ji8spsZxdA=";
+    sha256 = "x3R/pqhrVrGK1v+VD/kB5Z7n+sEcaLKmcnr4bq7tgnA=";
   };
 
   nativeBuildInputs = [
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication rec {
     itstool
     pkg-config
     libxml2
-    wrapGAppsHook
+    wrapGAppsHook4
     desktop-file-utils
     appstream-glib
     gobject-introspection
@@ -60,7 +60,6 @@ python3.pkgs.buildPythonApplication rec {
     gnome-online-accounts
     gobject-introspection
     gdk-pixbuf
-    gnome.adwaita-icon-theme
     python3
     grilo
     grilo-plugins


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/gnome-music/-/compare/42.0...42.1

Overview of changes in 42.1

- Make shuffle shuffle again
- Fix time display in RTL languages
- No longer mismatch art on scrolling
- Fix async queue block on fresh art retrieval

Bugs fixed
- Rework ArtStack to handle cycling widgets better (<a href="https://gitlab.gnome.org/GNOME/gnome-music/issues/500">#500</a>)
- Shuffle broken in Music 42 (<a href="https://gitlab.gnome.org/GNOME/gnome-music/issues/515">#515</a>)
- Time is reversed in RTL (<a href="https://gitlab.gnome.org/GNOME/gnome-music/issues/509">#509</a>)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Built on x86_64-linux.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
