### PR TITLE
Use new style recursive mkDerivation

### DIFF
--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, imake, gccmakedep, xlibsWrapper }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (final: {
   version_name = "1.2.hanami.6";
   version = "1.2.6";
   pname = "oneko";
   src = fetchFromGitHub {
     owner = "IreneKnapp";
     repo = "oneko";
-    rev = version_name;
+    rev = final.version_name;
     sha256 = "0vx12v5fm8ar3f1g6jbpmd3b1q652d32nc67ahkf28djbqjgcbnc";
   };
   nativeBuildInputs = [ imake gccmakedep ];
@@ -29,4 +29,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xaverdh irenes ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/applications/misc/xteddy/default.nix
+++ b/pkgs/applications/misc/xteddy/default.nix
@@ -1,20 +1,20 @@
 { lib, stdenv, fetchFromGitLab, pkg-config, xorg, imlib2, makeWrapper }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (final: {
   pname = "xteddy";
   version = "2.2-5";
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "games-team";
-    repo = pname;
-    rev = "debian/${version}";
+    repo = "xteddy";
+    rev = "debian/${final.version}";
     sha256 = "0rm7w78d6qajq4fvi4agyqm0c70f3c1i0cy2jdb6kqql2k8w78qy";
   };
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = [ imlib2 xorg.libX11 xorg.libXext ];
 
-  patches = [ "${src}/debian/patches/10_libXext.patch" "${src}/debian/patches/wrong-man-page-section.patch" ];
+  patches = [ "${final.src}/debian/patches/10_libXext.patch" "${final.src}/debian/patches/wrong-man-page-section.patch" ];
 
   postPatch = ''
     sed -i "s:/usr/games/xteddy:$out/bin/xteddy:" xtoys
@@ -40,4 +40,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.xaverdh ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, mkDerivation
 , fetchFromGitHub
 , cmake
 , fuse
@@ -10,14 +9,14 @@
 , qttools
 , wrapQtAppsHook }:
 
-mkDerivation rec {
+stdenv.mkDerivation (final: {
   pname = "android-file-transfer";
   version = "4.2";
 
   src = fetchFromGitHub {
     owner = "whoozle";
     repo = "android-file-transfer-linux";
-    rev = "v${version}";
+    rev = "v${final.version}";
     sha256 = "125rq8ji83nw6chfw43i0h9c38hjqh1qjibb0gnf9wrigar9zc8b";
   };
 
@@ -38,4 +37,4 @@ mkDerivation rec {
     maintainers = [ maintainers.xaverdh ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes
Make use of #119942 in packages I maintain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
