### PR TITLE
mindustry: propagate more runtime depends

### DIFF
--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -128,15 +128,6 @@ stdenv.mkDerivation rec {
     rm Arc/backends/backend-sdl/libs/linux64/libsdl-arc*.so
   '' + cleanupMindustrySrc;
 
-  # Propagate glew to prevent it from being cleaned up.
-  # Since a jar is a compressed archive, nix can't figure out that the dependency is actually in there,
-  # and will assume that it's not actually needed.
-  # This can cause issues.
-  # See https://github.com/NixOS/nixpkgs/issues/109798.
-  propagatedBuildInputs = lib.optionals enableClient [
-    glew.out
-  ];
-
   buildInputs = lib.optionals enableClient [
     SDL2
     glew
@@ -183,6 +174,17 @@ stdenv.mkDerivation rec {
     makeWrapper ${jdk}/bin/java $out/bin/mindustry \
       --add-flags "-jar $out/share/mindustry.jar" \
       --set ALSA_PLUGIN_DIR ${alsa-plugins}/lib/alsa-lib/
+
+    # Retain runtime depends to prevent them from being cleaned up.
+    # Since a jar is a compressed archive, nix can't figure out that the dependency is actually in there,
+    # and will assume that it's not actually needed.
+    # This can cause issues.
+    # See https://github.com/NixOS/nixpkgs/issues/109798.
+    echo "# Retained runtime dependencies: " >> $out/bin/mindustry
+    for dep in ${SDL2.out} ${alsa-lib.out} ${glew.out}; do
+      echo "# $dep" >> $out/bin/mindustry
+    done
+
     install -Dm644 core/assets/icons/icon_64.png $out/share/icons/hicolor/64x64/apps/mindustry.png
   '' + optionalString enableServer ''
     install -Dm644 server/build/libs/server-release.jar $out/share/mindustry-server.jar


### PR DESCRIPTION
glew alone is not enough to propagate explicitly:

```
$ nix run nixpkgs#mindustry
[E] Failed to initialize discord. Enable debug logging for details.
[E] java.lang.ExceptionInInitializerError
        at arc.backend.sdl.SdlApplication.lambda$init$0(SdlApplication.java:73)
        at arc.backend.sdl.SdlApplication.check(SdlApplication.java:181)
        at arc.backend.sdl.SdlApplication.init(SdlApplication.java:73)
        at arc.backend.sdl.SdlApplication.<init>(SdlApplication.java:29)
        at mindustry.desktop.DesktopLauncher.main(DesktopLauncher.java:36)
Caused by: arc.util.ArcRuntimeException: Couldn't load shared library 'libsdl-arc64.so' for target: Linux, 64-bit
        at arc.util.SharedLibraryLoader.load(SharedLibraryLoader.java:85)
        at arc.backend.sdl.jni.SDL.<clinit>(SDL.java:142)
        ... 5 more
Caused by: arc.util.ArcRuntimeException: java.lang.UnsatisfiedLinkError: /tmp/arc/35a2b27b/libsdl-arc64.so: /nix/store/v8pdm5rd4f89ng08zgxryyil065g1dh2-SDL2-2.0.20/lib/libSDL2.so: cannot open shared object file: No such file or directory
        at arc.util.SharedLibraryLoader.loadFile(SharedLibraryLoader.java:288)
        at arc.util.SharedLibraryLoader.load(SharedLibraryLoader.java:81)
        ... 6 more
Caused by: java.lang.UnsatisfiedLinkError: /tmp/arc/35a2b27b/libsdl-arc64.so: /nix/store/v8pdm5rd4f89ng08zgxryyil065g1dh2-SDL2-2.0.20/lib/libSDL2.so: cannot open shared object file: No such file or directory
        at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
        at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:383)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:227)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:169)
        at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2407)
        at java.base/java.lang.Runtime.load0(Runtime.java:747)
        at java.base/java.lang.System.load(System.java:1857)
        at arc.util.SharedLibraryLoader.loadFile(SharedLibraryLoader.java:294)
        at arc.backend.sdl.jni.SDL$3.loadFile(SDL.java:140)
        at arc.util.SharedLibraryLoader.loadFile(SharedLibraryLoader.java:260)
        ... 7 more
```

Let's add all SDL and alsa-lib as well.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
