### PR TITLE
python38Packages.backports-zoneinfo: test data for zoneinfo 2022a

### DIFF
--- a/pkgs/development/python-modules/backports-zoneinfo/default.nix
+++ b/pkgs/development/python-modules/backports-zoneinfo/default.nix
@@ -7,6 +7,7 @@
 , tzdata
 , hypothesis
 , pytestCheckHook
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -22,7 +23,25 @@ buildPythonPackage rec {
     sha256 = "sha256-00xdDOVdDanfsjQTd3yjMN2RFGel4cWRrAA3CvSnl24=";
   };
 
+  # Make sure test data update patch applies
+  prePatch = ''
+    substituteInPlace tests/data/zoneinfo_data.json --replace \"2020a\" \"2021a\"
+  '';
+
   patches = [
+    # Update test suite's test data to zoneinfo 2022a
+    # https://github.com/pganssle/zoneinfo/pull/115
+    (fetchpatch {
+      name = "backports-zoneinfo-2022a-update-test-data1.patch";
+      url = "https://github.com/pganssle/zoneinfo/pull/115/commits/837e2a0f9f1a1332e4233f83e3648fa564a9ec9e.patch";
+      sha256 = "196knwa212mr0b7zsh8papzr3f5mii87gcjjjx1r9zzvmk3g3ri0";
+    })
+    (fetchpatch {
+      name = "backports-zoneinfo-2022a-update-test-data2.patch";
+      url = "https://github.com/pganssle/zoneinfo/pull/115/commits/9fd330265b177916d6182249439bb40d5691eb58.patch";
+      sha256 = "1zxa5bkwi8hbnh4c0qv72wv6vdp5jlxqizfjsc05ymzvwa99cf75";
+    })
+
     (substituteAll {
       name = "zoneinfo-path";
       src = ./zoneinfo.patch;


### PR DESCRIPTION
Unfortunately test data needs to be continuously updated to match
zoneinfo or the tests will fail. This was relatively annoying and I'd
recommend just disabling the tests if this happens again.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
