### PR TITLE
pkgsCross.mingw32.gcc11Stdenv: update mcfgthread patches for gcc-11

### DIFF
--- a/pkgs/development/compilers/gcc/11/Added-mcf-thread-model-support-from-mcfgthread.patch
+++ b/pkgs/development/compilers/gcc/11/Added-mcf-thread-model-support-from-mcfgthread.patch
@@ -222,16 +222,16 @@ index de920d714c6..665fb74bd6b 100644
 +#ifdef __USING_MCFGTHREAD__
 +
 +#include <mcfgthread/gthread.h>
-+
++namespace __cxxabiv1 {
 +extern "C" int
-+__cxxabiv1::__cxa_thread_atexit (void (*dtor)(void *),
++__cxa_thread_atexit (void (_GLIBCXX_CDTOR_CALLABI *dtor)(void *),
 +				 void *obj, void *dso_handle)
 +  _GLIBCXX_NOTHROW
 +{
 +  return ::_MCFCRT_AtThreadExit((void (*)(_MCFCRT_STD intptr_t))dtor, (_MCFCRT_STD intptr_t)obj) ? 0 : -1;
 +  (void)dso_handle;
 +}
-+
++}
 +#else // __USING_MCFGTHREAD__
 +
  #ifdef _GLIBCXX_THREAD_ATEXIT_WIN32


### PR DESCRIPTION
Without the change mingw32-gcc fails to build as:

    In file included from /build/gcc-11.2.0/libstdc++-v3/libsupc++/cxxabi.h:49,
                     from ../../../../gcc-11.2.0/libstdc++-v3/libsupc++/atexit_thread.cc:24:
    ../../../../gcc-11.2.0/libstdc++-v3/libsupc++/atexit_thread.cc:36:3: error: 'int __cxxabiv1::__cxa_thread_atexit(void (*)(void*), void*, void*)' should have been declared inside '__cxxabiv1'
       36 |   _GLIBCXX_NOTHROW
          |   ^~~~~~~~~~~~~~~~
    ../../../../gcc-11.2.0/libstdc++-v3/libsupc++/atexit_thread.cc:34:1: error: conflicting declaration of C function 'int __cxxabiv1::__cxa_thread_atexit(void (*)(void*), void*, void*)'
       34 | __cxxabiv1::__cxa_thread_atexit (void (*dtor)(void *),
          | ^~~~~~~~~~

The change follows upstream change introduced in
https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=7fc0f78c3f43af1967cb7b1ee8f4947f3b890aa2

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
