### PR TITLE
qscreenshot: 1.0 -> unstable-2021-10-18

### DIFF
--- a/pkgs/applications/graphics/qscreenshot/default.nix
+++ b/pkgs/applications/graphics/qscreenshot/default.nix
@@ -1,23 +1,34 @@
-{ lib, stdenv, fetchurl, dos2unix, which, qt, Carbon }:
+{ lib
+, stdenv
+, fetchgit
+, dos2unix
+, qtbase
+, qttools
+, qtx11extras
+, wrapQtAppsHook
+, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "qscreenshot";
-  version = "1.0";
+  version = "unstable-2021-10-18";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/qscreenshot/qscreenshot-${version}-src.tar.gz";
-    sha256 = "1spj5fg2l8p5bk81xsv6hqn1kcrdiy54w19jsfb7g5i94vcb1pcx";
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/qscreenshot/code";
+    rev = "e340f06ae2f1a92a353eaa68e103d1c840adc12d";
+    sha256 = "0mdiwn74vngiyazr3lq72f3jnv5zw8wyd2dw6rik6dbrvfs69jig";
   };
 
-  buildInputs = [ dos2unix which qt ]
-    ++ lib.optional stdenv.isDarwin Carbon;
+  preConfigure = "cd qScreenshot";
 
-  # Remove carriage returns that cause /bin/sh to abort
-  preConfigure = ''
-    dos2unix configure
-    sed -i "s|lrelease-qt4|lrelease|" src/src.pro
-  '';
-
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    qtbase
+    qttools
+    qtx11extras
+  ];
   meta = with lib; {
     description = "Simple creation and editing of screenshots";
     homepage = "https://sourceforge.net/projects/qscreenshot/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29023,10 +29023,7 @@ with pkgs;
 
   qsampler = libsForQt5.callPackage ../applications/audio/qsampler { };
 
-  qscreenshot = callPackage ../applications/graphics/qscreenshot {
-    inherit (darwin.apple_sdk.frameworks) Carbon;
-    qt = qt4;
-  };
+  qscreenshot = libsForQt5.callPackage ../applications/graphics/qscreenshot { };
 
   qsstv = qt5.callPackage ../applications/radio/qsstv { };
 


### PR DESCRIPTION
###### Description of changes
update, because of #33248

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).