### PR TITLE
libpcap: move dev things to extra output

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -6,6 +6,8 @@ stdenv.mkDerivation rec {
   pname = "libpcap";
   version = "1.10.1";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "https://www.tcpdump.org/release/${pname}-${version}.tar.gz";
     sha256 = "sha256-7ShfSsyvBTRPkJdXV7Pb/ncrpB0cQBwmSLf6RbcRvdQ=";
@@ -27,6 +29,8 @@ stdenv.mkDerivation rec {
     if [ "$dontDisableStatic" -ne "1" ]; then
       rm -f $out/lib/libpcap.a
     fi
+
+    moveToOutput "bin/pcap-config" "$dev"
   '';
 
   meta = {


### PR DESCRIPTION
###### Description of changes

@jtojnar I wanted to move things to ``dev`` output but that causes a reference loop between ``bin/pcap-config`` and the other dev things. Should I move the script to dev, too or leave it like it is?

```
$ tree result*
 result
├──  bin
│   └──  pcap-config
├──  include
│   ├──  pcap
│   │   ├──  bluetooth.h
│   │   ├──  bpf.h
│   │   ├──  can_socketcan.h
│   │   ├──  compiler-tests.h
│   │   ├──  dlt.h
│   │   ├──  funcattrs.h
│   │   ├──  ipnet.h
│   │   ├──  namedb.h
│   │   ├──  nflog.h
│   │   ├──  pcap-inttypes.h
│   │   ├──  pcap.h
│   │   ├──  sll.h
│   │   ├──  socket.h
│   │   ├──  usb.h
│   │   └──  vlan.h
│   ├──  pcap-bpf.h
│   ├──  pcap-namedb.h
│   └──  pcap.h
├──  lib
│   └──  pkgconfig
│       └──  libpcap.pc
├──  nix-support
│   └──  propagated-build-inputs
└──  share
    └──  man
        ├──  man1
        │   └──  pcap-config.1.gz
        ├──  man3
        │   ├──  pcap.3pcap.gz
        │   ├──  pcap_activate.3pcap.gz
        │   ├──  pcap_breakloop.3pcap.gz
        │   ├──  pcap_can_set_rfmon.3pcap.gz
        │   ├──  pcap_close.3pcap.gz
        │   ├──  pcap_compile.3pcap.gz
        │   ├──  pcap_create.3pcap.gz
        │   ├──  pcap_datalink.3pcap.gz
        │   ├──  pcap_datalink_name_to_val.3pcap.gz
        │   ├──  pcap_datalink_val_to_description.3pcap.gz
        │   ├──  pcap_datalink_val_to_description_or_dlt.3pcap.gz
        │   ├──  pcap_datalink_val_to_name.3pcap.gz
        │   ├──  pcap_dispatch.3pcap.gz
        │   ├──  pcap_dump.3pcap.gz
        │   ├──  pcap_dump_close.3pcap.gz
        │   ├──  pcap_dump_file.3pcap.gz
        │   ├──  pcap_dump_flush.3pcap.gz
        │   ├──  pcap_dump_fopen.3pcap.gz
        │   ├──  pcap_dump_ftell.3pcap.gz
        │   ├──  pcap_dump_open.3pcap.gz
        │   ├──  pcap_file.3pcap.gz
        │   ├──  pcap_fileno.3pcap.gz
        │   ├──  pcap_findalldevs.3pcap.gz
        │   ├──  pcap_fopen_offline.3pcap.gz
        │   ├──  pcap_fopen_offline_with_tstamp_precision.3pcap.gz
        │   ├──  pcap_free_datalinks.3pcap.gz
        │   ├──  pcap_free_tstamp_types.3pcap.gz
        │   ├──  pcap_freealldevs.3pcap.gz
        │   ├──  pcap_freecode.3pcap.gz
        │   ├──  pcap_get_required_select_timeout.3pcap.gz
        │   ├──  pcap_get_selectable_fd.3pcap.gz
        │   ├──  pcap_get_tstamp_precision.3pcap.gz
        │   ├──  pcap_geterr.3pcap.gz
        │   ├──  pcap_getnonblock.3pcap.gz
        │   ├──  pcap_init.3pcap.gz
        │   ├──  pcap_inject.3pcap.gz
        │   ├──  pcap_is_swapped.3pcap.gz
        │   ├──  pcap_lib_version.3pcap.gz
        │   ├──  pcap_list_datalinks.3pcap.gz
        │   ├──  pcap_list_tstamp_types.3pcap.gz
        │   ├──  pcap_lookupdev.3pcap.gz
        │   ├──  pcap_lookupnet.3pcap.gz
        │   ├──  pcap_loop.3pcap.gz
        │   ├──  pcap_major_version.3pcap.gz
        │   ├──  pcap_minor_version.3pcap.gz
        │   ├──  pcap_next.3pcap.gz
        │   ├──  pcap_next_ex.3pcap.gz
        │   ├──  pcap_offline_filter.3pcap.gz
        │   ├──  pcap_open_dead.3pcap.gz
        │   ├──  pcap_open_dead_with_tstamp_precision.3pcap.gz
        │   ├──  pcap_open_live.3pcap.gz
        │   ├──  pcap_open_offline.3pcap.gz
        │   ├──  pcap_open_offline_with_tstamp_precision.3pcap.gz
        │   ├──  pcap_perror.3pcap.gz
        │   ├──  pcap_sendpacket.3pcap.gz
        │   ├──  pcap_set_buffer_size.3pcap.gz
        │   ├──  pcap_set_datalink.3pcap.gz
        │   ├──  pcap_set_immediate_mode.3pcap.gz
        │   ├──  pcap_set_promisc.3pcap.gz
        │   ├──  pcap_set_protocol_linux.3pcap.gz
        │   ├──  pcap_set_rfmon.3pcap.gz
        │   ├──  pcap_set_snaplen.3pcap.gz
        │   ├──  pcap_set_timeout.3pcap.gz
        │   ├──  pcap_set_tstamp_precision.3pcap.gz
        │   ├──  pcap_set_tstamp_type.3pcap.gz
        │   ├──  pcap_setdirection.3pcap.gz
        │   ├──  pcap_setfilter.3pcap.gz
        │   ├──  pcap_setnonblock.3pcap.gz
        │   ├──  pcap_snapshot.3pcap.gz
        │   ├──  pcap_stats.3pcap.gz
        │   ├──  pcap_statustostr.3pcap.gz
        │   ├──  pcap_strerror.3pcap.gz
        │   ├──  pcap_tstamp_type_name_to_val.3pcap.gz
        │   ├──  pcap_tstamp_type_val_to_description.3pcap.gz
        │   └──  pcap_tstamp_type_val_to_name.3pcap.gz
        ├──  man5
        │   └──  pcap-savefile.5.gz
        └──  man7
            ├──  pcap-filter.7.gz
            ├──  pcap-linktype.7.gz
            └──  pcap-tstamp.7.gz
 result-lib
└──  lib
    ├──  libpcap.a
    ├──  libpcap.so
    ├──  libpcap.so.1
    └──  libpcap.so.1.10.1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
