### PR TITLE
xpra: fix SyntaxError: invalid syntax

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -56,6 +56,7 @@ in buildPythonApplication rec {
       inherit libfakeXinerama;
     })
     ./fix-41106.patch  # https://github.com/NixOS/nixpkgs/issues/41106
+    ./fix-122159.patch  # https://github.com/NixOS/nixpkgs/issues/122159
   ];
 
   INCLUDE_DIRS = "${pam}/include";

--- a/pkgs/tools/X11/xpra/fix-122159.patch
+++ b/pkgs/tools/X11/xpra/fix-122159.patch
@@ -1,0 +1,15 @@
+--- a/xpra/scripts/main.py
++++ b/xpra/scripts/main.py
+@@ -90,6 +90,12 @@
+ 
+ 
+ def main(script_file, cmdline):
++    # Nixpkgs contortion:
++    # script_file points to a shell wrapper, not to the python script.
++    dirname, basename = os.path.split(script_file)
++    script_file = os.path.join(dirname, "."+basename+"-wrapped")
++    cmdline[0] = script_file
++
+     ml = envint("XPRA_MEM_USAGE_LOGGER")
+     if ml>0:
+         from xpra.util import start_mem_watcher


### PR DESCRIPTION
###### Description of changes

fix #122159

possible alternative solution #87982

in my case, the bug is triggered by

```
firejail --x11=xpra openbox
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
