### PR TITLE
godot-export-templates: strip export template file

### DIFF
--- a/pkgs/development/tools/godot/export-templates.nix
+++ b/pkgs/development/tools/godot/export-templates.nix
@@ -10,6 +10,14 @@ godot.overrideAttrs (oldAttrs: rec {
     mkdir -p "$out/share/godot/templates/${oldAttrs.version}.stable"
     cp bin/godot.x11.opt.64 $out/share/godot/templates/${oldAttrs.version}.stable/linux_x11_64_release
   '';
+
+  # https://docs.godotengine.org/en/stable/development/compiling/optimizing_for_size.html
+  # Stripping reduces the template size from around 500MB to 40MB for Linux.
+  # This also impacts the size of the exported games.
+  # This is added explicitly here because mkDerivation does not automatically
+  # strip binaries in the template directory.
+  stripAllList = (oldAttrs.stripAllList or []) ++ [ "share/godot/templates" ];
+
   outputs = [ "out" ];
   meta.description =
     "Free and Open Source 2D and 3D game engine (export templates)";


### PR DESCRIPTION
###### Description of changes

Stripping reduces the template size from around 500MB to 40MB for Linux.
This also impacts the size of the exported games.
This is done explicitly here because mkDerivation does not automatically
strip binaries in the template directory.

GitHub: closes https://github.com/NixOS/nixpkgs/issues/170470

CC maintainers: @Twey @jojosch

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).