### PR TITLE
treewide: add meta.mainProgram to many packages

### DIFF
--- a/pkgs/applications/editors/oed/default.nix
+++ b/pkgs/applications/editors/oed/default.nix
@@ -24,9 +24,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/ibara/oed";
     description = "Portable ed editor from OpenBSD";
+    homepage = "https://github.com/ibara/oed";
     license = with licenses; [ bsd2 ];
+    mainProgram = "ed";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -60,6 +60,7 @@ in
       downloadPage = "https://github.com/VSCodium/vscodium/releases";
       license = licenses.mit;
       maintainers = with maintainers; [ synthetica turion bobby285271 ];
+      mainProgram = "codium";
       platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" "armv7l-linux" ];
     };
   }

--- a/pkgs/applications/emulators/commanderx16/emulator.nix
+++ b/pkgs/applications/emulators/commanderx16/emulator.nix
@@ -29,10 +29,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://www.commanderx16.com/forum/index.php?/home/";
     description = "The official emulator of CommanderX16 8-bit computer";
+    homepage = "https://www.commanderx16.com/forum/index.php?/home/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "x16emu";
     inherit (SDL2.meta) platforms;
   };
 

--- a/pkgs/applications/misc/nanoblogger/default.nix
+++ b/pkgs/applications/misc/nanoblogger/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     description = "Small weblog engine written in Bash for the command line";
     homepage = "http://nanoblogger.sourceforge.net/";
     license = lib.licenses.gpl2;
+    mainProgram = "nb";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/misc/oil-buku/default.nix
+++ b/pkgs/applications/misc/oil-buku/default.nix
@@ -38,7 +38,8 @@ stdenvNoCC.mkDerivation rec {
     description = "Search-as-you-type cli frontend for the buku bookmarks manager using peco";
     homepage = "https://github.com/AndreiUlmeyda/oil";
     license = licenses.gpl3Only;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ atila ];
+    mainProgram = "oil";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "https://taskwarrior.org";
     license = licenses.mit;
     maintainers = with maintainers; [ marcweber oxalica ];
+    mainProgram = "task";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/translate-shell/default.nix
+++ b/pkgs/applications/misc/translate-shell/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     description = "Command-line translator using Google Translate, Bing Translator, Yandex.Translate, and Apertium";
     license = licenses.unlicense;
     maintainers = with maintainers; [ ebzzry infinisil ];
+    mainProgram = "trans";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/web-media-controller/default.nix
+++ b/pkgs/applications/misc/web-media-controller/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     description = "MPRIS proxy for usage with 'Web Media Controller' web extension";
     license = licenses.unlicense;
     maintainers = with maintainers; [ doronbehar ];
+    mainProgram = "web-media-controller";
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/cluster/bosh-cli/default.nix
+++ b/pkgs/applications/networking/cluster/bosh-cli/default.nix
@@ -39,5 +39,6 @@ buildGoModule rec {
     changelog = "https://github.com/cloudfoundry/bosh-cli/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ ris ];
+    mainProgram = "bosh";
   };
 }

--- a/pkgs/applications/networking/cluster/fluxcd/default.nix
+++ b/pkgs/applications/networking/cluster/fluxcd/default.nix
@@ -66,5 +66,6 @@ in buildGoModule rec {
     homepage = "https://fluxcd.io";
     license = licenses.asl20;
     maintainers = with maintainers; [ bryanasdev000 jlesquembre superherointj ];
+    mainProgram = "flux";
   };
 }

--- a/pkgs/applications/networking/cluster/krelay/default.nix
+++ b/pkgs/applications/networking/cluster/krelay/default.nix
@@ -27,5 +27,6 @@ buildGoModule rec {
     changelog = "https://github.com/knight42/krelay/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ ivankovnatsky ];
+    mainProgram = "kubectl-relay";
   };
 }

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -60,9 +60,10 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Build, deploy, and manage your applications with Docker and Kubernetes";
-    license = licenses.asl20;
     homepage = "http://www.openshift.org";
+    license = licenses.asl20;
     maintainers = with maintainers; [ offline bachp moretea stehessel ];
+    mainProgram = "oc";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -45,6 +45,7 @@ let
         changelog = "https://github.com/syncthing/syncthing/releases/tag/v${version}";
         license = licenses.mpl20;
         maintainers = with maintainers; [ joko peterhoeg andrew-d ];
+        mainProgram = target;
         platforms = platforms.unix;
       };
     };

--- a/pkgs/applications/office/todo.txt-cli/default.nix
+++ b/pkgs/applications/office/todo.txt-cli/default.nix
@@ -23,6 +23,7 @@ in stdenv.mkDerivation {
     description = "Simple plaintext todo list manager";
     homepage = "http://todotxt.com";
     license = lib.licenses.gpl3;
+    mainProgram = "todo.sh";
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/applications/radio/kalibrate-rtl/default.nix
+++ b/pkgs/applications/radio/kalibrate-rtl/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/steve-m/kalibrate-rtl";
     license = licenses.bsd2;
-    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor viraptor ];
+    mainProgram = "kal";
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -51,6 +51,7 @@ in stdenv.mkDerivation {
     description = "Vendor and platform neutral SDR support library";
     license = licenses.boost;
     maintainers = with maintainers; [ markuskowa ];
+    mainProgram = "SoapySDRUtil";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
     description = "A tool for squential logic synthesis and formal verification";
     homepage    = "https://people.eecs.berkeley.edu/~alanmi/abc";
     license     = licenses.mit;
-    platforms   = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice ];
+    mainProgram = "abc";
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/science/logic/key/default.nix
+++ b/pkgs/applications/science/logic/key/default.nix
@@ -115,6 +115,7 @@ in stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2;
     maintainers = with maintainers; [ fgaz ];
+    mainProgram = executable-name;
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/dotnet/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/build-dotnet.nix
@@ -87,10 +87,11 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://dotnet.github.io/";
     description = builtins.getAttr type descriptions;
-    platforms = builtins.attrNames srcs;
-    maintainers = with maintainers; [ kuznero ];
+    homepage = "https://dotnet.github.io/";
     license = licenses.mit;
+    maintainers = with maintainers; [ kuznero ];
+    mainProgram = "dotnet";
+    platforms = builtins.attrNames srcs;
   };
 }

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -64,9 +64,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "ML-like functional programming language aimed at program verification";
     homepage = "https://www.fstar-lang.org";
-    license = licenses.asl20;
     changelog = "https://github.com/FStarLang/FStar/raw/v${version}/CHANGES.md";
-    platforms = with platforms; darwin ++ linux;
+    license = licenses.asl20;
     maintainers = with maintainers; [ gebner pnmadelaine ];
+    mainProgram = "fstar.exe";
+    platforms = with platforms; darwin ++ linux;
   };
 }

--- a/pkgs/development/compilers/jasmin-compiler/default.nix
+++ b/pkgs/development/compilers/jasmin-compiler/default.nix
@@ -34,8 +34,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A workbench for high-assurance and high-speed cryptography";
     homepage = "https://github.com/jasmin-lang/jasmin/";
-    platforms = lib.platforms.all;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
+    mainProgram = "jasminc";
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -183,6 +183,14 @@ in {
       install -Dt $out/bin src/nimble
       runHook postBuild
     '';
+
+    meta = with lib; {
+      description = "Package manager for the Nim programming language";
+      homepage = "https://github.com/nim-lang/nimble";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ ehmry ];
+      mainProgram = "nimble";
+    };
   };
 
   nim = let

--- a/pkgs/development/compilers/vlang/default.nix
+++ b/pkgs/development/compilers/vlang/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
     description = "Simple, fast, safe, compiled language for developing maintainable software";
     license = licenses.mit;
     maintainers = with maintainers; [ Madouura ];
+    mainProgram = "v";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/interpreters/kona/default.nix
+++ b/pkgs/development/interpreters/kona/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     description = "An interpreter of K, APL-like programming language";
     homepage = "https://github.com/kevinlawler/kona/";
     maintainers = with maintainers; [ raskin ];
+    mainProgram = "k";
     platforms = platforms.all;
     license = licenses.isc;
   };

