### PR TITLE
coq_kernel: init at 1.6.0

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/coq/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/coq/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, callPackage
+, runCommand
+, makeWrapper
+, coq
+, imagemagick
+, python3
+}:
+
+# Jupyter console:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel coq-kernel.definition'
+
+# Jupyter console with packages:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel (coq-kernel.definitionWithPackages [coqPackages.bignums])'
+
+# Jupyter notebook:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions.coq = coq-kernel.definition; }'
+
+let
+  python = python3.withPackages (ps: [ ps.traitlets ps.jupyter_core ps.ipykernel (callPackage ./kernel.nix {}) ]);
+
+  logos = runCommand "coq-logos" { buildInputs = [ imagemagick ]; } ''
+    mkdir -p $out
+    convert ${coq.src}/ide/coqide/coq.png -resize 32x32 $out/logo-32x32.png
+    convert ${coq.src}/ide/coqide/coq.png -resize 64x64 $out/logo-64x64.png
+  '';
+
+in
+
+rec {
+  launcher = runCommand "coq-kernel-launcher" {
+    nativeBuildInputs = [ makeWrapper ];
+  } ''
+    mkdir -p $out/bin
+
+    makeWrapper ${python.interpreter} $out/bin/coq-kernel \
+      --add-flags "-m coq_jupyter" \
+      --suffix PATH : ${coq}/bin
+  '';
+
+  definition = definitionWithPackages [];
+
+  definitionWithPackages = packages: {
+    displayName = "Coq " + coq.version;
+    argv = [
+      "${launcher}/bin/coq-kernel"
+      "-f"
+      "{connection_file}"
+    ];
+    language = "coq";
+    logo32 = "${logos}/logo-32x32.png";
+    logo64 = "${logos}/logo-64x64.png";
+    env = {
+      COQPATH = lib.concatStringsSep ":" (map (x: "${x}/lib/coq/${coq.coq-version}/user-contrib/") packages);
+    };
+  };
+}

--- a/pkgs/applications/editors/jupyter-kernels/coq/kernel.nix
+++ b/pkgs/applications/editors/jupyter-kernels/coq/kernel.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, python3
+, coq
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "coq-jupyter";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "EugeneLoy";
+    repo = "coq_jupyter";
+    rev = "v${version}";
+    sha256 = "sha256-+Pp51cxeqjg5MW4CEccNWVjNcY9iyFNATIEage9RWJ0=";
+  };
+
+  propagatedBuildInputs = (with python3.pkgs; [ ipykernel future ]) ++ [ coq ];
+
+  nativeBuildInputs = [ coq ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/EugeneLoy/coq_jupyter";
+    description = "Jupyter kernel for Coq";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ thomasjm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39494,6 +39494,8 @@ with pkgs;
 
   coq2html = callPackage ../tools/typesetting/coq2html { };
 
+  coq-kernel = callPackage ../applications/editors/jupyter-kernels/coq { };
+
   cryptoverif = callPackage ../applications/science/logic/cryptoverif { };
 
   crypto-org-wallet = callPackage ../applications/blockchains/crypto-org-wallet { };


### PR DESCRIPTION
###### Description of changes

This is a Jupyter kernel for Coq, the formal proof management system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
