### PR TITLE
abra: init at 0.4.1-alpha

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -453,6 +453,12 @@
     githubId = 786394;
     name = "Alexander Krupenkin ";
   };
+  akshaymankar = {
+    name = "Akshay Mankar";
+    email = "itsakshaymankar@gmail.com";
+    github = "akshaymankar";
+    githubId = 649161;
+  };
   akshgpt7 = {
     email = "akshgpt7@gmail.com";
     github = "akshgpt7";

--- a/pkgs/applications/networking/cluster/coop-cloud/abra.nix
+++ b/pkgs/applications/networking/cluster/coop-cloud/abra.nix
@@ -1,0 +1,26 @@
+{ buildGoModule, fetchFromGitea, lib, srcOnly }:
+
+buildGoModule rec {
+  pname = "abra";
+  version = "0.4.1-alpha";
+  src = fetchFromGitea {
+    domain = "git.coopcloud.tech";
+    owner = "coop-cloud";
+    repo = "abra";
+    rev = "${version}";
+    sha256 = "sha256-HSAWnwxMsX09PdPy2AyQGprV1fRN+lG+a67L+xd3GlA=";
+  };
+  vendorSha256 = "sha256-2o7GPEStjdBEY2RMhApMTPjrC5H/B9c3s1B2t2pTh+A=";
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+  meta = with lib; {
+    description = "The Co-op Cloud command-line utility belt 🎩🐇";
+    homepage = "https://coopcloud.tech";
+    downloadPage = "https://coopcloud.tech/abra";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ akshaymankar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24912,6 +24912,8 @@ with pkgs;
 
   abook = callPackage ../applications/misc/abook { };
 
+  abra = callPackage ../applications/networking/cluster/coop-cloud/abra.nix { };
+
   acd-cli = callPackage ../applications/networking/sync/acd_cli {
     inherit (python3Packages)
       buildPythonApplication appdirs colorama python-dateutil


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

abra is the command line tool to control [the Co-op Cloud](https://coopcloud.tech/). The code can be found here: https://git.coopcloud.tech/coop-cloud/abra.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