--- a/pkgs/development/interpreters/rakudo/moarvm.nix
+++ b/pkgs/development/interpreters/rakudo/moarvm.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
     description = "VM with adaptive optimization and JIT compilation, built for Rakudo";
     homepage = "https://moarvm.org";
     license = licenses.artistic2;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice vrthra sgo ];
+    mainProgram = "moar";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -93,14 +93,15 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Software metadata handling library";
-    homepage = "https://www.freedesktop.org/wiki/Distributions/AppStream/";
     longDescription = ''
       AppStream is a cross-distro effort for building Software-Center applications
       and enhancing metadata provided by software components.  It provides
       specifications for meta-information which is shipped by upstream projects and
       can be consumed by other software.
     '';
+    homepage = "https://www.freedesktop.org/wiki/Distributions/AppStream/";
     license = licenses.lgpl21Plus;
+    mainProgram = "appstreamcli";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/aribb25/default.nix
+++ b/pkgs/development/libraries/aribb25/default.nix
@@ -48,10 +48,11 @@ stdenv.mkDerivation rec {
     lib.optional stdenv.isDarwin "pcsclite_CFLAGS=-I${PCSC}/Library/Frameworks/PCSC.framework/Headers";
 
   meta = with lib; {
-    homepage = "https://code.videolan.org/videolan/aribb25";
     description = "Sample implementation of the ARIB STD-B25 standard";
-    platforms = platforms.all;
+    homepage = "https://code.videolan.org/videolan/aribb25";
     license = licenses.isc;
     maintainers = with maintainers; [ midchildan ];
+    mainProgram = "b25";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/audio/libsmf/default.nix
+++ b/pkgs/development/libraries/audio/libsmf/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/stump/libsmf";
     license = licenses.bsd2;
     maintainers = [ maintainers.goibhniu ];
+    mainProgram = "smfsh";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/aws-c-s3/default.nix
+++ b/pkgs/development/libraries/aws-c-s3/default.nix
@@ -44,7 +44,8 @@ stdenv.mkDerivation rec {
     description = "C99 library implementation for communicating with the S3 service";
     homepage = "https://github.com/awslabs/aws-c-s3";
     license = licenses.asl20;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ r-burns ];
+    mainProgram = "s3";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/boolstuff/default.nix
+++ b/pkgs/development/libraries/boolstuff/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     homepage = "http://perso.b2b2c.ca/~sarrazip/dev/boolstuff.html";
     license = "GPL";
     maintainers = [ lib.maintainers.marcweber ];
+    mainProgram = "booldnf";
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/capstone/default.nix
+++ b/pkgs/development/libraries/capstone/default.nix
@@ -39,7 +39,8 @@ stdenv.mkDerivation rec {
     description = "Advanced disassembly library";
     homepage    = "http://www.capstone-engine.org";
     license     = lib.licenses.bsd3;
-    platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ris ];
+    mainProgram = "cstool";
+    platforms   = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/check/default.nix
+++ b/pkgs/development/libraries/check/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "https://libcheck.github.io/check/";
 
     license = licenses.lgpl2Plus;
+    mainProgram = "checkmk";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/faad2/default.nix
+++ b/pkgs/development/libraries/faad2/default.nix
@@ -21,8 +21,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An open source MPEG-4 and MPEG-2 AAC decoder";
+    homepage = "https://sourceforge.net/projects/faac/";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ codyopel ];
+    mainProgram = "faad";
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/fcgi/default.nix
+++ b/pkgs/development/libraries/fcgi/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     description = "A language independent, scalable, open extension to CG";
     homepage = "https://fastcgi-archives.github.io/"; # Formerly http://www.fastcgi.com/
     license = "FastCGI see LICENSE.TERMS";
+    mainProgram = "cgi-fcgi";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/flatbuffers/generic.nix
+++ b/pkgs/development/libraries/flatbuffers/generic.nix
@@ -38,9 +38,10 @@ stdenv.mkDerivation rec {
       access serialized data without unpacking/parsing it first, while still
       having great forwards/backwards compatibility.
     '';
-    maintainers = [ maintainers.teh ];
-    license = licenses.asl20;
-    platforms = platforms.unix;
     homepage = "https://google.github.io/flatbuffers/";
+    license = licenses.asl20;
+    maintainers = [ maintainers.teh ];
+    mainProgram = "flatc";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -149,8 +149,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A library for image loading and manipulation";
     homepage = "https://gitlab.gnome.org/GNOME/gdk-pixbuf";
-    maintainers = [ maintainers.eelco ] ++ teams.gnome.members;
     license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.eelco ] ++ teams.gnome.members;
+    mainProgram = "gdk-pixbuf-thumbnailer";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gensio/default.nix
+++ b/pkgs/development/libraries/gensio/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "https://sourceforge.net/projects/ser2net/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ emantor ];
+    mainProgram = "gensiot";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/glpk/default.nix
+++ b/pkgs/development/libraries/glpk/default.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
 
     maintainers = with maintainers; [ bjg ] ++ teams.sage.members;
+    mainProgram = "glpsol";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/keystone/default.nix
+++ b/pkgs/development/libraries/keystone/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.keystone-engine.org";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ luc65r ];
+    mainProgram = "kstool";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/ldns/default.nix
+++ b/pkgs/development/libraries/ldns/default.nix
@@ -42,9 +42,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Library with the aim of simplifying DNS programming in C";
-    license = licenses.bsd3;
     homepage = "http://www.nlnetlabs.nl/projects/ldns/";
-    platforms = platforms.unix;
+    license = licenses.bsd3;
     maintainers = with maintainers; [ dtzWill ];
+    mainProgram = "drill";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libargon2/default.nix
+++ b/pkgs/development/libraries/libargon2/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.argon2.com/";
     license = with licenses; [ asl20 cc0 ];
     maintainers = with maintainers; [ taeer olynch ];
+    mainProgram = "argon2";
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libaudec/default.nix
+++ b/pkgs/development/libraries/libaudec/default.nix
@@ -18,9 +18,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja pkg-config ];
 
   meta = with lib; {
-    homepage = "https://www.zrythm.org";
     description = "A library for reading and resampling audio files";
+    homepage = "https://www.zrythm.org";
     license = licenses.agpl3Plus;
+    mainProgram = "audec";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libb64/default.nix
+++ b/pkgs/development/libraries/libb64/default.nix
@@ -36,7 +36,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "ANSI C routines for fast base64 encoding/decoding";
+    homepage = "https://github.com/libb64/libb64";
     license = lib.licenses.publicDomain;
+    mainProgram = "base64";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libbencodetools/default.nix
+++ b/pkgs/development/libraries/libbencodetools/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/heikkiorsila/bencodetools";
     license = licenses.bsd2;
     maintainers = with maintainers; [ OPNA2608 ];
+    mainProgram = "bencat";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libburn/default.nix
+++ b/pkgs/development/libraries/libburn/default.nix
@@ -10,10 +10,11 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://libburnia-project.org/";
     description = "A library by which preformatted data get onto optical media: CD, DVD, BD (Blu-Ray)";
+    homepage = "http://libburnia-project.org/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ abbradar vrthra ];
+    mainProgram = "cdrskin";
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/development/libraries/libcddb/default.nix
+++ b/pkgs/development/libraries/libcddb/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     description = "C library to access data on a CDDB server (freedb.org)";
     homepage = "http://libcddb.sourceforge.net/";
     license = licenses.lgpl2Plus;
+    mainProgram = "cddb_query";
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libcdio-paranoia/default.nix
+++ b/pkgs/development/libraries/libcdio-paranoia/default.nix
@@ -28,9 +28,10 @@ stdenv.mkDerivation rec {
       This is a port of xiph.org's cdda paranoia to use libcdio for CDROM
       access. By doing this, cdparanoia runs on platforms other than GNU/Linux.
     '';
-    license = licenses.gpl3;
     homepage = "https://github.com/rocky/libcdio-paranoia";
-    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.gpl3;
     maintainers = [ ];
+    mainProgram = "cd-paranoia";
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libcmis/default.nix
+++ b/pkgs/development/libraries/libcmis/default.nix
@@ -25,8 +25,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "C++ client library for the CMIS interface";
-    homepage = "https://sourceforge.net/projects/libcmis/";
+    homepage = "https://github.com/tdf/libcmis";
     license = licenses.gpl2;
+    mainProgram = "cmis-client";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libdc1394/default.nix
+++ b/pkgs/development/libraries/libdc1394/default.nix
@@ -15,10 +15,11 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isDarwin CoreServices;
 
   meta = with lib; {
-    homepage = "https://sourceforge.net/projects/libdc1394/";
     description = "Capture and control API for IIDC compliant cameras";
+    homepage = "https://sourceforge.net/projects/libdc1394/";
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.viric ];
+    mainProgram = "dc1394_reset_bus";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libdigidoc/default.nix
+++ b/pkgs/development/libraries/libdigidoc/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
     description = "Library for creating DigiDoc signature files";
     homepage = "https://github.com/open-eid/libdigidoc";
     license = licenses.lgpl2;
-    platforms = platforms.unix;
     maintainers = [ maintainers.jagajaga ];
+    mainProgram = "cdigidoc";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libeatmydata/default.nix
+++ b/pkgs/development/libraries/libeatmydata/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     description = "Small LD_PRELOAD library to disable fsync and friends";
     homepage = "https://www.flamingspork.com/projects/libeatmydata/";
     license = licenses.gpl3Plus;
+    mainProgram = "eatmydata";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libee/default.nix
+++ b/pkgs/development/libraries/libee/default.nix
@@ -12,9 +12,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ libestr];
 
   meta = {
-    homepage = "http://www.libee.org/";
     description = "An Event Expression Library inspired by CEE";
-    platforms = lib.platforms.unix;
+    homepage = "http://www.libee.org/";
     license = lib.licenses.lgpl21Plus;
+    mainProgram = "libee-convert";
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libexttextcat/default.nix
+++ b/pkgs/development/libraries/libexttextcat/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An N-Gram-Based Text Categorization library primarily intended for language guessing";
     homepage = "https://wiki.documentfoundation.org/Libexttextcat";
-    platforms = platforms.all;
     license = licenses.bsd3;
+    mainProgram = "createfp";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl2Plus;
 
     maintainers = [ ];
+    mainProgram = "iconv";
 
     # This library is not needed on GNU platforms.
     hydraPlatforms = with lib.platforms; cygwin ++ darwin ++ freebsd;

--- a/pkgs/development/libraries/libirecovery/default.nix
+++ b/pkgs/development/libraries/libirecovery/default.nix
@@ -39,16 +39,17 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/libimobiledevice/libirecovery";
     description = "Library and utility to talk to iBoot/iBSS via USB on Mac OS X, Windows, and Linux";
     longDescription = ''
       libirecovery is a cross-platform library which implements communication to
       iBoot/iBSS found on Apple's iOS devices via USB. A command-line utility is also
       provided.
     '';
+    homepage = "https://github.com/libimobiledevice/libirecovery";
     license = licenses.lgpl21;
+    maintainers = with maintainers; [ nh2 ];
+    mainProgram = "irecovery";
     # Upstream description says it works on more platforms, but packager hasn't tried that yet
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ nh2 ];
   };
 }

