### PR TITLE
go-protobuf: enable tests

### DIFF
--- a/pkgs/development/tools/go-protobuf/default.nix
+++ b/pkgs/development/tools/go-protobuf/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-CcJjFMslSUiZMM0LLMM3BR53YMxyWk8m7hxjMI9tduE=";
 
-  doCheck = false;
-
   meta = with lib; {
     homepage    = "https://github.com/golang/protobuf";
     description = " Go bindings for protocol buffer";


### PR DESCRIPTION
go-protobuf: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestEnumDescriptor
--- PASS: TestEnumDescriptor (0.00s)
=== RUN   TestMessageDescriptor
--- PASS: TestMessageDescriptor (0.00s)
PASS
ok  	github.com/golang/protobuf/descriptor	0.003s
=== RUN   TestMarshaling
--- PASS: TestMarshaling (0.00s)
=== RUN   TestMarshalingNil
--- PASS: TestMarshalingNil (0.00s)
=== RUN   TestMarshalIllegalTime
--- PASS: TestMarshalIllegalTime (0.00s)
=== RUN   TestMarshalJSONPBMarshaler
--- PASS: TestMarshalJSONPBMarshaler (0.00s)
=== RUN   TestMarshalAnyJSONPBMarshaler
--- PASS: TestMarshalAnyJSONPBMarshaler (0.00s)
=== RUN   TestMarshalWithCustomValidation
--- PASS: TestMarshalWithCustomValidation (0.00s)
=== RUN   TestMarshalUnsetRequiredFields
--- PASS: TestMarshalUnsetRequiredFields (0.00s)
=== RUN   TestUnmarshaling
--- PASS: TestUnmarshaling (0.00s)
=== RUN   TestUnmarshalNullArray
--- PASS: TestUnmarshalNullArray (0.00s)
=== RUN   TestUnmarshalNullObject
--- PASS: TestUnmarshalNullObject (0.00s)
=== RUN   TestUnmarshalNext
--- PASS: TestUnmarshalNext (0.00s)
=== RUN   TestUnmarshalingBadInput
--- PASS: TestUnmarshalingBadInput (0.00s)
=== RUN   TestAnyWithCustomResolver
--- PASS: TestAnyWithCustomResolver (0.00s)
=== RUN   TestUnmarshalJSONPBUnmarshaler
--- PASS: TestUnmarshalJSONPBUnmarshaler (0.00s)
=== RUN   TestUnmarshalNullWithJSONPBUnmarshaler
--- PASS: TestUnmarshalNullWithJSONPBUnmarshaler (0.00s)
=== RUN   TestUnmarshalAnyJSONPBUnmarshaler
--- PASS: TestUnmarshalAnyJSONPBUnmarshaler (0.00s)
=== RUN   TestUnmarshalUnsetRequiredFields
--- PASS: TestUnmarshalUnsetRequiredFields (0.00s)
PASS
ok  	github.com/golang/protobuf/jsonpb	0.008s
=== RUN   TestDiscardUnknown
--- PASS: TestDiscardUnknown (0.00s)
=== RUN   TestGetExtensionsWithMissingExtensions
--- PASS: TestGetExtensionsWithMissingExtensions (0.00s)
=== RUN   TestGetExtensionForIncompleteDesc
--- PASS: TestGetExtensionForIncompleteDesc (0.00s)
=== RUN   TestExtensionDescsWithUnregisteredExtensions
--- PASS: TestExtensionDescsWithUnregisteredExtensions (0.00s)
=== RUN   TestGetExtensionStability
--- PASS: TestGetExtensionStability (0.00s)
=== RUN   TestGetExtensionDefaults
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_double/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_double/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_double/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_float/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_float/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_float/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_int32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_int32/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_int32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_int64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_int64/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_int64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_uint32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_uint32/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_uint32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_uint64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_uint64/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_uint64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sint32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sint32/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sint32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sint64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sint64/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sint64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_fixed32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_fixed32/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_fixed32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_fixed64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_fixed64/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_fixed64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sfixed32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sfixed32/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sfixed32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sfixed64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sfixed64/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_sfixed64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bool/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bool/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bool/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bool/initial#01
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bool/set#01
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bool/cleared#01
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_string/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_string/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_string/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bytes/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bytes/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_bytes/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_enum/initial
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_enum/set
=== RUN   TestGetExtensionDefaults/proto2_test.no_default_enum/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_double/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_double/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_double/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_float/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_float/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_float/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_int32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_int32/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_int32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_int64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_int64/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_int64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_uint32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_uint32/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_uint32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_uint64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_uint64/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_uint64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_sint32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_sint32/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_sint32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_sint64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_sint64/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_sint64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_fixed32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_fixed32/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_fixed32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_fixed64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_fixed64/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_fixed64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_sfixed32/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_sfixed32/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_sfixed32/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_sfixed64/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_sfixed64/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_sfixed64/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_bool/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_bool/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_bool/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_bool/initial#01
=== RUN   TestGetExtensionDefaults/proto2_test.default_bool/set#01
=== RUN   TestGetExtensionDefaults/proto2_test.default_bool/cleared#01
=== RUN   TestGetExtensionDefaults/proto2_test.default_string/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_string/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_string/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_bytes/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_bytes/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_bytes/cleared
=== RUN   TestGetExtensionDefaults/proto2_test.default_enum/initial
=== RUN   TestGetExtensionDefaults/proto2_test.default_enum/set
=== RUN   TestGetExtensionDefaults/proto2_test.default_enum/cleared
--- PASS: TestGetExtensionDefaults (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_double/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_double/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_double/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_float/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_float/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_float/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_int32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_int32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_int32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_int64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_int64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_int64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_uint32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_uint32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_uint32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_uint64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_uint64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_uint64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sint32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sint32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sint32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sint64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sint64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sint64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_fixed32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_fixed32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_fixed32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_fixed64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_fixed64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_fixed64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sfixed32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sfixed32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sfixed32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sfixed64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sfixed64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_sfixed64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bool/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bool/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bool/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bool/initial#01 (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bool/set#01 (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bool/cleared#01 (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_string/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_string/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_string/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bytes/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bytes/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_bytes/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_enum/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_enum/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.no_default_enum/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_double/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_double/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_double/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_float/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_float/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_float/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_int32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_int32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_int32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_int64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_int64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_int64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_uint32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_uint32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_uint32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_uint64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_uint64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_uint64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sint32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sint32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sint32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sint64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sint64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sint64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_fixed32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_fixed32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_fixed32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_fixed64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_fixed64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_fixed64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sfixed32/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sfixed32/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sfixed32/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sfixed64/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sfixed64/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_sfixed64/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bool/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bool/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bool/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bool/initial#01 (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bool/set#01 (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bool/cleared#01 (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_string/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_string/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_string/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bytes/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bytes/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_bytes/cleared (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_enum/initial (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_enum/set (0.00s)
    --- PASS: TestGetExtensionDefaults/proto2_test.default_enum/cleared (0.00s)
=== RUN   TestNilMessage
--- PASS: TestNilMessage (0.00s)
=== RUN   TestExtensionsRoundTrip
--- PASS: TestExtensionsRoundTrip (0.00s)
=== RUN   TestNilExtension
--- PASS: TestNilExtension (0.00s)
=== RUN   TestMarshalUnmarshalRepeatedExtension
--- PASS: TestMarshalUnmarshalRepeatedExtension (0.00s)
=== RUN   TestUnmarshalRepeatingNonRepeatedExtension
--- PASS: TestUnmarshalRepeatingNonRepeatedExtension (0.00s)
=== RUN   TestClearAllExtensions
--- PASS: TestClearAllExtensions (0.00s)
=== RUN   TestMarshalRace
--- PASS: TestMarshalRace (0.00s)
=== RUN   TestClone
--- PASS: TestClone (0.00s)
=== RUN   TestCloneNil
--- PASS: TestCloneNil (0.00s)
=== RUN   TestMerge
--- PASS: TestMerge (0.00s)
=== RUN   TestEqual
--- PASS: TestEqual (0.00s)
=== RUN   TestNumericPrimitives
--- PASS: TestNumericPrimitives (0.00s)
=== RUN   TestMarshalerEncoding
=== RUN   TestMarshalerEncoding/Marshaler_that_fails
=== RUN   TestMarshalerEncoding/Marshaler_that_fails_with_RequiredNotSetError
=== RUN   TestMarshalerEncoding/Marshaler_that_succeeds
--- PASS: TestMarshalerEncoding (0.00s)
    --- PASS: TestMarshalerEncoding/Marshaler_that_fails (0.00s)
    --- PASS: TestMarshalerEncoding/Marshaler_that_fails_with_RequiredNotSetError (0.00s)
    --- PASS: TestMarshalerEncoding/Marshaler_that_succeeds (0.00s)
=== RUN   TestBufferMarshalAllocs
--- PASS: TestBufferMarshalAllocs (0.00s)
=== RUN   TestBytesPrimitives
--- PASS: TestBytesPrimitives (0.00s)
=== RUN   TestStringPrimitives
--- PASS: TestStringPrimitives (0.00s)
=== RUN   TestRequiredBit
--- PASS: TestRequiredBit (0.00s)
=== RUN   TestReset
--- PASS: TestReset (0.00s)
=== RUN   TestEncodeDecode1
--- PASS: TestEncodeDecode1 (0.00s)
=== RUN   TestEncodeDecode2
--- PASS: TestEncodeDecode2 (0.00s)
=== RUN   TestEncodeDecode3
--- PASS: TestEncodeDecode3 (0.00s)
=== RUN   TestEncodeDecode4
--- PASS: TestEncodeDecode4 (0.00s)
=== RUN   TestEncodeDecode5
--- PASS: TestEncodeDecode5 (0.00s)
=== RUN   TestEncodeDecode6
--- PASS: TestEncodeDecode6 (0.00s)
=== RUN   TestEncodeDecodeBytes1
--- PASS: TestEncodeDecodeBytes1 (0.00s)
=== RUN   TestEncodeDecodeBytes2
--- PASS: TestEncodeDecodeBytes2 (0.00s)
=== RUN   TestSkippingUnrecognizedFields
--- PASS: TestSkippingUnrecognizedFields (0.00s)
=== RUN   TestSubmessageUnrecognizedFields
    proto_test.go:975: Marshal(nested:<name:"Nigel" 2:"carbs" > ) -> "\n\x0e\n\x05Nigel\x12\x05carbs"
--- PASS: TestSubmessageUnrecognizedFields (0.00s)
=== RUN   TestNegativeInt32
--- PASS: TestNegativeInt32 (0.00s)
=== RUN   TestBigRepeated
--- PASS: TestBigRepeated (0.00s)
=== RUN   TestBadWireTypeUnknown
--- PASS: TestBadWireTypeUnknown (0.00s)
=== RUN   TestPackedNonPackedDecoderSwitching
--- PASS: TestPackedNonPackedDecoderSwitching (0.00s)
=== RUN   TestProto1RepeatedGroup
--- PASS: TestProto1RepeatedGroup (0.00s)
=== RUN   TestEnum
--- PASS: TestEnum (0.00s)
=== RUN   TestPrintingNilEnumFields
--- PASS: TestPrintingNilEnumFields (0.00s)
=== RUN   TestRequiredFieldEnforcement
--- PASS: TestRequiredFieldEnforcement (0.00s)
=== RUN   TestRequiredFieldEnforcementGroups
--- PASS: TestRequiredFieldEnforcementGroups (0.00s)
=== RUN   TestTypedNilMarshal
--- PASS: TestTypedNilMarshal (0.00s)
=== RUN   TestTypedNilMarshalInOneof
--- PASS: TestTypedNilMarshalInOneof (0.00s)
=== RUN   TestNilMarshaler
--- PASS: TestNilMarshaler (0.00s)
=== RUN   TestAllSetDefaults
--- PASS: TestAllSetDefaults (0.00s)
=== RUN   TestSetDefaultsWithSetField
--- PASS: TestSetDefaultsWithSetField (0.00s)
=== RUN   TestSetDefaultsWithSubMessage
--- PASS: TestSetDefaultsWithSubMessage (0.00s)
=== RUN   TestSetDefaultsWithRepeatedSubMessage
--- PASS: TestSetDefaultsWithRepeatedSubMessage (0.00s)
=== RUN   TestSetDefaultWithRepeatedNonMessage
--- PASS: TestSetDefaultWithRepeatedNonMessage (0.00s)
=== RUN   TestMaximumTagNumber
--- PASS: TestMaximumTagNumber (0.00s)
=== RUN   TestJSON
--- PASS: TestJSON (0.00s)
=== RUN   TestBadWireType
--- PASS: TestBadWireType (0.00s)
=== RUN   TestBytesWithInvalidLength
--- PASS: TestBytesWithInvalidLength (0.00s)
=== RUN   TestLengthOverflow
--- PASS: TestLengthOverflow (0.00s)
=== RUN   TestVarintOverflow
--- PASS: TestVarintOverflow (0.00s)
=== RUN   TestBytesWithInvalidLengthInGroup
--- PASS: TestBytesWithInvalidLengthInGroup (0.00s)
=== RUN   TestUnmarshalFuzz
    proto_test.go:1525: RNG seed is 1650923535258155592
--- PASS: TestUnmarshalFuzz (0.00s)
=== RUN   TestMergeMessages
--- PASS: TestMergeMessages (0.00s)
=== RUN   TestExtensionMarshalOrder
--- PASS: TestExtensionMarshalOrder (0.00s)
=== RUN   TestExtensionMapFieldMarshalDeterministic
--- PASS: TestExtensionMapFieldMarshalDeterministic (0.00s)
=== RUN   TestUnmarshalMergesMessages
--- PASS: TestUnmarshalMergesMessages (0.00s)
=== RUN   TestUnmarshalMergesGroups
--- PASS: TestUnmarshalMergesGroups (0.00s)
=== RUN   TestEncodingSizes
--- PASS: TestEncodingSizes (0.00s)
=== RUN   TestRequiredNotSetError
--- PASS: TestRequiredNotSetError (0.00s)
=== RUN   TestRequiredNotSetErrorWithBadWireTypes
--- PASS: TestRequiredNotSetErrorWithBadWireTypes (0.00s)
=== RUN   TestMapFieldMarshal
    proto_test.go:1848: FYI b: "\n\b\b\b\x12\x04Dave\n\a\b\x01\x12\x03Rob\n\a\b\x04\x12\x03Ian"
--- PASS: TestMapFieldMarshal (0.00s)
=== RUN   TestMapFieldDeterministicMarshal
--- PASS: TestMapFieldDeterministicMarshal (0.00s)
=== RUN   TestMapFieldRoundTrips
    proto_test.go:1896: FYI b: "\n\a\b\x01\x12\x03Rob\n\a\b\x04\x12\x03Ian\n\b\b\b\x12\x04Dave\x12\x0f\b\x82\xc0\x03\x12\t\t\x00\x00\x00\x00\x00\x00\x00@\x1a\x15\b\x00\x12\x11that's not right!\x1a\x13\b\x01\x12\x0faye, 'tis true!"
--- PASS: TestMapFieldRoundTrips (0.00s)
=== RUN   TestMapFieldWithNil
--- PASS: TestMapFieldWithNil (0.00s)
=== RUN   TestMapFieldWithNilBytes
--- PASS: TestMapFieldWithNilBytes (0.00s)
=== RUN   TestDecodeMapFieldMissingKey
--- PASS: TestDecodeMapFieldMissingKey (0.00s)
=== RUN   TestDecodeMapFieldMissingValue
--- PASS: TestDecodeMapFieldMissingValue (0.00s)
=== RUN   TestOneof
--- PASS: TestOneof (0.00s)
=== RUN   TestOneofNilBytes
--- PASS: TestOneofNilBytes (0.00s)
=== RUN   TestInefficientPackedBool
--- PASS: TestInefficientPackedBool (0.00s)
=== RUN   TestRepeatedEnum2
--- PASS: TestRepeatedEnum2 (0.00s)
=== RUN   TestConcurrentMarshal
--- PASS: TestConcurrentMarshal (0.00s)
=== RUN   TestInvalidUTF8
--- PASS: TestInvalidUTF8 (0.00s)
=== RUN   TestRequired
--- PASS: TestRequired (0.00s)
=== RUN   TestUnknownV2
--- PASS: TestUnknownV2 (0.00s)
=== RUN   TestProto3ZeroValues
--- PASS: TestProto3ZeroValues (0.00s)
=== RUN   TestRoundTripProto3
    proto_test.go:2295:  m: name:"David" hilarity:PUNS height_in_cm:178 data:"roboto" result_count:47 true_scotsman:true score:8.1 key:1 key:3735928559 nested:<bunny:"Monty" > 
    proto_test.go:2301:  b: "\n\x05David\x10\x01\x18\xb2\x01\"\x06roboto*\x06\x01\xef\xfd\xb6\xf5\r2\a\n\x05Monty8/@\x01M\x9a\x99\x01A"
    proto_test.go:2307: m2: name:"David" hilarity:PUNS height_in_cm:178 data:"roboto" result_count:47 true_scotsman:true score:8.1 key:1 key:3735928559 nested:<bunny:"Monty" > 
--- PASS: TestRoundTripProto3 (0.00s)
=== RUN   TestGettersForBasicTypesExist
--- PASS: TestGettersForBasicTypesExist (0.00s)
=== RUN   TestProto3SetDefaults
--- PASS: TestProto3SetDefaults (0.00s)
=== RUN   TestUnknownFieldPreservation
--- PASS: TestUnknownFieldPreservation (0.00s)
=== RUN   TestMap
--- PASS: TestMap (0.00s)
=== RUN   TestSize
=== RUN   TestSize/empty
=== RUN   TestSize/bool
=== RUN   TestSize/int32
=== RUN   TestSize/negative_int32
=== RUN   TestSize/small_int64
=== RUN   TestSize/big_int64
=== RUN   TestSize/negative_int64
=== RUN   TestSize/fixed32
=== RUN   TestSize/fixed64
=== RUN   TestSize/uint32
=== RUN   TestSize/uint64
=== RUN   TestSize/float
=== RUN   TestSize/double
=== RUN   TestSize/string
=== RUN   TestSize/bytes
=== RUN   TestSize/bytes,_empty
=== RUN   TestSize/sint32
=== RUN   TestSize/sint64
=== RUN   TestSize/enum
=== RUN   TestSize/empty_repeated_bool
=== RUN   TestSize/repeated_bool
=== RUN   TestSize/packed_repeated_bool
=== RUN   TestSize/repeated_int32
=== RUN   TestSize/repeated_int32_packed
=== RUN   TestSize/repeated_int64_packed
=== RUN   TestSize/repeated_string
=== RUN   TestSize/repeated_fixed
=== RUN   TestSize/nested
=== RUN   TestSize/group
=== RUN   TestSize/unrecognized
=== RUN   TestSize/extension_(unencoded)
=== RUN   TestSize/extension_(encoded)
=== RUN   TestSize/proto3_empty
=== RUN   TestSize/proto3_bool
=== RUN   TestSize/proto3_int64
=== RUN   TestSize/proto3_uint32
=== RUN   TestSize/proto3_float
=== RUN   TestSize/proto3_string
=== RUN   TestSize/proto3_bytes
=== RUN   TestSize/proto3_bytes,_empty
=== RUN   TestSize/proto3_enum
=== RUN   TestSize/proto3_map_field_with_empty_bytes
=== RUN   TestSize/map_field
=== RUN   TestSize/map_field_with_message
=== RUN   TestSize/map_field_with_bytes
=== RUN   TestSize/map_field_with_empty_bytes
=== RUN   TestSize/map_field_with_big_entry
=== RUN   TestSize/map_field_with_big_key_and_val
=== RUN   TestSize/map_field_with_big_numeric_key
=== RUN   TestSize/oneof_not_set
=== RUN   TestSize/oneof_bool
=== RUN   TestSize/oneof_zero_int32
=== RUN   TestSize/oneof_big_int32
=== RUN   TestSize/oneof_int64
=== RUN   TestSize/oneof_fixed32
=== RUN   TestSize/oneof_fixed64
=== RUN   TestSize/oneof_uint32
=== RUN   TestSize/oneof_uint64
=== RUN   TestSize/oneof_float
=== RUN   TestSize/oneof_double
=== RUN   TestSize/oneof_string
=== RUN   TestSize/oneof_bytes
=== RUN   TestSize/oneof_sint32
=== RUN   TestSize/oneof_sint64
=== RUN   TestSize/oneof_enum
=== RUN   TestSize/message_for_oneof
=== RUN   TestSize/oneof_message
=== RUN   TestSize/oneof_group
=== RUN   TestSize/oneof_largest_tag
=== RUN   TestSize/multiple_oneofs
=== RUN   TestSize/non-pointer_message
--- PASS: TestSize (0.00s)
    --- PASS: TestSize/empty (0.00s)
    --- PASS: TestSize/bool (0.00s)
    --- PASS: TestSize/int32 (0.00s)
    --- PASS: TestSize/negative_int32 (0.00s)
    --- PASS: TestSize/small_int64 (0.00s)
    --- PASS: TestSize/big_int64 (0.00s)
    --- PASS: TestSize/negative_int64 (0.00s)
    --- PASS: TestSize/fixed32 (0.00s)
    --- PASS: TestSize/fixed64 (0.00s)
    --- PASS: TestSize/uint32 (0.00s)
    --- PASS: TestSize/uint64 (0.00s)
    --- PASS: TestSize/float (0.00s)
    --- PASS: TestSize/double (0.00s)
    --- PASS: TestSize/string (0.00s)
    --- PASS: TestSize/bytes (0.00s)
    --- PASS: TestSize/bytes,_empty (0.00s)
    --- PASS: TestSize/sint32 (0.00s)
    --- PASS: TestSize/sint64 (0.00s)
    --- PASS: TestSize/enum (0.00s)
    --- PASS: TestSize/empty_repeated_bool (0.00s)
    --- PASS: TestSize/repeated_bool (0.00s)
    --- PASS: TestSize/packed_repeated_bool (0.00s)
    --- PASS: TestSize/repeated_int32 (0.00s)
    --- PASS: TestSize/repeated_int32_packed (0.00s)
    --- PASS: TestSize/repeated_int64_packed (0.00s)
    --- PASS: TestSize/repeated_string (0.00s)
    --- PASS: TestSize/repeated_fixed (0.00s)
    --- PASS: TestSize/nested (0.00s)
    --- PASS: TestSize/group (0.00s)
    --- PASS: TestSize/unrecognized (0.00s)
    --- PASS: TestSize/extension_(unencoded) (0.00s)
    --- PASS: TestSize/extension_(encoded) (0.00s)
    --- PASS: TestSize/proto3_empty (0.00s)
    --- PASS: TestSize/proto3_bool (0.00s)
    --- PASS: TestSize/proto3_int64 (0.00s)
    --- PASS: TestSize/proto3_uint32 (0.00s)
    --- PASS: TestSize/proto3_float (0.00s)
    --- PASS: TestSize/proto3_string (0.00s)
    --- PASS: TestSize/proto3_bytes (0.00s)
    --- PASS: TestSize/proto3_bytes,_empty (0.00s)
    --- PASS: TestSize/proto3_enum (0.00s)
    --- PASS: TestSize/proto3_map_field_with_empty_bytes (0.00s)
    --- PASS: TestSize/map_field (0.00s)
    --- PASS: TestSize/map_field_with_message (0.00s)
    --- PASS: TestSize/map_field_with_bytes (0.00s)
    --- PASS: TestSize/map_field_with_empty_bytes (0.00s)
    --- PASS: TestSize/map_field_with_big_entry (0.00s)
    --- PASS: TestSize/map_field_with_big_key_and_val (0.00s)
    --- PASS: TestSize/map_field_with_big_numeric_key (0.00s)
    --- PASS: TestSize/oneof_not_set (0.00s)
    --- PASS: TestSize/oneof_bool (0.00s)
    --- PASS: TestSize/oneof_zero_int32 (0.00s)
    --- PASS: TestSize/oneof_big_int32 (0.00s)
    --- PASS: TestSize/oneof_int64 (0.00s)
    --- PASS: TestSize/oneof_fixed32 (0.00s)
    --- PASS: TestSize/oneof_fixed64 (0.00s)
    --- PASS: TestSize/oneof_uint32 (0.00s)
    --- PASS: TestSize/oneof_uint64 (0.00s)
    --- PASS: TestSize/oneof_float (0.00s)
    --- PASS: TestSize/oneof_double (0.00s)
    --- PASS: TestSize/oneof_string (0.00s)
    --- PASS: TestSize/oneof_bytes (0.00s)
    --- PASS: TestSize/oneof_sint32 (0.00s)
    --- PASS: TestSize/oneof_sint64 (0.00s)
    --- PASS: TestSize/oneof_enum (0.00s)
    --- PASS: TestSize/message_for_oneof (0.00s)
    --- PASS: TestSize/oneof_message (0.00s)
    --- PASS: TestSize/oneof_group (0.00s)
    --- PASS: TestSize/oneof_largest_tag (0.00s)
    --- PASS: TestSize/multiple_oneofs (0.00s)
    --- PASS: TestSize/non-pointer_message (0.00s)
=== RUN   TestVarintSize
--- PASS: TestVarintSize (0.00s)
=== RUN   TestRegistry
--- PASS: TestRegistry (0.00s)
=== RUN   TestMarshalGolden
=== RUN   TestMarshalGolden/#00
=== RUN   TestMarshalGolden/#01
=== RUN   TestMarshalGolden/#02
=== RUN   TestMarshalGolden/#03
=== RUN   TestMarshalGolden/#04
=== RUN   TestMarshalGolden/#05
--- PASS: TestMarshalGolden (0.00s)
    --- PASS: TestMarshalGolden/#00 (0.00s)
    --- PASS: TestMarshalGolden/#01 (0.00s)
    --- PASS: TestMarshalGolden/#02 (0.00s)
    --- PASS: TestMarshalGolden/#03 (0.00s)
    --- PASS: TestMarshalGolden/#04 (0.00s)
    --- PASS: TestMarshalGolden/#05 (0.00s)
=== RUN   TestUnmarshalGolden
=== RUN   TestUnmarshalGolden/#00
=== RUN   TestUnmarshalGolden/#01
=== RUN   TestUnmarshalGolden/#02
=== RUN   TestUnmarshalGolden/#03
=== RUN   TestUnmarshalGolden/#04
=== RUN   TestUnmarshalGolden/#05
--- PASS: TestUnmarshalGolden (0.00s)
    --- PASS: TestUnmarshalGolden/#00 (0.00s)
    --- PASS: TestUnmarshalGolden/#01 (0.00s)
    --- PASS: TestUnmarshalGolden/#02 (0.00s)
    --- PASS: TestUnmarshalGolden/#03 (0.00s)
    --- PASS: TestUnmarshalGolden/#04 (0.00s)
    --- PASS: TestUnmarshalGolden/#05 (0.00s)
=== RUN   TestMarshalUnknownAny
--- PASS: TestMarshalUnknownAny (0.00s)
=== RUN   TestAmbiguousAny
--- PASS: TestAmbiguousAny (0.00s)
=== RUN   TestUnmarshalOverwriteAny
--- PASS: TestUnmarshalOverwriteAny (0.00s)
=== RUN   TestUnmarshalAnyMixAndMatch
--- PASS: TestUnmarshalAnyMixAndMatch (0.00s)
=== RUN   TestMarshalText
--- PASS: TestMarshalText (0.00s)
=== RUN   TestMarshalTextCustomMessage
--- PASS: TestMarshalTextCustomMessage (0.00s)
=== RUN   TestMarshalTextNil
--- PASS: TestMarshalTextNil (0.00s)
=== RUN   TestMarshalTextUnknownEnum
--- PASS: TestMarshalTextUnknownEnum (0.00s)
=== RUN   TestTextOneof
--- PASS: TestTextOneof (0.00s)
=== RUN   TestCompactText
--- PASS: TestCompactText (0.00s)
=== RUN   TestStringEscaping
=== RUN   TestStringEscaping/#00
=== RUN   TestStringEscaping/#01
=== RUN   TestStringEscaping/#02
--- PASS: TestStringEscaping (0.00s)
    --- PASS: TestStringEscaping/#00 (0.00s)
    --- PASS: TestStringEscaping/#01 (0.00s)
    --- PASS: TestStringEscaping/#02 (0.00s)
=== RUN   TestMarshalTextFailing
--- PASS: TestMarshalTextFailing (0.01s)
=== RUN   TestFloats
--- PASS: TestFloats (0.00s)
=== RUN   TestRepeatedNilText
--- PASS: TestRepeatedNilText (0.00s)
=== RUN   TestProto3Text
--- PASS: TestProto3Text (0.00s)
=== RUN   TestRacyMarshal
--- PASS: TestRacyMarshal (0.00s)
=== RUN   TestUnmarshalText
=== RUN   TestUnmarshalText/#00
=== RUN   TestUnmarshalText/#01
=== RUN   TestUnmarshalText/#02
=== RUN   TestUnmarshalText/#03
=== RUN   TestUnmarshalText/#04
=== RUN   TestUnmarshalText/#05
=== RUN   TestUnmarshalText/#06
=== RUN   TestUnmarshalText/#07
=== RUN   TestUnmarshalText/#08
=== RUN   TestUnmarshalText/#09
=== RUN   TestUnmarshalText/#10
=== RUN   TestUnmarshalText/#11
=== RUN   TestUnmarshalText/#12
=== RUN   TestUnmarshalText/#13
=== RUN   TestUnmarshalText/#14
=== RUN   TestUnmarshalText/#15
=== RUN   TestUnmarshalText/#16
=== RUN   TestUnmarshalText/#17
=== RUN   TestUnmarshalText/#18
=== RUN   TestUnmarshalText/#19
=== RUN   TestUnmarshalText/#20
=== RUN   TestUnmarshalText/#21
=== RUN   TestUnmarshalText/#22
=== RUN   TestUnmarshalText/#23
=== RUN   TestUnmarshalText/#24
=== RUN   TestUnmarshalText/#25
=== RUN   TestUnmarshalText/#26
=== RUN   TestUnmarshalText/#27
=== RUN   TestUnmarshalText/#28
=== RUN   TestUnmarshalText/#29
=== RUN   TestUnmarshalText/#30
=== RUN   TestUnmarshalText/#31
=== RUN   TestUnmarshalText/#32
=== RUN   TestUnmarshalText/#33
=== RUN   TestUnmarshalText/#34
=== RUN   TestUnmarshalText/#35
=== RUN   TestUnmarshalText/#36
=== RUN   TestUnmarshalText/#37
=== RUN   TestUnmarshalText/#38
=== RUN   TestUnmarshalText/#39
=== RUN   TestUnmarshalText/#40
=== RUN   TestUnmarshalText/#41
=== RUN   TestUnmarshalText/#42
=== RUN   TestUnmarshalText/#43
=== RUN   TestUnmarshalText/#44
=== RUN   TestUnmarshalText/#45
=== RUN   TestUnmarshalText/#46
=== RUN   TestUnmarshalText/#47
=== RUN   TestUnmarshalText/#48
=== RUN   TestUnmarshalText/#49
=== RUN   TestUnmarshalText/#50
=== RUN   TestUnmarshalText/#51
=== RUN   TestUnmarshalText/#52
=== RUN   TestUnmarshalText/#53
=== RUN   TestUnmarshalText/#54
--- PASS: TestUnmarshalText (0.00s)
    --- PASS: TestUnmarshalText/#00 (0.00s)
    --- PASS: TestUnmarshalText/#01 (0.00s)
    --- PASS: TestUnmarshalText/#02 (0.00s)
    --- PASS: TestUnmarshalText/#03 (0.00s)
    --- PASS: TestUnmarshalText/#04 (0.00s)
    --- PASS: TestUnmarshalText/#05 (0.00s)
    --- PASS: TestUnmarshalText/#06 (0.00s)
    --- PASS: TestUnmarshalText/#07 (0.00s)
    --- PASS: TestUnmarshalText/#08 (0.00s)
    --- PASS: TestUnmarshalText/#09 (0.00s)
    --- PASS: TestUnmarshalText/#10 (0.00s)
    --- PASS: TestUnmarshalText/#11 (0.00s)
    --- PASS: TestUnmarshalText/#12 (0.00s)
    --- PASS: TestUnmarshalText/#13 (0.00s)
    --- PASS: TestUnmarshalText/#14 (0.00s)
    --- PASS: TestUnmarshalText/#15 (0.00s)
    --- PASS: TestUnmarshalText/#16 (0.00s)
    --- PASS: TestUnmarshalText/#17 (0.00s)
    --- PASS: TestUnmarshalText/#18 (0.00s)
    --- PASS: TestUnmarshalText/#19 (0.00s)
    --- PASS: TestUnmarshalText/#20 (0.00s)
    --- PASS: TestUnmarshalText/#21 (0.00s)
    --- PASS: TestUnmarshalText/#22 (0.00s)
    --- PASS: TestUnmarshalText/#23 (0.00s)
    --- PASS: TestUnmarshalText/#24 (0.00s)
    --- PASS: TestUnmarshalText/#25 (0.00s)
    --- PASS: TestUnmarshalText/#26 (0.00s)
    --- PASS: TestUnmarshalText/#27 (0.00s)
    --- PASS: TestUnmarshalText/#28 (0.00s)
    --- PASS: TestUnmarshalText/#29 (0.00s)
    --- PASS: TestUnmarshalText/#30 (0.00s)
    --- PASS: TestUnmarshalText/#31 (0.00s)
    --- PASS: TestUnmarshalText/#32 (0.00s)
    --- PASS: TestUnmarshalText/#33 (0.00s)
    --- PASS: TestUnmarshalText/#34 (0.00s)
    --- PASS: TestUnmarshalText/#35 (0.00s)
    --- PASS: TestUnmarshalText/#36 (0.00s)
    --- PASS: TestUnmarshalText/#37 (0.00s)
    --- PASS: TestUnmarshalText/#38 (0.00s)
    --- PASS: TestUnmarshalText/#39 (0.00s)
    --- PASS: TestUnmarshalText/#40 (0.00s)
    --- PASS: TestUnmarshalText/#41 (0.00s)
    --- PASS: TestUnmarshalText/#42 (0.00s)
    --- PASS: TestUnmarshalText/#43 (0.00s)
    --- PASS: TestUnmarshalText/#44 (0.00s)
    --- PASS: TestUnmarshalText/#45 (0.00s)
    --- PASS: TestUnmarshalText/#46 (0.00s)
    --- PASS: TestUnmarshalText/#47 (0.00s)
    --- PASS: TestUnmarshalText/#48 (0.00s)
    --- PASS: TestUnmarshalText/#49 (0.00s)
    --- PASS: TestUnmarshalText/#50 (0.00s)
    --- PASS: TestUnmarshalText/#51 (0.00s)
    --- PASS: TestUnmarshalText/#52 (0.00s)
    --- PASS: TestUnmarshalText/#53 (0.00s)
    --- PASS: TestUnmarshalText/#54 (0.00s)
=== RUN   TestUnmarshalTextCustomMessage
--- PASS: TestUnmarshalTextCustomMessage (0.00s)
=== RUN   TestRepeatedEnum
--- PASS: TestRepeatedEnum (0.00s)
=== RUN   TestProto3TextParsing
--- PASS: TestProto3TextParsing (0.00s)
=== RUN   TestMapParsing
--- PASS: TestMapParsing (0.00s)
=== RUN   TestOneofParsing
--- PASS: TestOneofParsing (0.00s)
PASS
ok  	github.com/golang/protobuf/proto	0.029s
=== RUN   TestErrors
    remap_test.go:24: Got expected error: wrong number of tokens, 1 ≠ 2
    remap_test.go:24: Got expected error: wrong number of tokens, 2 ≠ 1
    remap_test.go:24: Got expected error: wrong number of tokens, 6 ≠ 5
    remap_test.go:24: Got expected error: token 3 type mismatch: STRING ≠ CHAR
--- PASS: TestErrors (0.00s)
=== RUN   TestMatching
--- PASS: TestMatching (0.00s)
PASS
ok  	github.com/golang/protobuf/protoc-gen-go/generator/internal/remap	0.001s
=== RUN   TestMarshalUnmarshal
--- PASS: TestMarshalUnmarshal (0.00s)
=== RUN   TestIs
--- PASS: TestIs (0.00s)
=== RUN   TestIsDifferentUrlPrefixes
--- PASS: TestIsDifferentUrlPrefixes (0.00s)
=== RUN   TestIsCornerCases
--- PASS: TestIsCornerCases (0.00s)
=== RUN   TestUnmarshalDynamic
--- PASS: TestUnmarshalDynamic (0.00s)
=== RUN   TestEmpty
--- PASS: TestEmpty (0.00s)
=== RUN   TestEmptyCornerCases
--- PASS: TestEmptyCornerCases (0.00s)
=== RUN   TestAnyReflect
--- PASS: TestAnyReflect (0.00s)
=== RUN   TestValidateDuration
--- PASS: TestValidateDuration (0.00s)
=== RUN   TestDuration
--- PASS: TestDuration (0.00s)
=== RUN   TestDurationProto
--- PASS: TestDurationProto (0.00s)
=== RUN   TestValidateTimestamp
--- PASS: TestValidateTimestamp (0.00s)
=== RUN   TestTimestamp
--- PASS: TestTimestamp (0.00s)
=== RUN   TestTimestampProto
--- PASS: TestTimestampProto (0.00s)
=== RUN   TestTimestampString
--- PASS: TestTimestampString (0.00s)
=== RUN   TestTimestampNow
--- PASS: TestTimestampNow (0.00s)
PASS
ok  	github.com/golang/protobuf/ptypes	0.002s
```