### PR TITLE
noto-fonts: 2020-01-23 -> unstable-2022-04-25 and other changes

### DIFF
--- a/nixos/tests/noto-fonts.nix
+++ b/nixos/tests/noto-fonts.nix
@@ -26,6 +26,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
   testScript =
     # extracted from http://www.clagnut.com/blog/2380/
+    # emoji are from Unicode 14 (latest standard)
     let testText = builtins.toFile "test.txt" ''
       the quick brown fox jumps over the lazy dog
       視野無限廣，窗外有藍天
@@ -33,6 +34,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       いろはにほへと ちりぬるを わかよたれそ つねならむ うゐのおくやま けふこえて あさきゆめみし ゑひもせす
       다람쥐 헌 쳇바퀴에 타고파
       中国智造，慧及全球
+      🫠🫣🫱🏻‍🫲🏿
     ''; in
     ''
       machine.wait_for_x()

--- a/pkgs/data/fonts/noto-fonts/analyze_scan.py
+++ b/pkgs/data/fonts/noto-fonts/analyze_scan.py
@@ -1,0 +1,156 @@
+import csv
+import re
+from collections import defaultdict
+
+# fc-scan ./hinted ./unhinted -f '"%{fullname[0]}","%{file}"\n' > scan.csv
+
+blacklist = [
+  # provides "Noto S Display, M" while main font provides "Noto S, Display M".
+  # package both by blacklisting and force-adding Display fonts later
+  # https://github.com/googlefonts/noto-fonts/issues/2315
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansDisplay-Italic-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansDisplay-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSerifDisplay-VF\.ttf",
+  # provides "Noto Sans Display X, Regular" instead of "Noto Sans Display, X"
+  # https://github.com/googlefonts/noto-fonts/issues/2315
+  r"\./unhinted/otf/NotoSansDisplay/NotoSansDisplay-[A-Za-z]+\.otf",
+  # provides "Noto Sans X" instead of "Noto Sans X UI"
+  # https://github.com/googlefonts/noto-fonts/issues/2316
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansKannadaUI-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansMalayalamUI-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansSinhalaUI-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansTamilUI-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansTeluguUI-VF\.ttf",
+  # extraneous files
+  # comment in https://github.com/googlefonts/noto-fonts/issues/2316
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansTamil-android-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansTamilUI-android-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansTamilUI-VF-torecover\.ttf",
+  # provides "FontName" instead of "Font Name"
+  # https://github.com/googlefonts/noto-fonts/issues/2317
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansMeeteiMayek-VF\.ttf",
+  r"\./unhinted/(slim-)?variable-ttf/NotoSerifTamilSlanted-VF\.ttf",
+  # font names are missing Bold, Italic, etc.
+  # https://github.com/googlefonts/noto-fonts/issues/2317
+  r"\./unhinted/(slim-)?variable-ttf/NotoSansHanifiRohingya-VF\.ttf",
+  # duplicate fonts in NotoSansTifinagh
+  # https://github.com/googlefonts/noto-fonts/issues/2326
+  r"\./unhinted/otf/NotoSansTifinagh/NotoSansTifinagh[A-Z].*\.otf"
+]
+
+blacklist = list(map(re.compile, blacklist))
+
+class Font:
+  def __init__(self):
+    self.hinted_ttf = None
+    self.unhinted_ttf = None
+    self.otf = None
+    self.vf = None
+    self.slimvf = None
+    self.extra = None
+
+fonts = defaultdict(Font)
+
+# KDE uses Light/LightItalic, so keep those in the main package, see
+# https://mail.kde.org/pipermail/distributions/2017-November/000706.html
+# https://mail.kde.org/pipermail/distributions/2017-November/000709.html
+extrafontpattern = re.compile(r".*(Black|Condensed|Extra|Medium|Semi|Thin).*")
+
+with open('scan.csv', newline='') as csvfile:
+  scanreader = csv.reader(csvfile, delimiter=',', quotechar='"')
+  for row in scanreader:
+    [font, fontfile] = row
+    if any(rgx.match(fontfile) for rgx in blacklist):
+      continue
+    if fontfile.startswith("./hinted/ttf"):
+      if fonts[font].hinted_ttf and fonts[font].hinted_ttf != fontfile:
+        print("duplicate httf", font, ":", fonts[font].hinted_ttf, "and", fontfile)
+      fonts[font].hinted_ttf = fontfile
+    elif fontfile.startswith("./unhinted/ttf"):
+      if fonts[font].unhinted_ttf and fonts[font].unhinted_ttf != fontfile:
+        print("duplicate uttf", font, ":", fonts[font].unhinted_ttf, "and", fontfile)
+      fonts[font].unhinted_ttf = fontfile
+    elif fontfile.startswith("./unhinted/otf"):
+      if fonts[font].otf and fonts[font].otf != fontfile:
+        print("duplicate otf", font, ":", fonts[font].otf, "and", fontfile)
+      fonts[font].otf = fontfile
+    elif fontfile.startswith("./unhinted/variable-ttf"):
+      if fonts[font].vf and fonts[font].vf != fontfile and font != "":
+        print("duplicate vf", font, ":", fonts[font].vf, "and", fontfile)
+      fonts[font].vf = fontfile
+    elif fontfile.startswith("./unhinted/slim-variable-ttf"):
+      if fonts[font].slimvf and fonts[font].slimvf != fontfile and font != "":
+        print("duplicate slim", font, ":", fonts[font].slimvf, "and", fontfile)
+      fonts[font].slimvf = fontfile
+    else:
+      print("Unknown font directory: ", ', '.join(row))
+      raise NotImplementedError
+
+    fonts[font].extra = extrafontpattern.match(font) != None or font == ""
+
+# inconsistent names, see https://github.com/googlefonts/noto-fonts/issues/2317
+# for these names the VF names seem acceptable
+lightlightpattern = re.compile(r"Noto Sans Hebrew (New )?Light Light")
+hmongpattern = re.compile(r"Noto Serif Nyiakeng Puachue Hmong .+")
+
+# compute noto-font files
+
+mode = "vf" # "otf" "slimvf" "vf"
+modeextra = "vf" # "otf" "vf"
+
+# force-add Display VF's to file list, see above
+# https://github.com/googlefonts/noto-fonts/issues/2315
+filelist = set(
+  ["./unhinted/variable-ttf/NotoSansDisplay-Italic-VF.ttf",
+  "./unhinted/variable-ttf/NotoSansDisplay-VF.ttf",
+  "./unhinted/variable-ttf/NotoSerifDisplay-VF.ttf"])
+
+for name, font in fonts.items():
+  if font.extra:
+    continue
+
+  if font.vf and mode == "vf":
+    if not font.otf and name != "" and not lightlightpattern.match(name) and not hmongpattern.match(name):
+      print("missing otf:", name, ", ", font.vf)
+      continue
+    filelist.add(font.vf)
+  elif font.slimvf and mode == "slimvf":
+    if not font.otf and font.slimvf != "":
+      print("missing otf:", name, ", ", font.slimvf)
+      continue
+    filelist.add(font.slimvf)
+  elif font.otf:
+    filelist.add(font.otf)
+  elif font.vf:
+    continue
+  else:
+    print("weird font: ", name, ", ", font)
+    raise NotImplementedError
+
+with open('noto_fonts_list.txt', 'w') as f:
+    for item in filelist:
+        f.write("%s\n" % item)
+
+extra_list = set()
+
+for name, font in fonts.items():
+  if font.vf in filelist or font.slimvf in filelist or font.otf in filelist:
+    continue
+
+  if font.vf and modeextra != "otf":
+    if not font.otf and name != "" and not lightlightpattern.match(name) and not hmongpattern.match(name):
+      print("missing otf:", name, ", ", font.vf)
+      continue
+    extra_list.add(font.vf)
+  elif font.otf:
+    extra_list.add(font.otf)
+  elif font.vf:
+    continue
+  else:
+    print("weird font: ", name, ", ", font)
+    raise NotImplementedError
+
+with open('noto_extra_list.txt', 'w') as f:
+    for item in extra_list:
+        f.write("%s\n" % item)
+

