### PR TITLE
protonvpn-cli: 2.2.6 -> 3.11.1, protonvpn-cli_2: init at 2.2.11

### DIFF
--- a/pkgs/applications/networking/protonvpn-cli/2.nix
+++ b/pkgs/applications/networking/protonvpn-cli/2.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, pythonOlder
+, requests
+, docopt
+, pythondialog
+, jinja2
+, distro
+, dialog
+, iptables
+, openvpn }:
+
+buildPythonApplication rec {
+  pname = "protonvpn-cli_2";
+  version = "2.2.11";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "Rafficer";
+    repo = "linux-cli-community";
+    # There is a tag and branch with the same name
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-CWQpisJPBXbf+d5tCGuxfSQQZBeF36WFF4b6OSUn3GY=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    docopt
+    pythondialog
+    jinja2
+    distro
+    dialog
+    openvpn
+    iptables
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Linux command-line client for ProtonVPN using Openvpn";
+    homepage = "https://github.com/Rafficer/linux-cli-community";
+    maintainers = with maintainers; [ jtcoolen jefflabonte shamilton ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    mainProgram = "protonvpn";
+  };
+}

--- a/pkgs/applications/networking/protonvpn-cli/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli/default.nix
@@ -1,37 +1,41 @@
-{ lib, fetchFromGitHub, python3Packages, openvpn, dialog, iptables }:
+{ lib
+, buildPythonApplication
+, pythonOlder
+, fetchFromGitHub
+, protonvpn-nm-lib
+, pythondialog
+, dialog
+}:
 
