### PR TITLE
python310Packages.netutils: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/netutils/default.nix
+++ b/pkgs/development/python-modules/netutils/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, jinja2
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "netutils";
+  version = "1.1.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "networktocode";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rTSesG7XmIzu2DcJMVgZMlh0kRQ8jEB3t++rgf63Flw=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  checkInputs = [
+    jinja2
+    pytestCheckHook
+    pyyaml
+    toml
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/networktocode/netutils/pull/115
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/networktocode/netutils/commit/edc8b06686db4e5b4c8c4deb6d0effbc22177b31.patch";
+      sha256 = "sha256-K5oSbtOJYeKbxzbaZQBXcl6LsHQAK8CxBLfkak15V6M=";
+    })
+  ];
+
+  pythonImportsCheck = [
+    "netutils"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_is_fqdn_resolvable"
+    "test_fqdn_to_ip"
+    "test_tcp_ping"
+    # Skip SPhinx test
+    "test_sphinx_build"
+  ];
+
+  meta = with lib; {
+    description = "Library that is a collection of objects for common network automation tasks";
+    homepage = "https://github.com/networktocode/netutils";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5581,6 +5581,8 @@ in {
 
   nettigo-air-monitor = callPackage ../development/python-modules/nettigo-air-monitor { };
 
+  netutils = callPackage ../development/python-modules/netutils { };
+
   networkx = callPackage ../development/python-modules/networkx { };
 
   neuron-mpi = pkgs.neuron-mpi.override { inherit python; };


### PR DESCRIPTION
###### Description of changes
Library that is a collection of objects for common network automation tasks

https://github.com/networktocode/netutils
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
