### PR TITLE
Various strictDeps and cross fixes v2

### DIFF
--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -13,7 +13,7 @@
 , python3
 , tzdata
 , fixDarwinDylibNames
-, introspectionSupport ? stdenv.buildPlatform == stdenv.hostPlatform
+, withIntrospection ? stdenv.buildPlatform == stdenv.hostPlatform
 , gobject-introspection
 , vala
 }:
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gZ6IBjG5pNKJ+hWcTzXMP7yxL4he4LTklZGoC9vXra8=";
   };
 
+  strictDeps = true;
   nativeBuildInputs = [
     cmake
     ninja
@@ -43,7 +44,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # provides ical-glib-src-generator that runs during build
     libical
-  ] ++ lib.optionals introspectionSupport [
+  ] ++ lib.optionals withIntrospection [
     gobject-introspection
     vala
   ] ++ lib.optionals stdenv.isDarwin [
@@ -60,13 +61,14 @@ stdenv.mkDerivation rec {
     glib
     libxml2
     icu
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
   ];
 
   cmakeFlags = [
     "-DENABLE_GTK_DOC=False"
-  ] ++ lib.optionals introspectionSupport [
-    "-DGOBJECT_INTROSPECTION=True"
-    "-DICAL_GLIB_VAPI=True"
+    "-DGOBJECT_INTROSPECTION=${if withIntrospection then "True" else "False"}"
+    "-DICAL_GLIB_VAPI=${if withIntrospection then "True" else "False"}"
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DIMPORT_ICAL_GLIB_SRC_GENERATOR=${lib.getDev buildPackages.libical}/lib/cmake/LibIcal/IcalGlibSrcGenerator.cmake"
   ];

--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -2,7 +2,7 @@
   lib, stdenv, buildPackages, fetchurl, fetchpatch,
   runCommand,
   autoreconfHook,
-  autoconf, automake, libtool,
+  autoconf, automake, libtool, bash,
   # Enabling python support while cross compiling would be possible, but
   # the configure script tries executing python to gather info instead of
   # relying on python3-config exclusively
@@ -21,9 +21,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "man" ];
 
+  strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = lib.optionals enablePython [ python3 swig ];
+  nativeBuildInputs = [ autoreconfHook ]
+    ++ lib.optionals enablePython [ python3 swig ];
+  buildInputs = [ bash ];
 
   configureFlags = [
     # z/OS plugin is not useful on Linux,


### PR DESCRIPTION
sequel to https://github.com/NixOS/nixpkgs/pull/142602
see commit messages

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).