### PR TITLE
kube-router: 1.2.2 -> 1.4.0

### DIFF
--- a/pkgs/applications/networking/cluster/kube-router/default.nix
+++ b/pkgs/applications/networking/cluster/kube-router/default.nix
@@ -1,22 +1,32 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, testers, kube-router }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "kube-router";
-  version = "1.2.2";
-
-  goPackagePath = "github.com/cloudnativelabs/kube-router";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "cloudnativelabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/VToLQexvRtcBU+k8WnGEcfLfxme/hgRnhU8723BEFU=";
+    sha256 = "sha256-WBnJPCZHtJWckoFvE8e+eAa2EC/RA7yOMlW+Cemw53Q=";
   };
 
+  vendorSha256 = "sha256-5co+288KZf/dx/jZ7xIGh6kxuW3DdbpAsrZgYob3nWk=";
+
+  CGO_ENABLED = 0;
+
   ldflags = [
-    "-X ${goPackagePath}/pkg/cmd.version=${version}"
-    "-X ${goPackagePath}/pkg/cmd.buildDate=Nix"
+    "-s"
+    "-w"
+    "-X github.com/cloudnativelabs/kube-router/pkg/version.Version=${version}"
+    "-X github.com/cloudnativelabs/kube-router/pkg/version.BuildDate=Nix"
   ];
+
+  checkFlags = [ "-short" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = kube-router;
+  };
 
   meta = with lib; {
     homepage = "https://www.kube-router.io/";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
