### PR TITLE
haruna: 0.7.3 -> 0.8.0

### DIFF
--- a/pkgs/applications/video/haruna/default.nix
+++ b/pkgs/applications/video/haruna/default.nix
@@ -6,69 +6,68 @@
 , cmake
 , extra-cmake-modules
 , ffmpeg-full
-, kcodecs
 , kconfig
 , kcoreaddons
 , kfilemetadata
 , ki18n
 , kiconthemes
 , kio
-, kio-extras
 , kirigami2
 , kxmlgui
+, kdoctools
 , mpv
 , pkg-config
+, wrapQtAppsHook
 , qqc2-desktop-style
 , qtbase
 , qtquickcontrols2
-, qtwayland
-, youtube-dl
+, yt-dlp
 }:
 
 mkDerivation rec {
   pname = "haruna";
-  version = "0.7.3";
+  version = "0.8.0";
 
   src = fetchFromGitLab {
     owner = "multimedia";
     repo = "haruna";
     rev = "v${version}";
-    sha256 = "sha256-pFrmTaRvsqxJw34VULzfjx2k56kJgkB96nJtai2D1wY=";
+    sha256 = "sha256-Lom9iQUKH3lQHrVK4dJzo+FG79xSCg0b4gY/KAevL6I=";
     domain = "invent.kde.org";
   };
 
   buildInputs = [
     breeze-icons
     breeze-qt5
+    qqc2-desktop-style
+    yt-dlp
+
     ffmpeg-full
-    kcodecs
     kconfig
     kcoreaddons
     kfilemetadata
     ki18n
     kiconthemes
     kio
-    kio-extras
     kirigami2
     kxmlgui
+    kdoctools
     mpv
-    qqc2-desktop-style
     qtbase
     qtquickcontrols2
-    qtwayland
-    youtube-dl
   ];
 
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
     pkg-config
+    wrapQtAppsHook
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/g-fb/haruna";
+    homepage = "https://invent.kde.org/multimedia/haruna";
     description = "Open source video player built with Qt/QML and libmpv";
-    license = with licenses; [ bsd3 cc-by-40 gpl3Plus wtfpl ];
+    license = with licenses; [ bsd3 cc-by-40 cc-by-sa-40 cc0 gpl2Plus gpl3Plus wtfpl ];
     maintainers = with maintainers; [ jojosch ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Supersedes #171328.
Closes #169970 (which contains info on what's done here).

For some reason, when I try to open the resulting binary, I get a segfault (see the issue above), whether it's a simple version bump or this PR. It's the reason I opened it as draft.
However there seems to be no problem to the person in the PR I linked, so I don't know if this is a problem in my end...
(TL;DR, test whether it opens on your end, if it does then it won't be draft anymore.)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