--- a/pkgs/development/libraries/liblognorm/default.nix
+++ b/pkgs/development/libraries/liblognorm/default.nix
@@ -15,9 +15,10 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-regexp" ];
 
   meta = with lib; {
-    homepage = "https://www.liblognorm.com/";
     description = "Help to make sense out of syslog data, or, actually, any event data that is present in text form";
+    homepage = "https://www.liblognorm.com/";
     license = licenses.lgpl21;
+    mainProgram = "lognormalizer";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libmaxminddb/default.nix
+++ b/pkgs/development/libraries/libmaxminddb/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     description = "C library for working with MaxMind geolocation DB files";
     homepage = "https://github.com/maxmind/libmaxminddb";
     license = licenses.asl20;
-    platforms = platforms.all;
     maintainers = [ maintainers.vcunat ];
+    mainProgram = "mmdblookup";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libnatpmp/default.nix
+++ b/pkgs/development/libraries/libnatpmp/default.nix
@@ -22,10 +22,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://miniupnp.free.fr/libnatpmp.html";
     description = "NAT-PMP client";
+    homepage = "http://miniupnp.free.fr/libnatpmp.html";
     license = licenses.bsd3;
     maintainers = with maintainers; [ orivej ];
+    mainProgram = "natpmpc";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -61,10 +61,11 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://gitlab.gnome.org/GNOME/libnotify";
     description = "A library that sends desktop notifications to a notification daemon";
-    platforms = platforms.unix;
-    maintainers = teams.gnome.members;
+    homepage = "https://gitlab.gnome.org/GNOME/libnotify";
     license = licenses.lgpl21;
+    maintainers = teams.gnome.members;
+    mainProgram = "notify-send";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libpostal/default.nix
+++ b/pkgs/development/libraries/libpostal/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/openvenues/libpostal";
     license = licenses.mit;
     maintainers = [ maintainers.Thra11 ];
+    mainProgram = "libpostal_data";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libpsl/default.nix
+++ b/pkgs/development/libraries/libpsl/default.nix
@@ -85,7 +85,8 @@ in stdenv.mkDerivation rec {
     homepage = "https://rockdaboot.github.io/libpsl/";
     changelog = "https://raw.githubusercontent.com/rockdaboot/${pname}/${pname}-${version}/NEWS";
     license = licenses.mit;
-    platforms = platforms.unix;
     maintainers = [ maintainers.c0bw3b ];
+    mainProgram = "psl";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libqalculate/default.nix
+++ b/pkgs/development/libraries/libqalculate/default.nix
@@ -41,8 +41,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An advanced calculator library";
     homepage = "http://qalculate.github.io";
-    maintainers = with maintainers; [ gebner doronbehar ];
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ gebner doronbehar ];
+    mainProgram = "qalc";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libroxml/default.nix
+++ b/pkgs/development/libraries/libroxml/default.nix
@@ -10,10 +10,11 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://www.libroxml.net/";
     description = "This library is minimum, easy-to-use, C implementation for xml file parsing";
+    homepage = "https://www.libroxml.net/";
     license = licenses.lgpl3;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ mpickering ];
+    mainProgram = "roxml";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -146,6 +146,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Projects/LibRsvg";
     license = licenses.lgpl2Plus;
     maintainers = teams.gnome.members;
+    mainProgram = "rsvg-convert";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/librsync/default.nix
+++ b/pkgs/development/libraries/librsync/default.nix
@@ -17,9 +17,10 @@ stdenv.mkDerivation rec {
   dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
 
   meta = with lib; {
+    description = "Implementation of the rsync remote-delta algorithm";
     homepage = "http://librsync.sourceforge.net/";
     license = licenses.lgpl2Plus;
-    description = "Implementation of the rsync remote-delta algorithm";
+    mainProgram = "rdiff";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -110,6 +110,7 @@ stdenv.mkDerivation rec {
     description = "A library for storing and retrieving passwords and other secrets";
     homepage = "https://wiki.gnome.org/Projects/Libsecret";
     license = lib.licenses.lgpl21Plus;
+    mainProgram = "secret-tool";
     inherit (glib.meta) platforms maintainers;
   };
 }

--- a/pkgs/development/libraries/libshout/default.nix
+++ b/pkgs/development/libraries/libshout/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.icecast.org";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ jcumming ];
+    mainProgram = "shout";
     platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/development/libraries/libu2f-host/default.nix
+++ b/pkgs/development/libraries/libu2f-host/default.nix
@@ -24,9 +24,10 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = "https://developers.yubico.com/libu2f-host";
     description = "A C library and command-line tool that implements the host-side of the U2F protocol";
+    homepage = "https://developers.yubico.com/libu2f-host";
     license = with licenses; [ gpl3Plus lgpl21Plus ];
+    mainProgram = "u2f-host";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libubox/default.nix
+++ b/pkgs/development/libraries/libubox/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation {
     description = "C utility functions for OpenWrt";
     homepage = "https://git.openwrt.org/?p=project/libubox.git;a=summary";
     license = licenses.isc;
-    platforms = platforms.all;
     maintainers = with maintainers; [ fpletz ];
+    mainProgram = "jshn";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -21,12 +21,13 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = "https://github.com/Netflix/vmaf";
     description = "Perceptual video quality assessment based on multi-method fusion (VMAF)";
+    homepage = "https://github.com/Netflix/vmaf";
     changelog = "https://github.com/Netflix/vmaf/raw/v${version}/CHANGELOG.md";
-    platforms = platforms.unix;
     license = licenses.bsd2Patent;
     maintainers = [ maintainers.cfsmp3 maintainers.marsam ];
+    mainProgram = "vmaf";
+    platforms = platforms.unix;
   };
 
 }

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/xkbcommon/libxkbcommon/blob/xkbcommon-${version}/NEWS";
     license = licenses.mit;
     maintainers = with maintainers; [ primeos ttuegel ];
