### PR TITLE
python310Packages.smart-open: 5.2.1 -> 6.0.0, python39Packages.spacy: 3.2.4 -> 3.3.0, snakemake: 6.15.5 -> 7.5.0

### DIFF
--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -1,10 +1,21 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib
+, fetchFromGitHub
+, python3
+}:
 
-python3Packages.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "snakemake";
-  version = "6.15.5";
+  version = "7.5.0";
+  format = "setuptools";
 
-  propagatedBuildInputs = with python3Packages; [
+  src = fetchFromGitHub {
+    owner = "snakemake";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-KIKuV6DVHn3dDY/rJG1zNWM79tdDB6GGVH9/kYn6XaE=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
     appdirs
     configargparse
     connection-pool
@@ -22,26 +33,21 @@ python3Packages.buildPythonApplication rec {
     pyyaml
     ratelimiter
     requests
+    retry
     smart-open
     stopit
     tabulate
     toposort
     wrapt
+    yte
   ];
-
-  src = fetchFromGitHub {
-    owner = "snakemake";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-i8C7gPLzUzSxNH9xwpr+fUKI1SvpYFsFBlspS74LoWU=";
-  };
 
   # See
   # https://github.com/snakemake/snakemake/blob/main/.github/workflows/main.yml#L99
   # for the current basic test suite. Tibanna and Tes require extra
   # setup.
 
-  checkInputs = with python3Packages; [
+  checkInputs = with python3.pkgs; [
     pandas
     pytestCheckHook
     requests-mock
@@ -53,7 +59,15 @@ python3Packages.buildPythonApplication rec {
     "tests/test_linting.py"
   ];
 
-  pythonImportsCheck = [ "snakemake" ];
+  disabledTests = [
+    # Tests require network access
+    "test_github_issue1396"
+    "test_github_issue1460"
+  ];
+
+  pythonImportsCheck = [
+    "snakemake"
+  ];
 
   meta = with lib; {
     homepage = "https://snakemake.github.io";

--- a/pkgs/development/python-modules/pathy/default.nix
+++ b/pkgs/development/python-modules/pathy/default.nix
@@ -1,36 +1,59 @@
 { lib
 , buildPythonPackage
+, dataclasses
 , fetchPypi
-, pytestCheckHook
-, typer
-, smart-open
-, mock
+, fetchpatch
 , google-cloud-storage
+, mock
+, pytestCheckHook
+, pythonOlder
+, smart-open
+, typer
 }:
 
 buildPythonPackage rec {
   pname = "pathy";
   version = "0.6.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "838624441f799a06b446a657e4ecc9ebc3fdd05234397e044a7c87e8f6e76b1c";
   };
 
-  propagatedBuildInputs = [ smart-open typer google-cloud-storage ];
+  propagatedBuildInputs = [
+    smart-open
+    typer
+    google-cloud-storage
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    dataclasses
+  ];
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "smart-open>=2.2.0,<4.0.0" "smart-open>=2.2.0"
-  '';
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
 
-  checkInputs = [ pytestCheckHook mock ];
+  patches = [
+    # Support for smart-open >= 6.0.0, https://github.com/justindujardin/pathy/pull/71
+    (fetchpatch {
+      name = "support-later-smart-open.patch";
+      url = "https://github.com/justindujardin/pathy/commit/ba1c23df6ee5d1e57bdfe845ff6a9315cba3df6a.patch";
+      sha256 = "sha256-V1i4tx73Xkdqb/wZhQIv4p6FVpF9SEfDhlBkwaaRE3w=";
+    })
+  ];
 
-  # Exclude tests that require provider credentials
-  pytestFlagsArray = [
-    "--ignore=pathy/_tests/test_clients.py"
-    "--ignore=pathy/_tests/test_gcs.py"
-    "--ignore=pathy/_tests/test_s3.py"
+  disabledTestPaths = [
+    # Exclude tests that require provider credentials
+    "pathy/_tests/test_clients.py"
+    "pathy/_tests/test_gcs.py"
+    "pathy/_tests/test_s3.py"
+  ];
+
+  pythonImportsCheck = [
+    "pathy"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -9,21 +9,21 @@
 , google-cloud-storage
 , requests
 , moto
-, parameterizedtestcase
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "smart-open";
-  version = "5.2.1";
+  version = "6.0.0";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "RaRe-Technologies";
     repo = "smart_open";
     rev = "v${version}";
-    sha256 = "13a1qsb4vwrhx45hz4qcl0d7bgv20ai5vsy7cq0q6qbj212nff19";
+    sha256 = "sha256-FEIJ1DBW0mz7n+J03C1Lg8uAs2ZxI0giM7+mvuNPyGg=";
   };
 
   propagatedBuildInputs = [
@@ -37,34 +37,16 @@ buildPythonPackage rec {
 
   checkInputs = [
     moto
-    parameterizedtestcase
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "smart_open" ];
-
-  disabledTestPaths = [
-    "smart_open/tests/test_http.py"
-    "smart_open/tests/test_s3.py"
-    "smart_open/tests/test_s3_version.py"
-    "smart_open/tests/test_sanity.py"
+  pytestFlagsArray = [
+    "smart_open"
   ];
 
-  disabledTests = [
-    "test_compression_invalid"
-    "test_gs_uri_contains_question_mark"
-    "test_gzip_compress_sanity"
-    "test_http"
-    "test_ignore_ext"
-    "test_initialize_write"
-    "test_read_explicit"
-    "test_s3_handles_querystring"
-    "test_s3_uri_contains_question_mark"
-    "test_webhdfs"
-    "test_write"
+  pythonImportsCheck = [
+    "smart_open"
   ];
-
-  pythonImportsCheck = [ "smart_open" ];
 
   meta = with lib; {
     description = "Library for efficient streaming of very large file";

--- a/pkgs/development/python-modules/spacy-transformers/default.nix
+++ b/pkgs/development/python-modules/spacy-transformers/default.nix
@@ -2,6 +2,7 @@
 , callPackage
 , fetchPypi
 , buildPythonPackage
+, dataclasses
 , pytorch
 , pythonOlder
 , spacy
@@ -13,17 +14,14 @@
 buildPythonPackage rec {
   pname = "spacy-transformers";
   version = "1.1.5";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-nxbmnFyHptbe5M7rQi2ECGoBpxUuutdCtY20eHsGDPI=";
+    hash = "sha256-nxbmnFyHptbe5M7rQi2ECGoBpxUuutdCtY20eHsGDPI=";
   };
-
-  postPatch = ''
-    sed -i 's/transformers>=3.4.0,<4.13.0/transformers/' setup.cfg
-  '';
 
   propagatedBuildInputs = [
     pytorch
@@ -31,12 +29,16 @@ buildPythonPackage rec {
     spacy-alignments
     srsly
     transformers
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    dataclasses
   ];
 
   # Test fails due to missing arguments for trfs2arrays().
   doCheck = false;
 
-  pythonImportsCheck = [ "spacy_transformers" ];
+  pythonImportsCheck = [
+    "spacy_transformers"
+  ];
 
   passthru.tests.annotation = callPackage ./annotation-test { };
 

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -1,43 +1,44 @@
 { lib
+, blis
 , buildPythonPackage
 , callPackage
-, fetchPypi
-, pythonOlder
-, pytest
-, blis
 , catalogue
 , cymem
+, fetchPypi
 , jinja2
 , jsonschema
+, langcodes
 , murmurhash
 , numpy
-, preshed
-, requests
-, setuptools
-, srsly
-, spacy-legacy
-, thinc
-, typer
-, wasabi
 , packaging
 , pathy
+, preshed
 , pydantic
+, pytest
 , python
-, tqdm
-, typing-extensions
+, pythonOlder
+, requests
+, setuptools
+, spacy-legacy
 , spacy-loggers
-, langcodes
+, srsly
+, thinc
+, tqdm
+, typer
+, typing-extensions
+, wasabi
 }:
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "3.2.4";
+  version = "3.3.0";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-PkxvKY1UBEWC2soRQrCC7jiDG7PXu5MdLuYB6Ljc5k8=";
+    hash = "sha256-xJ1Q++NxWtxXQUGTZ7OaRo0lVmSEIvELb8Tt846uLLM=";
   };
 
   propagatedBuildInputs = [
@@ -46,6 +47,7 @@ buildPythonPackage rec {
     cymem
     jinja2
     jsonschema
+    langcodes
     murmurhash
     numpy
     packaging
@@ -54,15 +56,16 @@ buildPythonPackage rec {
     pydantic
     requests
     setuptools
-    srsly
     spacy-legacy
+    spacy-loggers
+    srsly
     thinc
     tqdm
     typer
     wasabi
-    spacy-loggers
-    langcodes
-  ] ++ lib.optional (pythonOlder "3.8") typing-extensions;
+  ] ++ lib.optional (pythonOlder "3.8") [
+    typing-extensions
+  ];
 
   postPatch = ''
     substituteInPlace setup.cfg \
@@ -78,12 +81,14 @@ buildPythonPackage rec {
     ${python.interpreter} -m pytest spacy/tests --vectors --models --slow
   '';
 
-  pythonImportsCheck = [ "spacy" ];
+  pythonImportsCheck = [
+    "spacy"
+  ];
 
   passthru.tests.annotation = callPackage ./annotation-test { };
 
   meta = with lib; {
-    description = "Industrial-strength Natural Language Processing (NLP) with Python and Cython";
+    description = "Industrial-strength Natural Language Processing (NLP)";
     homepage = "https://github.com/explosion/spaCy";
     license = licenses.mit;
     maintainers = with maintainers; [ ];

--- a/pkgs/development/python-modules/yte/default.nix
+++ b/pkgs/development/python-modules/yte/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, plac
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "yte";
+  version = "1.2.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "koesterlab";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-x0CmPiV/6zTnawPW9lgrZ9NsUhmK8fhafwqOP9o3Mdc=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    plac
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "yte"
+  ];
+
+  pytestFlagsArray = [
+    "tests.py"
+  ];
+
+  preCheck = ''
+    # The CLI test need yte on the PATH
+    export PATH=$out/bin:$PATH
+  '';
+
+  meta = with lib; {
+    description = "YAML template engine with Python expressions";
+    homepage = "https://github.com/koesterlab/yte";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11145,6 +11145,8 @@ in {
     inherit (pkgs) jq;
   };
 
+  yte = callPackage ../development/python-modules/yte { };
+
   ytmusicapi = callPackage ../development/python-modules/ytmusicapi { };
 
   yubico-client = callPackage ../development/python-modules/yubico-client { };


### PR DESCRIPTION
###### Description of changes
Related #171055

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
