### PR TITLE
rhythmbox: 3.4.4 → 3.4.5

### DIFF
--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -1,17 +1,30 @@
-{ lib, stdenv, fetchurl, pkg-config, fetchFromGitLab
+{ stdenv
+, lib
+, fetchurl
+, fetchpatch
+, pkg-config
+, meson
+, ninja
+, fetchFromGitLab
 , python3
-, perl
-, perlPackages
+, vala
+, glib
 , gtk3
-, intltool
 , libpeas
 , libsoup
+, libxml2
 , libsecret
 , libnotify
 , libdmapsharing
 , gnome
 , gobject-introspection
 , totem-pl-parser
+, libgudev
+, libgpod
+, libmtp
+, lirc
+, brasero
+, grilo
 , tdb
 , json-glib
 , itstool
@@ -19,38 +32,32 @@
 , gst_all_1
 , gst_plugins ? with gst_all_1; [ gst-plugins-good gst-plugins-ugly ]
 }:
-let
 
-  # The API version of libdmapsharing required by rhythmbox 3.4.4 is 3.0.
-
-  # This PR would solve the issue:
-  # https://gitlab.gnome.org/GNOME/rhythmbox/-/merge_requests/12
-  # Unfortunately applying this patch produces a rhythmbox which
-  # cannot fetch data from DAAP shares.
-
-  libdmapsharing_3 = libdmapsharing.overrideAttrs (old: rec {
-    version = "2.9.41";
-    src = fetchFromGitLab {
-      domain = "gitlab.gnome.org";
-      owner = "GNOME";
-      repo = old.pname;
-      rev = "${lib.toUpper old.pname}_${lib.replaceStrings ["."] ["_"] version}";
-      sha256 = "05kvrzf0cp3mskdy6iv7zqq24qdczl800q2dn1h4bk3d9wchgm4p";
-    };
-  });
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "rhythmbox";
-  version = "3.4.4";
+  version = "3.4.5";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "142xcvw4l19jyr5i72nbnrihs953pvrrzcbijjn9dxmxszbv03pf";
+    sha256 = "l+u8YPN4sibaRbtEbYmQL26hgx4j8Q76ujZVk7HnTyo=";
   };
+
+  patches = [
+    # Fix stuff linking against rhythmdb not finding libxml headers
+    # included by rhythmdb.h header.
+    # https://gitlab.gnome.org/GNOME/rhythmbox/-/merge_requests/147
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/rhythmbox/-/commit/7e8c7b803a45b7badf350132f8e78e3d75b99a21.patch";
+      sha256 = "5CE/NVlmx7FItNJCVQxx+x0DCYhUkAi/UuksfAiyWBg=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
-    intltool perl perlPackages.XMLParser
+    meson
+    ninja
+    vala
+    glib
     itstool
     wrapGAppsHook
   ];
@@ -58,13 +65,20 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     python3
     libsoup
+    libxml2
     tdb
     json-glib
 
+    glib
     gtk3
     libpeas
     totem-pl-parser
-    gnome.adwaita-icon-theme
+    libgudev
+    libgpod
+    libmtp
+    lirc
+    brasero
+    grilo
 
     gobject-introspection
     python3.pkgs.pygobject3
@@ -76,24 +90,20 @@ in stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-ugly
     gst_all_1.gst-libav
 
-    libdmapsharing_3 # necessary for daap support
+    libdmapsharing # for daap support
     libsecret
     libnotify
   ] ++ gst_plugins;
 
-  configureFlags = [
-    "--enable-daap"
-    "--enable-libnotify"
-    "--with-libsecret"
-  ];
+  postInstall = ''
+    glib-compile-schemas "$out/share/glib-2.0/schemas"
+  '';
 
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "${python3.pkgs.pygobject3}/${python3.sitePackages}:$out/lib/rhythmbox/plugins/"
     )
   '';
-
-  enableParallelBuilding = true;
 
   passthru = {
     updateScript = gnome.updateScript {


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/rhythmbox/-/compare/v3.4.4...v3.4.5

- Switched to Meson, which enabled all features by default.
- Replaces mediakeys removed in GNOME 42 (https://www.hadess.net/2021/10/psa-gnome-settings-daemons-mediakeys.html)

cc @jyp @rasendubi

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
