### PR TITLE
python310Packages.docstring-parser: 0.12 -> 0.14.1

### DIFF
--- a/pkgs/development/python-modules/docstring-parser/default.nix
+++ b/pkgs/development/python-modules/docstring-parser/default.nix
@@ -1,25 +1,39 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools
-, setuptools-scm
-, wheel
-, pytest
-}: buildPythonPackage rec {
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
   pname = "docstring-parser";
-  version = "0.12";
+  version = "0.14.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "rr-";
     repo = "docstring_parser";
     rev = "${version}";
-    sha256 = "sha256-hQuPJQrGvDs4dJrMLSR4sSnqy45xrF2ufinBG+azuCg=";
+    hash = "sha256-NIijq+QR0panVCGDEQrTlkAvHfIexwS0PxFikglxd74=";
   };
-  nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ pytest setuptools wheel ];
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "docstring_parser"
+  ];
 
   meta = with lib; {
-    description = "Parse Python docstrings in various flavors. ";
+    description = "Parse Python docstrings in various flavors";
     homepage = "https://github.com/rr-/docstring_parser";
     license = licenses.mit;
     maintainers = with maintainers; [ SomeoneSerge ];


### PR DESCRIPTION
###### Description of changes
https://github.com/rr-/docstring_parser/blob/master/CHANGELOG.md#014-2022-04-25
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
