### PR TITLE
linuxPackages.rtl8723ds: init at unstable-2022-10-20

### DIFF
--- a/pkgs/os-specific/linux/rtl8723ds/default.nix
+++ b/pkgs/os-specific/linux/rtl8723ds/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchFromGitHub, kernel, bc }:
+
+stdenv.mkDerivation {
+  pname = "rtl8723ds";
+  version = "${kernel.version}-unstable-2022-10-20";
+
+  src = fetchFromGitHub {
+    owner = "lwfinger";
+    repo = "rtl8723ds";
+    rev = "912fdb30531bc8c071267a047e7df16feae7a865";
+    sha256 = "sha256-HhoCKrrRg1Q995sekQvzhaiqANeTP8pANItj2vLV+Cw=";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = [ bc ];
+  buildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ];
+
+  postPatch = ''
+    substituteInPlace ./Makefile \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
+      --replace "/sbin/depmod" "#" \
+      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Linux driver for RTL8723DS.";
+    homepage = "https://github.com/lwfinger/rtl8723ds";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ chuangzhu ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -390,6 +390,8 @@ in {
 
     rtl8723bs = callPackage ../os-specific/linux/rtl8723bs { };
 
+    rtl8723ds = callPackage ../os-specific/linux/rtl8723ds { };
+
     rtl8812au = callPackage ../os-specific/linux/rtl8812au { };
 
     rtl8814au = callPackage ../os-specific/linux/rtl8814au { };


### PR DESCRIPTION
###### Description of changes

Added driver for RTL8723DS. This code is upstreamed from https://github.com/chuangzhu/nixos-sun20iw1p1. Tested on a RISC-V board (LicheeRV Dock).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).