### PR TITLE
decoder: init at unstable-2021-11-20

### DIFF
--- a/pkgs/tools/security/decoder/default.nix
+++ b/pkgs/tools/security/decoder/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "decoder";
+  version = "unstable-2021-11-20";
+
+  src = fetchFromGitHub {
+    owner = "PeterPawn";
+    repo = "decoder";
+    rev = "da0f826629d4e7b873f9d1a39f24c50ff0a68cd2";
+    sha256 = "sha256-1sT1/iwtc2ievmLuNuooy9b14pTs1ZC5noDwzFelk7w=";
+  };
+
+  buildInputs = [
+    openssl
+  ];
+
+  makeFlags = [ "OPENSSL=y" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/decoder "$out/bin/decoder"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/PeterPawn/decoder";
+    description = ''"secrets" decoding for FRITZ!OS devices'';
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6995,6 +6995,8 @@ with pkgs;
 
   deco = callPackage ../applications/misc/deco { };
 
+  decoder = callPackage ../tools/security/decoder { };
+
   icoutils = callPackage ../tools/graphics/icoutils { };
 
   idutils = callPackage ../tools/misc/idutils { };


### PR DESCRIPTION
###### Description of changes
https://github.com/PeterPawn/decoder
This package allows decrypting the backup from a FRITZ!Box (common home router in Germany) when you know the password. This is useful for example for easily recovering the DSL provider login credentials when you forgot them.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).