### PR TITLE
go-motion: add meta.mainProgram

### DIFF
--- a/pkgs/development/tools/go-motion/default.nix
+++ b/pkgs/development/tools/go-motion/default.nix
@@ -32,6 +32,7 @@ buildGoPackage rec {
     homepage = "https://github.com/fatih/motion";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];
+    mainProgram = "motion";
     platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

Add `meta.mainProgram` so that package is usable with `nix run`.

```console
~/C/nixpkgs on go-motion-add-mainProgram
❯ nix run .#go-motion -- --help
Usage of /nix/store/0vj8h7nzy45w4mddpv3q28bqa346gaj7-motion-unstable-2018-04-09/bin/motion:
  -dir string
    	Directory to be parsed
  -file string
    	Filename to be parsed
  -format string
    	Output format. One of {json, vim} (default "json")
  -include string
    	Included declarations for mode {decls}. Comma delimited. Options: {func, type}
  -mode string
    	Running mode. One of {enclosing, next, prev, decls, comment}
  -offset int
    	Byte offset of the cursor position
  -parse-comments
    	Parse comments and add them to AST
  -shift int
    	Shift value for the modes {next, prev}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
