### PR TITLE
sptlrx: add version test

### DIFF
--- a/pkgs/applications/audio/sptlrx/default.nix
+++ b/pkgs/applications/audio/sptlrx/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, testVersion, sptlrx }:
+{ lib, buildGoModule, fetchFromGitHub, testers, sptlrx }:
 
 buildGoModule rec {
   pname = "sptlrx";
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  passthru.tests.version = testVersion {
+  passthru.tests.version = testers.testVersion {
     package = sptlrx;
     # TODO Wrong version in `0.2.0`. Has been fixed upstream.
     version = "v0.1.0";

--- a/pkgs/applications/audio/sptlrx/default.nix
+++ b/pkgs/applications/audio/sptlrx/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "sptlrx";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "raitonoberu";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Wk4vXm6sB+Rw0VFAhfD0GKxsP+1LwpS6VFHa3UENuJk=";
+    sha256 = "sha256-b38DACSdnjwPsLMrkt0Ubpqpn/4SDAgrdSlp9iAcxfE=";
   };
 
-  vendorSha256 = "sha256-l5gIbjB2rJyNmZBqrHo4kwClmAgjgDWHTs5KWzrfC08=";
+  vendorSha256 = "sha256-/fqWnRQBpLNoTwqrFDKqQuv1r9do1voysBhLuj223S0=";
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/applications/audio/sptlrx/default.nix
+++ b/pkgs/applications/audio/sptlrx/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, testVersion, sptlrx }:
 
 buildGoModule rec {
   pname = "sptlrx";
@@ -14,6 +14,12 @@ buildGoModule rec {
   vendorSha256 = "sha256-/fqWnRQBpLNoTwqrFDKqQuv1r9do1voysBhLuj223S0=";
 
   ldflags = [ "-s" "-w" ];
+
+  passthru.tests.version = testVersion {
+    package = sptlrx;
+    # TODO Wrong version in `0.2.0`. Has been fixed upstream.
+    version = "v0.1.0";
+  };
 
   meta = with lib; {
     description = "Spotify lyrics in your terminal";


### PR DESCRIPTION
###### Description of changes

Add a simple version test to sptlrx.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
