### PR TITLE
treewide: Simplify negated uses of versionAtLeast, versionOlder

### DIFF
--- a/nixos/modules/services/misc/sourcehut/default.nix
+++ b/nixos/modules/services/misc/sourcehut/default.nix
@@ -1018,7 +1018,7 @@ in
       inherit configIniOfService;
       mainService = mkMerge [ baseService {
         serviceConfig.StateDirectory = [ "sourcehut/gitsrht" "sourcehut/gitsrht/repos" ];
-        preStart = mkIf (!versionAtLeast config.system.stateVersion "22.05") (mkBefore ''
+        preStart = mkIf (versionOlder config.system.stateVersion "22.05") (mkBefore ''
           # Fix Git hooks of repositories pre-dating https://github.com/NixOS/nixpkgs/pull/133984
           (
           set +f

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -7,8 +7,8 @@ let Dune =
   { "1" = dune_1; "2" = dune_2; "3" = dune_3; }."${dune-version}"
 ; in
 
-if (args ? minimumOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion) ||
-   (args ? minimalOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimalOCamlVersion)
+if (args ? minimumOCamlVersion && lib.versionOlder ocaml.version args.minimumOCamlVersion) ||
+   (args ? minimalOCamlVersion && lib.versionOlder ocaml.version args.minimalOCamlVersion)
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -8,7 +8,7 @@
 }@args:
 
 if args ? minimumOCamlVersion &&
-   ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion
+   lib.versionOlder ocaml.version args.minimumOCamlVersion
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -7,7 +7,7 @@ let
 in
 
 { lib, stdenv, fetchurl, ncurses, buildEnv, libunwind, fetchpatch
-, libX11, xorgproto, useX11 ? safeX11 stdenv && !lib.versionAtLeast version "4.09"
+, libX11, xorgproto, useX11 ? safeX11 stdenv && lib.versionOlder version "4.09"
 , aflSupport ? false
 , flambdaSupport ? false
 , spaceTimeSupport ? false
@@ -87,14 +87,14 @@ stdenv.mkDerivation (args // {
   buildFlags = if useNativeCompilers
     then ["nixpkgs_world_bootstrap_world_opt"]
     else ["nixpkgs_world"];
-  buildInputs = optional (!lib.versionAtLeast version "4.07") ncurses
+  buildInputs = optional (lib.versionOlder version "4.07") ncurses
     ++ optionals useX11 [ libX11 xorgproto ];
   propagatedBuildInputs = optional spaceTimeSupport libunwind;
   installTargets = [ "install" ] ++ optional useNativeCompilers "installopt";
-  preConfigure = optionalString (!lib.versionAtLeast version "4.04") ''
+  preConfigure = optionalString (lib.versionOlder version "4.04") ''
     CAT=$(type -tp cat)
     sed -e "s@/bin/cat@$CAT@" -i config/auto-aux/sharpbang
-  '' + optionalString (stdenv.isDarwin && !lib.versionAtLeast version "4.13") ''
+  '' + optionalString (stdenv.isDarwin && lib.versionOlder version "4.13") ''
     # Do what upstream does by default now: https://github.com/ocaml/ocaml/pull/10176
     # This is required for aarch64-darwin, everything else works as is.
     AS="${stdenv.cc}/bin/cc -c" ASPP="${stdenv.cc}/bin/cc -c"
@@ -137,7 +137,7 @@ stdenv.mkDerivation (args // {
     '';
 
     platforms = with platforms; linux ++ darwin;
-    broken = stdenv.isAarch64 && !lib.versionAtLeast version "4.06";
+    broken = stdenv.isAarch64 && lib.versionOlder version "4.06";
   };
 
 })

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -272,7 +272,7 @@ let
               export EXTENSION_DIR=$out/lib/php/extensions
             ''
             # PKG_CONFIG need not be a relative path
-            + lib.optionalString (!lib.versionAtLeast version "7.4") ''
+            + lib.optionalString (lib.versionOlder version "7.4") ''
               for i in $(find . -type f -name "*.m4"); do
                 substituteInPlace $i \
                   --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -32,7 +32,7 @@ assert enablePython -> stdenv.hostPlatform == stdenv.buildPlatform;
 assert enableNumpy -> enablePython;
 
 # Boost <1.69 can't be built on linux with clang >8, because pth was removed
-assert with lib; ((stdenv.isLinux && toolset == "clang" && !(versionOlder stdenv.cc.version "8.0.0")) -> !(versionOlder version "1.69"));
+assert with lib; (stdenv.isLinux && toolset == "clang" && versionAtLeast stdenv.cc.version "8.0.0") -> versionAtLeast version "1.69";
 
 with lib;
 let
@@ -143,7 +143,7 @@ stdenv.mkDerivation {
     stripLen = 1;
     extraPrefix = "libs/context/";
   })
-  ++ optional (and (versionAtLeast version "1.70") (!versionAtLeast version "1.73")) ./cmake-paths.patch
+  ++ optional (versionAtLeast version "1.70" && versionOlder version "1.73") ./cmake-paths.patch
   ++ optional (versionAtLeast version "1.73") ./cmake-paths-173.patch
   ++ optional (version == "1.77.0") (fetchpatch {
     url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -10,7 +10,7 @@
 , z3
 }:
 
-if !lib.versionAtLeast ocaml.version "4.08"
+if lib.versionOlder ocaml.version "4.08"
 then throw "BAP is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -2,7 +2,7 @@
 , doCheck ? lib.versionAtLeast ocaml.version "4.08" && !stdenv.isAarch64
 }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "batteries is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/bitstring/ppx.nix
+++ b/pkgs/development/ocaml-modules/bitstring/ppx.nix
@@ -3,7 +3,7 @@
 , ounit
 }:
 
-if !lib.versionAtLeast ppxlib.version "0.18.0"
+if lib.versionOlder ppxlib.version "0.18.0"
 then throw "ppx_bitstring is not available with ppxlib-${ppxlib.version}"
 else
 

--- a/pkgs/development/ocaml-modules/bitv/default.nix
+++ b/pkgs/development/ocaml-modules/bitv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook, which, ocaml, findlib }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "bitv is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/bz2/default.nix
+++ b/pkgs/development/ocaml-modules/bz2/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitLab, ocaml, findlib, bzip2, autoreconfHook }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "bz2 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, which, ocaml, findlib }:
 
