### PR TITLE
obsidian: 0.13.30 -> 0.14.6

### DIFF
--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -12,20 +12,20 @@
 let
   inherit (stdenv.hostPlatform) system;
   pname = "obsidian";
-  version = "0.14.2";
+  version = "0.14.6";
   appname = "Obsidian";
   meta = with lib; {
     description = "A powerful knowledge base that works on top of a local folder of plain text Markdown files";
     homepage = "https://obsidian.md";
     downloadPage = "https://github.com/obsidianmd/obsidian-releases/releases";
     license = licenses.obsidian;
-    maintainers = with maintainers; [ conradmearns zaninime opeik ];
+    maintainers = with maintainers; [ atila conradmearns zaninime opeik ];
   };
 
   filename = if stdenv.isDarwin then "Obsidian-${version}-universal.dmg" else "obsidian-${version}.tar.gz";
   src = fetchurl {
     url = "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/${filename}";
-    sha256 = if stdenv.isDarwin then "128kgqkf54ljkglwqa6i0qnfqhhmsv7hwbaqnml95n5dzyxrbm4s" else "00gip6pvkbywywlx71j87sxyh8yhkd36i1ydncbpnhsplr6smsq3";
+    sha256 = if stdenv.isDarwin then "1zzccwlim3gi6f5czzyddqjzy1xsk6ayx1hljhw6bmnid72km3q2" else "sha256-KieAE13SIYHDoXTqzk1QY+TPjwF9LRzlfm1yFg9hsTc=";
   };
 
   icon = fetchurl {


### PR DESCRIPTION
##### Description of changes

Closes #168339

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
###### Shiny new things

+ Electron update from v18.0.3 to v18.0.4, fixes PDF embeds not displaying. (Requires installer update from Download - Obsidian 981)
+ You can now add folders to an ignore filter. Files matched by this filter will be down-ranked when using Quick Switcher and link suggestions, and will be excluded in search results and graph view.

###### Improved

+ Spellcheck corrections should now work better in text with styling applied such as headings, bold/italics, etc.
+ Show context menu under cursor should now also display the spellcheck options.
+ Obsidian Publish upload dialog now displays the total count of each section.

###### No longer broken

+ Fixed backlinks linked mentions causes lag on large vaults.
+ Exporting to PDF when using dark mode no longer causes unreadable code blocks.
+ Dragging items and resizing panes should no longer get stuck when moving across <iframe> and <webview>.
+ Dragging and dropping files from outside Obsidian should no longer cause its contents to be inserted before or after the link.
+ Fixed soft-wrapping not working if line was folded when the note was opened.

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
