### PR TITLE
oh-my-posh: init at 8.29.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14928,4 +14928,10 @@
     github = "yisuidenghua";
     githubId = 102890144;
   };
+  shrykewindgrace = {
+    email = "shryke.windgrace@gmail.com";
+    github = "ShrykeWindgrace";
+    githubId = 6421233;
+    name = "Timofey Zakrevskiy";
+  };
 }

--- a/pkgs/tools/misc/oh-my-posh/default.nix
+++ b/pkgs/tools/misc/oh-my-posh/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "oh-my-posh";
+  version = "8.29.4";
+
+  src = fetchFromGitHub {
+    owner = "JanDeDobbeleer";
+    repo = "oh-my-posh";
+    rev = "v${version}";
+    sha256 = "u6xZJ+XVzAtY9UNqdpKRdeBqo99r1b3Riph/6KzHYaI=";
+  };
+  modRoot = "./src";
+  vendorSha256 = "t4FpvXsGVsTYoGM8wY2JelscnlmDzrLMPYk7zGUfo58=";
+
+  ldflags = [ "-a" "-s" "-w" "-X" "main.Version=${version}" "-extldflags" ''"-static"'' ];
+
+  tags = [ "netgo" "osusergo" "static_build" ];
+
+  postInstall = ''
+    mkdir -p $out
+    cp -r ${src}/themes $out
+  '';
+
+  meta = with lib; {
+    description = "A prompt theme engine for any shell";
+    homepage = "https://ohmyposh.dev/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shrykewindgrace ];
+    # it should work on darwin, too, but I do not have the expertise to make it work on nix
+    # it has something to do with -lpthread
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9266,6 +9266,8 @@ with pkgs;
 
   ogdf = callPackage ../development/libraries/ogdf { };
 
+  oh-my-posh = callPackage ../tools/misc/oh-my-posh { };
+
   oh-my-zsh = callPackage ../shells/zsh/oh-my-zsh { };
 
   ola = callPackage ../applications/misc/ola { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Packaging `oh-my-posh` by `JanDeDobbeleer` - a prompt theme engine for any shell.

Homepage is here: https://ohmyposh.dev/
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
