### PR TITLE
ocamlPackages.uuuu: 0.2.0 → 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/uuuu/default.nix
+++ b/pkgs/development/ocaml-modules/uuuu/default.nix
@@ -1,20 +1,19 @@
 { angstrom
 , buildDunePackage
-, fetchzip
+, fetchurl
 , findlib
 , lib
-, menhir
 , ocaml
 , re
 }:
 
 buildDunePackage rec {
   pname = "uuuu";
-  version = "0.2.0";
+  version = "0.3.0";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/uuuu/releases/download/v${version}/uuuu-v${version}.tbz";
-    sha256 = "0457qcxvakbbc56frsh8a5v4y4l0raj9p4zz7jx3brn9255j1mw3";
+  src = fetchurl {
+    url = "https://github.com/mirage/uuuu/releases/download/v${version}/uuuu-${version}.tbz";
+    sha256 = "sha256:19n39yc7spgzpk9i70r0nhkwsb0bfbvbgpf8d863p0a3wgryhzkb";
   };
 
   postPatch = ''
@@ -22,9 +21,7 @@ buildDunePackage rec {
       'ocaml} -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib '
   '';
 
-  useDune2 = true;
-
-  nativeBuildInputs = [ menhir findlib ];
+  nativeBuildInputs = [ findlib ];
 
   buildInputs = [ angstrom ];
 


### PR DESCRIPTION
###### Description of changes

Drop dependency on `menhir`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
