### PR TITLE
python310Packages.secretstorage: 3.3.1 -> 3.3.2

### DIFF
--- a/pkgs/development/python-modules/secretstorage/default.nix
+++ b/pkgs/development/python-modules/secretstorage/default.nix
@@ -1,15 +1,22 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder, cryptography, jeepney }:
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchPypi
+, jeepney
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "secretstorage";
-  version = "3.3.1";
+  version = "3.3.2";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "SecretStorage";
     inherit version;
-    sha256 = "15ginv4gzxrx77n7517xnvf2jcpqc6ran12s951hc85zlr8nqrpx";
+    hash = "sha256-Co65ZFsyCIHCIugnwm9M/PVTY+izdKAhmB74hmV6kS8=";
   };
 
   propagatedBuildInputs = [
@@ -17,12 +24,16 @@ buildPythonPackage rec {
     jeepney
   ];
 
-  # Needs a D-Bus Sesison
+  # Needs a D-Bus session
   doCheck = false;
 
+  pythonImportsCheck = [
+    "secretstorage"
+  ];
+
   meta = with lib; {
-    homepage = "https://github.com/mitya57/secretstorage";
     description = "Python bindings to FreeDesktop.org Secret Service API";
+    homepage = "https://github.com/mitya57/secretstorage";
     license = licenses.bsd3;
     maintainers = with maintainers; [ teto ];
   };


### PR DESCRIPTION
###### Description of changes
https://github.com/mitya57/secretstorage/blob/master/changelog

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
