### PR TITLE
nixos xfce: fix eval by avoiding package alias

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -113,7 +113,7 @@ in
 
       (thunar.override { thunarPlugins = cfg.thunarPlugins; })
     ] # TODO: NetworkManager doesn't belong here
-      ++ optional config.networking.networkmanager.enable networkmanagerapplet
+      ++ optional config.networking.networkmanager.enable networkmanager-applet
       ++ optional config.powerManagement.enable xfce4-power-manager
       ++ optionals config.hardware.pulseaudio.enable [
         pavucontrol


### PR DESCRIPTION
Regressed in cecb014d5d from PR #170952

(no rebuilds)