### PR TITLE
lib/flakes: move eachSystem from flake-utils

### DIFF
--- a/lib/flakes.nix
+++ b/lib/flakes.nix
@@ -19,4 +19,57 @@ rec {
     in
     self;
 
+
+  /* Builds a map from <attr>=value to <attr>.<system>=value for each system,
+     except for the `hydraJobs` attribute, where it maps the inner attributes,
+     from hydraJobs.<attr>=value to hydraJobs.<attr>.<system>=value.
+
+     Example:
+       eachSystem [ "x86_64-linux" "aarch64-linux" ] (system: { hello = 42; })
+       => { hello = { aarch64-linux = 42; x86_64-linux = 42; }; }
+  */
+  eachSystem = systems: f:
+    let
+      # Used to match Hydra's convention of how to define jobs. Basically transforms
+      #
+      #     hydraJobs = {
+      #       hello = <derivation>;
+      #       haskellPackages.aeson = <derivation>;
+      #     }
+      #
+      # to
+      #
+      #     hydraJobs = {
+      #       hello.x86_64-linux = <derivation>;
+      #       haskellPackages.aeson.x86_64-linux = <derivation>;
+      #     }
+      #
+      # if the given flake does `eachSystem [ "x86_64-linux" ] { ... }`.
+      pushDownSystem = system: merged:
+        builtins.mapAttrs
+          (name: value:
+            if ! (builtins.isAttrs value) then value
+            else if lib.isDerivation value then (merged.${name} or {}) // { ${system} = value; }
+            else pushDownSystem system (merged.${name} or {}) value);
+
+      # Merge together the outputs for all systems.
+      op = attrs: system:
+        let
+          ret = f system;
+          op = attrs: key:
+            let
+              appendSystem = key: system: ret:
+                if key == "hydraJobs"
+                  then (pushDownSystem system (attrs.hydraJobs or {}) ret.hydraJobs)
+                  else { ${system} = ret.${key}; };
+            in attrs //
+              {
+                ${key} = (attrs.${key} or { })
+                  // (appendSystem key system ret);
+              }
+          ;
+        in
+        builtins.foldl' op attrs (builtins.attrNames ret);
+    in
+    builtins.foldl' op { } systems;
 }


### PR DESCRIPTION
###### Description of changes
moved https://github.com/numtide/flake-utils/blob/a4b154ebbdc88c8498a5c7b01589addc9e9cb678/default.nix#L75 to nixpkgs

https://github.com/numtide/flake-utils/issues/62
supersedes https://github.com/NixOS/nixpkgs/pull/123117

see @lilyball comment https://github.com/NixOS/nixpkgs/pull/123117#issuecomment-1015778014

intentionally not added to `lib` to keep it only available at `lib.flakes.eachSystem` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
