### PR TITLE
ventoy-bin: 1.0.72 -> 1.0.74

### DIFF
--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -24,7 +24,7 @@ let
   }.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
 in stdenv.mkDerivation rec {
   pname = "ventoy-bin";
-  version = "1.0.72";
+  version = "1.0.74";
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ]
     ++ lib.optional withQt5 qt5.wrapQtAppsHook;
@@ -40,13 +40,13 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz";
-    sha256 = "sha256-1mfe6ZnqkeBNGNjI7Qx7jG5FLgfn6rVwr0VQvSOG7Ow=";
+    sha256 = "sha256-raoVbj1+6nSR4knq/FmgVpzXRV71Hrcqd8C6Zsi34Uo=";
   };
   patches = [
     (fetchpatch {
       name = "sanitize.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/sanitize.patch?h=19f8922b3d96c5ff55eeefc269ae43369a0748e8";
-      sha256 = "sha256-RDdxPCmrfNMwXNuJwQW48fAiJPbMjdHiBmF03fKqm2o=";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/sanitize.patch?h=2f861f1297e1d11770279ebb58cbf185fee46b9b";
+      sha256 = "sha256-iAtLtM+Q4OsXDK83eCnPNomeNSEqdRLFfK2x7ybPSpk=";
     })
     ./fix-for-read-only-file-system.patch
     ./add-mips64.patch
@@ -82,7 +82,7 @@ in stdenv.mkDerivation rec {
         aarch64) rm -r {tool/,VentoyGUI.}{x86_64,i386,mips64el};;
         mips64el) rm -r {tool/,VentoyGUI.}{x86_64,i386,aarch64};;
     esac
-    rm README tool/VentoyWorker.sh.orig
+    rm README
     rm tool/"$ARCH"/Ventoy2Disk.gtk2 || true  # For aarch64 and mips64el.
 
     # Copy from "$src" to "$out".


### PR DESCRIPTION
###### Description of changes

- ventoy-bin: 1.0.72 -> 1.0.74

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
