### PR TITLE
elmerfem: make elmerfem-9.0 run properly

### DIFF
--- a/pkgs/applications/science/physics/elmerfem/default.nix
+++ b/pkgs/applications/science/physics/elmerfem/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, git, gfortran, mpi, blas, liblapack, qt4, qwt6_qt4, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, cmake, git, gfortran, mpi, blas, liblapack, pkg-config, libGL, libGLU, opencascade, libsForQt5, vtkWithQt5}:
 
 stdenv.mkDerivation rec {
   pname = "elmerfem";
@@ -13,12 +13,34 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  nativeBuildInputs = [ cmake gfortran pkg-config git ];
-  buildInputs = [ mpi blas liblapack qt4 qwt6_qt4 ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    pkg-config
+    libsForQt5.wrapQtAppsHook
+  ];
+  buildInputs = [
+    mpi
+    blas
+    liblapack
+    libsForQt5.qtbase
+    libsForQt5.qtscript
+    libsForQt5.qwt
+    libGL
+    libGLU
+    opencascade
+    vtkWithQt5
+  ];
 
   preConfigure = ''
     patchShebangs ./
   '';
+
+  patches = [
+    ./patches/0001-fix-import-of-QPainterPath.patch
+    ./patches/0002-fem-rename-loopvars-to-avoid-redefinition.patch
+    ./patches/0003-ignore-qwt_compat.patch
+  ];
 
   storepath = placeholder "out";
 
@@ -26,6 +48,9 @@ stdenv.mkDerivation rec {
   "-DELMER_INSTALL_LIB_DIR=${storepath}/lib"
   "-DWITH_OpenMP:BOOLEAN=TRUE"
   "-DWITH_MPI:BOOLEAN=TRUE"
+  "-DWITH_QT5:BOOLEAN=TRUE"
+  "-DWITH_OCC:BOOLEAN=TRUE"
+  "-DWITH_VTK:BOOLEAN=TRUE"
   "-DWITH_ELMERGUI:BOOLEAN=TRUE"
   "-DCMAKE_INSTALL_LIBDIR=lib"
   "-DCMAKE_INSTALL_INCLUDEDIR=include"

--- a/pkgs/applications/science/physics/elmerfem/patches/0001-fix-import-of-QPainterPath.patch
+++ b/pkgs/applications/science/physics/elmerfem/patches/0001-fix-import-of-QPainterPath.patch
@@ -1,0 +1,24 @@
+From 87885de957aa3f891fe963503c94685675c24f49 Mon Sep 17 00:00:00 2001
+From: grindhold <grindhold@gmx.net>
+Date: Wed, 27 Apr 2022 19:16:42 +0200
+Subject: [PATCH] fix import of QPainterPath
+
+---
+ ElmerGUI/Application/twod/renderarea.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ElmerGUI/Application/twod/renderarea.cpp b/ElmerGUI/Application/twod/renderarea.cpp
+index 4c2515c5..65128ea9 100644
+--- a/ElmerGUI/Application/twod/renderarea.cpp
++++ b/ElmerGUI/Application/twod/renderarea.cpp
+@@ -38,6 +38,7 @@
+  *                                                                           *
+  *****************************************************************************/
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QMouseEvent>
+ #include <QFile>
+ #include <QTextStream>
+-- 
+2.33.3
+

--- a/pkgs/applications/science/physics/elmerfem/patches/0002-fem-rename-loopvars-to-avoid-redefinition.patch
+++ b/pkgs/applications/science/physics/elmerfem/patches/0002-fem-rename-loopvars-to-avoid-redefinition.patch
@@ -1,0 +1,82 @@
+From 06634e5fd46a27dca11b87d4a38e9ead561de3d5 Mon Sep 17 00:00:00 2001
+From: grindhold <grindhold@gmx.net>
+Date: Thu, 28 Apr 2022 15:47:07 +0200
+Subject: [PATCH] fem: rename loopvars to avoid redefinition
+
+---
+ fem/src/modules/DCRComplexSolve.F90 | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/fem/src/modules/DCRComplexSolve.F90 b/fem/src/modules/DCRComplexSolve.F90
+index 469214ee..268591fd 100644
+--- a/fem/src/modules/DCRComplexSolve.F90
++++ b/fem/src/modules/DCRComplexSolve.F90
+@@ -502,14 +502,14 @@ CONTAINS
+ 
+       IF ( SIZE(Hwrk,1) == 1 ) THEN
+ 
+-         DO i=1,MIN(3,SIZE(Hwrk,2))
+-            Tensor( i,1:n ) = Hwrk( 1,1,1:n )
++         DO k=1,MIN(3,SIZE(Hwrk,2))
++            Tensor( k,1:n ) = Hwrk( 1,1,1:n )
+          END DO
+ 
+       ELSE
+ 
+-        DO i=1,MIN(3,SIZE(Hwrk,1))
+-           Tensor( i,1:n ) = Hwrk( i,1,1:n )
++        DO k=1,MIN(3,SIZE(Hwrk,1))
++           Tensor( k,1:n ) = Hwrk( k,1,1:n )
+         END DO
+ 
+       END IF
+@@ -1391,21 +1391,21 @@ contains
+ 
+       IF ( SIZE(Hwrk,1) == 1 ) THEN
+ 
+-         DO i=1,MIN(3,SIZE(Hwrk,2))
+-            Tensor( i,i,1:n ) = Hwrk( 1,1,1:n )
++         DO k=1,MIN(3,SIZE(Hwrk,2))
++            Tensor( k,k,1:n ) = Hwrk( 1,1,1:n )
+          END DO
+ 
+       ELSE IF ( SIZE(Hwrk,2) == 1 ) THEN
+ 
+-         DO i=1,MIN(3,SIZE(Hwrk,1))
+-            Tensor(i,i,1:n) = Hwrk(i,1,1:n)
++         DO k=1,MIN(3,SIZE(Hwrk,1))
++            Tensor(k,k,1:n) = Hwrk(k,1,1:n)
+          END DO
+ 
+       ELSE
+ 
+-        DO i=1,MIN(3,SIZE(Hwrk,1))
++        DO k=1,MIN(3,SIZE(Hwrk,1))
+            DO j=1,MIN(3,SIZE(Hwrk,2))
+-              Tensor( i,j,1:n ) = Hwrk(i,j,1:n)
++              Tensor( k,j,1:n ) = Hwrk(k,j,1:n)
+            END DO
+         END DO
+ 
+@@ -1443,14 +1443,14 @@ contains
+ 
+       IF ( SIZE(Hwrk,1) == 1 ) THEN
+ 
+-         DO i=1,MIN(3,SIZE(Hwrk,2))
+-            Tensor( i,1:n ) = Hwrk( 1,1,1:n )
++         DO k=1,MIN(3,SIZE(Hwrk,2))
++            Tensor( k,1:n ) = Hwrk( 1,1,1:n )
+          END DO
+ 
+       ELSE
+ 
+-        DO i=1,MIN(3,SIZE(Hwrk,1))
+-           Tensor( i,1:n ) = Hwrk( i,1,1:n )
++        DO k=1,MIN(3,SIZE(Hwrk,1))
++           Tensor( k,1:n ) = Hwrk( k,1,1:n )
+         END DO
+ 
+       END IF
+-- 
+2.33.3
+

--- a/pkgs/applications/science/physics/elmerfem/patches/0003-ignore-qwt_compat.patch
+++ b/pkgs/applications/science/physics/elmerfem/patches/0003-ignore-qwt_compat.patch
@@ -1,0 +1,36 @@
+From 26601fec36a4978e805aad40e6d0cbf268c653d2 Mon Sep 17 00:00:00 2001
+From: grindhold <grindhold@gmx.net>
+Date: Thu, 28 Apr 2022 17:13:06 +0200
+Subject: [PATCH] ignore qwt_compat
+
+---
+ ElmerGUI/Application/src/convergenceview.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/ElmerGUI/Application/src/convergenceview.h b/ElmerGUI/Application/src/convergenceview.h
+index 377b644b..64250149 100755
+--- a/ElmerGUI/Application/src/convergenceview.h
++++ b/ElmerGUI/Application/src/convergenceview.h
+@@ -52,7 +52,7 @@
+ #include <qwt_plot_grid.h>
+ #include <qwt_legend.h>
+ /*#include <qwt_data.h> <-- deprecated in Qwt6, using qwt_compat.h instead*/
+-#include <qwt_compat.h>
++/*#include <qwt_compat.h>*/
+ #include <qwt_text.h>
+ #include <qwt_scale_engine.h>
+ 
+@@ -76,8 +76,8 @@ public:
+   
+ private:
+   int d_count;
+-  QwtArray<double> d_x;
+-  QwtArray<double> d_y;
++  QVector<double> d_x;
++  QVector<double> d_y;
+ };
+ 
+ class Curve
+-- 
+2.33.3
+


### PR DESCRIPTION

###### Description of changes

This is the result of my efforts to clear out the problems mentioned in #167599 . The import-problem was not the only one to fix in order to receive a working build of ElmerFEM:

  0) ElmerGUI displays things in the Model tree on the left screen side now [Before it was blank space which is not as intended by the developers]
  1) Enable the import of STEP- and other format by building against opencascade [This is used in many tutorials and will annoy users even if the software is theoretically usable without it]
  2) Patch the source to enable builds with gcc-11 and gfortran-11
  3) Build against Qt5  instead of Qt4 and supply relevant patches

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
