### PR TITLE
python3Packages.dropbox: Clean up package and enable more tests

### DIFF
--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "dropbox";
     repo = "dropbox-sdk-python";
     rev = "v${version}";
-    hash = "sha256-pq/LkyOCS0PnujfN9aIx42aeZ8tw4XvRQ4Vid/nXgWE=";
+    hash = "sha256-w07r95MBAClf0F3SICiZsHLdslzf+JuxC+BVdTACCog=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -1,12 +1,13 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
 , requests
-, urllib3
-, mock
-, setuptools
+, six
 , stone
-, pythonOlder
+, mock
+, pytest-mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -20,15 +21,19 @@ buildPythonPackage rec {
     owner = "dropbox";
     repo = "dropbox-sdk-python";
     rev = "v${version}";
-    sha256 = "sha256-pq/LkyOCS0PnujfN9aIx42aeZ8tw4XvRQ4Vid/nXgWE=";
+    hash = "sha256-pq/LkyOCS0PnujfN9aIx42aeZ8tw4XvRQ4Vid/nXgWE=";
   };
 
   propagatedBuildInputs = [
     requests
-    urllib3
-    mock
-    setuptools
+    six
     stone
+  ];
+
+  checkInputs = [
+    mock
+    pytest-mock
+    pytestCheckHook
   ];
 
   postPatch = ''
@@ -36,11 +41,32 @@ buildPythonPackage rec {
       --replace "'pytest-runner == 5.2.0'," ""
   '';
 
-  # Set DROPBOX_TOKEN environment variable to a valid token.
-  doCheck = false;
+  doCheck = true;
 
   pythonImportsCheck = [
     "dropbox"
+  ];
+
+  # Set SCOPED_USER_DROPBOX_TOKEN environment variable to a valid value.
+  disabledTests = [
+    "test_default_oauth2_urls"
+    "test_bad_auth"
+    "test_multi_auth"
+    "test_refresh"
+    "test_app_auth"
+    "test_downscope"
+    "test_rpc"
+    "test_upload_download"
+    "test_bad_upload_types"
+    "test_clone_when_user_linked"
+    "test_with_path_root_constructor"
+    "test_path_root"
+    "test_path_root_err"
+    "test_versioned_route"
+    "test_team"
+    "test_as_user"
+    "test_as_admin"
+    "test_clone_when_team_linked"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Followup to #170261 .
Clean up dependencies, enable the unittests at least.

~Open issue (tips welcome):~

```
$ ls result/lib/python3.9/site-packages/
dropbox  dropbox-0.0.0.dist-info
```

~Any idea why this would get a 0.0.0 version? This (probably) causes `maestral` to fail to find a matching version.~

@peterhoeg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
