### PR TITLE
calibre-web: 0.6.17 -> 0.6.18

### DIFF
--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -7,16 +7,17 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "calibre-web";
-  version = "0.6.17";
+  version = "0.6.18";
 
   src = fetchFromGitHub {
     owner = "janeczku";
     repo = "calibre-web";
     rev = version;
-    sha256 = "sha256-K2va9as+z00txpg/0fR89+kpMzpQSiSSIV489NDs8Bs=";
+    sha256 = "sha256-KjmpFetNhNM5tL34e/Pn1i3hc86JZglubSMsHZWu198=";
   };
 
   propagatedBuildInputs = with python3Packages; [
+    advocate
     backports_abc
     flask-babel
     flask_login
@@ -30,6 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     tornado
     unidecode
     Wand
+    werkzeug
   ];
 
   patches = [
@@ -55,11 +57,12 @@ python3.pkgs.buildPythonApplication rec {
       --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
       --replace "Flask>=1.0.2,<2.1.0" "Flask>=1.0.2" \
       --replace "Flask-Login>=0.3.2,<0.5.1" "Flask-Login>=0.3.2" \
-      --replace "flask-wtf>=0.14.2,<0.16.0" "flask-wtf>=0.14.2" \
-      --replace "lxml>=3.8.0,<4.8.0" "lxml>=3.8.0" \
-      --replace "PyPDF3>=1.0.0,<1.0.4" "PyPDF3>=1.0.0" \
-      --replace "requests>=2.11.1,<2.25.0" "requests" \
-      --replace "unidecode>=0.04.19,<1.3.0" "unidecode>=0.04.19"
+      --replace "flask-wtf>=0.14.2,<1.1.0" "flask-wtf>=0.14.2" \
+      --replace "lxml>=3.8.0,<4.9.0" "lxml>=3.8.0" \
+      --replace "PyPDF3>=1.0.0,<1.0.7" "PyPDF3>=1.0.0" \
+      --replace "requests>=2.11.1,<2.28.0" "requests" \
+      --replace "unidecode>=0.04.19,<1.4.0" "unidecode>=0.04.19" \
+      --replace "werkzeug<2.1.0" ""
   '';
 
   # Upstream repo doesn't provide any tests.


### PR DESCRIPTION
###### Description of changes

The PR updates calibre-web to 0.6.18.

Closes #168658

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
