### PR TITLE
wprecon: 1.6.3a -> 2.4.5

### DIFF
--- a/pkgs/tools/security/wprecon/default.nix
+++ b/pkgs/tools/security/wprecon/default.nix
@@ -5,16 +5,21 @@
 
 buildGoModule rec {
   pname = "wprecon";
-  version = "1.6.3a";
+  version = "2.4.5";
 
   src = fetchFromGitHub {
     owner = "blackbinn";
     repo = pname;
     rev = version;
-    sha256 = "0gqi4799ha3mf8r7ini0wj4ilkfsh80vnnxijfv9a343r6z5w0dn";
+    hash = "sha256-23zJD3Nnkeko+J2FjPq5RA5dIjORMXvwt3wtAYiVlQs=";
   };
 
-  vendorSha256 = "1sab58shspll96rqy1rp659s0yikqdcx59z9b88d6p4w8a98ns87";
+  vendorSha256 = "sha256-FYdsLcW6FYxSgixZ5US9cBPABOAVwidC3ejUNbs1lbA=";
+
+  postFixup = ''
+    # Rename binary
+    mv $out/bin/cli $out/bin/${pname}
+  '';
 
   meta = with lib; {
     description = "WordPress vulnerability recognition tool";
@@ -23,6 +28,5 @@ buildGoModule rec {
     # https://github.com/blackbinn/wprecon/blob/master/LICENSE
     license = with licenses; [ unfree ];
     maintainers = with maintainers; [ fab ];
-    broken = true; # build fails, missing tag
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/blackcrw/wprecon/releases/tag/2.4.5
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
