### PR TITLE
setuptoolsDepsVersionHook: init

### DIFF
--- a/pkgs/applications/misc/archivy/default.nix
+++ b/pkgs/applications/misc/archivy/default.nix
@@ -49,21 +49,9 @@ buildPythonApplication rec {
     hash = "sha256-o5dVJDbdKgo6hMMU9mKzoouSgVWl7xSAp+Aq61VcfeU=";
   };
 
-  # Relax some dependencies
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace 'WTForms ==' 'WTForms >=' \
-      --replace 'attrs == 20.2.0' 'attrs' \
-      --replace 'elasticsearch ==' 'elasticsearch >=' \
-      --replace 'python_dotenv ==' 'python_dotenv >=' \
-      --replace 'python_frontmatter == 0.5.0' 'python_frontmatter' \
-      --replace 'requests ==' 'requests >=' \
-      --replace 'validators ==' 'validators >=' \
-      --replace 'flask-login == ' 'flask-login >= ' \
-      --replace 'tinydb ==' 'tinydb >=' \
-      --replace 'Flask_WTF == 0.14.3' 'Flask_WTF' \
-      --replace 'Flask ==' 'Flask >='
-  '';
+  nativeBuildInputs = [ setuptoolsDepsVersionsHook ];
+
+  relaxPythonDeps = true;
 
   propagatedBuildInputs = [
     appdirs

--- a/pkgs/applications/misc/bikeshed/default.nix
+++ b/pkgs/applications/misc/bikeshed/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonApplication
 , fetchPypi
+, setuptoolsDepsVersionsHook
 # build inputs
 , aiofiles
 , aiohttp
@@ -29,12 +30,10 @@ buildPythonApplication rec {
     sha256 = "sha256-vJW4yNbKCZraJ5vx8FheNsBl+zObGoLFgAVqoU0p9QQ=";
   };
 
-  # Relax requirements from "==" to ">="
+  nativeBuildInputs = [ setuptoolsDepsVersionsHook ];
+
   # https://github.com/tabatkins/bikeshed/issues/2178
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "==" ">="
-  '';
+  relaxPythonDeps = true;
 
   propagatedBuildInputs = [
     aiofiles

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -1,11 +1,12 @@
 # Hooks for building Python packages.
-{ python
-, lib
-, makeSetupHook
+{ lib
 , disabledIf
-, isPy3k
 , ensureNewerSourcesForZipFilesHook
 , findutils
+, isPy3k
+, makeSetupHook
+, python
+, pythonOlder
 }:
 
 let
@@ -60,6 +61,16 @@ in rec {
         inherit pythonInterpreter;
       };
     } ./flit-build-hook.sh) {};
+
+  setuptoolsDepsVersionsHook = disabledIf (pythonOlder "3.7") callPackage ({ requirements-parser }:
+    makeSetupHook {
+      name = "fix-python-deps-hook";
+      deps = [ requirements-parser ];
+      substitutions = {
+        inherit pythonInterpreter;
+        setuptoolsRequirementsTxtDepsVersionsHookPy = ./setuptools-requirements-txt-deps-versions-hook.py;
+      };
+    } ./setuptools-deps-versions-hook.sh) {};
 
   pipBuildHook = callPackage ({ pip, wheel }:
     makeSetupHook {

--- a/pkgs/development/interpreters/python/hooks/setuptools-deps-versions-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-deps-versions-hook.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+
+# Setup hook that fixes Python dependencies versions.
+#
+# Example usage in a derivation:
+#
+#   { …, pythonPackages, … }:
+#
+#   pythonPackages.buildPythonPackage {
+#     …
+#     nativeBuildInputs = [ pythonPackages.setuptoolsDepsVersionsHook ];
+#
+#     # Location of the requirements.txt file, supports Python's glob
+#     # Defaults to `**/requirements*.txt`
+#     requirementsTxt = "requirements_*.txt";
+#
+#     # This will relax the dependency restrictions
+#     # e.g.: abc>1,<=2 -> abc
+#     relaxPythonDeps = [ "abc" ];
+#     # This will relax all dependencies restrictions instead
+#     # relaxPythonDeps = true;
+#     # This will remove the dependency
+#     # e.g.: cde>1,<=2 -> <nothing>
+#     removePythonDeps = [ "cde" ];
+#     # This will remove all dependencies from the project
+#     # removePythonDeps = true;
+#     …
+#   }
+
+setuptoolsDepsVersionsHook() {
+    echo "Executing setuptoolsDepsVersionsHook"
+
+    # Exporting env vars so the Python interpreter can see them
+    export requirementsTxt relaxPythonDeps removePythonDeps NIX_DEBUG
+    @pythonInterpreter@ @setuptoolsRequirementsTxtDepsVersionsHookPy@
+}
+
+preBuild+=" setuptoolsDepsVersionsHook"

--- a/pkgs/development/interpreters/python/hooks/setuptools-requirements-txt-deps-versions-hook.py
+++ b/pkgs/development/interpreters/python/hooks/setuptools-requirements-txt-deps-versions-hook.py
@@ -1,0 +1,84 @@
+import os
+import sys
+from glob import iglob
+from shutil import copyfile
+from tempfile import NamedTemporaryFile
+
+import requirements
+
+
+try:
+    NIX_DEBUG = int(os.environ.get("NIX_DEBUG", "0")) >= 7
+except ValueError:
+    NIX_DEBUG = False
+
+
+def debug_msg(*args):
+    if NIX_DEBUG:
+        print(f"setuptoolsDepsVersionsHook:", *args, file=sys.stderr)
+
+
+def fix_deps(requirements_txt, relax_python_deps, remove_python_deps):
+    with NamedTemporaryFile(mode="w") as tmp:
+        with open(requirements_txt, mode="r") as f:
+            for req in requirements.parse(f):
+                if remove_python_deps == True or req.name in remove_python_deps:
+                    if isinstance(remove_python_deps, list):
+                        remove_python_deps.remove(req.name)
+                    debug_msg(f"Removing '{req.name}' dependency")
+                    continue
+                elif relax_python_deps == True or req.name in relax_python_deps:
+                    if isinstance(relax_python_deps, list):
+                        relax_python_deps.remove(req.name)
+                    debug_msg(f"Relaxing '{req.name}' dependency")
+                    print(req.name, file=tmp)
+                else:
+                    print(req.line, file=tmp)
+
+        # Should have replaced all declared removePythonDeps/relaxPythonDeps
+        assert (
+            remove_python_deps == True or remove_python_deps == []
+        ), f"These declared deps in removePythonDeps were not found in '{requirements_txt}' file: {remove_python_deps}"
+        assert (
+            relax_python_deps == True or relax_python_deps == []
+        ), f"These declared deps in relaxPythonDeps were not found in '{requirements_txt}' file: {relax_python_deps}"
+
+        tmp.flush()
+        copyfile(tmp.name, requirements_txt)
+
+
+def get_and_parse_nix_env_var(env_var, default_value=""):
+    # nix converts true to 1, false to 0 and arrays to space-separated string
+    env = os.environ.get(env_var, default_value)
+    if env == "0":
+        return False
+    elif env == "1":
+        return True
+    else:
+        return env.split()
+
+
+def main():
+    # From glob documentation: https://docs.python.org/3/library/glob.html
+    # > Using the “**” pattern in large directory trees may consume an inordinate amount of time.
+    # Shouldn't be an issue for most Python projects, but if it is best is to set
+    # `requirementsTxt` to something specific for your project
+    requirements_txts = iglob(
+        os.environ.get("requirementsTxt", "**/requirements*.txt"), recursive=True
+    )
+    relax_python_deps = get_and_parse_nix_env_var("relaxPythonDeps")
+    remove_python_deps = get_and_parse_nix_env_var("removePythonDeps")
+
+    for requirements_txt in requirements_txts:
+        debug_msg(f"Fixing {requirements_txt} file")
+
+        fix_deps(requirements_txt, relax_python_deps, remove_python_deps)
+
+        debug_msg(f"Resulting {requirements_txt} file:")
+        if NIX_DEBUG:
+            with open(requirements_txt, mode="r") as f:
+                print(f.read(), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -7,6 +7,7 @@
 , unittest2
 , traceback2
 , testscenarios
+, setuptoolsDepsVersionsHook
 }:
 
 buildPythonPackage rec {
@@ -18,6 +19,7 @@ buildPythonPackage rec {
     sha256 = "57c13433d94f9ffde3be6534177d10fb0c1507cc499319128958ca91a65cb23f";
   };
 
+  nativeBuildInputs = [ setuptoolsDepsVersionsHook ];
   propagatedBuildInputs = [ pbr python-mimeparse extras ];
   buildInputs = [ traceback2 ];
 
@@ -25,10 +27,7 @@ buildPythonPackage rec {
   doCheck = false;
   checkInputs = [ testscenarios ];
 
-  # testtools 2.0.0 and up has a circular run-time dependency on futures
-  postPatch = ''
-    substituteInPlace requirements.txt --replace "fixtures>=1.3.0" ""
-  '';
+  removePythonDeps = [ "fixtures" ];
 
   meta = {
     description = "A set of extensions to the Python standard library's unit testing framework";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -123,6 +123,7 @@ in {
     pythonRemoveTestsDirHook
     setuptoolsBuildHook
     setuptoolsCheckHook
+    setuptoolsDepsVersionsHook
     venvShellHook
     wheelUnpackHook;
 


### PR DESCRIPTION
###### Description of changes

We have a common pattern here in `nixpkgs` for Python applications: when a Python package ships with either a `requirements.txt` or `setup.py` file, we generally end up having to modify its version restriction, otherwise we have build failures since we package only one specific version of each package normally.

However, this end up being done in a completely ad-hoc way: some people use `substituteInPlace`, some others use `sed`, others uses `patches`, etc. In many cases, the code ends up being buggy, so it may work in one version and breaks on the next one. We can instead implement one standard way of doing this, and trying to be a correct as possible.

So the idea of this PR is for a initial proposal of this standard approach. For now it only supports `requirements.txt` format, doesn't have tests, uses a build hook that I still am not sure if this is the best idea, etc. I mostly opened this here to collect ideas and early feedback, so this is why I marked this PR as a RFC for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
