### PR TITLE
python3Packages.preprocess-cancellation: Fetch from PyPi

### DIFF
--- a/pkgs/development/python-modules/preprocess-cancellation/default.nix
+++ b/pkgs/development/python-modules/preprocess-cancellation/default.nix
@@ -1,26 +1,20 @@
-{ lib, fetchFromGitHub, buildPythonPackage, pythonOlder, poetry-core
-, pytestCheckHook, pytest-cov
+{ lib, fetchPypi, buildPythonPackage, pythonOlder
 , shapely }:
 
 buildPythonPackage rec {
   pname = "preprocess-cancellation";
   version = "0.2.0";
   disabled = pythonOlder "3.6"; # >= 3.6
-  format = "pyproject";
 
-  # No tests in PyPI
-  src = fetchFromGitHub {
-    owner = "kageurufu";
-    repo = "cancelobject-preprocessor";
-    rev = version;
-    hash = "sha256-mn3/etXA5dkL+IsyxwD4/XjU/t4/roYFVyqQxlLOoOI=";
+  src = fetchPypi {
+    inherit version;
+    pname = "preprocess_cancellation";
+    hash = "sha256-62hJTjXAof6DcW8qFOErPhze35RYdSvhys4A+UTZB2A=";
   };
-
-  nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [ shapely ];
 
-  checkInputs = [ pytestCheckHook pytest-cov ];
+  pythonImportsCheck = [ "preprocess_cancellation" ];
 
   meta = with lib; {
     description = "Klipper GCode Preprocessor for Object Cancellation";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package was broken by [breaking changes in setuptools 61](https://setuptools.pypa.io/en/latest/history.html#v61-0-0). Since fixing this requires adding setuptools-specific project discovery configs as well as PEP 621 metadata to `pyproject.toml` and upstream uses Poetry, let's just fetch the wheel from PyPi.

Unblocks https://github.com/NixOS/nixpkgs/pull/165896#issuecomment-1113912001.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
