### PR TITLE
python310Packages.proton-client: enable tests

### DIFF
--- a/pkgs/development/python-modules/proton-client/0001-OpenSSL-path-fix.patch
+++ b/pkgs/development/python-modules/proton-client/0001-OpenSSL-path-fix.patch
@@ -1,0 +1,41 @@
+From 48da17d61e38657dfb10f2ac642fd3e6a45ee607 Mon Sep 17 00:00:00 2001
+From: "P. R. d. O" <d.ol.rod@tutanota.com>
+Date: Wed, 27 Apr 2022 14:29:53 -0600
+Subject: [PATCH] OpenSSL path fix
+
+---
+ proton/srp/_ctsrp.py | 12 ++----------
+ 1 file changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/proton/srp/_ctsrp.py b/proton/srp/_ctsrp.py
+index e19f184..af359c5 100644
+--- a/proton/srp/_ctsrp.py
++++ b/proton/srp/_ctsrp.py
+@@ -24,22 +24,14 @@ from .util import PM_VERSION, SRP_LEN_BYTES, SALT_LEN_BYTES, hash_password
+ dlls = list()
+ 
+ platform = sys.platform
+-if platform == 'darwin':
+-    dlls.append(ctypes.cdll.LoadLibrary('libssl.dylib'))
+-elif 'win' in platform:
++if 'win' in platform:
+     for d in ('libeay32.dll', 'libssl32.dll', 'ssleay32.dll'):
+         try:
+             dlls.append(ctypes.cdll.LoadLibrary(d))
+         except Exception:
+             pass
+ else:
+-    try:
+-        dlls.append(ctypes.cdll.LoadLibrary('libssl.so.10'))
+-    except OSError:
+-        try:
+-            dlls.append(ctypes.cdll.LoadLibrary('libssl.so.1.0.0'))
+-        except OSError:
+-            dlls.append(ctypes.cdll.LoadLibrary('libssl.so'))
++    dlls.append(ctypes.cdll.LoadLibrary('@openssl@/lib/libssl@ext@'))
+ 
+ 
+ class BIGNUM_Struct(ctypes.Structure):
+-- 
+2.35.1
+

--- a/pkgs/development/python-modules/proton-client/default.nix
+++ b/pkgs/development/python-modules/proton-client/default.nix
@@ -1,10 +1,13 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, substituteAll
 , bcrypt
 , pyopenssl
 , python-gnupg
+, pytestCheckHook
 , requests
 , openssl
 }:
@@ -30,14 +33,21 @@ buildPythonPackage rec {
 
   buildInputs = [ openssl ];
 
-  # This patch is supposed to indicate where to load OpenSSL library,
-  # but it is not working as intended.
-  #patchPhase = ''
-  #  substituteInPlace proton/srp/_ctsrp.py --replace \
-  #    "ctypes.cdll.LoadLibrary('libssl.so.10')" "'${lib.getLib openssl}/lib/libssl.so'"
-  #'';
-  # Regarding the issue above, I'm disabling tests for now
-  doCheck = false;
+  patches = [
+    # Patches library by fixing the openssl path
+    (substituteAll {
+      src = ./0001-OpenSSL-path-fix.patch;
+      openssl = openssl.out;
+      ext = stdenv.hostPlatform.extensions.sharedLibrary;
+    })
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    #ValueError: Invalid modulus
+    "test_modulus_verification"
+  ];
 
   pythonImportsCheck = [ "proton" ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Taken from #129333. Patches the code to identify OpenSSL and enables tests on the library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
