### PR TITLE
asterisk: add nixos test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -78,6 +78,7 @@ in {
   amazon-init-shell = handleTest ./amazon-init-shell.nix {};
   apfs = handleTest ./apfs.nix {};
   apparmor = handleTest ./apparmor.nix {};
+  asterisk = handleTest ./asterisk.nix {};
   atd = handleTest ./atd.nix {};
   atop = handleTest ./atop.nix {};
   auth-mysql = handleTest ./auth-mysql.nix {};

--- a/nixos/tests/asterisk.nix
+++ b/nixos/tests/asterisk.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "asterisk";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ yorickvp ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      services.asterisk = {
+        enable = true;
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("asterisk.service")
+
+    with machine.nested("Waiting for asterisk to work"):
+        machine.wait_until_succeeds("asterisk -r -x \"show uptime\"", timeout=10)
+  '';
+})

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchsvn, fetchFromGitHub,
+{ stdenv, lib, fetchurl, fetchsvn, fetchFromGitHub, nixosTests,
   jansson, libedit, libxml2, libxslt, ncurses, openssl, sqlite,
   util-linux, dmidecode, libuuid, newt,
   lua, speex, libopus, opusfile, libogg,
@@ -162,7 +162,10 @@ in {
   asterisk-lts = versions.asterisk_18;
   asterisk-stable = versions.asterisk_19;
   asterisk = versions.asterisk_19.overrideAttrs (o: {
-    passthru = (o.passthru or {}) // { inherit updateScript; };
+    passthru = (o.passthru or {}) // {
+      inherit updateScript;
+      tests = { inherit (nixosTests) asterisk; };
+    };
   });
 
 } // versions


### PR DESCRIPTION
###### Description of changes

Added a test for the `asterisk` package.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc: @DerTim1 @yayayayaka @sbruder 