### PR TITLE
dive: enable tests

### DIFF
--- a/pkgs/development/tools/dive/default.nix
+++ b/pkgs/development/tools/dive/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-0gJ3dAPoilh3IWkuesy8geNsuI1T0DN64XvInc9LvlM=";
 
-  doCheck = false;
-
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = lib.optionals stdenv.isLinux [ btrfs-progs gpgme lvm2 ];


### PR DESCRIPTION
dive: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestEfficency
--- PASS: TestEfficency (0.00s)
=== RUN   TestEfficency_ScratchImage
--- PASS: TestEfficency_ScratchImage (0.00s)
=== RUN   TestAddChild
--- PASS: TestAddChild (0.00s)
=== RUN   TestRemoveChild
--- PASS: TestRemoveChild (0.00s)
=== RUN   TestPath
--- PASS: TestPath (0.00s)
=== RUN   TestIsWhiteout
--- PASS: TestIsWhiteout (0.00s)
=== RUN   TestDiffTypeFromAddedChildren
--- PASS: TestDiffTypeFromAddedChildren (0.00s)
=== RUN   TestDiffTypeFromRemovedChildren
--- PASS: TestDiffTypeFromRemovedChildren (0.00s)
=== RUN   TestDirSize
--- PASS: TestDirSize (0.00s)
=== RUN   TestStringCollapsed
--- PASS: TestStringCollapsed (0.00s)
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestStringBetween
--- PASS: TestStringBetween (0.00s)
=== RUN   TestRejectPurelyRelativePath
--- PASS: TestRejectPurelyRelativePath (0.00s)
=== RUN   TestAddRelativePath
--- PASS: TestAddRelativePath (0.00s)
=== RUN   TestAddPath
--- PASS: TestAddPath (0.00s)
=== RUN   TestAddWhiteoutPath
--- PASS: TestAddWhiteoutPath (0.00s)
=== RUN   TestRemovePath
--- PASS: TestRemovePath (0.00s)
=== RUN   TestStack
--- PASS: TestStack (0.00s)
=== RUN   TestCopy
--- PASS: TestCopy (0.00s)
=== RUN   TestCompareWithNoChanges
--- PASS: TestCompareWithNoChanges (0.00s)
=== RUN   TestCompareWithAdds
--- PASS: TestCompareWithAdds (0.00s)
=== RUN   TestCompareWithChanges
--- PASS: TestCompareWithChanges (0.00s)
=== RUN   TestCompareWithRemoves
--- PASS: TestCompareWithRemoves (0.00s)
=== RUN   TestStackRange
--- PASS: TestStackRange (0.00s)
=== RUN   TestRemoveOnIterate
--- PASS: TestRemoveOnIterate (0.00s)
=== RUN   TestAssignDiffType
--- PASS: TestAssignDiffType (0.00s)
=== RUN   TestMergeDiffTypes
--- PASS: TestMergeDiffTypes (0.00s)
PASS
ok  	github.com/wagoodman/dive/dive/filetree	0.002s
=== RUN   Test_Analysis
--- PASS: Test_Analysis (0.00s)
PASS
ok  	github.com/wagoodman/dive/dive/image/docker	0.008s
=== RUN   TestRun
--- PASS: TestRun (0.07s)
PASS
ok  	github.com/wagoodman/dive/runtime	0.076s
=== RUN   Test_Evaluator
--- PASS: Test_Evaluator (0.00s)
PASS
ok  	github.com/wagoodman/dive/runtime/ci	0.008s
=== RUN   Test_Export
--- PASS: Test_Export (0.00s)
PASS
ok  	github.com/wagoodman/dive/runtime/export	0.008s
=== RUN   Test_planAndLayoutHeaders
    manager_test.go:134: case:  single header  ---
    manager_test.go:134: case:  two headers  ---
    manager_test.go:134: case:  two odd-sized headers  ---
--- PASS: Test_planAndLayoutHeaders (0.00s)
=== RUN   Test_planAndLayoutColumns
    manager_test.go:234: case:  single column  ---
    manager_test.go:234: case:  two equal columns  ---
    manager_test.go:234: case:  two odd-sized columns  ---
--- PASS: Test_planAndLayoutColumns (0.00s)
=== RUN   Test_layout
    manager_test.go:369: case:  1 header + 1 footer + 1 column  ---
    manager_test.go:369: case:  1 header + 1 footer + 3 column  ---
    manager_test.go:369: case:  1 header + 1 footer + 2 equal columns + 1 sized column  ---
--- PASS: Test_layout (0.00s)
PASS
ok  	github.com/wagoodman/dive/runtime/ui/layout	0.001s
=== RUN   TestFileTreeGoCase
--- PASS: TestFileTreeGoCase (0.03s)
=== RUN   TestFileTreeNoAttributes
--- PASS: TestFileTreeNoAttributes (0.02s)
=== RUN   TestFileTreeRestrictedHeight
--- PASS: TestFileTreeRestrictedHeight (0.02s)
=== RUN   TestFileTreeDirCollapse
--- PASS: TestFileTreeDirCollapse (0.02s)
=== RUN   TestFileTreeDirCollapseAll
--- PASS: TestFileTreeDirCollapseAll (0.02s)
=== RUN   TestFileTreeSelectLayer
--- PASS: TestFileTreeSelectLayer (0.02s)
=== RUN   TestFileShowAggregateChanges
--- PASS: TestFileShowAggregateChanges (0.02s)
=== RUN   TestFileTreePageDown
--- PASS: TestFileTreePageDown (0.02s)
=== RUN   TestFileTreePageUp
--- PASS: TestFileTreePageUp (0.02s)
=== RUN   TestFileTreeDirCursorRight
--- PASS: TestFileTreeDirCursorRight (0.02s)
=== RUN   TestFileTreeFilterTree
--- PASS: TestFileTreeFilterTree (0.02s)
=== RUN   TestFileTreeHideAddedRemovedModified
--- PASS: TestFileTreeHideAddedRemovedModified (0.02s)
=== RUN   TestFileTreeHideUnmodified
--- PASS: TestFileTreeHideUnmodified (0.02s)
=== RUN   TestFileTreeHideTypeWithFilter
--- PASS: TestFileTreeHideTypeWithFilter (0.02s)
PASS
ok  	github.com/wagoodman/dive/runtime/ui/viewmodel	0.314s
```
