### PR TITLE
nut: 2.7.4 -> 2.8.0 WIP

### DIFF
--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -1,42 +1,31 @@
 { lib, stdenv, fetchurl, pkg-config, neon, libusb-compat-0_1, openssl, udev, avahi, freeipmi
-, libtool, makeWrapper, autoreconfHook, fetchpatch
+, libtool, makeWrapper, autoreconfHook, libmodbus, i2c-tools, net-snmp, gd
 }:
 
 stdenv.mkDerivation rec {
   pname = "nut";
-  version = "2.7.4";
+  version = "2.8.0";
 
   src = fetchurl {
-    url = "https://networkupstools.org/source/2.7/${pname}-${version}.tar.gz";
-    sha256 = "19r5dm07sfz495ckcgbfy0pasx0zy3faa0q7bih69lsjij8q43lq";
+    url = "https://networkupstools.org/source/2.8/${pname}-${version}.tar.gz";
+    sha256 = "1rdzjbvm6qyz9kz1jmdq0fszq0500q97plsknrq7qyvrv84agrf3";
   };
 
-  patches = [
-    (fetchpatch {
-      # Fix build with openssl >= 1.1.0
-      url = "https://github.com/networkupstools/nut/commit/612c05efb3c3b243da603a3a050993281888b6e3.patch";
-      sha256 = "0jdbii1z5sqyv24286j5px65j7b3gp8zk3ahbph83pig6g46m3hs";
-    })
-  ];
-
-  buildInputs = [ neon libusb-compat-0_1 openssl udev avahi freeipmi ];
+  buildInputs = [ neon libusb-compat-0_1 openssl udev avahi freeipmi libmodbus gd i2c-tools net-snmp ];
 
   nativeBuildInputs = [ autoreconfHook libtool pkg-config makeWrapper ];
 
   configureFlags =
     [ "--with-all"
       "--with-ssl"
-      "--without-snmp" # Until we have it ...
       "--without-powerman" # Until we have it ...
-      "--without-cgi"
-      "--without-hal"
       "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+      "--with-systemdshutdowndir=$(out)/lib/systemd"
+      "--with-systemdtmpfilesdir=$(out)/lib/tmpfiles.d"
       "--with-udev-dir=$(out)/etc/udev"
     ];
 
   enableParallelBuilding = true;
-
-  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];
 
   postInstall = ''
     wrapProgram $out/bin/nut-scanner --prefix LD_LIBRARY_PATH : \


### PR DESCRIPTION
###### Description of changes

Updated nut package to new release 2.8.0.

The SSL patch was incorporated in 2.8.0, so it was removed here.

There is still an issue with `nut-scanner` finding dynamic libraries at runtime: https://github.com/NixOS/nixpkgs/issues/91730

The usage of dynamic exception specifications should be eliminated, removing the need for `CFLAGS`. Will look for confirmation from ofborg. @jhh 

Considering WIP until other users verify with their UPS.

This is a big release as the last one was 6 years ago! Changes: https://github.com/networkupstools/nut/releases/tag/v2.8.0

Does this need a release notes entry?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
