### PR TITLE
coccinelle: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/tools/misc/coccinelle/default.nix
+++ b/pkgs/development/tools/misc/coccinelle/default.nix
@@ -1,21 +1,53 @@
-{ fetchurl, lib, stdenv, python3, ncurses, ocamlPackages, pkg-config }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, ocamlPackages
+, pkg-config
+, autoreconfHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "coccinelle";
-  version = "1.1.0";
+  version = "1.1.1";
 
-  src = fetchurl {
-    url = "https://coccinelle.gitlabpages.inria.fr/website/distrib/${pname}-${version}.tar.gz";
-    sha256 = "0k0x4qnxzj8fymkp6y9irggcah070hj7hxq8l6ddj8ccpmjbhnsb";
+  src = fetchFromGitHub {
+    repo = pname;
+    rev = version;
+    owner = "coccinelle";
+    hash = "sha256-rS9Ktp/YcXF0xUtT4XZtH5F9huvde0vRztY7vGtyuqY=";
   };
 
-  buildInputs = with ocamlPackages; [
-    ocaml findlib menhir
-    ocaml_pcre parmap stdcompat
-    python3 ncurses pkg-config
+  patches = [
+    # Fix data path lookup.
+    # https://github.com/coccinelle/coccinelle/pull/270
+    (fetchpatch {
+      url = "https://github.com/coccinelle/coccinelle/commit/540888ff426e0b1f7907b63ce26e712d1fc172cc.patch";
+      sha256 = "sha256-W8RNIWDAC3lQ5bG+gD50r7x919JIcZRpt3QSOSMWpW4=";
+    })
   ];
 
-  doCheck = false;
+  nativeBuildInputs = with ocamlPackages; [
+    autoreconfHook
+    pkg-config
+    ocaml
+    findlib
+    menhir
+  ];
+
+  buildInputs = with ocamlPackages; [
+    ocaml_pcre
+    parmap
+    pyml
+    stdcompat
+  ];
+
+  strictDeps = true;
+
+  postPatch = ''
+    # Ensure dependencies from Nixpkgs are picked up.
+    rm -rf bundles/
+  '';
 
   meta = {
     description = "Program to apply semantic patches to C code";
@@ -33,8 +65,8 @@ stdenv.mkDerivation rec {
       and others) for finding and fixing bugs in systems code.
     '';
 
-    homepage = "http://coccinelle.lip6.fr/";
-    license = lib.licenses.gpl2;
+    homepage = "https://coccinelle.gitlabpages.inria.fr/website/";
+    license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.thoughtpolice ];
   };


### PR DESCRIPTION
###### Description of changes
Update to 1.1.1 

use github mirror instead.
update license. (use proper one)
enable test (I could not find any reason why disabled)
ran nixpkgs-fmt

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
