### PR TITLE
sov: init at 0.63

### DIFF
--- a/pkgs/tools/wayland/sov/default.nix
+++ b/pkgs/tools/wayland/sov/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, meson
+, ninja
+, pkg-config
+, wayland
+, wayland-protocols
+, wayland-scanner
+, freetype
+, linuxHeaders
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sov";
+  version = "0.63";
+
+  src = fetchFromGitHub {
+    owner = "milgra";
+    repo = "sov";
+    rev = "${version}";
+    sha256 = "0qi0xhi47rmagcxzqcvfhbr3jp5ir24q3lahbdikv894yl85774i";
+  };
+
+  # Need <linux/limits.h> in addition to <limits.h>
+  patchPhase = ''
+    find . -type f -iname "*.c" -exec sed -i.bak '/limits.h/a #include <linux/limits.h>' "{}" +;
+  '';
+
+  outPath = [ "bin" "share" ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    cmake
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    linuxHeaders
+    freetype
+    wayland
+    wayland-protocols
+  ];
+
+  postInstall = ''
+    install -v -m0755 ../config $out/share/config
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/milgra/sov";
+    description = "An overlay that shows schemas for all workspaces to make navigation in sway easier.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ twitchyliquid64 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3052,6 +3052,8 @@ with pkgs;
 
   slurp = callPackage ../tools/wayland/slurp { };
 
+  sov = callPackage ../tools/wayland/sov { };
+
   swaykbdd = callPackage ../tools/wayland/swaykbdd { };
 
   swaycwd = callPackage ../tools/wayland/swaycwd { };


### PR DESCRIPTION
###### Description of changes

Sov - Sway overview. Its super neat: https://www.reddit.com/r/swaywm/comments/ubsw9a/swayoverview_is_released/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
