### PR TITLE
Fix / update pulseview and libsigrok

### DIFF
--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -1,15 +1,15 @@
 { mkDerivation, lib, fetchurl, fetchpatch, pkg-config, cmake, glib, boost, libsigrok
 , libsigrokdecode, libserialport, libzip, udev, libusb1, libftdi1, glibmm
-, pcre, librevisa, python3, qtbase, qtsvg
+, pcre, librevisa, python3, qtbase, qtsvg, qttools
 }:
 
 mkDerivation rec {
   pname = "pulseview";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchurl {
     url = "https://sigrok.org/download/source/pulseview/${pname}-${version}.tar.gz";
-    sha256 = "0bvgmkgz37n2bi9niskpl05hf7rsj1lj972fbrgnlz25s4ywxrwy";
+    sha256 = "sha256-8EL3ej4bNb8wZmMw427Dj6uNJIw2k8N7fjXUAcO/q8s=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -17,7 +17,7 @@ mkDerivation rec {
   buildInputs = [
     glib boost libsigrok libsigrokdecode libserialport libzip udev libusb1 libftdi1 glibmm
     pcre librevisa python3
-    qtbase qtsvg
+    qtbase qtsvg qttools
   ];
 
   patches = [

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -235,6 +235,8 @@ let
         };
       } ../hooks/qmake-hook.sh;
 
+      inherit stdenv;
+
       wrapQtAppsHook = makeSetupHook {
         deps = [ self.qtbase.dev makeWrapper ]
           ++ lib.optional stdenv.isLinux self.qtwayland.dev;

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -233,6 +233,8 @@ let
         };
       } ../hooks/qmake-hook.sh;
 
+      inherit stdenv;
+
       wrapQtAppsHook = makeSetupHook {
         deps = [ self.qtbase.dev makeWrapper ]
           ++ lib.optional stdenv.isLinux self.qtwayland.dev;

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -191,6 +191,8 @@ let
         };
       } ../hooks/qmake-hook.sh;
 
+      inherit stdenv;
+
       wrapQtAppsHook = makeSetupHook {
         deps = [ self.qtbase.dev makeWrapper ]
           ++ lib.optional stdenv.isLinux self.qtwayland.dev;

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, libzip, glib, libusb1, libftdi1, check
 , libserialport, librevisa, doxygen, glibmm, python
-, version ? "0.5.1", sha256 ? "171b553dir5gn6w4f7n37waqk62nq2kf1jykx4ifjacdz5xdw3z4", doInstallCheck ? true
+, version ? "0.5.2", sha256 ? "sha256-TTQfkLYiDT6MslHaz3JsQRZShWEiSPLFLRXfRZChzjw=", doInstallCheck ? true
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29036,7 +29036,9 @@ with pkgs;
 
   pulseaudio-dlna = callPackage ../applications/audio/pulseaudio-dlna { };
 
-  pulseview = libsForQt514.callPackage ../applications/science/electronics/pulseview { };
+  pulseview = libsForQt514.callPackage ../applications/science/electronics/pulseview {
+    boost = boost.override { inherit (libsForQt514) stdenv; };
+  };
 
   puredata = callPackage ../applications/audio/puredata { };
   puredata-with-plugins = plugins: callPackage ../applications/audio/puredata/wrapper.nix { inherit plugins; };


### PR DESCRIPTION
###### Description of changes

Fixed pulseview build error, that crept in due to gcc9 <> gcc11 mismatch in qt514 vs boost.

Took the opportunity to also update it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


