### PR TITLE
dcm2niix: add DICOM validation tests

### DIFF
--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, callPackage
 , substituteAll
 , cmake
 , openjpeg
@@ -54,6 +55,42 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals withCloudflareZlib [
     "-DZLIB_IMPLEMENTATION=Cloudflare"
   ];
+
+  passthru.tests = {
+    dcm-qa = callPackage ./tests/dicom-validation {
+      name = "${pname}-dcm-qa";
+
+      src = fetchFromGitHub {
+        owner = "neurolabusc";
+        repo = "dcm_qa";
+        # HEAD revision of the master branch on 2022-04-19.
+        rev = "bb457d98bdb320af3b9f29fad1c706788490dab8";
+        sha256 = "sha256-rlfChr/A45x1oxozZJxozS/rHUfXlLgmERDpPAx8LKA=";
+      };
+    };
+    dcm-qa-nih = callPackage ./tests/dicom-validation {
+      name = "${pname}-dcm-qa-nih";
+
+      src = fetchFromGitHub {
+        owner = "neurolabusc";
+        repo = "dcm_qa_nih";
+        # HEAD revision of the master branch on 2022-04-19.
+        rev = "aa82e560d5471b53f0d0332c4de33d88bf179157";
+        sha256 = "sha256-4Yjgs7UnpFv5KjVqWQXdfhKDhaSKQp7PUghmMoWC5KU=";
+      };
+    };
+    dcm-qa-uih = callPackage ./tests/dicom-validation {
+      name = "${pname}-dcm-qa-uih";
+
+      src = fetchFromGitHub {
+        owner = "neurolabusc";
+        repo = "dcm_qa_uih";
+        # HEAD revision of the master branch on 2022-04-19.
+        rev = "4c0e2b37430fa566a501bb65f35a9ad4089e71a9";
+        sha256 = "sha256-TtBfgL8XWUozS3XKFa4DVzM4y0o58oR9E56f7ANSDP4=";
+      };
+    };
+  };
 
   meta = with lib; {
     description = "DICOM to NIfTI converter";

--- a/pkgs/applications/science/biology/dcm2niix/tests/dicom-validation/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/tests/dicom-validation/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, dcm2niix
+, python
+, name
+, src
+}:
+
+stdenv.mkDerivation {
+  inherit name src;
+
+  nativeBuildInputs = [ dcm2niix python ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = true;
+  dontFixup = true;
+
+  patchPhase = ''
+    patchShebangs batch.sh
+  '';
+
+  checkPhase = ''
+    ./batch.sh
+  '';
+
+  installPhase = ''
+    touch "$out"
+  '';
+
+  meta.timeout = 120;
+}


### PR DESCRIPTION
###### Description of changes

Add the DICOM validation tests [suggested](https://github.com/NixOS/nixpkgs/pull/165477#issuecomment-1097191300) by @neurolabusc that the upstream runs as part of their Travis CI [build](https://github.com/rordenlab/dcm2niix/blob/002ebcdb9b2a87de7b883e9ddada3963a1cc2327/.travis.yml#L27-L33/).


Resolves https://github.com/d3b-center/image-deid-etl/issues/19

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
