### PR TITLE
apple-cursor: init at 2.0.0

### DIFF
--- a/pkgs/data/icons/apple-cursor/default.nix
+++ b/pkgs/data/icons/apple-cursor/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchzip
+, stdenv
+}:
+
+let
+  _src = variant: suffix: hash: fetchzip ({
+    name = variant;
+    url = "https://github.com/ful1e5/apple_cursor/releases/download/v${version}/${variant}.${suffix}";
+    hash = hash;
+  } // (if suffix == "zip" then { stripRoot = false; } else {}));
+
+  version = "2.0.0";
+  srcs = [
+    (_src "macOS-BigSur-White" "tar.gz" "sha256-3Ax2hMfkEL4cyJtGQpK3PqC/L5wtmgO0LsY4gkTQ2Bg=")
+    (_src "macOS-BigSur-White-Windows" "zip" "sha256-V6J2Ddgq46BkgxCWVReZrvE7CsOczzV7slOpilKFG9E=")
+    (_src "macOS-BigSur" "tar.gz" "sha256-VZWFf1AHum2xDJPMZrBmcyVrrmYGKwCdXOPATw7myOA=")
+    (_src "macOS-BigSur-Windows" "zip" "sha256-lp28ACsK8BXe6rSDELL4GdXb1QEdOVC8Y6eLofctkR4=")
+    (_src "macOS-Monterey-White" "tar.gz" "sha256-IfFYUbDW6mBe209iU1sBhFzolZd6YDVdJf+DPe9AQDM=")
+    (_src "macOS-Monterey-White-Windows" "zip" "sha256-gUuBFOi0nDBoX9TWPg4eQhCAhwYeEhfDEbYpc+XsQNE=")
+    (_src "macOS-Monterey" "tar.gz" "sha256-MHmaZs56Q1NbjkecvfcG1zAW85BCZDn5kXmxqVzPc7M=")
+    (_src "macOS-Monterey-Windows" "zip" "sha256-ajxEgq7besaRajLn0gTPpp4euOWVqbzc78u720PWlyE=")
+  ];
+in stdenv.mkDerivation rec {
+  pname = "apple_cursor";
+  inherit version;
+  inherit srcs;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    install -dm 0755 $out/share/icons
+    cp -r macOS* $out/share/icons/
+  '';
+
+  meta = with lib; {
+    description = "Opensource macOS Cursors.";
+    homepage = "https://github.com/ful1e5/apple_cursor";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24028,6 +24028,8 @@ with pkgs;
   bibata-extra-cursors = callPackage ../data/icons/bibata-cursors/extra.nix { };
   bibata-cursors-translucent = callPackage ../data/icons/bibata-cursors/translucent.nix { };
 
+  apple-cursor = callPackage ../data/icons/apple-cursor { };
+
   blackbird = callPackage ../data/themes/blackbird { };
 
   brise = callPackage ../data/misc/brise { };


### PR DESCRIPTION
###### Description of changes

Adds https://github.com/ful1e5/apple_cursor.

This theme seems to have most/all cursor icons, which is nice, it quiets some noise in my sway log, for example.

Review Considerations:
- `apple-cursor` vs `apple_cursor` for the nixpkgs attr name

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
