### PR TITLE
[21.11] zsh: 5.8 -> 5.8.1

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, fetchpatch, ncurses, pcre, buildPackages }:
 
 let
-  version = "5.8";
+  version = "5.8.1";
 
   documentation = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}-doc.tar.xz";
-    sha256 = "1i6wdzq6rfjx5yjrpzan1jf50hk2pfzy5qib9mb7cnnbjfar6klv";
+    sha256 = "05zrcz321jjn2whwvpmqy73m52lf5rj0ns58cybkxw9jchyvb74b";
   };
 in
 
@@ -15,19 +15,12 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}.tar.xz";
-    sha256 = "09yyaadq738zlrnlh1hd3ycj1mv3q5hh4xl1ank70mjnqm6bbi6w";
+    sha256 = "sha256-tpc1ILrOYAtHeSACabHl155fUFrElSBYwRrVu/DdmRk=";
   };
 
   patches = [
     # fix location of timezone data for TZ= completion
     ./tz_completion.patch
-    # This commit will be released with the next version of zsh
-    (fetchpatch {
-      name = "fix-git-stash-drop-completions.patch";
-      url = "https://github.com/zsh-users/zsh/commit/754658aff38e1bdf487c58bec6174cbecd019d11.patch";
-      sha256 = "sha256-ud/rLD+SqvyTzT6vwOr+MWH+LY5o5KACrU1TpmL15Lo=";
-      excludes = [ "ChangeLog" ];
-    })
   ];
 
   buildInputs = [ ncurses pcre ];


### PR DESCRIPTION
###### Description of changes
Fixes #166710

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).