### PR TITLE
Static bioinformatics packages: samtools, megahit, prodigal, and bwa

### DIFF
--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sed -i '/^CC/d' Makefile
   '';
 
+  makeFlags = lib.optional stdenv.hostPlatform.isStatic "AR=${stdenv.cc.targetPrefix}ar";
+
   # it's unclear which headers are intended to be part of the public interface
   # so we may find ourselves having to add more here over time
   installPhase = ''

--- a/pkgs/applications/science/biology/megahit/default.nix
+++ b/pkgs/applications/science/biology/megahit/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
 
+  cmakeFlags = lib.optional stdenv.hostPlatform.isStatic [
+    "-DSTATIC_BUILD=ON"
+    ];
   meta = with lib; {
     description = "An ultra-fast single-node solution for large and complex metagenomics assembly via succinct de Bruijn graph";
     license     = licenses.gpl3;

--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -22,8 +22,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ncurses htslib ];
 
+  preConfigure = lib.optional stdenv.hostPlatform.isStatic ''
+    export LIBS="-lz -lbz2 -llzma"
+  '';
+  makeFlags = lib.optional stdenv.hostPlatform.isStatic "AR=${stdenv.cc.targetPrefix}ar";
+
   configureFlags = [ "--with-htslib=${htslib}" ]
-    ++ lib.optional (ncurses == null) "--without-curses";
+    ++ lib.optional (ncurses == null) "--without-curses"
+    ++ lib.optional stdenv.hostPlatform.isStatic ["--without-curses" ]
+    ;
 
   preCheck = ''
     patchShebangs test/

--- a/pkgs/development/libraries/science/biology/htslib/default.nix
+++ b/pkgs/development/libraries/science/biology/htslib/default.nix
@@ -14,9 +14,25 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib bzip2 xz curl ];
 
-  configureFlags = [ "--enable-libcurl" ]; # optional but strongly recommended
+  configureFlags = if ! stdenv.hostPlatform.isStatic
+                    then [ "--enable-libcurl" ] # optional but strongly recommended
+                    else [ "--disable-libcurl" "--disable-plugins" ];
 
-  installFlags = [ "prefix=$(out)" ];
+
+  # In the case of static builds, we need to replace the build and install phases
+  buildPhase = lib.optional stdenv.hostPlatform.isStatic ''
+    make AR=$AR lib-static
+    make LDFLAGS=-static bgzip htsfile tabix
+  '';
+
+  installPhase = lib.optional stdenv.hostPlatform.isStatic ''
+    install -d $out/bin
+    install -d $out/lib
+    install -d $out/include/htslib
+    install -D libhts.a $out/lib
+    install  -m644 htslib/*h $out/include/htslib
+    install -D bgzip htsfile tabix $out/bin
+  '';
 
   preCheck = ''
     patchShebangs test/


### PR DESCRIPTION
None of these changes should have any effect on standard builds, but they enable static building 

- Built on platform(s)
  - [x] x86_64-linux


```bash
for pkg in megahit samtools bwa ; do
  nix-build . -A pkgsCross.musl64.pkgsStatic.${pkg}
done
```
