### PR TITLE
intel-compute-runtime: 21.42.21270 -> 22.17.23034

### DIFF
--- a/pkgs/development/compilers/intel-graphics-compiler/default.nix
+++ b/pkgs/development/compilers/intel-graphics-compiler/default.nix
@@ -9,6 +9,8 @@
 , lld_11
 , opencl-clang
 , python3
+, spirv-tools
+, spirv-headers
 , spirv-llvm-translator
 
 , buildWithPatches ? true
@@ -18,8 +20,8 @@ let
   vc_intrinsics_src = fetchFromGitHub {
     owner = "intel";
     repo = "vc-intrinsics";
-    rev = "e5ad7e02aa4aa21a3cd7b3e5d1f3ec9b95f58872";
-    sha256 = "Vg1mngwpIQ3Tik0GgRXPG22lE4sLEAEFch492G2aIXs=";
+    rev = "v0.3.0";
+    sha256 = "sha256-1Rm4TCERTOcPGWJF+yNoKeB9x3jfqnh7Vlv+0Xpmjbk=";
   };
   llvmPkgs = llvmPackages_11 // {
     inherit spirv-llvm-translator;
@@ -31,18 +33,18 @@ in
 
 stdenv.mkDerivation rec {
   pname = "intel-graphics-compiler";
-  version = "1.0.8744";
+  version = "1.0.11061";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "intel-graphics-compiler";
     rev = "igc-${version}";
-    sha256 = "G5+dYD8uZDPkRyn1sgXsRngdq4NJndiCJCYTRXyUgTA=";
+    sha256 = "sha256-qS/+GTqHtp3T6ggPKrCDsrTb7XvVOUaNbMzGU51jTu4=";
   };
 
   nativeBuildInputs = [ clang cmake bison flex python3 ];
 
-  buildInputs = [ clang opencl-clang spirv-llvm-translator llvm lld_11 ];
+  buildInputs = [ spirv-headers spirv-tools clang opencl-clang spirv-llvm-translator llvm lld_11 ];
 
   strictDeps = true;
 
@@ -51,6 +53,21 @@ stdenv.mkDerivation rec {
   # FIXME: How do we run the test suite?
   # https://github.com/intel/intel-graphics-compiler/issues/98
   doCheck = false;
+
+  patchPhase = ''
+    substituteInPlace ./external/SPIRV-Tools/CMakeLists.txt \
+            --replace '$'''{SPIRV-Tools_DIR}../../..' \
+                      '${spirv-tools}' \
+            --replace 'SPIRV-Headers_INCLUDE_DIR "/usr/include"' \
+                      'SPIRV-Headers_INCLUDE_DIR "${spirv-headers}/include"' \
+            --replace 'set_target_properties(SPIRV-Tools' \
+                      'set_target_properties(SPIRV-Tools-shared' \
+            --replace 'IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools' \
+                      'IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools-shared'
+          substituteInPlace ./IGC/AdaptorOCL/igc-opencl.pc.in \
+            --replace '/@CMAKE_INSTALL_INCLUDEDIR@' "/include" \
+            --replace '/@CMAKE_INSTALL_LIBDIR@' "/lib"
+  '';
 
   # Handholding the braindead build script
   # cmake requires an absolute path
@@ -64,7 +81,9 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
+    "-Wno-dev"
     "-DVC_INTRINSICS_SRC=${vc_intrinsics_src}"
+    "-DIGC_OPTION__SPIRV_TOOLS_MODE=Prebuilds"
     "-DINSTALL_SPIRVDLL=0"
     "-DCCLANG_BUILD_PREBUILDS=ON"
     "-DCCLANG_BUILD_PREBUILDS_DIR=${prebuilds}"

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -4,28 +4,41 @@
 , pkg-config
 , lit
 , llvm_11
+, spirv-headers
+, spirv-tools
 }:
 
 stdenv.mkDerivation rec {
   pname = "SPIRV-LLVM-Translator";
-  version = "unstable-2021-06-13";
+  version = "unstable-2022-05-04";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-LLVM-Translator";
-    rev = "c67e6f26a7285aa753598ef792593ac4a545adf9";
-    sha256 = "sha256-1s3lVNTQDl+pUvbzSMsp3cOUSm6I4DzqJxnLMeeE3F4=";
+    rev = "99420daab98998a7e36858befac9c5ed109d4920";
+    sha256 = "sha256-/vUyL6Wh8hykoGz1QmT1F7lfGDEmG4U3iqmqrJxizOg=";
   };
 
   nativeBuildInputs = [ pkg-config cmake llvm_11.dev ];
 
-  buildInputs = [ llvm_11 ];
+  buildInputs = [ spirv-headers spirv-tools llvm_11 ];
 
   checkInputs = [ lit ];
 
+  makeFlags = [ "llvm-spirv" ];
+
   cmakeFlags = [
     "-DLLVM_INCLUDE_TESTS=ON"
+    "-DLLVM_DIR=${llvm_11.dev}"
+    "-DBUILD_SHARED_LIBS=YES"
+    "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
   ];
+
+  prePatch = ''
+    substituteInPlace ./test/CMakeLists.txt \
+      --replace 'SPIRV-Tools' 'SPIRV-Tools-shared'
+  '';
+
 
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;

--- a/pkgs/development/libraries/opencl-clang/default.nix
+++ b/pkgs/development/libraries/opencl-clang/default.nix
@@ -67,15 +67,15 @@ let
   in
     stdenv.mkDerivation rec {
       pname = "opencl-clang";
-      version = "unstable-2021-06-22";
+      version = "unstable-2022-03-16";
 
       inherit passthru;
 
       src = fetchFromGitHub {
         owner = "intel";
         repo = "opencl-clang";
-        rev = "fd68f64b33e67d58f6c36b9e25c31c1178a1962a";
-        sha256 = "sha256-q1YPBb/LY67iEuQx1fMUQD/I7OsNfobW3yNfJxLXx3E=";
+        rev = "bbdd1587f577397a105c900be114b56755d1f7dc";
+        sha256 = "sha256-qEZoQ6h4XAvSnJ7/gLXBb1qrzeYa6Jp6nij9VFo8MwQ=";
       };
 
       patches = [

--- a/pkgs/os-specific/linux/intel-compute-runtime/default.nix
+++ b/pkgs/os-specific/linux/intel-compute-runtime/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-compute-runtime";
-  version = "21.42.21270";
+  version = "22.17.23034";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "compute-runtime";
     rev = version;
-    sha256 = "N9MsDcsL8kBWxfZjhukcxZiSJnXxqMgWF0etOhf2/AE=";
+    sha256 = "sha256-ae6kPiVQe3+hcqXVu2ncCaVQAoMKoDHifrkKpt6uWX8=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
###### Description of changes
intel-compute-runtime is currently broken. Fixes #169729

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
