### PR TITLE
duckdb: run unit tests

### DIFF
--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     ''
       runHook preInstallCheck
 
-      $PWD/test/unittest ${toString excludes}
+      $PWD/test/unittest ${lib.concatStringsSep " " excludes}
 
       runHook postInstallCheck
     '';

--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
 
+  preInstallCheck = lib.optionalString stdenv.isDarwin ''
+    export DYLD_LIBRARY_PATH="$out/lib''${DYLD_LIBRARY_PATH:+:}''${DYLD_LIBRARY_PATH}"
+  '';
+
   installCheckPhase =
     let
       excludes = map (pattern: "exclude:'${pattern}'") [

--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -47,6 +47,22 @@ stdenv.mkDerivation rec {
     "-DJDBC_DRIVER=${enableFeature withJdbc}"
   ];
 
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $PWD/test/unittest \
+      'exclude:[test_slow]' \
+      'exclude:*test_slow' \
+      exclude:test/sql/copy/csv/test_csv_remote.test \
+      exclude:test/sql/copy/parquet/test_parquet_remote.test \
+      exclude:test/common/test_cast_hugeint.test \
+      exclude:'Test file buffers for reading/writing to file'
+
+    runHook postInstallCheck
+  '';
+
   nativeBuildInputs = [ cmake ninja ];
   buildInputs = lib.optionals withHttpFs [ openssl ]
     ++ lib.optionals withJdbc [ openjdk11 ]


### PR DESCRIPTION
###### Description of changes

This PR runs duckdb's test suite as an install check.

Running the tests takes about 3m30s on my machine, so I'm happy to close this
PR if that adds too much time to the build.

Unfortunately, it doesn't look like there's a way to get more output during the
test phase than what I've already got here, which isn't much.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
