### PR TITLE
Add Unicode Sinhala font by Lanka Linux User Group

### DIFF
--- a/pkgs/data/fonts/lklug-sinhala/default.nix
+++ b/pkgs/data/fonts/lklug-sinhala/default.nix
@@ -1,0 +1,23 @@
+{ fetchzip, lib }:
+
+let
+  version = "0.6";
+in
+fetchzip {
+  name = "lklug-sinhala-${version}";
+  url = "mirror://debian/pool/main/f/fonts-lklug-sinhala/fonts-lklug-sinhala_${version}.orig.tar.xz";
+  sha256 = "sha256-Fy+QnAajA4yLf/I1vOQll5pRd0ZLfLe8UXq4XMC9qNc=";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    tar xf $downloadedFile --strip-components=1 -C $out/share/fonts fonts-lklug-sinhala-${version}/lklug.ttf
+  '';
+
+  meta = with lib; {
+    description = "Unicode Sinhala font by Lanka Linux User Group";
+    homepage = "http://www.lug.lk/fonts/lklug";
+    license = licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ serge ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24342,6 +24342,8 @@ with pkgs;
 
   linux-manual = callPackage ../data/documentation/linux-manual { };
 
+  lklug-sinhala = callPackage ../data/fonts/lklug-sinhala {};
+
   lmmath = callPackage ../data/fonts/lmmath {};
 
   lmodern = callPackage ../data/fonts/lmodern { };


### PR DESCRIPTION
###### Description of changes

Add Unicode Sinhala font. It closes #170372.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

