### PR TITLE
3llo: 0.3.0 -> 1.3.1

### DIFF
--- a/pkgs/tools/misc/3llo/Gemfile
+++ b/pkgs/tools/misc/3llo/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem '3llo', '0.3.0'
+gem '3llo', '1.3.1'

--- a/pkgs/tools/misc/3llo/Gemfile.lock
+++ b/pkgs/tools/misc/3llo/Gemfile.lock
@@ -1,27 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    3llo (0.3.0)
-      tty-prompt (~> 0.12.0)
-    equatable (0.6.1)
-    necromancer (0.4.0)
-    pastel (0.7.3)
-      equatable (~> 0.6)
+    3llo (1.3.1)
+      tty-prompt (~> 0.20)
+    pastel (0.8.0)
       tty-color (~> 0.5)
-    tty-color (0.5.0)
-    tty-cursor (0.4.0)
-    tty-prompt (0.12.0)
-      necromancer (~> 0.4.0)
-      pastel (~> 0.7.0)
-      tty-cursor (~> 0.4.0)
-      wisper (~> 1.6.1)
-    wisper (1.6.1)
+    tty-color (0.6.0)
+    tty-cursor (0.7.1)
+    tty-prompt (0.23.1)
+      pastel (~> 0.8)
+      tty-reader (~> 0.8)
+    tty-reader (0.9.0)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      wisper (~> 2.0)
+    tty-screen (0.8.1)
+    wisper (2.0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  3llo (= 0.3.0)
+  3llo (= 1.3.1)
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/pkgs/tools/misc/3llo/default.nix
+++ b/pkgs/tools/misc/3llo/default.nix
@@ -1,24 +1,10 @@
-{ lib, ruby, bundlerApp, fetchpatch }:
+{ lib, ruby_3_0, bundlerApp, fetchpatch }:
 
 bundlerApp {
   pname = "3llo";
+  ruby = ruby_3_0;
 
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-
-  gemset = lib.recursiveUpdate (import ./gemset.nix) ({
-    "3llo" = {
-      dontBuild = false;
-      patches = [
-        (fetchpatch {
-          url = "https://github.com/qcam/3llo/commit/7667c67fdc975bac315da027a3c69f49e7c06a2e.patch";
-          sha256 = "0ahp19igj77x23b2j9zk3znlmm7q7nija7mjgsmgqkgfbz2r1y7v";
-        })
-      ];
-    };
-  });
-
-  inherit ruby;
+  gemdir  = ./.;
 
   exes = [ "3llo" ];
 

--- a/pkgs/tools/misc/3llo/gemset.nix
+++ b/pkgs/tools/misc/3llo/gemset.nix
@@ -5,81 +5,82 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "082g42lkkynnb2piz37ih696zm2ms63mz2q9rnfzjsd149ig39yy";
+      sha256 = "1w327skga2lpq9rbqqxy6w1r6k9k1l8prk5wmzrycvydn1wp7jk2";
       type = "gem";
     };
-    version = "0.3.0";
-  };
-  equatable = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0fzx2ishipnp6c124ka6fiw5wk42s7c7gxid2c4c1mb55b30dglf";
-      type = "gem";
-    };
-    version = "0.6.1";
-  };
-  necromancer = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0v9nhdkv6zrp7cn48xv7n2vjhsbslpvs0ha36mfkcd56cp27pavz";
-      type = "gem";
-    };
-    version = "0.4.0";
+    version = "1.3.1";
   };
   pastel = {
-    dependencies = ["equatable" "tty-color"];
+    dependencies = ["tty-color"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0m43wk7gswwkl6lfxwlliqc9v1qp8arfygihyz91jc9icf270xzm";
+      sha256 = "0xash2gj08dfjvq4hy6l1z22s5v30fhizwgs10d6nviggpxsj7a8";
       type = "gem";
     };
-    version = "0.7.3";
+    version = "0.8.0";
   };
   tty-color = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zpp6zixkkchrc2lqnabrsy24pxikz2px87ggz5ph6355fs803da";
+      sha256 = "0aik4kmhwwrmkysha7qibi2nyzb4c8kp42bd5vxnf8sf7b53g73g";
       type = "gem";
     };
-    version = "0.5.0";
+    version = "0.6.0";
   };
   tty-cursor = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "07whfm8mnp7l49s2cm2qy1snhsqq3a90sqwb71gvym4hm2kx822a";
+      sha256 = "0j5zw041jgkmn605ya1zc151bxgxl6v192v2i26qhxx7ws2l2lvr";
       type = "gem";
     };
-    version = "0.4.0";
+    version = "0.7.1";
   };
   tty-prompt = {
-    dependencies = ["necromancer" "pastel" "tty-cursor" "wisper"];
+    dependencies = ["pastel" "tty-reader"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1026nyqhgmgxi2nmk8xk3hca07gy5rpisjs8y6w00wnw4f01kpv0";
+      sha256 = "1j4y8ik82azjxshgd4i1v4wwhsv3g9cngpygxqkkz69qaa8cxnzw";
       type = "gem";
     };
-    version = "0.12.0";
+    version = "0.23.1";
+  };
+  tty-reader = {
+    dependencies = ["tty-cursor" "tty-screen" "wisper"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cf2k7w7d84hshg4kzrjvk9pkyc2g1m3nx2n1rpmdcf0hp4p4af6";
+      type = "gem";
+    };
+    version = "0.9.0";
+  };
+  tty-screen = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18jr6s1cg8yb26wzkqa6874q0z93rq0y5aw092kdqazk71y6a235";
+      type = "gem";
+    };
+    version = "0.8.1";
   };
   wisper = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "19bw0z1qw1dhv7gn9lad25hgbgpb1bkw8d599744xdfam158ms2s";
+      sha256 = "1rpsi0ziy78cj82sbyyywby4d0aw0a5q84v65qd28vqn79fbq5yf";
       type = "gem";
     };
-    version = "1.6.1";
+    version = "2.0.1";
   };
 }


### PR DESCRIPTION
###### Description of changes

```
v1.3.1

    Require Ruby version 3

v1.3.0

    Support Ruby version 3
    Fix comment listing (#86)

v1.2.0

    Support running multiple commands with --init switch (#83)
    Include current board name to status line (#77)
    Introduce card add-label command (#74)
    Support multiline card description (#72)

v1.1.0

    Introduce "list add" command.
    Introduce "board add" command.
    Introduce label related command.
    Support exiting with Ctrl+D.

v1.0.0

    Support using shortcuts to access entities.
    Introduce --config switch.
    Introduce --init switch.
    Introduce --configure switch.
    Deprecate using environment variables for configuration.
    Improve performance of several commands.
    Support checklist related commands.
    Support Ruby 2.5+.
    Introduce card edit command.
    Improve command auto completion.
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).