### PR TITLE
fwupd: 1.7.7 → 1.8.0

### DIFF
--- a/pkgs/development/libraries/libjcat/default.nix
+++ b/pkgs/development/libraries/libjcat/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
 , docbook_xml_dtd_43
 , docbook-xsl-nons
@@ -18,7 +19,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libjcat";
-  version = "0.1.10";
+  version = "0.1.11";
 
   outputs = [ "bin" "out" "dev" "devdoc" "man" "installedTests" ];
 
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "hughsie";
     repo = "libjcat";
     rev = version;
-    sha256 = "sha256-6fqcP8LWvRoDf5gJz+kW0w5+3PP/luuoPMak1QLKzzM=";
+    sha256 = "2kdoOwgaLpo/Cp3wkCMgdyQ++BC3Cn7CRhXhVCHn/iM=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libxmlb/default.nix
+++ b/pkgs/development/libraries/libxmlb/default.nix
@@ -1,9 +1,8 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , docbook_xml_dtd_43
-, docbook_xsl
+, docbook-xsl-nons
 , glib
 , gobject-introspection
 , gtk-doc
@@ -18,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libxmlb";
-  version = "0.3.7";
+  version = "0.3.8";
 
   outputs = [ "out" "lib" "dev" "devdoc" "installedTests" ];
 
@@ -26,23 +25,16 @@ stdenv.mkDerivation rec {
     owner = "hughsie";
     repo = "libxmlb";
     rev = version;
-    sha256 = "sha256-ZzA1YJYxTR91X79NU9dWd11Ze+PX2wuZeumuEuNdC48=";
+    sha256 = "vT/NGFDzP0ut+TKD8pYVQrjTkepzKEJUo3uKF4MX334=";
   };
 
   patches = [
     ./installed-tests-path.patch
-    # Fix darwin build, can be removed on next release
-    # `--version-script` isn't supported by the macOS linker
-    # https://github.com/hughsie/libxmlb/pull/119
-    (fetchpatch {
-      url = "https://github.com/hughsie/libxmlb/commit/d83aac5bd78cfbbfa2ecd428ff54b811071dfe4d.patch";
-      sha256 = "sha256-UNRMbyNzdxfTZ8xV6J8a622hPnr3mowooP1q8Dg19yw=";
-    })
   ];
 
   nativeBuildInputs = [
     docbook_xml_dtd_43
-    docbook_xsl
+    docbook-xsl-nons
     gobject-introspection
     gtk-doc
     meson

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -3,7 +3,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , fetchFromGitHub
 , gtk-doc
 , pkg-config
@@ -54,6 +53,8 @@
 , modemmanager
 , libqmi
 , libmbim
+, libcbor
+, xz
 }:
 
 let
@@ -116,7 +117,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.7.7";
+    version = "1.8.0";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -125,7 +126,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "sha256-QUmU06zfZ0qQ9wotoW2k4XalrRH+Y25qs/DhpJ4GKWk=";
+      sha256 = "LAliLnOSowtORQQ0M4z2cNQzKMLyE/RsX//xAWifrps=";
     };
 
     patches = [
@@ -139,13 +140,6 @@ let
       # Install plug-ins and libfwupdplugin to $out output,
       # they are not really part of the library.
       ./install-fwupdplugin-to-out.patch
-
-      # Fix detection of installed tests
-      # https://github.com/fwupd/fwupd/issues/3880
-      (fetchpatch {
-        url = "https://github.com/fwupd/fwupd/commit/5bc546221331feae9cedc1892219a25d8837955f.patch";
-        sha256 = "XcLhcDrB2/MFCXjKAyhftQgvJG4BBkp07geM9eK3q1g=";
-      })
 
       # Installed tests are installed to different output
       # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
@@ -197,16 +191,20 @@ let
       protobufc
       modemmanager
       libmbim
+      libcbor
       libqmi
+      xz # for liblzma.
     ] ++ lib.optionals haveDell [
       libsmbios
+    ] ++ lib.optionals haveFlashrom [
+      flashrom
     ];
 
     mesonFlags = [
       "-Ddocs=gtkdoc"
       "-Dplugin_dummy=true"
       # We are building the official releases.
-      "-Dsupported_build=true"
+      "-Dsupported_build=enabled"
       # Would dlopen libsoup to preserve compatibility with clients linking against older fwupd.
       # https://github.com/fwupd/fwupd/commit/173d389fa59d8db152a5b9da7cc1171586639c97
       "-Dsoup_session_compat=false"
@@ -217,7 +215,7 @@ let
       "--sysconfdir=/etc"
       "-Dsysconfdir_install=${placeholder "out"}/etc"
       "-Defi_os_dir=nixos"
-      "-Dplugin_modem_manager=true"
+      "-Dplugin_modem_manager=enabled"
 
       # We do not want to place the daemon into lib (cyclic reference)
       "--libexecdir=${placeholder "out"}/libexec"
@@ -225,14 +223,14 @@ let
       # against libfwupdplugin which is in $out/lib.
       "-Dc_link_args=-Wl,-rpath,${placeholder "out"}/lib"
     ] ++ lib.optionals (!haveDell) [
-      "-Dplugin_dell=false"
-      "-Dplugin_synaptics_mst=false"
+      "-Dplugin_dell=disabled"
+      "-Dplugin_synaptics_mst=disabled"
     ] ++ lib.optionals (!haveRedfish) [
-      "-Dplugin_redfish=false"
-    ] ++ lib.optionals haveFlashrom [
-      "-Dplugin_flashrom=true"
+      "-Dplugin_redfish=disabled"
+    ] ++ lib.optionals (!haveFlashrom) [
+      "-Dplugin_flashrom=disabled"
     ] ++ lib.optionals (!haveMSR) [
-      "-Dplugin_msr=false"
+      "-Dplugin_msr=disabled"
     ];
 
     # TODO: wrapGAppsHook wraps efi capsule even though it is not ELF
