### PR TITLE
libreoffice: add templates to dolphin "create new" menu

### DIFF
--- a/pkgs/applications/office/libreoffice/soffice-template.desktop
+++ b/pkgs/applications/office/libreoffice/soffice-template.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=LibreOffice @app@...
+Comment=Enter LibreOffice @app@ filename:
+Type=Link
+URL=.source/soffice.@ext@
+Icon=libreoffice-oasis-@type@

--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -1,19 +1,32 @@
-{ libreoffice, runCommand, dbus, bash }:
-let
-  jdk = libreoffice.jdk;
-in
-(runCommand libreoffice.name {
-  inherit dbus libreoffice jdk bash;
-} ''
+{ lib, runCommand
+, libreoffice, dbus, bash, substituteAll
+, dolphinTemplates ? true
+}:
+runCommand libreoffice.name {
+  inherit (libreoffice) jdk meta;
+  inherit dbus libreoffice bash;
+} (''
   mkdir -p "$out/bin"
-  ln -s "${libreoffice}/share" "$out/share"
   substituteAll "${./wrapper.sh}" "$out/bin/soffice"
   chmod a+x "$out/bin/soffice"
 
   for i in $(ls "${libreoffice}/bin/"); do
     test "$i" = "soffice" || ln -s soffice "$out/bin/$(basename "$i")"
   done
-'') // {
-  inherit libreoffice dbus;
-  meta = libreoffice.meta;
-}
+
+  mkdir -p "$out/share"
+  ln -s "${libreoffice}/share"/* $out/share
+'' + lib.optionalString dolphinTemplates ''
+  # Add templates to dolphin "Create new" menu - taken from debian
+
+  # We need to unpack the core source since the necessary files aren't available in the libreoffice output
+  unpackFile "${libreoffice.src}"
+
+  install -D "${libreoffice.name}"/extras/source/shellnew/soffice.* --target-directory="$out/share/templates/.source"
+
+  cp ${substituteAll {src = ./soffice-template.desktop; app="Writer";  ext="odt"; type="text";        }} $out/share/templates/soffice.odt.desktop
+  cp ${substituteAll {src = ./soffice-template.desktop; app="Calc";    ext="ods"; type="spreadsheet"; }} $out/share/templates/soffice.ods.desktop
+  cp ${substituteAll {src = ./soffice-template.desktop; app="Impress"; ext="odp"; type="presentation";}} $out/share/templates/soffice.odp.desktop
+  cp ${substituteAll {src = ./soffice-template.desktop; app="Draw";    ext="odg"; type="drawing";     }} $out/share/templates/soffice.odg.desktop
+'')
+


### PR DESCRIPTION
###### Description of changes


Add templates to dolphin "create new" menu.

Taken from [arch](https://github.com/archlinux/svntogit-packages/blob/6ff67138333a448b03c32a55526750ee7d60d8c8/trunk/PKGBUILD#L355) which takes it from [debian](https://salsa.debian.org/libreoffice-team/libreoffice/libreoffice/-/blob/609ada477ad56e528918c73962c65621e27bb015/rules#L2911) 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
