### PR TITLE
buildVimPlugin: add vimCommandCheckHook

### DIFF
--- a/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
+++ b/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , rtpPath
 , vim
+, vimCommandCheckHook
 , vimGenDocHook
 }:
 
@@ -30,6 +31,7 @@ rec {
       forceShare= [ "man" "info" ];
 
       nativeBuildInputs = attrs.nativeBuildInputs or []
+      ++ [ vimCommandCheckHook ]
       ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) vimGenDocHook;
       inherit unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
 

--- a/pkgs/applications/editors/vim/plugins/default.nix
+++ b/pkgs/applications/editors/vim/plugins/default.nix
@@ -3,7 +3,7 @@
 
 let
 
-  inherit (vimUtils.override {inherit vim;}) buildVimPluginFrom2Nix vimGenDocHook;
+  inherit (vimUtils.override {inherit vim;}) buildVimPluginFrom2Nix vimGenDocHook vimCommandCheckHook;
 
   inherit (lib) extends;
 
@@ -12,7 +12,10 @@ let
     toVimPlugin = drv:
       drv.overrideAttrs(oldAttrs: {
 
-        nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [ vimGenDocHook ];
+        nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [
+          vimGenDocHook
+          vimCommandCheckHook
+        ];
         passthru = (oldAttrs.passthru or {}) // {
           vimPlugin = true;
         };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -450,11 +450,8 @@ self: super: {
         --replace "code-minimap" "${code-minimap}/bin/code-minimap"
     '';
 
-    doCheck = true;
-    checkPhase = ''
-      ${neovim-unwrapped}/bin/nvim -n -u NONE -i NONE -V1 --cmd "set rtp+=$out" --cmd "runtime! plugin/*.vim" -c "MinimapToggle"  +quit!
-    '';
-
+    doInstallCheck = true;
+    vimCommandCheck = "MinimapToggle";
   });
 
   ncm2 = super.ncm2.overrideAttrs (old: {

--- a/pkgs/applications/editors/vim/plugins/vim-command-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/vim-command-check-hook.sh
@@ -1,0 +1,25 @@
+# Setup hook for checking whether a vim command exists
+echo "Sourcing vim-command-check-hook.sh"
+
+vimCommandCheckHook () {
+    echo "Executing vimCommandCheckHook"
+
+    if [ -n "$vimCommandCheck" ]; then
+        echo "Check whether the following modules can be imported: $vimCommandCheck"
+
+		# editorconfig-checker-disable
+        export HOME="$TMPDIR"
+        @vimBinary@ -es -n -u NONE -i NONE --clean -V1 --cmd "set rtp+=$out" \
+			--cmd "runtime! plugin/*.vim"  <<-EOF
+			if exists(":$vimCommandCheck") == 2
+				cquit 0
+			else
+				cquit 1
+			fi
+			EOF
+    fi
+}
+
+echo "Using vimCommandCheckHook"
+preDistPhases+=" vimCommandCheckHook"
+

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -521,8 +521,19 @@ rec {
       };
     } ./vim-gen-doc-hook.sh) {};
 
-  inherit (import ./build-vim-plugin.nix { inherit lib stdenv rtpPath vim vimGenDocHook; })
-    buildVimPlugin buildVimPluginFrom2Nix;
+  vimCommandCheckHook = callPackage ({ neovim-unwrapped }:
+    makeSetupHook {
+      name = "vim-command-check-hook";
+      deps = [ neovim-unwrapped ];
+      substitutions = {
+        vimBinary = "${neovim-unwrapped}/bin/nvim";
+        inherit rtpPath;
+      };
+    } ./vim-command-check-hook.sh) {};
+
+  inherit (import ./build-vim-plugin.nix {
+    inherit lib stdenv rtpPath vim vimGenDocHook vimCommandCheckHook;
+  }) buildVimPlugin buildVimPluginFrom2Nix;
 
   # used to figure out which python dependencies etc. neovim needs
   requiredPlugins = {


### PR DESCRIPTION

###### Description of changes

Modeled after pythonImportCheckHook, this checks a vim command can be run once the plugin is installed.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
