### PR TITLE
nixos/postfix: Add the option to use the postscreen daemon in front of smtpd

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -937,14 +937,14 @@ in
             mkKeyVal = opt: val: [ "-o" (opt + "=" + val) ];
           in concatLists (mapAttrsToList mkKeyVal cfg.submissionOptions);
         };
-      } // optionalAttrs useSmtp && !(cfg.enablePostscreen) {
+      } // optionalAttrs (useSmtp && !cfg.enablePostscreen) {
         smtp_inet = {
           name = "smtp";
           type = "inet";
           private = false;
           command = "smtpd";
         };
-      } // optionalAttrs useSmtp && cfg.enablePostscreen {
+      } // optionalAttrs (useSmtp && cfg.enablePostscreen) {
         smtpd = {
           type = "pass";
         };
@@ -952,7 +952,7 @@ in
           name = "smtp";
           type = "inet";
           private = false;
-          command = "smtpd";
+          command = "postscreen";
           maxproc = 1;
         };
         tlsproxy = {


### PR DESCRIPTION
Currently when configuring postfix with services.postfix, there is no option to
enable the postscreen daemon in front of smtpd. This commits adds the options
enablePostscreen that setups the daemon necessary to run postscreen as laid out
in the postfix documentation here
https://www.postfix.org/POSTSCREEN_README.html.

Signed-off-by: shirenn <shirenn@crans.org>

###### Description of changes
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).