### PR TITLE
obs-studio-plugins.obs-gstreamer: 0.2.1 -> 0.3.3

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
@@ -10,21 +10,21 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-gstreamer";
-  version = "0.2.1";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "fzwoch";
     repo = "obs-gstreamer";
     rev = "v${version}";
-    sha256 = "1fdpwr8br8x9cnrhr3j4f0l81df26n3bj2ibi3cg96rl86054nid";
+    hash = "sha256-KhSBZcV2yILTf5+aNoYWDfNwPiJoyYPeIOQMDFvOusg=";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja ];
-  buildInputs = [ gst_all_1.gstreamermm obs-studio ];
+  buildInputs = with gst_all_1; [ gstreamer gst-plugins-base obs-studio ];
 
   meta = with lib; {
     description = "An OBS Studio source, encoder and video filter plugin to use GStreamer elements/pipelines in OBS Studio";
-    homepage = "https://github.com/fswoch/obs-gstreamer";
+    homepage = "https://github.com/fzwoch/obs-gstreamer";
     maintainers = with maintainers; [ ahuzik ];
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" ];


### PR DESCRIPTION
###### Description of changes

Update obs-gstreamer from 0.2.1 to 0.3.3 and make drive-by changes to fix dependencies and homepage (gstreamermm is broken (#170186) but obs-gstreamer does not actually require it to build or run)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-gstreamer</li>
  </ul>
</details>