### PR TITLE
python310Packages.aws-adfs: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -5,7 +5,6 @@
 , click
 , configparser
 , fetchFromGitHub
-, fetchpatch
 , fido2
 , lxml
 , poetry-core
@@ -19,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "aws-adfs";
-  version = "2.0.1";
+  version = "2.0.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -28,7 +27,7 @@ buildPythonPackage rec {
     owner = "venth";
     repo = pname;
     rev = version;
-    hash = "sha256-0BURXbEOZvb8kszuajLtR+V7HjJycCBAQrm3WqpVB1w=";
+    hash = "sha256-T3AmPCOSeu7gvl57aHjnviy5iQAKlWy85fUOVecFRFc=";
   };
 
   nativeBuildInputs = [
@@ -45,15 +44,6 @@ buildPythonPackage rec {
     pyopenssl
     requests
     requests-kerberos
-  ];
-
-  patches = [
-    # Switch to poetry-core, https://github.com/venth/aws-adfs/pull/230
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/venth/aws-adfs/commit/da095ccf64629d36a6045ffec2684038378ee690.patch";
-      sha256 = "sha256-xg4c7iIonkUmNN74q/UeGSuYP3to7q4cLW6+TMW9nh4=";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes
https://github.com/venth/aws-adfs/releases/tag/2.0.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