--- a/pkgs/data/fonts/noto-fonts/analyze_scan.py
+++ b/pkgs/data/fonts/noto-fonts/analyze_scan.py
@@ -35,7 +35,11 @@ blacklist = [
   r"\./unhinted/(slim-)?variable-ttf/NotoSansHanifiRohingya-VF\.ttf",
   # duplicate fonts in NotoSansTifinagh
   # https://github.com/googlefonts/noto-fonts/issues/2326
-  r"\./unhinted/otf/NotoSansTifinagh/NotoSansTifinagh[A-Z].*\.otf"
+  r"\./unhinted/otf/NotoSansTifinagh/NotoSansTifinagh[A-Z].*\.otf",
+  # croscore fonts, packaged separately
+  r"\./unhinted/otf/Arimo/.*",
+  r"\./unhinted/otf/Cousine/.*",
+  r"\./unhinted/otf/Tinos/.*"
 ]
 
 blacklist = list(map(re.compile, blacklist))

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -36,7 +36,7 @@ let
 
       nativeBuildInputs = [ buildPackages.fontconfig.bin buildPackages.python3 ];
 
-      outputs = [ "out" "extra" ];
+      outputs = [ "out" "extra" "croscore" ];
 
       installPhase = ''
         fc-scan ./unhinted -f '"%{fullname[0]}","%{file}"\n' > scan.csv
