### PR TITLE
Add mingwW64-llvm cross-system.

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -301,6 +301,15 @@ rec {
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
   };
 
+  # 64 bit mingw-w64 with a llvm-based toolchain targetting ucrt
+  #
+  # Inspired by mstorsjo/llvm-mingw
+  mingwW64-llvm = {
+    config = "x86_64-w64-mingw32";
+    libc = "ucrt";
+    useLLVM = true;
+  };
+
   # BSDs
 
   amd64-netbsd = lib.warn "The amd64-netbsd system example is deprecated. Use x86_64-netbsd instead." x86_64-netbsd;

--- a/pkgs/build-support/bintools-wrapper/add-lld-ldflags-before.sh
+++ b/pkgs/build-support/bintools-wrapper/add-lld-ldflags-before.sh
@@ -1,0 +1,6 @@
+# ld.lld has two incompatible command-line drivers: One for the gnu-compatible COFF linker and one for
+# the ELF linker. If no emulation is set (with -m), it will default to the ELF linker;
+# unfortunately, some configure scripts use `ld --help` to check for certain Windows-specific flags,
+# which don't show up in the help for the ELF linker. So we set a default -m here.
+
+extraBefore+=("-m" "@mtype@")

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -335,6 +335,11 @@ stdenv.mkDerivation {
       echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/libc-ldflags
     ''
 
+    # lld's MinGW driver (e.g. `ld.lld -m i386pep`) does not support the `-z` flag.
+    + optionalString (targetPlatform.isWindows && isLld) ''
+      hardening_unsupported_flags+=" relro bindnow"
+    ''
+
     ##
     ## GNU specific extra strip flags
     ##

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -385,6 +385,24 @@ stdenv.mkDerivation {
     )
 
     ##
+    ## Set the default machine type so that $prefix-ld.lld uses the COFF driver for --help
+    ##
+    ## Needed because autotools parses --help for linker features...
+    ##
+    + optionalString (isLld && stdenv.targetPlatform.isWindows) (let
+      mtype =
+        /**/ if targetPlatform.isx86_32 then "i386pe"
+        else if targetPlatform.isx86_64 then "i386pep"
+        else if targetPlatform.isAarch32 then "thumb2pe"
+        else if targetPlatform.isAarch64 then "arm64pe"
+        else throw "unsupported target arch for lld";
+    in ''
+      export mtype=${mtype}
+      substituteAll ${./add-lld-ldflags-before.sh} add-local-ldflags-before.sh
+      cat add-local-ldflags-before.sh >> $out/nix-support/add-local-ldflags-before.sh
+    '')
+
+    ##
     ## Code signing on Apple Silicon
     ##
     + optionalString (targetPlatform.isDarwin && targetPlatform.isAarch64) ''

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -31,6 +31,13 @@
 
 # Darwin code signing support utilities
 , postLinkSignHook ? null, signingUtils ? null
+
+# Linker type
+, isLld ? bintools.isLld or false
+, isCctools ? bintools.isCctools or false
+, isGNU ? bintools.isGNU or false
+, isGold ? bintools.isGold or false
+, isBfd ? bintools.isBfd or false
 }:
 
 with lib;
@@ -112,6 +119,8 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit bintools libc nativeTools nativeLibc nativePrefix;
+
+    inherit isLld isCctools isGNU isGold isBfd;
 
     emacsBufferSetup = pkgs: ''
       ; We should handle propagation here too

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -476,6 +476,8 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" pic"
     '' + optionalString targetPlatform.isMinGW ''
       hardening_unsupported_flags+=" stackprotector fortify"
+    '' + optionalString (targetPlatform.isWindows && isClang) ''
+      hardening_unsupported_flags+=" pic"
     '' + optionalString targetPlatform.isAvr ''
       hardening_unsupported_flags+=" stackprotector pic"
     '' + optionalString (targetPlatform.libc == "newlib") ''

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -17,6 +17,7 @@
 , isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
 , buildPackages ? {}
 , libcxx ? null
+, isCompilerRT ? false
 }:
 
 with lib;
@@ -145,7 +146,7 @@ stdenv.mkDerivation {
     # Binutils, and Apple's "cctools"; "bintools" as an attempt to find an
     # unused middle-ground name that evokes both.
     inherit bintools;
-    inherit libc nativeTools nativeLibc nativePrefix isGNU isClang;
+    inherit libc nativeTools nativeLibc nativePrefix isGNU isClang isCompilerRT;
 
     emacsBufferSetup = pkgs: ''
       ; We should handle propagation here too

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -79,7 +79,7 @@ let majorVersion = "10";
       });
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -292,7 +292,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -82,7 +82,7 @@ let majorVersion = "11";
       ++ optional (!crossStageStatic && targetPlatform.isMinGW) ./Added-mcf-thread-model-support-from-mcfgthread.patch;
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -296,7 +296,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -114,7 +114,7 @@ let majorVersion = "4";
     javaAwtGtk = langJava && x11Support;
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -316,7 +316,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -130,7 +130,7 @@ let majorVersion = "4";
     javaAwtGtk = langJava && x11Support;
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -332,7 +332,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -111,7 +111,7 @@ let majorVersion = "6";
     javaAwtGtk = langJava && x11Support;
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -345,7 +345,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -87,7 +87,7 @@ let majorVersion = "7";
       ++ [ ../libsanitizer-no-cyclades-9.patch ];
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -301,7 +301,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -71,7 +71,7 @@ let majorVersion = "8";
       ++ [ ../libsanitizer-no-cyclades-9.patch ];
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -280,7 +280,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -98,7 +98,7 @@ let majorVersion = "9";
       ++ [ ../libsanitizer-no-cyclades-9.patch ];
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
     stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
     crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
 
@@ -311,7 +311,7 @@ stdenv.mkDerivation ({
   };
 }
 
-// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.isMinGW && crossStageStatic) {
   makeFlags = [ "all-gcc" "all-target-libgcc" ];
   installTargets = "install-gcc install-target-libgcc";
 }

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -41,7 +41,7 @@ let
   inherit (stdenv)
     buildPlatform hostPlatform targetPlatform;
 
-  crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+  crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
   crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
 
   targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)

--- a/pkgs/development/compilers/llvm/10/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/10/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/11/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/11/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/12/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/12/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/13/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/13/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } (''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/13/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/13/bintools/default.nix
@@ -5,7 +5,13 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } (''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLld = true;
+    targetPrefix = prefix;
+  };
+} (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/13/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/13/bintools/default.nix
@@ -1,11 +1,11 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ runCommand, stdenv, llvm, lld, version, lib }:
 
 let
   prefix =
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)
@@ -26,4 +26,7 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
-''
+'' + lib.optionalString stdenv.targetPlatform.isWindows ''
+   ln -s ${llvm}/bin/llvm-windres $out/bin/${prefix}windres
+   ln -s ${llvm}/bin/llvm-dlltool $out/bin/${prefix}dlltool
+'')

