### PR TITLE
init: pixel2svg at 0.3.0

### DIFF
--- a/pkgs/tools/graphics/pixel2svg/default.nix
+++ b/pkgs/tools/graphics/pixel2svg/default.nix
@@ -15,7 +15,6 @@ python310Packages.buildPythonPackage rec {
     homepage = "https://florian-berger.de/en/software/pixel2svg/";
     description = "Converts pixel art to SVG - pixel by pixel";
     license = licenses.gpl3Plus;
-    platform = platforms.all;
     maintainers = with maintainers; [ papojari ];
   };
 }

--- a/pkgs/tools/graphics/pixel2svg/default.nix
+++ b/pkgs/tools/graphics/pixel2svg/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub, python310Packages }:
+
+python310Packages.buildPythonPackage rec {
+  pname = "pixel2svg";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "cyChop";
+    repo = "pixel2svg-fork";
+    rev = "7eb24d3978675c9998c0a8cd3c7cba3e363b98a2";
+    sha256 = "sha256-ZuQ0cgjaunzAjVS23PapBLgCpflU7Qnd7dTVJX9v0fg=";
+  };
+
+  propagatedBuildInputs = with python310Packages; [ pillow svgwrite ];
+
+  meta = with lib; {
+    homepage = "https://florian-berger.de/en/software/pixel2svg/";
+    description = "Converts pixel art to SVG - pixel by pixel";
+    license = licenses.gpl3Plus;
+    platform = platforms.all;
+    maintainers = with maintainers; [ papojari ];
+  };
+}

--- a/pkgs/tools/graphics/pixel2svg/default.nix
+++ b/pkgs/tools/graphics/pixel2svg/default.nix
@@ -1,14 +1,12 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python310Packages }:
+{ lib, buildPythonPackage, fetchurl, python310Packages }:
 
 python310Packages.buildPythonPackage rec {
   pname = "pixel2svg";
-  version = "0.5.0";
+  version = "0.3.0";
 
-  src = fetchFromGitHub {
-    owner = "cyChop";
-    repo = "pixel2svg-fork";
-    rev = "7eb24d3978675c9998c0a8cd3c7cba3e363b98a2";
-    sha256 = "sha256-ZuQ0cgjaunzAjVS23PapBLgCpflU7Qnd7dTVJX9v0fg=";
+  src = fetchurl {
+    url = "https://static.florian-berger.de/pixel2svg-${version}.zip";
+    sha256 = "sha256-aqcTTmZKcdRdVd8GGz5cuaQ4gjPapVJNtiiZu22TZgQ=";
   };
 
   propagatedBuildInputs = with python310Packages; [ pillow svgwrite ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26883,6 +26883,8 @@ with pkgs;
 
   pinboard-notes-backup = haskell.lib.compose.justStaticExecutables haskellPackages.pinboard-notes-backup;
 
+  pixel2svg = python310Packages.callPackage ../tools/graphics/pixel2svg { };
+
   pixelnuke = callPackage ../applications/graphics/pixelnuke { };
 
   pixeluvo = callPackage ../applications/graphics/pixeluvo { };


### PR DESCRIPTION
###### Description of changes

Add original pixel2svg package

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
