### PR TITLE
python310Packages.ratelimiter: fix check part

### DIFF
--- a/pkgs/development/python-modules/ratelimiter/default.nix
+++ b/pkgs/development/python-modules/ratelimiter/default.nix
@@ -1,35 +1,43 @@
-{
-  lib
+{ lib
 , buildPythonPackage
 , fetchPypi
-, pytest
-, glibcLocales
+, pytest-asyncio
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "ratelimiter";
   version = "1.2.0.post0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5c395dcabdbbde2e5178ef3f89b568a3066454a6ddc223b76473dac22f89b4f7";
+    hash = "sha256-XDldyr273i5ReO8/ibVoowZkVKbdwiO3ZHPawi+JtPc=";
   };
 
-  LC_ALL = "en_US.utf-8";
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
 
-  nativeBuildInputs = [ glibcLocales ];
+  pythonImportsCheck = [
+    "ratelimiter"
+  ];
 
-  checkInputs = [ pytest ];
-
-  checkPhase = ''
-    py.test tests
+  preCheck = ''
+    # Uses out-dated options
+    rm tests/conftest.py
   '';
 
+  disabledTests = [
+    # TypeError: object Lock can't be used in 'await' expression
+    "test_alock"
+  ];
+
   meta = with lib; {
+    description = "Simple python rate limiting object";
     homepage = "https://github.com/RazerM/ratelimiter";
     license = licenses.asl20;
-    description = "Simple python rate limiting object";
     maintainers = with maintainers; [ helkafen ];
   };
 }
-


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/173995488)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
