### PR TITLE
gdb: 11.2 -> 12.1

### DIFF
--- a/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
+++ b/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
@@ -1,24 +1,17 @@
-diff -ur a/gdb/main.c b/gdb/main.c
---- a/gdb/main.c	2020-02-08 13:50:14.000000000 +0100
-+++ b/gdb/main.c	2020-02-24 10:02:07.731806739 +0100
-@@ -567,9 +567,17 @@
-       gdb_sysroot = xstrdup (TARGET_SYSROOT_PREFIX);
-     }
+--- a/gdb/main.c
++++ b/gdb/main.c
+@@ -708,8 +708,12 @@ captured_main_1 (struct captured_main_args *context)
+   if (gdb_sysroot.empty ())
+     gdb_sysroot = TARGET_SYSROOT_PREFIX;
  
 -  debug_file_directory
--    = xstrdup (relocate_gdb_directory (DEBUGDIR,
--				     DEBUGDIR_RELOCATABLE).c_str ());
-+  debug_file_directory = getenv ("NIX_DEBUG_INFO_DIRS");
-+  if (debug_file_directory != NULL)
-+    // This might be updated later using
-+    // $ set debug-file-directory /to/some/path
-+    // which will use xfree. We must then have a xmallocated
-+    // copy of the string that can be xfeed later.
-+    debug_file_directory = xstrdup (debug_file_directory);
+-    = relocate_gdb_directory (DEBUGDIR, DEBUGDIR_RELOCATABLE);
++  const char * nix_debug = getenv ("NIX_DEBUG_INFO_DIRS");
++  if (nix_debug != NULL)
++      debug_file_directory = nix_debug;
 +  else
 +    debug_file_directory
-+      = xstrdup (relocate_gdb_directory (DEBUGDIR,
-+                                         DEBUGDIR_RELOCATABLE).c_str ());
++      = relocate_gdb_directory (DEBUGDIR, DEBUGDIR_RELOCATABLE);
  
    gdb_datadir = relocate_gdb_directory (GDB_DATADIR,
  					GDB_DATADIR_RELOCATABLE);

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, targetPackages
 
 # Build time
-, fetchurl, fetchpatch, pkg-config, perl, texinfo, setupDebugInfoDirs, buildPackages
+, fetchurl, pkg-config, perl, texinfo, setupDebugInfoDirs, buildPackages
 
 # Run time
 , ncurses, readline, gmp, mpfr, expat, libipt, zlib, dejagnu, sourceHighlight
@@ -15,6 +15,7 @@
    # targetPackages so we get the right libc when cross-compiling and using buildPackages.gdb
    targetPackages.stdenv.cc.cc.lib
   ]
+, writeScript
 }:
 
 let
@@ -27,11 +28,11 @@ assert pythonSupport -> python3 != null;
 
 stdenv.mkDerivation rec {
   pname = targetPrefix + basename;
-  version = "11.2";
+  version = "12.1";
 
   src = fetchurl {
     url = "mirror://gnu/gdb/${basename}-${version}.tar.xz";
-    hash = "sha256-FJfDanGIG4ZxqahKDuQPqreIyjDXuhnYRjw8x4cVLjI=";
+    hash = "sha256-DheTv48rVNU/Rt6oTM/URvSPgbKXsoxPf8AXuBjWn+0=";
   };
 
   postPatch = if stdenv.isDarwin then ''
@@ -43,20 +44,9 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./debug-info-from-env.patch
-
-    # Pull upstream fix for gcc-12. Will be included in gdb-12.
-    (fetchpatch {
-      name = "gcc-12.patch";
-      url = "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=e97436b1b789dcdb6ffb502263f4c86f8bc22996";
-      sha256 = "1mpgw6s9qgnwhwyg3hagc6vhqhvia0l1s8nr22bcahwqxi3wvzcw";
-    })
   ] ++ lib.optionals stdenv.isDarwin [
     ./darwin-target-match.patch
-  ] ++ lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
-    name = "musl-fix-pagesize-page_size.patch";
-    url = "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=fd0975b96b16d96010dce439af9620d3dfb65426";
-    hash = "sha256-M3U7uIIFJnYu0g8/sMLJPhm02q7cGOi6pLjgsUUjeKI=";
-  });
+  ];
 
   nativeBuildInputs = [ pkg-config texinfo perl setupDebugInfoDirs ];
 
@@ -114,6 +104,20 @@ stdenv.mkDerivation rec {
 
   # TODO: Investigate & fix the test failures.
   doCheck = false;
+
+  passthru = {
+    updateScript = writeScript "update-gdb" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl pcre common-updater-scripts
+
+      set -eu -o pipefail
+
+      # Expect the text in format of '<h3>GDB version 12.1</h3>'
+      new_version="$(curl -s https://www.sourceware.org/gdb/ |
+          pcregrep -o1 '<h3>GDB version ([0-9.]+)</h3>')"
+      update-source-version ${pname} "$new_version"
+    '';
+  };
 
   meta = with lib; {
     description = "The GNU Project debugger";

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -35,12 +35,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-DheTv48rVNU/Rt6oTM/URvSPgbKXsoxPf8AXuBjWn+0=";
   };
 
-  postPatch = if stdenv.isDarwin then ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace gdb/darwin-nat.c \
       --replace '#include "bfd/mach-o.h"' '#include "mach-o.h"'
-  '' else if stdenv.hostPlatform.isMusl then ''
+  '' + lib.optionalString stdenv.hostPlatform.isMusl ''
+    substituteInPlace sim/erc32/erc32.c  --replace sys/fcntl.h fcntl.h
+    substituteInPlace sim/erc32/interf.c  --replace sys/fcntl.h fcntl.h
+    substituteInPlace sim/erc32/sis.c  --replace sys/fcntl.h fcntl.h
     substituteInPlace sim/ppc/emul_unix.c --replace sys/termios.h termios.h
-  '' else null;
+  '';
 
   patches = [
     ./debug-info-from-env.patch


### PR DESCRIPTION
Added trivial updater script.
Refreshed nix-specific patch with path to debug symbols.
Dropped upstreamed patches for gcc-12 support and musl support.

Changes: https://www.sourceware.org/gdb/download/ANNOUNCEMENT

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
