### PR TITLE
hyfetch: init at 1.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5145,6 +5145,12 @@
     githubId = 15371828;
     name = "Hugo Lageneste";
   };
+  hykilpikonna = {
+    name = "Azalea";
+    email = "hykilpikonna@gmail.com";
+    github = "hykilpikonna";
+    githubId = 22280294;
+  };
   hypersw = {
     email = "baltic@hypersw.net";
     github = "hypersw";

--- a/pkgs/tools/misc/hyfetch/default.nix
+++ b/pkgs/tools/misc/hyfetch/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, python3Packages
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "HyFetch";
+  version = "1.0.7";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    hash = "sha256-3/6/3EtTqHXTMuRIo2nclIxYSzOFvQegR29OJsKMQU4=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    typing-extensions
+    setuptools
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "neofetch with pride flags <3";
+    longDescription = ''
+        HyFetch is a command-line system information tool fork of neofetch.
+        HyFetch displays information about your system next to your OS logo
+        in ASCII representation. The ASCII representation is then colored in
+        the pattern of the pride flag of your choice. The main purpose of
+        HyFetch is to be used in screenshots to show other users what
+        operating system or distribution you are running, what theme or
+        icon set you are using, etc.
+    '';
+    homepage = "https://github.com/hykilpikonna/HyFetch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hykilpikonna ];
+    mainProgram = "hyfetch";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6930,6 +6930,8 @@ with pkgs;
     stdenv = gcc8Stdenv;
   };
 
+  hyfetch = callPackage ../tools/misc/hyfetch { };
+
   hylafaxplus = callPackage ../servers/hylafaxplus { };
 
   hyphen = callPackage ../development/libraries/hyphen { };


### PR DESCRIPTION
###### Description of changes

Add [HyFetch](https://github.com/hykilpikonna/hyfetch) package

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
