### PR TITLE
hcloud: fix version ldflag

### DIFF
--- a/pkgs/development/tools/hcloud/default.nix
+++ b/pkgs/development/tools/hcloud/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   ldflags = [
     "-s" "-w"
-    "-X github.com/hetznercloud/cli/cli.Version=${version}"
+    "-X github.com/hetznercloud/cli/internal/version.Version=${version}"
   ];
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
hcloud: fix version ldflag

![image](https://user-images.githubusercontent.com/5861043/165310060-82b5372b-5467-4977-bb97-62dcca297792.png)

@techknowlogick A bit delayed, but here it is.