### PR TITLE
python39Packages.fontmake: init at 3.3.0

### DIFF
--- a/pkgs/development/python-modules/fontmake/default.nix
+++ b/pkgs/development/python-modules/fontmake/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, glyphslib
+, setuptools-scm
+, ufo2ft
+, fonttools
+, fontmath
+, lxml
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "fontmake";
+  version = "3.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-lD7MvZdr9CeWdoZtD3+8stVJTeQN5/AQ4miA/I2TFoE=";
+    extension = "zip";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    glyphslib
+    ufo2ft
+    fonttools
+    fontmath
+    lxml
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "fontmake" ];
+
+  meta = {
+    description = "Compiles fonts from various sources (.glyphs, .ufo, designspace) into binaries formats (.otf, .ttf)";
+    homepage = "https://github.com/googlefonts/fontmake";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.BarinovMaxim ];
+  };
+}

--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -13,11 +13,12 @@
 , sphinx
 , pytestCheckHook
 , glibcLocales
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "4.30.0";
+  version = "4.33.3";
 
   disabled = pythonOlder "3.7";
 
@@ -25,8 +26,10 @@ buildPythonPackage rec {
     owner  = pname;
     repo   = pname;
     rev    = version;
-    sha256 = "1y9f071bdl66rsx42j16j5v53h85xra5qlg860rz3m054s2rmin9";
+    sha256 = "MUIZGnYwlfTat9655AOYgK5r6AvHj/xXghUvOZR8HIM=";
   };
+
+  nativeBuildInputs = [ setuptools-scm ];
 
   # all dependencies are optional, but
   # we run the checks with them
@@ -51,6 +54,8 @@ buildPythonPackage rec {
     unicodedata2
   ];
 
+  pythonImportsCheck = [ "fontTools" ];
+
   preCheck = ''
     # tests want to execute the "fonttools" executable from $PATH
     export PATH="$out/bin:$PATH"
@@ -71,7 +76,6 @@ buildPythonPackage rec {
     "Tests/pens"
     "Tests/ufoLib"
   ];
-
 
   meta = with lib; {
     homepage = "https://github.com/fonttools/fonttools";

--- a/pkgs/development/python-modules/glyphslib/default.nix
+++ b/pkgs/development/python-modules/glyphslib/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fonttools
+, openstep-plist
+, ufoLib2
+, pytestCheckHook
+, unicodedata2
+, setuptools-scm
+, ufonormalizer
+, xmldiff
+, defcon
+, ufo2ft
+, skia-pathops
+}:
+
+buildPythonPackage rec {
+  pname = "glyphslib";
+  version = "6.0.4";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    pname = "glyphsLib";
+    inherit version;
+    sha256 = "sha256-PT66n1WEO5FNcwov8GaXT1YNrAi22X4HN7iVNkuehKI=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "glyphsLib" ];
+
+  propagatedBuildInputs = [
+    fonttools
+    openstep-plist
+    ufoLib2
+    unicodedata2
+    ufonormalizer
+    xmldiff
+    defcon
+    ufo2ft
+    skia-pathops
+  ];
+
+  disabledTestPaths = [
+    "tests/builder/designspace_gen_test.py" # this test tries to use non-existent font "CoolFoundry Examplary Serif"
+    "tests/builder/interpolation_test.py" # this test tries to use a font that previous test should made
+  ];
+
+  meta = {
+    description = "Bridge from Glyphs source files (.glyphs) to UFOs and Designspace files via defcon and designspaceLib";
+    homepage = "https://github.com/googlefonts/glyphsLib";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.BarinovMaxim ];
+  };
+}
+

--- a/pkgs/development/python-modules/openstep-plist/default.nix
+++ b/pkgs/development/python-modules/openstep-plist/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, pytestCheckHook
+, cython
+, pythonImportsCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "openstep-plist";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    pname = "openstep_plist";
+    inherit version;
+    sha256 = "sha256-KO4sGKjod5BwUFQ1MU2S1dG0DyiJ06mdroMbRDsugBk=";
+    extension = "zip";
+  };
+
+  nativeBuildInputs = [ setuptools-scm cython ];
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "openstep_plist" ];
+
+  meta = {
+    description = "Parser for the 'old style' OpenStep property list format also known as ASCII plist";
+    homepage = "https://github.com/fonttools/openstep-plist";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.BarinovMaxim ];
+  };
+}

