### PR TITLE
kitty: 0.24.4 -> 0.25.0

### DIFF
--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -28,14 +28,14 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "kitty";
-  version = "0.24.4";
+  version = "0.25.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "sha256-c6XM/xeGZ68srf8xQJA1iYCUR3kXNceTMxsZAnbFmug=";
+    sha256 = "sha256-RYQVcbyKIv/FlrtROoQywWR+iF+4KYiYrrzErUrOCWM=";
   };
 
   buildInputs = [
@@ -80,21 +80,26 @@ buildPythonApplication rec {
   outputs = [ "out" "terminfo" "shell_integration" ];
 
   patches = [
+    # Required to get `test_ssh_env_vars` to pass.
     (fetchpatch {
-      name = "fix-zsh-completion-test-1.patch";
-      url = "https://github.com/kovidgoyal/kitty/commit/297592242c290a81ca4ba08802841f4c33a4de25.patch";
-      sha256 = "sha256-/V6y/4AaJsZvx1KS5UFZ+0zyAoZuLgbgFORZ1dX/1qE=";
+      name = "increase-pty-lines.patch";
+      url = "https://github.com/kovidgoyal/kitty/commit/eb84990f5a8edc458e04d24cc1cda05316d74ceb.patch";
+      sha256 = "sha256-eOANfhGPMoN4FqxtIGDBu5X0O3RPLABDnL+LKqSLROI=";
     })
-    (fetchpatch {
-      name = "fix-zsh-completion-test-2.patch";
-      url = "https://github.com/kovidgoyal/kitty/commit/d8ed42ae8e014d9abf9550a65ae203468f8bfa43.patch";
-      sha256 = "sha256-Azgzqf5atW999FVn9rSGKMyZLsI692dYXhJPx07GBO0=";
-    })
-    (fetchpatch {
-      name = "fix-build-with-non-framework-python-on-darwin.patch";
-      url = "https://github.com/kovidgoyal/kitty/commit/57cffc71b78244e6a9d49f4c9af24d1a88dbf537.patch";
-      sha256 = "sha256-1IGONSVCVo5SmLKw90eqxaI5Mwc764O1ur+aMsc7h94=";
-    })
+    # Fix to ensure that files in tar files used by SSH kitten have write permissions.
+    ./tarball-restore-write-permissions.patch
+
+    # Needed on darwin
+
+    # Gets `test_ssh_shell_integration` to pass for `zsh` when `compinit` complains about
+    # permissions.
+    ./zsh-compinit.patch
+    # Skip `test_ssh_login_shell_detection` in some cases, build users have their shell set to
+    # `/sbin/nologin` which causes issues.
+    ./disable-test_ssh_login_shell_detection.patch
+    # Skip `test_ssh_bootstrap_with_different_launchers` when launcher is `zsh` since it causes:
+    # OSError: master_fd is in error condition
+    ./disable-test_ssh_bootstrap_with_different_launchers.patch
   ];
 
   # Causes build failure due to warning
@@ -143,6 +148,9 @@ buildPythonApplication rec {
       # Fontconfig error: Cannot load default config file: No such file: (null)
       export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
 
+      # Required for `test_ssh_shell_integration` to pass.
+      export TERM=kitty
+
       env PATH="${buildBinPath}:$PATH" ${python.interpreter} test.py
     '';
 
@@ -181,6 +189,18 @@ buildPythonApplication rec {
 
     runHook postInstall
   '';
+
+  # Patch shebangs that Nix can't automatically patch
+  preFixup =
+    let
+      pathComponent = if stdenv.isDarwin then "Applications/kitty.app/Contents/Resources" else "lib";
+    in
+    ''
+      substituteInPlace $out/${pathComponent}/kitty/shell-integration/ssh/askpass.py \
+        --replace '/usr/bin/env -S ' $out/bin/
+      substituteInPlace $shell_integration/ssh/askpass.py \
+        --replace '/usr/bin/env -S ' $out/bin/
+    '';
 
   passthru.tests.test = nixosTests.terminal-emulators.kitty;
 

--- a/pkgs/applications/terminal-emulators/kitty/disable-test_ssh_bootstrap_with_different_launchers.patch
+++ b/pkgs/applications/terminal-emulators/kitty/disable-test_ssh_bootstrap_with_different_launchers.patch
@@ -1,0 +1,13 @@
+diff --git a/kitty_tests/ssh.py b/kitty_tests/ssh.py
+index 1f424146..d3cc191b 100644
+--- a/kitty_tests/ssh.py
++++ b/kitty_tests/ssh.py
+@@ -166,7 +166,7 @@ def test_ssh_bootstrap_with_different_launchers(self):
+             for sh in self.all_possible_sh:
+                 if sh == 'sh' or 'python' in sh:
+                     q = shutil.which(launcher)
+-                    if q:
++                    if q and not 'zsh' in q:
+                         with self.subTest(sh=sh, launcher=q), tempfile.TemporaryDirectory() as tdir:
+                             self.check_bootstrap(sh, tdir, test_script='env; exit 0', SHELL_INTEGRATION_VALUE='', launcher=q)
+ 

--- a/pkgs/applications/terminal-emulators/kitty/disable-test_ssh_login_shell_detection.patch
+++ b/pkgs/applications/terminal-emulators/kitty/disable-test_ssh_login_shell_detection.patch
@@ -1,0 +1,13 @@
+diff --git a/kitty_tests/ssh.py b/kitty_tests/ssh.py
+index 1f424146..57620334 100644
+--- a/kitty_tests/ssh.py
++++ b/kitty_tests/ssh.py
+@@ -197,7 +197,7 @@ def test_ssh_login_shell_detection(self):
+         expected_login_shell = pwd.getpwuid(os.geteuid()).pw_shell
+         for m in methods:
+             for sh in self.all_possible_sh:
+-                if 'python' in sh:
++                if 'python' in sh or '/sbin/nologin' in expected_login_shell:
+                     continue
+                 with self.subTest(sh=sh, method=m), tempfile.TemporaryDirectory() as tdir:
+                     pty = self.check_bootstrap(sh, tdir, test_script=f'{m}; echo "$login_shell"; exit 0', SHELL_INTEGRATION_VALUE='')

--- a/pkgs/applications/terminal-emulators/kitty/tarball-restore-write-permissions.patch
+++ b/pkgs/applications/terminal-emulators/kitty/tarball-restore-write-permissions.patch
@@ -1,0 +1,27 @@
+From 59f6876187da2c01b35e696e169ca98239c08a41 Mon Sep 17 00:00:00 2001
+From: Jason Felice <jason.m.felice@gmail.com>
+Date: Tue, 24 May 2022 07:54:25 -0400
+Subject: [PATCH] Restore write permissions in tarball
+
+In Nix, the source files are stored in an immutable store and
+therefore have been stripped of write permissions.  When the SSH
+kitten makes the tarfile, the files contained in it are also missing
+the write permissions, causing commands on the remote side to fail.
+---
+ kittens/ssh/main.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kittens/ssh/main.py b/kittens/ssh/main.py
+index 0b50d5ff..f80ac13d 100644
+--- a/kittens/ssh/main.py
++++ b/kittens/ssh/main.py
+@@ -123,6 +123,7 @@ def make_tarfile(ssh_opts: SSHOptions, base_env: Dict[str, str], compression: st
+     def normalize_tarinfo(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
+         tarinfo.uname = tarinfo.gname = ''
+         tarinfo.uid = tarinfo.gid = 0
++        tarinfo.mode |= 0o200
+         return tarinfo
+
+     def add_data_as_file(tf: tarfile.TarFile, arcname: str, data: Union[str, bytes]) -> tarfile.TarInfo:
+--
+2.36.0

--- a/pkgs/applications/terminal-emulators/kitty/zsh-compinit.patch
+++ b/pkgs/applications/terminal-emulators/kitty/zsh-compinit.patch
@@ -1,0 +1,13 @@
+diff --git a/kitty_tests/ssh.py b/kitty_tests/ssh.py
+index 1f424146..d9a65d25 100644
+--- a/kitty_tests/ssh.py
++++ b/kitty_tests/ssh.py
+@@ -268,6 +268,8 @@ def check_untar_or_fail():
+                 return 'UNTAR_DONE' in q
+             pty.wait_till(check_untar_or_fail)
+             self.assertTrue(os.path.exists(os.path.join(home_dir, '.terminfo/kitty.terminfo')))
++            if login_shell == 'zsh':
++                pty.send_cmd_to_child('y')
+             if SHELL_INTEGRATION_VALUE != 'enabled':
+                 pty.wait_till(lambda: len(pty.screen_contents().splitlines()) > 1)
+                 self.assertEqual(pty.screen.cursor.shape, 0)


### PR DESCRIPTION
###### Description of changes

* Updated to latest version of package.
* Removed patches, since they are included in this version.
* Manually patched shebangs that Nix can't automatically patch for us.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