@@ -291,7 +289,7 @@ let
         efibootmgr
         bubblewrap
         tpm2-tools
-      ] ++ lib.optional haveFlashrom flashrom;
+      ];
     in ''
       gappsWrapperArgs+=(
         --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"

--- a/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
@@ -10,10 +10,10 @@ index b8ec916f0..38209b363 100644
 +  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index 32fe6e408..b35d741e0 100644
+index d8bd9fdc7..ff924d373 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -183,8 +183,8 @@ else
+@@ -187,8 +187,8 @@ else
    datadir = join_paths(prefix, get_option('datadir'))
    sysconfdir = join_paths(prefix, get_option('sysconfdir'))
    localstatedir = join_paths(prefix, get_option('localstatedir'))
@@ -24,7 +24,7 @@ index 32fe6e408..b35d741e0 100644
  endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
-@@ -484,6 +484,7 @@ gnome = import('gnome')
+@@ -487,6 +487,7 @@ gnome = import('gnome')
  i18n = import('i18n')
  
  conf.set_quoted('FWUPD_PREFIX', prefix)
@@ -33,19 +33,19 @@ index 32fe6e408..b35d741e0 100644
  conf.set_quoted('FWUPD_LIBDIR', libdir)
  conf.set_quoted('FWUPD_LIBEXECDIR', libexecdir)
 diff --git a/meson_options.txt b/meson_options.txt
-index 0a0e2853..5f68d78b 100644
+index d00038dbc..be1c45b40 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -25,6 +26,7 @@ option('plugin_coreboot', type : 'boolean', value : true, description : 'enable
- option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
+@@ -56,6 +56,7 @@ option('systemd', type : 'feature', description : 'systemd support', deprecated:
+ option('systemd_unit_user', type : 'string', description : 'User account to use for fwupd-refresh.service (empty for DynamicUser)')
  option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')
- option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
+ option('elogind', type : 'feature', description : 'elogind support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 +option('installed_test_prefix', type: 'string', description: 'Prefix for installed tests')
  option('tests', type : 'boolean', value : true, description : 'enable tests')
- option('tpm', type : 'boolean', value : true, description : 'enable TPM support')
- option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')
+ option('soup_session_compat', type : 'boolean', value : true, description : 'enable SoupSession runtime compatibility support')
+ option('curl', type : 'feature', description : 'libcurl support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 diff --git a/plugins/redfish/fu-self-test.c b/plugins/redfish/fu-self-test.c
-index c507fabc8..0cddc3248 100644
+index 4d19e560f..91cfaa616 100644
 --- a/plugins/redfish/fu-self-test.c
 +++ b/plugins/redfish/fu-self-test.c
 @@ -27,7 +27,7 @@ fu_test_is_installed_test(void)


### PR DESCRIPTION
###### Description of changes

https://github.com/fwupd/fwupd/releases/tag/1.8.0
https://blogs.gnome.org/hughsie/2022/04/28/fwupd-1-8-0-and-50-million-updates/

- [libjcat installed tests failure](https://github.com/hughsie/libjcat/pull/67) is pre-existing.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
