### PR TITLE
nss_latest: 3.76.1 -> 3.77

### DIFF
--- a/pkgs/development/libraries/nss/85_security_load_3.77+.patch
+++ b/pkgs/development/libraries/nss/85_security_load_3.77+.patch
@@ -1,0 +1,77 @@
+diff --git nss/cmd/shlibsign/shlibsign.c nss/cmd/shlibsign/shlibsign.c
+index ad8f3b84e..74676d039 100644
+--- nss/cmd/shlibsign/shlibsign.c
++++ nss/cmd/shlibsign/shlibsign.c
+@@ -875,6 +875,8 @@ main(int argc, char **argv)
+         goto cleanup;
+     }
+     lib = PR_LoadLibrary(libname);
++    if (!lib)
++        lib = PR_LoadLibrary(NIX_NSS_LIBDIR"libsoftokn3.so");
+     assert(lib != NULL);
+     if (!lib) {
+         PR_fprintf(PR_STDERR, "loading softokn3 failed");
+diff --git nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
+index 119c8c512..4f06ef628 100644
+--- nss/lib/pk11wrap/pk11load.c
++++ nss/lib/pk11wrap/pk11load.c
+@@ -485,6 +485,16 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
+         }
+ #else
+         library = PR_LoadLibrary(mod->dllName);
++
++#ifndef NSS_STATIC_SOFTOKEN
++	if ((library == NULL) &&
++            !rindex(mod->dllName, PR_GetDirectorySeparator())) {
++            library = PORT_LoadLibraryFromOrigin(my_shlib_name,
++                (PRFuncPtr) &softoken_LoadDSO,
++                mod->dllName);
++	}
++#endif
++
+ #endif // defined(_WIN32)
+         mod->library = (void *)library;
+ 
+diff --git nss/lib/util/secload.c nss/lib/util/secload.c
+index 12efd2f75..8b74478f6 100644
+--- nss/lib/util/secload.c
++++ nss/lib/util/secload.c
+@@ -70,9 +70,14 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
+ 
+     /* Remove the trailing filename from referencePath and add the new one */
+     c = strrchr(referencePath, PR_GetDirectorySeparator());
++    if (!c) { /* referencePath doesn't contain a / means that dladdr gave us argv[0]
++               * and program was called from $PATH. Hack to get libs from NIX_NSS_LIBDIR */
++        referencePath = NIX_NSS_LIBDIR;
++        c = (char*) &referencePath[sizeof(NIX_NSS_LIBDIR) - 1]; /* last / */
++    }
+     if (c) {
+         size_t referencePathSize = 1 + c - referencePath;
+-        fullName = (char*)PORT_Alloc(strlen(name) + referencePathSize + 1);
++        fullName = (char*) PORT_Alloc(strlen(name) + referencePathSize + 5);
+         if (fullName) {
+             memcpy(fullName, referencePath, referencePathSize);
+             strcpy(fullName + referencePathSize, name);
+@@ -82,6 +87,11 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
+ #endif
+             libSpec.type = PR_LibSpec_Pathname;
+             libSpec.value.pathname = fullName;
++            if ((referencePathSize >= 4) &&
++                (strncmp(fullName + referencePathSize - 4, "bin", 3) == 0)) {
++                memcpy(fullName + referencePathSize -4, "lib", 3);
++            }
++            strcpy(fullName + referencePathSize, name);
+             dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL
+ #ifdef PR_LD_ALT_SEARCH_PATH
+                                                        /* allow library's dependencies to be found in the same directory
+@@ -89,6 +99,10 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
+                                                        | PR_LD_ALT_SEARCH_PATH
+ #endif
+                                           );
++            if (! dlh) {
++                strcpy(fullName + referencePathSize, name);
++                dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL);
++            }
+             PORT_Free(fullName);
+         }
+     }

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -60,9 +60,12 @@ stdenv.mkDerivation rec {
     substituteInPlace nss/coreconf/config.gypi --replace "/usr/bin/grep" "${buildPackages.coreutils}/bin/env grep"
   '';
 
-  patches = [
+  patches = (if lib.versionOlder version "3.77" then [
     # Based on http://patch-tracker.debian.org/patch/series/dl/nss/2:3.15.4-1/85_security_load.patch
     ./85_security_load.patch
+  ] else [
+    ./85_security_load_3.77+.patch
+  ]) ++ [
     ./ckpem.patch
     ./fix-cross-compilation.patch
   ];

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.76.1";
-  sha256 = "0ai37ncg50n4s5243bfvsip8isqq1y6w2swg1n4xgqg2fk1h8cg1";
+  version = "3.77";
+  sha256 = "sha256-gl7fWi/TW3iKI/+A+s5ZH4KRmuOtK4931CSkUNYY3t0=";
 }


### PR DESCRIPTION
###### Description of changes
https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_77.html#mozilla-projects-nss-nss-3-77-release-notes

Will open a separate PR against staging for cacert.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)