### PR TITLE
firrtl: init at 1.5.3

### DIFF
--- a/pkgs/development/compilers/firrtl/default.nix
+++ b/pkgs/development/compilers/firrtl/default.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, jre, setJavaClassPath, coursier, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "firrtl";
+  version = "1.5.3";
+  scalaVersion = "2.13"; # pin, for determinism
+
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version;
+    nativeBuildInputs = [ coursier ];
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      cs fetch edu.berkeley.cs:${pname}_${scalaVersion}:${version} > deps
+      mkdir -p $out/share/java
+      cp $(< deps) $out/share/java
+    '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-xy3zdJZk6Q2HbEn5tRQ9Z0AjyXEteXepoWDaATjiUUw=";
+  };
+
+  nativeBuildInputs = [ makeWrapper setJavaClassPath ];
+  buildInputs = [ deps ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-cp $CLASSPATH firrtl.stage.FirrtlMain"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/firrtl --firrtl-source "${''
+        circuit test:
+          module test:
+            input a: UInt<8>
+            input b: UInt<8>
+            output o: UInt
+            o <= add(a, not(b))
+      ''}" -o test.v
+    cat test.v
+    grep -qFe "module test" -e "endmodule" test.v
+  '';
+
+  meta = with lib; {
+    description = "Flexible Intermediate Representation for RTL";
+    longDescription = ''
+      Firrtl is an intermediate representation (IR) for digital circuits
+      designed as a platform for writing circuit-level transformations.
+    '';
+    homepage = "https://www.chisel-lang.org/firrtl/";
+    license = licenses.asl20;
+    maintainers =  with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12414,6 +12414,8 @@ with pkgs;
 
   fennel = callPackage ../development/compilers/fennel { };
 
+  firrtl = callPackage ../development/compilers/firrtl { };
+
   flasm = callPackage ../development/compilers/flasm { };
 
   flyctl = callPackage ../development/web/flyctl { };


### PR DESCRIPTION
###### Description of changes

Add firrtl!

Firrtl is an intermediate representation (IR) for digital circuits
designed as a platform for writing circuit-level transformations.

https://www.chisel-lang.org/firrtl/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).