### PR TITLE
crossfire: fix version parsing for nix-env

### DIFF
--- a/pkgs/games/crossfire/crossfire-arch.nix
+++ b/pkgs/games/crossfire/crossfire-arch.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "crossfire-arch";
-  version = "r${toString rev}";
+  version = rev;
 
   src = fetchsvn {
     url = "http://svn.code.sf.net/p/crossfire/code/arch/trunk/";
-    sha256 = sha256;
-    rev = rev;
+    inherit sha256;
+    rev = "r${rev}";
   };
 
   installPhase = ''

--- a/pkgs/games/crossfire/crossfire-client.nix
+++ b/pkgs/games/crossfire/crossfire-client.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   pname = "crossfire-client";
-  version = "r${toString rev}";
+  version = rev;
 
   src = fetchsvn {
     url = "http://svn.code.sf.net/p/crossfire/code/client/trunk/";
-    sha256 = sha256;
-    rev = rev;
+    inherit sha256;
+    rev = "r${rev}";
   };
 
   nativeBuildInputs = [ cmake pkg-config perl vala ];

--- a/pkgs/games/crossfire/crossfire-maps.nix
+++ b/pkgs/games/crossfire/crossfire-maps.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "crossfire-maps";
-  version = "r${toString rev}";
+  version = rev;
 
   src = fetchsvn {
     url = "http://svn.code.sf.net/p/crossfire/code/maps/trunk/";
-    sha256 = sha256;
-    rev = rev;
+    inherit sha256;
+    rev = "r${rev}";
   };
 
   installPhase = ''

--- a/pkgs/games/crossfire/crossfire-server.nix
+++ b/pkgs/games/crossfire/crossfire-server.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   pname = "crossfire-server";
-  version = "r${toString rev}";
+  version = rev;
 
   src = fetchsvn {
     url = "http://svn.code.sf.net/p/crossfire/code/server/trunk/";
-    sha256 = sha256;
-    rev = rev;
+    inherit sha256;
+    rev = "r${rev}";
   };
 
   nativeBuildInputs = [ autoconf automake libtool flex perl check pkg-config python3 ];

--- a/pkgs/games/crossfire/default.nix
+++ b/pkgs/games/crossfire/default.nix
@@ -3,26 +3,26 @@
 rec {
   crossfire-client = callPackage ./crossfire-client.nix {
     version = "1.75.0";
-    rev = 21760;
+    rev = "21760";
     sha256 = "0b42sak8hj60nywfswkps777asy9p8r9wsn7pmj2nqbd29ng1p9d";
   };
 
   crossfire-server = callPackage ./crossfire-server.nix {
     version = "latest";
-    rev = 22111;
+    rev = "22111";
     sha256 = "04fjif6zv642n2zlw27cgzkak2kknwrxqzg42bvzl7q901bsr9l7";
     maps = crossfire-maps; arch = crossfire-arch;
   };
 
   crossfire-arch = callPackage ./crossfire-arch.nix {
     version = "latest";
-    rev = 22111;
+    rev = "22111";
     sha256 = "0l4rp3idvbhknpxxs0w4i4nqfg01wblzm4v4j375xwxxbf00j0ms";
   };
 
   crossfire-maps = callPackage ./crossfire-maps.nix {
     version = "latest";
-    rev = 22111;
+    rev = "22111";
     sha256 = "1dwfc84acjvbjgjakkb8z8pdlksbsn90j0z8z8rq37lqx0kx1sap";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
