### PR TITLE
wine{Unstable,Staging}: 7.4 -> 7.8; winetricks: 20210825 -> 20220411

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -175,7 +175,9 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
     done
   '';
 
-  enableParallelBuilding = true;
+  # Until https://github.com/NixOS/nixpkgs/pull/172617 is applied,
+  # parallel builds do not always work because of a bug in dlltool.
+  enableParallelBuilding = false;
 
   # https://bugs.winehq.org/show_bug.cgi?id=43530
   # https://github.com/NixOS/nixpkgs/issues/31989

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -84,8 +84,8 @@ in rec {
 
   winetricks = fetchFromGitHub rec {
     # https://github.com/Winetricks/winetricks/releases
-    version = "20210825";
-    sha256 = "sha256-exMhj3dS8uXCEgOaWbftaq94mBOmtZIXsXb9xNX5ha8=";
+    version = "20220411";
+    sha256 = "sha256-FjH10nZDYbqXI6/vKpZJKfv2maXSVkahNDf5UTU3eyU=";
     owner = "Winetricks";
     repo = "winetricks";
     rev = version;

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -46,9 +46,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "7.7";
+    version = "7.8";
     url = "https://dl.winehq.org/wine/source/7.x/wine-${version}.tar.xz";
-    sha256 = "sha256-UqTQa6dwgN9KSwIr+cLMBc+h15vUuwjGuI98OuCdFGQ=";
+    sha256 = "sha256-j3bpyWtQ8qyOJOXe7fo+DZWWpXBnCSJvZalMahYAGbg=";
     inherit (stable) gecko32 gecko64 patches;
 
     mono = fetchurl rec {
@@ -61,7 +61,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-+aR5+pJD+uDo4wITgs7njYUHxB9FwqUtgS+aXC0PLQ0=";
+    sha256 = "sha256-payP+lx/aGZErGbkpogNMgsE393e7F2VGrllDKu/Lws=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -46,9 +46,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "7.4";
+    version = "7.5";
     url = "https://dl.winehq.org/wine/source/7.x/wine-${version}.tar.xz";
-    sha256 = "sha256-co6GbW5JzpKioMUUMz6f8Ivb9shvXvTmGAFDuNK31BY=";
+    sha256 = "sha256-Riwxha7e7IUQZ6UWXWSPVJn7k8G2VfRrgl9LwRkU4oE=";
     inherit (stable) gecko32 gecko64 patches;
 
     mono = fetchurl rec {
@@ -61,7 +61,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "0vlj3b8bnidyhlgkjrnlbah3878zjy3s557vbp16qka42zjaa51q";
+    sha256 = "sha256-BGfQqy4UMUfpc1XX4MXKrygHeffHsKuFZpeA4LHwzPg=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -46,9 +46,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "7.6";
+    version = "7.7";
     url = "https://dl.winehq.org/wine/source/7.x/wine-${version}.tar.xz";
-    sha256 = "sha256-7qt3LwkTKKP7nbiarKtr4IfD1ZwWjvK0GvXsUBDPAyg=";
+    sha256 = "sha256-UqTQa6dwgN9KSwIr+cLMBc+h15vUuwjGuI98OuCdFGQ=";
     inherit (stable) gecko32 gecko64 patches;
 
     mono = fetchurl rec {
@@ -61,7 +61,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-0RbfCC8pjjVoWppaa+tQyO/l7ZafbNKA6V2Ea4hNehI=";
+    sha256 = "sha256-+aR5+pJD+uDo4wITgs7njYUHxB9FwqUtgS+aXC0PLQ0=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -46,22 +46,22 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "7.5";
+    version = "7.6";
     url = "https://dl.winehq.org/wine/source/7.x/wine-${version}.tar.xz";
-    sha256 = "sha256-Riwxha7e7IUQZ6UWXWSPVJn7k8G2VfRrgl9LwRkU4oE=";
+    sha256 = "sha256-7qt3LwkTKKP7nbiarKtr4IfD1ZwWjvK0GvXsUBDPAyg=";
     inherit (stable) gecko32 gecko64 patches;
 
     mono = fetchurl rec {
-      version = "7.1.1";
+      version = "7.2.0";
       url = "https://dl.winehq.org/wine/wine-mono/${version}/wine-mono-${version}-x86.msi";
-      sha256 = "sha256-ncjlYDt7xkNU65SuTqD2ghQkdno/9E/w0Z40akkMEeo=";
+      sha256 = "sha256-Xwbq+646SezDHfzqd3B1vUTwzBJuT7Tijs76ButDYyM=";
     };
   };
 
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-BGfQqy4UMUfpc1XX4MXKrygHeffHsKuFZpeA4LHwzPg=";
+    sha256 = "sha256-0RbfCC8pjjVoWppaa+tQyO/l7ZafbNKA6V2Ea4hNehI=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Description of changes

Three upstream version bumps.
However, it seems that even wine 7.4 doesn't build on master anymore for me.
This is to be investigated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
