### PR TITLE
nixos/utils: Let escapeSystemdPath be correct for more paths

### DIFF
--- a/nixos/tests/systemd-escaping.nix
+++ b/nixos/tests/systemd-escaping.nix
@@ -10,6 +10,24 @@ let
   # deliberately using a local empty file instead of pkgs.emptyFile to have
   # a non-store path in the test
   args = [ "a%Nything" "lang=\${LANG}" ";" "/bin/sh -c date" ./empty-file 4.2 23 ];
+
+  testPaths = [
+    "/"
+    "/dev/input/event0"
+    "/home/user/My Documents"
+    "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-9/3-9.3/3-9.3.2/3-9.3.2.3/3-9.3.2.3:1.0/0003:3297:4976.0030/input/input71/event23"
+    "/mnt/2+2"
+    "/mnt/result=4"
+    "/usr/bin/pg_dump"
+    "/tmp/"
+    "/.Trash-1000"
+    # systemd-escape -p warns that this path can't be reversed, but it's still valid input
+    ""
+    # # Test disabled: result should be home-p\xc3\xb6ttering
+    # "/home/pöttering"
+    # # Test disabled: result should be tmp-waldi-foobar
+    # "/tmp//waldi/foobar/"
+  ];
 in
 {
   name = "systemd-escaping";
@@ -27,10 +45,23 @@ in
           ${echoAll} ${utils.escapeSystemdExecArgs args}
         '';
       };
+
+    systemd.services.echo-paths =
+      assert !(builtins.tryEval (utils.escapeSystemdPath null)).success;
+      { description = "Echo path test results to the journal";
+        serviceConfig.Type = "oneshot";
+        script = lib.concatImapStringsSep "\n"
+          (i: path: ''
+            printf 'test ${toString i}:\t%s\n' '${path}'
+            printf 'expect:\t%s\n' $(2>/dev/null ${pkgs.systemd}/bin/systemd-escape -p '${path}')
+            printf 'actual:\t%s\n' '${utils.escapeSystemdPath path}'
+          '') testPaths;
+      };
   };
 
   testScript = ''
     machine.wait_for_unit("multi-user.target")
+
     machine.succeed("systemctl start echo.service")
     # skip the first 'Starting <service> ...' line
     logs = machine.succeed("journalctl -u echo.service -o cat").splitlines()[1:]
@@ -41,5 +72,16 @@ in
     assert "/nix/store/ij3gw72f4n5z4dz6nnzl1731p9kmjbwr-empty-file" == logs[4]
     assert "4.2" in logs[5] # toString produces extra fractional digits!
     assert "23" == logs[6]
+
+    machine.succeed("systemctl start echo-paths.service")
+    num_tests = ${toString (builtins.length testPaths)}
+    # skip the first 'Starting <service> ...' line
+    logs = machine.succeed("journalctl -u echo-paths.service -o cat").splitlines()[1:]
+    # for each group of 3 log lines make a dictionary of test/expected/actual
+    results = [dict(tuple(log.split(":", 1)) for log in logs[i:i+3]) for i in range(0, num_tests*3, 3)]
+    assert len(results) == num_tests, "Incorrect number of test results found in journal"
+    # test actual == expected for each test case
+    for result in results:
+        assert result["actual"] == result["expect"], "Expected {expect}, got {actual}".format(**result)
   '';
 })


### PR DESCRIPTION
###### Description of changes

I was working with the systemd services for `networking.wireguard.interfaces.<name>.peers.*` and noticed that `utils.escapeSystemdPath` didn't escape + or =.

This commit expands the range of characters which `escapeSystemdPath` can correctly escape. It also adds some type checking, plus handling of a trailing slash, leading dot, and the special case for /.

`escapeSystemdPath` is now defined in terms of a new function `escapeSystemd`.

Some unit tests have been added to the nixos tests.

I have removed the "FIXME: slow" comment because I believe that it is less relevant now than previously. This is because `escapeSystemdPath` was last touched in 3f6d53cc972fe8bf34b5cb0184087d95c1130c1d (2012-10-13). But since then, `replaceChars` was modified to use the `replaceStrings` primop in 9cfd128a4219ba9d1d143852fdf25be0710f97f3 (2015-07-24). Is this correct, @edolstra?

Finally, I added some code comments and a `traceIf` warning for the situations where `escapeSystemdPath` still doesn't return correct results. I don't believe it's feasible to make a pure nix `escapeSystemdPath` 100% correct, nor is it really necessary. But if correctness is truly needed, then the best way is probably by adding a new builtin function to nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages. ⇒ I _think_ this is N/A, right?
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
