### PR TITLE
nixos/nextcloud: Expose more config.php options via Nix module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -2349,8 +2349,8 @@
       <listitem>
         <para>
           The Nextcloud module now exposes the
-          <literal>default_locale</literal>
-          <literal>config.php</literal> setting.
+          <literal>default_locale</literal>, and two-factor
+          authentication <literal>config.php</literal> settings.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -2348,6 +2348,13 @@
       </listitem>
       <listitem>
         <para>
+          The Nextcloud module now exposes the
+          <literal>default_locale</literal>
+          <literal>config.php</literal> setting.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>spark3</literal> package has been updated from
           3.1.2 to 3.2.1
           (<link xlink:href="https://github.com/NixOS/nixpkgs/pull/160075">#160075</link>):

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -2349,8 +2349,9 @@
       <listitem>
         <para>
           The Nextcloud module now exposes the
-          <literal>default_locale</literal>, and two-factor
-          authentication <literal>config.php</literal> settings.
+          <literal>default_locale</literal>, two-factor authentication,
+          and email settings that otherwise live in
+          <literal>config.php</literal>.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -835,8 +835,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The Nextcloud module now supports to create a Mysql database automatically
   with `services.nextcloud.database.createLocally` enabled.
 
-- The Nextcloud module now exposes the `default_locale`, and two-factor
-  authentication `config.php` settings.
+- The Nextcloud module now exposes the `default_locale`, two-factor
+  authentication, and email settings that otherwise live in `config.php`.
 
 - The `spark3` package has been updated from 3.1.2 to 3.2.1 ([#160075](https://github.com/NixOS/nixpkgs/pull/160075)):
 

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -835,7 +835,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The Nextcloud module now supports to create a Mysql database automatically
   with `services.nextcloud.database.createLocally` enabled.
 
-- The Nextcloud module now exposes the `default_locale` `config.php` setting.
+- The Nextcloud module now exposes the `default_locale`, and two-factor
+  authentication `config.php` settings.
 
 - The `spark3` package has been updated from 3.1.2 to 3.2.1 ([#160075](https://github.com/NixOS/nixpkgs/pull/160075)):
 

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -835,6 +835,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The Nextcloud module now supports to create a Mysql database automatically
   with `services.nextcloud.database.createLocally` enabled.
 
+- The Nextcloud module now exposes the `default_locale` `config.php` setting.
+
 - The `spark3` package has been updated from 3.1.2 to 3.2.1 ([#160075](https://github.com/NixOS/nixpkgs/pull/160075)):
 
   - Testing has been enabled for `aarch64-linux` in addition to `x86_64-linux`.

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -272,7 +272,7 @@ in {
       uiClashWarning = ''
         <warning>
           <para>Setting this option will prevent changing this via the
-          Nextcloud UI, but it wil still appear editable in the UI.</para>
+          Nextcloud UI, but it will still appear editable in the UI.</para>
         </warning>
         '';
     in {

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -368,11 +368,6 @@ in {
         type = types.nullOr types.str;
         example = "DE";
         description = ''
-          <warning>
-           <para>This option exists since Nextcloud 21! If older versions are used,
-            this will throw an eval-error!</para>
-          </warning>
-
           <link xlink:href="https://www.iso.org/iso-3166-country-codes.html">ISO 3611-1</link>
           country codes for automatic phone-number detection without a country code.
 
@@ -386,11 +381,6 @@ in {
         type = types.nullOr types.str;
         example = "de_CH";
         description = ''
-          <warning>
-           <para>This option exists since Nextcloud 21! If older versions are used,
-            this will throw an eval-error!</para>
-          </warning>
-
           Default locale to use when Nextcloud fails to detect the user's
           locale.
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -399,10 +399,10 @@ in {
         '';
       };
 
-      twofactorEnforced = let
+      twofactorEnforcement = let
         twoFactorAuthUpstreamManualUrl = "https://docs.nextcloud.com/server/latest/admin_manual/configuration_user/two_factor-auth.html";
       in {
-        enabled = mkOption {
+        enable = mkOption {
           default = null;
           type = types.nullOr types.bool;
           example = true;
@@ -942,9 +942,9 @@ in {
               'trusted_proxies' => ${writePhpArrary (c.trustedProxies)},
               ${optionalString (c.defaultPhoneRegion != null) "'default_phone_region' => '${c.defaultPhoneRegion}',"}
               ${optionalString (c.defaultLocale != null) "'default_locale' => '${c.defaultLocale}',"}
-              ${optionalString (c.twofactorEnforced.enabled != null) "'twofactor_enforced' => '${lib.boolToString c.twofactorEnforced.enabled}',"}
-              ${optionalString (c.twofactorEnforced.groups != null) "'twofactor_enforced_groups' => ${writePhpArrary c.twofactorEnforced.groups},"}
-              ${optionalString (c.twofactorEnforced.excludedGroups != null) "'twofactor_enforced_excluded_groups' => ${writePhpArrary c.twofactorEnforced.excludedGroups},"}
+              ${optionalString (c.twofactorEnforcement.enable != null) "'twofactor_enforced' => '${lib.boolToString c.twofactorEnforcement.enable}',"}
+              ${optionalString (c.twofactorEnforcement.groups != null) "'twofactor_enforced_groups' => ${writePhpArrary c.twofactorEnforcement.groups},"}
+              ${optionalString (c.twofactorEnforcement.excludedGroups != null) "'twofactor_enforced_excluded_groups' => ${writePhpArrary c.twofactorEnforcement.excludedGroups},"}
               ${optionalString (c.mail.mode != null) "'mail_smtpmode' => '${c.mail.mode}',"}
               ${optionalString (c.mail.host != null) "'mail_smtphost' => '${c.mail.host}',"}
               ${optionalString (c.mail.port != null) "'mail_smtpport' => '${toString c.mail.port}',"}

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -374,6 +374,24 @@ in {
         '';
       };
 
+      defaultLocale = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        example = "de_CH";
+        description = ''
+          <warning>
+           <para>This option exists since Nextcloud 21! If older versions are used,
+            this will throw an eval-error!</para>
+          </warning>
+
+          Default locale to use when Nextcloud fails to detect the user's
+          locale.
+
+          Further details about this setting and supported locale codes can be found in the
+          <link xlink:href="https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/language_configuration.html">upstream documentation</link>.
+        '';
+      };
+
       objectstore = {
         s3 = {
           enable = mkEnableOption ''
@@ -714,6 +732,7 @@ in {
               'trusted_domains' => ${writePhpArrary ([ cfg.hostName ] ++ c.extraTrustedDomains)},
               'trusted_proxies' => ${writePhpArrary (c.trustedProxies)},
               ${optionalString (c.defaultPhoneRegion != null) "'default_phone_region' => '${c.defaultPhoneRegion}',"}
+              ${optionalString (c.defaultLocale != null) "'default_locale' => '${c.defaultLocale}',"}
               ${optionalString (nextcloudGreaterOrEqualThan "23") "'profile.enabled' => ${boolToString cfg.globalProfiles}"}
               ${objectstoreConfig}
             ];

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -268,7 +268,14 @@ in {
     };
 
 
-    config = {
+    config = let
+      uiClashWarning = ''
+        <warning>
+          <para>Setting this option will prevent changing this via the
+          Nextcloud UI, but it wil still appear editable in the UI.</para>
+        </warning>
+        '';
+    in {
       dbtype = mkOption {
         type = types.enum [ "sqlite" "pgsql" "mysql" ];
         default = "sqlite";
@@ -390,6 +397,53 @@ in {
           Further details about this setting and supported locale codes can be found in the
           <link xlink:href="https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/language_configuration.html">upstream documentation</link>.
         '';
+      };
+
+      twofactorEnforced = let
+        twoFactorAuthUpstreamManualUrl = "https://docs.nextcloud.com/server/latest/admin_manual/configuration_user/two_factor-auth.html";
+      in {
+        enabled = mkOption {
+          default = null;
+          type = types.nullOr types.bool;
+          example = true;
+          description = ''
+            ${uiClashWarning}
+
+            Whether to enforce two-factor authentication.
+
+            Further details about this setting and supported locale codes can be found in the
+            <link xlink:href="${twoFactorAuthUpstreamManualUrl}">upstream documentation</link>.
+          '';
+        };
+        groups = mkOption {
+          default = null;
+          type = types.nullOr (types.listOf types.str);
+          example = [ "admin" ];
+          description = ''
+            ${uiClashWarning}
+
+            Enforce two-factor authentication for only users in these named
+            groups.  The groups must already exist in the Nextcloud database.
+
+            Further details about this setting and supported locale codes can be found in the
+            <link xlink:href="${twoFactorAuthUpstreamManualUrl}">upstream documentation</link>.
+          '';
+        };
+        excludedGroups = mkOption {
+          default = null;
+          type = types.nullOr (types.listOf types.str);
+          example = [ "guests" ];
+          description = ''
+            ${uiClashWarning}
+
+            Do <emphasis>not</emphasis> enforce two-factor authentication for
+            users in these named groups.  The groups must already exist in the
+            Nextcloud database.
+
+            Further details about this setting and supported locale codes can be found in the
+            <link xlink:href="${twoFactorAuthUpstreamManualUrl}">upstream documentation</link>.
+          '';
+        };
       };
 
       objectstore = {
@@ -733,6 +787,9 @@ in {
               'trusted_proxies' => ${writePhpArrary (c.trustedProxies)},
               ${optionalString (c.defaultPhoneRegion != null) "'default_phone_region' => '${c.defaultPhoneRegion}',"}
               ${optionalString (c.defaultLocale != null) "'default_locale' => '${c.defaultLocale}',"}
+              ${optionalString (c.twofactorEnforced.enabled != null) "'twofactor_enforced' => '${lib.boolToString c.twofactorEnforced.enabled}',"}
+              ${optionalString (c.twofactorEnforced.groups != null) "'twofactor_enforced_groups' => ${writePhpArrary c.twofactorEnforced.groups},"}
+              ${optionalString (c.twofactorEnforced.excludedGroups != null) "'twofactor_enforced_excluded_groups' => ${writePhpArrary c.twofactorEnforced.excludedGroups},"}
               ${optionalString (nextcloudGreaterOrEqualThan "23") "'profile.enabled' => ${boolToString cfg.globalProfiles}"}
               ${objectstoreConfig}
             ];


### PR DESCRIPTION
###### Description of changes

Expose more Nextcloud `config.php` options through the Nix module:
- `default_locale`
- 2FA settings
- mail settings

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
