### PR TITLE
[21.11] matrix-appservice-irc: update matrix-org-irc to 1.2.1

### DIFF
--- a/nixos/tests/matrix-appservice-irc.nix
+++ b/nixos/tests/matrix-appservice-irc.nix
@@ -19,6 +19,11 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
             enable_registration = true;
 
+            extraConfig = ''
+              # don't use this in production, always use some form of verification
+              enable_registration_without_verification: true
+            '';
+
             listeners = [
               # The default but tls=false
               {

--- a/pkgs/servers/matrix-synapse/matrix-appservice-irc/node-packages.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-irc/node-packages.nix
@@ -3112,10 +3112,10 @@ let
     "matrix-org-irc-1.2.0" = {
       name = "matrix-org-irc";
       packageName = "matrix-org-irc";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/matrix-org-irc/-/matrix-org-irc-1.2.0.tgz";
-        sha512 = "RnfeR9FimJJD/iOWw0GiV7NIPRmBJobvFasUgjVmGre9A4qJ9klHIDOlQ5vXIoPPMjzG8XXuAf4WHgMCNBfZkQ==";
+        url = "https://registry.npmjs.org/matrix-org-irc/-/matrix-org-irc-1.2.1.tgz";
+        sha256 = "sha256-H+MDx3PftBtglgHThT7UJ5ePf6QXPDWCygydEUbMj7E=";
       };
     };
     "media-typer-0.3.0" = {


### PR DESCRIPTION
https://github.com/matrix-org/node-irc/blob/master/CHANGELOG.md#121-2022-05-04

###### Description of changes

Patching around the auto-generated node-packages is not ideal, but there were breaking changes since 0.30 in matrix-appservice-irc, so here we go.

Backport test fixes from #171505 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
