### PR TITLE
dotnet ecosystem: various fixes

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -74,13 +74,16 @@ let
     inherit dotnet-sdk dotnet-test-sdk disabledTests nuget-source dotnet-runtime runtimeDeps buildType;
   }) dotnetConfigureHook dotnetBuildHook dotnetCheckHook dotnetInstallHook dotnetFixupHook;
 
-  _nugetDeps = mkNugetDeps { name = "${name}-nuget-deps"; nugetDeps = import nugetDeps; };
-  _localDeps = linkFarmFromDrvs "${name}-local-nuget-deps" projectReferences;
+  localDeps = if (projectReferences != [])
+    then linkFarmFromDrvs "${name}-project-references" projectReferences
+    else null;
+
+  _nugetDeps = mkNugetDeps { inherit name; nugetDeps = import nugetDeps; };
 
   nuget-source = mkNugetSource {
-    name = "${args.pname}-nuget-source";
-    description = "A Nuget source with the dependencies for ${args.pname}";
-    deps = [ _nugetDeps _localDeps ];
+    name = "${name}-nuget-source";
+    description = "A Nuget source with the dependencies for ${name}";
+    deps = [ _nugetDeps ] ++ lib.optional (localDeps != null) localDeps;
   };
 
 in stdenvNoCC.mkDerivation (args // {
@@ -103,6 +106,8 @@ in stdenvNoCC.mkDerivation (args // {
   dontWrapGApps = args.dontWrapGApps or true;
 
   passthru = {
+    inherit nuget-source;
+
     fetch-deps = writeScript "fetch-${pname}-deps" ''
       set -euo pipefail
       cd "$(dirname "''${BASH_SOURCE[0]}")"

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-build-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-build-hook.sh
@@ -1,4 +1,5 @@
-declare -a projectFile testProjectFile dotnetBuildFlags dotnetFlags
+# inherit arguments from derivation
+dotnetBuildFlags=( ${dotnetBuildFlags[@]-} )
 
 dotnetBuildHook() {
     echo "Executing dotnetBuildHook"

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-check-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-check-hook.sh
@@ -1,4 +1,5 @@
-declare -a testProjectFile dotnetTestFlags dotnetFlags
+# inherit arguments from derivation
+dotnetTestFlags=( ${dotnetTestFlags[@]-} )
 
 dotnetCheckHook() {
     echo "Executing dotnetCheckHook"

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
@@ -1,4 +1,8 @@
-declare -a projectFile testProjectFile dotnetRestoreFlags dotnetFlags
+declare -a projectFile testProjectFile
+
+# inherit arguments from derivation
+dotnetFlags=( ${dotnetFlags[@]-} )
+dotnetRestoreFlags=( ${dotnetRestoreFlags[@]-} )
 
 dotnetConfigureHook() {
     echo "Executing dotnetConfigureHook"

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
@@ -1,4 +1,5 @@
-declare -a makeWrapperArgs gappsWrapperArgs
+# Inherit arguments from the derivation
+makeWrapperArgs=( ${makeWrapperArgs-} )
 
 # First argument is the executable you want to wrap,
 # the second is the destination for the wrapper.
@@ -15,9 +16,9 @@ wrapDotnetProgram() {
 dotnetFixupHook() {
     echo "Executing dotnetFixupPhase"
 
-    if [ "${executables-}" ]; then
+    if [ "${executables}" ]; then
         for executable in ${executables[@]}; do
-            execPath="$out/lib/${pname-}/$executable"
+            execPath="$out/lib/${pname}/$executable"
 
             if [[ -f "$execPath" && -x "$execPath" ]]; then
                 wrapDotnetProgram "$execPath" "$out/bin/$(basename "$executable")"
@@ -27,7 +28,7 @@ dotnetFixupHook() {
             fi
         done
     else
-        for executable in $out/lib/${pname-}/*; do
+        for executable in $out/lib/${pname}/*; do
             if [[ -f "$executable" && -x "$executable" && "$executable" != *"dll"* ]]; then
                 wrapDotnetProgram "$executable" "$out/bin/$(basename "$executable")"
             fi

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-install-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-install-hook.sh
@@ -1,4 +1,5 @@
-declare -a projectFile dotnetInstallFlags dotnetFlags
+# inherit arguments from derivation
+dotnetInstallFlags=( ${dotnetInstallFlags[@]-} )
 
 dotnetInstallHook() {
     echo "Executing dotnetInstallHook"

--- a/pkgs/build-support/dotnet/make-nuget-source/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-source/default.nix
@@ -1,30 +1,38 @@
 { dotnetPackages, lib, xml2, stdenvNoCC }:
-{ name, description ? "", deps ? [] }:
-let
-  _nuget-source = stdenvNoCC.mkDerivation rec {
-    inherit name;
-    meta.description = description;
 
+{ name
+, description ? ""
+, deps ? []
+}:
+
+let
+  nuget-source = stdenvNoCC.mkDerivation rec {
+    inherit name;
+
+    meta.description = description;
     nativeBuildInputs = [ dotnetPackages.Nuget xml2 ];
+
     buildCommand = ''
       export HOME=$(mktemp -d)
       mkdir -p $out/{lib,share}
 
-      nuget sources Add -Name nixos -Source "$out/lib"
-      ${ lib.concatMapStringsSep "\n" (dep:
-          ''nuget init "${dep}" "$out/lib"''
-        ) deps }
+      ${lib.concatMapStringsSep "\n" (dep: ''
+        nuget init "${dep}" "$out/lib"
+      '') deps}
 
-      # Generates a list of all unique licenses' spdx ids.
+      # Generates a list of all licenses' spdx ids, if available.
+      # Note that this currently ignores any license provided in plain text (e.g. "LICENSE.txt")
       find "$out/lib" -name "*.nuspec" -exec sh -c \
-        "xml2 < {} | grep "license=" | cut -d'=' -f2" \; | sort -u > $out/share/licenses
+        "NUSPEC=\$(xml2 < {}) && echo "\$NUSPEC" | grep license/@type=expression | tr -s \  '\n' | grep "license=" | cut -d'=' -f2" \
+      \; | sort -u > $out/share/licenses
     '';
-} // { # This is done because we need data from `$out` for `meta`. We have to use overrides as to not hit infinite recursion.
-  meta.licence = let
-    depLicenses = lib.splitString "\n" (builtins.readFile "${_nuget-source}/share/licenses");
-    getLicence = spdx: lib.filter (license: license.spdxId or null == spdx) (builtins.attrValues lib.licenses);
-  in (lib.flatten (lib.forEach depLicenses (spdx:
-    if (getLicence spdx) != [] then (getLicence spdx) else [] ++ lib.optional (spdx != "") spdx
-  )));
-};
-in _nuget-source
+  } // { # We need data from `$out` for `meta`, so we have to use overrides as to not hit infinite recursion.
+    meta.licence = let
+      depLicenses = lib.splitString "\n" (builtins.readFile "${nuget-source}/share/licenses");
+    in (lib.flatten (lib.forEach depLicenses (spdx:
+      if (spdx != "")
+        then lib.getLicenseFromSpdxId spdx
+        else []
+    )));
+  };
+in nuget-source

--- a/pkgs/build-support/dotnet/nuget-to-nix/default.nix
+++ b/pkgs/build-support/dotnet/nuget-to-nix/default.nix
@@ -1,5 +1,27 @@
-{ runCommand }:
+{ lib
+, runCommandLocal
+, runtimeShell
+, substituteAll
+, nix
+, coreutils
+, findutils
+, gnused
+}:
 
-runCommand "nuget-to-nix" { preferLocalBuild = true; } ''
-  install -D -m755 ${./nuget-to-nix.sh} $out/bin/nuget-to-nix
+runCommandLocal "nuget-to-nix" {
+  script = substituteAll {
+    src = ./nuget-to-nix.sh;
+    inherit runtimeShell;
+
+    binPath = lib.makeBinPath [
+      nix
+      coreutils
+      findutils
+      gnused
+    ];
+  };
+
+  meta.description = "Convert a nuget packages directory to a lockfile for buildDotnetModule";
+} ''
+  install -Dm755 $script $out/bin/nuget-to-nix
 ''

--- a/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
+++ b/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
@@ -1,6 +1,8 @@
-#!/usr/bin/env bash
+#!@runtimeShell@
 
 set -euo pipefail
+
+export PATH="@binPath@"
 
 if [ $# -eq 0 ]; then
   >&2 echo "Usage: $0 [packages directory] > deps.nix"


### PR DESCRIPTION
###### Description of changes
This fixes a few annoying bugs in `buildDotnetModule` and some of the functions it uses. Most notably flags like `dotnetFlags` and `makeWrapperArgs` we not properly interpreted from the child derivation, causing some issues if they contained spaces. As a workaround some derivations set those flags through bash, but that's obviously not great. I'll create a PR fixing those after this gets merged :+1: 

For more information see the commit descriptions. 

cc @SuperSandro2000 @Mic92 @jonringer @prusnak 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
