### PR TITLE
Disable GRUB by default

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -692,10 +692,6 @@ in
 
     boot.loader.grub.version = 2;
 
-    # Don't build the GRUB menu builder script, since we don't need it
-    # here and it causes a cyclic dependency.
-    boot.loader.grub.enable = false;
-
     environment.systemPackages =  [ grubPkgs.grub2 grubPkgs.grub2_efi ]
       ++ optional canx86BiosBoot pkgs.syslinux
     ;

--- a/nixos/modules/installer/cd-dvd/system-tarball-fuloong2f.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-fuloong2f.nix
@@ -150,7 +150,6 @@ in
   services.openssh.enable = true;
   systemd.services.openssh.wantedBy = lib.mkOverride 50 [];
 
-  boot.loader.grub.enable = false;
   boot.loader.generationsDir.enable = false;
   system.boot.loader.kernelFile = "vmlinux";
 

--- a/nixos/modules/installer/cd-dvd/system-tarball-pc.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-pc.nix
@@ -117,9 +117,6 @@ in
     kernelPackages = pkgs.linuxKernel.packages.linux_3_4;
   };
 
-  # No grub for the tarball.
-  boot.loader.grub.enable = false;
-
   /* fake entry, just to have a happy stage-1. Users
      may boot without having stage-1 though */
   fileSystems.fake =

--- a/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
@@ -80,7 +80,6 @@ in
       pkgs.joe
     ];
 
-  boot.loader.grub.enable = false;
   boot.loader.generationsDir.enable = false;
   system.boot.loader.kernelFile = "uImage";
 

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -19,10 +19,6 @@ with lib;
   };
 
   config = {
-    # Don't build the GRUB menu builder script, since we don't need it
-    # here and it causes a cyclic dependency.
-    boot.loader.grub.enable = false;
-
     # !!! Hack - attributes expected by other modules.
     environment.systemPackages = [ pkgs.grub2_efi ]
       ++ (if pkgs.stdenv.hostPlatform.system == "aarch64-linux"

--- a/nixos/modules/installer/sd-card/sd-image-aarch64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64.nix
@@ -8,7 +8,6 @@
     ./sd-image.nix
   ];
 
-  boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.consoleLogLevel = lib.mkDefault 7;

--- a/nixos/modules/installer/sd-card/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/sd-card/sd-image-armv7l-multiplatform.nix
@@ -8,7 +8,6 @@
     ./sd-image.nix
   ];
 
-  boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.consoleLogLevel = lib.mkDefault 7;

--- a/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
@@ -8,7 +8,6 @@
     ./sd-image.nix
   ];
 
-  boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.consoleLogLevel = lib.mkDefault 7;

--- a/nixos/modules/installer/sd-card/sd-image-riscv64-qemu.nix
+++ b/nixos/modules/installer/sd-card/sd-image-riscv64-qemu.nix
@@ -9,7 +9,6 @@
   ];
 
   boot.loader = {
-    grub.enable = false;
     generic-extlinux-compatible = {
       enable = true;
 

--- a/nixos/modules/installer/sd-card/sd-image-x86_64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-x86_64.nix
@@ -10,11 +10,7 @@
     ./sd-image.nix
   ];
 
-  boot.loader = {
-    grub.enable = false;
-    generic-extlinux-compatible.enable = true;
-  };
-
+  boot.loader.generic-extlinux-compatible.enable = true;
   boot.consoleLogLevel = lib.mkDefault 7;
 
   sdImage = {

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -644,8 +644,6 @@ if ($showHardwareConfig) {
 EOF
         } elsif (-e "/boot/extlinux") {
             $bootLoaderConfig = <<EOF;
-  # Use the extlinux boot loader. (NixOS wants to enable GRUB by default)
-  boot.loader.grub.enable = false;
   # Enables the generation of /boot/extlinux/extlinux.conf
   boot.loader.generic-extlinux-compatible.enable = true;
 EOF

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -100,8 +100,7 @@ in
     boot.loader.grub = {
 
       enable = mkOption {
-        default = !config.boot.isContainer;
-        defaultText = literalExpression "!config.boot.isContainer";
+        default = false;
         type = types.bool;
         description = ''
           Whether to enable the GNU GRUB boot loader.

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -259,8 +259,6 @@ in {
         }
       ]) (builtins.attrNames cfg.extraFiles);
 
-    boot.loader.grub.enable = mkDefault false;
-
     boot.loader.supportsInitrdSecrets = true;
 
     boot.loader.systemd-boot.extraFiles = mkMerge [

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -877,5 +877,14 @@ in
       "tap"
       "tun"
     ];
+
+    assertions = [
+      {
+        assertion = !(config.boot.isContainer && config.boot.loader.grub.enable);
+        message = ''
+          GRUB should not be used in a container.
+        '';
+      }
+    ];
   });
 }

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -20,6 +20,7 @@ let
 
     hardware.enableAllFirmware = mkForce false;
     documentation.nixos.enable = false;
