### PR TITLE
adguardhome: fix eval error when source does not exist and source for `aarch64-darwin`

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,18 +1,22 @@
 { fetchurl, fetchzip }:
 {
-"x86_64-darwin" = fetchzip {
+x86_64-darwin = fetchzip {
   sha256 = "sha256-vUOdHDyvVg+8GhctW925WfjONi7TnPRfVfXmehOweB4=";
   url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.6/AdGuardHome_darwin_amd64.zip";
 };
-"i686-linux" = fetchurl {
+aarch64-darwin = fetchzip {
+  sha256 = "sha256-3JmMvxd317Qmyrv7vWyfQsLol+yPuKBXHByt5YRrbX8=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.6/AdGuardHome_darwin_arm64.zip";
+};
+i686-linux = fetchurl {
   sha256 = "sha256-A6IsDRbRHyU0+IUKkrudKvlKiJkVNNs12MrKQ6RlpMQ=";
   url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.6/AdGuardHome_linux_386.tar.gz";
 };
-"x86_64-linux" = fetchurl {
+x86_64-linux = fetchurl {
   sha256 = "sha256-nPcqAk0m1e9izkylBuNcatHESgvSewR+MKmVdz+HBec=";
   url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.6/AdGuardHome_linux_amd64.tar.gz";
 };
-"aarch64-linux" = fetchurl {
+aarch64-linux = fetchurl {
   sha256 = "sha256-ITkZdVU03FG9AUAMgD6nlCyioPJX357wB9m1jYdPlS4=";
   url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.6/AdGuardHome_linux_arm64.tar.gz";
 };

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -1,10 +1,14 @@
 { lib, stdenv, fetchurl, fetchzip, nixosTests }:
 
+let
+  inherit (stdenv.hostPlatform) system;
+  sources = import ./bins.nix { inherit fetchurl fetchzip; };
+in
+
 stdenv.mkDerivation rec {
   pname = "adguardhome";
   version = "0.107.6";
-
-  src = (import ./bins.nix { inherit fetchurl fetchzip; }).${stdenv.hostPlatform.system};
+  src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''
     install -m755 -D ./AdGuardHome $out/bin/adguardhome
@@ -18,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/AdguardTeam/AdGuardHome";
     description = "Network-wide ads & trackers blocking DNS server";
-    platforms = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" ];
+    platforms = builtins.attrNames sources;
     maintainers = with maintainers; [ numkem iagoq ];
     license = licenses.gpl3Only;
   };

--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -18,9 +18,10 @@ systems[linux_386]=i686-linux
 systems[linux_amd64]=x86_64-linux
 systems[linux_arm64]=aarch64-linux
 systems[darwin_amd64]=x86_64-darwin
+systems[darwin_arm64]=aarch64-darwin
 
 echo '{ fetchurl, fetchzip }:' > "$bins"
-echo '{'        >> "$bins"
+echo '{' >> "$bins"
 
 for asset in $(curl --silent https://api.github.com/repos/AdguardTeam/AdGuardHome/releases/latest | jq -c '.assets[]') ; do
     url="$(jq -r '.browser_download_url' <<< "$asset")"
@@ -29,7 +30,7 @@ for asset in $(curl --silent https://api.github.com/repos/AdguardTeam/AdGuardHom
         fetch="$(grep '\.zip$' <<< "$url" > /dev/null && echo fetchzip || echo fetchurl)"
         nix_system=${systems[$adg_system]}
         nix_src="$(nix-prefetch -s --output nix $fetch --url $url)"
-        echo "\"$nix_system\" = $fetch $nix_src;" >> $bins
+        echo "$nix_system = $fetch $nix_src;" >> $bins
     fi
 done
 


### PR DESCRIPTION
###### Description of changes

Currently this derivation produces an error when evaluated on a system for which a source is not available. fe7acb625cb1a4c3b7a33018d486456b6699e4be fixes this and c4d00d46615a838d760dcc09c42389642841712f adds the source for `aarch64-darwin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
