### PR TITLE
protoc-gen-doc: 1.5.0 -> 1.5.1

### DIFF
--- a/pkgs/development/tools/protoc-gen-doc/default.nix
+++ b/pkgs/development/tools/protoc-gen-doc/default.nix
@@ -1,19 +1,17 @@
 { buildGoModule, fetchFromGitHub, lib }:
 
 buildGoModule rec {
-  pname = "protoc-gen-doc-unstable";
-  version = "1.5.0";
+  pname = "protoc-gen-doc";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "pseudomuto";
     repo = "protoc-gen-doc";
     rev = "v${version}";
-    sha256 = "1bpb5wv76p0sjffh5d1frbygp3q1p07sdh5c8pznl5bdh5pd7zxq";
+    sha256 = "sha256-19CN62AwqQGq5Gb5kQqVYhs+LKsJ9K2L0VAakwzPD5Y=";
   };
 
-  vendorSha256 = "08pk9nxsl28dw3qmrlb7vsm8xbdzmx98qwkxgg93ykrhzx235k1b";
-
-  doCheck = false;
+  vendorSha256 = "sha256-K0rZBERSKob5ubZW28QpbcPhgFKOOASkd9UyC9f8gyQ=";
 
   meta = with lib; {
     description = "Documentation generator plugin for Google Protocol Buffers";


### PR DESCRIPTION
[NEEDS FEEDACK] [Help! OfBorg is sad]

protoc-gen-doc: 1.5.0 -> 1.5.1

* Renamed, removed "unstable" from `pname`: Was this a bad idea? It seems so!

* Tests enabled
```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestPFilter
--- PASS: TestPFilter (0.00s)
=== RUN   TestParaFilter
--- PASS: TestParaFilter (0.00s)
=== RUN   TestNoBrFilter
--- PASS: TestNoBrFilter (0.00s)
=== RUN   TestAnchorFilter
--- PASS: TestAnchorFilter (0.00s)
=== RUN   TestParseOptionsForBuiltinTemplates
--- PASS: TestParseOptionsForBuiltinTemplates (0.00s)
=== RUN   TestParseOptionsForSourceRelative
--- PASS: TestParseOptionsForSourceRelative (0.00s)
=== RUN   TestParseOptionsForCustomTemplate
--- PASS: TestParseOptionsForCustomTemplate (0.00s)
=== RUN   TestParseOptionsForExcludePatterns
--- PASS: TestParseOptionsForExcludePatterns (0.00s)
=== RUN   TestParseOptionsWithInvalidValues
--- PASS: TestParseOptionsWithInvalidValues (0.00s)
=== RUN   TestRunPluginForBuiltinTemplate
--- PASS: TestRunPluginForBuiltinTemplate (0.00s)
=== RUN   TestRunPluginForCustomTemplate
--- PASS: TestRunPluginForCustomTemplate (0.00s)
=== RUN   TestRunPluginWithInvalidOptions
--- PASS: TestRunPluginWithInvalidOptions (0.00s)
=== RUN   TestRunPluginForSourceRelative
--- PASS: TestRunPluginForSourceRelative (0.00s)
=== RUN   TestRenderers
--- PASS: TestRenderers (0.01s)
=== RUN   TestNewRenderType
--- PASS: TestNewRenderType (0.00s)
=== RUN   TestNewRenderTypeUnknown
--- PASS: TestNewRenderTypeUnknown (0.00s)
=== RUN   TestTemplateProperties
--- PASS: TestTemplateProperties (0.00s)
=== RUN   TestFileProperties
--- PASS: TestFileProperties (0.00s)
=== RUN   TestFileEnumProperties
--- PASS: TestFileEnumProperties (0.00s)
=== RUN   TestFileExtensionProperties
--- PASS: TestFileExtensionProperties (0.00s)
=== RUN   TestMessageProperties
--- PASS: TestMessageProperties (0.00s)
=== RUN   TestNestedMessageProperties
--- PASS: TestNestedMessageProperties (0.00s)
=== RUN   TestMultiplyNestedMessages
--- PASS: TestMultiplyNestedMessages (0.00s)
=== RUN   TestMessageExtensionProperties
--- PASS: TestMessageExtensionProperties (0.00s)
=== RUN   TestFieldProperties
--- PASS: TestFieldProperties (0.00s)
=== RUN   TestFieldPropertiesProto3
--- PASS: TestFieldPropertiesProto3 (0.00s)
=== RUN   TestFieldPropertiesProto3Optional
--- PASS: TestFieldPropertiesProto3Optional (0.00s)
=== RUN   TestServiceProperties
--- PASS: TestServiceProperties (0.00s)
=== RUN   TestServiceMethodProperties
--- PASS: TestServiceMethodProperties (0.00s)
=== RUN   TestExcludedComments
--- PASS: TestExcludedComments (0.00s)
PASS
ok  	github.com/pseudomuto/protoc-gen-doc	0.021s
=== RUN   TestCode
flag provided but not defined: -whoawhoawhoa
--- PASS: TestCode (0.00s)
=== RUN   TestHasMatch
flag provided but not defined: -watthewhat
--- PASS: TestHasMatch (0.00s)
=== RUN   TestShowHelp
--- PASS: TestShowHelp (0.00s)
=== RUN   TestShowVersion
--- PASS: TestShowVersion (0.00s)
=== RUN   TestPrintHelp
--- PASS: TestPrintHelp (0.00s)
=== RUN   TestPrintVersion
--- PASS: TestPrintVersion (0.00s)
=== RUN   TestInvalidFlags
--- PASS: TestInvalidFlags (0.00s)
=== RUN   TestHandleFlags
--- PASS: TestHandleFlags (0.00s)
PASS
ok  	github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc	0.003s
=== RUN   TestTransform
--- PASS: TestTransform (0.00s)
PASS
ok  	github.com/pseudomuto/protoc-gen-doc/extensions/envoyproxy_validate	0.002s
=== RUN   TestTransform
--- PASS: TestTransform (0.00s)
PASS
ok  	github.com/pseudomuto/protoc-gen-doc/extensions/google_api_http	0.002s
=== RUN   TestTransform
--- PASS: TestTransform (0.00s)
PASS
ok  	github.com/pseudomuto/protoc-gen-doc/extensions/validator_field	0.002s
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
