### PR TITLE
zfs: reduce closure size

### DIFF
--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -20,7 +20,6 @@ let
       openssl,
       libtirpc,
       nfs-utils,
-      samba,
       gawk,
       gnugrep,
       gnused,
@@ -112,7 +111,7 @@ let
               enablePython = old.enablePython or true && enablePython;
             })
           }/bin/exportfs"
-          substituteInPlace ./lib/libshare/smb.h        --replace-fail "/usr/bin/net"            "${samba}/bin/net"
+          substituteInPlace ./lib/libshare/smb.h        --replace-fail "/usr/bin/net"            "/run/current-system/sw/bin/net"
           # Disable dynamic loading of libcurl
           substituteInPlace ./config/user-libfetch.m4   --replace-fail "curl-config --built-shared" "true"
           substituteInPlace ./config/user-systemd.m4    --replace-fail "/usr/lib/modules-load.d" "$out/etc/modules-load.d"


### PR DESCRIPTION
###### Description of changes
Minimize closure size for zfs package

After that PR https://github.com/NixOS/nixpkgs/pull/92378 increased the size of the iso image. The image now contains the samba package, which is not needed there.
This change keeps `zfs share` command working.

After closure size:
```
nix path-info -Sh ./result
/nix/store/yw1by07874clir1jqlnvc9xz7k27q3vh-zfs-user-2.1.4       358.6M
```

Before closure size:
```
nix path-info -Sh ./result
/nix/store/2zimgasxn13j860cg5pfgv79vz7ilpmg-zfs-user-2.1.4       278.6M
```
Reduced `Minimal ISO` size from 811M to 747M.

cc @SuperSandro2000
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
