### PR TITLE
uthenticode: 1.0.4 -> 1.0.8; pe-parse: 1.2.0 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/pe-parse/default.nix
+++ b/pkgs/development/libraries/pe-parse/default.nix
@@ -2,20 +2,20 @@
 
 stdenv.mkDerivation rec {
   pname = "pe-parse";
-  version = "1.2.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "pe-parse";
     rev = "v${version}";
-    sha256 = "1jvfjaiwddczjlx4xdhpbgwvvpycab7ix35lwp3wfy44hs6qpjqv";
+    hash = "sha256-HwWlMRhpB/sa/JRyAZF7LZzkXCCyuxB+gtDAfHt7e6k=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/dump-pe ../test/assets/example.exe
+    $out/bin/dump-pe ../tests/assets/example.exe
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/uthenticode/default.nix
+++ b/pkgs/development/libraries/uthenticode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, gtest, openssl, pe-parse }:
+{ stdenv, lib, fetchFromGitHub, cmake, gtest, openssl, pe-parse }:
 
 stdenv.mkDerivation rec {
   pname = "uthenticode";

--- a/pkgs/development/libraries/uthenticode/default.nix
+++ b/pkgs/development/libraries/uthenticode/default.nix
@@ -2,27 +2,20 @@
 
 stdenv.mkDerivation rec {
   pname = "uthenticode";
-  version = "1.0.4";
+  version = "1.0.8";
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "uthenticode";
     rev = "v${version}";
-    sha256 = "16j91cki63zk4d7wzwvq8al98l8hmvcdil3vfp44ink4q4bfswkx";
+    hash = "sha256-H4fAHZM+vYaUkXZE4f7r2bxw9dno7O+lYrqQ9/6YPWA=";
   };
 
-  patches = [
-    # adds USE_SYSTEM_GTEST cmake flag, the patch won't be necessary in next versions
-    (fetchpatch {
-      url = "https://github.com/trailofbits/uthenticode/commit/7a4c5499c8e5ea7bfae1c620e1f96c112866b1dd.patch";
-      sha256 = "17637j5zwp71jmi803mv1z04arld3k3kmrm8nvrkpg08q5kizh28";
-    })
-  ];
-
-  cmakeFlags = [ "-DBUILD_TESTS=1" "-DUSE_SYSTEM_GTEST=1" ];
+  cmakeFlags = [ "-DBUILD_TESTS=1" "-DUSE_EXTERNAL_GTEST=1" ];
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ pe-parse openssl gtest ];
+  checkInputs = [ gtest ];
+  buildInputs = [ pe-parse openssl ];
 
   doCheck = true;
   checkPhase = "test/uthenticode_test";


### PR DESCRIPTION
###### Description of changes
https://github.com/trailofbits/pe-parse/releases
https://github.com/trailofbits/uthenticode/releases
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
