### PR TITLE
bloop: 1.4.13 -> 1.5.0

### DIFF
--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchurl
-, coursier
 , autoPatchelfHook
 , installShellFiles
 , makeWrapper
@@ -11,58 +10,34 @@
 
 stdenv.mkDerivation rec {
   pname = "bloop";
-  version = "1.4.13";
+  version = "1.5.0";
 
-  bloop-coursier-channel = fetchurl {
-    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-coursier.json";
-    sha256 = "VbvBAz7mXhgQtbrlB6uCSmZXLcdYaROJRSREbazAReo=";
-  };
+  platform =
+    if stdenv.isLinux && stdenv.isx86_64 then "x86_64-pc-linux"
+    else if stdenv.isDarwin && stdenv.isx86_64 then "x86_64-apple-darwin"
+    else throw "unsupported platform";
 
   bloop-bash = fetchurl {
     url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bash-completions";
-    sha256 = "2mt+zUEJvQ/5ixxFLZ3Z0m7uDSj/YE9sg/uNMjamvdE=";
+    sha256 = "sha256-2mt+zUEJvQ/5ixxFLZ3Z0m7uDSj/YE9sg/uNMjamvdE=";
   };
 
   bloop-fish = fetchurl {
     url = "https://github.com/scalacenter/bloop/releases/download/v${version}/fish-completions";
-    sha256 = "eFESR6iPHRDViGv+Fk3sCvPgVAhk2L1gCG4LnfXO/v4=";
+    sha256 = "sha256-eFESR6iPHRDViGv+Fk3sCvPgVAhk2L1gCG4LnfXO/v4=";
   };
 
   bloop-zsh = fetchurl {
     url = "https://github.com/scalacenter/bloop/releases/download/v${version}/zsh-completions";
-    sha256 = "WNMsPwBfd5EjeRbRtc06lCEVI2FVoLfrqL82OR0G7/c=";
+    sha256 = "sha256-WNMsPwBfd5EjeRbRtc06lCEVI2FVoLfrqL82OR0G7/c=";
   };
 
-  bloop-coursier = stdenv.mkDerivation rec {
-    name = "${pname}-coursier-${version}";
-
-    platform = if stdenv.isLinux && stdenv.isx86_64 then "x86_64-pc-linux"
-    else if stdenv.isDarwin && stdenv.isx86_64 then "x86_64-apple-darwin"
-    else throw "unsupported platform";
-
-    dontUnpack = true;
-    installPhase = ''
-      runHook preInstall
-
-      export COURSIER_CACHE=$(pwd)
-      export COURSIER_JVM_CACHE=$(pwd)
-
-      mkdir channel
-      ln -s ${bloop-coursier-channel} channel/bloop.json
-      ${coursier}/bin/cs install --install-dir . --install-platform ${platform} --default-channels=false --channel channel --only-prebuilt=true bloop
-
-      # Only keeping the binary, we'll wrap it ourselves
-      # This guarantees the output of this fixed-output derivation doesn't have references to itself
-      install -D -m 0755 .bloop.aux $out
-
-      runHook postInstall
-    '';
-
-    outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash = if stdenv.isLinux && stdenv.isx86_64 then "sha256-AiF/ih15Jd0WuDP/0vU0vdaSo3FGjWXos+hNVBayFz4="
-    else if stdenv.isDarwin && stdenv.isx86_64 then "sha256-LD23YpcNhWfioGDMqb1plqLy87ZHzT0zvIyc4O4WP5g="
-    else throw "unsupported platform";
+  bloop-binary = fetchurl rec {
+    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-${platform}";
+    sha256 =
+      if stdenv.isLinux && stdenv.isx86_64 then "sha256-jif9z05W17vjFgb146qWC3o44HmbnX05gWPlbXttYsE="
+      else if stdenv.isDarwin && stdenv.isx86_64 then "sha256-YOnXgKXsGrTu9P4I0NZW6ollZVQUXnbW8WtZTJmy+w0="
+      else throw "unsupported platform";
   };
 
   dontUnpack = true;
@@ -74,14 +49,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    export COURSIER_CACHE=$(pwd)
-    export COURSIER_JVM_CACHE=$(pwd)
+    install -D -m 0755 ${bloop-binary} $out/.bloop-wrapped
 
-    install -D -m 0755 ${bloop-coursier} $out/.bloop-wrapped
-
-    makeWrapper $out/.bloop-wrapped $out/bin/bloop \
-      --set CS_NATIVE_LAUNCHER true \
-      --set IS_CS_INSTALLED_LAUNCHER true
+    makeWrapper $out/.bloop-wrapped $out/bin/bloop
 
     #Install completions
     installShellCompletion --name bloop --bash ${bloop-bash}


### PR DESCRIPTION
###### Description of changes

Updates bloop from 1.4.13 to 1.5.0.

This removes the dependency on coursier for installation. The reasoning is that, since we are using prepackaged binaries, coursier's use is very limited. It also reduces the complexity of the derivation since we are relying on fetchUrl instead.

I didn't see any issue with that change, however some more testing on darwin would be welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
