### PR TITLE
trilium: 0.50.3 -> 0.51.2

### DIFF
--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -19,16 +19,16 @@ let
     maintainers = with maintainers; [ fliegendewurst ];
   };
 
-  version = "0.50.3";
+  version = "0.51.2";
 
   desktopSource = {
     url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-    sha256 = "sha256-0N2+NcdZGxaj4LcG5edyd3ry+0dSQSfUQRqZEYFfWqQ=";
+    sha256 = "17bqcnpvflpi5dlz9m294diwd6as5wha5jcv9a3qvhh4pq0nyr4z";
   };
 
   serverSource = {
     url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-server-${version}.tar.xz";
-    sha256 = "sha256-za32yRhusReoGIRdbfx30CPH63BVXz2Z7jkhxtb7XSo=";
+    sha256 = "0jjvg75a4va5d81x8dvpzmzax7p0bqd7psv0alkkl13m91gai6ig";
   };
 
 in {


### PR DESCRIPTION
###### Description of changes
Regular update https://github.com/zadam/trilium/releases/tag/v0.51.2

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).