+    boot.loader.grub.enable = true;
     boot.loader.grub.device = "/dev/vda";
 
     systemd.services.backdoor.conflicts = [ "sleep.target" ];

--- a/nixos/tests/image-contents.nix
+++ b/nixos/tests/image-contents.nix
@@ -18,6 +18,7 @@ let
       ../modules/profiles/qemu-guest.nix
       {
         fileSystems."/".device = "/dev/disk/by-label/nixos";
+        boot.loader.grub.enable = true;
         boot.loader.grub.device = "/dev/vda";
         boot.loader.timeout = 0;
       }

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -27,6 +27,7 @@ let
         ${optionalString systemdStage1 "boot.initrd.systemd.enable = true;"}
 
         ${optionalString (bootLoader == "grub") ''
+          boot.loader.grub.enable = true;
           boot.loader.grub.version = ${toString grubVersion};
           ${optionalString (grubVersion == 1) ''
             boot.loader.grub.splashImage = null;

--- a/nixos/tests/iscsi-multipath-root.nix
+++ b/nixos/tests/iscsi-multipath-root.nix
@@ -120,7 +120,6 @@ import ./make-test-python.nix (
 
       initiatorRootDisk = { config, pkgs, modulesPath, lib, ... }: {
         boot.initrd.network.enable = true;
-        boot.loader.grub.enable = false;
 
         boot.kernelParams = lib.mkOverride 5 (
           [

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -103,7 +103,6 @@ import ./make-test-python.nix (
           };
 
           initiatorRootDisk = { config, pkgs, modulesPath, lib, ... }: {
-            boot.loader.grub.enable = false;
             boot.kernelParams = lib.mkOverride 5 (
               [
                 "boot.shell_on_fail"

--- a/nixos/tests/nixops/legacy/base-configuration.nix
+++ b/nixos/tests/nixops/legacy/base-configuration.nix
@@ -20,7 +20,6 @@ in
   virtualisation.graphics = false;
   documentation.enable = false;
   services.qemuGuest.enable = true;
-  boot.loader.grub.enable = false;
 
   services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keys = [

--- a/nixos/tests/sourcehut.nix
+++ b/nixos/tests/sourcehut.nix
@@ -83,6 +83,7 @@ let
           ];
           boot.loader = {
             grub = {
+              enable = true;
               version = 2;
               device = "/dev/vda";
             };

--- a/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
@@ -23,7 +23,6 @@ in pkg.overrideAttrs (o: {
     passthru = o.passthru // {
       # Does not test the package, but evaluation of the related NixOS module.
       tests.nixos-minimal-config = nixos {
-        boot.loader.grub.enable = false;
         fileSystems."/".device = "bogus";
         services.hercules-ci-agent.enable = true;
       };

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -22,7 +22,6 @@ in lib.optionalAttrs stdenv.hostPlatform.isLinux (
 
     nixos-test = (pkgs.nixos {
       system.nixos = dummyVersioning;
-      boot.loader.grub.enable = false;
       fileSystems."/".device = "/dev/null";
     }).toplevel;
 


### PR DESCRIPTION
###### Description of changes
See: #171133

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