--- a/pkgs/development/python-modules/skia-pathops/default.nix
+++ b/pkgs/development/python-modules/skia-pathops/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, cython
+, ninja
+, setuptools-scm
+, setuptools
+, fetchPypi
+, gn
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "skia-pathops";
+  version = "0.7.2";
+
+  src = fetchPypi {
+    pname = "skia-pathops";
+    inherit version;
+    extension = "zip";
+    sha256 = "sha256-Gdhcmv77oVr5KxPIiJlk935jgvWPQsYEC0AZ6yjLppA=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "build_cmd = [sys.executable, build_skia_py, build_dir]" \
+        'build_cmd = [sys.executable, build_skia_py, "--no-fetch-gn", "--no-virtualenv", "--gn-path", "${gn}/bin/gn", build_dir]'
+  '';
+
+  nativeBuildInputs = [ cython ninja setuptools-scm ];
+
+  propagatedBuildInputs = [ setuptools ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pathops" ];
+
+  meta = {
+    description = "Python access to operations on paths using the Skia library";
+    homepage = "https://skia.org/dev/present/pathops";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.BarinovMaxim ];
+  };
+}

--- a/pkgs/development/python-modules/ufo2ft/default.nix
+++ b/pkgs/development/python-modules/ufo2ft/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "ufo2ft";
-  version = "2.26.0";
+  version = "2.27.0";
 
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-1WQAs1ypWtLObgBzPtqtvHjkKnDWohu3PbI3bF7B0Sg=";
+    sha256 = "r5bE4M/blt5TKzP43MpijwYY6ll3aasszmGksY5WTTE=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ufoLib2/default.nix
+++ b/pkgs/development/python-modules/ufoLib2/default.nix
@@ -5,6 +5,7 @@
 , fonttools
 , pytestCheckHook
 , fs
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
@@ -24,6 +25,8 @@ buildPythonPackage rec {
     # required by fonttools[ufo]
     fs
   ];
+
+  nativeBuildInputs = [ setuptools-scm ];
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3109,6 +3109,8 @@ in {
 
   fontmake = callPackage ../development/python-modules/fontmake { };
 
+  openstep-plist = callPackage ../development/python-modules/openstep-plist { };
+
   foobot-async = callPackage ../development/python-modules/foobot-async { };
 
   foolscap = callPackage ../development/python-modules/foolscap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3109,6 +3109,8 @@ in {
 
   fontmake = callPackage ../development/python-modules/fontmake { };
 
+  skia-pathops = callPackage ../development/python-modules/skia-pathops { };
+
   openstep-plist = callPackage ../development/python-modules/openstep-plist { };
 
   glyphslib = callPackage ../development/python-modules/glyphslib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3107,6 +3107,8 @@ in {
 
   fonttools = callPackage ../development/python-modules/fonttools { };
 
+  fontmake = callPackage ../development/python-modules/fontmake { };
+
   foobot-async = callPackage ../development/python-modules/foobot-async { };
 
   foolscap = callPackage ../development/python-modules/foolscap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3111,6 +3111,8 @@ in {
 
   openstep-plist = callPackage ../development/python-modules/openstep-plist { };
 
+  glyphslib = callPackage ../development/python-modules/glyphslib { };
+
   foobot-async = callPackage ../development/python-modules/foobot-async { };
 
   foolscap = callPackage ../development/python-modules/foolscap { };


### PR DESCRIPTION
I want to add a new package. It's fontmake. Fontmake is a tool that can convert *.ufo fonts into *.ttf fonts.
Some packages were deprecated or broken that didn't allow to compile fontmake. So I changed them in separated commits. 