### PR TITLE
lagrange: 1.12.2 → 1.13.3

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -6,39 +6,45 @@
 , pkg-config
 , fribidi
 , harfbuzz
-, libunistring
 , libwebp
 , mpg123
-, openssl
-, pcre
 , SDL2
+, the-foundation
 , AppKit
 , zip
-, zlib
+, enableTUI ? false, ncurses, sealcurses
 }:
 
 stdenv.mkDerivation rec {
   pname = "lagrange";
-  version = "1.12.2";
+  version = "1.13.3";
 
   src = fetchFromGitHub {
     owner = "skyjake";
     repo = "lagrange";
     rev = "v${version}";
-    sha256 = "sha256-AVitXfHIJmCBBkhg+DLkHeCSoyH6YMaTMaa4REDXEFg=";
-    fetchSubmodules = true;
+    sha256 = "sha256-ZCG7i5WmhONockaTt/YCww7N+WvxCX2DIwQIFjAk+K8=";
   };
-
-  postPatch = ''
-    rm -r lib/fribidi lib/harfbuzz
-  '';
 
   nativeBuildInputs = [ cmake pkg-config zip ];
 
-  buildInputs = [ fribidi harfbuzz libunistring libwebp mpg123 openssl pcre SDL2 zlib ]
+  buildInputs = [ the-foundation ]
+    ++ lib.optionals (!enableTUI) [ fribidi harfbuzz libwebp mpg123 SDL2 ]
+    ++ lib.optionals enableTUI [ ncurses sealcurses ]
     ++ lib.optional stdenv.isDarwin AppKit;
 
-  installPhase = lib.optionalString stdenv.isDarwin ''
+  cmakeFlags = lib.optionals enableTUI [
+    "-DENABLE_TUI=YES"
+    "-DENABLE_MPG123=NO"
+    "-DENABLE_WEBP=NO"
+    "-DENABLE_FRIBIDI=NO"
+    "-DENABLE_HARFBUZZ=NO"
+    "-DENABLE_POPUP_MENUS=NO"
+    "-DENABLE_IDLE_SLEEP=NO"
+    "-DCMAKE_INSTALL_DATADIR=${placeholder "out"}/share"
+  ];
+
+  installPhase = lib.optionalString (stdenv.isDarwin && !enableTUI) ''
     mkdir -p $out/Applications
     mv Lagrange.app $out/Applications
   '';

--- a/pkgs/development/libraries/sealcurses/default.nix
+++ b/pkgs/development/libraries/sealcurses/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitea, cmake, pkg-config, ncurses, the-foundation }:
+
+stdenv.mkDerivation rec {
+  pname = "sealcurses";
+  version = "unstable-2022-04-28"; # No release yet
+
+  src = fetchFromGitea {
+    domain = "git.skyjake.fi";
+    owner = "skyjake";
+    repo = pname;
+    rev = "abf27cfd2567a0765aaa115cabab0abb7f862253";
+    hash = "sha256-c4zi/orHyr1hkuEisqZ9V8SaiH1IoxIbeGMrLBEkZ0A=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ ncurses the-foundation ];
+
+  cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" ];
+
+  meta = with lib; {
+    description = "SDL Emulation and Adaptation Layer for Curses (ncursesw)";
+    homepage = "https://git.skyjake.fi/skyjake/sealcurses";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/the-foundation/default.nix
+++ b/pkgs/development/libraries/the-foundation/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitea
+, cmake
+, pkg-config
+, curl
+, libunistring
+, openssl
+, pcre
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "the-foundation";
+  version = "1.4.0";
+
+  src = fetchFromGitea {
+    domain = "git.skyjake.fi";
+    owner = "skyjake";
+    repo = "the_Foundation";
+    rev = "v${version}";
+    hash = "sha256-IHwWJryG4HcrW9Bf8KJrisCrbF86RBQj6Xl1HTmcr6k=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ curl libunistring openssl pcre zlib ];
+
+  meta = with lib; {
+    description = "Opinionated C11 library for low-level functionality";
+    homepage = "https://git.skyjake.fi/skyjake/the_Foundation";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20483,6 +20483,8 @@ with pkgs;
 
   selinux-sandbox = callPackage ../os-specific/linux/selinux-sandbox { };
 
+  sealcurses = callPackage ../development/libraries/sealcurses { };
+
   seasocks = callPackage ../development/libraries/seasocks { };
 
   serd = callPackage ../development/libraries/serd {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20835,6 +20835,8 @@ with pkgs;
 
   tet = callPackage ../development/tools/misc/tet { };
 
+  the-foundation = callPackage ../development/libraries/the-foundation { };
+
   theft = callPackage ../development/libraries/theft { };
 
   thrift = callPackage ../development/libraries/thrift { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7621,6 +7621,7 @@ with pkgs;
   lagrange = callPackage ../applications/networking/browsers/lagrange {
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };
+  lagrange-tui = lagrange.override { enableTUI = true; };
 
   kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };
 


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/skyjake/lagrange/releases)
* unbundle `the-foundation` library
* add `sealcurses` library
* enable TUI (terminal that supports a modifiable palette should be used)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).