### PR TITLE
tokodon: init at 22.11.2

### DIFF
--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -79,6 +79,7 @@ let
       plasma-settings = callPackage ./plasma-settings.nix {};
       plasmatube = callPackage ./plasmatube {};
       spacebar = callPackage ./spacebar.nix { inherit srcs; };
+      tokodon = callPackage ./tokodon.nix {};
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/tokodon.nix
+++ b/pkgs/applications/plasma-mobile/tokodon.nix
@@ -1,0 +1,78 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+, pkg-config
+
+, kconfig
+, kdbusaddons
+, ki18n
+, kirigami2
+, kirigami-addons
+, knotifications
+, libwebsockets
+, qqc2-desktop-style
+, qtbase
+, qtkeychain
+, qtmultimedia
+, qtquickcontrols2
+, qttools
+, qtwebsockets
+, kitemmodels
+, pimcommon
+
+# Workarounds for the point release being missing.
+, libsForQt5
+, fetchFromGitLab
+}:
+
+# NOTE: we cannot use `mkDerivation` injected by the Plasma Mobile package
+#       set for the point release, as the point release was not uploaded to
+#       the Plasma Mobile gear repo, and the injected `mkDerivation` only can
+#       use the src (and version) from the `srcs` set.
+libsForQt5.mkDerivation rec {
+  pname = "tokodon";
+
+  version = "22.11.2";
+  # NOTE: the tokodon point release was not uploaded to the Plasma Mobile gear repo.
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "network";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-uE9iHZDfpn1NTCeJPgsp2WBe0curdguTUbMTrkrmJ6M=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+  ];
+
+  buildInputs = [
+    kconfig
+    kdbusaddons
+    ki18n
+    kirigami2
+    kirigami-addons
+    knotifications
+    qqc2-desktop-style
+    qtbase
+    qtkeychain
+    qtmultimedia
+    qtquickcontrols2
+    qttools
+    qtwebsockets
+    kitemmodels
+    pimcommon
+  ];
+
+  meta = with lib; {
+    description = "A Mastodon client for Plasma and Plasma Mobile";
+    homepage = "https://invent.kde.org/network/tokodon";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1513,6 +1513,7 @@ mapAliases ({
   timetable = throw "timetable has been removed, as the upstream project has been abandoned"; # Added 2021-09-05
   tkcvs = tkrev; # Added 2022-03-07
   togglesg-download = throw "togglesg-download was removed 2021-04-30 as it's unmaintained"; # Added 2021-04-30
+  tokodon = plasma5Packages.tokodon;
   tomboy = throw "tomboy is not actively developed anymore and was removed"; # Added 2022-01-27
   tomcat7 = throw "tomcat7 has been removed from nixpkgs as it has reached end of life"; # Added 2021-06-16
   tomcat8 = throw "tomcat8 has been removed from nixpkgs as it has reached end of life"; # Added 2021-06-16


### PR DESCRIPTION
###### Description of changes

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

nix builds some bash script that sets some environment variables before the application is `exec`d. The execution of the application itself then segfaults.

If I start the binary directly from the store it works.

Maybe someone with more KDE+nixpkgs knowledge can help me out here?