+    mainProgram = "xkbcli";
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/development/libraries/libxkbcommon/libxkbcommon_7.nix
+++ b/pkgs/development/libraries/libxkbcommon/libxkbcommon_7.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "https://xkbcommon.org";
     license = licenses.mit;
     maintainers = with maintainers; [ ttuegel ];
+    mainProgram = "xkbcli";
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/development/libraries/libxls/default.nix
+++ b/pkgs/development/libraries/libxls/default.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation rec {
     description = "Extract Cell Data From Excel xls files";
     homepage = "https://github.com/libxls/libxls";
     license = licenses.bsd2;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];
+    mainProgram = "xls2csv";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libykneomgr/default.nix
+++ b/pkgs/development/libraries/libykneomgr/default.nix
@@ -17,9 +17,10 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://developers.yubico.com/libykneomgr";
     description = "A C library to interact with the CCID-part of the Yubikey NEO";
+    homepage = "https://developers.yubico.com/libykneomgr";
     license = licenses.bsd3;
+    mainProgram = "ykneomgr";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/matio/default.nix
+++ b/pkgs/development/libraries/matio/default.nix
@@ -9,9 +9,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A C library for reading and writing Matlab MAT files";
-    license = licenses.bsd2;
-    platforms = platforms.all;
-    maintainers = [ maintainers.vbgl ];
     homepage = "http://matio.sourceforge.net/";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.vbgl ];
+    mainProgram = "matdump";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/md4c/default.nix
+++ b/pkgs/development/libraries/md4c/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/mity/md4c";
     description = "Markdown parser made in C";
     longDescription = ''
       MD4C is Markdown parser implementation in C, with the following features:
@@ -58,8 +57,10 @@ stdenv.mkDerivation rec {
         "Unicode"). See more details below.
       - Permissive license: MD4C is available under the MIT license.
     '';
+    homepage = "https://github.com/mity/md4c";
     license = licenses.mit;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "md2html";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/mongoc/default.nix
+++ b/pkgs/development/libraries/mongoc/default.nix
@@ -19,8 +19,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "The official C client library for MongoDB";
-    homepage = "https://github.com/mongodb/mongo-c-driver";
+    homepage = "http://mongoc.org";
     license = licenses.asl20;
+    mainProgram = "mongoc-stat";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/nanomsg/default.nix
+++ b/pkgs/development/libraries/nanomsg/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     description= "Socket library that provides several common communication patterns";
     homepage = "https://nanomsg.org/";
     license = licenses.mit;
+    mainProgram = "nanocat";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/ndpi/default.nix
+++ b/pkgs/development/libraries/ndpi/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.ntop.org/products/deep-packet-inspection/ndpi/";
     license = with licenses; [ lgpl3Plus bsd3 ];
     maintainers = with maintainers; [ takikawa ];
+    mainProgram = "ndpiReader";
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/development/libraries/pe-parse/default.nix
+++ b/pkgs/development/libraries/pe-parse/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     description = "A principled, lightweight parser for Windows portable executable files";
     homepage = "https://github.com/trailofbits/pe-parse";
     license = licenses.mit;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ arturcygan ];
+    mainProgram = "dump-pe";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/precice/default.nix
+++ b/pkgs/development/libraries/precice/default.nix
@@ -25,10 +25,11 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "preCICE stands for Precise Code Interaction Coupling Environment";
-    license = with lib.licenses; [ gpl3 ];
     homepage = "https://precice.org/";
-    platforms = lib.platforms.unix;
+    license = with lib.licenses; [ gpl3 ];
     maintainers = with lib.maintainers; [ Scriptkiddi ];
+    mainProgram = "binprecice";
+    platforms = lib.platforms.unix;
   };
 }
 

--- a/pkgs/development/libraries/proj-datumgrid/default.nix
+++ b/pkgs/development/libraries/proj-datumgrid/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
     description = "Repository for proj datum grids";
     homepage = "https://proj4.org";
     license = licenses.mit;
-    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ ];
+    mainProgram = "nad2bin";
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -48,9 +48,10 @@ mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
         yet extensible format. Google uses Protocol Buffers for almost all of
         its internal RPC protocols and file formats.
       '';
-    license = lib.licenses.bsd3;
-    platforms = lib.platforms.unix;
     homepage = "https://developers.google.com/protocol-buffers/";
+    license = lib.licenses.bsd3;
+    mainProgram = "protoc";
+    platforms = lib.platforms.unix;
   };
 
   passthru.version = version;

--- a/pkgs/development/libraries/rnnoise/default.nix
+++ b/pkgs/development/libraries/rnnoise/default.nix
@@ -18,10 +18,11 @@ stdenv.mkDerivation (rec {
   '';
 
   meta = with lib; {
-    homepage = "https://people.xiph.org/~jm/demo/rnnoise/";
     description = "Recurrent neural network for audio noise reduction";
+    homepage = "https://people.xiph.org/~jm/demo/rnnoise/";
     license = licenses.bsd3;
     maintainers = [ maintainers.nh2 ];
+    mainProgram = "rnnoise_demo";
     platforms = platforms.all;
   };
 })

--- a/pkgs/development/libraries/science/math/cliquer/default.nix
+++ b/pkgs/development/libraries/science/math/cliquer/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://users.aalto.fi/~pat/cliquer.html";
-    downloadPage = src.meta.homepage; # autocliquer
     description = "Routines for clique searching";
     longDescription = ''
       Cliquer is a set of C routines for finding cliques in an arbitrary weighted graph.
