### PR TITLE
gnome-secrets: 6.1 -> 6.4

### DIFF
--- a/pkgs/applications/misc/gnome-secrets/default.nix
+++ b/pkgs/applications/misc/gnome-secrets/default.nix
@@ -5,7 +5,6 @@
 , gettext
 , fetchFromGitLab
 , python3Packages
-, libpwquality
 , wrapGAppsHook4
 , gtk4
 , glib
@@ -17,7 +16,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-secrets";
-  version = "6.1";
+  version = "6.4";
   format = "other";
   strictDeps = false; # https://github.com/NixOS/nixpkgs/issues/56943
 
@@ -26,7 +25,7 @@ python3Packages.buildPythonApplication rec {
     owner = "World";
     repo = "secrets";
     rev = version;
-    sha256 = "sha256-TBGNiiR0GW8s/Efi4/Qqvwd87Ir0gCLGPfBmmqqSwQ8=";
+    sha256 = "sha256-qO2DJ/Eb9+G1R3un2+n9Tf6oxpGrEuH3SBrajQ9tCPU=";
   };
 
   nativeBuildInputs = [
@@ -45,6 +44,7 @@ python3Packages.buildPythonApplication rec {
     glib
     gdk-pixbuf
     libadwaita
+    python3Packages.libpwquality.dev # Use python-enabled libpwquality
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -52,13 +52,8 @@ python3Packages.buildPythonApplication rec {
     construct
     pykeepass
     pyotp
-  ] ++ [
-    libpwquality # using the python bindings
+    libpwquality
   ];
-
-  postPatch = ''
-    substituteInPlace meson_post_install.py --replace "gtk-update-icon-cache" "gtk4-update-icon-cache";
-  '';
 
   # Prevent double wrapping, let the Python wrapper use the args in preFixup.
   dontWrapGApps = true;
@@ -76,4 +71,3 @@ python3Packages.buildPythonApplication rec {
     maintainers = with maintainers; [ mvnetbiz ];
   };
 }
-


### PR DESCRIPTION
###### Description of changes
Changes:

https://gitlab.gnome.org/World/secrets/-/compare/6-1...6.4?from_project_id=4356
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Updated to 6.4, fixed missing module libpwquality

Fixes #170307

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
