### PR TITLE
ghostscript: 9.55.0 -> 9.56.1

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -1,6 +1,6 @@
 { config, stdenv, lib, fetchurl, pkg-config, zlib, expat, openssl, autoconf
 , libjpeg, libpng, libtiff, freetype, fontconfig, libpaper, jbig2dec
-, libiconv, ijs, lcms2, fetchpatch, callPackage, bash, buildPackages, openjpeg
+, libiconv, ijs, lcms2, callPackage, bash, buildPackages, openjpeg
 , cupsSupport ? config.ghostscript.cups or (!stdenv.isDarwin), cups
 , x11Support ? cupsSupport, xlibsWrapper # with CUPS, X11 only adds very little
 }:
@@ -30,19 +30,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ghostscript${lib.optionalString (x11Support) "-with-X"}";
-  version = "9.55.0";
+  version = "9.56.1";
 
   src = fetchurl {
     url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9${lib.versions.minor version}${lib.versions.patch version}/ghostscript-${version}.tar.xz";
-    sha512 = "27g72152mlwlalg232jxdhaf3ykgmqwi2pccbkwfygql1h9iz40plfbwbs1n0fkvm4zwzg5r9cr8g7w2dxih4jldiidv7rflxdy1is2";
+    sha512 = "22ysgdprh960rxmxyk2fy2my47cdrhfhbrwar1955hvad54iw79l916drp92wh3qzbxw6z40i70wk00vz8bn2ryig7qgpc1q01m2npy";
   };
 
   patches = [
-    (fetchpatch {
-      name = "fix-non-vendored-lcms2-typo.patch";
-      url = "https://github.com/ArtifexSoftware/ghostpdl/commit/830afae5454dea3bff903869d82022306890a96c.patch";
-      sha256 = "1w9yspsgxyabvrw9ld6pv6pb7708c44ihjqvag7qqh9v1lhm48j0";
-    })
     ./urw-font-files.patch
     ./doc-no-ref.diff
   ];


### PR DESCRIPTION
###### Description of changes
https://www.ghostscript.com/doc/9.56.1/News.htm

I've added the security label to this. I don't have specific CVE(s) to point you at, but having observed the ghostscript repo lately, let's just say we want 9.56 in 22.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
