### PR TITLE
pouf: init at 0.4.1

### DIFF
--- a/pkgs/tools/misc/pouf/default.nix
+++ b/pkgs/tools/misc/pouf/default.nix
@@ -1,0 +1,27 @@
+{ lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pouf";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "mothsart";
+    repo = pname;
+    rev = version;
+    sha256 = "0q7kj6x61xci8piax6vg3bsm9di11li7pm84vj13iwahdydhs1hn";
+  };
+
+  cargoSha256 = "sha256:128fgdp74lyv5k054cdjxzwmyb5cyy0jq0a9l4bsc34122mznnq7";
+
+  meta = with lib; {
+    description = "A cli program for produce fake datas.";
+    homepage = "https://github.com/mothsart/pouf";
+    changelog = "https://github.com/mothsart/pouf/releases/tag/${version}";
+    maintainers = with maintainers; [ mothsart ];
+    license = with licenses; [ mit ];
+  };
+}

--- a/pkgs/tools/misc/pouf/default.nix
+++ b/pkgs/tools/misc/pouf/default.nix
@@ -1,7 +1,7 @@
-{ lib,
-  stdenv,
-  fetchFromGitHub,
-  rustPlatform
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0q7kj6x61xci8piax6vg3bsm9di11li7pm84vj13iwahdydhs1hn";
   };
 
-  cargoSha256 = "sha256:128fgdp74lyv5k054cdjxzwmyb5cyy0jq0a9l4bsc34122mznnq7";
+  cargoSha256 = "128fgdp74lyv5k054cdjxzwmyb5cyy0jq0a9l4bsc34122mznnq7";
 
   meta = with lib; {
     description = "A cli program for produce fake datas.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4023,6 +4023,8 @@ with pkgs;
     electron = electron_14;
   };
 
+  pouf = callPackage ../tools/misc/pouf { };
+
   poweralertd = callPackage ../tools/misc/poweralertd { };
 
   ps_mem = callPackage ../tools/system/ps_mem { };


### PR DESCRIPTION
###### Description of changes

Pouf is a cli program to produce fake datas.
Examples on README : https://github.com/mothsart/pouf

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
