### PR TITLE
tridactyl-native: init new Nim rewrite at 0.3.6

### DIFF
--- a/pkgs/tools/networking/tridactyl-native/default.nix
+++ b/pkgs/tools/networking/tridactyl-native/default.nix
@@ -1,44 +1,29 @@
-{ lib, stdenv
-, fetchFromGitHub
-, python3
-}:
+{ lib, nimPackages, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  pname = "tridactyl-native";
-  # this is actually the version of tridactyl itself; the native messenger will
-  # probably not change with every tridactyl version
-  version = "1.20.4";
+nimPackages.buildNimPackage rec {
+  pname = "tridactly-native";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner = "tridactyl";
-    repo = "tridactyl";
-    rev = version;
-    sha256 = "sha256-BjjRB9VadQ/MSwNK2QLbcTDoRs6Ua+5MONHtmfq4xz0=";
+    repo = "native_messenger";
+    rev = "5cc315da79a1caa8fd5b27b192377d8824a311c1";
+    sha256 = "sha256-9IyVDJgdZleeNltD1b4PfqxeWAtFsPHtmq1ZC5Z0O9k=";
   };
-  sourceRoot = "source/native";
-
-  nativeBuildInputs = [
-    python3.pkgs.wrapPython
-  ];
-
-  buildPhase = ''
-    sed -i -e "s|REPLACE_ME_WITH_SED|$out/share/tridactyl/native_main.py|" "tridactyl.json"
-  '';
+  buildInputs = with nimPackages; [ tempfile ];
 
   installPhase = ''
     mkdir -p "$out/lib/mozilla/native-messaging-hosts"
+    sed -i -e "s|REPLACE_ME_WITH_SED|$out/bin/native_main|" "tridactyl.json"
     cp tridactyl.json "$out/lib/mozilla/native-messaging-hosts/"
-
-    mkdir -p "$out/share/tridactyl"
-    cp native_main.py "$out/share/tridactyl"
-    wrapPythonProgramsIn "$out/share/tridactyl"
   '';
 
   meta = with lib; {
-    description = "Tridactyl native messaging host application";
-    homepage = "https://github.com/tridactyl/tridactyl";
-    license = licenses.asl20;
+    description =
+      "Native messenger for Tridactyl, a vim-like Firefox webextension";
+    homepage = "https://github.com/tridactyl/native_messenger";
+    license = licenses.bsd2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ timokau ];
+    maintainers = with maintainers; [ timokau dit7ya ];
   };
 }


### PR DESCRIPTION
###### Description of changes

The current tridactyl-native packaged in Nixpkgs is [deprecated](https://github.com/tridactyl/tridactyl/blob/ab5e069fae1c05b0d71c280007c8bb9b86f24d06/native/README.md) and have been supplanted by a new rewrite (written in Nim instead of Python).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
