### PR TITLE
Fix rust nondeterminism

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -4,14 +4,15 @@
   crateFeatures, crateRenames, libName, release, libPath,
   crateType, metadata, crateBin, hasCrateBin,
   extraRustcOpts, verbose, colors,
-  buildTests
+  buildTests,
+  codegenUnits
 }:
 
   let
     baseRustcOpts =
       [
         (if release then "-C opt-level=3" else "-C debuginfo=2")
-        "-C codegen-units=$NIX_BUILD_CORES"
+        "-C codegen-units=${codegenUnits}"
         "--remap-path-prefix=$NIX_BUILD_TOP=/"
         (mkRustcDepArgs dependencies crateRenames)
         (mkRustcFeatureArgs crateFeatures)

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -12,7 +12,7 @@
     baseRustcOpts =
       [
         (if release then "-C opt-level=3" else "-C debuginfo=2")
-        "-C codegen-units=${codegenUnits}"
+        "-C codegen-units=${toString codegenUnits}"
         "--remap-path-prefix=$NIX_BUILD_TOP=/"
         (mkRustcDepArgs dependencies crateRenames)
         (mkRustcFeatureArgs crateFeatures)

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -25,7 +25,7 @@ let version_ = lib.splitString "-" crateVersion;
     version = lib.splitVersion (lib.head version_);
     rustcOpts = lib.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
-        (["-C codegen-units=${codegenUnits}"] ++ extraRustcOptsForBuildRs);
+        (["-C codegen-units=${toString codegenUnits}"] ++ extraRustcOptsForBuildRs);
     buildDeps = mkRustcDepArgs buildDependencies crateRenames;
     authors = lib.concatStringsSep ":" crateAuthors;
     optLevel = if release then 3 else 0;

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -2,6 +2,7 @@
 {
   build
 , buildDependencies
+, codegenUnits
 , colors
 , completeBuildDeps
 , completeDeps
@@ -24,7 +25,7 @@ let version_ = lib.splitString "-" crateVersion;
     version = lib.splitVersion (lib.head version_);
     rustcOpts = lib.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
-        (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOptsForBuildRs);
+        (["-C codegen-units=${codegenUnits}"] ++ extraRustcOptsForBuildRs);
     buildDeps = mkRustcDepArgs buildDependencies crateRenames;
     authors = lib.concatStringsSep ":" crateAuthors;
     optLevel = if release then 3 else 0;

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -316,7 +316,7 @@ crate_: lib.makeOverridable
       colors = lib.attrByPath [ "colors" ] "always" crate;
       extraLinkFlags = lib.concatStringsSep " " (crate.extraLinkFlags or [ ]);
       edition = crate.edition or null;
-      codegenUnits = if crate ? codegenUnits then crate.codegenUnits else "$NIX_BUILD_CORES";
+      codegenUnits = if crate ? codegenUnits then crate.codegenUnits else 1;
       extraRustcOpts =
         lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts
           ++ extraRustcOpts_

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -228,6 +228,7 @@ crate_: lib.makeOverridable
         "colors"
         "edition"
         "buildTests"
+        "codegenUnits"
       ];
       extraDerivationAttrs = builtins.removeAttrs crate processedAttrs;
       nativeBuildInputs_ = nativeBuildInputs;
@@ -310,6 +311,7 @@ crate_: lib.makeOverridable
       colors = lib.attrByPath [ "colors" ] "always" crate;
       extraLinkFlags = lib.concatStringsSep " " (crate.extraLinkFlags or [ ]);
       edition = crate.edition or null;
+      codegenUnits = if crate ? codegenUnits then crate.codegenUnits else "$NIX_BUILD_CORES";
       extraRustcOpts =
         lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts
           ++ extraRustcOpts_
@@ -324,13 +326,13 @@ crate_: lib.makeOverridable
         inherit crateName buildDependencies completeDeps completeBuildDeps crateDescription
           crateFeatures crateRenames libName build workspace_member release libPath crateVersion
           extraLinkFlags extraRustcOptsForBuildRs
-          crateAuthors crateHomepage verbose colors;
+          crateAuthors crateHomepage verbose colors codegenUnits;
       };
       buildPhase = buildCrate {
         inherit crateName dependencies
           crateFeatures crateRenames libName release libPath crateType
           metadata hasCrateBin crateBin verbose colors
-          extraRustcOpts buildTests;
+          extraRustcOpts buildTests codegenUnits;
       };
       installPhase = installCrate crateName metadata buildTests;
 


### PR DESCRIPTION
###### Description of changes

Fix the nondeterminism of buildRustCrate reported in #130309

Essentially reverts #57936 which introduced the nondeterminism while also making codegen-units configurable as in #132721

The codegen-units option of rustc affects the output of the build (as is documented), so it's not safe to default it to NIX_BUILD_CORES which may differ between builds of the same derivation (especially on different machines).  Default it to 1 since that supposedly produces the most efficient binaries but also make it configurable.  As far as I know, any fixed value should be deterministic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux

- [x] Tested, as applicable:

Before (d731df50f2ead61a08b8da3403f8eb3d115b85c2):

```shell-session
$ nix-build -A cargo-download --no-out-link --cores 1 --no-substitute
/nix/store/cknil3jb6h81f52rklmxsnpcyll786a2-rust_cargo-download-0.1.2
$ nix-build -A cargo-download --no-out-link --cores 1 --no-substitute --check
/nix/store/cknil3jb6h81f52rklmxsnpcyll786a2-rust_cargo-download-0.1.2
$ nix-build -A cargo-download --no-out-link --cores 3 --no-substitute --check
error: derivation '/nix/store/yb0gfvzip97d6h5cdva2bjjixnxpgs12-rust_cargo-download-0.1.2.drv' may not be deterministic: output '/nix/store/cknil3jb6h81f52rklmxsnpcyll786a2-rust_cargo-download-0.1.2' differs
````

After:

```shell-session
$ nix-build -A cargo-download --no-out-link --cores 1
/nix/store/ny86k3pp79y4biwzlaybh63rp207si20-rust_cargo-download-0.1.2
$ nix-build -A cargo-download --no-out-link --cores 1 --check
/nix/store/ny86k3pp79y4biwzlaybh63rp207si20-rust_cargo-download-0.1.2
$ nix-build -A cargo-download --no-out-link --cores 3 --check
/nix/store/ny86k3pp79y4biwzlaybh63rp207si20-rust_cargo-download-0.1.2
```

- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
