### PR TITLE
easycrypt: init at 2022.04

### DIFF
--- a/pkgs/applications/science/logic/easycrypt/default.nix
+++ b/pkgs/applications/science/logic/easycrypt/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchFromGitHub, ocamlPackages, why3 }:
+
+stdenv.mkDerivation rec {
+  pname = "easycrypt";
+  version = "2022.04";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "r${version}";
+    sha256 = "sha256:09rdwcj70lkamkhd895p284rfpz4bcnsf55mcimhiqncd2a21ml7";
+  };
+
+  nativeBuildInputs = with ocamlPackages; [
+    dune_3
+    findlib
+    menhir
+    ocaml
+  ];
+  buildInputs = with ocamlPackages; [
+    batteries
+    dune-build-info
+    inifiles
+    yojson
+    zarith
+  ];
+
+  propagatedBuildInputs = [ why3 ];
+
+  strictDeps = true;
+
+  postPatch = ''
+    substituteInPlace dune-project --replace '(name easycrypt)' '(name easycrypt)(version ${version})'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out ${pname}
+    rm $out/bin/ec-runtest
+    runHook postInstall
+  '';
+
+  meta = {
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+    platforms = lib.platforms.all;
+    homepage = "https://easycrypt.info/";
+    description = "Computer-Aided Cryptographic Proofs";
+  };
+}

--- a/pkgs/applications/science/logic/easycrypt/runtest.nix
+++ b/pkgs/applications/science/logic/easycrypt/runtest.nix
@@ -1,0 +1,24 @@
+{ python3Packages, easycrypt }:
+
+python3Packages.buildPythonApplication rec {
+  inherit (easycrypt) src version;
+
+  pname = "easycrypt-runtest";
+
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = false;
+
+  pythonPath = with python3Packages; [ pyyaml ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp scripts/testing/runtest $out/bin/ec-runtest
+    runHook postInstall
+  '';
+
+  meta = easycrypt.meta // {
+    description = "Testing program for EasyCrypt formalizations";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3325,6 +3325,8 @@ with pkgs;
 
   easycrypt = callPackage ../applications/science/logic/easycrypt { };
 
+  easycrypt-runtest = callPackage ../applications/science/logic/easycrypt/runtest.nix { };
+
   EBTKS = callPackage ../development/libraries/science/biology/EBTKS { };
 
   ecasound = callPackage ../applications/audio/ecasound { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3323,6 +3323,8 @@ with pkgs;
 
   earlyoom = callPackage ../os-specific/linux/earlyoom { };
 
+  easycrypt = callPackage ../applications/science/logic/easycrypt { };
+
   EBTKS = callPackage ../development/libraries/science/biology/EBTKS { };
 
   ecasound = callPackage ../applications/audio/ecasound { };


### PR DESCRIPTION
###### Description of changes

The first release ever of EasyCrypt!

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
