### PR TITLE
openjdk: mark major version 12 through 16 as EOL

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -147,7 +147,7 @@ let
 
     disallowedReferences = [ openjdk11-bootstrap ];
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/12.nix
+++ b/pkgs/development/compilers/openjdk/12.nix
@@ -151,7 +151,7 @@ let
 
     disallowedReferences = [ openjdk11 ];
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/13.nix
+++ b/pkgs/development/compilers/openjdk/13.nix
@@ -151,7 +151,7 @@ let
 
     disallowedReferences = [ openjdk13-bootstrap ];
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/14.nix
+++ b/pkgs/development/compilers/openjdk/14.nix
@@ -147,7 +147,7 @@ let
 
     disallowedReferences = [ openjdk14-bootstrap ];
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/15.nix
+++ b/pkgs/development/compilers/openjdk/15.nix
@@ -147,7 +147,7 @@ let
 
     disallowedReferences = [ openjdk15-bootstrap ];
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/16.nix
+++ b/pkgs/development/compilers/openjdk/16.nix
@@ -154,7 +154,7 @@ let
 
     disallowedReferences = [ openjdk16-bootstrap ];
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version.feature;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -157,7 +157,7 @@ let
 
     disallowedReferences = [ openjdk17-bootstrap ];
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version.feature;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -86,7 +86,7 @@ let
       home = jdk;
     };
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
   };
 in
 jdk

--- a/pkgs/development/compilers/openjdk/darwin/16.nix
+++ b/pkgs/development/compilers/openjdk/darwin/16.nix
@@ -86,7 +86,7 @@ let
       home = jdk;
     };
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
   };
 in
 jdk

--- a/pkgs/development/compilers/openjdk/darwin/17.nix
+++ b/pkgs/development/compilers/openjdk/darwin/17.nix
@@ -75,7 +75,7 @@ let
       home = jdk;
     };
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
   };
 in
 jdk

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -90,7 +90,7 @@ let
       home = jdk;
     };
 
-    meta = import ./meta.nix lib;
+    meta = import ./meta.nix lib version;
   };
 in
 jdk

--- a/pkgs/development/compilers/openjdk/darwin/meta.nix
+++ b/pkgs/development/compilers/openjdk/darwin/meta.nix
@@ -1,4 +1,4 @@
-lib: (removeAttrs (import ../meta.nix lib) [ "maintainers" ]) // {
+lib: version: (removeAttrs (import ../meta.nix lib version) [ "maintainers" ]) // {
   platforms = lib.platforms.darwin;
   homepage = "https://www.azul.com/";
 }

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -1,8 +1,11 @@
-lib: with lib; {
+lib: version: with lib; {
   homepage = "https://openjdk.java.net/";
   license = licenses.gpl2Only;
   description = "The open-source Java Development Kit";
   maintainers = with maintainers; [ edwtjo asbachb ];
   platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
   mainProgram = "java";
+  knownVulnerabilities = optionals (builtins.elem (versions.major version) [ "12" "13" "14" "15" "16" ]) [
+    "This OpenJDK version has reached its end of life."
+  ];
 }


### PR DESCRIPTION
Mark EOL versions with `knownVulnerabilities`.

https://endoflife.date/java

Related: #170825

I don't consider #178025 fixed until these packages are removed.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
