### PR TITLE
gmime3: 3.2.7 -> 3.2.11

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -79,6 +79,11 @@ stdenv.mkDerivation rec {
   in ''
     mkdir -p test/test-databases
     ln -s ${test-database} test/test-databases/database-v1.tar.xz
+  ''
+  # TODO: restore after resolved upstream
+  # https://www.mail-archive.com/notmuch@notmuchmail.org/msg52808.html
+  + ''
+    rm test/T355-smime.sh
   '';
 
   doCheck = !stdenv.hostPlatform.isDarwin && (lib.versionAtLeast gmime.version "3.0.3");

--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -2,12 +2,12 @@
 , vala }:
 
 stdenv.mkDerivation rec {
-  version = "3.2.7";
+  version = "3.2.11";
   pname = "gmime";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/gmime/3.2/${pname}-${version}.tar.xz";
-    sha256 = "0i3xfc84qn1z99i70q68kbnp9rmgqrnprqb418ba52s6g9j9dsia";
+  src = fetchurl { # https://github.com/jstedfast/gmime/releases
+    url = "https://github.com/jstedfast/gmime/releases/download/${version}/gmime-${version}.tar.xz";
+    sha256 = "5e023855a215b427645b400f5e55cf19cfd229f971317007e03e7bae72569bf8";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
The active repo is elsewhere now; reading linked from:
https://gitlab.gnome.org/GNOME/gmime/-/issues/10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
