### PR TITLE
nixos/thefuck: fix programs.thefuck.alias for fish

### DIFF
--- a/nixos/modules/programs/thefuck.nix
+++ b/nixos/modules/programs/thefuck.nix
@@ -6,8 +6,11 @@ let
   prg = config.programs;
   cfg = prg.thefuck;
 
-  initScript = ''
+  bashAndZshInitScript = ''
     eval $(${pkgs.thefuck}/bin/thefuck --alias ${cfg.alias})
+  '';
+  fishInitScript = ''
+    ${pkgs.thefuck}/bin/thefuck --alias ${cfg.alias} | source
   '';
 in
   {
@@ -30,10 +33,8 @@ in
     config = mkIf cfg.enable {
       environment.systemPackages = with pkgs; [ thefuck ];
 
-      programs.bash.interactiveShellInit = initScript;
-      programs.zsh.interactiveShellInit = mkIf prg.zsh.enable initScript;
-      programs.fish.interactiveShellInit = mkIf prg.fish.enable ''
-        ${pkgs.thefuck}/bin/thefuck --alias ${cfg.alias} | source
-      '';
+      programs.bash.interactiveShellInit = bashAndZshInitScript;
+      programs.zsh.interactiveShellInit = mkIf prg.zsh.enable bashAndZshInitScript;
+      programs.fish.interactiveShellInit = mkIf prg.fish.enable fishInitScript;
     };
   }

--- a/nixos/modules/programs/thefuck.nix
+++ b/nixos/modules/programs/thefuck.nix
@@ -33,7 +33,7 @@ in
       programs.bash.interactiveShellInit = initScript;
       programs.zsh.interactiveShellInit = mkIf prg.zsh.enable initScript;
       programs.fish.interactiveShellInit = mkIf prg.fish.enable ''
-        ${pkgs.thefuck}/bin/thefuck --alias | source
+        ${pkgs.thefuck}/bin/thefuck --alias ${cfg.alias} | source
       '';
     };
   }


### PR DESCRIPTION
###### Description of changes
This option was previously ignored when using fish as the shell.

Also rename a variable and move fishInitScript into its own variable.
Renaming the variable from `initScript` to `bashAndZshInitScript` makes it clearer, what it is actually used for.
Moving the fish init script right below the other call to `thefuck --alias` makes it more obvious, when one of them is different in some important way.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).