### PR TITLE
kabeljau: 1.1.0 → 1.2.0

### DIFF
--- a/pkgs/games/kabeljau/default.nix
+++ b/pkgs/games/kabeljau/default.nix
@@ -1,27 +1,29 @@
-{ stdenvNoCC, lib, fetchFromGitea, bash, dialog, makeWrapper }:
+{ stdenvNoCC, lib, fetchFromGitea, just, inkscape, makeWrapper, bash, dialog }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "kabeljau";
-  version = "1.0.1";
+  version = "1.2.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "papojari";
     repo = "kabeljau";
     rev = "v${version}";
-    sha256 = "sha256-LOvr5fgSUTXnYhbVmynCCjo0W098jKWQnFULtIprE3M=";
+    sha256 = "sha256-RedVItgfr6vgqXHA3bOiHXDpfGuHI+sX4jCHL9G5jYk=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  # Inkscape is needed in a just recipe where it is used to export the SVG icon to several different sized PNGs.
+  nativeBuildInputs = [ just inkscape makeWrapper ];
   postPatch = ''
     patchShebangs --host ${pname}
+    substituteInPlace ./justfile \
+      --replace " /bin" " $out/bin" \
+      --replace " /usr" " $out"
   '';
-
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    cp ${pname}.sh $out/bin/${pname}
+    just install
     wrapProgram $out/bin/${pname} --suffix PATH : ${
       lib.makeBinPath [ dialog ]
     }


### PR DESCRIPTION
###### Description of changes

- Added a justfile to source code which builds app icon in different sizes and a .desktop file and puts them in the right place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
