### PR TITLE
gnumake: move $out/include/gnumake.h to dev output, remove default in…

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/0001-No-impure-bin-sh.patch
+++ b/pkgs/development/tools/build-managers/gnumake/0001-No-impure-bin-sh.patch
@@ -1,4 +1,4 @@
-From e00a5257a6ca5fedbf68b09eee7df3502971a057 Mon Sep 17 00:00:00 2001
+From d64b63a96986164f6dcb7ed21d6b21c5dfcdf8e9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Sat, 24 Apr 2021 10:11:40 +0200
 Subject: [PATCH 1/2] No impure bin sh
@@ -18,7 +18,7 @@ hard-coded has some advantages:
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/job.c b/src/job.c
-index ae1f18b..6b4ddb3 100644
+index ae1f18b9..6b4ddb36 100644
 --- a/src/job.c
 +++ b/src/job.c
 @@ -77,7 +77,7 @@ char * vms_strsignal (int status);
@@ -31,5 +31,5 @@ index ae1f18b..6b4ddb3 100644
  
  #endif
 -- 
-2.31.1
+2.35.3
 

--- a/pkgs/development/tools/build-managers/gnumake/0002-remove-impure-dirs.patch
+++ b/pkgs/development/tools/build-managers/gnumake/0002-remove-impure-dirs.patch
@@ -1,21 +1,24 @@
-From 795d63d3c8b5c0dbb7e544954f75507b371b7228 Mon Sep 17 00:00:00 2001
+From e86e384c4d164a76c36fec8158f9de3fe3573ced Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Sat, 24 Apr 2021 10:20:16 +0200
 Subject: [PATCH 2/2] remove impure dirs
 
 ---
- src/read.c   | 3 ---
- src/remake.c | 2 --
- 2 files changed, 5 deletions(-)
+ src/read.c   | 6 ------
+ src/remake.c | 4 ----
+ 2 files changed, 10 deletions(-)
 
 diff --git a/src/read.c b/src/read.c
-index fa197fb..defacfb 100644
+index fa197fb8..4f391928 100644
 --- a/src/read.c
 +++ b/src/read.c
-@@ -109,9 +109,6 @@ static const char *default_include_directories[] =
- #endif
-     INCLUDEDIR,
- #ifndef _AMIGA
+@@ -106,12 +106,6 @@ static const char *default_include_directories[] =
+ /* This completely up to the user when they install MSVC or other packages.
+    This is defined as a placeholder.  */
+ # define INCLUDEDIR "."
+-#endif
+-    INCLUDEDIR,
+-#ifndef _AMIGA
 -    "/usr/gnu/include",
 -    "/usr/local/include",
 -    "/usr/include",
@@ -23,18 +26,20 @@ index fa197fb..defacfb 100644
      0
    };
 diff --git a/src/remake.c b/src/remake.c
-index fb237c5..94bff7d 100644
+index fb237c5e..94cf66f0 100644
 --- a/src/remake.c
 +++ b/src/remake.c
-@@ -1601,8 +1601,6 @@ library_search (const char *lib, FILE_TIMESTAMP *mtime_ptr)
+@@ -1600,10 +1600,6 @@ library_search (const char *lib, FILE_TIMESTAMP *mtime_ptr)
+ {
    static const char *dirs[] =
      {
- #ifndef _AMIGA
+-#ifndef _AMIGA
 -      "/lib",
 -      "/usr/lib",
- #endif
+-#endif
  #if defined(WINDOWS32) && !defined(LIBDIR)
  /*
+  * This is completely up to the user at product install time. Just define
 -- 
-2.31.1
+2.35.3
 

--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     # See https://github.com/NixOS/nixpkgs/issues/51221 for discussion.
     ++ lib.optional stdenv.isDarwin "ac_cv_struct_st_mtim_nsec=no";
 
-  outputs = [ "out" "man" "info" ];
+  outputs = [ "out" "man" "info" "dev" ];
   separateDebugInfo = true;
 
   meta = with lib; {


### PR DESCRIPTION
…clude dir which pointed to $out/include

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
