### PR TITLE
emacs: Build from git instead of tarball to fix native compilation

### DIFF
--- a/pkgs/applications/editors/emacs/28.nix
+++ b/pkgs/applications/editors/emacs/28.nix
@@ -1,5 +1,5 @@
 import ./generic.nix (rec {
   version = "28.1";
-  sha256 = "sha256-KLGz0JkDegiPCkyiUdfnJi6rXqFneqv/psRCaWGtdeE=";
+  sha256 = "sha256-D33wnlxhx0LyG9WZaQDj2II3tG0HcJdZTC4dSA3lrgY=";
   patches = _: [ ];
 })

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -13,6 +13,7 @@
 , sigtool, jansson, harfbuzz, sqlite, nixosTests
 , dontRecurseIntoAttrs, emacsPackagesFor
 , libgccjit, targetPlatform, makeWrapper # native-comp params
+, fetchFromSavannah
 , systemd ? null
 , withX ? !stdenv.isDarwin
 , withNS ? stdenv.isDarwin
@@ -23,7 +24,7 @@
 , withSQLite3 ? false
 , withCsrc ? true
 , withWebP ? false
-, srcRepo ? false, autoreconfHook ? null, texinfo ? null
+, srcRepo ? true, autoreconfHook ? null, texinfo ? null
 , siteStart ? ./site-start.el
 , nativeComp ? false
 , withAthena ? false
@@ -59,8 +60,9 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
 
   patches = patches fetchpatch;
 
-  src = fetchurl {
-    url = "mirror://gnu/emacs/${name}.tar.xz";
+  src = fetchFromSavannah {
+    repo = "emacs";
+    rev = version;
     inherit sha256;
   };
 


### PR DESCRIPTION
###### Description of changes
Quoting @collares from #170426:
> The difference between the two versions is that one is built from the
> tarball, while the other is built from Git. The tarball includes
> byte-compiled (.elc) files but not native-compiled (.eln)
> files. The build notices the .elc files and does not rebuild them,
> but native-compilation is a side-effect of byte-compilation and so
> the .eln files aren't built either.

Closes #170426

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
