### PR TITLE
cvehound: 1.0.4 -> 1.0.9

### DIFF
--- a/pkgs/development/tools/analysis/cvehound/default.nix
+++ b/pkgs/development/tools/analysis/cvehound/default.nix
@@ -1,30 +1,34 @@
-{ lib, fetchFromGitHub, coccinelle, gnugrep, python3Packages }:
+{ lib
+, fetchFromGitHub
+, coccinelle
+, gnugrep
+, python3
+}:
 
-with python3Packages;
-
-buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "cvehound";
-  version = "1.0.4";
+  version = "1.0.9";
 
   src = fetchFromGitHub {
     owner = "evdenis";
     repo = "cvehound";
     rev = version;
-    sha256 = "sha256-m8vpea02flQ8elSvGWv9FqBhsEcBzRYjcUk+dc4kb2M=";
+    hash = "sha256-qwQfpelY1Air3wVQ3RziM/+MNOR3jiKmLpO2w6kXZwM=";
   };
 
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [ coccinelle gnugrep ]}"
   ];
 
-  propagatedBuildInputs = [
-    psutil
+  propagatedBuildInputs = with python3.pkgs; [
+    lxml
     setuptools
     sympy
   ];
 
-  checkInputs = [
+  checkInputs = with python3.pkgs; [
     GitPython
+    psutil
     pytestCheckHook
   ];
 
@@ -32,10 +36,11 @@ buildPythonApplication rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "tool to check linux kernel source dump for known CVEs";
+    description = "Tool to check linux kernel source dump for known CVEs";
     homepage = "https://github.com/evdenis/cvehound";
+    changelog = "https://github.com/evdenis/cvehound/blob/${src.rev}/ChangeLog";
     # See https://github.com/evdenis/cvehound/issues/22
-    license = with licenses; [ gpl2Only gpl3Only ];
+    license = with licenses; [ gpl2Only gpl3Plus ];
     maintainers = with maintainers; [ ambroisie ];
   };
 }


### PR DESCRIPTION

###### Description of changes
https://github.com/evdenis/cvehound/blob/1.0.9/ChangeLog

fixes #170656 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
