### PR TITLE
dsq: replace package test with upstream test script

### DIFF
--- a/pkgs/tools/misc/dsq/default.nix
+++ b/pkgs/tools/misc/dsq/default.nix
@@ -4,9 +4,12 @@
 , buildGoModule
 , runCommand
 , nix-update-script
-, dsq
+, fetchurl
 , testers
-, diffutils
+, python3
+, curl
+, jq
+, dsq
 }:
 
 buildGoModule rec {
@@ -22,39 +25,41 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-yfhLQBmWkG0ZLjI/ArLZkEGvClmZXkl0o7fEu5JqHM8=";
 
-  nativeBuildInputs = [ diffutils ];
-
   ldflags = [ "-X" "main.Version=${version}" ];
+
+  checkInputs = [ python3 curl jq ];
+
+  preCheck =
+    let
+      taxiCsv = fetchurl {
+        url = "https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2021-04.csv";
+        hash = "sha256-CXJPraOYAy5tViDcBi9gxI/rJ3ZXqOa/nJ/d+aREV+M=";
+      };
+    in
+    ''
+      substituteInPlace scripts/test.py \
+        --replace '${taxiCsv.url}' file://${taxiCsv} \
+        --replace 'dsq latest' 'dsq ${version}'
+    '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    cp "$GOPATH/bin/dsq" .
+    python3 scripts/test.py
+
+    runHook postCheck
+  '';
 
   passthru = {
     updateScript = nix-update-script { attrPath = pname; };
 
-    tests = {
-      version = testers.testVersion { package = dsq; };
-
-      pretty-csv = runCommand "${pname}-test" { } ''
-        mkdir "$out"
-        cat <<EOF > "$out/input.csv"
-        first,second
-        1,a
-        2,b
-        EOF
-        cat <<EOF > "$out/expected.txt"
-        +-------+--------+
-        | first | second |
-        +-------+--------+
-        |     1 | a      |
-        |     2 | b      |
-        +-------+--------+
-        EOF
-        ${dsq}/bin/dsq --pretty "$out/input.csv" 'select first, second from {}' > "$out/actual.txt"
-        diff "$out/expected.txt" "$out/actual.txt"
-      '';
-    };
+    tests.version = testers.testVersion { package = dsq; };
   };
 
   meta = with lib; {
-    description = "Commandline tool for running SQL queries against JSON, CSV, Excel, Parquet, and more";
+    description =
+      "Commandline tool for running SQL queries against JSON, CSV, Excel, Parquet, and more";
     homepage = "https://github.com/multiprocessio/dsq";
     license = licenses.asl20;
     maintainers = with maintainers; [ liff ];

--- a/pkgs/tools/misc/dsq/default.nix
+++ b/pkgs/tools/misc/dsq/default.nix
@@ -58,8 +58,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description =
-      "Commandline tool for running SQL queries against JSON, CSV, Excel, Parquet, and more";
+    description = "Commandline tool for running SQL queries against JSON, CSV, Excel, Parquet, and more";
     homepage = "https://github.com/multiprocessio/dsq";
     license = licenses.asl20;
     maintainers = with maintainers; [ liff ];


### PR DESCRIPTION
###### Description of changes

The package has its own custom test data and suite. There are no Go tests so run the custom suite in `checkPhase` instead.

The test script wants to download a big CSV file from an S3 bucket, which won’t work in a sandbox. To keep that working We’ll use instead use `fetchurl` and point curl to the downloaded file in the Nix store.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
