### PR TITLE
Noise repellent : 0.1.5 -> 0.2.1

### DIFF
--- a/pkgs/applications/audio/noise-repellent/default.nix
+++ b/pkgs/applications/audio/noise-repellent/default.nix
@@ -1,22 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, fftwFloat, lv2 }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, cmake, libspecbleach, lv2 }:
 
 stdenv.mkDerivation rec {
   pname = "noise-repellent";
-  version = "0.1.5";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "lucianodato";
     repo = pname;
-    rev = version;
-    sha256 = "0hb89x9i2knzan46q4nwscf5zmnb2nwf4w13xl2c0y1mx1ls1mwl";
-    fetchSubmodules = true;
+    rev = "v${version}";
+    sha256 = "sha256-hMNVzhJZFGFeu5aygLkfq495O0zpaIk41ddzejvDITE=";
   };
 
-  mesonFlags = ("--prefix=${placeholder "out"}/lib/lv2");
+  mesonFlags = [
+    "--prefix=${placeholder "out"}/lib/lv2"
+    "--buildtype=release"
+  ];
 
-  nativeBuildInputs = [ meson ninja pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config cmake ];
   buildInputs = [
-    fftwFloat lv2
+    libspecbleach lv2
   ];
 
   meta = with lib; {
@@ -24,6 +26,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/lucianodato/noise-repellent";
     license     = licenses.gpl3;
     maintainers = [ maintainers.magnetophon ];
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "i686-darwin"  ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/libspecbleach/default.nix
+++ b/pkgs/development/libraries/audio/libspecbleach/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, fftwFloat}:
+
+stdenv.mkDerivation rec {
+  pname = "libspecbleach";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "lucianodato";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-WmUl8rA/+V+hv7FPG/5Or6aAQVqt1rIJtdb53KhSmuo=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [
+    fftwFloat
+  ];
+
+  meta = with lib; {
+    description = "C library for audio noise reduction";
+    homepage    = "https://github.com/lucianodato/libspecbleach";
+    license     = licenses.lgpl2;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18718,6 +18718,8 @@ with pkgs;
 
   libspectre = callPackage ../development/libraries/libspectre { };
 
+  libspecbleach = callPackage ../development/libraries/audio/libspecbleach { };
+
   libspnav = callPackage ../development/libraries/libspnav { };
 
   libgsf = callPackage ../development/libraries/libgsf { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
