### PR TITLE
darknet: init at 2022-05-05

### DIFF
--- a/pkgs/misc/darknet/default.nix
+++ b/pkgs/misc/darknet/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, lib
+, opencv2
+, fetchFromGitHub
+, cudaPackages
+, pkg-config
+, enableCuda ? false
+, enableCuDNN ? false
+, enableOpenCV ? false
+, enableOpenMP ? true
+, enableDebug ? false
+}:
+let
+  bool2str = b: if b then "1" else "0"; # what is this function from nixpkgs?
+in stdenv.mkDerivation {
+  name = "darknet";
+  version = "unstable-2022-05-05";
+
+  src = fetchFromGitHub {
+    owner = "pjreddie";
+    repo = "darknet";
+    rev = "b1ab3da442574364f82c09313a58f7fc93cea2bd";
+    sha256 = "sha256-3/rJU2l4VQGySnviRo+PasydKEbY+By9574rAa5xTUM=";
+  };
+
+  patches = [ ./remove-default-flags.patch ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [ ]
+    ++ lib.optionals enableCuda [ cudaPackages.cudatoolkit ]
+    ++ lib.optionals enableCuDNN [ cudaPackages.cudnn ]
+    ++ lib.optionals enableOpenCV [ (opencv2.override {enableGtk2 = true; }).dev ]
+  ;
+
+  makeFlags = [
+    "GPU=${bool2str enableCuda}"
+    "CUDNN=${bool2str enableCuDNN}"
+    "OPENCV=${bool2str enableOpenCV}"
+    "OPENMP=${bool2str enableOpenMP}"
+    "DEBUG=${bool2str enableDebug}" # is there any nixpkgs specific way to enable debugging that could propagate to this?
+  ];
+
+  installPhase = ''
+    mkdir $out/{bin,lib} -p
+    install -m 755 darknet $out/bin
+    install -m 755 libdarknet.a $out/lib
+    install -m 755 libdarknet.so $out/lib
+    ln -s include $out/include
+    for version in 3.7 3.8 3.9 3.10; do
+      mkdir -p $out/lib/python$version/site-packages/darknet
+      install -m 755 python/darknet.py $out/lib/python$version/site-packages/darknet/__init__.py
+      sed "s;libdarknet.so;$out/lib/libdarknet.so;" -i $out/lib/python$version/site-packages/darknet/__init__.py
+    done
+    ln -s $src $out/src
+  '';
+
+  meta = with lib; {
+    description = " Open source neural networks in C";
+    homepage = "https://pjreddie.com/darknet/";
+    license = licenses.unfree; # i am not sure
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lucasew ];
+  };
+}

--- a/pkgs/misc/darknet/remove-default-flags.patch
+++ b/pkgs/misc/darknet/remove-default-flags.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 63e15e6..5332016 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,8 +1,3 @@
+-GPU=0
+-CUDNN=0
+-OPENCV=0
+-OPENMP=0
+-DEBUG=0
+ 
+ ARCH= -gencode arch=compute_30,code=sm_30 \
+       -gencode arch=compute_35,code=sm_35 \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33651,6 +33651,8 @@ with pkgs;
 
   colort = callPackage ../applications/misc/colort { };
 
+  darknet = callPackage ../misc/darknet { };
+
   terminal-parrot = callPackage ../applications/misc/terminal-parrot { };
 
   epson-alc1100 = callPackage ../misc/drivers/epson-alc1100 { };


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added darknet, a convolutional neural network toolkit made in C.

For convenience I exposed:
- The original source folder for assets as src in the output derivation
- The python module that it ships patching it to load the .so library
- The header provided
- Static and dynamic libraries
- Feature flags -- OpenCV must be compiled with GTK support, this is already handled as an override but OpenCV is disabled by default.

Some stuff inside uses hardcoded relative paths so you will have to cd to the src folder and run what you want, for example, `darknet detect`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
