### PR TITLE
python39Packages.aiomysql: 0.0.21 -> 0.1.0

### DIFF
--- a/pkgs/development/python-modules/aiomysql/default.nix
+++ b/pkgs/development/python-modules/aiomysql/default.nix
@@ -2,55 +2,45 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pymysql
-, pytest
-, isPy27
-, fetchpatch
+, pythonOlder
+, setuptools-scm
+, setuptools-scm-git-archive
 }:
 
 buildPythonPackage rec {
   pname = "aiomysql";
-  version = "0.0.21";
-  disabled = isPy27;
+  version = "0.1.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1qvy3phbsxp55161dnppjfx2m1kn82v0irc3xzqw0adfd81vaiad";
+    hash = "sha256-TNaQ4EKiHwSmPpUco0pA5SBP3fljWQ/Kd5RLs649fu0=";
   };
 
-  patches = [
-    (fetchpatch {
-      # vendor functions previously provided by pymysql.util
-      url = "https://github.com/aio-libs/aiomysql/pull/554/commits/919b997a9de7f53d721af76762fba425e306531e.patch";
-      sha256 = "V1VYyqr6RwTXoVoGVyMuJst6uqTuuHbpMOpLoVZO1XA=";
-    })
+  nativeBuildInputs = [
+    setuptools-scm
+    setuptools-scm-git-archive
   ];
 
   propagatedBuildInputs = [
     pymysql
   ];
 
-  checkInputs = [
-    pytest
-  ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "PyMySQL>=0.9,<=0.9.3" "PyMySQL"
-  '';
-
-  checkPhase = ''
-    pytest
-  '';
-
-  # tests require mysql database
+  # Tests require MySQL database
   doCheck = false;
+
+  pythonImportsCheck = [
+    "aiomysql"
+  ];
 
   meta = with lib; {
     description = "MySQL driver for asyncio";
     homepage = "https://github.com/aio-libs/aiomysql";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/aio-libs/aiomysql/releases/tag/v0.1.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
