### PR TITLE
rofi-rbw : init at 0.5.0

### DIFF
--- a/pkgs/applications/misc/rofi-rbw/default.nix
+++ b/pkgs/applications/misc/rofi-rbw/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonApplication, fetchFromGitHub, configargparse, }:
+
+buildPythonApplication rec {
+  pname = "rofi-rbw";
+  version = "0.5.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "fdw";
+    repo = "rofi-rbw";
+    rev = version;
+    hash = "sha256-1RDwb8lKls6+X/XtARbi4F7sK4nT03Iy3Wb9N1LEa5o=";
+  };
+
+  pythonImportsCheck = [ "rofi_rbw" ];
+  propagatedBuildInputs = [ configargparse ];
+
+  meta = with lib; {
+    description = "Rofi frontend for Bitwarden";
+    homepage = "https://github.com/fdw/rofi-rbw";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/rofi-rbw/default.nix
+++ b/pkgs/applications/misc/rofi-rbw/default.nix
@@ -13,8 +13,8 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs = [ configargparse ];
-  
-  pythonImportsCheck = [ "rofi_rbw" ];  
+
+  pythonImportsCheck = [ "rofi_rbw" ];
 
   meta = with lib; {
     description = "Rofi frontend for Bitwarden";

--- a/pkgs/applications/misc/rofi-rbw/default.nix
+++ b/pkgs/applications/misc/rofi-rbw/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchFromGitHub, configargparse, }:
+{ lib, buildPythonApplication, fetchFromGitHub, configargparse }:
 
 buildPythonApplication rec {
   pname = "rofi-rbw";
@@ -12,8 +12,9 @@ buildPythonApplication rec {
     hash = "sha256-1RDwb8lKls6+X/XtARbi4F7sK4nT03Iy3Wb9N1LEa5o=";
   };
 
-  pythonImportsCheck = [ "rofi_rbw" ];
   propagatedBuildInputs = [ configargparse ];
+  
+  pythonImportsCheck = [ "rofi_rbw" ];  
 
   meta = with lib; {
     description = "Rofi frontend for Bitwarden";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28175,6 +28175,8 @@ with pkgs;
 
   rofi-pulse-select = callPackage ../applications/audio/rofi-pulse-select { };
 
+  rofi-rbw = python3Packages.callPackage ../applications/misc/rofi-rbw { };
+
   rofi-vpn = callPackage ../applications/networking/rofi-vpn { };
 
   ympd = callPackage ../applications/audio/ympd { };


### PR DESCRIPTION
###### Description of changes

Adds the package rofi-rbw - a bitwarden frontend via rofi and rbw.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Resolves #153841.