### PR TITLE
Fix etebase-server pyproject build error

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4092,11 +4092,18 @@
     matrix = "@felschr:matrix.org";
     github = "felschr";
     githubId = 3314323;
-    name = "Felix Tenley";
-    keys = [{
-      longkeyid = "ed25519/0x910ACB9F6BD26F58";
-      fingerprint = "6AB3 7A28 5420 9A41 82D9  0068 910A CB9F 6BD2 6F58";
-    }];
+    name = "Felix Schröter";
+    keys = [
+      {
+        # historical
+        longkeyid = "ed25519/0x910ACB9F6BD26F58";
+        fingerprint = "6AB3 7A28 5420 9A41 82D9  0068 910A CB9F 6BD2 6F58";
+      }
+      {
+        longkeyid = "ed25519/0x671E39E6744C807D";
+        fingerprint = "7E08 6842 0934 AA1D 6821  1F2A 671E 39E6 744C 807D";
+      }
+    ];
   };
   ffinkdevs = {
     email = "fink@h0st.space";

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -1,13 +1,5 @@
-{ lib, stdenv, python3, fetchFromGitHub }:
-
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-      django = super.django_3;
-    };
-  };
-in
-  with py.pkgs;
+{ lib, fetchFromGitHub, buildPythonPackage, aioredis, aiofiles, django_3
+, fastapi, msgpack, pynacl, typing-extensions }:
 
 buildPythonPackage rec {
   pname = "etebase-server";
@@ -23,21 +15,14 @@ buildPythonPackage rec {
 
   patches = [ ./secret.patch ];
 
-  propagatedBuildInputs = with pythonPackages; [
-    asgiref
-    cffi
-    django
-    django-cors-headers
-    djangorestframework
-    drf-nested-routers
+  propagatedBuildInputs = [
+    aioredis
+    aiofiles
+    django_3
     fastapi
     msgpack
-    psycopg2
-    pycparser
     pynacl
-    pytz
-    six
-    sqlparse
+    typing-extensions
   ];
 
   installPhase = ''

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -12,7 +12,7 @@ in
 buildPythonPackage rec {
   pname = "etebase-server";
   version = "0.8.3";
-  format = "pyproject";
+  format = "other";
 
   src = fetchFromGitHub {
     owner = "etesync";


### PR DESCRIPTION
###### Description of changes
Fixes build issues with `etebase-server`:
https://hydra.nixos.org/job/nixpkgs/trunk/etebase-server.x86_64-linux
I've also cleaned up the dependencies.

I'm not sure why the pyproject setup started to fail and I haven't seen any other packages being affected by this issue.
Switching to `format = "other"` resolves this issue for `etebase-server` at least.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).