### PR TITLE
libxcrypt: prevent build failure on warnings

### DIFF
--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
+  configureFlags = [
+    "--disable-werror"
+  ];
+
   nativeBuildInputs = [ autoconf automake libtool pkg-config perl ];
 
   doCheck = true;


### PR DESCRIPTION
The upstream autoconf build system has a default setting that treats
compiler warnings as errors. While this can be useful for development
and maintenance it's not ideal for packaging and distribution: newer
versions of compilers may detect warnings that previous versions of the
compilers failed to detect and cause this package to fail to build.

###### Description of changes

Pass `--disable-werror` via `configureFlags`.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - `libxcrypt` runs checks after build
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
