### PR TITLE
python310Packages.signedjson: 1.1.1 -> 1.1.4

### DIFF
--- a/pkgs/development/python-modules/signedjson/default.nix
+++ b/pkgs/development/python-modules/signedjson/default.nix
@@ -1,40 +1,53 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, fetchpatch
 , canonicaljson
-, unpaddedbase64
-, pynacl
-, typing-extensions
-, setuptools-scm
+, fetchPypi
 , importlib-metadata
+, pynacl
+, pytestCheckHook
 , pythonOlder
+, setuptools-scm
+, typing-extensions
+, unpaddedbase64
 }:
 
 buildPythonPackage rec {
   pname = "signedjson";
-  version = "1.1.1";
+  version = "1.1.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0280f8zyycsmd7iy65bs438flm7m8ffs1kcxfbvhi8hbazkqc19m";
+    hash = "sha256-zZHFavU/Fp7wMsYunEoyktwViGaTMxjQWS40Yts9ZJI=";
   };
 
-  patches = [
-    # Do not require importlib_metadata on python 3.8
-    (fetchpatch {
-      url = "https://github.com/matrix-org/python-signedjson/commit/c40c83f844fee3c1c7b0c5d1508f87052334b4e5.patch";
-      sha256 = "109f135zn9azg5h1ljw3v94kpvnzmlqz1aiknpl5hsqfa3imjca1";
-    })
+  nativeBuildInputs = [
+    setuptools-scm
   ];
 
-  nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ canonicaljson unpaddedbase64 pynacl typing-extensions ]
-    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  propagatedBuildInputs = [
+    canonicaljson
+    unpaddedbase64
+    pynacl
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+    typing-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "signedjson"
+  ];
 
   meta = with lib; {
-    homepage = "https://pypi.org/project/signedjson/";
     description = "Sign JSON with Ed25519 signatures";
+    homepage = "https://github.com/matrix-org/python-signedjson";
     license = licenses.asl20;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/matrix-org/python-signedjson/releases/tag/v1.1.4

- switch to `pytestCheckHook`
- add `pythonImportsCheck`
- update meta
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
