### PR TITLE
python310Packages.fastjsonschema: 2.15.2 -> 2.15.3

### DIFF
--- a/pkgs/development/python-modules/fastjsonschema/default.nix
+++ b/pkgs/development/python-modules/fastjsonschema/default.nix
@@ -1,24 +1,23 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "fastjsonschema";
-  version = "2.15.2";
+  version = "2.15.3";
   format = "setuptools";
 
-  disabled = pythonOlder "3.3";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "horejsek";
     repo = "python-fastjsonschema";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-zrdQVFfLZxZRr9qvss4CI3LJK97xl+bY+AcPzcweYeU=";
+    sha256 = "sha256-WKnjSlKtMGpWKPbPr7hpS6Dg0+9i/nWVYmar0N3Q9Pc=";
   };
 
   checkInputs = [
@@ -26,16 +25,6 @@ buildPythonPackage rec {
   ];
 
   dontUseSetuptoolsCheck = true;
-
-  patches = [
-    # Can be removed with the next release, https://github.com/horejsek/python-fastjsonschema/pull/134
-    (fetchpatch {
-      name = "fix-exception-name.patch";
-      url = "https://github.com/horejsek/python-fastjsonschema/commit/f639dcba0299926d688e1d8d08a6a91bfe70ce8b.patch";
-      sha256 = "sha256-yPV5ZNeyAobLrYf5QHanPsEomBPJ/7ZN2148R8NO4/U=";
-    })
-  ];
-
 
   disabledTests = [
     "benchmark"

--- a/pkgs/development/python-modules/typical/default.nix
+++ b/pkgs/development/python-modules/typical/default.nix
@@ -14,7 +14,7 @@
 , pytestCheckHook
 , pythonOlder
 , sqlalchemy
-, typing-extensions
+, ujson
 }:
 
 buildPythonPackage rec {
@@ -22,7 +22,8 @@ buildPythonPackage rec {
   version = "2.8.0";
   format = "pyproject";
 
-  disabled = pythonOlder "3.7";
+  # Support for typing-extensions >= 4.0.0 on Python < 3.10 is missing
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "seandstewart";
@@ -36,13 +37,12 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    inflection
-    pendulum
     fastjsonschema
-    orjson
     future-typing
-  ] ++ lib.optionals (pythonOlder "3.10") [
-    typing-extensions
+    inflection
+    orjson
+    pendulum
+    ujson
   ];
 
   checkInputs = [
@@ -63,13 +63,14 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # We use orjson
-    "test_ujson"
     # ConstraintValueError: Given value <{'key...
     "test_tagged_union_validate"
+    # TypeError: 'NoneType' object cannot be interpreted as an integer
+    "test_ujson"
   ];
 
   disabledTestPaths = [
+    # We don't care about benchmarks
     "benchmark/"
     # Tests are failing on Hydra
     "tests/mypy/test_mypy.py"


### PR DESCRIPTION
###### Description of changes
https://github.com/horejsek/python-fastjsonschema/blob/master/CHANGELOG.txt
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
