### PR TITLE
makeInitrdNG: Strip more and remove output

### DIFF
--- a/nixos/modules/system/boot/systemd/shutdown.nix
+++ b/nixos/modules/system/boot/systemd/shutdown.nix
@@ -44,7 +44,7 @@ in {
         ];
       };
 
-      path = [pkgs.util-linux pkgs.makeInitrdNGTool pkgs.glibc pkgs.patchelf];
+      path = [pkgs.util-linux pkgs.makeInitrdNGTool];
       serviceConfig.Type = "oneshot";
       script = ''
         mkdir -p /run/initramfs

--- a/nixos/tests/systemd-initrd-simple.nix
+++ b/nixos/tests/systemd-initrd-simple.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ lib, pkgs, ... }: {
   name = "systemd-initrd-simple";
 
-  machine = { pkgs, ... }: {
+  nodes.machine = { pkgs, ... }: {
     boot.initrd.systemd = {
       enable = true;
       emergencyAccess = true;

--- a/pkgs/build-support/kernel/make-initrd-ng-tool.nix
+++ b/pkgs/build-support/kernel/make-initrd-ng-tool.nix
@@ -1,4 +1,4 @@
-{ rustPlatform }:
+{ rustPlatform, lib, makeWrapper, patchelf, glibc, binutils }:
 
 rustPlatform.buildRustPackage {
   pname = "make-initrd-ng";
@@ -6,4 +6,11 @@ rustPlatform.buildRustPackage {
 
   src = ./make-initrd-ng;
   cargoLock.lockFile = ./make-initrd-ng/Cargo.lock;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/make-initrd-ng \
+      --prefix PATH : ${lib.makeBinPath [ patchelf glibc binutils ]}
+  '';
 }

--- a/pkgs/build-support/kernel/make-initrd-ng.nix
+++ b/pkgs/build-support/kernel/make-initrd-ng.nix
@@ -8,7 +8,7 @@ let
   # compression type and filename extension.
   compressorName = fullCommand: builtins.elemAt (builtins.match "([^ ]*/)?([^ ]+).*" fullCommand) 1;
 in
-{ stdenvNoCC, perl, cpio, ubootTools, lib, pkgsBuildHost, makeInitrdNGTool, patchelf, runCommand, glibc
+{ stdenvNoCC, perl, cpio, ubootTools, lib, pkgsBuildHost, makeInitrdNGTool, patchelf, runCommand
 # Name of the derivation (not of the resulting file!)
 , name ? "initrd"
 
@@ -72,7 +72,7 @@ in
   passAsFile = ["contents"];
   contents = lib.concatMapStringsSep "\n" ({ object, symlink, ... }: "${object}\n${if symlink == null then "" else symlink}") contents + "\n";
 
-  nativeBuildInputs = [makeInitrdNGTool patchelf glibc cpio] ++ lib.optional makeUInitrd ubootTools;
+  nativeBuildInputs = [makeInitrdNGTool patchelf cpio] ++ lib.optional makeUInitrd ubootTools;
 } ''
   mkdir ./root
   make-initrd-ng "$contentsPath" ./root

--- a/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
+++ b/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::io::{BufReader, BufRead, Error, ErrorKind};
 use std::os::unix;
 use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 struct NonRepeatingQueue<T> {
     queue: VecDeque<T>,
@@ -42,7 +42,6 @@ fn patch_elf<S: AsRef<OsStr>, P: AsRef<OsStr>>(mode: S, path: P) -> Result<Strin
     let output = Command::new("patchelf")
         .arg(&mode)
         .arg(&path)
-        .stderr(Stdio::inherit())
         .output()?;
     if output.status.success() {
         Ok(String::from_utf8(output.stdout).expect("Failed to parse output"))
@@ -51,16 +50,15 @@ fn patch_elf<S: AsRef<OsStr>, P: AsRef<OsStr>>(mode: S, path: P) -> Result<Strin
     }
 }
 
-fn copy_file<P: AsRef<Path> + AsRef<OsStr>, S: AsRef<Path>>(
+fn copy_file<P: AsRef<Path> + AsRef<OsStr>, S: AsRef<Path> + AsRef<OsStr>>(
     source: P,
     target: S,
     queue: &mut NonRepeatingQueue<Box<Path>>,
 ) -> Result<(), Error> {
-    fs::copy(&source, target)?;
+    fs::copy(&source, &target)?;
 
     if !Command::new("ldd").arg(&source).output()?.status.success() {
-        //stdout(Stdio::inherit()).stderr(Stdio::inherit()).
-        println!("{:?} is not dynamically linked. Not recursing.", OsStr::new(&source));
+        // Not dynamically linked - no need to recurse
         return Ok(());
     }
 
@@ -90,6 +88,17 @@ fn copy_file<P: AsRef<Path> + AsRef<OsStr>, S: AsRef<Path>>(
             println!("Warning: Couldn't satisfy dependency {} for {:?}", line, OsStr::new(&source));
         }
     }
+
+    // Make file writable to strip it
+    let mut permissions = fs::metadata(&target)?.permissions();
+    permissions.set_readonly(false);
+    fs::set_permissions(&target, permissions)?;
+
+    // Strip further than normal
+    if !Command::new("strip").arg("--strip-all").arg(OsStr::new(&target)).output()?.status.success() {
+        println!("{:?} was not successfully stripped.", OsStr::new(&target));
+    }
+
 
     Ok(())
 }
@@ -200,7 +209,6 @@ fn main() -> Result<(), Error> {
         }
     }
     while let Some(obj) = queue.pop_front() {
-        println!("{:?}", obj);
         handle_path(out_path, &*obj, &mut queue)?;
     }
 


### PR DESCRIPTION
This strips all elf files as far as possible and removes a lot of
unnecessary output.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
