### PR TITLE
chainer: fix cuda

### DIFF
--- a/pkgs/development/python-modules/chainer/default.nix
+++ b/pkgs/development/python-modules/chainer/default.nix
@@ -16,10 +16,6 @@ buildPythonPackage rec {
     sha256 = "1n07zjzc4g92m1sbgxvnansl0z00y4jnhma2mw06vnahs7s9nrf6";
   };
 
-  postPatch = ''
-    substituteInPlace chainer/_version.py --replace ",<8.0.0" ""
-  '';
-
   checkInputs = [
     pytestCheckHook
     mock
@@ -33,6 +29,11 @@ buildPythonPackage rec {
   ] ++ lib.optionals cudaSupport [ cupy ];
 
   pytestFlagsArray = [ "tests/chainer_tests/utils_tests" ];
+
+  # cf. https://github.com/chainer/chainer/issues/8621
+  preCheck = ''
+    export CHAINER_WARN_VERSION_MISMATCH=0
+  '';
 
   disabledTests = [
     "gpu"

--- a/pkgs/development/python-modules/chainer/default.nix
+++ b/pkgs/development/python-modules/chainer/default.nix
@@ -16,6 +16,10 @@ buildPythonPackage rec {
     sha256 = "1n07zjzc4g92m1sbgxvnansl0z00y4jnhma2mw06vnahs7s9nrf6";
   };
 
+  postPatch = ''
+    substituteInPlace chainer/_version.py --replace ",<8.0.0" ""
+  '';
+
   checkInputs = [
     pytestCheckHook
     mock
@@ -39,8 +43,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A flexible framework of neural networks for deep learning";
     homepage = "https://chainer.org/";
-    # Un-break me when updating chainer next time!
-    broken = cudaSupport && (lib.versionAtLeast cupy.version "8.0.0");
     license = licenses.mit;
     maintainers = with maintainers; [ hyphon81 ];
   };


### PR DESCRIPTION
Upstream is not testing chainer with `cupy >= 8.0.0`, whereas current major release of cupy packaged by nixpkgs is 10.
Chainer aborts at import time when it sees the new cupy, unless told not to by an environment variable.
This results in a failed `checkPhase` for us.

We can either remove the warning altogether (the first commit) or hide it
during the `checkPhase` (second commit). I prefer the former because it removes
the need for messing with environment variables at runtime (we could just stop
requesting for pkg-resources at runtime entirely even), but maybe then we
should add a message that cuda users should report issues in nixpkgs and not
upstream. The latter has the advantage that we don't modify the upstream
release in any way, so the users may actually go and report upstream if they
need to.

- python3Packages.chainer: rm cupy warning
- python3Packages: restore warning, but fix tests

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
