### PR TITLE
git-interactive-rebase-tool: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
@@ -1,25 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, rustPlatform, libiconv, Security }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, libiconv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "git-interactive-rebase-tool";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "MitMaro";
     repo = pname;
     rev = version;
-    sha256 = "sha256-DYl/GUbeNtKmXoR3gq8mK8EfsZNVNlrdngAwfzG+epw=";
+    sha256 = "sha256-++KTMzTt84dowoZP+Bc9E/jUS21YN5ybKrlpQUKCir0=";
   };
 
-  cargoPatches = [
-    # update git2 crate to fix a compile error
-    (fetchpatch {
-      url = "https://github.com/MitMaro/git-interactive-rebase-tool/commit/f4d3026f23118d29a263bbca6c83f963e76c34c4.patch";
-      sha256 = "sha256-6ErPRcPbPRXbEslNiNInbbUhbOWb9ZRll7ZDRgTpWS4=";
-    })
-  ];
-
-  cargoSha256 = "sha256-2aHW9JIiqkO0X0B0D44tSZ8QkmKH/QZoYvKNEQWldo4=";
+  cargoSha256 = "sha256-OUaP/nDs589FYaGYcleRMTQNu3/q/2wBjHSv2q8OyjA=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
 


### PR DESCRIPTION
https://github.com/MitMaro/git-interactive-rebase-tool/releases/tag/2.2.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
