### PR TITLE
python310Packages.raincloudy: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/raincloudy/default.nix
+++ b/pkgs/development/python-modules/raincloudy/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, fetchFromGitHub
+, html5lib
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-mock
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "raincloudy";
+  version = "1.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "vanstinator";
+    repo = pname;
+    rev = version;
+    hash = "sha256-c6tux0DZY56a4BpuiMXtaqm8+JKNDiyMxrFUju3cp2Y=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    beautifulsoup4
+    urllib3
+    html5lib
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  postPatch = ''
+    # https://github.com/vanstinator/raincloudy/pull/60
+    substituteInPlace setup.py \
+      --replace "bs4" "beautifulsoup4" \
+      --replace "html5lib==1.0.1" "html5lib"
+  '';
+
+  pythonImportsCheck = [
+    "raincloudy"
+  ];
+
+  disabledTests = [
+    # Test requires network access
+    "test_attributes"
+  ];
+
+  meta = with lib; {
+    description = "Module to interact with Melnor RainCloud Smart Garden Watering Irrigation Timer";
+    homepage = "https://github.com/vanstinator/raincloudy";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2124,7 +2124,8 @@
     "rainbird" = ps: with ps; [
     ]; # missing inputs: pyrainbird
     "raincloud" = ps: with ps; [
-    ]; # missing inputs: raincloudy
+      raincloudy
+    ];
     "rainforest_eagle" = ps: with ps; [
       aioeagle
       ueagle

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8821,6 +8821,8 @@ in {
 
   rainbowstream = callPackage ../development/python-modules/rainbowstream { };
 
+  raincloudy = callPackage ../development/python-modules/raincloudy { };
+
   ramlfications = callPackage ../development/python-modules/ramlfications { };
 
   random2 = callPackage ../development/python-modules/random2 { };


### PR DESCRIPTION
###### Description of changes
Module to interact with Melnor RainCloud Smart Garden Watering Irrigation Timer

https://github.com/vanstinator/raincloudy

This is a Home Assistant dependency.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