--- a/pkgs/development/compilers/llvm/13/default.nix
+++ b/pkgs/development/compilers/llvm/13/default.nix
@@ -168,6 +168,7 @@ let
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoLibcxx = wrapCCWith rec {
@@ -182,6 +183,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
         echo "-nostdlib++" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoLibc = wrapCCWith rec {
@@ -195,6 +197,7 @@ let
         echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoCompilerRt = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, llvm_meta, src, cmake, python3, fixDarwinDylibNames, version
-, libcxxabi
+, libcxxabi, libunwind
 , enableShared ? !stdenv.hostPlatform.isStatic
 
 # If headersOnly is true, the resulting package would only include the headers.
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  buildInputs = lib.optionals (!headersOnly) [ libcxxabi ];
+  buildInputs = lib.optionals (!headersOnly) ([ libcxxabi ] ++ lib.optional libcxxabi.useLLVMUnwinder libunwind);
 
   cmakeFlags = [ "-DLIBCXX_CXX_ABI=libcxxabi" ]
     ++ lib.optional (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) "-DLIBCXX_HAS_MUSL_LIBC=1"
@@ -41,7 +41,13 @@ stdenv.mkDerivation rec {
       "-DLIBCXX_ENABLE_THREADS=OFF"
       "-DLIBCXX_ENABLE_FILESYSTEM=OFF"
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
-    ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
+    ]
+    ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF"
+    ++ lib.optionals (!headersOnly && libcxxabi.semi-static) [
+      "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=TRUE"
+      "-DLIBCXX_CXX_ABI_LIBRARY_PATH=${libcxxabi}/lib"
+    ] ++ lib.optional (!headersOnly && libcxxabi.useLLVMUnwinder)
+      "-DLIBCXXABI_USE_LLVM_UNWINDER=ON";
 
   buildFlags = lib.optional headersOnly "generate-cxx-headers";
   installTargets = lib.optional headersOnly "install-cxx-headers";

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -37,7 +37,8 @@ stdenv.mkDerivation rec {
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
   ] ++ lib.optionals (!enableShared) [
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
-  ];
+  ] ++ lib.optional stdenv.cc.isCompilerRT
+    "-DLIBCXXABI_USE_COMPILER_RT=ON";
 
   installPhase = if stdenv.isDarwin
     then ''

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -2,9 +2,14 @@
 , enableShared ? !stdenv.hostPlatform.isStatic
 , standalone ? stdenv.hostPlatform.useLLVM or false
 , withLibunwind ? !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm
-}:
+}: let
+  # lld doesn't support unresolved references on Windows https://github.com/llvm/llvm-project/issues/55245
+  semi-static = enableShared && stdenv.hostPlatform.isWindows && stdenv.cc.bintools.isLld;
 
-stdenv.mkDerivation rec {
+  enableShared' = enableShared && !semi-static;
+
+  useLLVMUnwinder = standalone && withLibunwind;
+in stdenv.mkDerivation rec {
   pname = "libcxxabi";
   inherit version;
 
@@ -26,17 +31,22 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ];
   buildInputs = lib.optional withLibunwind libunwind;
 
+  passthru = { inherit semi-static useLLVMUnwinder; };
+
   cmakeFlags = [
     "-DLIBCXXABI_LIBCXX_INCLUDES=${cxx-headers}/include/c++/v1"
   ] ++ lib.optionals standalone [
     "-DLLVM_ENABLE_LIBCXX=ON"
-  ] ++ lib.optionals (standalone && withLibunwind) [
+  ] ++ lib.optionals useLLVMUnwinder [
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
   ] ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
-  ] ++ lib.optionals (!enableShared) [
+  ] ++ lib.optionals (!enableShared') [
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
+  ] ++ lib.optionals semi-static [
+    "-DLIBCXX_ENABLE_SHARED=ON"
+    "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON"
   ] ++ lib.optional stdenv.cc.isCompilerRT
     "-DLIBCXXABI_USE_COMPILER_RT=ON";
 
@@ -57,7 +67,7 @@ stdenv.mkDerivation rec {
       install -d -m 755 $out/include $out/lib
       install -m 644 lib/libc++abi.a $out/lib
       install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
+    '' + lib.optionalString enableShared' ''
       install -m 644 lib/libc++abi.so.1.0 $out/lib
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1

--- a/pkgs/development/compilers/llvm/13/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/13/libunwind/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
+  cmakeFlags =
+     lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF"
+  ++ lib.optional (stdenv.cc.isCompilerRT) "-DLIBUNWIND_USE_COMPILER_RT=TRUE";
 
   meta = llvm_meta // {
     # Details: https://github.com/llvm/llvm-project/blob/main/libunwind/docs/index.rst

--- a/pkgs/development/compilers/llvm/14/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/14/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } (''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/14/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/14/bintools/default.nix
@@ -5,7 +5,13 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } (''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLld = true;
+    targetPrefix = prefix;
+  };
+} (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/14/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/14/bintools/default.nix
@@ -1,11 +1,11 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ runCommand, stdenv, llvm, lld, version, lib }:
 
 let
   prefix =
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)
@@ -26,4 +26,7 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
-''
+'' + lib.optionalString stdenv.targetPlatform.isWindows ''
+   ln -s ${llvm}/bin/llvm-windres $out/bin/${prefix}windres
+   ln -s ${llvm}/bin/llvm-dlltool $out/bin/${prefix}dlltool
+'')

