### PR TITLE
distrobox: 1.2.14 -> 1.2.15

### DIFF
--- a/pkgs/applications/virtualization/distrobox/default.nix
+++ b/pkgs/applications/virtualization/distrobox/default.nix
@@ -2,13 +2,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "distrobox";
-  version = "1.2.14";
+  version = "1.2.15";
 
   src = fetchFromGitHub {
     owner = "89luca89";
     repo = pname;
     rev = version;
-    sha256 = "sha256-gHKyuIL4K/SLBJw8xNuPdNifDcHI91AFTiHaiv38gus=";
+    sha256 = "sha256-9rivXnHyEE1MoGY+CwUeDStLGPVq+4FvwPjV7Nblk60=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
##### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
###### What's Changed

```
+ docs: Fix misspellings by @maiki in #232
+ docs: Update host-distro instruction for openSUSE Tumbleweed and MicroOS by @dfaggioli in #218
+ docs: Update run_latest_gnome_kde_on_distrobox.md by @bam80
+ init: Allow all package manager checks to run by @nathanchance in #224
+ init: Fix compatibility with init containers by @89luca89 in #216
+ init: add pacman post-hook to neutralize systemd post-hooks in case we're not in an init-enabled container
+ init: exclude dbus system socket sharing, it doesn't work and creates confusing error messages, Fix #246
+ init: fix missing check before umounting on init-enabled containers
+ init: fix new archlinux mount: /usr/lib/libmount.so.1: version MOUNT_2_38 not found (required by mount) error, upgrade before installing packages
+ init: fix regression introduced in 3f014de where containers where thinking they were on a booted systemd
+ init: improve arch linux integration - add pacman pre-post hooks to reduce number of errors occurring
+ create/enter: print error messages only when not in dry-run
+ create: add work around for incompatibility between systemd/journald ACLs and overlayfs, Fix #243
+ enter: check for container errors during first start, Fix #242
+ enter: do not instantiate a tty if we do not have one
+ enter: extract container SHELL from inspect, use that as fallback if no custom command provided #227
+ enter: fix boolean logic on tty use
+ enter: fix unbound variable with --dry-run by @vyskocilm in #244
+ export: hide unuseful stderr in export
+ New Contributors
+ @maiki made their first contribution in #232
+ @bam80 made their first contribution in #233
+ @vyskocilm made their first contribution in #244
```

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
