### PR TITLE
stdenv/check-meta: add a warning for maintainerless derivations

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -50,6 +50,9 @@ let
     hasLicense attrs &&
     isUnfree (lib.lists.toList attrs.meta.license);
 
+  hasNoMaintainers = attrs:
+    attrs ? meta.maintainers && (lib.length attrs.meta.maintainers) == 0;
+
   isMarkedBroken = attrs: attrs.meta.broken or false;
 
   hasUnsupportedPlatform = attrs:
@@ -95,6 +98,7 @@ let
     insecure = remediate_insecure;
     broken-outputs = remediateOutputsToInstall;
     unknown-meta = x: "";
+    maintainerless = x: "";
   };
   remediation_env_var = allow_attr: {
     Unfree = "NIXPKGS_ALLOW_UNFREE";
@@ -302,6 +306,11 @@ let
       { valid = "no"; reason = "broken-outputs"; errormsg = "has invalid meta.outputsToInstall"; }
     else let res = checkMeta (attrs.meta or {}); in if res != [] then
       { valid = "no"; reason = "unknown-meta"; errormsg = "has an invalid meta attrset:${lib.concatMapStrings (x: "\n\t - " + x) res}"; }
+    # --- warnings ---
+    # Please also update the type in /pkgs/top-level/config.nix alongside this.
+    else if hasNoMaintainers attrs then
+      { valid = "warn"; reason = "maintainerless"; errormsg = "has no maintainers"; }
+    # -----
     else { valid = "yes"; });
 
   assertValidity = { meta, attrs }: let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -370,7 +370,7 @@ else let
     } // {
       # Expose the result of the checks for everyone to see.
       inherit (validity) unfree broken unsupported insecure;
-      available = validity.valid
+      available = validity.valid != "no"
                && (if config.checkMetaRecursively or false
                    then lib.all (d: d.meta.available or true) references
                    else true);

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -94,6 +94,21 @@ let
       '';
     };
 
+    showDerivationWarnings = mkOption {
+      type = types.listOf (types.enum [ "maintainerless" ]);
+      default = [];
+      description = ''
+        Which warnings to display for potentially dangerous
+        or deprecated values passed into `stdenv.mkDerivation`.
+
+        A list of warnings can be found in
+        <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/stdenv/generic/check-meta.nix">/pkgs/stdenv/generic/check-meta.nix</link>.
+
+        This is not a stable interface; warnings may be added, changed
+        or removed without prior notice.
+      '';
+    };
+
   };
 
 in {


### PR DESCRIPTION
###### Description of changes

This makes stdenv.mkDerivation emit warnings when a package does not
have any maintainers in order to encourage these core packages to be adopted.

Evaluating `pkgs.hello` currently results in 12 warnings, demonstrating
the need for this.

This behavior is gated behind a `showDerivationWarnings` nixpkgs config option
to reduce unnecessary output for end users.


Example output:
```
ckie@cookiemonster ~/git/nixpkgs -> nix-build --expr '(import ./. { config = {showDerivationWarnings = true;};}).hello'
trace: Package ed-1.18 in /home/ckie/git/nixpkgs/pkgs/applications/editors/ed/default.nix:23 has no maintainers, continuing anyway.
trace: Package patch-2.7.6 in /home/ckie/git/nixpkgs/pkgs/tools/text/gnupatch/default.nix:44 has no maintainers, continuing anyway.
[...]
/nix/store/g124820p9hlv4lj8qplzxw1c44dxaw1k-hello-2.12
```
cc @lheckemann, thanks for the idea.

###### TODO

- [ ] ~~Figure out why a warning for `python3-minimal-3.9.12` is emitted even though it does have a maintainer~~ *Not block-worthy*
- [x] Add a way to suppress warnings?