### PR TITLE
BCHD: init at 0.18.1

### DIFF
--- a/pkgs/applications/blockchains/bchd/default.nix
+++ b/pkgs/applications/blockchains/bchd/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "bchd";
+  version = "0.18.1";
+
+  src = fetchFromGitHub {
+    owner = "gcash";
+    repo = "bchd";
+    rev = "v${version}";
+    sha256 = "012alma773y8vkzplx4flh9zf0bkb8ia69phlfq4l97mbapcq213";
+  };
+
+  vendorSha256 = "047xpbykw2m0fgyiys4kynfxd18byyj92g6fbvfhbqayyjg8gkah";
+
+  # Tests are disabled because they try to write files to absolute paths. (/var/...)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An alternative full node bitcoin cash implementation written in Go (golang)";
+    homepage = "https://bchd.cash";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ilyakooo0 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30966,6 +30966,8 @@ with pkgs;
 
   balanceofsatoshis = nodePackages.balanceofsatoshis;
 
+  bchd = callPackage ../applications/blockchains/bchd { };
+
   bitcoin  = libsForQt5.callPackage ../applications/blockchains/bitcoin {
     boost = boost17x;
     miniupnpc = miniupnpc_2;


### PR DESCRIPTION
###### Description of changes

BCHD is a Bitcoin Cash (BCH) node: https://bchd.cash

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).