### PR TITLE
linphone: Cleanup dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -1,51 +1,18 @@
-{ bcg729
-, bctoolbox
-, bcunit
+{ bctoolbox
 , belcard
 , belle-sip
 , belr
-, bzrtp
-, cairo
 , cmake
-, cyrus_sasl
 , fetchFromGitLab
-, fetchurl
-, ffmpeg
-, gdk-pixbuf
-, glib
-, graphviz
-, gtk2
-, intltool
 , lib
-, libexosip
 , liblinphone
-, libmatroska
-, libnotify
-, libosip
-, libsoup
-, libupnp
-, libX11
-, libxml2
-, makeWrapper
-, mbedtls
 , mediastreamer
 , mediastreamer-openh264
 , minizip2
 , mkDerivation
-, openldap
-, ortp
-, pango
-, pkg-config
-, qtbase
 , qtgraphicaleffects
 , qtquickcontrols2
 , qttranslations
-, readline
-, speex
-, sqlite
-
-, udev
-, zlib
 }:
 
 # How to update Linphone? (The Qt desktop app)
@@ -95,57 +62,22 @@ mkDerivation rec {
   # linphone-desktop.
   buildInputs = [
     # Made by BC
-    bcg729
     bctoolbox
     belcard
     belle-sip
     belr
-    bzrtp
     liblinphone
     mediastreamer
     mediastreamer-openh264
-    ortp
 
-    # Vendored by BC but we use upstream, might cause problems
-    libmatroska
-
-    cairo
-    cyrus_sasl
-    ffmpeg
-    gdk-pixbuf
-    glib
-    gtk2
-    libX11
-    libexosip
-    libnotify
-    libosip
-    libsoup
-    libupnp
-    libxml2
-    mbedtls
     minizip2
-    openldap
-    pango
-    qtbase
     qtgraphicaleffects
     qtquickcontrols2
     qttranslations
-    readline
-    speex
-    sqlite
-    udev
-    zlib
   ];
 
   nativeBuildInputs = [
-    # Made by BC
-    bcunit
-
     cmake
-    graphviz
-    intltool
-    makeWrapper
-    pkg-config
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/belcard/default.nix
+++ b/pkgs/development/libraries/belcard/default.nix
@@ -22,8 +22,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ bctoolbox belr ];
   nativeBuildInputs = [ cmake ];
 
-  # Do not build static libraries
-  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+  cmakeFlags = [
+    "-DENABLE_STATIC=NO" # Do not build static libraries
+    "-DENABLE_UNIT_TESTS=NO" # Do not build test executables
+  ];
 
   meta = with lib; {
     description = "C++ library to manipulate VCard standard format. Part of the Linphone project.";

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -1,50 +1,20 @@
-{ bcg729
-, bctoolbox
-, bcunit
+{ bctoolbox
 , belcard
 , belle-sip
 , belr
-, bzrtp
-, cairo
 , cmake
-, cyrus_sasl
 , doxygen
 , fetchFromGitLab
-, ffmpeg
-, gdk-pixbuf
-, glib
-, graphviz
-, gtk2
-, intltool
 , jsoncpp
-, libexosip
-, libmatroska
-, libnotify
-, libosip
-, libsoup
-, libupnp
-, libX11
 , libxml2
 , lime
-, makeWrapper
-, mbedtls
 , mediastreamer
-, openldap
-, ortp
-, pango
-, pkg-config
 , python3
-, readline
 , bc-soci
-, boost
-, speex
 , sqlite
 , lib
 , stdenv
-, udev
 , xercesc
-, xsd
-, zlib
 }:
 
 stdenv.mkDerivation rec {
@@ -62,69 +32,31 @@ stdenv.mkDerivation rec {
 
   patches = [ ./use-normal-jsoncpp.patch ];
 
-  # Do not build static libraries
-  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+  cmakeFlags = [
+    "-DENABLE_STATIC=NO" # Do not build static libraries
+    "-DENABLE_UNIT_TESTS=NO" # Do not build test executables
+  ];
 
-  # TODO: Not sure if all these inputs are actually needed. Most of them were
-  # defined when liblinphone and linphone-desktop weren't separated yet, so some
-  # of them might not be needed for liblinphone alone.
   buildInputs = [
-    (python3.withPackages (ps: [ ps.pystache ps.six ]))
-
     # Made by BC
-    bcg729
-    bctoolbox
     belcard
     belle-sip
-    belr
-    bzrtp
     lime
     mediastreamer
-    ortp
 
     # Vendored by BC
     bc-soci
 
-    # Vendored by BC but we use upstream, might cause problems
-    libmatroska
-
-    cairo
-    cyrus_sasl
-    ffmpeg
-    gdk-pixbuf
-    glib
-    gtk2
-    libX11
-    libexosip
-    libnotify
-    libosip
-    libsoup
-    libupnp
-    libxml2
-    mbedtls
-    openldap
-    pango
-    readline
-    boost
-    speex
-    sqlite
-    udev
-    xercesc
-    xsd
-    zlib
     jsoncpp
+    libxml2
+    (python3.withPackages (ps: [ ps.pystache ps.six ]))
+    sqlite
+    xercesc
   ];
 
   nativeBuildInputs = [
-    # Made by BC
-    bcunit
-
     cmake
     doxygen
-    graphviz
-    intltool
-    makeWrapper
-    pkg-config
   ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/lime/default.nix
+++ b/pkgs/development/libraries/lime/default.nix
@@ -5,7 +5,6 @@
 , lib
 , bc-soci
 , sqlite
-, boost
 , stdenv
 }:
 
@@ -31,12 +30,13 @@ stdenv.mkDerivation rec {
     bc-soci
 
     sqlite
-    boost
   ];
   nativeBuildInputs = [ cmake ];
 
-  # Do not build static libraries
-  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+  cmakeFlags = [
+    "-DENABLE_STATIC=NO" # Do not build static libraries
+    "-DENABLE_UNIT_TESTS=NO" # Do not build test executables
+  ];
 
   meta = with lib; {
     description = "End-to-end encryption library for instant messaging. Part of the Linphone project.";

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -1,33 +1,21 @@
-{ alsa-lib
-, bctoolbox
+{ bctoolbox
 , bzrtp
 , cmake
-, doxygen
 , fetchFromGitLab
 , ffmpeg
 , glew
 , gsm
-, intltool
 , lib
-, libGL
-, libGLU
 , libX11
 , libXext
-, libXv
-, libmatroska
 , libopus
-, libpcap
 , libpulseaudio
-, libtheora
-, libupnp
 , libv4l
 , libvpx
 , ortp
-, pkg-config
 , python3
 , qtbase
 , qtdeclarative
-, SDL
 , speex
 , srtp
 , stdenv
@@ -59,9 +47,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    doxygen
-    intltool
-    pkg-config
     python3
     qtbase
     qtdeclarative
@@ -73,28 +58,19 @@ stdenv.mkDerivation rec {
     bzrtp
     ortp
 
-    # Vendored by BC but we use upstream, might cause problems
-    libmatroska
-
-    alsa-lib
     ffmpeg
     glew
-    gsm
-    libGL
-    libGLU
     libX11
     libXext
-    libXv
-    libopus
-    libpcap
     libpulseaudio
-    libtheora
-    libupnp
     libv4l
-    libvpx
-    SDL
     speex
     srtp
+
+    # Optional
+    gsm  # GSM audio codec
+    libopus  # Opus audio codec
+    libvpx  # VP8 video codec
   ];
 
   strictDeps = true;
@@ -104,6 +80,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_QT_GL=ON" # Build necessary MSQOGL plugin for Linphone desktop
     "-DCMAKE_C_FLAGS=-DGIT_VERSION=\"v${version}\""
     "-DENABLE_STRICT=NO" # Disable -Werror
+    "-DENABLE_UNIT_TESTS=NO" # Do not build test executables
   ];
 
   NIX_LDFLAGS = "-lXext";

--- a/pkgs/development/libraries/mediastreamer/msopenh264.nix
+++ b/pkgs/development/libraries/mediastreamer/msopenh264.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-AqZ7tsNZw2Djgyo1JBJbT/c3eQVyEn6r3CT6DQLD/B8=";
   };
 
-  nativeBuildInputs = [ autoreconfHook cmake pkg-config ];
+  nativeBuildInputs = [ cmake ];
   buildInputs = [ mediastreamer openh264 ];
 
   # Do not build static libraries


### PR DESCRIPTION
###### Description of changes

Cleaned up the build inputs of all linphone-related derivations. A lot of bloat had been accumulated through updates (e.g. with linphone migrating from Gtk to Qt, or linphone being split to liblinphone & linphone-desktop).

I have tested everything I could, but it is possible that some optional features have been silently disabled with dependencies not being found now. (Codecs, encryption schemes, etc...)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
