### PR TITLE
lib/types: Drop misleading plural from type descriptions

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -313,7 +313,7 @@ checkConfigOutput "bar" config.priorities ./raw.nix
 
 ## Option collision
 checkConfigError \
-  'The option .set. in module .*/declare-set.nix. would be a parent of the following options, but its type .attribute set of signed integers. does not support nested options.\n\s*- option[(]s[)] with prefix .set.enable. in module .*/declare-enable-nested.nix.' \
+  'The option .set. in module .*/declare-set.nix. would be a parent of the following options, but its type .attribute set of signed integer. does not support nested options.\n\s*- option[(]s[)] with prefix .set.enable. in module .*/declare-enable-nested.nix.' \
   config.set \
   ./declare-set.nix ./declare-enable-nested.nix
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -397,7 +397,7 @@ rec {
 
     listOf = elemType: mkOptionType rec {
       name = "listOf";
-      description = "list of ${elemType.description}s";
+      description = "list of ${elemType.description}";
       check = isList;
       merge = loc: defs:
         map (x: x.value) (filter (x: x ? value) (concatLists (imap1 (n: def:
@@ -426,7 +426,7 @@ rec {
 
     attrsOf = elemType: mkOptionType rec {
       name = "attrsOf";
-      description = "attribute set of ${elemType.description}s";
+      description = "attribute set of ${elemType.description}";
       check = isAttrs;
       merge = loc: defs:
         mapAttrs (n: v: v.value) (filterAttrs (n: v: v ? value) (zipAttrsWith (name: defs:
@@ -449,7 +449,7 @@ rec {
     # error that it's not defined. Use only if conditional definitions don't make sense.
     lazyAttrsOf = elemType: mkOptionType rec {
       name = "lazyAttrsOf";
-      description = "lazy attribute set of ${elemType.description}s";
+      description = "lazy attribute set of ${elemType.description}";
       check = isAttrs;
       merge = loc: defs:
         zipAttrsWith (name: defs:


### PR DESCRIPTION
Probably being the most prominent document demonstrating the problem,
configuration.nix(5) describes various types in plural, e.g.
- `           Type: list of strings`
- `           Type: list of systemd options`

However, there are other cases where appending "s" to the inner type
effectively changes the type, e.g.
```
Type: list of string matching the pattern
[a-zA-Z0-9@%:_.\-]+[.](service|socket|device|mount|automount|swap|target|path|timer|scope|slice)s
```
This should've read "list of string[s]..." but instead changes the
regular expression.

Simply drop the best-effort plural in favour of correctness and
simplicity rather than adding more grammar related logic/trying to fix
this.
