### PR TITLE
paperless-ngx: 1.6.0 -> 1.7.1

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -196,6 +196,6 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     description = "A supercharged version of paperless: scan, index, and archive all of your physical documents";
     homepage = "https://paperless-ngx.readthedocs.io/en/latest/";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ lukegb ];
+    maintainers = with maintainers; [ lukegb gador earvstedt ];
   };
 }

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchurl
-, fetchpatch
 , nixosTests
 , python3
 , ghostscript
@@ -15,11 +14,16 @@
 }:
 
 let
+  # Use specific package versions required by paperless-ngx
   py = python3.override {
     packageOverrides = self: super: {
-      django = super.django_3;
+      django = super.django_4;
 
-      # Incompatible with aioredis 2
+      # django-extensions 3.1.5 is required, but its tests are incompatible with Django 4
+      django-extensions = super.django-extensions.overridePythonAttrs (_: {
+        doCheck = false;
+      });
+
       aioredis = super.aioredis.overridePythonAttrs (oldAttrs: rec {
         version = "1.3.1";
         src = oldAttrs.src.override {
@@ -34,11 +38,12 @@ let
 in
 py.pkgs.pythonPackages.buildPythonApplication rec {
   pname = "paperless-ngx";
-  version = "1.6.0";
+  version = "1.7.1";
 
+  # Fetch the release tarball instead of a git ref because it contains the prebuilt fontend
   src = fetchurl {
-    url = "https://github.com/paperless-ngx/paperless-ngx/releases/download/ngx-${version}/${pname}-${version}.tar.xz";
-    sha256 = "07mrxbwahkm00n9nvssd6d13p80w333g84cd38bzp0l34nzim5zl";
+    url = "https://github.com/paperless-ngx/paperless-ngx/releases/download/v${version}/${pname}-v${version}.tar.xz";
+    hash = "sha256-8vx4hvbIqaChjPyS8Q0ar2bz/pLzEdxoF7P2gBEeFzc=";
   };
 
   format = "other";
@@ -92,6 +97,7 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     numpy
     ocrmypdf
     pathvalidate
+    pdf2image
     pdfminer-six
     pikepdf
     pillow
@@ -109,6 +115,7 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     python-magic
     pytz
     pyyaml
+    pyzbar
     redis
     regex
     reportlab

--- a/pkgs/development/python-modules/pdf2image/default.nix
+++ b/pkgs/development/python-modules/pdf2image/default.nix
@@ -4,12 +4,17 @@ buildPythonPackage rec {
   pname = "pdf2image";
   version = "1.16.0";
 
-  propagatedBuildInputs = [ pillow poppler_utils ];
+  propagatedBuildInputs = [ pillow ];
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "d58ed94d978a70c73c2bb7fdf8acbaf2a7089c29ff8141be5f45433c0c4293bb";
   };
+
+  postPatch = ''
+    # Only replace first match in file
+    sed -i '0,/poppler_path=None/s||poppler_path="${poppler_utils}/bin"|' pdf2image/pdf2image.py
+  '';
 
   meta = with lib; {
     description = "A python module that wraps the pdftoppm utility to convert PDF to PIL Image object";


### PR DESCRIPTION
**Edit:** This PR is now ready to merge

### Old PR description

I gave this a quick shot, here are some preliminary results.

Changes in `requirements.txt` from 1.6.0 to 1.7.1:
```
# Added pkgs:
anyio
pdf2image
pyzbar
sniffio

# Changed pkgs:
psycopg2-binary -> psycopg2
```
I've only added pkgs `pdf2image`, `pyzbar`. These are the only new pkgs that are used directly by paperless (i.e., they are not a transitive dependency).

With this PR, one `paperless-ngx` tests is failing. (**Edit: Updating 1.7.0 -> 1.7.1 fixed a previously failing test**)
I'm happy to accept patches.

```
paperless-ngx> ――――――――――――――――――――――― TestConsumer.testNormalOperation ―――――――――――――――――――――――
paperless-ngx> [gw2] linux -- Python 3.9.12 /nix/store/hym1n0ygqp9wcm7pxn4sfrql3fg7xa09-python3-3.9.12/bin/python3.9
paperless-ngx> self = <documents.tests.test_consumer.TestConsumer testMethod=testNormalOperation>
paperless-ngx>     @override_settings(PAPERLESS_FILENAME_FORMAT=None, TIME_ZONE="America/Chicago")
paperless-ngx>     def testNormalOperation(self):
paperless-ngx>         filename = self.get_test_file()
paperless-ngx>         document = self.consumer.try_consume_file(filename)
paperless-ngx>         self.assertEqual(document.content, "The Text")
paperless-ngx>         self.assertEqual(
paperless-ngx>             document.title,
paperless-ngx>             os.path.splitext(os.path.basename(filename))[0],
paperless-ngx>         )
paperless-ngx>         self.assertIsNone(document.correspondent)
paperless-ngx>         self.assertIsNone(document.document_type)
paperless-ngx>         self.assertEqual(document.filename, "0000001.pdf")
paperless-ngx>         self.assertEqual(document.archive_filename, "0000001.pdf")
paperless-ngx>         self.assertTrue(os.path.isfile(document.source_path))
paperless-ngx>         self.assertTrue(os.path.isfile(document.thumbnail_path))
paperless-ngx>         self.assertTrue(os.path.isfile(document.archive_path))
paperless-ngx>         self.assertEqual(document.checksum, "42995833e01aea9b3edee44bbfdd7ce1")
paperless-ngx>         self.assertEqual(document.archive_checksum, "62acb0bcbfbcaa62ca6ad3668e4e404b")
paperless-ngx>         self.assertFalse(os.path.isfile(filename))
paperless-ngx>         self._assert_first_last_send_progress()
paperless-ngx> >       self.assertEqual(document.created.tzinfo, zoneinfo.ZoneInfo("America/Chicago"))
paperless-ngx> E       AssertionError: <DstTzInfo 'America/Chicago' CDT-1 day, 19:00:00 DST> != zoneinfo.ZoneInfo(key='America/Chicago')
paperless-ngx> src/documents/tests/test_consumer.py:349: AssertionError
paperless-ngx> ----------------------------- Captured stderr call -----------------------------
paperless-ngx> [2022-05-29 10:56:22,769] [INFO] [paperless.consumer] Consuming sample.pdf
paperless-ngx> [2022-05-29 10:56:22,801] [INFO] [paperless.consumer] Document 2022-05-29 sample consumption finished
paperless-ngx> ------------------------------ Captured log call -------------------------------
paperless-ngx> INFO     paperless.consumer:loggers.py:21 Consuming sample.pdf
paperless-ngx> DEBUG    paperless.consumer:loggers.py:21 Detected mime type: application/pdf
paperless-ngx> DEBUG    paperless.consumer:loggers.py:21 Parser: DummyParser
paperless-ngx> DEBUG    paperless.consumer:loggers.py:21 Parsing sample.pdf...
paperless-ngx> DEBUG    paperless.consumer:loggers.py:21 Generating thumbnail for sample.pdf...
paperless-ngx> DEBUG    paperless.classifier:classifier.py:32 Document classification model does not exist (yet), not performing automatic matching.
paperless-ngx> DEBUG    paperless.consumer:loggers.py:21 Saving record to database
paperless-ngx> DEBUG    paperless.consumer:loggers.py:21 Deleting file /build/tmp7sg8t13f/sample.pdf
paperless-ngx> DEBUG    paperless.parsing:loggers.py:21 Deleting directory /build/tmp7sg8t13f/paperless-if2x7q1k
paperless-ngx> INFO     paperless.consumer:loggers.py:21 Document 2022-05-29 sample consumption finished
```