### PR TITLE
nixos-rebuild: always call sudo when not root

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -30,7 +30,6 @@ upgrade_all=
 profile=/nix/var/nix/profiles/system
 buildHost=localhost
 targetHost=
-remoteSudo=
 verboseScript=
 noFlake=
 # comma separated list of vars to preserve when using sudo
@@ -113,9 +112,6 @@ while [ "$#" -gt 0 ]; do
         targetHost="$1"
         shift 1
         ;;
-      --use-remote-sudo)
-        remoteSudo=1
-        ;;
       --flake)
         flake="$1"
         flakeFlags=(--extra-experimental-features 'nix-command flakes')
@@ -143,7 +139,7 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-if [[ -n "$SUDO_USER" || -n $remoteSudo ]]; then
+if [[ "$UID" != 0 ]]; then
     maybeSudo=(sudo --preserve-env="$preservedSudoVars" --)
 fi
 


### PR DESCRIPTION
###### Description of changes
Perhaps there is some circumstance I am overlooking, but root access is necessary to rebuild the system, so the only scenario where we don't need `sudo` is when calling `nixos-rebuild` as root.

Perhaps as a failsafe for those who use `sudo` alternatives, we should check if sudo exists in PATH first? Open to suggestions on that.

Fixes #169193