### PR TITLE
mastodon: update ruby version

### DIFF
--- a/pkgs/servers/mastodon/gemset.nix
+++ b/pkgs/servers/mastodon/gemset.nix
@@ -1899,10 +1899,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0zaghgvva2q4jqbachg8jvpwgbg3w1jqr0d00m8rqciqznjgsw3c";
+      sha256 = "sha256-7aTXtJu/3a07bKnN+yMwLuxs9zwugIttWwzJFh98DnY=";
       type = "gem";
     };
-    version = "3.1.1.0";
+    version = "3.1.2.0";
   };
   parslet = {
     groups = ["default"];

--- a/pkgs/servers/mastodon/ruby_version.patch
+++ b/pkgs/servers/mastodon/ruby_version.patch
@@ -1,0 +1,20 @@
+diff --git a/.ruby-version b/.ruby-version
+index 75a22a26ac4a..b0f2dcb32fc2 100644
+--- a/.ruby-version
++++ b/.ruby-version
+@@ -1 +1 @@
+-3.0.3
++3.0.4
+diff --git a/Gemfile.lock b/Gemfile.lock
+index 08f137dd0152..bb79948ec4c7 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -442,7 +442,7 @@ GEM
+     orm_adapter (0.5.0)
+     ox (2.14.11)
+     parallel (1.22.1)
+-    parser (3.1.1.0)
++    parser (3.1.2.0)
+       ast (~> 2.4.1)
+     parslet (2.0.0)
+     pastel (0.8.0)

--- a/pkgs/servers/mastodon/source.nix
+++ b/pkgs/servers/mastodon/source.nix
@@ -7,5 +7,5 @@
   };
 in applyPatches {
   inherit src;
-  patches = [];
+  patches = [ ./ruby_version.patch ];
 }


### PR DESCRIPTION
###### Description of changes
Fix this warning message:
```
warning: parser/current is loading parser/ruby30, which recognizes3.0.3-compliant syntax, but you are running 3.0.4.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

cc @erictapen

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
