### PR TITLE
Hare programming language: init

### DIFF
--- a/pkgs/development/compilers/hare/config-template.mk
+++ b/pkgs/development/compilers/hare/config-template.mk
@@ -1,0 +1,27 @@
+## Template to generate config.mk via substitute-all
+
+# set PREFIX externally
+BINDIR = $(PREFIX)/bin
+MANDIR = $(PREFIX)/share/man
+SRCDIR = $(PREFIX)/src
+STDLIB = $(SRCDIR)/hare/stdlib
+
+HAREPATH = $(SRCDIR)/hare/stdlib:$(SRCDIR)/hare/third-party
+
+## Build configuration
+
+# Platform to build for
+PLATFORM = @platform@
+ARCH = @arch@
+
+# External tools and flags
+HAREC = harec
+HAREFLAGS = @hareflags@
+QBE = qbe
+AS = as
+LD = ld
+AR = ar
+SCDOC = scdoc
+
+# Where to store build artifacts
+# set HARECACHE externally

--- a/pkgs/development/compilers/hare/hare.nix
+++ b/pkgs/development/compilers/hare/hare.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, binutils-unwrapped
+, harec
+, makeWrapper
+, qbe
+, scdoc
+, substituteAll
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hare";
+  version = "0.pre+date=2022-04-27";
+
+  src = fetchFromSourcehut {
+    name = pname + "-src";
+    owner = "~sircmpwn";
+    repo = pname;
+    rev = "1bfb2e6dee850c675a8831b41420800d3c62c2a0";
+    hash = "sha256-1b7U5u3PM3jmnH/OnY9O++GTPyVOdFkJ0fwJBoDZgSU=";
+  };
+
+  nativeBuildInputs = [
+    binutils-unwrapped
+    harec
+    makeWrapper
+    qbe
+    scdoc
+  ];
+
+  buildInputs = [
+    binutils-unwrapped
+    harec
+    qbe
+  ];
+
+  strictDeps = true;
+
+  configurePhase =
+    let
+      # https://harelang.org/platforms/
+      arch =
+        if stdenv.isx86_64 then "x86_64"
+        else if stdenv.isAarch64 then "aarch64"
+        else if stdenv.isRiscV64 then "riscv64"
+        else "unsupported";
+      platform =
+        if stdenv.isLinux then "linux"
+        else if stdenv.isFreeBSD then "freebsd"
+        else "unsupported";
+      hareflags = "";
+      config-file = substituteAll {
+        src = ./config-template.mk;
+        inherit arch platform hareflags;
+      };
+    in
+      ''
+        runHook preConfigure
+
+        export HARECACHE="$NIX_BUILD_TOP/.harecache"
+        cat ${config-file} > config.mk
+
+        runHook postConfigure
+      '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  postInstall =
+    let
+      binPath = lib.makeBinPath [
+        binutils-unwrapped
+        harec
+        qbe
+      ];
+    in
+      ''
+        wrapProgram $out/bin/hare --prefix PATH : ${binPath}
+      '';
+
+  meta = with lib; {
+    homepage = "http://harelang.org/";
+    description =
+      "A systems programming language designed to be simple, stable, and robust";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ AndersonTorres ];
+    inherit (harec.meta) platforms badPlatforms;
+  };
+}

--- a/pkgs/development/compilers/hare/harec.nix
+++ b/pkgs/development/compilers/hare/harec.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, qbe
+}:
+
+stdenv.mkDerivation rec {
+  pname = "harec";
+  version = "0.pre+date=2022-04-26";
+
+  src = fetchFromSourcehut {
+    name = pname + "-src";
+    owner = "~sircmpwn";
+    repo = pname;
+    rev = "e5fb5176ba629e98ace5fcb3aa427b2c25d8fdf0";
+    hash = "sha256-sqt3q6sarzrpyJ/1QYM1WTukrZpflAmAYq6pQwAwe18=";
+  };
+
+  nativeBuildInputs = [
+    qbe
+  ];
+
+  buildInputs = [
+    qbe
+  ];
+
+  # TODO: report upstream
+  hardeningDisable = [ "fortify" ];
+
+  strictDeps = true;
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "http://harelang.org/";
+    description = "Bootstrapping Hare compiler written in C for POSIX systems";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ AndersonTorres ];
+    # The upstream developers do not like proprietary operating systems; see
+    # https://harelang.org/platforms/
+    platforms = with platforms;
+      lib.intersectLists (freebsd ++ linux) (aarch64 ++ x86_64 ++ riscv64);
+    badPlatforms = with platforms; darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6799,6 +6799,8 @@ with pkgs;
     llvmPackages = llvmPackages_9;
   };
 
+  harec = callPackage ../development/compilers/hare/harec.nix { };
+
   ham = pkgs.perlPackages.ham;
 
   hardinfo = callPackage ../tools/system/hardinfo { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6800,6 +6800,7 @@ with pkgs;
   };
 
   harec = callPackage ../development/compilers/hare/harec.nix { };
+  hare = callPackage ../development/compilers/hare/hare.nix { };
 
   ham = pkgs.perlPackages.ham;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
