### PR TITLE
ranger: add optional python dependencies

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,5 +1,8 @@
-{ lib, fetchFromGitHub, python3Packages, file, less, highlight
-, imagePreviewSupport ? true, w3m }:
+{ lib, fetchFromGitHub, python3Packages, file, less, highlight, w3m
+, imagePreviewSupport ? true
+, neoVimSupport ? true
+, improvedEncodingDetection ? true
+, rightToLeftTextSupport ? false}:
 
 python3Packages.buildPythonApplication rec {
   pname = "ranger";
@@ -15,8 +18,14 @@ python3Packages.buildPythonApplication rec {
   LC_ALL = "en_US.UTF-8";
 
   checkInputs = with python3Packages; [ pytestCheckHook ];
-  propagatedBuildInputs = [ file ]
-    ++ lib.optionals (imagePreviewSupport) [ python3Packages.pillow ];
+  propagatedBuildInputs = [
+    less
+    file
+  ]
+    ++ lib.optionals (imagePreviewSupport) [ python3Packages.pillow ]
+    ++ lib.optionals (neoVimSupport) [ python3Packages.pynvim ]
+    ++ lib.optionals (improvedEncodingDetection) [ python3Packages.chardet ]
+    ++ lib.optionals (rightToLeftTextSupport) [ python3Packages.python-bidi ];
 
   preConfigure = ''
     ${lib.optionalString (highlight != null) ''

--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -22,11 +22,10 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = [
     less
     file
-  ]
-    ++ lib.optionals (imagePreviewSupport) [ python3Packages.pillow ]
-    ++ lib.optionals (neoVimSupport) [ python3Packages.pynvim ]
-    ++ lib.optionals (improvedEncodingDetection) [ python3Packages.chardet ]
-    ++ lib.optionals (rightToLeftTextSupport) [ python3Packages.python-bidi ];
+  ] ++ lib.optionals imagePreviewSupport [ python3Packages.pillow ]
+    ++ lib.optionals neoVimSupport [ python3Packages.pynvim ]
+    ++ lib.optionals improvedEncodingDetection [ python3Packages.chardet ]
+    ++ lib.optionals rightToLeftTextSupport [ python3Packages.python-bidi ];
 
   preConfigure = ''
     ${lib.optionalString (highlight != null) ''

--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -2,7 +2,8 @@
 , imagePreviewSupport ? true
 , neoVimSupport ? true
 , improvedEncodingDetection ? true
-, rightToLeftTextSupport ? false}:
+, rightToLeftTextSupport ? false
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "ranger";


### PR DESCRIPTION
Ranger has some [optional python
dependencies](https://github.com/ranger/ranger#dependencies).
Also, for use with the rnvimr NeoVim plugin, the pynvim packgage needs
to be included (see https://github.com/kevinhwang91/rnvimr/issues/110).

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
