### PR TITLE
blackfire: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/development/tools/misc/blackfire/default.nix
+++ b/pkgs/development/tools/misc/blackfire/default.nix
@@ -9,28 +9,28 @@
 }:
 
 let
-  version = "2.8.0";
+  version = "2.8.1";
 
   sources = {
     "x86_64-linux" = fetchurl {
       url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_amd64.deb";
-      sha256 = "0bgd4hnpaxrqw0s0y2qiak8lbskfi2cqp147vj1kbhvm8834hwhg";
+      sha256 = "znaM00jM6yrpb+bGTxzJUxViCUzv4G+CYK2EB5dxhfY=";
     };
     "i686-linux" = fetchurl {
       url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_i386.deb";
-      sha256 = "06lf642m4imz8xvwipflmvjy1ih7k8bx8jpay0xawvilh14pqz8f";
+      sha256 = "QIY4qGm333H5MWhe3CIfEieqTEk8st5A7SJHkwGnnxw=";
     };
     "aarch64-linux" = fetchurl {
       url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_arm64.deb";
-      sha256 = "0rddafjgdnj3na96x83paq5z14grj46v4iv38qbkvmdllrj26a0a";
+      sha256 = "eZbKoKYC2tt4Rxn5OJr7iA1aJlYFC0tpRmbLq7qSrIU=";
     };
     "aarch64-darwin" = fetchurl {
       url = "https://packages.blackfire.io/blackfire/${version}/blackfire-darwin_arm64.pkg.tar.gz";
-      sha256 = "YWiZnYdsW7dyQ0IeKeC1U00ZIdJRnzs9keeQTEU2ozA=";
+      sha256 = "tn2vF3v7KfF7CfWqyydL5Iyh5tP9Tez87PJH+URgSIw=";
     };
     "x86_64-darwin" = fetchurl {
       url = "https://packages.blackfire.io/blackfire/${version}/blackfire-darwin_amd64.pkg.tar.gz";
-      sha256 = "391b0d239b11095bb8515cb60ee95f02d5862fcb509724081f314819967206b6";
+      sha256 = "CRFlnqpX4j2CMGzS+UvXwNty2mHpONOjym6UJPE2Yg4=";
     };
   };
 in


### PR DESCRIPTION
###### Description of changes

Updated Blackfire

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
