### PR TITLE
dbus-broker: use config files in /etc/dbus-1/

### DIFF
--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -28,6 +28,13 @@ stdenv.mkDerivation rec {
 
     sed -i $out/lib/systemd/{system,user}/dbus-broker.service \
       -e 's,^ExecReload.*busctl,ExecReload=${systemd}/bin/busctl,'
+
+    # patch service units to use config files in /etc/dbus-1/ instead of /usr/share/dbus-1/
+    sed -i $out/lib/systemd/system/dbus-broker.service \
+      -e 's,^\(ExecStart=.*\)bin/dbus-broker-launch ,\1bin/dbus-broker-launch --config-file=/etc/dbus-1/system.conf ,'
+
+    sed -i $out/lib/systemd/user/dbus-broker.service \
+      -e 's,^\(ExecStart=.*\)bin/dbus-broker-launch ,\1bin/dbus-broker-launch --config-file=/etc/dbus-1/session.conf ,'
   '';
 
   doCheck = true;


### PR DESCRIPTION
dbus-broker by default (and in Nix too) expects a /usr/share/dbus-1/system.conf config file,
and that's hard-coded in the source https://github.com/bus1/dbus-broker/blob/main/src/launch/launcher.c#L1017

but Nixos only has /etc/dbus-1/system.conf (and session.conf).

patch the service units with an explicit `--config-file=` to use the files in /etc/dbus-1/, for both the system and user service


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
