### PR TITLE
qFlipper: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/tools/misc/qflipper/default.nix
+++ b/pkgs/tools/misc/qflipper/default.nix
@@ -19,12 +19,14 @@
 , qtquickcontrols2
 , qtgraphicaleffects
 , qtwayland
+, nix-update-script
 }:
 let
-  version = "1.0.1";
+  pname = "qFlipper";
+  version = "1.0.2";
+  sha256 = "sha256-CJQOEUwYPNd4x+uBINrxeYVITtYrsEFaYLHQh2l12kA=";
   timestamp = "99999999999";
   commit = "nix-${version}";
-  hash = "sha256-vHBlrtQ06kjjXXGL/jSdpAPHgqb7Vn1c6jXZVXwxHPQ=";
 
   udev_rules = ''
     #Flipper Zero serial port
@@ -35,15 +37,14 @@ let
 
 in
 mkDerivation {
-  pname = "qFlipper";
-  inherit version;
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "flipperdevices";
     repo = "qFlipper";
     rev = version;
-    inherit hash;
     fetchSubmodules = true;
+    inherit sha256;
   };
 
   nativeBuildInputs = [
@@ -95,6 +96,10 @@ mkDerivation {
     ${udev_rules}
     EOF
   '';
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
 
   meta = with lib; {
     description = "Cross-platform desktop tool to manage your flipper device";


### PR DESCRIPTION
Also checked and enabled updateScript

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
