### PR TITLE
faq: init at unstable-2022-01-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13444,6 +13444,12 @@
     githubId = 18196237;
     name = "Quentin Inkling";
   };
+  quentin-m = {
+    email = "me+nix@quentin-machu.fr";
+    github = "Quentin-M";
+    githubId = 1332289;
+    name = "Quentin Machu";
+  };
   qyliss = {
     email = "hi@alyssa.is";
     github = "alyssais";

--- a/pkgs/development/tools/faq/default.nix
+++ b/pkgs/development/tools/faq/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, jq
+, oniguruma
+}:
+
+buildGoModule rec {
+  pname = "faq";
+  # Latest git release (0.0.7) presents vendor issues - using latest commit instead.
+  version = "unstable-2022-01-09";
+
+  src = fetchFromGitHub {
+    owner = "jzelinskie";
+    repo = "faq";
+    rev = "594bb8e15dc4070300f39c168354784988646231";
+    sha256 = "1lqrchj4sj16n6y5ljsp8v4xmm57gzkavbddq23dhlgkg2lfyn91";
+  };
+  vendorSha256 = "sha256-731eINkboZiuPXX/HQ4r/8ogLedKBWx1IV7BZRKwU3A";
+
+  buildInputs = [
+    jq
+    oniguruma
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/jzelinskie/faq/internal/version.Version=${version}"
+  ];
+
+  tags = [
+    "netgo"
+  ];
+
+  subPackages = [
+    "cmd/faq"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "faq is a tool intended to be a more flexible jq, supporting additional formats";
+    homepage = "https://github.com/jzelinskie/faq";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ quentin-m ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -585,6 +585,8 @@ with pkgs;
 
   expressvpn = callPackage ../applications/networking/expressvpn { };
 
+  faq = callPackage ../development/tools/faq { };
+
   figma-agent = callPackage ../applications/graphics/figma-agent { };
 
   figma-linux = callPackage ../applications/graphics/figma-linux { };


### PR DESCRIPTION
###### Description of changes

Add https://github.com/jzelinskie/faq

> faq is a tool intended to be a more flexible [jq](https://github.com/stedolan/jq), supporting additional formats. The additional formats are converted into JSON and processed with [libjq](https://github.com/stedolan/jq/wiki/C-API:-libjq).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