-if !lib.versionAtLeast ocaml.version "4.10"
+if lib.versionOlder ocaml.version "4.10"
 then throw "camlpdf is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, camlpdf, ncurses }:
 
-if !lib.versionAtLeast ocaml.version "4.10"
+if lib.versionOlder ocaml.version "4.10"
 then throw "cpdf is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/cstruct/lwt.nix
+++ b/pkgs/development/ocaml-modules/cstruct/lwt.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, cstruct, lwt }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
+if lib.versionOlder (cstruct.version or "1") "3"
 then cstruct
 else
 

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -2,7 +2,7 @@
 , ounit, cppo, ppx_sexp_conv, cstruct-unix, cstruct-sexp
 }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
+if lib.versionOlder (cstruct.version or "1") "3"
 then cstruct
 else
 

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, ocaml, alcotest, cstruct, sexplib }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
+if lib.versionOlder (cstruct.version or "1") "3"
 then cstruct
 else
 

--- a/pkgs/development/ocaml-modules/cstruct/unix.nix
+++ b/pkgs/development/ocaml-modules/cstruct/unix.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, cstruct }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
+if lib.versionOlder (cstruct.version or "1") "3"
 then cstruct
 else
 

--- a/pkgs/development/ocaml-modules/csv/lwt.nix
+++ b/pkgs/development/ocaml-modules/csv/lwt.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, ocaml, csv, ocaml_lwt }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "csv-lwt is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, libffi, pkg-config, ncurses, integers, bigarray-compat }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "ctypes is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/erm_xml/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xml/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "erm_xml is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/expat/default.nix
+++ b/pkgs/development/ocaml-modules/expat/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  doCheck = !lib.versionAtLeast ocaml.version "4.06";
+  doCheck = lib.versionOlder ocaml.version "4.06";
   checkTarget = "testall";
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/farfadet/default.nix
+++ b/pkgs/development/ocaml-modules/farfadet/default.nix
@@ -2,7 +2,7 @@
 , faraday
 }:
 
