### PR TITLE
pylint: 2.13.5 -> 2.13.8

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.11.2"; # Check whether the version is compatible with pylint
+  version = "2.11.4"; # Check whether the version is compatible with pylint
 
   disabled = pythonOlder "3.6.2";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-adnvJCchsMWQxsIlenndUb6Mw1MgCNAanZcTmssmsEc=";
+    sha256 = "sha256-NJ8TzxK+PjMRScwptl2zwvcTSdmd2OX3LQLP3JUFjNQ=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "pylint";
-  version = "2.13.5";
+  version = "2.13.8";
   format = "setuptools";
 
   disabled = pythonOlder "3.6.2";
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-FB99vmUtoTc0cTjDUSbx80Tesh0vASigSpPktrDYk08=";
+    sha256 = "sha256-43L6G15zXGgQeWLdJgzNeAX9rVdRbQP/HS3ec4uAg/E=";
   };
 
   nativeBuildInputs = [
@@ -74,14 +74,14 @@ buildPythonPackage rec {
   '';
 
   disabledTestPaths = [
-    # tests miss multiple input files
-    # FileNotFoundError: [Errno 2] No such file or directory
+    # Tests fail due to missing input files with error message:
+    # FileNotFoundError: [Errno 2] No such file or directory: ...
     "tests/pyreverse/test_writer.py"
-  ];
-
-  disabledTests = lib.optionals stdenv.isDarwin [
-    "test_parallel_execution"
-    "test_py3k_jobs_option"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Fail with error message:
+    # 'timeout' not found in `markers` configuration option
+    "tests/checkers/unittest_refactoring.py"
+    "tests/test_regr.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -88,6 +88,6 @@ buildPythonPackage rec {
     homepage = "https://pylint.pycqa.org/";
     description = "A bug and style checker for Python";
     license = licenses.gpl1Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ totoroot ];
   };
 }

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -87,6 +87,15 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://pylint.pycqa.org/";
     description = "A bug and style checker for Python";
+    longDescription = ''
+      Pylint is a Python static code analysis tool which looks for programming errors,
+      helps enforcing a coding standard, sniffs for code smells and offers simple
+      refactoring suggestions.
+      Pylint is shipped with following additional commands:
+      - pyreverse: an UML diagram generator
+      - symilar: an independent similarities checker
+      - epylint: Emacs and Flymake compatible Pylint
+    '';
     license = licenses.gpl1Plus;
     maintainers = with maintainers; [ totoroot ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9572,6 +9572,8 @@ with pkgs;
 
   pyinfra = with python3Packages; toPythonApplication pyinfra;
 
+  pylint = with python3Packages; toPythonApplication pylint;
+
   pympress = callPackage ../applications/office/pympress { };
 
   pyspread = libsForQt5.callPackage ../applications/office/pyspread { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update pylint from 2.13.5 to 2.13.8
Update astroid from 2.11.2 to 2.11.4 (tested compatibility with pylint)
Add top-level package reference for pylint
Add longDescription with included commands (pyreverse, epylint and symilar)
Disable failing tests on x86_64-darwin. Enable formerly non-working tests.
Add myself as maintainer (totoroot)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