-python3Packages.buildPythonApplication rec {
-  pname = "protonvpn-linux-cli";
-  version = "2.2.6";
+buildPythonApplication rec {
+  pname = "protonvpn-cli";
+  version = "3.11.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "protonvpn";
     repo = "linux-cli";
-    rev = "v${version}";
-    sha256 = "0y7v9ikrmy5dbjlpbpacp08gy838i8z54m8m4ps7ldk1j6kyia3n";
+    rev = version;
+    sha256 = "sha256-u+POtUz7NoGS23aOmvDCZPUp2HW1xXGtfbZR88cWCBc=";
   };
 
-  propagatedBuildInputs = (with python3Packages; [
-      requests
-      docopt
-      setuptools
-      jinja2
-      pythondialog
-    ]) ++ [
-      dialog
-      openvpn
-      iptables
-    ];
+  propagatedBuildInputs = [
+    protonvpn-nm-lib
+    pythondialog
+    dialog
+  ];
 
-  # No tests
+  # Project has a dummy test
   doCheck = false;
 
   meta = with lib; {
     description = "Linux command-line client for ProtonVPN";
     homepage = "https://github.com/protonvpn/linux-cli";
-    maintainers = with maintainers; [ jtcoolen jefflabonte shamilton ];
+    maintainers = with maintainers; [ wolfangaukang ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    mainProgram = "protonvpn";
+    mainProgram = "protonvpn-cli";
   };
 }

--- a/pkgs/development/python-modules/protonvpn-nm-lib/0001-Patching-GIRepository.patch
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/0001-Patching-GIRepository.patch
@@ -1,0 +1,22 @@
+From 2867f022aad754fe54d95222b3ae52f6e7f14c2f Mon Sep 17 00:00:00 2001
+From: "P. R. d. O" <d.ol.rod@tutanota.com>
+Date: Wed, 27 Apr 2022 21:49:12 -0600
+Subject: [PATCH] Patching GIRepository
+
+---
+ protonvpn_nm_lib/__init__.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/protonvpn_nm_lib/__init__.py b/protonvpn_nm_lib/__init__.py
+index e69de29..00b95f4 100644
+--- a/protonvpn_nm_lib/__init__.py
++++ b/protonvpn_nm_lib/__init__.py
+@@ -0,0 +1,5 @@
++import gi
++gi.require_version('GIRepository', '2.0')
++from gi.repository import GIRepository
++repo = GIRepository.Repository.get_default()
++repo.prepend_search_path('@networkmanager_path@')
+-- 
+2.35.1
+

--- a/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, substituteAll
 , distro
 , jinja2
 , keyring
@@ -9,18 +10,19 @@
 , pygobject3
 , pyxdg
 , systemd
+, networkmanager
 }:
 
 buildPythonPackage rec {
   pname = "protonvpn-nm-lib";
-  version = "3.8.0";
+  version = "3.9.0";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = pname;
     rev = version;
-    sha256 = "sha256-fAaP9c66LcbZgezadGPUt400YRnrnFoBvpzlc1zxuc4=";
+    sha256 = "sha256-yV3xeIyPc2DJj5DOa5PA1MHt00bjJ/Y9zZK77s/XRAA=";
   };
 
   propagatedBuildInputs = [
@@ -33,7 +35,15 @@ buildPythonPackage rec {
     systemd
   ];
 
-  # Project has a dummy test.
+  patches = [
+    (substituteAll {
+      src = ./0001-Patching-GIRepository.patch;
+      networkmanager_path = "${networkmanager}/lib/girepository-1.0";
+    })
+  ];
+
+  # Checks cannot be run in the sandbox
+  # "Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory"
   doCheck = false;
 
   pythonImportsCheck = [ "protonvpn_nm_lib" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29023,6 +29023,7 @@ with pkgs;
   protonmail-bridge = callPackage ../applications/networking/protonmail-bridge { };
 
   protonvpn-cli = python3Packages.callPackage ../applications/networking/protonvpn-cli { };
+  protonvpn-cli_2 = python3Packages.callPackage ../applications/networking/protonvpn-cli/2.nix { };
 
   protonvpn-gui = python3Packages.callPackage ../applications/networking/protonvpn-gui { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29022,7 +29022,7 @@ with pkgs;
 
   protonmail-bridge = callPackage ../applications/networking/protonmail-bridge { };
 
-  protonvpn-cli = callPackage ../applications/networking/protonvpn-cli { };
+  protonvpn-cli = python3Packages.callPackage ../applications/networking/protonvpn-cli { };
 
   protonvpn-gui = python3Packages.callPackage ../applications/networking/protonvpn-gui { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a major update on ProtonVPN CLI. I was able to test it with my basic account and here are the logs:
```
2022-04-28 03:59:41,850 — cli.py — INFO — __init__:17 — 
-------------------------------------------------

-----------	Initialized protonvpn-cli	-----------

-------------------------------------------------
2022-04-28 03:59:41,850 — cli.py — INFO — __init__:29 — ProtonVPN CLI v3.11.1 (protonvpn-nm-lib v3.8.0; proton-client v0.7.1)
2022-04-28 03:59:41,857 — cli.py — INFO — __init__:64 — CLI command: Namespace(command='c', version=False, help=False, get_logs=False)
2022-04-28 03:59:41,859 — cli.py — INFO — connect:128 — Options: Namespace(servername=None, fastest=False, random=False, cc=None, sc=False, p2p=False, tor=False, protocol=None, help=False)
2022-04-28 03:59:43,968 — cli_dialog.py — INFO — start:59 — Selected country: "United States"
2022-04-28 03:59:48,192 — cli_dialog.py — INFO — start:63 — Selected server: "US-FREE#24"
2022-04-28 03:59:49,087 — cli_dialog.py — INFO — start:67 — Selected protocol: "udp"
2022-04-28 03:59:53,902 — cli_wrapper.py — INFO — _connect:485 — Dbus response: {<ConnectionStartStatusEnum.STATE: 'state'>: <VPNConnectionStateEnum.IS_ACTIVE: 5>, <ConnectionStartStatusEnum.MESSAGE: 'message'>: 'Successfully connected to ProtonVPN.', <ConnectionStartStatusEnum.REASON: 'reason'>: <VPNConnectionReasonEnum.NOT_PROVIDED: 1>}
2022-04-28 03:59:57,697 — cli.py — INFO — __init__:17 — 
-------------------------------------------------

-----------	Initialized protonvpn-cli	-----------

-------------------------------------------------
2022-04-28 03:59:57,697 — cli.py — INFO — __init__:29 — ProtonVPN CLI v3.11.1 (protonvpn-nm-lib v3.8.0; proton-client v0.7.1)
2022-04-28 03:59:57,704 — cli.py — INFO — __init__:64 — CLI command: Namespace(command='d', version=False, help=False, get_logs=False)
2022-04-28 04:00:08,039 — cli.py — INFO — __init__:17 — 
-------------------------------------------------

-----------	Initialized protonvpn-cli	-----------

-------------------------------------------------
2022-04-28 04:00:08,039 — cli.py — INFO — __init__:29 — ProtonVPN CLI v3.11.1 (protonvpn-nm-lib v3.8.0; proton-client v0.7.1)
```

The fix done on `protonvpn-nm-lib` is taken from #129333. Without it, ProtonVPN CLI is not able to find some libraries from NetworkManager

Also, as the previous unofficial version (2) performs the connection through OpenVPN instead of NetworkManager (which does not require root), I am naming it `protonvpn-cli2`. Both are working as intended.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