-if !lib.versionAtLeast ocaml.version "4.3"
+if lib.versionOlder ocaml.version "4.3"
 then throw "farfadet is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, cmdliner, seq, stdlib-shims }:
 
-if !lib.versionAtLeast ocaml.version "4.05"
+if lib.versionOlder ocaml.version "4.05"
 then throw "fmt is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/fpath/default.nix
+++ b/pkgs/development/ocaml-modules/fpath/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, astring }:
 
-if !lib.versionAtLeast ocaml.version "4.03"
+if lib.versionOlder ocaml.version "4.03"
 then throw "fpath is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -8,7 +8,7 @@
 , extlib
 }:
 
-if !lib.versionAtLeast ocaml.version "4.04"
+if lib.versionOlder ocaml.version "4.04"
 then throw "javalib is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, libGLU, libGL, freeglut } :
 
-if !lib.versionAtLeast ocaml.version "4.03"
+if lib.versionOlder ocaml.version "4.03"
 then throw "lablgl is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitLab, ocaml, findlib, camlp4, config-file, lablgtk, xmlm }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 || lib.versionAtLeast ocaml.version "4.13"
 then throw "lablgtk-extras is not available for OCaml ${ocaml.version}"
 else

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -8,7 +8,7 @@ let
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-if !lib.versionAtLeast ocaml.version "4.03"
+if lib.versionOlder ocaml.version "4.03"
 then throw "logs is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, opaline }:
 
-if !lib.versionAtLeast ocaml.version "4.07"
+if lib.versionOlder ocaml.version "4.07"
 then throw "lua-ml is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -4,7 +4,7 @@
 , ocaml-syntax-shims
 }:
 
-let inherit (lib) optional versionAtLeast; in
+let inherit (lib) optional versionOlder; in
 
 buildDunePackage rec {
   pname = "lwt";
@@ -22,9 +22,9 @@ buildDunePackage rec {
   strictDeps = true;
 
   nativeBuildInputs = [ pkg-config cppo ]
-    ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims;
+    ++ optional (versionOlder ocaml.version "4.08") ocaml-syntax-shims;
   buildInputs = [ dune-configurator ]
-    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
+    ++ optional (versionOlder ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -15,7 +15,7 @@ let
   '';
 in
 
-if !versionAtLeast ocaml.version "4.08"
+if versionOlder ocaml.version "4.08"
 then throw "nocrypto is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -4,7 +4,7 @@
 
 with lib;
 
-if !versionAtLeast ocaml.version "4.05"
+if versionOlder ocaml.version "4.05"
 then throw "notty is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
+++ b/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, astring, pprint }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "ocp-ocamlres is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
@@ -9,7 +9,7 @@
 , num
 }:
 
-if !lib.versionAtLeast ocaml.version "4.03"
+if lib.versionOlder ocaml.version "4.03"
 then throw "ocsigen-deriving is not available of OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -49,7 +49,7 @@ let param = {
 }."${version}"; in
 
 if param ? max_version && lib.versionAtLeast ocaml.version param.max_version
-|| param ? min_version && !lib.versionAtLeast ocaml.version param.min_version
+|| param ? min_version && lib.versionOlder ocaml.version param.min_version
 then throw "ppxlib-${version} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/reactivedata/default.nix
+++ b/pkgs/development/ocaml-modules/reactivedata/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, react, opaline }:
 
-if !lib.versionAtLeast ocaml.version "4.04"
+if lib.versionOlder ocaml.version "4.04"
 then throw "reactiveData is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -5,7 +5,7 @@ let
   version = "1.5.11";
 in
 
-if !lib.versionAtLeast ocaml.version "4.07"
+if lib.versionOlder ocaml.version "4.07"
 then throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, gen, ppx_tools_versioned, ocaml-migrate-parsetree }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "sedlex is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/sosa/default.nix
+++ b/pkgs/development/ocaml-modules/sosa/default.nix
@@ -2,7 +2,7 @@
 , findlib, ocaml, ocamlbuild
 }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "sosa is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ctypes, result, SDL2, pkg-config, ocb-stubblr }:
 
-if !lib.versionAtLeast ocaml.version "4.03"
+if lib.versionOlder ocaml.version "4.03"
 then throw "tsdl is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/uri/sexp.nix
