### PR TITLE
python3Packages.pydeps: init at 1.10.17

### DIFF
--- a/pkgs/development/python-modules/pydeps/default.nix
+++ b/pkgs/development/python-modules/pydeps/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, graphviz
+, stdlib-list
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "pydeps";
+  version = "1.10.17";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "thebjorn";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-V0LgHFvGvJqDHmyXJNb0sJjRuqGGDZpV467XDmdFg5k=";
+  };
+
+  buildInputs = [
+    graphviz
+  ];
+
+  propagatedBuildInputs = [
+    graphviz
+    stdlib-list
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pyyaml
+  ];
+
+  postPatch = ''
+    # Path is hard-coded
+    substituteInPlace pydeps/dot.py \
+      --replace "dot -Gstart=1" "${lib.makeBinPath [ graphviz ]}/dot -Gstart=1"
+  '';
+
+  disabledTests = [
+    # Would require to have additional modules available
+    "test_find_package_names"
+  ];
+
+  pythonImportsCheck = [
+    "pydeps"
+  ];
+
+  meta = with lib; {
+    description = "Python module dependency visualization";
+    homepage = "https://github.com/thebjorn/pydeps";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9558,6 +9558,8 @@ with pkgs;
 
   py-spy = callPackage ../development/tools/py-spy { };
 
+  pydeps = with python3Packages; toPythonApplication pydeps;
+
   pytrainer = callPackage ../applications/misc/pytrainer { };
 
   pywal = with python3Packages; toPythonApplication pywal;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6993,6 +6993,10 @@ in {
 
   pydenticon = callPackage ../development/python-modules/pydenticon { };
 
+  pydeps = callPackage ../development/python-modules/pydeps {
+    inherit (pkgs) graphviz;
+  };
+
   pydes = callPackage ../development/python-modules/pydes { };
 
   py-desmume = callPackage ../development/python-modules/py-desmume { };


### PR DESCRIPTION
###### Description of changes
Python module dependency visualization

https://github.com/thebjorn/pydeps

```bash
$ ./result/bin/pydeps result/lib/python3.9/site-packages/pydeps
```

![pydeps](https://user-images.githubusercontent.com/116184/166111342-a8ebedcf-be34-49b2-8605-12d14ac93d3a.svg)

Fixes #170755

Note: There is no support for `xdg-open` at the moment.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
