### PR TITLE
qgroundcontrol: fix build

### DIFF
--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -68,6 +68,12 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # fix build problems caused by https://github.com/mavlink/qgroundcontrol/pull/10132
+    # remove once updated past 4.2.0
+    ./fix-10132.patch
+  ];
+
   meta = with lib; {
     description = "Provides full ground station support and configuration for the PX4 and APM Flight Stacks";
     homepage = "http://qgroundcontrol.com/";

--- a/pkgs/applications/science/robotics/qgroundcontrol/fix-10132.patch
+++ b/pkgs/applications/science/robotics/qgroundcontrol/fix-10132.patch
@@ -1,0 +1,62 @@
+diff --git a/libs/qmlglsink/gst-plugins-good/ext/qt/gstqsgtexture.cc b/libs/qmlglsink/gst-plugins-good/ext/qt/gstqsgtexture.cc
+index 2b314e0..ad1425e 100644
+--- a/libs/qmlglsink/gst-plugins-good/ext/qt/gstqsgtexture.cc
++++ b/libs/qmlglsink/gst-plugins-good/ext/qt/gstqsgtexture.cc
+@@ -35,7 +35,7 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
+ 
+ GstQSGTexture::GstQSGTexture ()
+ {
+-  static volatile gsize _debug;
++  static gsize _debug;
+ 
+   initializeOpenGLFunctions();
+ 
+diff --git a/libs/qmlglsink/gst-plugins-good/ext/qt/gstqtglutility.cc b/libs/qmlglsink/gst-plugins-good/ext/qt/gstqtglutility.cc
+index 3a68576..5203d13 100644
+--- a/libs/qmlglsink/gst-plugins-good/ext/qt/gstqtglutility.cc
++++ b/libs/qmlglsink/gst-plugins-good/ext/qt/gstqtglutility.cc
+@@ -58,7 +58,7 @@ gst_qt_get_gl_display ()
+ {
+   GstGLDisplay *display = NULL;
+   QGuiApplication *app = static_cast<QGuiApplication *> (QCoreApplication::instance ());
+-  static volatile gsize _debug;
++  static gsize _debug;
+ 
+   g_assert (app != NULL);
+ 
+diff --git a/libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.cc b/libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.cc
+index f031b36..3c6722a 100644
+--- a/libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.cc
++++ b/libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.cc
+@@ -106,7 +106,7 @@ void InitializeSceneGraph::run()
+ 
+ QtGLVideoItem::QtGLVideoItem()
+ {
+-  static volatile gsize _debug;
++  static gsize _debug;
+ 
+   if (g_once_init_enter (&_debug)) {
+     GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, "qtglwidget", 0, "Qt GL Widget");
+diff --git a/libs/qmlglsink/gst-plugins-good/ext/qt/qtwindow.cc b/libs/qmlglsink/gst-plugins-good/ext/qt/qtwindow.cc
+index 8bf14ae..2f88aa9 100644
+--- a/libs/qmlglsink/gst-plugins-good/ext/qt/qtwindow.cc
++++ b/libs/qmlglsink/gst-plugins-good/ext/qt/qtwindow.cc
+@@ -107,7 +107,7 @@ QtGLWindow::QtGLWindow ( QWindow * parent, QQuickWindow *src ) :
+   QQuickWindow( parent ), source (src)
+ {
+   QGuiApplication *app = static_cast<QGuiApplication *> (QCoreApplication::instance ());
+-  static volatile gsize _debug;
++  static gsize _debug;
+ 
+   g_assert (app != NULL);
+ 
+@@ -156,7 +156,7 @@ QtGLWindow::beforeRendering()
+ 
+   g_mutex_lock (&this->priv->lock);
+ 
+-  static volatile gsize once = 0;
++  static gsize once = 0;
+   if (g_once_init_enter(&once)) {
+     this->priv->start = QDateTime::currentDateTime().toMSecsSinceEpoch();
+     g_once_init_leave(&once,1);
+


### PR DESCRIPTION
Fixes build problems on x86_64 caused by a bug in their vendored version of
gst-plugins-good. Unfortunately I can't `fetchpatch` the fix because it just
changes a submodule pointer. The patch I added was generated from the fix at
https://github.com/mavlink/qgroundcontrol/issues/10140 .

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
