### PR TITLE
fluxcd: update script improved v1

### DIFF
--- a/pkgs/applications/networking/cluster/fluxcd/update.sh
+++ b/pkgs/applications/networking/cluster/fluxcd/update.sh
@@ -3,36 +3,43 @@
 
 set -x -eu -o pipefail
 
-cd $(dirname "${BASH_SOURCE[0]}")
+NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
+FLUXCD_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/fluxcd/flux2/releases/latest | jq -r '.tag_name')
+OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; fluxcd.version or (builtins.parseDrvName fluxcd.name).version" | tr -d '"')"
+LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/fluxcd/flux2/releases/latest | jq -r '.tag_name')
+LATEST_VERSION=$(echo ${LATEST_TAG} | sed 's/^v//')
 
-VERSION=$(echo ${TAG} | sed 's/^v//')
+if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
+    SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/archive/refs/tags/${LATEST_TAG}.tar.gz)
+    SPEC_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/releases/download/${LATEST_TAG}/manifests.tar.gz)
 
-SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/archive/refs/tags/${TAG}.tar.gz)
+    setKV () {
+        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${FLUXCD_PATH}/default.nix"
+    }
 
-SPEC_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/releases/download/${TAG}/manifests.tar.gz)
+    setKV version ${LATEST_VERSION}
+    setKV sha256 ${SHA256}
+    setKV manifestsSha256 ${SPEC_SHA256}
+    setKV vendorSha256 "0000000000000000000000000000000000000000000000000000" # The same as lib.fakeSha256
 
-setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
-}
+    set +e
+    VENDOR_SHA256=$(nix-build --no-out-link -A fluxcd $NIXPKGS_PATH 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
+    set -e
 
-setKV version ${VERSION}
-setKV sha256 ${SHA256}
-setKV manifestsSha256 ${SPEC_SHA256}
-setKV vendorSha256 "0000000000000000000000000000000000000000000000000000" # The same as lib.fakeSha256
+    if [ -n "${VENDOR_SHA256:-}" ]; then
+        setKV vendorSha256 ${VENDOR_SHA256}
+    else
+        echo "Update failed. VENDOR_SHA256 is empty."
+        exit 1
+    fi
 
-cd ../../../../../
-set +e
-VENDOR_SHA256=$(nix-build --no-out-link -A fluxcd 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
-set -e
-
-cd - > /dev/null
-
-if [ -n "${VENDOR_SHA256:-}" ]; then
-    setKV vendorSha256 ${VENDOR_SHA256}
+    # `git` flag here is to be used by local maintainers to speed up the bump process
+    if [ "$1" = "git" ]; then
+        git switch -c "package-fluxcd-${LATEST_VERSION}"
+        git add "$FLUXCD_PATH"/default.nix
+        git commit -m "fluxcd: ${OLD_VERSION} -> ${LATEST_VERSION}"
+    fi
 else
-    echo "Update failed. VENDOR_SHA256 is empty."
-    exit 1
+    echo "fluxcd is already up-to-date at $OLD_VERSION"
 fi
-


### PR DESCRIPTION
fluxcd: update script improved v1

* optional `git` flag: executes commit on it's own (useful to skip steps when manually bumping package)
* doesn't run nix-build if update is not necessary
* better path logic

Note: This package is already outdated, fluxcd 2.29.5 is out, if this gets merged sooner it can be promptly tested in practice. Logs at:
https://r.ryantm.com/log/updatescript/fluxcd/

Addendum:
Usually I wouldn't bother improving this script further but this application is releasing too often and it warns when outdated, gets annoying. Ideally we could automatically bump these packages without needing intervention. So we can actually focus on tests instead of bumping it. I guess if upstream does something unsafe, we wouldn't notice anyway, I don't read upstream source code. Do you? Let me know of thoughts on this. Seeking a solution to this daily routine.