### PR TITLE
python3Packages.limits: enable tests

### DIFF
--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -1,21 +1,69 @@
-{ lib, fetchPypi, buildPythonPackage, six }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hiro
+, pymemcache
+, pymongo
+, pytest-asyncio
+, pytest-lazy-fixture
+, pytestCheckHook
+, pythonOlder
+, redis
+, setuptools
+}:
 
 buildPythonPackage rec {
   pname = "limits";
   version = "2.4.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-jiK2PfJjECB6d7db1HRZnwpGE6fZFjZQ7TpCjpzHrjU=";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "alisaifee";
+    repo = pname;
+    rev = version;
+    hash = "sha256-KSYcIdLQ6TZpimxXyV88/V35GbBJ/9k9+UBM2KTMRR4=";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [
+    setuptools
+    redis
+    pymemcache
+    pymongo
+  ];
 
-  doCheck = false; # ifilter
+  checkInputs = [
+    hiro
+    pytest-asyncio
+    pytest-lazy-fixture
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--cov=limits" "" \
+      --replace "-K" ""
+    # redis-py-cluster doesn't support redis > 4
+    substituteInPlace tests/conftest.py \
+      --replace "import rediscluster" ""
+  '';
+
+  pythonImportsCheck = [
+    "limits"
+  ];
+
+  pytestFlagsArray = [
+    # All other tests require a running Docker instance
+    "tests/test_limits.py"
+    "tests/test_ratelimit_parser.py"
+    "tests/test_limit_granularities.py"
+  ];
 
   meta = with lib; {
     description = "Rate limiting utilities";
-    license = licenses.mit;
     homepage = "https://limits.readthedocs.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -1,7 +1,9 @@
 { lib
 , buildPythonPackage
+, deprecated
 , fetchFromGitHub
 , hiro
+, packaging
 , pymemcache
 , pymongo
 , pytest-asyncio
@@ -10,6 +12,7 @@
 , pythonOlder
 , redis
 , setuptools
+, typing-extensions
 }:
 
 buildPythonPackage rec {
@@ -27,17 +30,20 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    deprecated
+    packaging
     setuptools
-    redis
-    pymemcache
-    pymongo
+    typing-extensions
   ];
 
   checkInputs = [
     hiro
+    pymemcache
+    pymongo
     pytest-asyncio
     pytest-lazy-fixture
     pytestCheckHook
+    redis
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "limits";
-  version = "2.4.0";
+  version = "2.6.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "alisaifee";
     repo = pname;
     rev = version;
-    hash = "sha256-KSYcIdLQ6TZpimxXyV88/V35GbBJ/9k9+UBM2KTMRR4=";
+    hash = "sha256-4Njai0LT72U9Ra4pgHU0ZjF9oZexbijUgLFYaZi/LgE=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes
Enable basic tests
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Successor for #160299