### PR TITLE
pythonPackages.pycapnp: fix by moving pkgconfig back to buildInputs

### DIFF
--- a/pkgs/development/python-modules/pycapnp/default.nix
+++ b/pkgs/development/python-modules/pycapnp/default.nix
@@ -20,9 +20,9 @@ buildPythonPackage rec {
     sha256 = "1xi6df93ggkpmwckwbi356v7m32zv5qry8s45hvsps66dz438kmi";
   };
 
-  nativeBuildInputs = [ cython pkgconfig ];
+  nativeBuildInputs = [ cython ];
 
-  buildInputs = [ capnproto ];
+  buildInputs = [ capnproto pkgconfig ];
 
   # Tests depend on schema_capnp which fails to generate
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

Unbreak pycapnp, by moving pkgconfig back to buildInputs.

(FWIW pkgconfig here is the python package, not pkg-config the native
tool).

Fixes #170796.

Partially reverts 30b30332967dc5caadd84c3d5930221e5c7813d6 .

As an aside, it's curious why this needs to be a buildInputs-- and
cython doesn't-- but it does appear to be the case.

That commit does not appear to have worked even at the point it was
made, I'm not sure what the story is there.

(it appears to be the "right thing" AFAICT based on docs, however)

There's more to look into re:pkgconfig but I'll file an issue soon.
If/until that's resolved, this fixes pycapnp.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).