### PR TITLE
python3Packages.validict: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/validobj/default.nix
+++ b/pkgs/development/python-modules/validobj/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, flit
+, hypothesis
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "validobj";
+  version = "0.5.1";
+  format = "pyproject";
+
+  # tests are missing from the PyPi tarball
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "430b0b56931a2cebdb857a9fe9da2467c06a3b4db37b728e7f1a8706e8887705";
+  };
+
+  buildInputs = [ flit ];
+
+  pythonImportsCheck = [ "validobj" ];
+  checkInputs = [ hypothesis pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Validobj is library that takes semistructured data (for example JSON and YAML configuration files) and converts it to more structured Python objects";
+    homepage = "https://github.com/Zaharid/validobj";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/validobj/default.nix
+++ b/pkgs/development/python-modules/validobj/default.nix
@@ -11,7 +11,6 @@ buildPythonPackage rec {
   version = "0.5.1";
   format = "pyproject";
 
-  # tests are missing from the PyPi tarball
   src = fetchPypi {
     inherit pname version;
     sha256 = "430b0b56931a2cebdb857a9fe9da2467c06a3b4db37b728e7f1a8706e8887705";
@@ -19,8 +18,9 @@ buildPythonPackage rec {
 
   buildInputs = [ flit ];
 
-  pythonImportsCheck = [ "validobj" ];
   checkInputs = [ hypothesis pytestCheckHook ];
+
+  pythonImportsCheck = [ "validobj" ];
 
   meta = with lib; {
     description = "Validobj is library that takes semistructured data (for example JSON and YAML configuration files) and converts it to more structured Python objects";

--- a/pkgs/development/python-modules/validobj/default.nix
+++ b/pkgs/development/python-modules/validobj/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "430b0b56931a2cebdb857a9fe9da2467c06a3b4db37b728e7f1a8706e8887705";
   };
 
-  buildInputs = [ flit ];
+  nativeBuildInputs = [ flit ];
 
   checkInputs = [ hypothesis pytestCheckHook ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10662,6 +10662,8 @@ in {
 
   validictory = callPackage ../development/python-modules/validictory { };
 
+  validobj = callPackage ../development/python-modules/validobj { };
+
   variants = callPackage ../development/python-modules/variants { };
 
   varint = callPackage ../development/python-modules/varint { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
