### PR TITLE
chickenPackages: recurse into attrs

### DIFF
--- a/pkgs/development/compilers/chicken/4/default.nix
+++ b/pkgs/development/compilers/chicken/4/default.nix
@@ -13,7 +13,7 @@ let
       bootstrap-chicken = self.chicken.override { bootstrap-chicken = null; };
     };
 
-    chickenEggs = callPackage ./eggs.nix { };
+    chickenEggs = lib.recurseIntoAttrs (callPackage ./eggs.nix { });
 
     egg2nix = callPackage ./egg2nix.nix { };
   };

--- a/pkgs/development/compilers/chicken/5/default.nix
+++ b/pkgs/development/compilers/chicken/5/default.nix
@@ -13,7 +13,7 @@ let
       bootstrap-chicken = self.chicken.override { bootstrap-chicken = null; };
     };
 
-    chickenEggs = callPackage ./eggs.nix { };
+    chickenEggs = lib.recurseIntoAttrs (callPackage ./eggs.nix { });
 
     egg2nix = callPackage ./egg2nix.nix { };
   };


### PR DESCRIPTION
###### Description of changes

This makes chicken packages (eggs) discoverable.

This came up during:

https://github.com/NixOS/nixpkgs/pull/165023#issuecomment-1116655349

cc @Mindavi 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).