### PR TITLE
python3Packages.pytest-aiohttp: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/development/python-modules/pytest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/pytest-aiohttp/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , setuptools-scm
 , aiohttp
 , pytest
@@ -11,29 +10,27 @@
 
 buildPythonPackage rec {
   pname = "pytest-aiohttp";
-  version = "1.0.3";
+  version = "1.0.4";
+
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-DI/rSNyOuAhw4rFTrK9iu7zCB5d+vLdDZf/P4WrcnxU=";
+    sha256 = "39ff3a0d15484c01d1436cbedad575c6eafbf0f57cdf76fb94994c97b5b8c5a4";
   };
-
-  patches = [
-    # https://github.com/aio-libs/pytest-aiohttp/pull/26
-    (fetchpatch {
-      name = "fix-tests-with-pytest-asyncio-0.18.0.patch";
-      url = "https://github.com/aio-libs/pytest-aiohttp/commit/97152c2dfdd368f799ec6bcb5fc315736a726f53.patch";
-      hash = "sha256-g7MTyCKUHnufOfrbhVV58WtfbGt1uXx8F7U9U+EaXfg=";
-    })
-  ];
 
   nativeBuildInputs = [
     setuptools-scm
   ];
 
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  buildInputs = [
+    pytest
+  ];
+
   propagatedBuildInputs = [
     aiohttp
-    pytest
     pytest-asyncio
   ];
 
@@ -43,6 +40,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/aio-libs/pytest-aiohttp/";
+    changelog = "https://github.com/aio-libs/pytest-aiohttp/blob/v${version}/CHANGES.rst";
     description = "Pytest plugin for aiohttp support";
     license = licenses.asl20;
     maintainers = with maintainers; [ dotlambda ];


### PR DESCRIPTION

###### Description of changes
https://github.com/aio-libs/pytest-aiohttp/blob/v1.0.4/CHANGES.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
