### PR TITLE
libdwarf_0_4: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1170,6 +1170,12 @@
     githubId = 706854;
     name = "Etienne Laurin";
   };
+  atry = {
+    name = "Bo Yang";
+    email = "atry@fb.com";
+    github = "Atry";
+    githubId = 601530;
+  };
   attila-lendvai = {
     name = "Attila Lendvai";
     email = "attila@lendvai.name";

--- a/pkgs/development/libraries/libdwarf/0.4.nix
+++ b/pkgs/development/libraries/libdwarf/0.4.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchurl, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "libdwarf";
+  version = "0.4.0";
+
+  src = fetchurl {
+    url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
+    sha512 = "30e5c6c1fc95aa28a014007a45199160e1d9ba870b196d6f98e6dd21a349e9bb31bba1bd6817f8ef9a89303bed0562182a7d46fcbb36aedded76c2f1e0052e1e";
+  };
+
+  configureFlags = [ "--enable-shared" "--disable-nonshared" ];
+
+  buildInputs = [ zlib ];
+
+  outputs = [ "bin" "lib" "dev" "out" ];
+
+  meta = {
+    homepage = "https://github.com/davea42/libdwarf-code";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.atry ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18429,6 +18429,7 @@ with pkgs;
 
   inherit (callPackage ../development/libraries/libdwarf { })
     libdwarf dwarfdump;
+  libdwarf_0_4 = callPackage ../development/libraries/libdwarf/0.4.nix { };
 
   libe57format = callPackage ../development/libraries/libe57format { };
 


### PR DESCRIPTION
###### Description of changes

Release note copied from https://www.prevanders.net/dwarf.html

> Date: 2022-04-12. Made changes to 6 interfaces to make three dealloc functions be named with a pattern consistent with the rest of libdwarf, a function reverted to a pre-DWARF5 version for correctness, and changes to the .debug_names API functions to enable full access to the section. See details in the Recent Changes section of libdwarf.pdf. dwarfdump now prints all the information in .debug_names with --print-debug-names.

Note that `dwarfdump` is now part of `libdwarf` code base because of upstream change in https://github.com/davea42/libdwarf-code/commit/312206de97cfe6191054d1b51e6d4cc2039b6c06.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
