### PR TITLE
protolock: enable tests

### DIFF
--- a/pkgs/development/libraries/protolock/default.nix
+++ b/pkgs/development/libraries/protolock/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-kgSJUSjY8kgrGCNDPgw1WA8KwAqI5koJQ0IcE+tC5nk=";
 
-  doCheck = false;
-
   postInstall = ''
     rm $out/bin/plugin*
   '';


### PR DESCRIPTION
protolock: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestHints
HINT: @protolock:skip proto:4:1
HINT: @protolock:skip proto:15:2
HINT: @protolock:skip proto:20:1
HINT: @protolock:skip proto:23:1
HINT: @protolock:internal proto:23:1
HINT: @protolock:skip proto:31:1
HINT: @protolock:skip proto:36:1
=== RUN   TestHints/skip:messages
=== RUN   TestHints/skip:services
=== RUN   TestHints/skip:enums
--- PASS: TestHints (0.00s)
    --- PASS: TestHints/skip:messages (0.00s)
    --- PASS: TestHints/skip:services (0.00s)
    --- PASS: TestHints/skip:enums (0.00s)
=== RUN   TestOrder
HINT: @protolock:skip testdata/test.proto:70:1
--- PASS: TestOrder (0.00s)
=== RUN   TestParseSingleQuoteReservedNames
--- PASS: TestParseSingleQuoteReservedNames (0.00s)
=== RUN   TestParseRequiredAndOptionalFields
--- PASS: TestParseRequiredAndOptionalFields (0.00s)
=== RUN   TestParseIncludingImports
--- PASS: TestParseIncludingImports (0.00s)
=== RUN   TestParseIncludingPackage
--- PASS: TestParseIncludingPackage (0.00s)
=== RUN   TestParseIncludingMessageOptions
--- PASS: TestParseIncludingMessageOptions (0.00s)
=== RUN   TestParseIncludingNestedMessageOptions
--- PASS: TestParseIncludingNestedMessageOptions (0.00s)
=== RUN   TestParseIncludingFieldOptions
--- PASS: TestParseIncludingFieldOptions (0.00s)
=== RUN   TestParseIncludingNestedFieldOptions
--- PASS: TestParseIncludingNestedFieldOptions (0.00s)
=== RUN   TestParseIncludingNestedFieldOptionsAggregated
--- PASS: TestParseIncludingNestedFieldOptionsAggregated (0.00s)
=== RUN   TestParseIncludingEnumFieldOptions
--- PASS: TestParseIncludingEnumFieldOptions (0.00s)
=== RUN   TestParseIncludingEnumOptions
--- PASS: TestParseIncludingEnumOptions (0.00s)
=== RUN   TestParseIncludingRpcOptions
--- PASS: TestParseIncludingRpcOptions (0.00s)
=== RUN   TestParseWithEntryOptions
--- PASS: TestParseWithEntryOptions (0.00s)
=== RUN   TestParseWithoutEntryOptions
--- PASS: TestParseWithoutEntryOptions (0.00s)
=== RUN   TestParseWithoutEntryOptionsWithRPCOptions
--- PASS: TestParseWithoutEntryOptionsWithRPCOptions (0.00s)
=== RUN   TestGetProtoFilesFiltersDirectories
--- PASS: TestGetProtoFilesFiltersDirectories (0.00s)
=== RUN   TestGetProtoFilesFiltersNonProto
--- PASS: TestGetProtoFilesFiltersNonProto (0.00s)
=== RUN   TestGetProtoFilesIgnoresDirectories
--- PASS: TestGetProtoFilesIgnoresDirectories (0.00s)
=== RUN   TestGetProtoFilesIgnoresFiles
--- PASS: TestGetProtoFilesIgnoresFiles (0.00s)
=== RUN   TestGetProtoFilesIgnoresMultiple
--- PASS: TestGetProtoFilesIgnoresMultiple (0.00s)
=== RUN   TestOSPathToProtoPath
--- PASS: TestOSPathToProtoPath (0.00s)
=== RUN   TestProtoPathToOSPath
--- PASS: TestProtoPathToOSPath (0.00s)
=== RUN   TestParseOnReader
--- PASS: TestParseOnReader (0.00s)
=== RUN   TestChangingRPCSignature
--- PASS: TestChangingRPCSignature (0.00s)
=== RUN   TestRemovingServiceRPCs
--- PASS: TestRemovingServiceRPCs (0.00s)
=== RUN   TestChangingFieldNames
--- PASS: TestChangingFieldNames (0.00s)
=== RUN   TestChangingFieldNamesNestedMessages
--- PASS: TestChangingFieldNamesNestedMessages (0.00s)
=== RUN   TestChangingFieldTypes
--- PASS: TestChangingFieldTypes (0.00s)
=== RUN   TestChangingFieldTypesNestedMessages
--- PASS: TestChangingFieldTypesNestedMessages (0.00s)
=== RUN   TestUsingReservedFields
--- PASS: TestUsingReservedFields (0.00s)
=== RUN   TestRemovingReservedFields
--- PASS: TestRemovingReservedFields (0.00s)
=== RUN   TestRemovingReservedFieldsNestedMessages
--- PASS: TestRemovingReservedFieldsNestedMessages (0.00s)
=== RUN   TestChangingFieldIDs
--- PASS: TestChangingFieldIDs (0.00s)
=== RUN   TestChangingFieldIdsNestedMessages
--- PASS: TestChangingFieldIdsNestedMessages (0.00s)
=== RUN   TestRemovingFieldsWithoutReserve
--- PASS: TestRemovingFieldsWithoutReserve (0.00s)
=== RUN   TestRemovingFieldsWithoutReserveNestedMessages
--- PASS: TestRemovingFieldsWithoutReserveNestedMessages (0.00s)
=== RUN   TestNoConflictSameNameNestedMessages
--- PASS: TestNoConflictSameNameNestedMessages (0.00s)
=== RUN   TestShouldConflictReusingFieldsNestedMessages
--- PASS: TestShouldConflictReusingFieldsNestedMessages (0.00s)
=== RUN   TestIsPermutation
--- PASS: TestIsPermutation (0.00s)
PASS
ok  	github.com/nilslice/protolock	0.005s
=== RUN   TestPluginInit
--- PASS: TestPluginInit (0.00s)
PASS
ok  	github.com/nilslice/protolock/extend	0.001s
```