### PR TITLE
python310Packages.jsonrpc-async: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/jsonrpc-async/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-async/default.nix
@@ -1,32 +1,53 @@
 { lib
+, aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, aiohttp
+, fetchpatch
 , jsonrpc-base
 , pytest-aiohttp
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "jsonrpc-async";
-  version = "2.0.0";
+  version = "2.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "emlove";
     repo = pname;
     rev = version;
-    sha256 = "1ff3523rwgira5llmf5iriwqag7b6ln9vmj0s70yyc6k98yg06rp";
+    hash = "sha256-Lr8gvQR0Q46b/e1K/XyvqtJo18nBpHjlDdNq4vjCMyU=";
   };
 
-  propagatedBuildInputs = [ aiohttp jsonrpc-base ];
+  propagatedBuildInputs = [
+    aiohttp
+    jsonrpc-base
+  ];
 
   checkInputs = [
     pytest-aiohttp
     pytestCheckHook
   ];
 
+  patches = [
+    # Fix tests with later pytest-aiohttp, https://github.com/emlove/jsonrpc-async/pull/9
+    (fetchpatch {
+      name = "support-later-pytest-aiohttp.patch";
+      url = "https://github.com/emlove/jsonrpc-async/commit/8b790f23af0d898df90460029d5ba3bcfb0423ed.patch";
+      sha256 = "sha256-rthHRF90hywMIbvIHo3Do/uzXKe+STPOoZIa80H4b/g=";
+    })
+  ];
+
   pytestFlagsArray = [
     "tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "jsonrpc_async"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/jsonrpc-base/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-base/default.nix
@@ -3,17 +3,21 @@
 , fetchFromGitHub
 , pytest-asyncio
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "jsonrpc-base";
   version = "2.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "emlove";
     repo = pname;
     rev = version;
-    sha256 = "1cd83m831ngck2v8m08pb2g29z4vr9iggi73l7h506v6clkb4n3y";
+    hash = "sha256-fliyJmVmG1DgoePE92LKm/wknlgXgYq2mOzZMFAdqLE=";
   };
 
   checkInputs = [
@@ -23,6 +27,10 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "jsonrpc_base"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/174885293)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Upstream issue: https://github.com/emlove/jsonrpc-async/pull/9