### PR TITLE
bchn: init at 24.0.0

### DIFF
--- a/pkgs/applications/blockchains/bchn/default.nix
+++ b/pkgs/applications/blockchains/bchn/default.nix
@@ -1,0 +1,41 @@
+{ fetchFromGitLab
+, stdenv
+, boost
+, libevent
+, miniupnpc
+, help2man
+, db62
+, openssl
+, zeromq
+, cmake
+, git
+, python3
+, libsForQt5
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  name = "bchn";
+  version = "24.0.0";
+  src = fetchFromGitLab {
+    owner = "bitcoin-cash-node";
+    repo = "bitcoin-cash-node";
+    rev = "v${version}";
+    sha256 = "sha256-5n7hqyyclj3fSaF3RBW1EQ3fO42n5biFSTvBRr3GN5c=";
+  };
+  buildInputs = [ boost libevent miniupnpc openssl zeromq db62 ];
+  nativeBuildInputs = [ cmake git python3 ];
+
+  # This can probably be supported, but I can't invest time into it right now.
+  cmakeFlags = [ "-DBUILD_BITCOIN_QT=OFF" "-DENABLE_MAN=OFF" ];
+  postConfigure = ''
+    chmod +x config/run_native_cmake.sh src/secp256k1/build_native_gen_context.sh
+  '';
+
+  meta = with lib; {
+    description = "A professional, miner-friendly node that solves practical problems for Bitcoin Cash";
+    homepage = "https://bitcoincashnode.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ilyakooo0 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30966,6 +30966,8 @@ with pkgs;
 
   balanceofsatoshis = nodePackages.balanceofsatoshis;
 
+  bchn = callPackage ../applications/blockchains/bchn { };
+
   bitcoin  = libsForQt5.callPackage ../applications/blockchains/bitcoin {
     boost = boost17x;
     miniupnpc = miniupnpc_2;


### PR DESCRIPTION
###### Description of changes

BCHN is a Bitcoin Cash (BCH) node: https://bitcoincashnode.org

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
