### PR TITLE
python310Packages.pyomo: 6.3.0 -> 6.4.0

### DIFF
--- a/pkgs/development/python-modules/pyomo/default.nix
+++ b/pkgs/development/python-modules/pyomo/default.nix
@@ -1,48 +1,60 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
-, pyutilib
-, appdirs
+, parameterized
 , ply
-, six
-, nose
-, glpk
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pyomo";
-  version = "6.3.0";
-  disabled = isPy27; # unable to import pyutilib.th
+  version = "6.4.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     repo = "pyomo";
     owner = "pyomo";
     rev = version;
-    sha256 = "sha256-xyjiB5fDRf5y9Av5Cr+8wtU4pHzMHsM45mcmJEOaTWs=";
+    hash = "sha256-FdUhne5Dn5hTIXMce1G6Zu6nx+AuP/JdK0a5fCE3hg8=";
   };
 
-  checkInputs = [ nose glpk ];
   propagatedBuildInputs = [
-    pyutilib
-    appdirs
     ply
-    six
   ];
 
-  checkPhase = ''
-    rm pyomo/bilevel/tests/test_blp.py \
-       pyomo/version/tests/test_installer.py \
-       pyomo/common/tests/test_download.py \
-       pyomo/core/tests/examples/test_pyomo.py
-    export HOME=$TMPDIR
-    nosetests
+  checkInputs = [
+    parameterized
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyomo"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
   '';
 
+  disabledTestPaths = [
+    # Don't test the documentation and the examples
+    "doc/"
+    "examples/"
+    # Tests don't work properly in the sandbox
+    "pyomo/environ/tests/test_environ.py"
+  ];
+
+  disabledTests = [
+    # Test requires lsb_release
+    "test_get_os_version"
+  ];
+
   meta = with lib; {
-    description = "Pyomo: Python Optimization Modeling Objects";
+    description = "Python Optimization Modeling Objects";
     homepage = "http://pyomo.org";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/Pyomo/pyomo/releases/tag/6.4.0

- fix build (https://hydra.nixos.org/build/175325106)
- switch to `pytestCheckHook`
- update meta
- add `pythonImportsCheck`
- update inputs
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
