### PR TITLE
brave: 1.37.116 -> 1.38.109 and fix VAAPI/Vulkan

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl
+{ lib, stdenv, fetchurl, wrapGAppsHook
 , dpkg
 , alsa-lib
 , at-spi2-atk
@@ -15,7 +15,6 @@
 , gnome
 , gsettings-desktop-schemas
 , gtk3
-, libpulseaudio
 , libuuid
 , libdrm
 , libX11
@@ -41,63 +40,58 @@
 , xorg
 , zlib
 , xdg-utils
-, wrapGAppsHook
+, snappy
+
+# command line arguments which are always set e.g "--disable-gpu"
 , commandLineArgs ? ""
+
+# Necessary for USB audio devices.
+, pulseSupport ? stdenv.isLinux
+, libpulseaudio
+
+# For video acceleration via VA-API (--enable-features=VaapiVideoDecoder,VaapiVideoEncoder)
+, libvaSupport ? stdenv.isLinux
+, libva
+, enableVideoAcceleration ? libvaSupport
+
+# For Vulkan support (--enable-features=Vulkan); disabled by default as it seems to break VA-API
+, vulkanSupport ? false
+, addOpenGLRunpath
+, enableVulkan ? vulkanSupport
 }:
 
 let
+  inherit (lib) optional optionals makeLibraryPath makeSearchPathOutput makeBinPath
+    optionalString strings escapeShellArg;
 
-rpath = lib.makeLibraryPath [
-  alsa-lib
-  at-spi2-atk
-  at-spi2-core
-  atk
-  cairo
-  cups
-  dbus
-  expat
-  fontconfig
-  freetype
-  gdk-pixbuf
-  glib
-  gtk3
-  libdrm
-  libpulseaudio
-  libX11
-  libxkbcommon
-  libXScrnSaver
-  libXcomposite
-  libXcursor
-  libXdamage
-  libXext
-  libXfixes
-  libXi
-  libXrandr
-  libXrender
-  libxshmfence
-  libXtst
-  libuuid
-  mesa
-  nspr
-  nss
-  pango
-  pipewire
-  udev
-  wayland
-  xdg-utils
-  xorg.libxcb
-  zlib
-];
+  deps = [
+    alsa-lib at-spi2-atk at-spi2-core atk cairo cups dbus expat
+    fontconfig freetype gdk-pixbuf glib gtk3 libdrm libX11
+    libxkbcommon libXScrnSaver libXcomposite libXcursor libXdamage
+    libXext libXfixes libXi libXrandr libXrender libxshmfence
+    libXtst libuuid mesa nspr nss pango pipewire udev wayland
+    xdg-utils xorg.libxcb zlib snappy
+  ]
+    ++ optional pulseSupport libpulseaudio
+    ++ optional libvaSupport libva;
 
+  rpath = makeLibraryPath deps + ":" + makeSearchPathOutput "lib" "lib64" deps;
+  binpath = makeBinPath deps;
+
+  enableFeatures = optionals enableVideoAcceleration [ "VaapiVideoDecoder" "VaapiVideoEncoder" ]
+    ++ optional enableVulkan "Vulkan";
+
+    # The feature disable is needed for VAAPI to work correctly: https://github.com/brave/brave-browser/issues/20935
+  disableFeatures = optional enableVideoAcceleration "UseChromeOSDirectVideoDecoder";
 in
 
 stdenv.mkDerivation rec {
   pname = "brave";
-  version = "1.37.116";
+  version = "1.38.109";
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-    sha256 = "HoqmzUyYas5ho9S8ZeXHj+LuNspejuQ69B6HxuKXWtw=";
+    sha256 = "sha256-w/Wm8msW4etF6E1UDujLfixhxmKBcnB+uw/CMcj4jGI=";
   };
 
   dontConfigure = true;
@@ -107,7 +101,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg wrapGAppsHook ];
 
-  buildInputs = [ glib gsettings-desktop-schemas gnome.adwaita-icon-theme ];
+  buildInputs = [
+    # needed for GSETTINGS_SCHEMAS_PATH
+    glib gsettings-desktop-schemas gtk3
+
+    # needed for XDG_ICON_DIRS
+    gnome.adwaita-icon-theme
+  ];
 
   unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
 
@@ -161,8 +161,21 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     # Add command line args to wrapGApp.
-    gappsWrapperArgs+=(--add-flags ${lib.escapeShellArg commandLineArgs})
-    gappsWrapperArgs+=(--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}")
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${rpath}
+      --prefix PATH : ${binpath}
+      ${optionalString (enableFeatures != []) ''
+      --add-flags "--enable-features=${strings.concatStringsSep "," enableFeatures}"
+      ''}
+      ${optionalString (disableFeatures != []) ''
+      --add-flags "--disable-features=${strings.concatStringsSep "," disableFeatures}"
+      ''}
+      --add-flags ${escapeShellArg commandLineArgs}
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}"
+      ${optionalString vulkanSupport ''
+      --prefix XDG_DATA_DIRS  : "${addOpenGLRunpath.driverLink}/share"
+      ''}
+    )
   '';
 
   installCheckPhase = ''
@@ -175,7 +188,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://brave.com/";
     description = "Privacy-oriented browser for Desktop and Laptop computers";
-    changelog = "https://github.com/brave/brave-browser/blob/master/CHANGELOG_DESKTOP.md#" + lib.replaceStrings [ "." ] [ "" ] version;
+    changelog = "https://github.com/brave/brave-browser/blob/master/CHANGELOG_DESKTOP.md#" + replaceStrings [ "." ] [ "" ] version;
     longDescription = ''
       Brave browser blocks the ads and trackers that slow you down,
       chew up your bandwidth, and invade your privacy. Brave lets you


### PR DESCRIPTION
###### Description of changes

This PR updates Brave to the newest release 1.38.109 (release notes [here](https://community.brave.com/t/release-channel-1-38-109/383796)) as well as fixes enabling video acceleration via VAAPI and Vulkan. Vulkan support is disabled by default as it breaks VAAPI support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
