### PR TITLE
mockgen: fix tests

### DIFF
--- a/pkgs/development/tools/mockgen/default.nix
+++ b/pkgs/development/tools/mockgen/default.nix
@@ -1,18 +1,23 @@
-{ buildGoModule, lib, fetchFromGitHub }:
+{ buildGoModule, fetchFromGitHub, lib }:
+
 buildGoModule rec {
   pname = "mockgen";
   version = "1.6.0";
+
   src = fetchFromGitHub {
     owner = "golang";
     repo = "mock";
     rev = "v${version}";
     sha256 = "sha256-5Kp7oTmd8kqUN+rzm9cLqp9nb3jZdQyltGGQDiRSWcE=";
   };
+
   vendorSha256 = "sha256-5gkrn+OxbNN8J1lbgbxM8jACtKA7t07sbfJ7gVJWpJM=";
 
-  doCheck = false;
-
   subPackages = [ "mockgen" ];
+
+  preCheck = ''
+    export GOROOT="$(go env GOROOT)"
+  '';
 
   meta = with lib; {
     description = "GoMock is a mocking framework for the Go programming language";


### PR DESCRIPTION
mockgen: fix tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestMakeArgString
=== RUN   TestMakeArgString/#0
=== RUN   TestMakeArgString/#1
=== RUN   TestMakeArgString/#2
=== RUN   TestMakeArgString/#3
=== RUN   TestMakeArgString/#4
=== RUN   TestMakeArgString/#5
=== RUN   TestMakeArgString/#6
=== RUN   TestMakeArgString/#7
=== RUN   TestMakeArgString/#8
=== RUN   TestMakeArgString/#9
=== RUN   TestMakeArgString/#10
=== RUN   TestMakeArgString/#11
=== RUN   TestMakeArgString/#12
=== RUN   TestMakeArgString/#13
=== RUN   TestMakeArgString/#14
=== RUN   TestMakeArgString/#15
=== RUN   TestMakeArgString/#16
--- PASS: TestMakeArgString (0.00s)
    --- PASS: TestMakeArgString/#0 (0.00s)
    --- PASS: TestMakeArgString/#1 (0.00s)
    --- PASS: TestMakeArgString/#2 (0.00s)
    --- PASS: TestMakeArgString/#3 (0.00s)
    --- PASS: TestMakeArgString/#4 (0.00s)
    --- PASS: TestMakeArgString/#5 (0.00s)
    --- PASS: TestMakeArgString/#6 (0.00s)
    --- PASS: TestMakeArgString/#7 (0.00s)
    --- PASS: TestMakeArgString/#8 (0.00s)
    --- PASS: TestMakeArgString/#9 (0.00s)
    --- PASS: TestMakeArgString/#10 (0.00s)
    --- PASS: TestMakeArgString/#11 (0.00s)
    --- PASS: TestMakeArgString/#12 (0.00s)
    --- PASS: TestMakeArgString/#13 (0.00s)
    --- PASS: TestMakeArgString/#14 (0.00s)
    --- PASS: TestMakeArgString/#15 (0.00s)
    --- PASS: TestMakeArgString/#16 (0.00s)
=== RUN   TestNewIdentifierAllocator
--- PASS: TestNewIdentifierAllocator (0.00s)
=== RUN   TestIdentifierAllocator_allocateIdentifier
--- PASS: TestIdentifierAllocator_allocateIdentifier (0.00s)
=== RUN   TestGenerateMockInterface_Helper
=== RUN   TestGenerateMockInterface_Helper/mock
=== RUN   TestGenerateMockInterface_Helper/recorder
=== RUN   TestGenerateMockInterface_Helper/mock_identifier_conflict
=== RUN   TestGenerateMockInterface_Helper/recorder_identifier_conflict
--- PASS: TestGenerateMockInterface_Helper (0.00s)
    --- PASS: TestGenerateMockInterface_Helper/mock (0.00s)
    --- PASS: TestGenerateMockInterface_Helper/recorder (0.00s)
    --- PASS: TestGenerateMockInterface_Helper/mock_identifier_conflict (0.00s)
    --- PASS: TestGenerateMockInterface_Helper/recorder_identifier_conflict (0.00s)
=== RUN   TestGetArgNames
=== RUN   TestGetArgNames/NamedArg
=== RUN   TestGetArgNames/NotNamedArg
=== RUN   TestGetArgNames/MixedNameArg
--- PASS: TestGetArgNames (0.00s)
    --- PASS: TestGetArgNames/NamedArg (0.00s)
    --- PASS: TestGetArgNames/NotNamedArg (0.00s)
    --- PASS: TestGetArgNames/MixedNameArg (0.00s)
=== RUN   Test_createPackageMap
=== RUN   Test_createPackageMap/golang_package
=== RUN   Test_createPackageMap/third_party
--- PASS: Test_createPackageMap (0.06s)
    --- PASS: Test_createPackageMap/golang_package (0.00s)
    --- PASS: Test_createPackageMap/third_party (0.00s)
=== RUN   TestParsePackageImport_FallbackGoPath
--- PASS: TestParsePackageImport_FallbackGoPath (0.00s)
=== RUN   TestParsePackageImport_FallbackMultiGoPath
--- PASS: TestParsePackageImport_FallbackMultiGoPath (0.00s)
=== RUN   TestFileParser_ParseFile
--- PASS: TestFileParser_ParseFile (0.05s)
=== RUN   TestFileParser_ParsePackage
--- PASS: TestFileParser_ParsePackage (0.08s)
=== RUN   TestImportsOfFile
--- PASS: TestImportsOfFile (0.05s)
=== RUN   TestParseArrayWithConstLength
--- PASS: TestParseArrayWithConstLength (0.01s)
PASS
ok  	github.com/golang/mock/mockgen	0.252s
```