### PR TITLE
spago: 0.20.8 -> 0.20.9

### DIFF
--- a/pkgs/development/tools/purescript/spago/spago.nix
+++ b/pkgs/development/tools/purescript/spago/spago.nix
@@ -14,11 +14,11 @@
 }:
 mkDerivation {
   pname = "spago";
-  version = "0.20.8";
+  version = "0.20.9";
   src = fetchgit {
     url = "https://github.com/purescript/spago.git";
-    sha256 = "0lakss2pg5kwbxqsmvzgkcc70l6j40cj9rarhkpcf0kxw98bb5x0";
-    rev = "744bdbbefc538750d4c36888ee53dc5d336314c4";
+    sha256 = "00vdqg7vaw3d9zwh47886lw9fhhlwjagzhaj3aqz4xm92pjavhih";
+    rev = "d16d4914200783fbd820ba89dbdf67270454faf5";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/pkgs/development/tools/purescript/spago/update.sh
+++ b/pkgs/development/tools/purescript/spago/update.sh
@@ -33,4 +33,7 @@ cabal2nix --revision "$new_version" "https://github.com/purescript/spago.git" >>
 # TODO: This should ideally also automatically update the docsSearchVersion
 # from pkgs/development/haskell/configuration-nix.nix.
 
-echo "Finished."
+echo
+echo "Finished.  Make sure you run the following commands to confirm Spago builds correctly:"
+echo ' - `nix build -L -f ./. spago`'
+echo ' - `sudo nix build -L -f ./. spago.passthru.tests --option sandbox relaxed`'


### PR DESCRIPTION
###### Description of changes

Update `spago` from 0.20.8 to 0.20.9:
<https://github.com/purescript/spago/blob/d16d4914200783fbd820ba89dbdf67270454faf5/CHANGELOG.md#0209---2022-05-03>

cc @f-f

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
