### PR TITLE
python39Packages.wandb: 0.12.15 -> 0.12.16

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -12,6 +12,7 @@
 , jsonref
 , jsonschema
 , matplotlib
+, nbconvert
 , nbformat
 , pandas
 , pathtools
@@ -36,7 +37,7 @@
 
 buildPythonPackage rec {
   pname = "wandb";
-  version = "0.12.15";
+  version = "0.12.16";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -45,7 +46,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = "client";
     rev = "v${version}";
-    hash = "sha256-Fq+JwUEZP1QDFKYVyiR8DUU0GQV6fK50FW78qaWh+Mo=";
+    hash = "sha256-ZY7nTj93piTEeHhW+H+nQ+ws2dDmmY6u3p7uz296PbA=";
   };
 
   # setuptools is necessary since pkg_resources is required at runtime.
@@ -66,23 +67,6 @@ buildPythonPackage rec {
     shortuuid
   ];
 
-  checkInputs = [
-    azure-core
-    bokeh
-    flask
-    jsonref
-    jsonschema
-    matplotlib
-    nbformat
-    pandas
-    pydantic
-    pytest-mock
-    pytest-xdist
-    pytestCheckHook
-    scikit-learn
-    tqdm
-  ];
-
   # wandb expects git to be in PATH. See https://gist.github.com/samuela/57aeee710e41ab2bf361b7ed8fbbeabf
   # for the error message, and an example usage here: https://github.com/wandb/client/blob/d5f655b7ca7e3eac2f3a67a84bc5c2a664a31baf/wandb/sdk/internal/meta.py#L128.
   # See https://github.com/NixOS/nixpkgs/pull/164176#discussion_r828801621 as to
@@ -92,6 +76,30 @@ buildPythonPackage rec {
     mkdir -p $out/bin
     ln -s ${git}/bin/git $out/bin/git
   '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkInputs = [
+    azure-core
+    bokeh
+    flask
+    jsonref
+    jsonschema
+    matplotlib
+    # Oddly enough, nbclient does not provide the `nbclient` module. Rather it's
+    # available in nbconvert. See https://github.com/NixOS/nixpkgs/issues/171493#issuecomment-1116960488.
+    nbconvert
+    nbformat
+    pandas
+    pydantic
+    pytest-mock
+    pytest-xdist
+    pytestCheckHook
+    scikit-learn
+    tqdm
+  ];
 
   disabledTestPaths = [
     # Tests that try to get chatty over sockets or spin up servers, not possible in the nix build environment.


### PR DESCRIPTION
###### Description of changes

Update wandb.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
