### PR TITLE
luaPackages.vicious: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -105,13 +105,13 @@ in
 
   vicious = luaLib.toLuaModule( stdenv.mkDerivation rec {
     pname = "vicious";
-    version = "2.5.0";
+    version = "2.5.1";
 
     src = fetchFromGitHub {
-      owner = "Mic92";
+      owner = "vicious-widgets";
       repo = "vicious";
       rev = "v${version}";
-      sha256 = "0lb90334mz0my8ydsmnsnkki0xr58kinsg0hf9d6k4b0vjfi0r0a";
+      sha256 = "sha256-geu/g/dFAVxtY1BuJYpZoVtFS/oL66NFnqiLAnJELtI=";
     };
 
     buildInputs = [ lua ];
@@ -124,9 +124,9 @@ in
 
     meta = with lib; {
       description = "A modular widget library for the awesome window manager";
-      homepage    = "https://github.com/Mic92/vicious";
-      license     = licenses.gpl2;
-      maintainers = with maintainers; [ makefu mic92 ];
+      homepage    = "https://vicious.rtfd.io";
+      license     = licenses.gpl2Plus;
+      maintainers = with maintainers; [ makefu mic92 McSinyx ];
       platforms   = platforms.linux;
     };
   });


### PR DESCRIPTION
###### Description of changes

[Changes in 2.5.1](https://vicious.readthedocs.io/en/latest/changelog.html#changes-in-2-5-1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).