### PR TITLE
python3Packages.pytest-isort: switch to GitHub as source

### DIFF
--- a/pkgs/development/python-modules/pytest-isort/default.nix
+++ b/pkgs/development/python-modules/pytest-isort/default.nix
@@ -1,26 +1,64 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, mock, pytest, isort }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, importlib-metadata
+, isort
+, poetry-core
+, pytest
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "pytest-isort";
   version = "3.0.0";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-T+Sybq0q93ZzDsI/WHDXQh81qs4ipBxOk4WG702Hh8s=";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "stephrdev";
+    repo = pname;
+    rev = version;
+    hash = "sha256-gbEO3HBDeZ+nUACzpeV6iVuCdNHS5956wFzIYkbam+M=";
   };
 
-  propagatedBuildInputs = [ isort ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
-  checkInputs = [ pytest ]
-    ++ lib.optionals isPy27 [ mock ];
+  buildInputs = [
+    pytest
+  ];
 
-  checkPhase = ''
-    py.test -vs --cache-clear
-  '';
+  propagatedBuildInputs = [
+    isort
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Can be removed with the next release, https://github.com/stephrdev/pytest-isort/pull/44
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/stephrdev/pytest-isort/commit/f17ed2d294ae90e415d051e1c720982e3dd01bff.patch";
+      sha256 = "sha256-PiOs0c61BNx/tZN11DYblOd7tNzGthNnlkmYMTI9v18=";
+    })
+  ];
+
+  pythonImportsCheck = [
+    "pytest_isort"
+  ];
 
   meta = with lib; {
     description = "Pytest plugin to perform isort checks (import ordering)";
     homepage = "https://github.com/moccu/pytest-isort/";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/174134269)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
