### PR TITLE
Physlock switch branch

### DIFF
--- a/pkgs/misc/screensavers/physlock/default.nix
+++ b/pkgs/misc/screensavers/physlock/default.nix
@@ -1,16 +1,20 @@
 { lib, stdenv, fetchFromGitHub, pam, systemd }:
 
 stdenv.mkDerivation rec {
-  version = "13";
+  version = "2020-07-28";
   pname = "physlock";
   src = fetchFromGitHub {
-    owner = "muennich";
+    owner = "menglishca";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1mz4xxjip5ldiw9jgfq9zvqb6w10bcjfx6939w1appqg8f521a7s";
+    rev = "9618016bee86c7af6121f96b4a54e85d8a49d3d1";
+    sha256 = "sha256-VzwT2aAflmjTWJMxJYQAH/jas/WOljgvrBDXP/bZ7ZU=";
   };
 
   buildInputs = [ pam systemd ];
+
+  patches = [
+    ./fix_options_struct.patch
+  ];
 
   preConfigure = ''
     substituteInPlace Makefile \

--- a/pkgs/misc/screensavers/physlock/fix_options_struct.patch
+++ b/pkgs/misc/screensavers/physlock/fix_options_struct.patch
@@ -1,0 +1,17 @@
+diff --git a/physlock.h b/physlock.h
+index 5d17111..9a3a7ea 100644
+--- a/physlock.h
++++ b/physlock.h
+@@ -58,11 +58,10 @@ typedef struct options_s {
+ 	int staggered;
+ 	int username;
+ 	const char *prompt;
+-	char issue_file[];
+ 	int no_auth;
+-	const char *prompt;
+ 	const char *command_before;
+ 	const char *command_after;
++	char issue_file[];
+ } options_t;
+ 
+ extern const options_t *options;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Change source to a fork that seams more maintained and add the new feature to the config.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
