### PR TITLE
pantheon.granite7: init at 7.0.0

### DIFF
--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -121,6 +121,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   granite = callPackage ./granite { };
 
+  granite7 = callPackage ./granite/7 { };
+
   #### SERVICES
 
   contractor = callPackage ./services/contractor { };

--- a/pkgs/desktops/pantheon/granite/7/default.nix
+++ b/pkgs/desktops/pantheon/granite/7/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, nix-update-script
+, python3
+, meson
+, ninja
+, vala
+, pkg-config
+, libgee
+, gtk4
+, glib
+, gettext
+, gsettings-desktop-schemas
+, gobject-introspection
+, wrapGAppsHook4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "granite";
+  version = "7.0.0";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-fuyjQDH3C8qRYuAfQDDeW3aSWVTLtGzMAjcuAHCB1Zw=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    python3
+    vala
+    wrapGAppsHook4
+  ];
+
+  propagatedBuildInputs = [
+    glib
+    gsettings-desktop-schemas # is_clock_format_12h uses "org.gnome.desktop.interface clock-format"
+    gtk4
+    libgee
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.granite7";
+    };
+  };
+
+  meta = with lib; {
+    description = "An extension to GTK used by elementary OS";
+    longDescription = ''
+      Granite is a companion library for GTK and GLib. Among other things, it provides complex widgets and convenience functions
+      designed for use in apps built for elementary OS.
+    '';
+    homepage = "https://github.com/elementary/granite";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.pantheon.members;
+    mainProgram = "granite-7-demo";
+  };
+}


### PR DESCRIPTION
###### Description of changes

#170361

`pantheon.granite` is for GTK3 apps and `pantheon.granite7` is for GTK4 apps.

Result of `diff pkgs/desktops/pantheon/granite/{,7/}default.nix -u`:

```diff
--- pkgs/desktops/pantheon/granite/default.nix	2022-04-30 10:15:19.406002606 +0800
+++ pkgs/desktops/pantheon/granite/7/default.nix	2022-05-01 10:04:04.205534372 +0800
@@ -1,23 +1,24 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nix-update-script
 , python3
 , meson
 , ninja
 , vala
 , pkg-config
 , libgee
-, gtk3
+, gtk4
 , glib
 , gettext
 , gsettings-desktop-schemas
 , gobject-introspection
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "granite";
-  version = "6.2.0"; # nixpkgs-update: no auto update
+  version = "7.0.0";
 
   outputs = [ "out" "dev" ];
 
@@ -25,7 +26,7 @@
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-WM0Wo9giVP5pkMFaPCHsMfnAP6xD71zg6QLCYV6lmkY=";
+    sha256 = "sha256-fuyjQDH3C8qRYuAfQDDeW3aSWVTLtGzMAjcuAHCB1Zw=";
   };
 
   nativeBuildInputs = [
@@ -36,13 +37,13 @@
     pkg-config
     python3
     vala
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   propagatedBuildInputs = [
     glib
     gsettings-desktop-schemas # is_clock_format_12h uses "org.gnome.desktop.interface clock-format"
-    gtk3
+    gtk4
     libgee
   ];
 
@@ -51,6 +52,12 @@
     patchShebangs meson/post_install.py
   '';
 
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.granite7";
+    };
+  };
+
   meta = with lib; {
     description = "An extension to GTK used by elementary OS";
     longDescription = ''
@@ -61,6 +68,6 @@
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
     maintainers = teams.pantheon.members;
-    mainProgram = "granite-demo";
+    mainProgram = "granite-7-demo";
   };
 }
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
