### PR TITLE
scalafix: 0.9.0 -> 0.10.0, completions, setup-hook instead of jdk

### DIFF
--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -2,18 +2,17 @@
 
 let
   baseName = "scalafix";
-  version = "0.9.0";
+  version = "0.10.0";
   deps = stdenv.mkDerivation {
     name = "${baseName}-deps-${version}";
     buildCommand = ''
       export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/cs fetch ch.epfl.scala:scalafix-cli_2.12.7:${version} > deps
+      ${coursier}/bin/cs fetch ch.epfl.scala:scalafix-cli_2.13.8:${version} > deps
       mkdir -p $out/share/java
       cp $(< deps) $out/share/java/
     '';
     outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash     = "19j260prx7k010nxyvc1m9jj1ncxr73m2cym7if39360v5dc05c0";
+    outputHash     = "sha256-lDeg90L484MggtQ2a9OyHv4UcfLPjzG3OJZCaWW2AC8=";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, jdk, jre, coursier, makeWrapper, installShellFiles }:
+{ lib, stdenv, jre, coursier, makeWrapper, installShellFiles, setJavaClassPath }:
 
 let
   baseName = "scalafix";
@@ -19,8 +19,8 @@ stdenv.mkDerivation {
   pname = baseName;
   inherit version;
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
-  buildInputs = [ jdk deps ];
+  nativeBuildInputs = [ makeWrapper installShellFiles setJavaClassPath ];
+  buildInputs = [ deps ];
 
   dontUnpack = true;
 

--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, jdk, jre, coursier, makeWrapper }:
+{ lib, stdenv, jdk, jre, coursier, makeWrapper, installShellFiles }:
 
 let
   baseName = "scalafix";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   pname = baseName;
   inherit version;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [ jdk deps ];
 
   dontUnpack = true;
@@ -27,6 +27,10 @@ stdenv.mkDerivation {
   installPhase = ''
     makeWrapper ${jre}/bin/java $out/bin/${baseName} \
       --add-flags "-cp $CLASSPATH scalafix.cli.Cli"
+
+    installShellCompletion --cmd ${baseName} \
+      --bash <($out/bin/${baseName} --bash) \
+      --zsh  <($out/bin/${baseName} --zsh)
   '';
 
   installCheckPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13792,7 +13792,6 @@ with pkgs;
   metals = callPackage ../development/tools/metals { };
   scalafix = callPackage ../development/tools/scalafix {
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-    jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
   scalafmt = callPackage ../development/tools/scalafmt { };
 


### PR DESCRIPTION
###### Description of changes

* https://github.com/scalacenter/scalafix/releases/tag/v0.10.0

* Shell completions

NOTE: I'm honestly unsure the significance of pinning to a scala version
tag (which I bump from 2.12.7 -> 2.13.8), so someone familiar with this
please take a look :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).