@@ -31,8 +29,11 @@ stdenv.mkDerivation rec {
       It is designed with the aim of being efficient while still being flexible and
       easy to use.
     '';
+    homepage = "https://users.aalto.fi/~pat/cliquer.html";
+    downloadPage = src.meta.homepage; # autocliquer
     license = licenses.gpl2Plus;
     maintainers = teams.sage.members;
+    mainProgram = "cl";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/flintqs/default.nix
+++ b/pkgs/development/libraries/science/math/flintqs/default.nix
@@ -30,10 +30,11 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = "https://github.com/sagemath/FlintQS";
     description = "Highly optimized multi-polynomial quadratic sieve for integer factorization";
+    homepage = "https://github.com/sagemath/FlintQS";
     license = with licenses; [ gpl2 ];
     maintainers = teams.sage.members;
+    mainProgram = "QuadraticSieve";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/serd/default.nix
+++ b/pkgs/development/libraries/serd/default.nix
@@ -14,10 +14,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config python3 wafHook ];
 
   meta = with lib; {
-    homepage = "http://drobilla.net/software/serd";
     description = "A lightweight C library for RDF syntax which supports reading and writing Turtle and NTriples";
+    homepage = "http://drobilla.net/software/serd";
     license = licenses.mit;
     maintainers = [ maintainers.goibhniu ];
+    mainProgram = "serdi";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -44,8 +44,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An advanced font engine";
-    maintainers = [ maintainers.raskin ];
-    platforms = platforms.unix;
+    homepage = "https://graphite.sil.org/";
     license = licenses.lgpl21;
+    maintainers = [ maintainers.raskin ];
+    mainProgram = "gr2fonttest";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/slang/default.nix
+++ b/pkgs/development/libraries/slang/default.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.jedsoft.org/slang/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "slsh";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/soundtouch/default.nix
+++ b/pkgs/development/libraries/soundtouch/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
     description = "A program and library for changing the tempo, pitch and playback rate of audio";
     homepage = "https://www.surina.net/soundtouch/";
     license = licenses.lgpl21Plus;
-    platforms = platforms.all;
     maintainers = with maintainers; [ orivej ];
+    mainProgram = "soundstretch";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/sqlite/tools.nix
+++ b/pkgs/development/libraries/sqlite/tools.nix
@@ -2,7 +2,7 @@
 
 let
   archiveVersion = import ./archive-version.nix lib;
-  mkTool = { pname, makeTarget, description, homepage }: stdenv.mkDerivation rec {
+  mkTool = { pname, makeTarget, description, homepage, mainProgram }: stdenv.mkDerivation rec {
     inherit pname;
     version = "3.38.2";
 
@@ -20,7 +20,7 @@ let
     installPhase = "install -Dt $out/bin ${makeTarget}";
 
     meta = with lib; {
-      inherit description homepage;
+      inherit description homepage mainProgram;
       downloadPage = "http://sqlite.org/download.html";
       license = licenses.publicDomain;
       maintainers = with maintainers; [ johnazoidberg ];
@@ -34,11 +34,13 @@ in
     makeTarget = "sqldiff";
     description = "A tool that displays the differences between SQLite databases";
     homepage = "https://www.sqlite.org/sqldiff.html";
+    mainProgram = "sqldiff";
   };
   sqlite-analyzer = mkTool {
     pname = "sqlite-analyzer";
     makeTarget = "sqlite3_analyzer";
     description = "A tool that shows statistics about SQLite databases";
     homepage = "https://www.sqlite.org/sqlanalyze.html";
+    mainProgram = "sqlite3_analyzer";
   };
 }

--- a/pkgs/development/libraries/stxxl/default.nix
+++ b/pkgs/development/libraries/stxxl/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/stxxl/stxxl";
     license = licenses.boost;
     maintainers = with maintainers; [ ];
+    mainProgram = "stxxl_tool";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/tecla/default.nix
+++ b/pkgs/development/libraries/tecla/default.nix
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://www.astro.caltech.edu/~mcs/tecla/";
     description = "Command-line editing library";
+    homepage = "https://www.astro.caltech.edu/~mcs/tecla/";
     license = "as-is";
-
+    mainProgram = "enhance";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/tre/default.nix
+++ b/pkgs/development/libraries/tre/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Lightweight and robust POSIX compliant regexp matching library";
     homepage = "https://laurikari.net/tre/";
-    platforms = lib.platforms.unix;
     license = lib.licenses.bsd2;
+    mainProgram = "agrep";
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -20,14 +20,15 @@ stdenv.mkDerivation rec {
   doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
 
   meta = with lib; {
-    homepage = "https://uriparser.github.io/";
     description = "Strictly RFC 3986 compliant URI parsing library";
     longDescription = ''
       uriparser is a strictly RFC 3986 compliant URI parsing and handling library written in C.
       API documentation is available on uriparser website.
     '';
+    homepage = "https://uriparser.github.io/";
     license = licenses.bsd3;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ bosu ];
+    mainProgram = "uriparse";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/xmlsec/default.nix
+++ b/pkgs/development/libraries/xmlsec/default.nix
@@ -68,10 +68,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    description = "XML Security Library in C based on libxml2";
     homepage = "http://www.aleksey.com/xmlsec";
     downloadPage = "https://www.aleksey.com/xmlsec/download.html";
-    description = "XML Security Library in C based on libxml2";
     license = lib.licenses.mit;
+    mainProgram = "xmlsec1";
     platforms = with lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/zlog/default.nix
+++ b/pkgs/development/libraries/zlog/default.nix
@@ -17,8 +17,9 @@ stdenv.mkDerivation rec {
     description= "Reliable, high-performance, thread safe, flexible, clear-model, pure C logging library";
     homepage = "https://hardysimpson.github.io/zlog/";
     license = licenses.lgpl21;
-    platforms = platforms.unix;
     maintainers = [ maintainers.matthiasbeyer ];
+    mainProgram = "zlog-chk-conf";
+    platforms = platforms.unix;
   };
 
 }

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -76,8 +76,9 @@ let
         '';
         homepage = "https://github.com/com-lihaoyi/Ammonite";
         license = licenses.mit;
-        platforms = platforms.all;
         maintainers = [ maintainers.nequissimus ];
+        mainProgram = "amm";
+        platforms = platforms.all;
       };
     };
 in {

--- a/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
@@ -40,10 +40,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "man" "info" ];
 
   meta = with lib; {
-    homepage = "https://www.gnu.org/software/make/";
     description = "A tool to control the generation of non-source files from sources";
-    license = licenses.gpl3Plus;
-
     longDescription = ''
       Make is a tool which controls the generation of executables and
       other non-source files of a program from the program's source files.
@@ -54,8 +51,11 @@ stdenv.mkDerivation rec {
       should write a makefile for it, so that it is possible to use Make
       to build and install the program.
     '';
+    homepage = "https://www.gnu.org/software/make/";
 
-    platforms = platforms.all;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.vrthra ];
+    mainProgram = "make";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -37,10 +37,7 @@ stdenv.mkDerivation rec {
   separateDebugInfo = true;
 
   meta = with lib; {
-    homepage = "https://www.gnu.org/software/make/";
     description = "A tool to control the generation of non-source files from sources";
-    license = licenses.gpl3Plus;
-
     longDescription = ''
       Make is a tool which controls the generation of executables and
       other non-source files of a program from the program's source files.
@@ -51,8 +48,11 @@ stdenv.mkDerivation rec {
       should write a makefile for it, so that it is possible to use Make
       to build and install the program.
     '';
+    homepage = "https://www.gnu.org/software/make/";
 
-    platforms = platforms.all;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.vrthra ];
+    mainProgram = "make";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/build-managers/jam/ftjam.nix
+++ b/pkgs/development/tools/build-managers/jam/ftjam.nix
@@ -42,10 +42,11 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = "https://freetype.org/jam/";
     description = "Freetype's enhanced, backwards-compatible Jam clone";
+    homepage = "https://freetype.org/jam/";
     license = licenses.free;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "jam";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/build-managers/samurai/default.nix
+++ b/pkgs/development/tools/build-managers/samurai/default.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/michaelforney/samurai";
     description = "ninja-compatible build tool written in C";
     longDescription = ''
       samurai is a ninja-compatible build tool with a focus on simplicity,
@@ -50,8 +49,10 @@ stdenv.mkDerivation rec {
       .ninja_deps as the original ninja tool, currently version 5 and 4
       respectively.
     '';
+    homepage = "https://github.com/michaelforney/samurai";
     license = with licenses; [ mit asl20 ]; # see LICENSE
     maintainers = with maintainers; [ dtzWill AndersonTorres ];
+    mainProgram = "samu";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/build-managers/sbt-extras/default.nix
+++ b/pkgs/development/tools/build-managers/sbt-extras/default.nix
@@ -67,11 +67,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description =
-      "A more featureful runner for sbt, the simple/scala/standard build tool";
+    description = "A more featureful runner for sbt, the simple/scala/standard build tool";
     homepage = "https://github.com/paulp/sbt-extras";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ nequissimus puffnfresh ];
+    mainProgram = "sbt";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/buildkit/default.nix
+++ b/pkgs/development/tools/buildkit/default.nix
@@ -24,5 +24,6 @@ buildGoModule rec {
     homepage = "https://github.com/moby/buildkit";
     license = licenses.asl20;
     maintainers = with maintainers; [ vdemeester marsam ];
+    mainProgram = "buildctl";
   };
 }

--- a/pkgs/development/tools/continuous-integration/jenkins/default.nix
+++ b/pkgs/development/tools/continuous-integration/jenkins/default.nix
@@ -69,7 +69,8 @@ stdenv.mkDerivation rec {
     description = "An extendable open source continuous integration server";
     homepage = "https://jenkins-ci.org";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ coconnor fpletz earldouglas nequissimus ];
+    mainProgram = "jenkins-cli";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/dapr/cli/default.nix
+++ b/pkgs/development/tools/dapr/cli/default.nix
@@ -28,9 +28,10 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    homepage = "https://dapr.io";
     description = "A CLI for managing Dapr, the distributed application runtime";
+    homepage = "https://dapr.io";
     license = licenses.mit;
     maintainers = with maintainers; [ lucperkins ];
+    mainProgram = "dapr";
   };
 }

