### PR TITLE
raspberry pi packages: pass through version info for auto-updates, first batch of auto-updates

### DIFF
--- a/pkgs/development/libraries/libraspberrypi/default.nix
+++ b/pkgs/development/libraries/libraspberrypi/default.nix
@@ -1,19 +1,24 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , fetchpatch
 , cmake
 , pkg-config
 }:
 
+let verinfo = {
+  rev = "54fd97ae4066a10b6b02089bc769ceed328737e0";
+  hash = "sha512-f7tBgIykcIdkwcFjBKk5ooD/5Bsyrd/0OFr7LNCwWFYeE4DH3XA7UR7YjArkwqUVCVBByr82EOaacw0g1blOkw==";
+  version = "unstable-2022-06-16";
+}; in
 stdenv.mkDerivation rec {
   pname = "libraspberrypi";
-  version = "unstable-2022-06-16";
+  version = verinfo.version;
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "userland";
-    rev = "54fd97ae4066a10b6b02089bc769ceed328737e0";
-    hash = "sha512-f7tBgIykcIdkwcFjBKk5ooD/5Bsyrd/0OFr7LNCwWFYeE4DH3XA7UR7YjArkwqUVCVBByr82EOaacw0g1blOkw==";
+    inherit (verinfo) rev hash;
   };
 
   patches = [
@@ -29,6 +34,8 @@ stdenv.mkDerivation rec {
     (if (stdenv.hostPlatform.isAarch64) then "-DARM64=ON" else "-DARM64=OFF")
     "-DVMCS_INSTALL_PREFIX=${placeholder "out"}"
   ];
+
+  passthru.verinfo = verinfo;
 
   meta = with lib; {
     description = "Userland tools & libraries for interfacing with Raspberry Pi hardware";

--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -1,23 +1,36 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 
+let
+  verinfo = {
+    version = "2022-07-06";
+    btfw = {
+      rev = "dd840d991939f5046959b8c564596c7228f9d41d";
+      hash = "sha512-XvF6IHDoKBJkSs0Wyt8O1vcCMpSNS9WSYopn0+EyCr4btABGsHWTkgxb4nQbd+VbE6Ls2dcKr+c+X6aw/y1jhQ==";
+    };
+    wififw = {
+      rev = "541e5a05d152e7e6f0d9be45622e4a3741e51c02";
+      hash = "sha512-0erVWiFom0V5AMu+XlolJnY9Q5/RCFlZwUovMBMNdEPb+L5rHcCdrA7zehDX1oRNe8DPb4S5gjny0iG/G7G6NQ==";
+    };
+  };
+in
 stdenvNoCC.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "2022-07-06";
+  version = verinfo.version;
 
   srcs = [
     (fetchFromGitHub {
       name = "bluez-firmware";
       owner = "RPi-Distro";
       repo = "bluez-firmware";
-      rev = "dd840d991939f5046959b8c564596c7228f9d41d";
-      hash = "sha512-XvF6IHDoKBJkSs0Wyt8O1vcCMpSNS9WSYopn0+EyCr4btABGsHWTkgxb4nQbd+VbE6Ls2dcKr+c+X6aw/y1jhQ==";
+      rev = verinfo.btfw.rev;
+      hash = verinfo.btfw.hash;
     })
     (fetchFromGitHub {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "541e5a05d152e7e6f0d9be45622e4a3741e51c02";
-      hash = "sha512-0erVWiFom0V5AMu+XlolJnY9Q5/RCFlZwUovMBMNdEPb+L5rHcCdrA7zehDX1oRNe8DPb4S5gjny0iG/G7G6NQ==";
+      rev = verinfo.wififw.rev;
+      hash = verinfo.wififw.hash;
     })
   ];
 
@@ -44,6 +57,8 @@ stdenvNoCC.mkDerivation {
 
     runHook postInstall
   '';
+
+  passthru.verinfo = verinfo;
 
   meta = with lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3+ and Zero W";

--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -49,10 +49,20 @@ stdenvNoCC.mkDerivation {
 
     # Bluetooth firmware
     cp -rv "$NIX_BUILD_TOP/bluez-firmware/broadcom/." "$out/lib/firmware/brcm"
+    
+    # jfc, some cypress fixup
+    (cd $out/lib/firmware/cypress; ln -s "cyfmac43455-sdio-standard.bin" "cyfmac43455-sdio.bin")
 
     # CM4 symlink must be added since it's missing from upstream
     pushd $out/lib/firmware/brcm &>/dev/null
     ln -s "./brcmfmac43455-sdio.txt" "$out/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.txt"
+
+    # RPI02W still stuck:
+    # [    2.352195] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43430b0-sdio.raspberrypi,model-zero-2-w.bin failed with error -2
+    # [    2.352331] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43430b0-sdio.bin failed with error -2
+    # ln -s "./brcmfmac43430b0-sdio.txt" "$out/lib/firmware/brcm/brcmfmac43430b0-sdio.raspberrypi,model-zero-2-w.txt"
+    ln -s "./brcmfmac43436s-sdio.txt" "$out/lib/firmware/brcm/brcmfmac43430b0-sdio.raspberrypi,model-zero-2-w.txt"
+
     popd &>/dev/null
 
     runHook postInstall

--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -2,14 +2,14 @@
 
 let
   verinfo = {
-    version = "2022-07-06";
+    version = "2022-07-14";
     btfw = {
-      rev = "dd840d991939f5046959b8c564596c7228f9d41d";
-      hash = "sha512-XvF6IHDoKBJkSs0Wyt8O1vcCMpSNS9WSYopn0+EyCr4btABGsHWTkgxb4nQbd+VbE6Ls2dcKr+c+X6aw/y1jhQ==";
+      rev = "31ad68831357d2019624004f1f0846475671088f";
+      hash = "sha256-wrNUD6FWD3Zsl3xo3ey4F/+v3Um8mylRvhL7N49NeiA=";
     };
     wififw = {
-      rev = "541e5a05d152e7e6f0d9be45622e4a3741e51c02";
-      hash = "sha512-0erVWiFom0V5AMu+XlolJnY9Q5/RCFlZwUovMBMNdEPb+L5rHcCdrA7zehDX1oRNe8DPb4S5gjny0iG/G7G6NQ==";
+      rev = "d9c88346cab86e23394ebf6cb6cb3069602d29f4";
+      hash = "sha256-1OqFWJMcQnQ03HXB2Kb2Tni+iao6Si3D5s/H1jLaK00=";
     };
   };
 in

--- a/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     description = "Firmware related ARM stubs for the Raspberry Pi";
     homepage = "https://github.com/raspberrypi/tools";
     license = licenses.bsd3;
-    platforms = [ "armv6l-linux" "armv7l-linux" "aarch64-linux" ];
+    platforms = [ "armv6l-linux" "armv7l-linux" "aarch64-linux" "x86_64-linux" ];
     maintainers = with maintainers; [ samueldr ];
   };
 }

--- a/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
@@ -2,16 +2,20 @@
 
 let
   inherit (lib) optionals;
+  verinfo = {
+    version = "2022-07-11";
+    rev = "439b6198a9b340de5998dd14a26a0d9d38a6bcac";
+    hash = "sha512-KMHgj73eXHT++IE8DbCsFeJ87ngc9R3XxMUJy4Z3s4/MtMeB9zblADHkyJqz9oyeugeJTrDtuVETPBRo7M4Y8A==";
+  };
 in
 stdenv.mkDerivation {
   pname = "raspberrypi-armstubs";
-  version = "unstable-2022-07-11";
+  version = verinfo.version;
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "tools";
-    rev = "439b6198a9b340de5998dd14a26a0d9d38a6bcac";
-    hash = "sha512-KMHgj73eXHT++IE8DbCsFeJ87ngc9R3XxMUJy4Z3s4/MtMeB9zblADHkyJqz9oyeugeJTrDtuVETPBRo7M4Y8A==";
+    inherit (verinfo) rev hash;
   };
 
   NIX_CFLAGS_COMPILE = [
@@ -42,6 +46,8 @@ stdenv.mkDerivation {
     cp -v *.bin $out/
     runHook postInstall
   '';
+
+  passthru.verinfo = verinfo;
 
   meta = with lib; {
     description = "Firmware related ARM stubs for the Raspberry Pi";

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -1,15 +1,20 @@
-{ lib, stdenvNoCC, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub
+, verinfo ? {
+    version = "2023-01-06";
+    rev = "refs/tags/1.20230106";
+    hash = "sha512-iKUR16RipN8BGAmXteTJUzd/P+m5gnbWCJ28LEzYfOTJnGSal63zI7LDQg/HIKXx9wMTARQKObeKn+7ioS4QkA==";
+  }
+}:
 
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  version = "1.20230106";
+  version = verinfo.version;
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
-    rev = version;
-    hash = "sha512-iKUR16RipN8BGAmXteTJUzd/P+m5gnbWCJ28LEzYfOTJnGSal63zI7LDQg/HIKXx9wMTARQKObeKn+7ioS4QkA==";
+    inherit (verinfo) rev hash;
   };
 
   installPhase = ''
@@ -20,6 +25,8 @@ stdenvNoCC.mkDerivation rec {
   dontConfigure = true;
   dontBuild = true;
   dontFixup = true;
+
+  passthru.verinfo = verinfo;
 
   meta = with lib; {
     description = "Firmware for the Raspberry Pi board";

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenvNoCC, fetchFromGitHub
 , verinfo ? {
     version = "2023-01-06";
-    rev = "refs/tags/1.20230106";
-    hash = "sha512-iKUR16RipN8BGAmXteTJUzd/P+m5gnbWCJ28LEzYfOTJnGSal63zI7LDQg/HIKXx9wMTARQKObeKn+7ioS4QkA==";
+    rev = "78852e166b4cf3ebb31d051e996d54792f0994b0";
+    hash = "sha256-tdaH+zZwmILNFBge2gMqtzj/1Hydj9cxhPvhw+7jTrU=";
   }
 }:
 

--- a/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
@@ -26,12 +26,13 @@ stdenvNoCC.mkDerivation rec {
   dontBuild = true;
   dontFixup = true;
 
+  passthru.verinfo = verinfo;
+
   meta = with lib; {
     description = "Firmware for the Raspberry Pi board (unstable master branch)";
     homepage = "https://github.com/raspberrypi/firmware";
     license = licenses.unfreeRedistributableFirmware; # See https://github.com/raspberrypi/firmware/blob/master/boot/LICENCE.broadcom
     maintainers = with maintainers; [ dezgeg ];
     broken = stdenvNoCC.isDarwin; # Hash mismatch on source, mystery.
-    inherit verinfo;
   };
 }

--- a/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
@@ -1,0 +1,37 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+let verinfo = {
+  version = "2022-11-15";
+  rev = "494eb71e5adfca31ec65dd535fce73de3c7c2efa";
+  hash = "sha256-ybJmHFAPMuqLs4gbr2VuJA1ET5eaSVfU9/Gfib7n/PM=";
+}; in
+stdenvNoCC.mkDerivation rec {
+  # NOTE: this should be updated with linux_rpi
+  pname = "raspberrypi-firmware-master";
+  # not a versioned tag, but this is "stable" as of 2022-01-10
+  version = verinfo.version;
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "firmware";
+    inherit (verinfo) rev hash;
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/raspberrypi/
+    mv boot "$out/share/raspberrypi/"
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  meta = with lib; {
+    description = "Firmware for the Raspberry Pi board (unstable master branch)";
+    homepage = "https://github.com/raspberrypi/firmware";
+    license = licenses.unfreeRedistributableFirmware; # See https://github.com/raspberrypi/firmware/blob/master/boot/LICENCE.broadcom
+    maintainers = with maintainers; [ dezgeg ];
+    broken = stdenvNoCC.isDarwin; # Hash mismatch on source, mystery.
+    inherit verinfo;
+  };
+}

--- a/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
@@ -1,9 +1,9 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 
 let verinfo = {
-  version = "2023-01-04";
-  rev = "03e04372dea46d38e42d3208a11f8ee37bff09bf";
-  hash = "sha256-jt4CJ5IZksJKPZF1wNhwLHlreGXJfeuuF29CRpx67gw=";
+  version = "2023-01-16";
+  rev = "76e9fa24526eb79428e236e165ea7a6d36ed0d2f";
+  hash = "sha256-HxUeHODp15TTko8uq69LF26/OYysgs0qbjMfVRAUqdU=";
 }; in
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi

--- a/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
@@ -1,9 +1,9 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 
 let verinfo = {
-  version = "2022-12-19";
-  rev = "4849b548c1ffda841481c54e62fff249ed00b32c";
-  hash = "sha256-us8pQmJn16YwfVpE3CPVh9vqV0PxFI9MBhzko2AFg3M=";
+  version = "2023-01-04";
+  rev = "03e04372dea46d38e42d3208a11f8ee37bff09bf";
+  hash = "sha256-jt4CJ5IZksJKPZF1wNhwLHlreGXJfeuuF29CRpx67gw=";
 }; in
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi

--- a/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/master.nix
@@ -1,9 +1,9 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 
 let verinfo = {
-  version = "2022-11-15";
-  rev = "494eb71e5adfca31ec65dd535fce73de3c7c2efa";
-  hash = "sha256-ybJmHFAPMuqLs4gbr2VuJA1ET5eaSVfU9/Gfib7n/PM=";
+  version = "2022-12-19";
+  rev = "4849b548c1ffda841481c54e62fff249ed00b32c";
+  hash = "sha256-us8pQmJn16YwfVpE3CPVh9vqV0PxFI9MBhzko2AFg3M=";
 }; in
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -50,6 +50,7 @@
 , ignoreConfigErrors ? stdenv.hostPlatform.linux-kernel.name != "pc" ||
                        stdenv.hostPlatform != stdenv.buildPlatform
 , extraMeta ? {}
+, extraPassthru ? {}
 
 , isZen      ? false
 , isLibre    ? false
@@ -225,7 +226,7 @@ let
           ) overridableKernel;
       };
     in [ (nixosTests.kernel-generic.testsForKernel overridableKernel) ] ++ kernelTests;
-  };
+  } // extraPassthru;
 
   finalKernel = lib.extendDerivation true passthru kernel;
 in finalKernel

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -11,9 +11,9 @@ let
   #   https://github.com/raspberrypi/firmware/blob/{{raspberrypifw->src->rev}}/extra/git_hash
   verinfo = {
     modDirVersion = "5.15.84";
-    version = "2023-01-06";
-    rev = "refs/tags/1.20230106";
-    hash = "sha512-6Dcpo81JBvc8NOv1nvO8JwjUgOOviRgHmXLLcGpE/pI2lEOcSeDRlB/FZtflzXTGilapvmwOSx5NxQfAmysHqQ==";
+    version = "20230105";
+    rev = "355bbe0f8114dcedd8ef5d9989a5c0f07301db9e";
+    hash = "sha256-Rs9cXYDCIXFRLcgmz+PLVloGYXUaNmyUVsCy2BW5R6k=";
   };
 in
 lib.overrideDerivation (buildLinux (args // {

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -12,7 +12,7 @@
 
 let verinfo = {
   version = "2022-12-07";
-  rev = "6e79e995bbc75c5fdd5305bd7fe029758cfade2f";
+  rev = "36886df55b9c9681f886b7f29039df7a02c3caa2";
   hash = "sha256-/Q9zj/Hn/8S7bF1CN6ZCg705VYU+QUagNr4RNgZl+oA=";
 }; in
 stdenvNoCC.mkDerivation rec {

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -11,9 +11,9 @@
 }:
 
 let verinfo = {
-  version = "2022-12-07";
-  rev = "36886df55b9c9681f886b7f29039df7a02c3caa2";
-  hash = "sha256-/Q9zj/Hn/8S7bF1CN6ZCg705VYU+QUagNr4RNgZl+oA=";
+  version = "2023-01-11";
+  rev = "5129267f6a7da63bac8e79998002b5342890e01f";
+  hash = "sha256-ELTEeN0gsZhGPtLNJ1+SXc+pYmMKjcGlVtWjDICu6XU=";
 }; in
 stdenvNoCC.mkDerivation rec {
   pname = "raspberrypi-eeprom";

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -1,15 +1,28 @@
-{ stdenvNoCC, lib, fetchFromGitHub, makeWrapper
-, python3, binutils-unwrapped, findutils, kmod, pciutils, libraspberrypi
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, makeWrapper
+, python3
+, binutils-unwrapped
+, findutils
+, kmod
+, pciutils
+, libraspberrypi
 }:
+
+let verinfo = {
+  version = "2022-12-07";
+  rev = "6e79e995bbc75c5fdd5305bd7fe029758cfade2f";
+  hash = "sha256-/Q9zj/Hn/8S7bF1CN6ZCg705VYU+QUagNr4RNgZl+oA=";
+}; in
 stdenvNoCC.mkDerivation rec {
   pname = "raspberrypi-eeprom";
-  version = "2022.12.07-138a1";
+  version = verinfo.version;
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
-    rev = "v${version}";
-    hash = "sha256-/Q9zj/Hn/8S7bF1CN6ZCg705VYU+QUagNr4RNgZl+oA=";
+    inherit (verinfo) rev hash;
   };
 
   buildInputs = [ python3 ];
@@ -48,6 +61,8 @@ stdenvNoCC.mkDerivation rec {
         ])}"
     done
   '';
+
+  passthru.verinfo = verinfo;
 
   meta = with lib; {
     description = "Installation scripts and binaries for the closed sourced Raspberry Pi 4 EEPROMs";

--- a/pkgs/tools/pyamlboot/default.nix
+++ b/pkgs/tools/pyamlboot/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitHub, pythonPackages
+# , libsepol, libselinux, checkpolicy
+# , withGraphics ? false
+}:
+
+with lib;
+
+pythonPackages.buildPythonApplication rec {
+  pname = "pyamlboot-unstable";
+  version = "2021-08-17";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "superna9999";
+    repo = "pyamlboot";
+    rev = "ffaaad9503192ece98970b7100a03c54ba58befc";
+    sha256 = "sha256-2TD9UtMcxA29p3K6i5+SDSAVDiFhY1050QWx5MHne3s=";
+  };
+
+  # nativeBuildInputs = [ cython ];
+  # buildInputs = [ libsepol ];
+  propagatedBuildInputs = with pythonPackages; [ setuptools pyusb ];
+
+  # checkInputs = [ tox checkpolicy ];
+  # preCheck = ''
+  #   export CHECKPOLICY=${checkpolicy}/bin/checkpolicy
+  # '';
+
+  # setupPyBuildFlags = [ "-i" ];
+
+  # preBuild = ''
+  #   export SEPOL="${lib.getLib libsepol}/lib/libsepol.a"
+  # '';
+
+  meta = {
+    # description = "SELinux Policy Analysis Tools";
+    # homepage = "https://github.com/SELinuxProject/setools";
+    # license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26173,6 +26173,7 @@ with pkgs;
   rasdaemon = callPackage ../os-specific/linux/rasdaemon { };
 
   raspberrypifw = callPackage ../os-specific/linux/firmware/raspberrypi {};
+  raspberrypifw-master = callPackage ../os-specific/linux/firmware/raspberrypi/master.nix {};
   raspberrypiWirelessFirmware = callPackage ../os-specific/linux/firmware/raspberrypi-wireless { };
 
   raspberrypi-eeprom = callPackage ../os-specific/linux/raspberrypi-eeprom {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26233,6 +26233,10 @@ with pkgs;
 
   setools = callPackage ../os-specific/linux/setools { };
 
+  pyamlboot = callPackage ../tools/pyamlboot {
+    pythonPackages = python3Packages;
+  };
+
   seturgent = callPackage ../os-specific/linux/seturgent { };
 
   sgx-azure-dcap-client = callPackage ../os-specific/linux/sgx/azure-dcap-client { };


### PR DESCRIPTION
###### Description of changes

cc: @lovesegfault

The first commit moves the rev/hashes into a `verinfo` attrset and then passes it thru meta, for the various raspberrypi firmware-esque packages.

I have a script that is a bit too messy to upstream right now, that knows how to update these packages according to what "upstream" recommends when you sufficiently read between the lines.

It's smart enough to update the Wifi+BT package and pick the newer version as the updated package version. It's smart enough to match the kernel commit to the version that is indicated in rpi eeprom repository, etc.

The subsequent commits are just the result of running my script. The script is flexible enough that it's fairly idempotent. I point it at some branch of nixpkgs (that has the `verinfo` commit), and a "target" branch, and it will reset the  target to the source, and then update all packages. (Meaning in theory, this script could run in a loop, auto-rebasing on itself and pushing, and it would just keep adding new commits as other packages get updated).

I am working on automated testing for this as well, but I need to get some of this rolling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
