### PR TITLE
WIP: Hatchling backport

### DIFF
--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -21,7 +21,7 @@
 
 let
   pname = "hatchling";
-  version = "0.22.0";
+  version = "0.24.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -29,7 +29,7 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-BUJ24F4oON/9dWpnnDNM5nIOuh3yuwlvDnLA9uQAIXo=";
+    hash = "sha256-zmdl9bW688tX0vgBlsUOIB43KMrNlTU/XJtPA9/fTrk=";
   };
 
   # listed in backend/src/hatchling/ouroboros.py

--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -21,7 +21,7 @@
 
 let
   pname = "hatchling";
-  version = "0.20.1";
+  version = "0.22.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -29,7 +29,7 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-l1VRce5H3CSAwZBeuxRyy7bNpOM6zX5s2L1/DXPo/Bg=";
+    hash = "sha256-BUJ24F4oON/9dWpnnDNM5nIOuh3yuwlvDnLA9uQAIXo=";
   };
 
   # listed in backend/src/hatchling/ouroboros.py

--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , pythonOlder
 
 # runtime
@@ -21,22 +21,16 @@
 
 let
   pname = "hatchling";
-  version = "0.20.0";
+  version = "0.20.1";
 in
 buildPythonPackage {
   inherit pname version;
   format = "pyproject";
 
-  src = fetchFromGitHub {
-    owner = "ofek";
-    repo = "hatch";
-    rev = "${pname}-v${version}";
-    hash = "sha256-Sm3utqkuofVDn815HPj501KEuypnaYKm06ehsu+m3i4=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-l1VRce5H3CSAwZBeuxRyy7bNpOM6zX5s2L1/DXPo/Bg=";
   };
-
-  prePatch = ''
-    cd backend
-  '';
 
   # listed in backend/src/hatchling/ouroboros.py
   propagatedBuildInputs = [
@@ -51,6 +45,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [
     "hatchling"
+    "hatchling.build"
   ];
 
   # tries to fetch packages from the internet
@@ -79,6 +74,6 @@ buildPythonPackage {
     description = "Modern, extensible Python build backend";
     homepage = "https://ofek.dev/hatch/latest/";
     license = licenses.mit;
-    maintainers = with maintainers; [ hexa ];
+    maintainers = with maintainers; [ hexa ofek ];
   };
 }

--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -21,7 +21,7 @@
 
 let
   pname = "hatchling";
-  version = "0.18.0";
+  version = "0.20.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -31,7 +31,7 @@ buildPythonPackage {
     owner = "ofek";
     repo = "hatch";
     rev = "${pname}-v${version}";
-    hash = "sha256-kCaEAM0cY1yQcuHfvnaLs3smN9MKATjrrQTXpCfGmWc=";
+    hash = "sha256-Sm3utqkuofVDn815HPj501KEuypnaYKm06ehsu+m3i4=";
   };
 
   prePatch = ''

--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+
+# runtime
+, editables
+, importlib-metadata # < 3.8
+, packaging
+, pathspec
+, pluggy
+, tomli
+
+# tests
+, build
+, python
+, requests
+, toml
+, virtualenv
+}:
+
+let
+  pname = "hatchling";
+  version = "0.18.0";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ofek";
+    repo = "hatch";
+    rev = "${pname}-v${version}";
+    hash = "sha256-kCaEAM0cY1yQcuHfvnaLs3smN9MKATjrrQTXpCfGmWc=";
+  };
+
+  prePatch = ''
+    cd backend
+  '';
+
+  # listed in backend/src/hatchling/ouroboros.py
+  propagatedBuildInputs = [
+    editables
+    packaging
+    pathspec
+    pluggy
+    tomli
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  pythonImportsCheck = [
+    "hatchling"
+  ];
+
+  # tries to fetch packages from the internet
+  doCheck = false;
+
+  # listed in /backend/tests/downstream/requirements.txt
+  checkInputs = [
+    build
+    packaging
+    requests
+    toml
+    virtualenv
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} tests/downstream/integrate.py
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Modern, extensible Python build backend";
+    homepage = "https://ofek.dev/hatch/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3497,6 +3497,8 @@ in {
 
   hatasmota = callPackage ../development/python-modules/hatasmota { };
 
+  hatchling = callPackage ../development/python-modules/hatchling { };
+
   haversine = callPackage ../development/python-modules/haversine { };
 
   hawkauthlib = callPackage ../development/python-modules/hawkauthlib { };


### PR DESCRIPTION
###### Description of changes

This is an attempt to backport to fix https://github.com/NixOS/nixpkgs/issues/171447#issuecomment-1117260205

I cherry-picked all the commits in the history of hatchling from here:
https://github.com/NixOS/nixpkgs/commits/235eee5537f37bbc721cd120b6c0fa66bfe763e4/pkgs/development/python-modules/hatchling/default.nix

I haven't been able to figure out whether this will work. Would like to make this PR a draft but I can't figure out how.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