+++ b/pkgs/development/ocaml-modules/uri/sexp.nix
@@ -1,6 +1,6 @@
 { lib, ocaml, buildDunePackage, uri, ounit, ppx_sexp_conv, sexplib0 }:
 
-if !lib.versionAtLeast ocaml.version "4.04"
+if lib.versionOlder ocaml.version "4.04"
 then throw "uri-sexp is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -8,7 +8,7 @@ let
   doCheck = true;
 in
 
-if !(lib.versionAtLeast ocaml.version minimumOCamlVersion)
+if lib.versionOlder ocaml.version minimumOCamlVersion
 then builtins.throw "${pname} needs at least OCaml ${minimumOCamlVersion}"
 else
 

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -5,7 +5,7 @@ let
   version = "14.0.0";
 in
 
-if !lib.versionAtLeast ocaml.version "4.03"
+if lib.versionOlder ocaml.version "4.03"
 then throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -8,14 +8,14 @@
 with lib;
 
 let
-  inherit (lib) optionals versionAtLeast;
+  inherit (lib) optionals versionOlder;
 
   pname = "vg";
   version = "0.9.4";
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-if !versionAtLeast ocaml.version "4.03"
+if versionOlder ocaml.version "4.03"
 then throw "vg is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
-if !lib.versionAtLeast ocaml.version "4.03"
+if lib.versionOlder ocaml.version "4.03"
 || lib.versionOlder "4.13" ocaml.version
 then throw "wasm is not available for OCaml ${ocaml.version}"
 else

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -4,7 +4,7 @@ let
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "xmlm is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/z3/default.nix
+++ b/pkgs/development/ocaml-modules/z3/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, ocaml, findlib, zarith, z3 }:
 
-if !lib.versionAtLeast ocaml.version "4.07"
+if lib.versionOlder ocaml.version "4.07"
 then throw "z3 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -3,7 +3,7 @@
 , gmp
 }:
 
-if !lib.versionAtLeast ocaml.version "4.04"
+if lib.versionOlder ocaml.version "4.04"
 then throw "zarith is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -62,10 +62,10 @@ let
 
   electronLibPath = with lib; makeLibraryPath (
     [ libuuid at-spi2-atk at-spi2-core libappindicator-gtk3 ]
-    ++ optionals (! versionOlder version "9.0.0") [ libdrm mesa ]
-    ++ optionals (! versionOlder version "11.0.0") [ libxkbcommon ]
-    ++ optionals (! versionOlder version "12.0.0") [ libxshmfence ]
-    ++ optionals (! versionOlder version "17.0.0") [ libglvnd ]
+    ++ optionals (versionAtLeast version "9.0.0") [ libdrm mesa ]
+    ++ optionals (versionAtLeast version "11.0.0") [ libxkbcommon ]
+    ++ optionals (versionAtLeast version "12.0.0") [ libxshmfence ]
+    ++ optionals (versionAtLeast version "17.0.0") [ libglvnd ]
   );
 
   linux = {
@@ -93,7 +93,7 @@ let
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "${atomEnv.libPath}:${electronLibPath}:$out/lib/electron" \
         $out/lib/electron/electron \
-        ${lib.optionalString (! lib.versionOlder version "15.0.0") "$out/lib/electron/chrome_crashpad_handler" }
+        ${lib.optionalString (lib.versionAtLeast version "15.0.0") "$out/lib/electron/chrome_crashpad_handler" }
 
       wrapProgram $out/lib/electron/electron \
         --prefix LD_PRELOAD : ${lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1 \

--- a/pkgs/development/tools/ocaml/cppo/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/cppo/ocamlbuild.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, cppo, ocamlbuild }:
 
-if !lib.versionAtLeast (lib.getVersion cppo) "1.6"
+if lib.versionOlder (lib.getVersion cppo) "1.6"
 then cppo
 else
 

--- a/pkgs/development/tools/ocaml/dune/1.nix
+++ b/pkgs/development/tools/ocaml/dune/1.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ncurses }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 || lib.versionAtLeast ocaml.version "4.12"
 then throw "dune 1 is not available for OCaml ${ocaml.version}"
 else

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -48,7 +48,7 @@ buildDunePackage {
       dot_merlin_reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
       dune = "${dune_2}/bin/dune";
     })
