### PR TITLE
hp-printer-app: init at unstable-2022-05-04 

### DIFF
--- a/pkgs/applications/printing/hp-printer-app/0001-fix-glibc-2.34-compat.patch
+++ b/pkgs/applications/printing/hp-printer-app/0001-fix-glibc-2.34-compat.patch
@@ -1,0 +1,25 @@
+From f7f453bc5de85ca8e4861b596390e4732e6a404c Mon Sep 17 00:00:00 2001
+From: ckie <git-525ff67@ckie.dev>
+Date: Wed, 4 May 2022 10:50:12 +0300
+Subject: [PATCH] fix glibc 2.34 compat
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d4c9324..1fd1972 100644
+--- a/Makefile
++++ b/Makefile
+@@ -27,7 +27,7 @@ unitdir 	=	`pkg-config --variable=systemdsystemunitdir systemd`
+ CSFLAGS		=	-s "$${CODESIGN_IDENTITY:=-}" --timestamp -o runtime
+ OPTIM		=	-g
+ CFLAGS		=	$(CPPFLAGS) $(OPTIM)
+-CPPFLAGS	=	'-DVERSION="$(VERSION)"' `cups-config --cflags` `pkg-config --cflags pappl`
++CPPFLAGS	=	'-DVERSION="$(VERSION)"' `cups-config --cflags` `pkg-config --cflags pappl -D_FILE_OFFSET_BITS=64`
+ ICONS		=	\
+ 			icons/hp-deskjet-lg.png \
+ 			icons/hp-deskjet-md.png \
+-- 
+2.35.1
+

--- a/pkgs/applications/printing/hp-printer-app/default.nix
+++ b/pkgs/applications/printing/hp-printer-app/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, cups, pappl, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "hp-printer-app";
+  version = "unstable-2022-05-04";
+
+  src = fetchFromGitHub {
+    owner = "michaelrsweet";
+    repo = pname;
+    rev = "fe874c0ed080968ccb6c09c3d764d2f5e05655b0";
+    sha256 = "sha256-OYVdiQoC3w0Ve614RGHlnwh9X7utzzzCZxMaILolaTQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ pappl cups ];
+
+  NIX_LDFLAGS = "-lm";
+  makeFlags = "prefix=${placeholder "out"}";
+
+  meta = with lib; {
+    description =
+      "Example printer application for HP PCL printers using PAPPL";
+    homepage = "https://github.com/michaelrsweet/${pname}";
+    license = licenses.asl20;
+    platforms =
+      platforms.linux; # should also work for darwin, but requires additional work
+    maintainers = with maintainers; [ ckie ];
+  };
+}

--- a/pkgs/applications/printing/pappl/0001-config.h.in-Configure-PAPPL_SOCKDIR-for-NixOS.patch
+++ b/pkgs/applications/printing/pappl/0001-config.h.in-Configure-PAPPL_SOCKDIR-for-NixOS.patch
@@ -1,0 +1,25 @@
+From d36ff8efa2bcc14580c6c98d654dfe578ff8651f Mon Sep 17 00:00:00 2001
+From: ckie <git-525ff67@ckie.dev>
+Date: Wed, 4 May 2022 11:21:09 +0300
+Subject: [PATCH] config.h.in: Configure PAPPL_SOCKDIR for NixOS
+
+---
+ config.h.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.h.in b/config.h.in
+index 828aaf5..7ff4a24 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -18,7 +18,7 @@
+ 
+ 
+ // Location of PAPPL domain socket (when run as root)
+-#define PAPPL_SOCKDIR		"/usr/local/var/run"
++#define PAPPL_SOCKDIR		"/run"
+ 
+ 
+ // Location of CUPS config files
+-- 
+2.35.1
+

--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-m9tGD1SN15dxBiqYcEWFC+YfZXGsflrKaIhdeznt3r8=";
   };
 
+  patches = [
+    ./0001-config.h.in-Configure-PAPPL_SOCKDIR-for-NixOS.patch
+  ];
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pappl";
-  version = "1.1.0";
+  version = "unstable-2022-05-04";
 
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-FsmR0fFb9bU9G3oUyJU1eDLcoZ6OQ2//TINlPrW6lU0=";
+    rev = "b09e21d62aabcb7344dc018fd9c340e76bc345c9";
+    sha256 = "sha256-m9tGD1SN15dxBiqYcEWFC+YfZXGsflrKaIhdeznt3r8=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2312,6 +2312,8 @@ with pkgs;
 
   hp2p = callPackage ../tools/networking/hp2p { };
 
+  hp-printer-app = callPackage ../applications/printing/hp-printer-app { };
+
   hpe-ltfs = callPackage ../tools/backup/hpe-ltfs { };
 
   http2tcp = callPackage ../tools/networking/http2tcp { };


### PR DESCRIPTION

###### Description of changes

This packages [hp-printer-app](https://github.com/michaelrsweet/hp-printer-app) which seems to still be in early stages but is getting close to working.
Also included are some fixes for the `pappl` for NixOS compatability and build fixes.

There is no changelog for `hp-printer-app`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
