### PR TITLE
octoprint: fix build failure due to python upgrades

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -174,6 +174,7 @@ let
               };
               disabledTestPaths = [
                 "t/unit/backends/test_mongodb.py"
+                "t/unit/backends/test_cassandra.py"
               ];
             });
           }
@@ -250,6 +251,24 @@ let
                 # requires network
                 "test_worker.py"
               ];
+            });
+          }
+        )
+
+         (
+          self: super: {
+            flask-restful = super.flask-restful.overridePythonAttrs (oldAttrs: rec {
+              # remove werkzeug patch
+              patches = [];
+            });
+          }
+        )
+
+        (
+          self: super: {
+            trytond = super.trytond.overridePythonAttrs (oldAttrs: rec {
+              # remove werkzeug patch
+              patches = [];
             });
           }
         )
@@ -406,6 +425,7 @@ let
                     "watchdog"
                     "wrapt"
                     "zeroconf"
+                    "Flask-Login"
                   ];
                 in
                 ''


### PR DESCRIPTION
###### Description of changes

Due to the recent python upgrades, octoprint fails to build. 
This is hopefully my last bandaid commit until #165328 lands. 

@abbradar @gebner @WhittlesJr : Do you still maintain this package?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

