### PR TITLE
apio: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/embedded/fpga/apio/default.nix
+++ b/pkgs/development/embedded/fpga/apio/default.nix
@@ -15,19 +15,20 @@
 
 buildPythonApplication rec {
   pname = "apio";
-  version = "0.8.0";
+  version = "0.8.1";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "FPGAwars";
     repo = "apio";
     rev = "v${version}";
-    sha256 = "sha256-nOZI+FHdZRnkJF/No8z0mZ4Q5aHFnF7c20ajTPI00N4=";
+    sha256 = "sha256-04qAGTzusMT3GsaRxDoXNJK1Mslzxu+ugQclBJx8xzE=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml --replace \
-      'scons==4.2.0' 'scons'
+    substituteInPlace pyproject.toml \
+      --replace 'scons==4.2.0' 'scons' \
+      --replace '==' '>='
 
     substituteInPlace apio/managers/scons.py --replace \
       'return "tinyprog --libusb --program"' \


### PR DESCRIPTION
###### Description of changes
https://github.com/FPGAwars/apio/releases/tag/v0.8.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).