### PR TITLE
cifs-utils: fix two security issues

### DIFF
--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/piastry/cifs-utils/commit/007c07fd91b6d42f8bd45187cf78ebb06801139d.patch";
       sha256 = "sha256-3uoHso2q17r2bcEW+ZjYUWsW4OIGYA7kxYZxQQy0JOg=";
     })
+    (fetchpatch {
+      # Fix disclosure of invalid credential configuration in verbose mode
+      name = "CVE-2022-29869.patch";
+      url = "https://github.com/piastry/cifs-utils/commit/8acc963a2e7e9d63fe1f2e7f73f5a03f83d9c379.patch";
+      sha256 = "sha256-MjfreeL1ME550EYK9LPOUAAjIk1BoMGfb+pQe3A1bz8=";
+    })
   ];
 
   nativeBuildInputs = [ autoreconfHook docutils pkg-config ];

--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoreconfHook, docutils, pkg-config
+{ stdenv, lib, fetchurl, fetchpatch, autoreconfHook, docutils, pkg-config
 , libkrb5, keyutils, pam, talloc, python3 }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,16 @@ stdenv.mkDerivation rec {
     url = "mirror://samba/pub/linux-cifs/cifs-utils/${pname}-${version}.tar.bz2";
     sha256 = "sha256-ZgnoB0tUISlf8BKjHwLM2aBYQVxhnIE2Lrt4jb8HVrg=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Fix buffer-overflow in handling of ip= parameter in mount.cifs
+      # https://www.openwall.com/lists/oss-security/2022/04/27/5
+      name = "CVE-2022-27239.patch";
+      url = "https://github.com/piastry/cifs-utils/commit/007c07fd91b6d42f8bd45187cf78ebb06801139d.patch";
+      sha256 = "sha256-3uoHso2q17r2bcEW+ZjYUWsW4OIGYA7kxYZxQQy0JOg=";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook docutils pkg-config ];
 


### PR DESCRIPTION
https://www.openwall.com/lists/oss-security/2022/04/27/5
https://github.com/piastry/cifs-utils/pull/7

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