--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -168,6 +168,7 @@ let
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoLibcxx = wrapCCWith rec {
@@ -182,6 +183,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
         echo "-nostdlib++" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoLibc = wrapCCWith rec {
@@ -195,6 +197,7 @@ let
         echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoCompilerRt = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/14/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxx/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, llvm_meta
 , monorepoSrc, runCommand
 , cmake, python3, fixDarwinDylibNames, version
-, libcxxabi
+, libcxxabi, libunwind
 , enableShared ? !stdenv.hostPlatform.isStatic
 
 # If headersOnly is true, the resulting package would only include the headers.
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  buildInputs = lib.optionals (!headersOnly) [ libcxxabi ];
+  buildInputs = lib.optionals (!headersOnly) ([ libcxxabi ] ++ lib.optional libcxxabi.useLLVMUnwinder libunwind);
 
   cmakeFlags = [ "-DLIBCXX_CXX_ABI=libcxxabi" ]
     ++ lib.optional (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) "-DLIBCXX_HAS_MUSL_LIBC=1"
@@ -57,7 +57,13 @@ stdenv.mkDerivation rec {
       "-DLIBCXX_ENABLE_THREADS=OFF"
       "-DLIBCXX_ENABLE_FILESYSTEM=OFF"
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
-    ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
+    ]
+    ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF"
+    ++ lib.optionals (!headersOnly && libcxxabi.semi-static) [
+      "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=TRUE"
+      "-DLIBCXX_CXX_ABI_LIBRARY_PATH=${libcxxabi}/lib"
+    ] ++ lib.optional (!headersOnly && libcxxabi.useLLVMUnwinder)
+      "-DLIBCXXABI_USE_LLVM_UNWINDER=ON";
 
   buildFlags = lib.optional headersOnly "generate-cxx-headers";
   installTargets = lib.optional headersOnly "install-cxx-headers";

--- a/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
@@ -47,7 +47,8 @@ stdenv.mkDerivation rec {
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
   ] ++ lib.optionals (!enableShared) [
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
-  ];
+  ] ++ lib.optional stdenv.cc.isCompilerRT
+    "-DLIBCXXABI_USE_COMPILER_RT=ON";
 
   installPhase = if stdenv.isDarwin
     then ''

--- a/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
@@ -2,9 +2,17 @@
 , monorepoSrc, runCommand
 , cxx-headers, libunwind, version
 , enableShared ? !stdenv.hostPlatform.isStatic
-}:
+}: let
+  withLibunwind = !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm;
 
-stdenv.mkDerivation rec {
+  semi-static = enableShared && stdenv.hostPlatform.isWindows && stdenv.cc.bintools.isLld;
+
+  enableShared' = enableShared && !semi-static;
+
+  standalone = stdenv.hostPlatform.useLLVM or false;
+
+  useLLVMUnwinder = standalone && withLibunwind;
+in stdenv.mkDerivation rec {
   pname = "libcxxabi";
   inherit version;
 
@@ -35,18 +43,24 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake python3 ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional withLibunwind libunwind;
+
+  passthru = { inherit semi-static useLLVMUnwinder; };
 
   cmakeFlags = [
     "-DLIBCXXABI_LIBCXX_INCLUDES=${cxx-headers}/include/c++/v1"
-  ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
+  ] ++ lib.optionals standalone [
     "-DLLVM_ENABLE_LIBCXX=ON"
+  ] ++ lib.optionals useLLVMUnwinder [
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
   ] ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
-  ] ++ lib.optionals (!enableShared) [
+  ] ++ lib.optionals (!enableShared') [
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
+  ] ++ lib.optionals semi-static [
+    "-DLIBCXX_ENABLE_SHARED=ON"
+    "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON"
   ] ++ lib.optional stdenv.cc.isCompilerRT
     "-DLIBCXXABI_USE_COMPILER_RT=ON";
 
@@ -67,7 +81,7 @@ stdenv.mkDerivation rec {
       install -d -m 755 $out/include $out/lib
       install -m 644 lib/libc++abi.a $out/lib
       install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
+    '' + lib.optionalString enableShared' ''
       install -m 644 lib/libc++abi.so.1.0 $out/lib
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1

--- a/pkgs/development/compilers/llvm/14/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/14/libunwind/default.nix
@@ -31,7 +31,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
+  cmakeFlags =
+     lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF"
+  ++ lib.optional (stdenv.cc.isCompilerRT) "-DLIBUNWIND_USE_COMPILER_RT=TRUE";
 
   meta = llvm_meta // {
     # Details: https://github.com/llvm/llvm-project/blob/main/libunwind/docs/index.rst

--- a/pkgs/development/compilers/llvm/7/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/7/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/8/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/8/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/9/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/9/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/git/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/git/bintools/default.nix
@@ -5,7 +5,7 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } (''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/git/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/git/bintools/default.nix
@@ -5,7 +5,13 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; passthru.isLld = true; } (''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLld = true;
+    targetPrefix = prefix;
+  };
+} (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/git/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/git/bintools/default.nix
@@ -1,11 +1,11 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ runCommand, stdenv, llvm, lld, version, lib }:
 
 let
   prefix =
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } (''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)
@@ -26,4 +26,7 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
-''
+'' + lib.optionalString stdenv.targetPlatform.isWindows ''
+   ln -s ${llvm}/bin/llvm-windres $out/bin/${prefix}windres
+   ln -s ${llvm}/bin/llvm-dlltool $out/bin/${prefix}dlltool
+'')

--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -168,6 +168,7 @@ let
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoLibcxx = wrapCCWith rec {
@@ -182,6 +183,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
         echo "-nostdlib++" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoLibc = wrapCCWith rec {
@@ -195,6 +197,7 @@ let
         echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + mkExtraBuildCommands cc;
+      isCompilerRT = true;
     };
 
     clangNoCompilerRt = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, llvm_meta
 , monorepoSrc, runCommand
 , cmake, python3, fixDarwinDylibNames, version
-, libcxxabi
+, libcxxabi, libunwind
 , enableShared ? !stdenv.hostPlatform.isStatic
 
 # If headersOnly is true, the resulting package would only include the headers.
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  buildInputs = lib.optionals (!headersOnly) [ libcxxabi ];
+  buildInputs = lib.optionals (!headersOnly) ([ libcxxabi ] ++ lib.optional libcxxabi.useLLVMUnwinder libunwind);
 
   cmakeFlags = [ "-DLIBCXX_CXX_ABI=libcxxabi" ]
     ++ lib.optional (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) "-DLIBCXX_HAS_MUSL_LIBC=1"
@@ -57,7 +57,14 @@ stdenv.mkDerivation rec {
       "-DLIBCXX_ENABLE_THREADS=OFF"
       "-DLIBCXX_ENABLE_FILESYSTEM=OFF"
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
-    ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
+    ]
+    ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF"
+    ++ lib.optionals (!headersOnly && libcxxabi.semi-static) [
+      "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=TRUE"
+      "-DLIBCXX_CXX_ABI_LIBRARY_PATH=${libcxxabi}/lib"
+    ] ++ lib.optional (!headersOnly && libcxxabi.useLLVMUnwinder)
+      "-DLIBCXXABI_USE_LLVM_UNWINDER=ON";
+
 
   buildFlags = lib.optional headersOnly "generate-cxx-headers";
   installTargets = lib.optional headersOnly "install-cxx-headers";

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -47,7 +47,9 @@ stdenv.mkDerivation rec {
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
   ] ++ lib.optionals (!enableShared) [
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
-  ];
+  ] ++ lib.optional stdenv.cc.isCompilerRT
+    "-DLIBCXXABI_USE_COMPILER_RT=ON";
+
 
   installPhase = if stdenv.isDarwin
     then ''

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -2,7 +2,17 @@
 , monorepoSrc, runCommand
 , cxx-headers, libunwind, version
 , enableShared ? !stdenv.hostPlatform.isStatic
