### PR TITLE
er-patcher: init at 1.04-1

### DIFF
--- a/pkgs/tools/games/er-patcher/default.nix
+++ b/pkgs/tools/games/er-patcher/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, runCommandLocal
+, fetchFromGitHub
+, python3
+}:
+
+runCommandLocal "er-patcher" rec {
+  pname = "er-patcher";
+  version = "1.04-1";
+
+  src = fetchFromGitHub {
+    owner = "gurrgur";
+    repo = "er-patcher";
+    rev = "v${version}";
+    sha256 = "sha256-SnqYGtdtl1KMwUAWvdPK0heHMBtwpH2Jk6lieng6ngw=";
+  };
+
+  buildInputs = [
+    python3
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/gurrgur/er-patcher";
+    changelog = "https://github.com/gurrgur/er-patcher/releases/tag/v${version}";
+    description = "Enhancement patches for Elden Ring adding ultrawide support, custom frame rate limits and more";
+    longDescription = ''
+      A tool aimed at enhancing the experience when playing the game on linux through proton or natively on windows.
+      This tool is based on patching the game executable through hex-edits. However it is done in a safe and non-destructive way,
+      that ensures the patched executable is never run with EAC enabled (unless explicity told to do so). Use at your own risk!
+    '';
+    license = licenses.mit;
+    maintainers = [ maintainers.ivar ];
+  };
+} ''
+  mkdir -p $out/bin
+  install -Dm755 $src/er-patcher $out/bin/er-patcher
+  patchShebangs $out/bin/er-patcher
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3460,6 +3460,8 @@ with pkgs;
 
   envsubst = callPackage ../tools/misc/envsubst { };
 
+  er-patcher = callPackage ../tools/games/er-patcher { };
+
   errcheck = callPackage ../development/tools/errcheck {
     buildGoModule = buildGo118Module;
   };


### PR DESCRIPTION
###### Description of changes
This adds [er-patcher](https://github.com/gurrgur/er-patcher), some enhancement patches for Elden Ring most notably adding ultrawide support. It's just a simple python script used as a wrapper through steam, so there's not much going on in this derivation. 

I've tested this for way longer than I should've already :sweat_smile:, everything seems to work just as expected.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
