### PR TITLE
pkgs/top-level/config.nix: Add warnUndeclaredOptions

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -248,7 +248,7 @@ rec {
   /* Apply fold functions to values grouped by key.
 
      Example:
-       foldAttrs (n: a: [n] ++ a) [] [{ a = 2; } { a = 3; }]
+       foldAttrs (item: acc: [item] ++ acc) [] [{ a = 2; } { a = 3; }]
        => { a = [ 2 3 ]; }
   */
   foldAttrs = op: nul:

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -122,11 +122,16 @@ in {
     let t = lib.types.attrsOf lib.types.raw;
     in t // {
       merge = loc: defs:
-        lib.mapAttrs
-          (k: v: lib.warnIf config.warnUndeclaredOptions "undeclared Nixpkgs option set: config.${k}" v)
-          (t.merge loc defs);
+        let r = t.merge loc defs;
+        in r // { _undeclared = r; };
     };
 
   inherit options;
+
+  config = {
+    warnings = lib.optionals config.warnUndeclaredOptions (
+      lib.mapAttrsToList (k: v: "undeclared Nixpkgs option set: config.${k}") config._undeclared
+    );
+  };
 
 }

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -1,6 +1,6 @@
 # This file defines the structure of the `config` nixpkgs option.
 
-{ lib, ... }:
+{ config, lib, ... }:
 
 with lib;
 
@@ -27,6 +27,11 @@ let
     };
 
     /* Config options */
+
+    warnUndeclaredOptions = mkOption {
+      description = "Whether to warn when <literal>config</literal> contains an unrecognized attribute.";
+      default = false;
+    };
 
     doCheckByDefault = mkMassRebuild {
       feature = "run <literal>checkPhase</literal> by default";
@@ -112,6 +117,15 @@ let
   };
 
 in {
+
+  freeformType =
+    let t = lib.types.attrsOf lib.types.raw;
+    in t // {
+      merge = loc: defs:
+        lib.mapAttrs
+          (k: v: lib.warnIf config.warnUndeclaredOptions "undeclared Nixpkgs option set: config.${k}" v)
+          (t.merge loc defs);
+    };
 
   inherit options;
 

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -79,15 +79,13 @@ in let
       ./config.nix
       ({ options, ... }: {
         _file = "nixpkgs.config";
-        # filter-out known options, FIXME: remove this eventually
-        config = builtins.intersectAttrs options config1;
+        config = config1;
       })
     ];
   };
 
   # take all the rest as-is
-  config = lib.showWarnings configEval.config.warnings
-    (config1 // builtins.removeAttrs configEval.config [ "_module" ]);
+  config = lib.showWarnings configEval.config.warnings configEval.config;
 
   # A few packages make a new package set to draw their dependencies from.
   # (Currently to get a cross tool chain, or forced-i686 package.) Rather than


### PR DESCRIPTION
###### Description of changes

Add option to warn about undeclared options.
Disabled for now because not all have been modeled as options yet.

cc @zhaofengli 


```
nix-repl> (import ./. { config = { k = true; warnUndeclaredOptions = true; }; }).config
trace: warning: undeclared Nixpkgs option set: config.k
{ allowAliases = true; contentAddressedByDefault = false; doCheckByDefault = false; k = true; strictDepsByDefault = false; warnUndeclaredOptions = true; warnings = [ ... ]; }

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
