### PR TITLE
elfutils: 0.186 -> 0.187

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -2,16 +2,17 @@
 , musl-obstack, m4, zlib, zstd, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
 , argp-standalone
 , enableDebuginfod ? false, sqlite, curl, libmicrohttpd_0_9_70, libarchive
+, gitUpdater
 }:
 
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
   pname = "elfutils";
-  version = "0.186";
+  version = "0.187";
 
   src = fetchurl {
     url = "https://sourceware.org/elfutils/ftp/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-f2+5FJsWc9ONkXig0+D7ih7E9TqfTC/4lGlgmHlkEXc=";
+    sha256 = "sha256-5wsN++YQ+QxNH+DXGvFCpOJcPE7566uNLXK2UVnUVMg=";
   };
 
   patches = [
@@ -62,10 +63,6 @@ stdenv.mkDerivation rec {
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];
 
-  NIX_CFLAGS_COMPILE = lib.optionals stdenv.hostPlatform.isMusl [
-    "-Wno-null-dereference"
-  ];
-
   configureFlags = [
     "--program-prefix=eu-" # prevent collisions with binutils
     "--enable-deterministic-archives"
@@ -80,6 +77,12 @@ stdenv.mkDerivation rec {
   # Let's disable tests there until musl support is fully upstreamed.
   doCheck = !stdenv.hostPlatform.isMusl;
   doInstallCheck = !stdenv.hostPlatform.isMusl;
+
+  passthru.updateScript = gitUpdater {
+    inherit pname version;
+    url = "https://sourceware.org/git/elfutils.git";
+    rev-prefix = "elfutils-";
+  };
 
   meta = with lib; {
     homepage = "https://sourceware.org/elfutils/";


### PR DESCRIPTION
Added trivial updater.
Dropped unneeded -Werror workaround (`pkgsMusl.elfutils` builds successfully now).

changelog: https://sourceware.org/git/?p=elfutils.git;a=blob_plain;f=NEWS;hb=HEAD

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
