### PR TITLE
python3Packages.labgrid: add packaging module

### DIFF
--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -6,6 +6,7 @@
 , jinja2
 , lib
 , mock
+, packaging
 , pexpect
 , psutil
 , pyserial
@@ -44,6 +45,7 @@ buildPythonPackage rec {
     attrs
     autobahn
     jinja2
+    packaging
     pexpect
     pyserial
     pyudev


### PR DESCRIPTION
###### Description of changes
Add missing packaging module, fixes the following backtrace while trying
to use labgrid-client:
```
  Traceback (most recent call last):
    File "/nix/store/izj1dw63bqh47bq10v1b2d7qqg9al7f7-python3.9-labgrid-0.4.1/bin/.labgrid-client-wrapped", line 6, in <module>
      from labgrid.remote.client import main
    File "/nix/store/izj1dw63bqh47bq10v1b2d7qqg9al7f7-python3.9-labgrid-0.4.1/lib/python3.9/site-packages/labgrid/__init__.py", line 1, in <module>
      from .target import Target
    File "/nix/store/izj1dw63bqh47bq10v1b2d7qqg9al7f7-python3.9-labgrid-0.4.1/lib/python3.9/site-packages/labgrid/target.py", line 9, in <module>
      from .driver import Driver
    File "/nix/store/izj1dw63bqh47bq10v1b2d7qqg9al7f7-python3.9-labgrid-0.4.1/lib/python3.9/site-packages/labgrid/driver/__init__.py", line 4, in <module>
      from .serialdriver import SerialDriver
    File "/nix/store/izj1dw63bqh47bq10v1b2d7qqg9al7f7-python3.9-labgrid-0.4.1/lib/python3.9/site-packages/labgrid/driver/serialdriver.py", line 5, in <module>
      from packaging import version
  ModuleNotFoundError: No module named 'packaging'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ x Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
