### PR TITLE
luau: init at 0.525

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1360,6 +1360,12 @@
       fingerprint = "A3E1 C409 B705 50B3 BF41  492B 5684 0A61 4DBE 37AE";
     }];
   };
+  basicer = {
+    email = "basicer@gmail.com";
+    github = "basicer";
+    githubId = 671513;
+    name = "Rob Blanckaert";
+  };
   basvandijk = {
     email = "v.dijk.bas@gmail.com";
     github = "basvandijk";

--- a/pkgs/development/interpreters/luau/default.nix
+++ b/pkgs/development/interpreters/luau/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "luau";
+  version = "0.525";
+
+  src = fetchFromGitHub {
+    owner = "roblox";
+    repo = "luau";
+    rev = version;
+    sha256 = "sha256-6317vVWfih3YRj/dINhA74F5Fiu/p06an46yGFYZ7Qg=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    install -Dm755 luau $out/bin/luau
+    install -Dm755 luau-analyze $out/bin/luau-analyze
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    ./Luau.UnitTest && ./Luau.Conformance
+  '';
+
+  meta = {
+    homepage = "https://luau-lang.org";
+    description = "A fast, small, safe, gradually typed embeddable scripting language derived from Lua";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.basicer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14252,6 +14252,8 @@ with pkgs;
     lua = lua5_1; # doesn't work with any other :(
   };
 
+  luau = callPackage ../development/interpreters/luau { };
+
   ### END OF LUA
 
   ### CuboCore


### PR DESCRIPTION
###### Description of changes

[Luau](https://github.com/roblox/luau) - A fast, small, safe, gradually typed embeddable scripting language derived from Lua

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