@@ -49,6 +49,10 @@ let
         while read p; do
           install -m444 -Dt $extra_ttf "$p"
         done <noto_extra_list.txt
+        local croscore_ttf=$croscore/share/fonts/google-croscore
+        install -m444 -Dt $croscore_ttf ./unhinted/otf/Arimo/*
+        install -m444 -Dt $croscore_ttf ./unhinted/otf/Cousine/*
+        install -m444 -Dt $croscore_ttf ./unhinted/otf/Tinos/*
       '';
 
       meta = with lib; {
@@ -69,7 +73,7 @@ let
           noto-fonts contains Regular, Bold, and Light weights and Italic style,
           and noto-fonts-extra contains the rest.
 
-          This package also includes the Arimo, Cousine, and Tinos fonts.
+          This package also outputs croscore-fonts which includes the Arimo, Cousine, and Tinos fonts.
         '';
         license = licenses.ofl;
         platforms = platforms.all;
@@ -123,6 +127,9 @@ in
 {
   noto-fonts = noto-pkg.out;
   noto-fonts-extra = noto-pkg.extra;
+  croscore-fonts = noto-pkg.croscore;
+  # TODO for croscore: use more recent VF versions from
+  # https://github.com/googlefonts/Arimo and similar repos
 
   noto-fonts-cjk-sans = mkNotoCJK {
     typeface = "Sans";

--- a/pkgs/data/fonts/noto-fonts/tools.nix
+++ b/pkgs/data/fonts/noto-fonts/tools.nix
@@ -3,7 +3,7 @@
 , defcon, fontmath, fontparts, fontpens, fonttools, lxml
 , mutatormath, pathspec, psautohint, pyclipper, pytz, regex, scour
 , toml, typed-ast, ufonormalizer, ufoprocessor, unicodedata2, zopfli
-, pillow, six, bash, setuptools-scm }:
+, pillow, six, bash, setuptools-scm, setuptools }:
 
 buildPythonPackage rec {
   pname = "nototools";
@@ -40,11 +40,13 @@ buildPythonPackage rec {
     lxml
     mutatormath
     pathspec
+    pillow
     psautohint
     pyclipper
     pytz
     regex
     scour
+    setuptools
     toml
     typed-ast
     ufonormalizer
@@ -54,7 +56,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pillow
     six
     bash
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24444,11 +24444,12 @@ with pkgs;
 
   inherit (callPackages ../data/fonts/noto-fonts {})
     noto-fonts
+    noto-fonts-extra
+    croscore-fonts
     noto-fonts-cjk-sans
     noto-fonts-cjk-serif
     noto-fonts-emoji
-    noto-fonts-emoji-blob-bin
-    noto-fonts-extra;
+    noto-fonts-emoji-blob-bin;
 
   nuclear = callPackage ../applications/audio/nuclear { };
 


### PR DESCRIPTION
###### Description of changes

* noto-tools: adjust dependencies to allow running notodiff
* noto-fonts: 
  * 2020-01-23 -> unstable-2022-04-25; various fonts have been added and updated
  * switch to variable fonts (closes #166953)
  * split out Chrome OS core fonts (Arimo, Tinos, Cousine) to new output croscore-fonts
  * add Emoji to test:
![image](https://user-images.githubusercontent.com/322214/165201988-7e3248ac-652a-480f-a524-5f191b3c3214.png)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested NixOS module test `noto-fonts.tests.noto-fonts`
- [x] Tested basic functionality of notodiff
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking - the worst case for the croscore change is falling back to an ugly font so I don't think it's necessary
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

