### PR TITLE
snort3: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14679,6 +14679,16 @@
     githubId = 32876;
     name = "Diego Zamboni";
   };
+  zzschmidc = {
+    name = "Christian Schmid";
+    email = "christian@schmid.nu";
+    github = "zzschmidc";
+    githubId = 6686119;
+    keys = [{
+      longkeyid = "rsa4096/0x705DA16CA644E62A";
+      fingerprint = "1C21 D23F 3679 BB40 29B1  20A9 705D A16C A644 E62A";
+    }];
+  };
   turbomack = {
     email = "marek.faj@gmail.com";
     github = "turboMaCk";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -926,6 +926,7 @@
   ./services/networking/snowflake-proxy.nix
   ./services/networking/smartdns.nix
   ./services/networking/smokeping.nix
+  ./services/networking/snort3.nix
   ./services/networking/softether.nix
   ./services/networking/solanum.nix
   ./services/networking/soju.nix

--- a/nixos/modules/services/networking/snort3.nix
+++ b/nixos/modules/services/networking/snort3.nix
@@ -1,0 +1,329 @@
+{ config, lib, utils, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.snort3;
+
+  makeNet = (l: if builtins.elem "any" l then "'any'" else
+  "'[[ ${removeSuffix " " (concatStringsSep " " l)} ]]'");
+
+  genericConfigDir = pkgs.runCommand "generic-snort3-config" { } ''
+    mkdir $out
+    cp ${cfg.package}/etc/snort/snort.lua $out/generic_snort.lua
+     substituteInPlace $out/generic_snort.lua \
+     --replace "HOME_NET" "--HOME_NET" \
+     --replace "EXTERNAL_NET" "--EXTERNAL_NET" \
+     --replace "include" "--include" \
+     --replace "if " "--if " --replace "end" "--end"
+  '';
+
+  generatedConfigFile = pkgs.writeText "snort.lua" ''
+    HOME_NET = ${makeNet cfg.homeNet}
+    EXTERNAL_NET = ${makeNet cfg.externalNet}
+
+    include '${cfg.package}/etc/snort/snort_defaults.lua'
+    include '${cfg.package}/etc/snort/file_magic.lua'
+    include '${genericConfigDir}/generic_snort.lua'
+
+    RULE_PATH = '${cfg.dataDir}/rules'
+    BUILTIN_RULE_PATH = '${cfg.dataDir}/builtin_rules'
+    PLUGIN_RULE_PATH = '${cfg.dataDir}/dynamic_rules'
+    WHITE_LIST_PATH = '${cfg.dataDir}/intel'
+    BLACK_LIST_PATH = '${cfg.dataDir}/intel'
+    APPID_PATH = '${cfg.dataDir}/appid'
+
+    ${cfg.extraConfigText}
+  '';
+
+  conf = (
+    if cfg.configFile == null
+    then generatedConfigFile
+    else cfg.configFile
+  );
+in
+{
+  options = {
+    services.snort3 = {
+      enable = mkEnableOption "Snort - Network intrusion prevention and detection system";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.snort3;
+        defaultText = literalExpression "pkgs.snort3";
+        description = "Package to use.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "snort3";
+        description = ''
+          User under which the service shall run after initialization.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "snort3";
+        description = ''
+          Group under which the service shall run after initialization.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/snort3";
+        description = ''
+          Specify the data directory of Snort used for e.g. Snort Rules.
+        '';
+      };
+
+      homeNet = mkOption {
+        type = types.listOf types.str;
+        default = [ "any" ];
+        example = literalExpression ''
+          [
+            "10.0.0.0/8"
+            "192.168.0.0/16"
+            "172.16.0.0/12"
+            "fc00::/7"
+            "fe80::/10"
+          ]
+        '';
+        description = ''
+          Specify the network addresses you are protecting before <option>services.snort3.extraConfigText</option>.
+        '';
+      };
+
+      externalNet = mkOption {
+        type = types.listOf types.str;
+        default = [ "any" ];
+        example = literalExpression ''
+          [
+            "203.0.113.0/24"
+            "2001:db8::/32"
+          ]
+        '';
+        description = ''
+          Specify external network addresses before <option>services.snort3.extraConfigText</option>.
+          Leave as "any" in most situations.
+        '';
+      };
+
+      extraConfigText = mkOption {
+        type = types.lines;
+        default = "";
+        example = literalExpression ''
+          SSH_PORTS = ' 22 2210'
+          ips =
+          {
+             enable_builtin_rules = true,
+             include = RULE_PATH .. "/snort.rules",
+             variables = default_variables
+          }
+          alert_json =
+          {
+            file = false,
+            fields = 'seconds action class dir dst_addr dst_ap dst_port eth_dst eth_len \
+            eth_src eth_type gid icmp_code icmp_id icmp_seq icmp_type iface ip_id ip_len msg mpls \
+            pkt_gen pkt_len pkt_num priority proto rev rule service sid src_addr src_ap src_port \
+            target tcp_ack tcp_flags tcp_len tcp_seq tcp_win tos ttl udp_len vlan timestamp'
+          }
+        '';
+        description = ''
+          Specify the configuration for the service when 'configFile' is not used. As long as this
+          option is empty a default template/starter configuration is loaded. To make use of Snort
+          fully it is advised to create and load your own configuration, adjusted to your needs.
+        '';
+      };
+
+      configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Specify a configuration file that should be used. It replaces <option>services.snort3.extraConfigText</option>.
+          To make use of Snort fully it is advised to create and load your own configuration, adjusted to your needs.
+        '';
+      };
+
+      maxThreads = mkOption {
+        type = types.int;
+        default = 1;
+        example = literalExpression "2";
+        description = ''
+          Specify the maximum number of packet processing threads. Set `0` to set maxThreads equal available CPU cores.
+        '';
+      };
+
+      netInterfaces = mkOption {
+        type = types.listOf types.str;
+        default = [ "eth0" ];
+        example = literalExpression ''
+          [ "eth0" "eth1" ]
+        '';
+        description = ''
+          Specify the network interfaces for Snort to use. Further examples: [ "eth0:eth1" ] (afpacket/inline),
+          [ "42" ] (nfqueue/inline).
+        '';
+      };
+
+      daqType = mkOption {
+        type = types.enum [
+          "afpacket"
+          "bpf"
+          "dump"
+          "fst"
+          "nfq"
+          "pcap"
+          "savefile"
+          "trace"
+        ];
+        default = "afpacket";
+        description = ''
+          Specify the packet acquisition module type.
+        '';
+      };
+
+      daqMode = mkOption {
+        type = types.enum [
+          "inline"
+          "passive"
+          "read-file"
+        ];
+        default = "passive";
+        description = ''
+          Specify the DAQ module operating mode.
+        '';
+      };
+
+      daqVars = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExpression ''
+          [
+            "buffer_size_mb=512"
+            "fanout_type=hash"
+          ]
+        '';
+        description = ''
+          Specify extra DAQ configuration variables.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExpression ''
+          [
+            "-s 65535"
+            "-k none"
+            "-M"
+            "-A alert_json"
+            "-U"
+            "-y"
+          ]
+        '';
+        description = ''
+          Specify a list of additional command line flags.
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf config.services.snort3.enable {
+    users.users."${cfg.user}" = {
+      description = "Snort Service User";
+      group = "${cfg.group}";
+      isSystemUser = true;
+      home = cfg.dataDir;
+      createHome = true;
+    };
+
+    users.groups."${cfg.group}" = { };
+
+    systemd.services.snort3 = {
+      description = "Snort - Network intrusion prevention and detection system";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig =
+        let
+          cmd = "${cfg.package}/bin/snort";
+
+          netInterfaces = lists.map (i: "-i " + i) cfg.netInterfaces;
+          daqVariables = lists.map (v: "--daq-var " + v) cfg.daqVars;
+
+          cmdArgs = builtins.replaceStrings [ "\"" ] [ "" ] (utils.escapeSystemdExecArgs (
+            [
+              "-c ${conf}"
+            ]
+            ++ optional (cfg.daqType != "nfq") "-u ${cfg.user}"
+            ++ optional (cfg.daqType != "nfq") "-g ${cfg.group}"
+            ++ cfg.extraFlags
+
+            ++ netInterfaces
+            ++ [
+              "-z ${toString cfg.maxThreads}"
+
+              "--daq ${cfg.daqType}"
+              "--daq-mode ${cfg.daqMode}"
+            ]
+            ++ daqVariables
+          ));
+        in
+        {
+          Restart = "on-failure";
+          TimeoutStartSec = "600";
+
+          User = cfg.user;
+          Group = cfg.group;
+
+          WorkingDirectory = cfg.dataDir;
+
+          ExecStartPre =
+            let
+              prepareScript = pkgs.writers.writeBash "snort-pre-start-prepare.sh" ''
+                ${pkgs.coreutils}/bin/mkdir -p {rules,builtin_rules,dynamic_rules,appid,intel}
+                ${pkgs.coreutils}/bin/touch rules/snort.rules
+              '';
+            in
+            [
+              prepareScript
+              "+${cmd} ${cmdArgs} -T"
+            ];
+
+          ExecStart = "+${cmd} ${cmdArgs}";
+
+          ExecReload = "+${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
+
+          AmbientCapabilities = [ "CAP_NET_ADMIN" "CAP_NET_RAW" "CAP_IPC_LOCK" ];
+          CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_NET_RAW" "CAP_IPC_LOCK" ];
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "full";
+          RemoveIPC = true;
+          RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_NETLINK" "AF_UNIX" ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          MemoryDenyWriteExecute = false;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" "@network-io" "~@privileged" "~@resources" ];
+          UMask = "0027";
+        };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -517,6 +517,7 @@ in {
   smokeping = handleTest ./smokeping.nix {};
   snapcast = handleTest ./snapcast.nix {};
   snapper = handleTest ./snapper.nix {};
+  snort3 = handleTest ./snort3.nix {};
   soapui = handleTest ./soapui.nix {};
   sogo = handleTest ./sogo.nix {};
   solanum = handleTest ./solanum.nix {};

--- a/nixos/tests/snort3.nix
+++ b/nixos/tests/snort3.nix
@@ -1,0 +1,263 @@
+import ./make-test-python.nix
+  (
+    { lib, pkgs, ... }:
+    {
+      name = "snort3";
+
+      meta = with lib.maintainers; {
+        maintainers = [ zzschmidc ];
+      };
+
+      # Test scenarios:
+      #   1. Snort as IDS to detect on ICMP packets to the 'homeNet'. Only alert on ICMP packets.
+      #   2. Snort as IPS to detect and reject ICMP packets to the 'homeNet'. Alert and reject packets.
+
+      nodes = {
+        client1 = {
+          # WAN
+          virtualisation.vlans = [ 1 ];
+
+          networking = {
+            useDHCP = false;
+            firewall.enable = false;
+            interfaces.eth1 = {
+              ipv4.addresses = lib.mkForce [ ];
+              ipv6.addresses = lib.mkForce [
+                { address = "2001:db8:0:a::2"; prefixLength = 64; }
+              ];
+            };
+            defaultGateway6 = {
+              address = "2001:db8:0:a::1";
+              interface = "eth1";
+            };
+          };
+        };
+
+        client2 = {
+          # LAN
+          virtualisation.vlans = [ 2 ];
+
+          networking = {
+            useDHCP = false;
+            firewall.enable = false;
+            interfaces.eth1 = {
+              ipv4.addresses = lib.mkForce [ ];
+              ipv6.addresses = lib.mkForce [
+                { address = "2001:db8:0:b::2"; prefixLength = 64; }
+              ];
+            };
+            defaultGateway6 = {
+              address = "2001:db8:0:b::1";
+              interface = "eth1";
+            };
+          };
+        };
+
+        gateway = { lib, ... }:
+          let
+            extraFlags = [ "-s 65535" "-k none" "-M" "-A alert_fast" "--warn-all" ];
+
+            extraConfigText = {
+              passiveMode = ''
+                ips =
+                {
+                  enable_builtin_rules = false,
+                  include = RULE_PATH .. "/snort.rules",
+                  variables = default_variables
+                }
+              '';
+              inlineMode = ''
+                ips =
+                {
+                  mode = inline,
+                  enable_builtin_rules = false,
+                  include = RULE_PATH .. "/snort.rules",
+                  variables = default_variables
+                }
+              '';
+              default = ''
+                alert_fast = { file = false, packet = false }
+                -- packet_tracer = { enable = true }
+              '';
+            };
+          in
+          {
+            virtualisation.vlans = [ 1 2 ];
+
+            boot.kernel.sysctl = {
+              "net.ipv6.conf.all.forwarding" = 1;
+            };
+
+            networking = {
+              useDHCP = false;
+              firewall.enable = false;
+              interfaces.eth1 = {
+                # WAN
+                ipv4.addresses = lib.mkForce [ ];
+                ipv6.addresses = lib.mkForce [
+                  { address = "2001:db8:0:a::1"; prefixLength = 64; }
+                ];
+              };
+              interfaces.eth2 = {
+                # LAN
+                ipv4.addresses = lib.mkForce [ ];
+                ipv6.addresses = lib.mkForce [
+                  { address = "2001:db8:0:b::1"; prefixLength = 64; }
+                ];
+              };
+            };
+
+            services.snort3 = {
+              enable = false; # start disabled
+              dataDir = "/var/lib/snort3";
+
+              # We protect 'client2' via eth2 (LAN)
+              homeNet = [ "2001:db8:0:b::2/128" ];
+
+              netInterfaces = [ "eth1" ]; # WAN interface
+            };
+
+            # Override to conduct the 1st test in 'passive' mode.
+            specialisation.passiveMode.configuration = {
+              services.snort3 = lib.mapAttrs (lib.const lib.mkForce) {
+                enable = true;
+                inherit extraFlags;
+                daqType = "afpacket";
+                daqMode = "passive";
+                extraConfigText = ''
+                  ${extraConfigText.passiveMode}
+                  ${extraConfigText.default}
+                '';
+              };
+            };
+
+            # Override to conduct the 2nd test in 'inline' mode.
+            specialisation.inlineMode.configuration = {
+              services.snort3 = lib.mapAttrs (lib.const lib.mkForce) {
+                enable = true;
+                extraFlags = (extraFlags ++ [ "-Q" ]);
+                daqType = "nfq";
+                daqMode = "inline";
+                daqVars = [ "buffer_size_mb=128" ];
+                netInterfaces = [ "42" ]; # no iface, but nfqueue
+                extraConfigText = ''
+                  ${extraConfigText.inlineMode}
+                  ${extraConfigText.default}
+                '';
+              };
+
+              networking.firewall = lib.mkForce {
+                enable = true;
+                extraCommands = ''
+                  # Pass traffic if Snort is not listing to NFQ by 'queue-bypass'.
+                  ip6tables -I FORWARD -i eth1 -o eth2 -j NFQUEUE --queue-num 42 --queue-bypass
+                '';
+              };
+            };
+          };
+      };
+
+      testScript = { nodes, ... }:
+        let
+          passiveModeSystem = "${nodes.gateway.config.system.build.toplevel}/specialisation/passiveMode";
+          inlineModeSystem = "${nodes.gateway.config.system.build.toplevel}/specialisation/inlineMode";
+
+          snortRulesFile = pkgs.writeText "snort.rules" ''
+            alert icmp $EXTERNAL_NET any -> $HOME_NET any ( msg:"PROTOCOL-ICMP ICMPv6 Echo Request"; icode:0; itype:128; classtype:icmp-event; sid:4000001; rev:1; )
+          '';
+        in
+        ''
+          start_all()
+
+          with subtest("Wait for networking to be configured"):
+            gateway.wait_for_unit("network.target")
+            client1.wait_for_unit("network.target")
+            client2.wait_for_unit("network.target")
+
+            # Print diagnostic information
+            client1.succeed("ip -6 addr >&2 && ip -6 route >&2")
+            client2.succeed("ip -6 addr >&2 && ip -6 route >&2")
+
+            with subtest("Verify that networking works as configured"):
+              # The connection goes via 'gateway'.
+              client1.wait_until_succeeds("ping -6 -c 1 2001:db8:0:b::2 >&2")
+              client2.wait_until_succeeds("ping -6 -c 1 2001:db8:0:a::2 >&2")
+
+          #
+          # Test 1.
+          #
+
+          with subtest("Snort - Start in 'passive' mode"):
+            gateway.succeed("${passiveModeSystem}/bin/switch-to-configuration test >&2")
+            gateway.wait_for_unit("snort3")
+
+            with subtest("Snort - Service is running"):
+              gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'successfully validated'")
+              gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'afpacket DAQ configured to passive'")
+
+              with subtest("Snort - Custom logger is loaded"):
+                gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'alert_fast'")
+
+              with subtest("Snort - No rules are present"):
+                gateway.wait_until_fails("journalctl -u snort3 -e | grep -q -i 'text rules: 1'")
+
+              with subtest("Snort - Add rules to the configuration"):
+                gateway.succeed("cp ${snortRulesFile} /var/lib/snort3/rules/snort.rules")
+                gateway.succeed("cat /var/lib/snort3/rules/snort.rules >&2")
+
+                ## Test service 'reload'
+                with subtest("Snort - Service is reloaded"):
+                  gateway.systemctl("reload snort3")
+                  gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'reload complete'")
+
+                with subtest("Snort - Rules are loaded"):
+                  gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'text rules: 1'")
+
+            ## Detection => alert on packets
+            with subtest("Snort - Detection and alerting works"):
+              client1.succeed("ping -6 -c 5 2001:db8:0:b::2 >&2")
+              gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i '4000001'")
+
+          ## Test service 'stop'
+          with subtest("Snort - Service is stopped"):
+            gateway.systemctl("stop snort3")
+            gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'Snort exiting'")
+
+          #
+          # Test 2.
+          #
+
+          # The rules need to be adjusted to 'reject' packets based on them
+          gateway.succeed("sed -i 's/alert/reject/' /var/lib/snort3/rules/snort.rules")
+          gateway.succeed("cat /var/lib/snort3/rules/snort.rules >&2")
+
+          with subtest("Snort - Start in 'inline' mode"):
+            gateway.succeed("${inlineModeSystem}/bin/switch-to-configuration test >&2")
+            gateway.wait_for_unit("snort3")
+            gateway.wait_for_unit("firewall")
+
+            # Print diagnostic information
+            gateway.succeed("ip6tables -L >&2")
+
+            with subtest("Snort - Service is running"):
+              gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'successfully validated'")
+              gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'nfq DAQ configured to inline'")
+
+              with subtest("Snort - Rules are loaded"):
+                gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'text rules: 1'")
+
+              with subtest("Snort - Custom logger is loaded"):
+                gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'alert_fast'")
+
+            ## Prevention => reject packets
+            with subtest("Snort - Detection and rejection works"):
+              client1.fail("ping -6 -c 5 2001:db8:0:b::2 >&2")
+              gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i '4000001'")
+
+          ## Test service 'stop'
+          with subtest("Snort - Service is stopped"):
+            gateway.systemctl("stop snort3")
+            gateway.wait_until_succeeds("journalctl -u snort3 -e | grep -q -i 'Snort exiting'")
+        '';
+    }
+  )

--- a/pkgs/applications/networking/ids/libdaq3/default.nix
+++ b/pkgs/applications/networking/ids/libdaq3/default.nix
@@ -1,0 +1,92 @@
+{ lib
+, clangStdenv
+, fetchFromGitHub
+, autoreconfHook
+, flex
+, bison
+, pkg-config
+, cmocka
+, file
+, writeScript
+
+, doCheck ? false # tests fail
+
+# Optional dependencies
+, withPcap ? true
+, libpcap
+, withNfq ? true
+, libmnl
+, libnfnetlink
+, libnetfilter_queue
+}:
+
+with lib;
+
+let
+  pname = "libdaq3";
+  version = "v3.0.9";
+
+  optionalDeps = [
+    { enabled = withPcap; deps = [ libpcap ]; } # modules: pcap, bpf, dump
+    { enabled = withNfq; deps = [ libmnl libnfnetlink libnetfilter_queue ]; } # modules: nfq
+  ];
+in
+clangStdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "snort3";
+    repo = "libdaq";
+    rev = version;
+    sha256 = "Vol0Qd6xtep7nZNwZbJyWvPv25XFiJOlxZ7MJVa+VA4=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    flex
+    bison
+    pkg-config
+  ];
+
+  checkInputs = [
+    cmocka
+  ];
+
+  buildInputs = concatMap (f: optionals f.enabled f.deps) (filter (f: f ? deps) optionalDeps);
+
+  preConfigure = ''
+    patchShebangs ./configure
+    substituteInPlace ./configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
+  '';
+
+  preAutoreconf = "./bootstrap";
+
+  enableParallelBuilding = true;
+
+  fixupPhase = ''
+    patchelf $out/bin/daqtest-static
+  '';
+
+  inherit doCheck;
+
+  passthru = {
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq common-updater-scripts
+
+      set -euo pipefail
+
+      version=$(curl --silent "https://api.github.com/repos/snort3/libdaq/releases/latest" | jq -r .tag_name)
+      update-source-version "${pname}" "$version"
+    '';
+  };
+
+  meta = {
+    description = "Data AcQuisition library (DAQ), for packet I/O";
+    homepage = "https://www.snort.org";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ zzschmidc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/ids/snort3/default.nix
+++ b/pkgs/applications/networking/ids/snort3/default.nix
@@ -12,6 +12,7 @@
 , writeScript
 , runCommand
 , snort3
+, nixosTests
 
 , doCheck ? false # tests fail
 
@@ -121,6 +122,7 @@ clangStdenv.mkDerivation {
       update-source-version "${pname}" "$version"
     '';
     tests = {
+      module = nixosTests.snort3;
       # tests fail
       #unitTests = runCommand "${pname}-unit-tests" { } ''
       #  ${snort3}/bin/snort --catch-test all

--- a/pkgs/applications/networking/ids/snort3/default.nix
+++ b/pkgs/applications/networking/ids/snort3/default.nix
@@ -1,0 +1,138 @@
+{ stdenv
+, lib
+, clangStdenv
+, fetchFromGitHub
+, cmake
+, flex
+, bison
+, pkg-config
+, makeWrapper
+, cppcheck # for unit tests
+, cpputest # for unit tests
+, writeScript
+, runCommand
+, snort3
+
+, doCheck ? false # tests fail
+
+# Mandatory dependencies
+, hwloc
+, libdaq3
+, libdnet
+, libmnl
+, libpcap
+, libunwind
+, libuuid
+, luajit
+, openssl
+, pcre
+, xz
+, zlib
+
+# Optional dependencies
+, withTcmalloc ? true
+, gperftools
+, withTscClock ? false # build fails
+, withLargePcap ? false
+, withHyperscan ? !(stdenv.isAarch64)
+, hyperscan
+, withFlatbuffers ? true
+, flatbuffers
+}:
+
+with lib;
+
+let
+  pname = "snort3";
+  version = "3.1.40.0";
+
+  optionalDeps = [
+    { enabled = withTcmalloc; deps = [ gperftools ]; }
+    { enabled = withHyperscan; deps = [ hyperscan ]; }
+    { enabled = withFlatbuffers; deps = [ flatbuffers ]; }
+  ];
+
+in
+clangStdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "snort3";
+    repo = "snort3";
+    rev = version;
+    sha256 = "oG6wORRk3QE86Vw+3L66iAm/a3NVmKliEheDmyVI6mI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    flex
+    bison
+    pkg-config
+    makeWrapper
+    cppcheck
+    cpputest
+  ];
+
+  buildInputs = [
+    hwloc
+    libdaq3
+    libdnet
+    libmnl
+    libpcap
+    libunwind
+    libuuid
+    luajit
+    openssl
+    pcre
+    xz
+    zlib
+  ] ++ concatMap (f: optionals f.enabled f.deps) (filter (f: f ? deps) optionalDeps);
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DENABLE_UNIT_TESTS=ON"
+    "-DENABLE_HARDENED_BUILD=ON"
+    "-DENABLE_PIE=ON"
+
+    "-DDAQ_INCLUDE_DIR_HINT=${libdaq3}/includes"
+    "-DDAQ_LIBRARIES_DIR_HINT=${libdaq3}/lib"
+
+    "-DENABLE_TCMALLOC=${if withTcmalloc then "ON" else "OFF"}"
+    "-DENABLE_TSC_CLOCK=${if withTscClock then "ON" else "OFF"}"
+    "-DENABLE_LARGE_PCAP=${if withLargePcap then "ON" else "OFF"}"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/snort \
+      --add-flags "--daq-dir ${libdaq3}/lib/daq"
+  '';
+
+  inherit doCheck;
+
+  passthru = {
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq common-updater-scripts
+
+      set -euo pipefail
+
+      version=$(curl --silent "https://api.github.com/repos/snort3/snort3/releases/latest" | jq -r .tag_name)
+      update-source-version "${pname}" "$version"
+    '';
+    tests = {
+      # tests fail
+      #unitTests = runCommand "${pname}-unit-tests" { } ''
+      #  ${snort3}/bin/snort --catch-test all
+      #'';
+    };
+  };
+
+  meta = {
+    description = "Network intrusion prevention and detection system (IDS/IPS)";
+    homepage = "https://www.snort.org";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ zzschmidc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10950,6 +10950,8 @@ with pkgs;
 
   snort = callPackage ../applications/networking/ids/snort { };
 
+  snort3 = callPackage ../applications/networking/ids/snort3 { };
+
   so = callPackage ../development/tools/so {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19176,6 +19176,8 @@ with pkgs;
 
   libdaemon = callPackage ../development/libraries/libdaemon { };
 
+  libdaq3 = callPackage ../applications/networking/ids/libdaq3 { };
+
   libdatrie = callPackage ../development/libraries/libdatrie { };
 
   libdazzle = callPackage ../development/libraries/libdazzle { };


### PR DESCRIPTION
###### Description of changes

This PR adds the Nix package for Snort 3 (https://snort.org/), for its dependency "libdaq3" and a NixOS module for Snort 3. I tested it on NixOS 21.11 on Linux x86 and aarch64 and it works as expected. The x86 package was used by me for over 6 months in production environments without any issues.

- New: pkgs.snort3, pkgs.libdaq3, services.snort3

I created a NixOS test to test two common configurations of Snort.

There is already a Nix package for Snort 2 (name "snort", version 2.9) with libdaq (name "daq", version 2) for the ones who want to use Snort 2.9. This is not touched here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
