### PR TITLE
.github/CODEOWNERS: add IvarWithoutBones for dotnet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -285,3 +285,7 @@
 /nixos/modules/services/misc/matrix-conduit.nix            @piegamesde
 /nixos/tests/matrix-appservice-irc.nix                     @piegamesde
 /nixos/tests/matrix-conduit.nix                            @piegamesde
+
+# Dotnet
+/pkgs/build-support/dotnet          @IvarWithoutBones
+/pkgs/development/compilers/dotnet  @IvarWithoutBones


### PR DESCRIPTION
###### Description of changes
This adds a section for `dotnet` in CODEOWNERS as I'd like to get notified when someone touches it. `pkgs/build-support/dotnet` contains `buildDotnetModule` and a few functions it uses, which I wrote. I've also been reviewing updates to the SDK so I've added that as well.
