### PR TITLE
python310Packages.pyeapi: fix Python 3.10 support

### DIFF
--- a/pkgs/development/python-modules/pyeapi/default.nix
+++ b/pkgs/development/python-modules/pyeapi/default.nix
@@ -38,15 +38,20 @@ buildPythonPackage rec {
       url = "https://github.com/arista-eosplus/pyeapi/commit/81754f57eb095703cc474f527a0915360af76f68.patch";
       sha256 = "sha256-ZNBTPRNmXCFVJeRAJxzIHmCOXZiGwU6t4ekSupU3BX8=";
     })
+    (fetchpatch {
+      name = "fix-collection-usage-2.patch";
+      url = "https://github.com/arista-eosplus/pyeapi/commit/cc9c584e4a3167e3c1624cccb6bc0d9c9bcdbc1c.patch";
+      sha256 = "sha256-EY0i1Skm1llEQAAzvrb2yelhhLBkqKAFJB5ObAIxAYo=";
+      excludes = [
+        ".github/workflows/ci.yml"
+      ];
+    })
+    (fetchpatch {
+      name = "fix-collection-usage-3.patch";
+      url = "https://github.com/arista-eosplus/pyeapi/commit/dc35ab076687ea71665ae9524480b05a4e893909.patch";
+      sha256 = "sha256-xPaYULCPTxiQGB9Im/qLet+XebW9wq+TAfrxcgQxcoE=";
+    })
   ];
-
-  postPatch = ''
-    # https://github.com/arista-eosplus/pyeapi/pull/223
-    substituteInPlace test/unit/test_utils.py \
-      --replace "collections.Iterable" "collections.abc.Iterable"
-    substituteInPlace pyeapi/api/abstract.py \
-      --replace "from collections" "from collections.abc"
-  '';
 
   pytestFlagsArray = [
     "test/unit"


### PR DESCRIPTION
###### Description of changes
Enable support for Python 3.10

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
