### PR TITLE
GNOME 42.1 staging update

### DIFF
--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -1,34 +1,47 @@
-{ lib, stdenv, fetchurl, meson, ninja, gettext, pkg-config, glib
-, fixDarwinDylibNames, gobject-introspection, gnome
+{ stdenv
+, lib
+, fetchurl
+, meson
+, ninja
+, gettext
+, pkg-config
+, glib
+, fixDarwinDylibNames
+, gobject-introspection
+, gnome
 }:
 
-let
-  pname = "atk";
-  version = "2.36.0";
-in
-
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
-
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1217cmmykjgkkim0zr1lv5j13733m4w5vipmy4ivw0ll6rz28xpv";
-  };
+  pname = "atk";
+  version = "2.38.0";
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkg-config gettext gobject-introspection glib ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-
-  propagatedBuildInputs = [
-    # Required by atk.pc
-    glib
-  ];
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "rE3ipO9L1WZQUpUv4WllfmXolcUFff+zwqgQ9hkaDDY=";
+  };
 
   patches = [
     # meson builds an incorrect .pc file
     # glib should be Requires not Requires.private
     ./fix_pc.patch
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    gobject-introspection
+    glib
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ];
+
+  propagatedBuildInputs = [
+    # Required by atk.pc
+    glib
   ];
 
   mesonFlags = [
@@ -55,7 +68,7 @@ stdenv.mkDerivation rec {
       control running applications.
     '';
 
-    homepage = "http://library.gnome.org/devel/atk/";
+    homepage = "https://gitlab.gnome.org/GNOME/atk";
 
     license = lib.licenses.lgpl2Plus;
 

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -24,14 +24,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pango";
-  version = "1.50.6";
+  version = "1.50.7";
 
   outputs = [ "bin" "out" "dev" ]
     ++ lib.optionals withDocs [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "qZi882iBw6wgSV1AvOswT06qkXW9KWfIVlZDTL2v6Go=";
+    sha256 = "BHfzaaPUxpXfcpmmmJ3ABHVqf03ifuysQFxnkLfjrTM=";
   };
 
   strictDeps = !withIntrospection;

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "pygobject";
-  version = "3.42.0";
+  version = "3.42.1";
 
   outputs = [ "out" "dev" ];
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "mxJhbjLPx5L53IQdnEcqQaNbhbpn06brQn4wem/kNns=";
+    sha256 = "HzS192JN415E61p+tCg1MoW9AwBNVRMaX39/qbkPPMk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

- atk: 2.36.0 → 2.38.0
- pango: 1.50.6 → 1.50.7
- python3.pkgs.pygobject3: 3.42.0 → 3.42.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