-}:
+}: let
+  withLibunwind = !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm;
+
+  semi-static = enableShared && stdenv.hostPlatform.isWindows && stdenv.cc.bintools.isLld;
+
+  enableShared' = enableShared && !semi-static;
+
+  standalone = stdenv.hostPlatform.useLLVM or false;
+
+  useLLVMUnwinder = standalone && withLibunwind;
+in
 
 stdenv.mkDerivation rec {
   pname = "libcxxabi";
@@ -35,21 +45,27 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake python3 ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional withLibunwind libunwind;
+
+  passthru = { inherit semi-static useLLVMUnwinder; };
+
 
   cmakeFlags = [
     "-DLIBCXXABI_LIBCXX_INCLUDES=${cxx-headers}/include/c++/v1"
-  ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
+  ] ++ lib.optionals standalone [
     "-DLLVM_ENABLE_LIBCXX=ON"
+  ] ++ lib.optionals useLLVMUnwinder [
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
   ] ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
-  ] ++ lib.optionals (!enableShared) [
+  ] ++ lib.optionals (!enableShared') [
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
+  ] ++ lib.optionals semi-static [
+    "-DLIBCXX_ENABLE_SHARED=ON"
+    "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON"
   ] ++ lib.optional stdenv.cc.isCompilerRT
     "-DLIBCXXABI_USE_COMPILER_RT=ON";
-
 
   installPhase = if stdenv.isDarwin
     then ''
@@ -68,7 +84,7 @@ stdenv.mkDerivation rec {
       install -d -m 755 $out/include $out/lib
       install -m 644 lib/libc++abi.a $out/lib
       install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
+    '' + lib.optionalString enableShared' ''
       install -m 644 lib/libc++abi.so.1.0 $out/lib
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1

--- a/pkgs/development/compilers/llvm/git/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/git/libunwind/default.nix
@@ -31,7 +31,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
+  cmakeFlags =
+     lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF"
+  ++ lib.optional stdenv.cc.isCompilerRT "-DLIBUNWIND_USE_COMPILER_RT=TRUE";
 
   meta = llvm_meta // {
     # Details: https://github.com/llvm/llvm-project/blob/main/libunwind/docs/index.rst

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -9,7 +9,7 @@
 , enableDebug ? false
 , enableSingleThreaded ? false
 , enableMultiThreaded ? true
-, enableShared ? !(with stdenv.hostPlatform; isStatic || libc == "msvcrt") # problems for now
+, enableShared ? !(with stdenv.hostPlatform; isStatic || isMinGW) # problems for now
 , enableStatic ? !enableShared
 , enablePython ? false
 , enableNumpy ? false
@@ -102,7 +102,7 @@ let
     ++ optional (toolset != null) "toolset=${toolset}"
     ++ optional (!enablePython) "--without-python"
     ++ optional needUserConfig "--user-config=user-config.jam"
-    ++ optionals (stdenv.hostPlatform.libc == "msvcrt") [
+    ++ optionals (stdenv.hostPlatform.isMinGW) [
     "threadapi=win32"
   ] ++ extraB2Args
   );
@@ -252,7 +252,7 @@ stdenv.mkDerivation {
     # Make boost header paths relative so that they are not runtime dependencies
     cd "$dev" && find include \( -name '*.hpp' -or -name '*.h' -or -name '*.ipp' \) \
       -exec sed '1s/^\xef\xbb\xbf//;1i#line 1 "{}"' -i '{}' \;
-  '' + optionalString (stdenv.hostPlatform.libc == "msvcrt") ''
+  '' + optionalString (stdenv.hostPlatform.isMinGW) ''
     $RANLIB "$out/lib/"*.a
   '';
 

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, m4
 , cxx ? !stdenv.hostPlatform.useAndroidPrebuilt && !stdenv.hostPlatform.isWasm
-, buildPackages
+, buildPackages, autoreconfHook
 , withStatic ? stdenv.hostPlatform.isStatic
 }:
 
@@ -29,7 +29,7 @@ let self = stdenv.mkDerivation rec {
   passthru.static = self.out;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ m4 ];
+  nativeBuildInputs = [ m4 ] ++ lib.optional stdenv.hostPlatform.isWindows autoreconfHook;
 
   configureFlags = [
     "--with-pic"

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -32,7 +32,9 @@ stdenv.mkDerivation rec {
     # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6155
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
     "--disable-exec-static-tramp"
-  ];
+  ] ++
+    # ld.lld on Windows doesn't support --version-script.
+    lib.optional (stdenv.hostPlatform.isWindows && stdenv.cc.bintools.isLld) "--disable-symvers";
 
   preCheck = ''
     # The tests use -O0 which is not compatible with -D_FORTIFY_SOURCE.

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ dejagnu ];
 
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isWindows autoreconfHook;
+
   meta = with lib; {
     description = "A foreign function call interface library";
     longDescription = ''

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch =
-    lib.optionalString ((stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.libc == "msvcrt") || stdenv.cc.nativeLibc)
+    lib.optionalString ((stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isMinGW) || stdenv.cc.nativeLibc)
       ''
         sed '/^_GL_WARN_ON_USE (gets/d' -i srclib/stdio.in.h
       ''

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   # This is needed by freeimage
   patches = [ ./0001-Compile-transupp.c-as-part-of-the-library.patch ]
-    ++ lib.optional (stdenv.hostPlatform.libc or null == "msvcrt")
+    ++ lib.optional (stdenv.hostPlatform.isMinGW)
     ./mingw-boolean.patch;
 
   outputs = [ "bin" "dev" "dev_private" "out" "man" "doc" ];

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -14,7 +14,7 @@
 , pythonSupport ? enableShared && stdenv.buildPlatform == stdenv.hostPlatform
 , icuSupport ? false
 , icu
-, enableShared ? stdenv.hostPlatform.libc != "msvcrt" && !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.hostPlatform.isMinGW && !stdenv.hostPlatform.isStatic
 , enableStatic ? !enableShared
 , gnome
 }:

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -46,7 +46,13 @@ stdenv.mkDerivation rec {
     ];
 
   # Only the C compiler, and explicitly not C++ compiler needs this flag on solaris:
