### PR TITLE
AWS C/C++ library bumps

### DIFF
--- a/pkgs/development/libraries/aws-c-auth/default.nix
+++ b/pkgs/development/libraries/aws-c-auth/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-auth";
-  version = "0.6.11";
+  version = "0.6.13";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-auth";
     rev = "v${version}";
-    sha256 = "sha256-3pFOnXDvB4CUUG992i5ErKMe3lAiyYoMTSvm6eKyLjs=";
+    sha256 = "sha256-f1STZdxj8cdK60dCgl2Xfsqaa/x3Z1xEjH3p4GUwGUg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/aws-c-cal/default.nix
+++ b/pkgs/development/libraries/aws-c-cal/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-cal";
-  version = "0.5.14";
+  version = "0.5.17";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-+hWiDlL0GVVmMajoC+hfyvT4rm16RoAWhUr04B8JZts=";
+    sha256 = "sha256-peaoTv2TLqtHScfnCPMNbE6fhUTKfRe1ZzuBsr/rpz0=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-common";
-  version = "0.6.19";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-oB5kAzIRyr8kfl4sILuIw343ghDZDXSEH97qkUeTqXI=";
+    sha256 = "sha256-DKorZUVUDEP4IRPchzaW35fPLmYoJRcfLMdPHrBrol8=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/aws-c-http/default.nix
+++ b/pkgs/development/libraries/aws-c-http/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-http";
-  version = "0.6.10";
+  version = "0.6.15";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-http";
     rev = "v${version}";
-    sha256 = "sha256-R+teEKSQjSFYt3+XXvooAy4GJwN4yzEhJtiuknBZIgU=";
+    sha256 = "sha256-WIKWF8G+fdX9MD6vQctM+5pDnR0/0TenabWE4PRteq8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/aws-c-io/default.nix
+++ b/pkgs/development/libraries/aws-c-io/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-io";
-  version = "0.10.19";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-dPstIWB+wuMJi+EfecPKw0WD1c3IvHS+L1XU72xrAoc=";
+    sha256 = "sha256-LIrAA3+Yd0lhCMQ9R4HT/ZFKm3y9iSm3h5vcn0ghiPA=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/aws-c-s3/default.nix
+++ b/pkgs/development/libraries/aws-c-s3/default.nix
@@ -6,19 +6,20 @@
 , aws-c-compression
 , aws-c-http
 , aws-c-io
+, aws-checksums
 , cmake
 , s2n-tls
 }:
 
 stdenv.mkDerivation rec {
   pname = "aws-c-s3";
-  version = "0.1.33";
+  version = "0.1.39";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-s3";
     rev = "v${version}";
-    sha256 = "sha256-lP5Luh/jFmlbb11rE5qYev+DMXjyMNwni0LcNvQGY4o=";
+    sha256 = "sha256-UbYh3awI7Y3mJnVQrltU+rZ1TI1TDaMF5TOcvxbzNa8=";
   };
 
   nativeBuildInputs = [
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
     aws-c-compression
     aws-c-http
     aws-c-io
+    aws-checksums
     s2n-tls
   ];
 

--- a/pkgs/development/libraries/aws-crt-cpp/default.nix
+++ b/pkgs/development/libraries/aws-crt-cpp/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , aws-c-auth
 , aws-c-cal
 , aws-c-common
@@ -16,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-crt-cpp";
-  version = "0.17.16";
+  version = "0.17.28";
 
   outputs = [ "out" "dev" ];
 
@@ -24,13 +25,22 @@ stdenv.mkDerivation rec {
     owner = "awslabs";
     repo = "aws-crt-cpp";
     rev = "v${version}";
-    sha256 = "sha256-RNcx/Enm1bd/NZOcNosNnYsT9Ot7AMQU7wsg+moT16c=";
+    sha256 = "sha256-4/BgwX8Pa5D2lEn0Dh3JlUiYUtA9u0rWpBixqmv1X/A=";
   };
 
   patches = [
     # Correct include path for split outputs.
     # https://github.com/awslabs/aws-crt-cpp/pull/325
     ./0001-build-Make-includedir-properly-overrideable.patch
+
+    # Fix build with new input stream api
+    # https://github.com/awslabs/aws-crt-cpp/pull/341
+    # Remove with next release
+    (fetchpatch {
+      url = "https://github.com/awslabs/aws-crt-cpp/commit/8adb8490fd4f1d1fe65aad01b0a7dda0e52ac596.patch";
+      excludes = [ "crt/*" ];
+      sha256 = "190v8rlj6z0qllih6w3kqmdvqjifj66hc4bchsgr3gpfv18vpzid";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/s2n-tls/default.nix
+++ b/pkgs/development/libraries/s2n-tls/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "s2n-tls";
-  version = "1.3.6";
+  version = "1.3.12";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-i1RbyHw+Fr1QABra6fskRpIbYxEfhOVToeesyax4NtU=";
+    sha256 = "1n1bak4s67cfizh8j5wpf05kfdcjvwqaca4rq9qys25z52bbpn9f";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION


###### Description of changes

Bumping aws-c-* collection, s2n-tls, and aws-crt-cpp to the latest versions.

These packages are all highly interdependent, and breaking changes in one can require updates in lockstep, so it makes sense to bundle these bumps into a single PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
