### PR TITLE
python39Packages.nest-asyncio: 1.5.4 -> 1.5.5

### DIFF
--- a/pkgs/development/python-modules/augmax/default.nix
+++ b/pkgs/development/python-modules/augmax/default.nix
@@ -1,15 +1,18 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , einops
 , fetchFromGitHub
 , jax
 , jaxlib
-, lib
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "augmax";
   version = "unstable-2022-02-19";
   format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "khdlr";
@@ -19,13 +22,22 @@ buildPythonPackage rec {
     sha256 = "046n43v7161w7najzlbi0443q60436xv24nh1mv23yw6psqqhx5i";
   };
 
-  propagatedBuildInputs = [ einops jax ];
+  propagatedBuildInputs = [
+    einops
+    jax
+  ];
 
   # augmax does not have any tests at the time of writing (2022-02-19), but
   # jaxlib is necessary for the pythonImportsCheckPhase.
-  checkInputs = [ jaxlib ];
+  checkInputs = [
+    jaxlib
+  ];
 
-  pythonImportsCheck = [ "augmax" ];
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "augmax"
+  ];
 
   meta = with lib; {
     description = "Efficiently Composable Data Augmentation on the GPU with Jax";

--- a/pkgs/development/python-modules/einops/default.nix
+++ b/pkgs/development/python-modules/einops/default.nix
@@ -12,11 +12,15 @@
 , mxnet
 , tensorflow
 , keras
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "einops";
   version = "0.4.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "arogozhnikov";
@@ -54,10 +58,14 @@ buildPythonPackage rec {
     nosetests -v -w tests
   '';
 
-  meta = {
+  pythonImportsCheck = [
+    "einops"
+  ];
+
+  meta = with lib; {
     description = "Flexible and powerful tensor operations for readable and reliable code";
     homepage = "https://github.com/arogozhnikov/einops";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ yl3dy ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ yl3dy ];
   };
 }

--- a/pkgs/development/python-modules/modeled/default.nix
+++ b/pkgs/development/python-modules/modeled/default.nix
@@ -1,16 +1,20 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, zetup
-, six
 , moretools
 , path
 , pytestCheckHook
+, pythonOlder
+, six
+, zetup
 }:
 
 buildPythonPackage rec {
   pname = "modeled";
   version = "0.1.8";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     extension = "zip";
@@ -18,18 +22,37 @@ buildPythonPackage rec {
     sha256 = "1wcl3r02q10gxy4xw7g8x2wg2sx4sbawzbfcl7a5xdydrxl4r4v4";
   };
 
-  buildInputs = [ zetup ];
+  buildInputs = [
+    zetup
+  ];
 
-  propagatedBuildInputs = [ six moretools path ];
+  propagatedBuildInputs = [
+    moretools
+    path
+    six
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "modeled" ];
+  postPatch = ''
+    # path.py was renamed to path
+    substituteInPlace requirements.txt \
+      --replace "path.py" "path"
+    # Issue with module name detection (path.py)
+    substituteInPlace modeled/__init__.py  \
+      --replace "__import__('zetup').annotate(__name__)" ""
+  '';
+
+  pythonImportsCheck = [
+    "modeled"
+  ];
 
   meta = with lib; {
     description = "Universal data modeling for Python";
     homepage = "https://github.com/modeled/modeled";
-    license = licenses.lgpl3Only;
-    maintainers = [ maintainers.costrouc ];
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/nest-asyncio/default.nix
+++ b/pkgs/development/python-modules/nest-asyncio/default.nix
@@ -1,23 +1,31 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, pythonAtLeast
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  version = "1.5.4";
-  pname = "nest_asyncio";
-  disabled = !(pythonAtLeast "3.5");
+  pname = "nest-asyncio";
+  version = "1.5.5";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f969f6013a16fadb4adcf09d11a68a4f617c6049d7af7ac2c676110169a63abd";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "erdewit";
+    repo = "nest_asyncio";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-gk29RZhWIaBfiCtOC64rgP/KNqpxQadYbOj7IshN7RA=";
   };
 
-  # tests not packaged with source dist as of 1.3.2/1.3.2, and
-  # can't check tests out of GitHub easily without specific commit IDs (no tagged releases)
-  doCheck = false;
-  pythonImportsCheck = [ "nest_asyncio" ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "nest_asyncio"
+  ];
 
   meta = with lib; {
     description = "Patch asyncio to allow nested event loops";


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 1.5.5
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