-  CFLAGS = lib.optionalString stdenv.isSunOS "-D_XOPEN_SOURCE_EXTENDED";
+  CFLAGS =
+    # Only the C compiler, and explicitly not C++ compiler needs this flag on solaris:
+    /**/ if stdenv.isSunOS then "-D_XOPEN_SOURCE_EXTENDED"
+    # ucrt doesn't support X_OK to access() without this flag
+    else if stdenv.hostPlatform.libc == "ucrt" then "-D__USE_MINGW_ACCESS"
+    else "";
+
 
   depsBuildBuild = [
     buildPackages.stdenv.cc

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation (rec {
   ''
     # Non-typical naming confuses libtool which then refuses to use zlib's DLL
     # in some cases, e.g. when compiling libpng.
-  + lib.optionalString (stdenv.hostPlatform.libc == "msvcrt" && shared) ''
+  + lib.optionalString (stdenv.hostPlatform.isMinGW && shared) ''
     ln -s zlib1.dll $out/bin/libz.dll
   '';
 
@@ -101,7 +101,7 @@ stdenv.mkDerivation (rec {
   dontStrip = stdenv.hostPlatform != stdenv.buildPlatform && static;
   configurePlatforms = [];
 
-  installFlags = lib.optionals (stdenv.hostPlatform.libc == "msvcrt") [
+  installFlags = lib.optionals (stdenv.hostPlatform.isMinGW) [
     "BINARY_PATH=$(out)/bin"
     "INCLUDE_PATH=$(dev)/include"
     "LIBRARY_PATH=$(out)/lib"
@@ -112,7 +112,7 @@ stdenv.mkDerivation (rec {
 
   makeFlags = [
     "PREFIX=${stdenv.cc.targetPrefix}"
-  ] ++ lib.optionals (stdenv.hostPlatform.libc == "msvcrt") [
+  ] ++ lib.optionals (stdenv.hostPlatform.isMinGW) [
     "-f" "win32/Makefile.gcc"
   ] ++ lib.optionals shared [
     # Note that as of writing (zlib 1.2.11), this flag only has an effect
@@ -134,6 +134,6 @@ stdenv.mkDerivation (rec {
   preConfigure = ''
     export CHOST=${stdenv.hostPlatform.config}
   '';
-} // lib.optionalAttrs (stdenv.hostPlatform.libc == "msvcrt") {
+} // lib.optionalAttrs (stdenv.hostPlatform.isMinGW) {
   dontConfigure = true;
 })

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -197,6 +197,11 @@ stdenv.mkDerivation {
     inherit targetPrefix;
     hasGold = enableGold;
     isGNU = true;
+    # TODO Currently platform.linker == "gold" has no effect outside
+    # of building GHC. If/when that's fixed, these flags should
+    # probably move to the invocations of bintools-wrapper
+    isGold = false;
+    isBfd = true;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/libtool/0002-cygwin-mingw-Create-UAC-manifest-files.mingw.patch
+++ b/pkgs/development/tools/misc/libtool/0002-cygwin-mingw-Create-UAC-manifest-files.mingw.patch
@@ -1,0 +1,99 @@
+[PATCH 2/6] [cygwin|mingw] Create UAC manifest files.
+
+* build-aux/ltmain.in (func_emit_exe_manifest): New function.
+(func_mode_link) [cygwin|mingw]: Create manifest files for wrapper
+and target exe when target name matches heuristic that triggers
+UAC problems for newer win32 OSs. Clean up $cwrapper.manifest on
+error. Ensure manifest files have executable permission.
+(func_mode_uninstall): Clean up manifest files.
+Various reports by Eric Blake, Kai Tietz, and Cesar Strauss.
+---
+ build-auxltmain.in |   50 ++++++++++++++++++++++++++++++++++++++++++-
+ 1 files changed, 48 insertions(+), 2 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index 0418007..1821779 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -4277,6 +4277,41 @@ EOF
+ }
+ # end: func_emit_cwrapperexe_src
+ 
++# func_emit_exe_manifest
++# emit a Win32 UAC manifest for executable on stdout
++# Must ONLY be called from within func_mode_link because
++# it depends on a number of variable set therein.
++func_emit_exe_manifest ()
++{
++    cat <<EOF
++<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
++<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
++  <assemblyIdentity version="1.0.0.0"
++EOF
++
++    case $host in
++    i?86-*-* )   echo '     processorArchitecture="x86"' ;;
++    ia64-*-* )   echo '     processorArchitecture="ia64"' ;;
++    x86_64-*-* ) echo '     processorArchitecture="amd64"' ;;
++    *)           echo '     processorArchitecture="*"' ;;
++    esac
++
++    cat <<EOF
++     name="$host_os.$PROGRAM.$outputname"
++     type="win32"/>
++
++  <!-- Identify the application security requirements. -->
++  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
++    <security>
++      <requestedPrivileges>
++        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
++      </requestedPrivileges>
++    </security>
++  </trustInfo>
++</assembly>
++EOF
++}
++
+ # func_win32_import_lib_p ARG
+ # True if ARG is an import lib, as indicated by $file_magic_cmd
+ func_win32_import_lib_p ()
+@@ -8237,7 +8272,7 @@ EOF
+ 	    cwrappersource="$output_path/$objdir/lt-$output_name.c"
+ 	    cwrapper="$output_path/$output_name.exe"
+ 	    $RM $cwrappersource $cwrapper
+-	    trap "$RM $cwrappersource $cwrapper; exit $EXIT_FAILURE" 1 2 15
++	    trap "$RM $cwrappersource $cwrapper $cwrapper.manifest; exit $EXIT_FAILURE" 1 2 15
+ 
+ 	    func_emit_cwrapperexe_src > $cwrappersource
+ 
+@@ -8257,6 +8292,16 @@ EOF
+ 	    $opt_dry_run || {
+ 	      # note: this script will not be executed, so do not chmod.
+ 	      if test "x$build" = "x$host"; then
++		# Create the UAC manifests first if necessary (but the
++		# manifest files must have executable permission regardless).
++		case $output_name in
++		  *instal*|*patch*|*setup*|*update*)
++		    func_emit_exe_manifest > $cwrapper.manifest
++		    func_emit_exe_manifest > $output_path/$objdir/$output_name.exe.manifest
++		    chmod +x $cwrapper.manifest
++		    chmod +x $output_path/$objdir/$output_name.exe.manifest
++		  ;;
++		esac
+ 		$cwrapper --lt-dump-script > $func_ltwrapper_scriptname_result
+ 	      else
+ 		func_emit_wrapper no > $func_ltwrapper_scriptname_result
+@@ -8777,8 +8822,9 @@ func_mode_uninstall ()
+ 	    # note $name still contains .exe if it was in $file originally
+ 	    # as does the version of $file that was added into $rmfiles
+ 	    func_append rmfiles " $odir/$name $odir/${name}S.$objext"
++	    func_append rmfiles " ${name}.manifest $objdir/${name}.manifest"
+ 	    if test yes = "$fast_install" && test -n "$relink_command"; then
+-	      func_append rmfiles " $odir/lt-$name"
++	      func_append rmfiles " $odir/lt-$name $objdir/lt-${name}.manifest"
+ 	    fi
+ 	    if test "X$noexename" != "X$name"; then
+ 	      func_append rmfiles " $odir/lt-$noexename.c"
+-- 
+1.7.1
+

--- a/pkgs/development/tools/misc/libtool/0005-Fix-seems-to-be-moved.patch
+++ b/pkgs/development/tools/misc/libtool/0005-Fix-seems-to-be-moved.patch
@@ -1,0 +1,24 @@
+[PATCH 5/6] Fix "seems to be moved"
+* build-aux/ltmain.in (func_mode_link): Compare files by inode
+to fix "seems to be moved" warning.
+---
+ build-aux/ltmain.in |    4 +++-
+ 1 files changed, 3 insertions(+), 1 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index af46cb8..244bb5b 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -6283,7 +6283,9 @@ func_mode_link ()
+ 		  eval libdir=`$SED -n -e 's/^libdir=\(.*\)$/\1/p' $deplib`
+ 		  test -z "$libdir" && \
+ 		    func_fatal_error "'$deplib' is not a valid libtool archive"
+-		  test "$absdir" != "$libdir" && \
++		  abs_inode=`ls -i "$deplib" | awk '{print $1}'`
++		    lib_inode=`ls -i "$libdir/$(basename $deplib)" | awk '{print $1}'`
++		  test "$abs_inode" != "$lib_inode" && \
+ 		    func_warning "'$deplib' seems to be moved"
+ 
+ 		  path=-L$absdir
+-- 
+1.7.0.2.msysgit.0

--- a/pkgs/development/tools/misc/libtool/0006-Fix-strict-ansi-vs-posix.patch
+++ b/pkgs/development/tools/misc/libtool/0006-Fix-strict-ansi-vs-posix.patch
@@ -1,0 +1,22 @@
+[PATCH 6/6] Fix STRICT_ANSI vs POSIX
+* build-aux/ltmain.in (func_mode_link): Also check for _POSIX
+as well as __STRICT_ANSI__ to avoid re-definitions.
+---
+ build-aux/ltmain.in |    4 +++-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index af46cb8..244bb5b 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -3382,7 +3382,7 @@
+ 
+ /* declarations of non-ANSI functions */
+ #if defined __MINGW32__
+-# ifdef __STRICT_ANSI__
++# if defined(__STRICT_ANSI__) && !defined(__MINGW64_VERSION_MAJOR) || defined(_POSIX_)
+ int _putenv (const char *);
+ # endif
+ #elif defined __CYGWIN__
+-- 
+1.7.0.2.msysgit.0

--- a/pkgs/development/tools/misc/libtool/0007-fix-cr-for-awk-in-configure.all.patch
+++ b/pkgs/development/tools/misc/libtool/0007-fix-cr-for-awk-in-configure.all.patch
@@ -1,0 +1,22 @@
+--- libtool-2.4.2/configure.orig	2011-10-17 10:18:58.000000000 +0000
++++ libtool-2.4.2/configure	2013-08-04 19:01:30.220494400 +0000
+@@ -28825,7 +28825,7 @@
+ fi
+ ac_cs_awk_cr=`$AWK 'BEGIN { print "a\rb" }' </dev/null 2>/dev/null`
+ if test "$ac_cs_awk_cr" = "a${ac_cr}b"; then
+-  ac_cs_awk_cr='\\r'
++  ac_cs_awk_cr='\r'
+ else
+   ac_cs_awk_cr=$ac_cr
+ fi
+--- libtool-2.4.2/libltdl/configure.orig	2011-10-17 10:19:47.000000000 +0000
++++ libtool-2.4.2/libltdl/configure	2013-08-05 11:49:24.990792500 +0000
+@@ -13574,7 +13574,7 @@
+ fi
+ ac_cs_awk_cr=`$AWK 'BEGIN { print "a\rb" }' </dev/null 2>/dev/null`
+ if test "$ac_cs_awk_cr" = "a${ac_cr}b"; then
+-  ac_cs_awk_cr='\\r'
++  ac_cs_awk_cr='\r'
+ else
+   ac_cs_awk_cr=$ac_cr
+ fi

--- a/pkgs/development/tools/misc/libtool/0010-libtool-2.4.2-include-process-h.patch
+++ b/pkgs/development/tools/misc/libtool/0010-libtool-2.4.2-include-process-h.patch
@@ -1,0 +1,24 @@
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index 0418007..91276c2 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -4163,6 +4163,7 @@
+ # include <unistd.h>
+ # include <stdint.h>
+ # ifdef __CYGWIN__
++#  include <process.h>
+ #  include <io.h>
+ # endif
+ #endif
+diff --git a/build-aux/ltmain.sh b/build-aux/ltmain.sh
+index 0418007..91276c2 100644
+--- a/build-aux/ltmain.sh
++++ b/build-aux/ltmain.sh
+@@ -4163,6 +4163,7 @@
+ # include <unistd.h>
+ # include <stdint.h>
+ # ifdef __CYGWIN__
++#  include <process.h>
+ #  include <io.h>
+ # endif
+ #endif

--- a/pkgs/development/tools/misc/libtool/0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
+++ b/pkgs/development/tools/misc/libtool/0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
@@ -1,0 +1,33 @@
+From a18473ed4e5574dab899db640b8efeff78939b54 Mon Sep 17 00:00:00 2001
+From: Manoj Gupta <manojgupta@chromium.org>
+Date: Wed, 10 Oct 2018 10:50:23 +0300
+Subject: [PATCH 1/2] Pick up clang_rt static archives compiler internal
+ libraries
+
+Libtool checks only for libraries linked as -l* when trying to
+find internal compiler libraries. Clang, however uses the absolute
+path to link its internal libraries e.g. compiler_rt. This patch
+handles clang's statically linked libraries when finding internal
+compiler libraries.
+https://crbug.com/749263
+https://debbugs.gnu.org/cgi/bugreport.cgi?bug=27866
+---
+ m4/libtool.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index b55a6e5..d9322d0 100644
+--- a/m4/libtool.m4
++++ b/m4/libtool.m4
+@@ -7556,7 +7556,7 @@ if AC_TRY_EVAL(ac_compile); then
+   for p in `eval "$output_verbose_link_cmd"`; do
+     case $prev$p in
+ 
+-    -L* | -R* | -l*)
++    -L* | -R* | -l* | */libclang_rt.*.a)
+        # Some compilers place space between "-{L,R}" and the path.
+        # Remove the space.
+        if test x-L = "$p" ||
+-- 
+2.7.4
+

--- a/pkgs/development/tools/misc/libtool/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
+++ b/pkgs/development/tools/misc/libtool/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
@@ -1,0 +1,83 @@
+From ec15841963ca3aab3bc88fb0932c014337284bfc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Wed, 10 Oct 2018 10:47:21 +0300
+Subject: [PATCH 2/2] Prefer response files over linker scripts for mingw tools
+
+The GCC/binutils tools support response files just fine, while
+lld (impersonating GNU ld) only supports response files, not
+linker scripts. Using a linker script as input just to pass a
+list of files is overkill for cases when a response file is enough.
+---
+ build-aux/ltmain.in | 28 ++++++++++++++--------------
+ m4/libtool.m4       |  2 ++
+ 2 files changed, 16 insertions(+), 14 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index e2fb263..db5d590 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -7932,20 +7932,7 @@ EOF
+ 	  last_robj=
+ 	  k=1
+ 
+-	  if test -n "$save_libobjs" && test : != "$skipped_export" && test yes = "$with_gnu_ld"; then
+-	    output=$output_objdir/$output_la.lnkscript
+-	    func_verbose "creating GNU ld script: $output"
+-	    echo 'INPUT (' > $output
+-	    for obj in $save_libobjs
+-	    do
+-	      func_to_tool_file "$obj"
+-	      $ECHO "$func_to_tool_file_result" >> $output
+-	    done
+-	    echo ')' >> $output
+-	    func_append delfiles " $output"
+-	    func_to_tool_file "$output"
+-	    output=$func_to_tool_file_result
+-	  elif test -n "$save_libobjs" && test : != "$skipped_export" && test -n "$file_list_spec"; then
++	  if test -n "$save_libobjs" && test : != "$skipped_export" && test -n "$file_list_spec"; then
+ 	    output=$output_objdir/$output_la.lnk
+ 	    func_verbose "creating linker input file list: $output"
+ 	    : > $output
+@@ -7964,6 +7951,19 @@ EOF
+ 	    func_append delfiles " $output"
+ 	    func_to_tool_file "$output"
+ 	    output=$firstobj\"$file_list_spec$func_to_tool_file_result\"
++	  elif test -n "$save_libobjs" && test : != "$skipped_export" && test yes = "$with_gnu_ld"; then
++	    output=$output_objdir/$output_la.lnkscript
++	    func_verbose "creating GNU ld script: $output"
++	    echo 'INPUT (' > $output
++	    for obj in $save_libobjs
++	    do
++	      func_to_tool_file "$obj"
++	      $ECHO "$func_to_tool_file_result" >> $output
++	    done
++	    echo ')' >> $output
++	    func_append delfiles " $output"
++	    func_to_tool_file "$output"
++	    output=$func_to_tool_file_result
+ 	  else
+ 	    if test -n "$save_libobjs"; then
+ 	      func_verbose "creating reloadable object files..."
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index d9322d0..9046a84 100644
+--- a/m4/libtool.m4
++++ b/m4/libtool.m4
+@@ -5130,6 +5130,7 @@ _LT_EOF
+       _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
+       _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[[BCDGRS]][[ ]]/s/.*[[ ]]\([[^ ]]*\)/\1 DATA/;s/^.*[[ ]]__nm__\([[^ ]]*\)[[ ]][[^ ]]*/\1 DATA/;/^I[[ ]]/d;/^[[AITW]][[ ]]/s/.* //'\'' | sort | uniq > $export_symbols'
+       _LT_TAGVAR(exclude_expsyms, $1)=['[_]+GLOBAL_OFFSET_TABLE_|[_]+GLOBAL__[FID]_.*|[_]+head_[A-Za-z0-9_]+_dll|[A-Za-z0-9_]+_dll_iname']
++      _LT_TAGVAR(file_list_spec, $1)='@'
+ 
+       if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+         _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+@@ -6706,6 +6707,7 @@ if test yes != "$_lt_caught_CXX_error"; then
+ 	  _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
+ 	  _LT_TAGVAR(always_export_symbols, $1)=no
+ 	  _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++	  _LT_TAGVAR(file_list_spec, $1)='@'
+ 
+ 	  if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+ 	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+-- 
+2.7.4
+

--- a/pkgs/development/tools/misc/libtool/0013-Allow-statically-linking-compiler-support-libraries-.patch
+++ b/pkgs/development/tools/misc/libtool/0013-Allow-statically-linking-compiler-support-libraries-.patch
@@ -1,0 +1,38 @@
+From b9f77cae8cfbe850e58cac686fcb4d246b5bfc51 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 19 Aug 2019 13:34:51 +0300
+Subject: [PATCH] Allow statically linking compiler support libraries when
+ linking a library
+
+For cases with deplibs_check_method="file_magic ..." (as it is for mingw),
+there were previously no way that a static library could be accepted
+here.
+---
+ build-aux/ltmain.in | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index e2fb2633..db4d775c 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -5870,8 +5870,15 @@ func_mode_link ()
+ 	  fi
+ 	  case $linkmode in
+ 	  lib)
+-	    # Linking convenience modules into shared libraries is allowed,
+-	    # but linking other static libraries is non-portable.
++	    # Linking convenience modules and compiler provided static libraries
++	    # into shared libraries is allowed, but linking other static
++	    # libraries is non-portable.
++	    case $deplib in
++	      */libgcc*.$libext | */libclang_rt*.$libext)
++		deplibs="$deplib $deplibs"
++		continue
++	      ;;
++	    esac
+ 	    case " $dlpreconveniencelibs " in
+ 	    *" $deplib "*) ;;
+ 	    *)
+-- 
+2.17.1
+