-  ] ++ lib.optional (!lib.versionAtLeast ocaml.version "4.12")
+  ] ++ lib.optional (lib.versionOlder ocaml.version "4.12")
     # This fixes the test-suite on macOS
     # See https://github.com/ocaml/merlin/pull/1399
     # Fixed in 4.4 for OCaml ≥ 4.12

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -3,8 +3,8 @@
 let
   generic = args: let
     imported = import ./generic.nix args;
-  in if ((!lib.versionOlder args.version "391")
-    && stdenv.hostPlatform.system != "x86_64-linux") then null
+  in if lib.versionAtLeast args.version "391"
+    && stdenv.hostPlatform.system != "x86_64-linux" then null
   else callPackage imported {
     lib32 = (pkgsi686Linux.callPackage imported {
       libsOnly = true;

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -33,7 +33,7 @@ with lib;
 
 assert !libsOnly -> kernel != null;
 assert versionOlder version "391" -> sha256_32bit != null;
-assert ! versionOlder version "391" -> stdenv.hostPlatform.system == "x86_64-linux";
+assert versionAtLeast version "391" -> stdenv.hostPlatform.system == "x86_64-linux";
 
 let
   nameSuffix = optionalString (!libsOnly) "-${kernel.version}";

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/hadess/rtl8723bs";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
-    broken = (! versionOlder kernel.version "4.12"); # Now in kernel staging drivers
+    broken = versionAtLeast kernel.version "4.12"; # Now in kernel staging drivers
     maintainers = with maintainers; [ elitak ];
   };
 }

--- a/pkgs/os-specific/linux/sch_cake/default.nix
+++ b/pkgs/os-specific/linux/sch_cake/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation {
     license = with licenses; [ bsd3 gpl2 ];
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.linux;
-    broken = !lib.versionOlder kernel.version "4.13";
+    broken = lib.versionAtLeast kernel.version "4.13";
   };
 }

--- a/pkgs/servers/foundationdb/vsmake.nix
+++ b/pkgs/servers/foundationdb/vsmake.nix
@@ -84,7 +84,7 @@ let
         makeFlags = [ "all" "fdb_java" "fdb_python" ]
           # Don't compile FDBLibTLS if we don't need it in 6.0 or later;
           # it gets statically linked in
-          ++ lib.optional (!lib.versionAtLeast version "6.0") [ "fdb_c" ]
+          ++ lib.optional (lib.versionOlder version "6.0") [ "fdb_c" ]
           # Needed environment overrides
           ++ [ "KVRELEASE=1"
                "NOSTRIP=1"
@@ -100,7 +100,7 @@ let
         installPhase = ''
           mkdir -vp $out/{bin,libexec/plugins} $lib/{lib,share/java} $dev/include/foundationdb
 
-        '' + lib.optionalString (!lib.versionAtLeast version "6.0") ''
+        '' + lib.optionalString (lib.versionOlder version "6.0") ''
           # we only copy the TLS library on < 6.0, since it's compiled-in otherwise
           cp -v ./lib/libFDBLibTLS.so $out/libexec/plugins/FDBLibTLS.so
         '' + ''

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -461,7 +461,7 @@ lib.makeScope pkgs.newScope (self: with self; {
             '')
           ];
           zendExtension = true;
-          doCheck = !(lib.versionOlder php.version "7.4");
+          doCheck = lib.versionAtLeast php.version "7.4";
           # Tests launch the builtin webserver.
           __darwinAllowLocalNetworking = true;
         }
@@ -525,7 +525,7 @@ lib.makeScope pkgs.newScope (self: with self; {
           '';
           doCheck = false;
         }
-        { name = "session"; doCheck = !(lib.versionAtLeast php.version "8.0"); }
+        { name = "session"; doCheck = lib.versionOlder php.version "8.0"; }
         { name = "shmop"; }
         {
           name = "simplexml";


### PR DESCRIPTION
###### Description of changes

Simplify `!lib.versionAtLeast v1 v2` to `lib.versionOlder v1 v2`, and `!lib.versionOlder v1 v2` to `lib.versionAtLeast v1 v2`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
