### PR TITLE
overgrowth: init

### DIFF
--- a/pkgs/games/overgrowth/default.nix
+++ b/pkgs/games/overgrowth/default.nix
@@ -1,0 +1,56 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, makeDesktopItem, copyDesktopItems
+, libGL, libGLU, SDL2, SDL2_net, gtk2, glib, bzip2
+, openal, libogg, libvorbis, libjpeg, freetype
+, overgrowth-data ? "" }:
+
+stdenv.mkDerivation rec {
+  pname = "overgrowth";
+  version = "unstable-2023-05-17";
+
+  src = fetchFromGitHub {
+    owner = "WolfireGames";
+    repo = pname;
+    rev = "594a2a4f9da0855304ee8cd5335d042f8e954ce1";
+    hash = "sha256-gsVI0eFONfO3fgHpcbAnc1FYS/J3/jWDIUYqs++XfEs=";
+  };
+
+  desktopItems = [ (makeDesktopItem {
+    name = "overgrowth";
+    desktopName = "Overgrowth";
+    icon = "overgrowth";
+    exec = "overgrowth";
+    path = overgrowth-data;
+    categories = [ "Game" ];
+  }) ];
+
+  nativeBuildInputs = [ cmake pkg-config copyDesktopItems ];
+  buildInputs = [
+    libGL libGLU SDL2 SDL2_net gtk2 glib bzip2
+    openal libogg libvorbis libjpeg freetype
+  ];
+
+  cmakeFlags = [
+    "-S../Projects"
+    "-DAUX_DATA=${overgrowth-data}"
+    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${lib.getLib gtk2}/lib/gtk-2.0/include"
+    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${lib.getLib glib}/lib/glib-2.0/include"
+  ];
+  hardeningDisable = [ "format" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D Overgrowth.bin.* $out/bin/overgrowth
+    install -D $src/Projects/OGIcon.png\
+      $out/share/icons/hicolor/1024x1024/apps/overgrowth.png
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Engine of Overgrowth, a rabbit fighting game";
+    homepage = "https://overgrowth.wolfire.com";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.McSinyx ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37506,6 +37506,8 @@ with pkgs;
 
   opensoldat = callPackage ../games/opensoldat { };
 
+  overgrowth = callPackage ../games/overgrowth { };
+
   portmod = callPackage ../games/portmod { };
 
   tetrio-desktop = callPackage ../games/tetrio-desktop { };


### PR DESCRIPTION
###### Description of changes

Overgrowth engine has recently been released under Apache 2.0.  I am not sure if this should be named overgrowth-engine instead though, since the data are not included.  This PR shall remain to be a draft until Wolfire tag a new version on the engine repo (a lot of cleaning up is still going on).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
