### PR TITLE
streamlink: 3.2.0 -> 4.1.0; pythonPackages.versioningit: init at 1.1.1

### DIFF
--- a/pkgs/applications/video/streamlink/default.nix
+++ b/pkgs/applications/video/streamlink/default.nix
@@ -6,18 +6,24 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "streamlink";
-  version = "3.2.0";
+  version = "4.1.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-l3DS2DhExTeKc+FBMNy3YKvIVlZsqgpB/FuXoN7V2SY=";
+    sha256 = "sha256-C0ks9IzxyPEq3BEuQt9QSFcIg2PwNvQAvJMw+A/wCJM=";
   };
+
+  format = "pyproject";
 
   checkInputs = with python3Packages; [
     pytestCheckHook
     mock
     requests-mock
     freezegun
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    versioningit
   ];
 
   propagatedBuildInputs = (with python3Packages; [

--- a/pkgs/development/python-modules/versioningit/default.nix
+++ b/pkgs/development/python-modules/versioningit/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, importlib-metadata
+, packaging
+, setuptools
+, tomli
+, pytestCheckHook
+, build
+, pydantic
+, pytest-cov
+, pytest-mock
+, git
+, mercurial
+}:
+
+buildPythonPackage rec {
+  pname = "versioningit";
+  version = "1.1.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-O3VlotuS8SBrW4M6csxpNsinTWXpQiTwqetUeZ0VYdk=";
+  };
+
+  format = "pyproject";
+
+  propagatedBuildInputs = [
+    packaging
+    setuptools
+    tomli
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    build
+    pydantic
+    pytest-cov
+    pytest-mock
+    git
+    mercurial
+  ];
+
+  disabledTests = [
+    # wants to write to the Nix store
+    "test_editable_mode"
+  ];
+
+  pythonImportsCheck = [
+    "versioningit"
+  ];
+
+  meta = with lib; {
+    description = "setuptools plugin for determining package version from VCS";
+    homepage = "https://github.com/jwodder/versioningit";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ DeeUnderscore ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10895,6 +10895,8 @@ in {
 
   versionfinder = callPackage ../development/python-modules/versionfinder { };
 
+  versioningit = callPackage ../development/python-modules/versioningit { };
+
   versiontag = callPackage ../development/python-modules/versiontag { };
 
   versiontools = callPackage ../development/python-modules/versiontools { };


### PR DESCRIPTION
###### Description of changes
Changelogs:
* https://github.com/streamlink/streamlink/releases/tag/4.0.0
* https://github.com/streamlink/streamlink/releases/tag/4.0.1
* https://github.com/streamlink/streamlink/releases/tag/4.1.0

In 4.0.0, Streamlink switched to the PEP 518 format (pyproject.toml), and additionally introduced a build-time dependency on versioningit (although the PyPI source distribution has the version number substituted in, so we don't need the full Git history). 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
