### PR TITLE
[21.11] libxml2: Backport CVE fixes from v2.9.13 and v2.9.14

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -35,6 +35,26 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/libxml2/commit/85b1792e37b131e7a51af98a37f92472e8de5f3f.patch";
       sha256 = "epqlNs2S0Zczox3KyCB6R2aJKh87lXydlZ0x6tLHweE=";
     })
+
+    # Fix [CVE-2022-23308] Use-after-free of ID and IDREF attributes
+    # See https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.9.13
+    # TODO: Remove once this package is >= v2.9.13
+    (fetchpatch {
+      name = "libxml2-CVE-2022-23308-Use-after-free-of-ID-and-IDREF-attributes.patch";
+      url = "https://gitlab.gnome.org/GNOME/libxml2/-/commit/652dd12a858989b14eed4e84e453059cd3ba340e.patch";
+      sha256 = "1rwb2xbvddkqgigdq9vjzqqaj6hhrhzk8m6hkcicqrc4ik9d636r";
+    })
+
+    # Fix [CVE-2022-29824] Integer overflow in xmlBuf and xmlBuffer
+    # See https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.9.14
+    # Page https://nvd.nist.gov/vuln/detail/CVE-2022-29824 links the fix commits for
+    # `libxml2` master and the 2.9.14 backport we use here.
+    # TODO: Remove once this package is >= v2.9.14
+    (fetchpatch {
+      name = "libxml2-CVE-2022-29824-Fix-integer-overflows-in-xmlBuf-and-xmlBuffer.patch";
+      url = "https://gitlab.gnome.org/GNOME/libxml2/-/commit/2554a2408e09f13652049e5ffb0d26196b02ebab.patch";
+      sha256 = "1kyzxh8fp5sfyqi9zghd7c2d32ld0mvp8hrk55mnvkg7aq42j0nz";
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "man" "doc" ]


### PR DESCRIPTION
###### Description of changes

* https://nvd.nist.gov/vuln/detail/CVE-2022-29824
* https://nvd.nist.gov/vuln/detail/CVE-2022-23308

This backports only the CVE fixes from newer releases:

* https://github.com/NixOS/nixpkgs/pull/161071#issuecomment-1047881082
* https://github.com/NixOS/nixpkgs/pull/171461#issuecomment-1116928872

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
