### PR TITLE
prometheus-openldap-exporter: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/servers/monitoring/prometheus/openldap-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/openldap-exporter.nix
@@ -1,27 +1,29 @@
-{ buildGoPackage, lib, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "openldap_exporter";
-  version = "2.2.0";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "tomcz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-+lrLA9CbGNzvvbwn79ili/kFRCr6vMKDtkvyfnL9n9k=";
+    sha256 = "sha256-ok2fTYz1oQiNdTPsssPb/VuFqny1i8nKTngSpKgCpC4=";
   };
 
+  vendorSha256 = null;
+
   ldflags = [
-    "-s" "-w"
+    "-s"
+    "-w"
     "-X github.com/tomcz/openldap_exporter.tag=v${version}"
     "-X github.com/tomcz/openldap_exporter.commit=unknown"
   ];
 
-  goPackagePath = "github.com/tomcz/openldap_exporter";
 
   meta = with lib; {
     homepage = "https://github.com/tomcz/openldap_exporter";
-    description = " Simple service that scrapes metrics from OpenLDAP and exports them via HTTP for Prometheus consumption";
+    description = "Simple service that scrapes metrics from OpenLDAP and exports them via HTTP for Prometheus consumption";
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 ];
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
