### PR TITLE
kalibrate-rtl: unstable-2013-12-14 -> unstable-2022-02-02

### DIFF
--- a/pkgs/applications/radio/kalibrate-rtl/default.nix
+++ b/pkgs/applications/radio/kalibrate-rtl/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/steve-m/kalibrate-rtl";
     license = licenses.bsd2;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ bjornfor ];
+    maintainers = with maintainers; [ bjornfor viraptor ];
   };
 }

--- a/pkgs/applications/radio/kalibrate-rtl/default.nix
+++ b/pkgs/applications/radio/kalibrate-rtl/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "kalibrate-rtl";
-  version = "unstable-2013-12-14";
+  version = "unstable-2022-02-02";
 
   src = fetchFromGitHub {
     owner = "steve-m";
     repo = "kalibrate-rtl";
-    rev = "aae11c8a8dc79692a94ccfee39ba01e8c8c05d38";
-    sha256 = "1spbfflkqnw9s8317ppsf7b1nnkicqsmaqsnz1zf8i49ix70i6kn";
+    rev = "340003eb0846b069c3edef19ed3363b8ac7b5215";
+    sha256 = "n9mfu8H2OS8dKPNhtJxBfMDp8aHEIcxg/R+kcRNOBpk=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/steve-m/kalibrate-rtl";
     license = licenses.bsd2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Update to a more recent version. It includes darwin support as one of the features.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
