### PR TITLE
vim/update.py: fix handling of redirects

### DIFF
--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -87,7 +87,8 @@ def make_request(url: str, token=None) -> urllib.request.Request:
     return urllib.request.Request(url, headers=headers)
 
 
-Redirects = Dict['Repo', 'Repo']
+# a dictionary of plugins and their new repositories
+Redirects = Dict['PluginDesc', 'Repo']
 
 class Repo:
     def __init__(
@@ -96,8 +97,8 @@ class Repo:
         self.uri = uri
         '''Url to the repo'''
         self._branch = branch
-        # {old_uri: new_uri}
-        self.redirect: Redirects = {}
+        # Redirect is the new Repo to use
+        self.redirect: Optional['Repo'] = None
         self.token = "dummy_token"
 
     @property
@@ -207,7 +208,7 @@ class RepoGitHub(Repo):
             )
 
             new_repo = RepoGitHub(owner=new_owner, repo=new_name, branch=self.branch)
-            self.redirect[self] = new_repo
+            self.redirect = new_repo
 
 
     def prefetch(self, commit: str) -> str:
@@ -237,7 +238,7 @@ class RepoGitHub(Repo):
     }}'''
 
 
-@dataclass
+@dataclass(frozen=True)
 class PluginDesc:
     repo: Repo
     branch: str
@@ -332,9 +333,19 @@ class Editor:
         self.deprecated = deprecated or root.joinpath("deprecated.json")
         self.cache_file = cache_file or f"{name}-plugin-cache.json"
 
-    def get_current_plugins(self):
+    def get_current_plugins(editor) -> List[Plugin]:
         """To fill the cache"""
-        return get_current_plugins(self)
+        with CleanEnvironment():
+            cmd = ["nix", "eval", "--extra-experimental-features", "nix-command", "--impure", "--json", "--expr", editor.get_plugins]
+            log.debug("Running command %s", cmd)
+            out = subprocess.check_output(cmd)
+        data = json.loads(out)
+        plugins = []
+        for name, attr in data.items():
+            print("get_current_plugins: name %s" % name)
+            p = Plugin(name, attr["rev"], attr["submodules"], attr["sha256"])
+            plugins.append(p)
+        return plugins
 
     def load_plugin_spec(self, config: FetchConfig, plugin_file) -> List[PluginDesc]:
         '''CSV spec'''
@@ -448,24 +459,10 @@ class CleanEnvironment(object):
         self.empty_config.close()
 
 
-def get_current_plugins(editor: Editor) -> List[Plugin]:
-    with CleanEnvironment():
-        cmd = ["nix", "eval", "--extra-experimental-features", "nix-command", "--impure", "--json", "--expr", editor.get_plugins]
-        log.debug("Running command %s", cmd)
-        out = subprocess.check_output(cmd)
-    data = json.loads(out)
-    plugins = []
-    for name, attr in data.items():
-        print("get_current_plugins: name %s" % name)
-        p = Plugin(name, attr["rev"], attr["submodules"], attr["sha256"])
-        plugins.append(p)
-    return plugins
-
-
 def prefetch_plugin(
     p: PluginDesc,
     cache: "Optional[Cache]" = None,
-) -> Tuple[Plugin, Redirects]:
+) -> Tuple[Plugin, Optional[Repo]]:
     repo, branch, alias = p.repo, p.branch, p.alias
     name = alias or p.repo.name
     commit = None
@@ -479,7 +476,7 @@ def prefetch_plugin(
         return cached_plugin, repo.redirect
 
     has_submodules = repo.has_submodules()
-    print(f"prefetch {name}")
+    log.debug(f"prefetch {name}")
     sha256 = repo.prefetch(commit)
 
     return (
@@ -488,7 +485,7 @@ def prefetch_plugin(
     )
 
 
-def print_download_error(plugin: str, ex: Exception):
+def print_download_error(plugin: PluginDesc, ex: Exception):
     print(f"{plugin}: {ex}", file=sys.stderr)
     ex_traceback = ex.__traceback__
     tb_lines = [
@@ -498,19 +495,21 @@ def print_download_error(plugin: str, ex: Exception):
     print("\n".join(tb_lines))
 
 def check_results(
-    results: List[Tuple[PluginDesc, Union[Exception, Plugin], Redirects]]
+    results: List[Tuple[PluginDesc, Union[Exception, Plugin], Optional[Repo]]]
 ) -> Tuple[List[Tuple[PluginDesc, Plugin]], Redirects]:
     ''' '''
-    failures: List[Tuple[str, Exception]] = []
+    failures: List[Tuple[PluginDesc, Exception]] = []
     plugins = []
-    # {old: new} plugindesc
-    redirects: Dict[Repo, Repo] = {}
+    redirects: Redirects = {}
     for (pdesc, result, redirect) in results:
         if isinstance(result, Exception):
-            failures.append((pdesc.name, result))
+            failures.append((pdesc, result))
         else:
-            plugins.append((pdesc, result))
-            redirects.update(redirect)
+            new_pdesc = pdesc
+            if redirect is not None:
+                redirects.update({pdesc: redirect})
+                new_pdesc = PluginDesc(redirect, pdesc.branch, pdesc.alias)
+            plugins.append((new_pdesc, result))
 
     print(f"{len(results) - len(failures)} plugins were checked", end="")
     if len(failures) == 0:
@@ -591,13 +590,13 @@ class Cache:
 
 def prefetch(
     pluginDesc: PluginDesc, cache: Cache
-) -> Tuple[PluginDesc, Union[Exception, Plugin], dict]:
+) -> Tuple[PluginDesc, Union[Exception, Plugin], Optional[Repo]]:
     try:
         plugin, redirect = prefetch_plugin(pluginDesc, cache)
         cache[plugin.commit] = plugin
         return (pluginDesc, plugin, redirect)
     except Exception as e:
-        return (pluginDesc, e, {})
+        return (pluginDesc, e, None)
 
 
 
@@ -606,7 +605,7 @@ def rewrite_input(
     input_file: Path,
     deprecated: Path,
     # old pluginDesc and the new
-    redirects: Dict[PluginDesc, PluginDesc] = {},
+    redirects: Redirects = {},
     append: List[PluginDesc] = [],
 ):
     plugins = load_plugins_from_csv(config, input_file,)
@@ -618,9 +617,10 @@ def rewrite_input(
         cur_date_iso = datetime.now().strftime("%Y-%m-%d")
         with open(deprecated, "r") as f:
             deprecations = json.load(f)
-        for old, new in redirects.items():
-            old_plugin, _ = prefetch_plugin(old)
-            new_plugin, _ = prefetch_plugin(new)
+        for pdesc, new_repo in redirects.items():
+            new_pdesc = PluginDesc(new_repo, pdesc.branch, pdesc.alias)
+            old_plugin, _ = prefetch_plugin(pdesc)
+            new_plugin, _ = prefetch_plugin(new_pdesc)
             if old_plugin.normalized_name != new_plugin.normalized_name:
                 deprecations[old_plugin.normalized_name] = {
                     "new": new_plugin.normalized_name,


### PR DESCRIPTION
###### Description of changes

I've noticed while working on the updater that it was broken when dealing with redirects, master currently stumble on lspkind-nvim for instance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
