### PR TITLE
spotify-tui: add collection variant patch

### DIFF
--- a/pkgs/applications/audio/spotify-tui/0001-Add-Collection-SearchType.patch
+++ b/pkgs/applications/audio/spotify-tui/0001-Add-Collection-SearchType.patch
@@ -1,0 +1,41 @@
+From 408e6a5170bbe9f854bf46e1cbae21265cf25294 Mon Sep 17 00:00:00 2001
+From: Florian Bruhin <me@the-compiler.org>
+Date: Mon, 25 Apr 2022 18:39:07 +0200
+Subject: [PATCH] Add Collection SearchType
+
+Backport of https://github.com/ramsayleung/rspotify/pull/306
+---
+ src/senum.rs | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/senum.rs b/src/senum.rs
+index c94c31c..79d8730 100644
+--- a/src/senum.rs
++++ b/src/senum.rs
+@@ -87,6 +87,7 @@ pub enum Type {
+     User,
+     Show,
+     Episode,
++    Collection,
+ }
+ impl Type {
+     pub fn as_str(&self) -> &str {
+@@ -98,6 +99,7 @@ pub fn as_str(&self) -> &str {
+             Type::User => "user",
+             Type::Show => "show",
+             Type::Episode => "episode",
++            Type::Collection => "collection",
+         }
+     }
+ }
+@@ -112,6 +114,7 @@ fn from_str(s: &str) -> Result<Self, Self::Err> {
+             "user" => Ok(Type::User),
+             "show" => Ok(Type::Show),
+             "episode" => Ok(Type::Episode),
++            "collection" => Ok(Type::Collection),
+             _ => Err(Error::new(ErrorKind::NoEnum(s.to_owned()))),
+         }
+     }
+-- 
+2.35.3
+

--- a/pkgs/applications/audio/spotify-tui/Cargo.lock.patch
+++ b/pkgs/applications/audio/spotify-tui/Cargo.lock.patch
@@ -1,0 +1,11 @@
+--- a/Cargo.lock	2022-04-27 17:25:49.017415644 +0300
++++ b/Cargo.lock	2022-04-27 17:25:51.307433984 +0300
+@@ -1722,8 +1722,6 @@
+ [[package]]
+ name = "rspotify"
+ version = "0.10.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eefd7bb58b714606b30a490f751d7926942e2874eef5e82934d60d7a4a68dca4"
+ dependencies = [
+  "base64 0.10.1",
+  "chrono",

--- a/pkgs/applications/audio/spotify-tui/Cargo.toml.patch
+++ b/pkgs/applications/audio/spotify-tui/Cargo.toml.patch
@@ -1,0 +1,12 @@
+--- a/Cargo.toml	2022-04-25 18:20:04.329712912 +0200
++++ b/Cargo.toml	2022-04-25 18:20:44.296429608 +0200
+@@ -29,6 +29,9 @@
+ rand = "0.8.3"
+ anyhow = "1.0.43"
+ 
++[patch.crates-io]
++rspotify = { path = "./rspotify-0.10.0" }
++
+ [[bin]]
+ bench = false
+ path = "src/main.rs"

--- a/pkgs/applications/audio/spotify-tui/default.nix
+++ b/pkgs/applications/audio/spotify-tui/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, installShellFiles, pkg-config, openssl, python3, libxcb, AppKit, Security }:
+{ lib, stdenv, fetchFromGitHub, fetchCrate, rustPlatform, installShellFiles, pkg-config, openssl, python3, libxcb, AppKit, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "spotify-tui";
@@ -11,7 +11,40 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-L5gg6tjQuYoAC89XfKE38KCFONwSAwfNoFEUPH4jNAI=";
   };
 
-  cargoSha256 = "sha256-iucI4/iMF+uXRlnMttobu4xo3IQXq7tGiSSN8eCrLM0=";
+  # Use patched rspotify
+  cargoPatches = [
+    ./Cargo.lock.patch
+  ];
+  patches = [
+    ./Cargo.toml.patch
+  ];
+
+  preBuild = let
+    rspotify = stdenv.mkDerivation rec {
+      pname = "rspotify";
+      version = "0.10.0";
+
+      src = fetchCrate {
+        inherit pname version;
+        sha256 = "sha256-KDtqjVQlMHlhL1xXP3W1YG/YuX9pdCjwW/7g18469Ts=";
+      };
+
+      dontBuild = true;
+      installPhase = ''
+        mkdir $out
+        cp -R . $out
+      '';
+
+      patches = [
+        # add `collection` variant
+        ./0001-Add-Collection-SearchType.patch
+      ];
+    };
+  in ''
+    ln -s ${rspotify} ./rspotify-${rspotify.version}
+  '';
+
+  cargoSha256 = "sha256-S8zuVYcyYvrwggIvlpxNydhoN9kx6xLBwYJSHcbEK40=";
 
   nativeBuildInputs = [ installShellFiles ] ++ lib.optionals stdenv.isLinux [ pkg-config python3 ];
   buildInputs = [ ]


### PR DESCRIPTION
###### Description of changes
Add patch adding the collection variant to rspotify used by spotify-tui.
https://github.com/Rigellute/spotify-tui/issues/960#issuecomment-1108813658

This fixes the issue of getting an error when playing liked songs. https://github.com/Rigellute/spotify-tui/issues/960

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
