### PR TITLE
cdparanoiaIII: Cleanup

### DIFF
--- a/pkgs/applications/audio/cdparanoia/configure.patch
+++ b/pkgs/applications/audio/cdparanoia/configure.patch
@@ -1,0 +1,22 @@
+diff --git a/configure.in b/configure.ac
+similarity index 90%
+rename from configure.in
+rename to configure.ac
+index 3ad98ca11da..8fad378faf4 100644
+--- a/configure.in
++++ b/configure.ac
+@@ -1,13 +1,8 @@
+ AC_INIT(interface/interface.c)
+ 
+-cp $srcdir/configure.guess $srcdir/config.guess
+-cp $srcdir/configure.sub $srcdir/config.sub
+-
+ AC_CANONICAL_HOST
+ 
+-if test -z "$CC"; then
+-	AC_PROG_CC	
+-fi
++AC_PROG_CC
+ AC_PROG_RANLIB
+ AC_CHECK_PROG(AR,ar,ar)
+ AC_CHECK_PROG(INSTALL,install,install)

--- a/pkgs/applications/audio/cdparanoia/default.nix
+++ b/pkgs/applications/audio/cdparanoia/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchurl, gnu-config, IOKit, Carbon }:
+{ lib, stdenv, fetchurl
+, updateAutotoolsGnuConfigScriptsHook, autoreconfHook
+, IOKit, Carbon
+}:
 
 stdenv.mkDerivation rec {
   pname = "cdparanoia-III";
@@ -9,7 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "1pv4zrajm46za0f6lv162iqffih57a8ly4pc69f7y0gfyigb8p80";
   };
 
-  patches = lib.optionals stdenv.isDarwin [
+  patches = [
+    ./fix_private_keyword.patch
+    ./configure.patch
+  ] ++ lib.optionals stdenv.isDarwin [
     (fetchurl {
       url = "https://trac.macports.org/export/70964/trunk/dports/audio/cdparanoia/files/osx_interface.patch";
       sha256 = "1n86kzm2ssl8fdf5wlhp6ncb2bf6b9xlb5vg0mhc85r69prqzjiy";
@@ -18,8 +24,12 @@ stdenv.mkDerivation rec {
       url = "https://trac.macports.org/export/70964/trunk/dports/audio/cdparanoia/files/patch-paranoia_paranoia.c.10.4.diff";
       sha256 = "17l2qhn8sh4jy6ryy5si6ll6dndcm0r537rlmk4a6a8vkn852vad";
     })
-    ] ++ lib.optional stdenv.hostPlatform.isMusl ./utils.patch
-    ++ [./fix_private_keyword.patch];
+  ] ++ lib.optional stdenv.hostPlatform.isMusl ./utils.patch;
+
+  nativeBuildInputs = [
+    updateAutotoolsGnuConfigScriptsHook
+    autoreconfHook
+  ];
 
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [
     Carbon
@@ -27,13 +37,6 @@ stdenv.mkDerivation rec {
   ];
 
   hardeningDisable = [ "format" ];
-
-  preConfigure = ''
-    unset CC
-  '' + lib.optionalString (!stdenv.hostPlatform.isx86) ''
-    cp ${gnu-config}/config.sub configure.sub
-    cp ${gnu-config}/config.guess configure.guess
-  '';
 
   # Build system reuses the same object file names for shared and static
   # library. Occasionally fails in the middle:


### PR DESCRIPTION
###### Description of changes

Handle CC the normal way, `unset CC` was from quite old
28b6fb61e651a3e2cca57d087781e7ba6ab45e7c during early macOS experiments
and no longer needed.

Regenerate autoconf stuff unconditionally because it is so old, and
unconditional is just simpler.

Put conditional patches after unconditional ones as is more idiomatic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
