### PR TITLE
libarchive: disable cpio file-access-time related tests

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -40,18 +40,21 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace Makefile.am --replace '/bin/pwd' "$(type -P pwd)"
 
-    declare -a skip_tests=(
+    declare -a skip_test_paths=(
       # test won't work in nix sandbox
-      'test_write_disk_perms'
+      'libarchive/test/test_write_disk_perms.c'
       # can't be sure builder will have sparse-capable fs
-      'test_sparse_basic'
+      'libarchive/test/test_sparse_basic.c'
       # can't even be sure builder will have hardlink-capable fs
-      'test_write_disk_hardlink'
+      'libarchive/test/test_write_disk_hardlink.c'
+      # access-time-related tests flakey on some systems
+      'cpio/test/test_option_a.c'
+      'cpio/test/test_option_t.c'
     )
 
-    for test_name in "''${skip_tests[@]}" ; do
-      sed -i "/$test_name/d" Makefile.am
-      rm "libarchive/test/$test_name.c"
+    for test_path in "''${skip_test_paths[@]}" ; do
+      substituteInPlace Makefile.am --replace "$test_path" ""
+      rm "$test_path"
     done
   '';
 


### PR DESCRIPTION
###### Description of changes

These are mysteriously flakey on some peoples darwin systems, which could be the result of stray accesses or timezone issues.

See discussion in #171016

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
