### PR TITLE
yarn2nix: extend NixOS/nix#5128 workaround to 2.4+

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -49,7 +49,8 @@ function fetchgit(fileName, url, rev, branch, builtinFetchGit) {
           url = "${url}";
           ref = "${branch}";
           rev = "${rev}";
-        } // (if builtins.substring 0 3 builtins.nixVersion == "2.4" then {
+        } // (if builtins.compareVersions "2.4pre" builtins.nixVersion < 0 then {
+          # workaround for https://github.com/NixOS/nix/issues/5128
           allRefs = true;
         } else {}));
       ` : `


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/141005 continued.

The issue was not fixed in later versions, so we need the workaround for all versions [greater than `2.4pre`](https://github.com/NixOS/nix/issues/4713#issuecomment-821031575).