--- a/pkgs/development/tools/ent/default.nix
+++ b/pkgs/development/tools/ent/default.nix
@@ -31,10 +31,11 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "An entity framework for Go";
+    homepage = "https://entgo.io/";
     downloadPage = "https://github.com/ent/ent";
     license = licenses.asl20;
-    homepage = "https://entgo.io/";
     maintainers = with maintainers; [ superherointj ];
+    mainProgram = "ent";
   };
 }
 

--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -27,9 +27,10 @@ stdenv.mkDerivation {
   dontFixup = true;
 
   meta = with lib; {
-    homepage = "https://www.gnu.org/software/gnulib/";
     description = "Central location for code to be shared among GNU packages";
+    homepage = "https://www.gnu.org/software/gnulib/";
     license = licenses.gpl3Plus;
+    mainProgram = "gnulib-tool";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/go-swag/default.nix
+++ b/pkgs/development/tools/go-swag/default.nix
@@ -20,5 +20,6 @@ buildGoModule rec {
     homepage = "https://github.com/swaggo/swag";
     license = licenses.mit;
     maintainers = with maintainers; [ stephenwithph ];
+    mainProgram = "swag";
   };
 }

--- a/pkgs/development/tools/goa/default.nix
+++ b/pkgs/development/tools/goa/default.nix
@@ -17,9 +17,10 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    homepage = "https://goa.design";
     description = "A framework for building microservices in Go using a unique design-first approach";
+    homepage = "https://goa.design";
     license = licenses.mit;
     maintainers = [ maintainers.rushmorem ];
+    mainProgram = "goagen";
   };
 }

--- a/pkgs/development/tools/jd-diff-patch/default.nix
+++ b/pkgs/development/tools/jd-diff-patch/default.nix
@@ -23,5 +23,6 @@ buildGoModule rec {
     homepage = "https://github.com/josephburnett/jd";
     license = licenses.mit;
     maintainers = with maintainers; [ bryanasdev000 blaggacao ];
+    mainProgram = "jd";
   };
 }

--- a/pkgs/development/tools/jmespath/default.nix
+++ b/pkgs/development/tools/jmespath/default.nix
@@ -16,7 +16,8 @@ buildGoPackage rec {
   meta = with lib; {
     description = "A JMESPath implementation in Go";
     homepage = "https://github.com/jmespath/go-jmespath";
-    maintainers = with maintainers; [ cransom ];
     license = licenses.asl20;
+    maintainers = with maintainers; [ cransom ];
+    mainProgram = "jpgo";
   };
 }

--- a/pkgs/development/tools/kustomize/3.nix
+++ b/pkgs/development/tools/kustomize/3.nix
@@ -36,5 +36,6 @@ buildGoModule rec {
     homepage = "https://github.com/kubernetes-sigs/kustomize";
     license = licenses.asl20;
     maintainers = with maintainers; [ carlosdagos vdemeester zaninime Chili-Man saschagrunert ];
+    mainProgram = "kustomize";
   };
 }

--- a/pkgs/development/tools/literate-programming/Literate/default.nix
+++ b/pkgs/development/tools/literate-programming/Literate/default.nix
@@ -18,8 +18,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "A literate programming tool for any language";
-    homepage    = "http://literate.zbyedidia.webfactional.com/";
+    homepage = "https://zyedidia.github.io/literate/";
     license = licenses.mit;
+    mainProgram = "lit";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/chruby/default.nix
+++ b/pkgs/development/tools/misc/chruby/default.nix
@@ -37,7 +37,8 @@ in stdenv.mkDerivation rec {
     description = "Changes the current Ruby";
     homepage = "https://github.com/postmodern/chruby";
     license = licenses.mit;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan ];
+    mainProgram = "chruby-exec";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -19,9 +19,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-syscmd-shell=${stdenv.shell}" ];
 
   meta = {
-    homepage = "https://www.gnu.org/software/m4/";
     description = "GNU M4, a macro processor";
-
     longDescription = ''
       GNU M4 is an implementation of the traditional Unix macro
       processor.  It is mostly SVR4 compatible although it has some
@@ -38,8 +36,10 @@ stdenv.mkDerivation rec {
       recursion etc...  m4 can be used either as a front-end to a
       compiler or as a macro processor in its own right.
     '';
+    homepage = "https://www.gnu.org/software/m4/";
 
     license = lib.licenses.gpl3Plus;
+    mainProgram = "m4";
     platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 

--- a/pkgs/development/tools/misc/premake/default.nix
+++ b/pkgs/development/tools/misc/premake/default.nix
@@ -23,10 +23,11 @@ stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   meta = with lib; {
-    homepage = "https://premake.github.io/";
     description = "A simple build configuration and project generation tool using lua";
+    homepage = "https://premake.github.io/";
     license = lib.licenses.bsd3;
-    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
+    mainProgram = "premake4";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/watson-ruby/default.nix
+++ b/pkgs/development/tools/misc/watson-ruby/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://goosecode.com/watson/";
     license     = with licenses; mit;
     maintainers = with maintainers; [ robertodr nicknovitski ];
+    mainProgram = "watson";
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -46,7 +46,8 @@ in rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://github.com/rust-lang/rust-bindgen";
     license = with licenses; [ bsd3 ];
-    platforms = platforms.unix;
     maintainers = with maintainers; [ johntitor ralith ];
+    mainProgram = "bindgen";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -61,5 +61,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://rust-analyzer.github.io";
     license = with licenses; [ mit asl20 ];
     maintainers = with maintainers; [ oxalica ];
+    mainProgram = "rust-analyzer";
   };
 }

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -33,8 +33,9 @@ in stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.seleniumhq.org/";
     description = "Selenium Server for remote WebDriver";
-    maintainers = with maintainers; [ coconnor offline ];
-    platforms = platforms.all;
     license = licenses.asl20;
+    maintainers = with maintainers; [ coconnor offline ];
+    mainProgram = "selenium-server";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/web/lucky-cli/default.nix
+++ b/pkgs/development/web/lucky-cli/default.nix
@@ -33,11 +33,11 @@ crystal.buildCrystalPackage rec {
   '';
 
   meta = with lib; {
-    description =
-      "A Crystal library for creating and running tasks. Also generates Lucky projects";
+    description = "A Crystal library for creating and running tasks. Also generates Lucky projects";
     homepage = "https://luckyframework.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
+    mainProgram = "lucky";
     platforms = platforms.unix;
     broken = lib.versionOlder crystal.version "0.35.1";
   };

--- a/pkgs/development/web/shopify-cli/default.nix
+++ b/pkgs/development/web/shopify-cli/default.nix
@@ -27,8 +27,9 @@ stdenv.mkDerivation rec {
     description = "CLI which helps you build against the Shopify platform faster";
     homepage    = "https://github.com/Shopify/shopify-cli";
     license     = licenses.mit;
-    platforms = ruby.meta.platforms;
     maintainers = with maintainers; [ onny ];
+    mainProgram = "shopify";
+    platforms = ruby.meta.platforms;
   };
 }
 

--- a/pkgs/games/bugdom/default.nix
+++ b/pkgs/games/bugdom/default.nix
@@ -57,10 +57,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A port of Bugdom, a 1999 Macintosh game by Pangea Software, for modern operating systems";
     homepage = "https://github.com/jorio/Bugdom";
-    license = with licenses; [
-      cc-by-sa-40
-    ];
+    license = with licenses; [ cc-by-sa-40 ];
     maintainers = with maintainers; [ lux ];
+    mainProgram = "Bugdom";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/games/r2mod_cli/default.nix
+++ b/pkgs/games/r2mod_cli/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/foldex/r2mod_cli";
     license = licenses.gpl3Only;
     maintainers = [ maintainers.reedrw ];
+    mainProgram = "r2mod";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/games/tcl2048/default.nix
+++ b/pkgs/games/tcl2048/default.nix
@@ -21,7 +21,8 @@ tcl.mkTclDerivation rec {
     homepage = "https://github.com/dbohdan/2048.tcl";
     description = "The game of 2048 implemented in Tcl";
     license = lib.licenses.mit;
-    platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ dbohdan ];
+    mainProgram = "2048";
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/misc/openrussian-cli/default.nix
+++ b/pkgs/misc/openrussian-cli/default.nix
@@ -49,10 +49,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage    = "https://github.com/rhaberkorn/openrussian-cli";
     description = "Offline Console Russian Dictionary (based on openrussian.org)";
+    homepage    = "https://github.com/rhaberkorn/openrussian-cli";
     license     = with licenses; [ gpl3Only mit cc-by-sa-40 ];
     maintainers = with maintainers; [ zane ];
+    mainProgram = "openrussian";
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/misc/platformsh/default.nix
+++ b/pkgs/misc/platformsh/default.nix
@@ -42,9 +42,10 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "The unified tool for managing your Platform.sh services from the command line.";
-    license = licenses.mit;
     homepage = "https://github.com/platformsh/platformsh-cli";
+    license = licenses.mit;
     maintainers = with maintainers; [ shyim ];
+    mainProgram = "platform";
     platforms = platforms.all;
   };
 }