--- a/pkgs/development/tools/misc/libtool/0014-Support-llvm-objdump-f-output.patch
+++ b/pkgs/development/tools/misc/libtool/0014-Support-llvm-objdump-f-output.patch
@@ -1,0 +1,39 @@
+From 03dabb6a70847761e65572a2a7b770a3b1b9f123 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mateusz=20Miku=C5=82a?= <mati865@gmail.com>
+Date: Mon, 12 Apr 2021 23:44:10 +0200
+Subject: [PATCH] Support llvm-objdump -f output
+
+---
+ build-aux/ltmain.in | 2 +-
+ m4/libtool.m4       | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index a9f070a..4a434cc 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -3019,7 +3019,7 @@ func_win32_libid ()
+   *ar\ archive*) # could be an import, or static
+     # Keep the egrep pattern in sync with the one in _LT_CHECK_MAGIC_METHOD.
+     if eval $OBJDUMP -f $1 | $SED -e '10q' 2>/dev/null |
+-       $EGREP 'file format (pei*-i386(.*architecture: i386)?|pe-arm-wince|pe-x86-64)' >/dev/null; then
++       $EGREP 'file format (pei*-i386(.*architecture: i386)?|pe-arm-wince|pe-x86-64|coff-arm|coff-arm64|coff-i386|coff-x86-64)' >/dev/null; then
+       case $nm_interface in
+       "MS dumpbin")
+ 	if func_cygming_ms_implib_p "$1" ||
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index 21a7d60..594be9c 100644
+--- a/m4/libtool.m4
++++ b/m4/libtool.m4
+@@ -3473,7 +3473,7 @@ mingw* | pw32*)
+     lt_cv_file_magic_cmd='func_win32_libid'
+   else
+     # Keep this pattern in sync with the one in func_win32_libid.
+-    lt_cv_deplibs_check_method='file_magic file format (pei*-i386(.*architecture: i386)?|pe-arm-wince|pe-x86-64)'
++    lt_cv_deplibs_check_method='file_magic file format (pei*-i386(.*architecture: i386)?|pe-arm-wince|pe-x86-64|coff-arm|coff-arm64|coff-i386|coff-x86-64)'
+     lt_cv_file_magic_cmd='$OBJDUMP -f'
+   fi
+   ;;
+-- 
+2.31.1
+

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -23,6 +23,20 @@ stdenv.mkDerivation rec {
   #   https://lists.gnu.org/archive/html/autotools-announce/2022-03/msg00000.html
   FILECMD = "${file}/bin/file";
 
+  patches = [
+    # Patches from msys2 fixing various bugs with useClang platforms
+    # targeting Windows. Especially https://debbugs.gnu.org/cgi/bugreport.cgi?bug=27866
+    ./0002-cygwin-mingw-Create-UAC-manifest-files.mingw.patch
+    ./0005-Fix-seems-to-be-moved.patch
+    ./0006-Fix-strict-ansi-vs-posix.patch
+    ./0007-fix-cr-for-awk-in-configure.all.patch
+    ./0010-libtool-2.4.2-include-process-h.patch
+    ./0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
+    ./0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
+    ./0013-Allow-statically-linking-compiler-support-libraries-.patch
+    ./0014-Support-llvm-objdump-f-output.patch
+  ];
+
   # Normally we'd use autoreconfHook, but that includes libtoolize.
   postPatch = ''
     aclocal -I m4

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit targetPrefix;
+    isCctools = true;
   };
 
   meta = {

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -1,14 +1,31 @@
 { lib, stdenv, windows, fetchurl }:
 
 let
-  version = "9.0.0";
+  version = "10.0.0";
+
+  knownArches = [ "32" "64" "arm32" "arm64" ];
+  enabledArch =
+    if stdenv.targetPlatform.isAarch32
+    then "arm32"
+    else if stdenv.targetPlatform.isAarch64
+    then "arm64"
+    else if stdenv.targetPlatform.isx86_32
+    then "32"
+    else if stdenv.targetPlatform.isx86_64
+    then "64"
+    else null;
+  archFlags =
+    if enabledArch == null
+    then [] # maybe autoconf will save us
+    else map (arch: lib.enableFeature (arch == enabledArch) "lib${arch}") knownArches;
+
 in stdenv.mkDerivation {
   pname = "mingw-w64";
   inherit version;
 
   src = fetchurl {
     url = "mirror://sourceforge/mingw-w64/mingw-w64-v${version}.tar.bz2";
-    sha256 = "10a15bi4lyfi0k0haj0klqambicwma6yi7vssgbz8prg815vja8r";
+    sha256 = "sha256-umtDCu1yxjo3aFMfaj/8Kw/eLFejslFFDc9ImolPCJQ=";
   };
 
   outputs = [ "out" "dev" ];
@@ -16,7 +33,7 @@ in stdenv.mkDerivation {
   configureFlags = [
     "--enable-idl"
     "--enable-secure-api"
-  ];
+  ] ++ archFlags;
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -19,6 +19,7 @@ let
     then [] # maybe autoconf will save us
     else map (arch: lib.enableFeature (arch == enabledArch) "lib${arch}") knownArches;
 
+  crt = stdenv.hostPlatform.libc;
 in stdenv.mkDerivation {
   pname = "mingw-w64";
   inherit version;
@@ -33,6 +34,7 @@ in stdenv.mkDerivation {
   configureFlags = [
     "--enable-idl"
     "--enable-secure-api"
+    "--with-default-msvcrt=${crt}"
   ] ++ archFlags;
 
   enableParallelBuilding = true;
@@ -43,5 +45,6 @@ in stdenv.mkDerivation {
 
   meta = {
     platforms = lib.platforms.windows;
+    broken = !(lib.elem crt [ "msvcrt" "ucrt" ]);
   };
 }

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -1,11 +1,19 @@
 { stdenvNoCC, mingw_w64 }:
 
-stdenvNoCC.mkDerivation {
+let
+  crt = stdenvNoCC.hostPlatform.libc;
+in stdenvNoCC.mkDerivation {
   name = "${mingw_w64.name}-headers";
   inherit (mingw_w64) src meta;
 
   preConfigure = ''
     cd mingw-w64-headers
   '';
+
+  configureFlags = [
+    "--enable-idl"
+    "--enable-secure-api"
+    "--with-default-msvcrt=${crt}"
+  ];
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17415,7 +17415,7 @@ with pkgs;
   # These are used when buiding compiler-rt / libgcc, prior to building libc.
   preLibcCrossHeaders = let
     inherit (stdenv.targetPlatform) libc;
-  in     if libc == "msvcrt" then targetPackages.windows.mingw_w64_headers or windows.mingw_w64_headers
+  in     if libc == "msvcrt" || libc == "ucrt" then targetPackages.windows.mingw_w64_headers or windows.mingw_w64_headers
     else if libc == "nblibc" then targetPackages.netbsdCross.headers or netbsdCross.headers
     else if libc == "libSystem" && stdenv.targetPlatform.isAarch64 then targetPackages.darwin.LibsystemCross or darwin.LibsystemCross
     else null;
@@ -17434,7 +17434,7 @@ with pkgs;
     else if name == "newlib" then targetPackages.newlibCross or newlibCross
     else if name == "newlib-nano" then targetPackages.newlib-nanoCross or newlib-nanoCross
     else if name == "musl" then targetPackages.muslCross or muslCross
-    else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
+    else if name == "msvcrt" || name == "ucrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
     else if name == "libSystem" then
       if stdenv.targetPlatform.useiOSPrebuilt
       then targetPackages.darwin.iosSdkPkgs.libraries or darwin.iosSdkPkgs.libraries

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -145,7 +145,6 @@ in {
       inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
       buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
       llvmPackages = pkgs.llvmPackages_12;
-      libffi = pkgs.libffi;
     };
 
     ghcjs = compiler.ghcjs810;


### PR DESCRIPTION
This adds a new cross system targeting mingwW64 + ucrt using an llvm-based toolchain.

Similar in spirit to and inspired by @mstorsjo's https://github.com/mstorsjo/llvm-mingw.

Among other benefits of LLVM + ucrt, this will be necessary to build a GHC compiler targeting Windows in 9.4 or later.