### PR TITLE
datalad: init at 0.16.5

### DIFF
--- a/pkgs/applications/version-management/datalad/default.nix
+++ b/pkgs/applications/version-management/datalad/default.nix
@@ -1,0 +1,80 @@
+{ lib, stdenv, fetchFromGitHub, installShellFiles, python3, git }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "datalad";
+  version = "0.16.5";
+
+  src = fetchFromGitHub {
+    owner = "datalad";
+    repo = pname;
+    rev = version;
+    hash = "sha256-6uWOKsYeNZJ64WqoGHL7AsoK4iZd24TQOJ1ECw+K28Y=";
+  };
+
+  nativeBuildInputs = [ installShellFiles git ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    # core
+    platformdirs
+    chardet
+    iso8601
+    humanize
+    fasteners
+    packaging
+    patool
+    tqdm
+    annexremote
+
+    # downloaders-extra
+    # requests-ftp # not in nixpkgs yet
+
+    # downloaders
+    boto
+    keyrings-alt
+    keyring
+    msgpack
+    requests
+
+    # publish
+    python-gitlab
+
+    # misc
+    argcomplete
+    pyperclip
+    python-dateutil
+
+    # metadata
+    simplejson
+    whoosh
+
+    # metadata-extra
+    pyyaml
+    mutagen
+    exifread
+    python-xmp-toolkit
+    pillow
+
+    # duecredit
+    duecredit
+
+    # python>=3.8
+    distro
+  ] ++ lib.optional stdenv.hostPlatform.isWindows [ colorama ]
+    ++ lib.optional (python3.pythonOlder "3.10") [ importlib-metadata ];
+
+  postInstall = ''
+    installShellCompletion --cmd datalad \
+         --bash <($out/bin/datalad shell-completion) \
+         --zsh  <($out/bin/datalad shell-completion)
+  '';
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Keep code, data, containers under control with git and git-annex";
+    homepage = "https://www.datalad.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ renesat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -352,6 +352,8 @@ with pkgs;
 
   cryptowatch-desktop = callPackage ../applications/finance/cryptowatch { };
 
+  datalad = callPackage ../applications/version-management/datalad { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