--- a/pkgs/misc/screensavers/pipes/default.nix
+++ b/pkgs/misc/screensavers/pipes/default.nix
@@ -22,10 +22,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/pipeseroni/pipes.sh";
     description = "Animated pipes terminal screensaver";
+    homepage = "https://github.com/pipeseroni/pipes.sh";
     license = licenses.mit;
     maintainers = [ maintainers.matthiasbeyer ];
+    mainProgram = "pipes.sh";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/exhibitor/default.nix
+++ b/pkgs/servers/exhibitor/default.nix
@@ -37,9 +37,10 @@ stdenv.mkDerivation rec {
       mvn package --offline -Dmaven.repo.local=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
   '';
   meta = with lib; {
-    homepage = "https://github.com/soabase/exhibitor";
     description = "ZooKeeper co-process for instance monitoring, backup/recovery, cleanup and visualization";
+    homepage = "https://github.com/soabase/exhibitor";
     license = licenses.asl20;
+    mainProgram = "startExhibitor.sh";
     platforms = platforms.unix;
   };
 

--- a/pkgs/servers/gotify/default.nix
+++ b/pkgs/servers/gotify/default.nix
@@ -54,6 +54,7 @@ buildGoModule rec {
     homepage = "https://gotify.net";
     license = licenses.mit;
     maintainers = with maintainers; [ doronbehar ];
+    mainProgram = "server";
   };
 
 }

--- a/pkgs/servers/icingaweb2/default.nix
+++ b/pkgs/servers/icingaweb2/default.nix
@@ -29,7 +29,8 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "https://www.icinga.com/products/icinga-web-2/";
     license = licenses.gpl2Only;
-    platforms = platforms.all;
     maintainers = with maintainers; [ das_j ];
+    mainProgram = "icingacli";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/mail/opensmtpd/filter-rspamd.nix
+++ b/pkgs/servers/mail/opensmtpd/filter-rspamd.nix
@@ -22,9 +22,10 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    homepage = "https://github.com/poolpOrg/filter-rspamd";
     description = "OpenSMTPD filter integration for the Rspamd daemon";
+    homepage = "https://github.com/poolpOrg/filter-rspamd";
     license = licenses.isc;
     maintainers = with maintainers; [ Flakebi ];
+    mainProgram = "filter-rspamd";
   };
 }

--- a/pkgs/servers/monitoring/prometheus/json-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/json-exporter.nix
@@ -20,5 +20,6 @@ buildGoModule rec {
     homepage = "https://github.com/prometheus-community/json_exporter";
     license = licenses.asl20;
     maintainers = with maintainers; [ willibutz ];
+    mainProgram = "json_exporter";
   };
 }

--- a/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
@@ -20,6 +20,7 @@ buildGoModule rec {
     homepage = "https://github.com/xperimental/nextcloud-exporter";
     license = licenses.mit;
     maintainers = with maintainers; [ willibutz ];
+    mainProgram = "nextcloud-exporter";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/t-rex/default.nix
+++ b/pkgs/servers/t-rex/default.nix
@@ -23,6 +23,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/t-rex-tileserver/t-rex/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
+    mainProgram = "t_rex";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/unifiedpush-common-proxies/default.nix
+++ b/pkgs/servers/unifiedpush-common-proxies/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/UnifiedPush/common-proxies";
     license = licenses.mit;
     maintainers = with maintainers; [ yuka ];
+    mainProgram = "up_rewrite";
   };
 }

--- a/pkgs/servers/web-apps/engelsystem/default.nix
+++ b/pkgs/servers/web-apps/engelsystem/default.nix
@@ -42,9 +42,10 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description =
       "Coordinate your volunteers in teams, assign them to work shifts or let them decide for themselves when and where they want to help with what";
-    license = licenses.gpl2;
     homepage = "https://engelsystem.de";
+    license = licenses.gpl2;
     maintainers = with maintainers; [ kloenk ];
+    mainProgram = "migrate";
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -46,5 +46,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://join-lemmy.org/";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ happysalada ];
+    mainProgram = "lemmy_server";
   };
 }

--- a/pkgs/servers/web-apps/vikunja/api.nix
+++ b/pkgs/servers/web-apps/vikunja/api.nix
@@ -52,6 +52,7 @@ buildGoModule rec {
     homepage = "https://vikunja.io/";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ em0lar ];
+    mainProgram = "vikunja";
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/shells/zsh/zplug/default.nix
+++ b/pkgs/shells/zsh/zplug/default.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
     description = "A next-generation plugin manager for zsh";
     homepage = "https://github.com/zplug/zplug";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = [ maintainers.s1341 ];
+    mainProgram = "zplug-env";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/shells/zsh/zsh-history/default.nix
+++ b/pkgs/shells/zsh/zsh-history/default.nix
@@ -25,10 +25,11 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "A CLI to provide enhanced history for your ZSH shell";
-    license = licenses.mit;
     homepage = "https://github.com/b4b4r07/history";
-    platforms = platforms.unix;
+    license = licenses.mit;
     maintainers = with maintainers; [ ];
