### PR TITLE
Revert "zimg: 3.0.3 -> 3.0.4"

### DIFF
--- a/pkgs/development/libraries/zimg/default.nix
+++ b/pkgs/development/libraries/zimg/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zimg";
-  version = "3.0.4";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner  = "sekrit-twc";
     repo   = "zimg";
     rev    = "release-${version}";
-    sha256 = "1069x49l7kh1mqcq1h3f0m5j0h832jp5x230bh4c613ymgg5kn00";
+    sha256 = "0pwgf1mybpa3fs13p6jryzm32vfldyql9biwaypqdcimlnlmyk20";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#171144.  Let's move it to `staging-next` for now.