### PR TITLE
authenticator: 4.0.3 -> 4.1.1

### DIFF
--- a/pkgs/applications/misc/authenticator/default.nix
+++ b/pkgs/applications/misc/authenticator/default.nix
@@ -3,11 +3,11 @@
 , fetchFromGitLab
 , fetchpatch
 , appstream-glib
+, clang
 , desktop-file-utils
 , meson
 , ninja
 , pkg-config
-, python3
 , rustPlatform
 , wrapGAppsHook
 , gdk-pixbuf
@@ -15,7 +15,9 @@
 , gst_all_1
 , gtk4
 , libadwaita
+, libclang
 , openssl
+, pipewire
 , sqlite
 , wayland
 , zbar
@@ -23,33 +25,29 @@
 
 stdenv.mkDerivation rec {
   pname = "authenticator";
-  version = "4.0.3";
+  version = "4.1.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Authenticator";
     rev = version;
-    sha256 = "0fvs76f3fm5pxn7wg6sjbqpgip5w2j7xrh4siasdcl2bx6vsld8b";
+    hash = "sha256-wl7wyj0vVDkOB7XKQFOEFzCmffTsrUsaM83fWgZ6tG0=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    sha256 = "1s97jyszxf24rs3ni11phiyvmp1wm8sicb0rh1jgwz4bn1cnakx4";
+    hash = "sha256-3SzemDjLsZUXPPtSlDMBQXQf5P3Sz8caJL73mHRv1js=";
   };
-
-  postPatch = ''
-    patchShebangs build-aux
-  '';
 
   nativeBuildInputs = [
     appstream-glib
+    clang
     desktop-file-utils
     meson
     ninja
     pkg-config
-    python3
     wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
@@ -62,39 +60,23 @@ stdenv.mkDerivation rec {
     glib
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
-
-    # gst-plugins-good needs gtk4 support:
-    # https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/767
-    # We copy the way it is built from the Flatpak:
-    # https://gitlab.gnome.org/World/Authenticator/-/blob/master/build-aux/com.belmoussaoui.Authenticator.Devel.json
-    (gst_all_1.gst-plugins-good.overrideAttrs (old: {
-      patches = old.patches or [ ] ++ [
-        "${src}/build-aux/767.patch"
-      ];
-      mesonFlags = old.mesonFlags ++ [
-        "-Dgtk3=disabled"
-        "-Dgtk4=enabled"
-        "-Dgtk4-experiments=true"
-      ];
-      buildInputs = old.buildInputs ++ [
-        gtk4
-      ];
-    }))
-
     (gst_all_1.gst-plugins-bad.override { enableZbar = true; })
     gtk4
     libadwaita
     openssl
+    pipewire
     sqlite
     wayland
     zbar
   ];
 
-  meta = with lib; {
-    broken = true; # https://gitlab.gnome.org/World/Authenticator/-/issues/271
+  LIBCLANG_PATH = "${lib.getLib libclang}/lib";
+
+  meta = {
     description = "Two-factor authentication code generator for GNOME";
     homepage = "https://gitlab.gnome.org/World/Authenticator";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ dotlambda ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ dotlambda ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes
fixes #168272 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I don't know how to fix
```
(gst-plugin-scanner:1753898): GStreamer-WARNING **: 05:16:43.174: Failed to load plugin '/nix/store/22kywzfzzmxm2lk1r1wfa6436389airy-gst-plugins-bad-1.20.0/lib/gstreamer-1.0/libgstmplex.so': /nix/store/khg2yz8aklbagx09h878a6c5vz94b9p0-gcc-10.3.0-lib/lib/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /nix/store/kfkzi9iwr4g3n6gdcz1rlkzyzg31i67m-mjpegtools-2.2.1-lib/lib/libmplex2-2.2.so.0)
```
Do I need to use `clangStdenv`?

cc @nesnera