### PR TITLE
python310Packages.requests-http-signature: 0.2.0 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/http-message-signatures/default.nix
+++ b/pkgs/development/python-modules/http-message-signatures/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, http-sfv
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "http-message-signatures";
+  version = "0.4.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pyauth";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-CMF9p913P04Hx/221ck1e0AoAsP7aXkX2UKp4S1nnU0=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    cryptography
+    http-sfv
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    requests
+  ];
+
+  pytestFlagsArray = [
+    "test/test.py"
+  ];
+
+  pythonImportsCheck = [
+    "http_message_signatures"
+  ];
+
+  meta = with lib; {
+    description = "Requests authentication module for HTTP Signature";
+    homepage = "https://github.com/pyauth/http-message-signatures";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/http-sfv/default.nix
+++ b/pkgs/development/python-modules/http-sfv/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "http-sfv";
+  version = "0.9.5";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mnot";
+    repo = "http_sfv";
+    rev = "http_sfv-${version}";
+    hash = "sha256-hzg5vRX0vNKS/hYLF6n8mLK5qiwP7do4M8YMlBAA66I=";
+  };
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  # Tests require external data (https://github.com/httpwg/structured-field-tests)
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "http_sfv"
+  ];
+
+  meta = with lib; {
+    description = "Module to parse and serialise HTTP structured field values";
+    homepage = "https://github.com/mnot/http_sfv";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/requests-http-signature/default.nix
+++ b/pkgs/development/python-modules/requests-http-signature/default.nix
@@ -1,25 +1,37 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, cryptography
+, http-message-signatures
+, http-sfv
 , requests
 , pytestCheckHook
+, pythonOlder
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "requests-http-signature";
-  version = "0.2.0";
+  version = "0.7.1";
   format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pyauth";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-B45P/loXcRKOChSDeHOnlz+67mtmTeAMYlo21TOmV8s=";
+    hash = "sha256-sW2vYqT/nY27DvEKHdptc3dUpuqKmD7PLMs+Xp+cpeU=";
   };
 
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
   propagatedBuildInputs = [
-    cryptography
+    http-message-signatures
+    http-sfv
     requests
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3887,6 +3887,8 @@ in {
 
   httplib2 = callPackage ../development/python-modules/httplib2 { };
 
+  http-message-signatures = callPackage ../development/python-modules/http-message-signatures { };
+
   http-parser = callPackage ../development/python-modules/http-parser { };
 
   http-sfv = callPackage ../development/python-modules/http-sfv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3889,6 +3889,8 @@ in {
 
   http-parser = callPackage ../development/python-modules/http-parser { };
 
+  http-sfv = callPackage ../development/python-modules/http-sfv { };
+
   httpretty = callPackage ../development/python-modules/httpretty { };
 
   httpserver = callPackage ../development/python-modules/httpserver { };


### PR DESCRIPTION
###### Description of changes
https://github.com/pyauth/requests-http-signature/releases
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