+    mainProgram = "history";
+    platforms = platforms.unix;
   };
 
   passthru.tests = {

--- a/pkgs/tools/archivers/gnutar/default.nix
+++ b/pkgs/tools/archivers/gnutar/default.nix
@@ -45,9 +45,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = false; # fails
 
   meta = {
-    homepage = "https://www.gnu.org/software/tar/";
     description = "GNU implementation of the `tar' archiver";
-
     longDescription = ''
       The Tar program provides the ability to create tar archives, as
       well as various other kinds of manipulation.  For example, you
@@ -62,10 +60,12 @@ stdenv.mkDerivation rec {
       pipes), it can even access remote devices or files (as
       archives).
     '';
+    homepage = "https://www.gnu.org/software/tar/";
 
     license = lib.licenses.gpl3Plus;
 
     maintainers = [ ];
+    mainProgram = "tar";
     platforms = lib.platforms.all;
 
     priority = 10;

--- a/pkgs/tools/audio/glyr/default.nix
+++ b/pkgs/tools/audio/glyr/default.nix
@@ -16,10 +16,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ sqlite glib curl ];
 
   meta = with lib; {
-    license = licenses.lgpl3;
     description = "A music related metadata searchengine";
     homepage = "https://github.com/sahib/glyr";
+    license = licenses.lgpl3;
     maintainers = [ maintainers.sternenseemann ];
+    mainProgram = "glyrc";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/compression/xdelta/default.nix
+++ b/pkgs/tools/compression/xdelta/default.nix
@@ -56,6 +56,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage = "http://xdelta.org/";
     license = licenses.gpl2Plus;
+    mainProgram = "xdelta3";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/compression/xdelta/unstable.nix
+++ b/pkgs/tools/compression/xdelta/unstable.nix
@@ -60,6 +60,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage = "http://xdelta.org/";
     license = licenses.gpl2Plus;
+    mainProgram = "xdelta3";
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/anystyle-cli/default.nix
+++ b/pkgs/tools/misc/anystyle-cli/default.nix
@@ -38,6 +38,7 @@ buildRubyGem rec {
     homepage    = "https://anystyle.io/";
     license     = licenses.bsd2;
     maintainers = with maintainers; [ shamilton ];
+    mainProgram = "anystyle";
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/didyoumean/default.nix
+++ b/pkgs/tools/misc/didyoumean/default.nix
@@ -28,5 +28,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/hisbaan/didyoumean";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ evanjs ];
+    mainProgram = "dym";
   };
 }

--- a/pkgs/tools/misc/go.rice/default.nix
+++ b/pkgs/tools/misc/go.rice/default.nix
@@ -16,9 +16,10 @@ buildGoModule rec {
   subPackages = [ "." "rice" ];
 
   meta = with lib; {
-    homepage = "https://github.com/GeertJohan/go.rice";
     description = "A Go package that makes working with resources such as html, js, css, images, templates very easy";
+    homepage = "https://github.com/GeertJohan/go.rice";
     license = licenses.bsd2;
     maintainers = with maintainers; [ blaggacao ];
+    mainProgram = "rice";
   };
 }

--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation rec {
     description = "Open source log management solution";
     homepage    = "https://www.graylog.org/";
     license     = licenses.gpl3;
-    platforms   = platforms.unix;
     maintainers = [ maintainers.fadenb ];
+    mainProgram = "graylogctl";
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/mysql2pgsql/default.nix
+++ b/pkgs/tools/misc/mysql2pgsql/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     description = "Convert MySQL dump files to PostgreSQL-loadable files";
     homepage = "https://pgfoundry.org/projects/mysql2pgsql/";
     license = lib.licenses.bsdOriginal;
+    mainProgram = "mysql2psql";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/misc/opentelemetry-collector/contrib.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/contrib.nix
@@ -31,8 +31,6 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/open-telemetry/opentelemetry-collector-contrib";
-    changelog = "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v${version}/CHANGELOG.md";
     description = "OpenTelemetry Collector superset with additional community collectors";
     longDescription = ''
       The OpenTelemetry Collector offers a vendor-agnostic implementation on how
@@ -44,7 +42,10 @@ buildGoModule rec {
       components that are only useful to a relatively small number of users and
       is multiple times larger as a result.
     '';
+    homepage = "https://github.com/open-telemetry/opentelemetry-collector-contrib";
+    changelog = "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ uri-canva jk ];
+    mainProgram = "otelcontribcol";
   };
 }

--- a/pkgs/tools/misc/wakatime/default.nix
+++ b/pkgs/tools/misc/wakatime/default.nix
@@ -23,5 +23,6 @@ buildGoModule rec {
       to install the wakatime CLI interface manually.
     '';
     license = licenses.bsd3;
+    mainProgram = "wakatime-cli";
   };
 }

--- a/pkgs/tools/misc/zsh-autoenv/default.nix
+++ b/pkgs/tools/misc/zsh-autoenv/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
       variables (overwriting and restoring).
     '';
     homepage = "https://github.com/Tarrasch/zsh-autoenv";
+    mainProgram = "zsh-autoenv-share";
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -16,5 +16,6 @@ buildGoModule rec {
     description = "A pluggable transport proxy";
     homepage = "https://www.torproject.org/projects/obfsproxy";
     maintainers = with maintainers; [ thoughtpolice ];
+    mainProgram = "obfs4proxy";
   };
 }

--- a/pkgs/tools/networking/ooniprobe-cli/default.nix
+++ b/pkgs/tools/networking/ooniprobe-cli/default.nix
@@ -23,5 +23,6 @@ buildGoModule rec {
     homepage = "https://ooni.org/install/cli";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dotlambda ];
+    mainProgram = "ooniprobe";
   };
 }

--- a/pkgs/tools/networking/samplicator/default.nix
+++ b/pkgs/tools/networking/samplicator/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     description = "Send copies of (UDP) datagrams to multiple receivers";
     homepage = "https://github.com/sleinen/samplicator/";
     license = lib.licenses.gpl2Plus;
+    mainProgram = "samplicate";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/networking/slack-cli/default.nix
+++ b/pkgs/tools/networking/slack-cli/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
   meta = {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.qyliss ];
+    mainProgram = "slack";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/networking/tinc/default.nix
+++ b/pkgs/tools/networking/tinc/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     '';
     homepage="http://www.tinc-vpn.org/";
     license = lib.licenses.gpl2Plus;
+    mainProgram = "tincd";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/nix/nixos-generators/default.nix
+++ b/pkgs/tools/nix/nixos-generators/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/nix-community/nixos-generators";
     license     = licenses.mit;
     maintainers = with maintainers; [ lassulus ];
+    mainProgram = "nixos-generate";
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -40,9 +40,10 @@ stdenv.mkDerivation {
 
       supergenpass will ask for your master password interactively, and it will not be displayed on your terminal.
     '';
-    license = licenses.mit;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ fgaz ];
     homepage = "https://github.com/lanzz/bash-supergenpass";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+    mainProgram = "supergenpass";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -95,5 +95,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://sequoia-pgp.org/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ minijackson doronbehar ];
+    mainProgram = "sq";
   };
 }

--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -52,10 +52,11 @@ stdenv.mkDerivation rec {
   passthru.updateScript = ./update-bin.sh;
 
   meta = with lib; {
-    homepage = "https://www.vaultproject.io";
     description = "A tool for managing secrets, this binary includes the UI";
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
+    homepage = "https://www.vaultproject.io";
     license = licenses.mpl20;
     maintainers = with maintainers; teams.serokell.members ++ [ offline psyanticy Chili-Man techknowlogick ];
+    mainProgram = "vault";
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
   };
 }

--- a/pkgs/tools/system/nkeys/default.nix
+++ b/pkgs/tools/system/nkeys/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/nats-io/nkeys";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "nk";
   };
 }

--- a/pkgs/tools/system/taskspooler/default.nix
+++ b/pkgs/tools/system/taskspooler/default.nix
@@ -23,9 +23,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Simple single node task scheduler";
-    license = licenses.gpl2Plus;
     homepage = "https://vicerveza.homeunix.net/~viric/wsgi-bin/hgweb.wsgi/ts";
-    platforms = platforms.unix;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.sheepforce ];
+    mainProgram = "ts";
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/text/discount/default.nix
+++ b/pkgs/tools/text/discount/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.pell.portland.or.us/~orc/Code/discount/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ shell ];
+    mainProgram = "markdown";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/text/replace/default.nix
+++ b/pkgs/tools/text/replace/default.nix
@@ -27,8 +27,9 @@ stdenv.mkDerivation rec {
   patches = [./malloc.patch];
 
   meta = {
-    homepage = "https://replace.richardlloyd.org.uk/";
     description = "A tool to replace verbatim strings";
+    homepage = "https://replace.richardlloyd.org.uk/";
+    mainProgram = "replace-literal";
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

Following on from my efforts in #166865, I refined my hacky script and I've been able to find an additional 167 packages that provide a single binary whose name differs from the package's name in `nixpkgs` (or the package's `pname`) and so don't work with `nix run`.

The `mainProgram` additions in 16e15fa68f0247d1ccc9bf94e2906097bcaa2d5c should be pretty boring and uncontroversial. 

I separated out additions of `mainProgram` to files located in `pkgs/development/libraries/` into a separate commit (9e4be532219685cdd81e4db54f9fc061d250ba25) since a lot of these required more judgement. I think it makes sense for many of these packages to include a `mainProgram` as they often provide a single binary utility as part of the package that folks might want to use. However, in some cases it's pretty marginal. For those cases, I looked into the functionality of the binary and what it's used for, and made a judgment call. (I did err on the side of adding `mainProgram` in a lot of the marginal cases since it does little to no harm, but there were many cases where I left it off since it made no sense.)

Finally I made separate commit for `nimble-unwrapped` (d8da6a153b7951f55f4e0243047ad4ae644b4ed5) since I added a new `meta` attribute set since it was missing entirely.

I've gone through these changes pretty carefully, but a couple more skims for others is probably in order as a sanity check.

(While I was at it, I also ended up tweaking the order of the `meta` attributes to my understanding of which order is best practice, as well as updating some of the homepages and adding some when they were missing.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
