### PR TITLE
.github/stale bot: stop commenting

### DIFF
--- a/.github/STALE-BOT.md
+++ b/.github/STALE-BOT.md
@@ -1,6 +1,7 @@
 # Stale bot information
 
 - Thanks for your contribution!
+- Our stale bot will never close an issue or PR.
 - To remove the stale label, just leave a new comment.
 - _How to find the right people to ping?_ &rarr; [`git blame`](https://git-scm.com/docs/git-blame) to the rescue! (or GitHub's history and blame buttons.)
 - You can always ask for help on [our Discourse Forum](https://discourse.nixos.org/), [our Matrix room](https://matrix.to/#/#nix:nixos.org), or on the [#nixos IRC channel](https://web.libera.chat/#nixos).

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,5 @@ exemptLabels:
   - "1.severity: security"
   - "2.status: never-stale"
 staleLabel: "2.status: stale"
-markComment: |
-  I marked this as stale due to inactivity. &rarr; [More info](https://github.com/NixOS/nixpkgs/blob/master/.github/STALE-BOT.md)
+markComment: false
 closeComment: false


### PR DESCRIPTION
Niklas Hambüchen (@nh2) noted in

https://github.com/NixOS/rfcs/pull/124#issuecomment-1113647856

that we can add a label description for the stale label that appears
when you hover over the label, or look on

https://github.com/NixOS/nixpkgs/labels

I set the description to be

> https://github.com/NixOS/nixpkgs/blob/master/.github/STALE-BOT.md

which is our page explaining the stale bot.

The stale bot comments/emails are a significant burden on our most
prodigious contributors, and the reason for their existence to orient
new contributors.

Since our stale bot's configuration is benign enough to ignore (it
does not close), I believe it is good enough to satisfy the new
contributor orientation with the label description.

Therefore, this commit disables commenting when labeling an issue or
PR stale.

cc @blaggacao who worked on the comment with me last