### PR TITLE
Revert "networkmanager-applet: rename from networkmanagerapplet"

### DIFF
--- a/nixos/modules/programs/nm-applet.nix
+++ b/nixos/modules/programs/nm-applet.nix
@@ -23,7 +23,7 @@
       description = "Network manager applet";
       wantedBy = [ "graphical-session.target" ];
       partOf = [ "graphical-session.target" ];
-      serviceConfig.ExecStart = "${pkgs.networkmanager-applet}/bin/nm-applet ${lib.optionalString config.programs.nm-applet.indicator "--indicator"}";
+      serviceConfig.ExecStart = "${pkgs.networkmanagerapplet}/bin/nm-applet ${lib.optionalString config.programs.nm-applet.indicator "--indicator"}";
     };
 
     services.dbus.packages = [ pkgs.gcr ];

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -136,7 +136,7 @@ in
         # session requirements
         cinnamon-screensaver
         # cinnamon-killer-daemon: provided by cinnamon-common
-        networkmanager-applet # session requirement - also nm-applet not needed
+        networkmanagerapplet # session requirement - also nm-applet not needed
 
         # For a polkit authentication agent
         polkit_gnome

--- a/pkgs/applications/networking/firewalld/default.nix
+++ b/pkgs/applications/networking/firewalld/default.nix
@@ -12,7 +12,7 @@
 , libnotify
 , libxml2
 , libxslt
-, networkmanager-applet
+, networkmanagerapplet
 , pkg-config
 , python3
 , wrapGAppsNoGuiHook
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     done
   '' + lib.optionalString withGui ''
     substituteInPlace src/firewall-applet.in \
-      --replace "/usr/bin/nm-connection-editor" "${networkmanager-applet}/bin/nm-conenction-editor"
+      --replace "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-conenction-editor"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-control-center/default.nix
@@ -42,7 +42,7 @@
 , modemmanager
 , mutter
 , networkmanager
-, networkmanager-applet
+, networkmanagerapplet
 , libnma-gtk4
 , ninja
 , pkg-config
@@ -76,9 +76,8 @@ stdenv.mkDerivation rec {
       src = ./paths.patch;
       gcm = gnome-color-manager;
       gnome_desktop = gnome-desktop;
-      networkmanagerapplet = networkmanager-applet;
       inherit glibc libgnomekbd tzdata;
-      inherit cups;
+      inherit cups networkmanagerapplet;
     })
 
     # Fix Online Accounts configuration on X11

--- a/pkgs/desktops/gnome/default.nix
+++ b/pkgs/desktops/gnome/default.nix
@@ -379,7 +379,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   dconf = throw "The ‘gnome.dconf’ alias was removed on 2022-01-13. Please use ‘pkgs.dconf’ directly."; # added 2019-11-30
 
-  networkmanagerapplet = throw "The ‘gnome.networkmanagerapplet’ alias was removed on 2022-01-13. Please use ‘pkgs.networkmanager-applet’ directly."; # added 2019-12-12
+  networkmanagerapplet = throw "The ‘gnome.networkmanagerapplet’ alias was removed on 2022-01-13. Please use ‘pkgs.networkmanagerapplet’ directly."; # added 2019-12-12
 
   glade = throw "The ‘gnome.glade’ alias was removed on 2022-01-13. Please use ‘pkgs.glade’ directly."; # added 2020-05-15
 

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -11,7 +11,7 @@
 , granite
 , gtk3
 , networkmanager
-, networkmanager-applet
+, networkmanagerapplet
 , libnma
 , switchboard
 }:
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      networkmanagerapplet = networkmanager-applet;
+      inherit networkmanagerapplet;
     })
   ];
 

--- a/pkgs/tools/networking/networkmanager/applet/default.nix
+++ b/pkgs/tools/networking/networkmanager/applet/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;
-      attrPath = "networkmanager-applet";
+      attrPath = "networkmanagerapplet";
       versionPolicy = "odd-unstable";
     };
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -850,7 +850,6 @@ mapAliases ({
   neap = throw "neap was removed from nixpkgs, as it relies on python2"; # Added 2022-01-12
   netcat-openbsd = throw "'netcat-openbsd' has been renamed to/replaced by 'libressl.nc'"; # Converted to throw 2022-02-22
   netease-cloud-music = throw "netease-cloud-music has been removed together with deepin"; # Added 2020-08-31
-  networkmanagerapplet = networkmanager-applet; # Added 2022-04-30
   networkmanager_fortisslvpn = throw "'networkmanager_fortisslvpn' has been renamed to/replaced by 'networkmanager-fortisslvpn'"; # Converted to throw 2022-02-22
   networkmanager_iodine = throw "'networkmanager_iodine' has been renamed to/replaced by 'networkmanager-iodine'"; # Converted to throw 2022-02-22
   networkmanager_l2tp = throw "'networkmanager_l2tp' has been renamed to/replaced by 'networkmanager-l2tp'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8562,8 +8562,6 @@ with pkgs;
 
   networkmanager = callPackage ../tools/networking/networkmanager { };
 
-  networkmanager-applet = callPackage ../tools/networking/networkmanager/applet { };
-
   networkmanager-iodine = callPackage ../tools/networking/networkmanager/iodine { };
 
   networkmanager-openvpn = callPackage ../tools/networking/networkmanager/openvpn { };
@@ -8579,6 +8577,8 @@ with pkgs;
   networkmanager_strongswan = callPackage ../tools/networking/networkmanager/strongswan { };
 
   networkmanager-sstp = callPackage ../tools/networking/networkmanager/sstp { };
+
+  networkmanagerapplet = callPackage ../tools/networking/networkmanager/applet { };
 
   libnma = callPackage ../tools/networking/networkmanager/libnma { };
 


### PR DESCRIPTION
###### Description of changes

network-manager-applet uses differrent naming scheme from the VPN plug-ins, see https://github.com/NixOS/nixpkgs/pull/170952#discussion_r862346215.
Let’s revert to the previous state, for now, to fix eval. We can do the rename later.

This reverts commit cecb014d5daeb8b0c75361ed8ba89d9e84279c8e.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
