### PR TITLE
libqrtr-glib: only enable gtk-doc when not cross-compiling

### DIFF
--- a/pkgs/development/libraries/libqrtr-glib/default.nix
+++ b/pkgs/development/libraries/libqrtr-glib/default.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "MNh5sq3m+PRh3vOmd3VdtcAji6v2iNXIPAOz5qvjXO4=";
   };
 
+  strictDeps = true;
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     pkg-config
     gobject-introspection
@@ -32,7 +38,7 @@ stdenv.mkDerivation rec {
     glib
   ];
 
-  configureFlags = [
+  configureFlags = lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
     "--enable-gtk-doc"
   ];
 


### PR DESCRIPTION
###### Description of changes

Otherwise this error is shown when cross-compiling:

configure: WARNING:
  You will not be able to create source packages with 'make dist'
  because gtk-doc >= 1.0 is not found.
checking for gtkdoc-check... gtkdoc-check.test
checking for gtkdoc-check... /nix/store/c54j3jcj3cijg9kf54lcr94lsc09xd4r-gtk-doc-1.33.2/bin/gtkdoc-check
checking for gtkdoc-rebase... /nix/store/c54j3jcj3cijg9kf54lcr94lsc09xd4r-gtk-doc-1.33.2/bin/gtkdoc-rebase
checking for gtkdoc-mkpdf... /nix/store/c54j3jcj3cijg9kf54lcr94lsc09xd4r-gtk-doc-1.33.2/bin/gtkdoc-mkpdf
checking whether to build gtk-doc documentation... yes
configure: error:
  You must have gtk-doc >= 1.0 installed to build documentation for
  libqrtr-glib. Please install gtk-doc or disable building the
  documentation by adding '--disable-gtk-doc' to ### './configure'.

(Note that gtk-doc has issues regardless when cross-compiling, so it's preferable to not have it enabled anyway when cross-compiling, even if it could be found.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (no change)
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

