### PR TITLE
zq: init at v1.2.0

### DIFF
--- a/pkgs/development/tools/zq/default.nix
+++ b/pkgs/development/tools/zq/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildGoModule
+, testers
+, zq
+}:
+
+buildGoModule rec {
+  pname = "zq";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "brimdata";
+    repo = "zed";
+    rev = "v${version}";
+    hash = "sha256-BK4LB37jr/9O0sjYgFtnEkbFqTsp/1+hcmCNMFDPiPM=";
+  };
+
+  vendorSha256 = "sha256-oAkQRUaEP/RNjpDH4U8XFVokf7KiLk0OWMX+U7qny70=";
+
+  subPackages = [ "cmd/zq" ];
+
+  ldflags = [ "-s" "-X" "github.com/brimdata/zed/cli.Version=${version}" ];
+
+  passthru.tests = testers.testVersion { package = zq; };
+
+  meta = with lib; {
+    description = "A command-line tool for processing data in diverse input formats, providing search, analytics, and extensive transformations using the Zed language";
+    homepage = "https://zed.brimdata.io";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ knl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1356,6 +1356,8 @@ with pkgs;
 
   breitbandmessung = callPackage ../applications/networking/breitbandmessung { };
 
+  zq = callPackage ../development/tools/zq { buildGoModule = buildGo118Module; };
+
   ### APPLICATIONS/EMULATORS
 
   atari800 = callPackage ../applications/emulators/atari800 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
