### PR TITLE
Reduce netboot image

### DIFF
--- a/pkgs/applications/editors/ed/generic.nix
+++ b/pkgs/applications/editors/ed/generic.nix
@@ -18,7 +18,7 @@
 stdenv.mkDerivation {
   inherit pname version src patches;
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [ lzip ];
 

--- a/pkgs/applications/editors/ed/generic.nix
+++ b/pkgs/applications/editors/ed/generic.nix
@@ -18,6 +18,8 @@
 stdenv.mkDerivation {
   inherit pname version src patches;
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ lzip ];
 
   configureFlags = [

--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ texinfo ] ++ lib.optional enableNls gettext;
   buildInputs = [ ncurses ] ++ lib.optional (!enableTiny) file;
 
-  outputs = [ "out" "info" "man" ];
+  outputs = [ "out" "doc" "info" "man" ];
 
   configureFlags = [
     "--sysconfdir=/etc"

--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ texinfo ] ++ lib.optional enableNls gettext;
   buildInputs = [ ncurses ] ++ lib.optional (!enableTiny) file;
 
-  outputs = [ "out" "info" ];
+  outputs = [ "out" "info" "man" ];
 
   configureFlags = [
     "--sysconfdir=/etc"

--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -2,7 +2,7 @@
 rec {
   version = "9.1.0075";
 
-  outputs = [ "out" "xxd" ];
+  outputs = [ "out" "xxd" "man" ];
 
   src = fetchFromGitHub {
     owner = "vim";

--- a/pkgs/applications/file-managers/mc/default.nix
+++ b/pkgs/applications/file-managers/mc/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-JBkc+GZ2dbjjH8Sp0YoKZb3AWYwsXE6gkklM0Tq0qxo=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config unzip ]
     # The preFixup hook rewrites the binary, which invaliates the code
     # signature. Add the fixup hook to sign the output.

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -53,6 +53,8 @@ in stdenv.mkDerivation rec {
     sed -ie 's!mktable.*:.*!mktable:!' Makefile.in
   '';
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config gettext ];
   buildInputs = [ ncurses boehmgc zlib ]
     ++ lib.optional sslSupport openssl

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
   version = "4.2.2";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   src = fetchFromGitLab {
     repo = "wireshark";

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Tn2dP27RCHjFjF+3JKZ9rPS2qsc0CxPkiPstxBNG8rs=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ perl ];
 
   patches = [

--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
 
   meta = rsync.meta // {
     description = "A helper to run rsync-only environments from ssh-logins";
+    outputsToInstall = [ "out" ];
   };
 }

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-VEZgPnPZEXgdJZ5WV1Dc0nekKDbI45LKyRzxN6qbduw=";
   };
 
-  outputs = [ "out" ] ++ lib.optional withManual "doc";
+  outputs = [ "out" ] ++ lib.optionals withManual [ "doc" "man" ];
   separateDebugInfo = true;
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/version-management/gitweb/default.nix
+++ b/pkgs/applications/version-management/gitweb/default.nix
@@ -23,5 +23,6 @@ in buildEnv {
 
   meta = git.meta // {
     maintainers = with lib.maintainers; [ ];
+    outputsToInstall = [ "out" ];
   };
 }

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -42,6 +42,8 @@ let
     } else null;
     cargoRoot = if rustSupport then "rust" else null;
 
+    outputs = [ "out" "man" ];
+
     propagatedBuildInputs = lib.optional re2Support fb-re2
       ++ lib.optional gitSupport pygit2
       ++ lib.optional highlightSupport pygments;

--- a/pkgs/applications/version-management/tig/default.nix
+++ b/pkgs/applications/version-management/tig/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VuuqR5fj0YvqIfVPH7N3rpAfIbcTwOx9W3H60saCToQ=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   nativeBuildInputs = [ makeWrapper autoreconfHook asciidoc xmlto docbook_xsl docbook_xml_dtd_45 findXMLCatalogs pkg-config ];
 

--- a/pkgs/applications/version-management/tig/default.nix
+++ b/pkgs/applications/version-management/tig/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VuuqR5fj0YvqIfVPH7N3rpAfIbcTwOx9W3H60saCToQ=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ makeWrapper autoreconfHook asciidoc xmlto docbook_xsl docbook_xml_dtd_45 findXMLCatalogs pkg-config ];
 
   autoreconfFlags = [ "-I" "tools" "-v" ];

--- a/pkgs/applications/virtualization/crun/default.nix
+++ b/pkgs/applications/virtualization/crun/default.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook go-md2man pkg-config python3 ];
 
   buildInputs = [ criu libcap libseccomp systemd yajl ];

--- a/pkgs/by-name/li/libcpuid/package.nix
+++ b/pkgs/by-name/li/libcpuid/package.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Zs5GKvSasdfLqo8oErDQNAuXRG27Bm9vNwyooqbol0Q=";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {

--- a/pkgs/by-name/sy/syslogng/package.nix
+++ b/pkgs/by-name/sy/syslogng/package.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
     "--without-compile-date"
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/data/misc/mailcap/default.nix
+++ b/pkgs/data/misc/mailcap/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Xuou8XswSXe6PsuHr61DGfoEQPgl5Pb7puj6L/64h4U=";
   };
 
+  outputs = [ "out" "man" ];
+
   installPhase = ''
     runHook preInstall
 
@@ -17,7 +19,7 @@ stdenv.mkDerivation rec {
 
     install -D -m0644 nginx-mime.types $out/etc/nginx/mime.types
     install -D -m0644 -t $out/etc mailcap mime.types
-    install -D -m0644 -t $out/share/man/man5 mailcap.5
+    install -D -m0644 -t $man/share/man/man5 mailcap.5
 
     runHook postInstall
   '';

--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   pname = "shared-mime-info";
   version = "2.4";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -318,7 +318,7 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
   inherit (callFile ./common/dependencies.nix { }) depsBuildBuild nativeBuildInputs depsBuildTarget buildInputs depsTargetTarget;
 
   preConfigure = (callFile ./common/pre-configure.nix { }) + lib.optionalString atLeast10 ''
-    ln -sf ${libxcrypt}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
+    ln -sf ${libxcrypt.dev}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
   '';
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isNewDarwinBootstrap) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isAarch64) [
     "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [

--- a/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.libc == "glibc") [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/16/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/16/compiler-rt/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.libc == "glibc") [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isDarwinStatic) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/17/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/17/compiler-rt/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.libc == "glibc") [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isDarwinStatic) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/git/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/git/compiler-rt/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.libc == "glibc") [
-    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
+    "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt.dev}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isDarwinStatic) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -407,7 +407,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (sqlite != null) [
     "--enable-loadable-sqlite-extensions"
   ] ++ optionals (libxcrypt != null) [
-    "CFLAGS=-I${libxcrypt}/include"
+    "CFLAGS=-I${libxcrypt.dev}/include"
     "LIBS=-L${libxcrypt}/lib"
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_buggy_getaddrinfo=no"

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-KHijT4BBKfDvTpHpwognN+3ZXoC6JabBTFSYFyOUT9o=";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "doc" "man" ];
   separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-yosEmjwtOyIloejRXWE3mOvHSOOVA4jtomlN5Qe6YCA=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.cracklib;
   buildInputs = [ zlib gettext ];
 

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  outputs = [ "out" "dev" ]; # TODO: fix referrers
+  outputs = [ "out" "dev" "doc" ]; # TODO: fix referrers
   outputBin = "dev";
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
   pname = "fontconfig";
   version = "2.15.0";
 
-  outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config
-
   src = fetchurl {
     url = "https://www.freedesktop.org/software/fontconfig/release/${pname}-${version}.tar.xz";
     hash = "sha256-Y6BljQ4G4PqIYQZFK1jvBPIfWCAuoCqUw53g0zNdfA4=";
   };
+
+  outputs = [ "bin" "dev" "lib" "out" "man" ]; # $out contains all the config
 
   nativeBuildInputs = [
     autoreconfHook
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     mv fonts.conf.tmp $out/etc/fonts/fonts.conf
     # We don't keep section 3 of the manpages, as they are quite large and
     # probably not so useful.
-    rm -r $bin/share/man/man3
+    rm -r $man/share/man/man3
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-Y6BljQ4G4PqIYQZFK1jvBPIfWCAuoCqUw53g0zNdfA4=";
   };
 
-  outputs = [ "bin" "dev" "lib" "out" "man" ]; # $out contains all the config
+  outputs = [ "bin" "dev" "lib" "out" "doc" "man" ]; # $out contains all the config
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./enable-table-validation.patch
   ] ++ lib.optional useEncumberedCode ./enable-subpixel-rendering.patch;
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   configureFlags = [ "--bindir=$(dev)/bin" "--enable-freetype-config" ];
 

--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dLEIHSH/8TrkvXwW5dblBKTCb3zeHcoNljpIQXS7ys0=";
   };
 
+  outputs = [ "out" "man" ];
+
   doCheck = true; # not cross;
 
   # Linking static stubs on cygwin requires correct ordering.

--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dLEIHSH/8TrkvXwW5dblBKTCb3zeHcoNljpIQXS7ys0=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   doCheck = true; # not cross;
 

--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dLEIHSH/8TrkvXwW5dblBKTCb3zeHcoNljpIQXS7ys0=";
   };
 
-  outputs = [ "out" "info" "man" ];
+  outputs = [ "out" "dev" "info" "man" ];
 
   doCheck = true; # not cross;
 

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ./0001-msginit-Do-not-use-POT-Creation-Date.patch
   ];
 
-  outputs = [ "out" "man" "doc" "info" ];
+  outputs = [ "out" "dev" "man" "doc" "info" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/libraries/inih/default.nix
+++ b/pkgs/development/libraries/inih/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-b2f6hQvkmWgni/zdfv3I1b9ypd7zSyEBv/JVBA6K7/w=";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ meson ninja ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/jansson/default.nix
+++ b/pkgs/development/libraries/jansson/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-FQgy2+g3AyRVJeniqPQj0KNeHgPdza2pmEIXqSyYry4=";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   configureFlags =
     # see the comment on stripPrefix

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   configureFlags =
     # see the comment on stripPrefix
     lib.optional stripPrefix "--with-jemalloc-prefix="

--- a/pkgs/development/libraries/judy/default.nix
+++ b/pkgs/development/libraries/judy/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1sv3990vsx8hrza1mvq3bhvv9m6ff08y4yz7swn6znszz24l0w6j";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
   depsBuildBuild = [ pkgsBuildBuild.stdenv.cc ];
   patches = [ ./cross.patch ];

--- a/pkgs/development/libraries/judy/default.nix
+++ b/pkgs/development/libraries/judy/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sv3990vsx8hrza1mvq3bhvv9m6ff08y4yz7swn6znszz24l0w6j";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ autoreconfHook ];
   depsBuildBuild = [ pkgsBuildBuild.stdenv.cc ];

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-lWCUGp2EPAJDpxsXp6xv4xx867W845g9t55Srn6FBJE=";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   configureFlags = [ "--localstatedir=/var/lib" ]
     # krb5's ./configure does not allow passing --enable-shared and --enable-static at the same time.
@@ -92,8 +92,9 @@ stdenv.mkDerivation rec {
   installPhase = lib.optionalString libOnly ''
     runHook preInstall
 
-    mkdir -p "$out"/{bin,sbin,lib/pkgconfig,share/{et,man/man1}} \
-      "$dev"/include/{gssapi,gssrpc,kadm5,krb5}
+    mkdir -p "$out"/{bin,sbin,lib/pkgconfig,share/et} \
+      "$dev"/include/{gssapi,gssrpc,kadm5,krb5} \
+      "$man"/share/man/man1
     for folder in $libFolders; do
       $MAKE -C $folder install
     done
@@ -104,6 +105,8 @@ stdenv.mkDerivation rec {
   # not via outputBin, due to reference from libkrb5.so
   postInstall = ''
     moveToOutput bin/krb5-config "$dev"
+  '' + lib.optionalString (!libOnly) ''
+    rmdir "$man"/share/man/cat{1,5,7,8}
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -46,8 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  outputs = [ "out" "lib" "dev" ];
-
   postPatch = let
     skipTestPaths = [
       # test won't work in nix sandbox
@@ -69,6 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     ${lib.concatStringsSep "\n" (map removeTest skipTestPaths)}
   '';
+
+  outputs = [ "out" "lib" "dev" "man" ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/development/libraries/libargon2/default.nix
+++ b/pkgs/development/libraries/libargon2/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0p4ry9dn0mi9js0byijxdyiwx74p1nr8zj7wjpd1fjgqva4sk23i";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = lib.optionals stdenv.isDarwin [
     fixDarwinDylibNames
   ];

--- a/pkgs/development/libraries/libdmtx/default.nix
+++ b/pkgs/development/libraries/libdmtx/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-UQy8iFfl8BNT5cBUMVF1tIScFPfHekSofaebtel9JWk=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   meta = {

--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-TugYK25WkpDn0fRPD3jayHFrNfZWt2Uo9pnGnJiBTa0=";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
   # NROFF = "${groff}/bin/nroff";

--- a/pkgs/development/libraries/libesmtp/default.nix
+++ b/pkgs/development/libraries/libesmtp/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1bhh8hlsl9597x0bnfl563k2c09b61qnkb9mfyqcmzlq63m1zw5y";
   };
 
+  outputs = [ "out" "dev" ];
+
   meta = with lib; {
     description = "A Library for Posting Electronic Mail";
     longDescription = ''

--- a/pkgs/development/libraries/libev/default.nix
+++ b/pkgs/development/libraries/libev/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sjs4324is7fp21an4aas2z4dwsvs6z4xwrmp72vwpq1s6wbfzjh";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   configureFlags = lib.optional (static) "LDFLAGS=-static";
 

--- a/pkgs/development/libraries/libev/default.nix
+++ b/pkgs/development/libraries/libev/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "1sjs4324is7fp21an4aas2z4dwsvs6z4xwrmp72vwpq1s6wbfzjh";
   };
 
+  outputs = [ "out" "man" ];
+
   configureFlags = lib.optional (static) "LDFLAGS=-static";
 
   meta = {

--- a/pkgs/development/libraries/libewf/default.nix
+++ b/pkgs/development/libraries/libewf/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-7AjUEaXasOzJV9ErZK2a4HMTaqhcBbLKd8M+A5SbKrc=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ zlib openssl libuuid ]
     ++ lib.optionals stdenv.isDarwin [ bzip2 ];

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   # Beware: non-bootstrap libidn2 is overridden by ./hack.nix
-  outputs = [ "bin" "dev" "out" "info" "devdoc" ];
+  outputs = [ "bin" "dev" "out" "info" "devdoc" "man" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libivykis/default.nix
+++ b/pkgs/development/libraries/libivykis/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0abi0rc3wnncvr68hy6rmzp96x6napd7fs1mff20dr8lb0jyvy3f";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ file protobufc ];
 

--- a/pkgs/development/libraries/libivykis/default.nix
+++ b/pkgs/development/libraries/libivykis/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0abi0rc3wnncvr68hy6rmzp96x6napd7fs1mff20dr8lb0jyvy3f";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ file protobufc ];

--- a/pkgs/development/libraries/libmd/default.nix
+++ b/pkgs/development/libraries/libmd/default.nix
@@ -12,11 +12,13 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-G9aqQidTE68xQcfPLluWTosf1IgCXK8vlx9DsAd2szI=";
   };
 
+  outputs = [ "out" "dev" "man" ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
   enableParallelBuilding = true;
 
   doCheck = true;
-
-  nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {
     homepage = "https://www.hadrons.org/software/libmd/";

--- a/pkgs/development/libraries/libmnl/default.nix
+++ b/pkgs/development/libraries/libmnl/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "09851ns07399rbz0y8slrlmnw3fn1nakr8d37pxjn5gkks8rnjr7";
   };
 
+  outputs = [ "out" "dev" ];
+
   meta = {
     description = "Minimalistic user-space library oriented to Netlink developers";
     longDescription = ''

--- a/pkgs/development/libraries/libnet/default.nix
+++ b/pkgs/development/libraries/libnet/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-P3LaDMMNPyEnA8nO1Bm7H0mW/hVBr0cFdg+p2JmWcGI=";
   };
 
+  outputs = [ "out" "doc" ];
+
   nativeBuildInputs = [
     autoconf
     automake

--- a/pkgs/development/libraries/libnetfilter_acct/default.nix
+++ b/pkgs/development/libraries/libnetfilter_acct/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "06lsjndgfjsgfjr43px2n2wk3nr7whz6r405mks3887y7vpwwl22";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libmnl ];
 

--- a/pkgs/development/libraries/libnetfilter_conntrack/default.nix
+++ b/pkgs/development/libraries/libnetfilter_conntrack/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "dev" ];
+
   buildInputs = [ libmnl ];
   propagatedBuildInputs = [ libnfnetlink ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/libraries/libnfnetlink/default.nix
+++ b/pkgs/development/libraries/libnfnetlink/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0xn3rcrzxr6g82kfxzs9bqn2zvl2kf2yda30drwb9vr6sk1wfr5h";
   };
 
+  outputs = [ "out" "dev" ];
+
   meta = {
     description = "Low-level library for netfilter related kernel/userspace communication";
     longDescription = ''

--- a/pkgs/development/libraries/libnftnl/default.nix
+++ b/pkgs/development/libraries/libnftnl/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-zurqLNkhR9oZ8To1p/GkvCdn/4l+g45LR5z1S1nHd/Q=";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libmnl ];
 

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   pname = "libpcap";
   version = "1.10.4";
 
+  outputs = [ "out" "man" ];
+
   src = fetchurl {
     url = "https://www.tcpdump.org/release/${pname}-${version}.tar.gz";
     hash = "sha256-7RmgOD+tcuOtQ1/SOdfNgNZJFrhyaVUBWdIORxYOvl8=";

--- a/pkgs/development/libraries/libpipeline/default.nix
+++ b/pkgs/development/libraries/libpipeline/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-uLRRlJiQIqeewTF/ZKKnWxVRsqVb6gb2dwTLKi5GkLA=";
   };
 
+  outputs = [ "out" "man" ];
+
   patches = lib.optionals stdenv.isDarwin [ ./fix-on-osx.patch ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/librsync/default.nix
+++ b/pkgs/development/libraries/librsync/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-fiOby8tOhv0KJ+ZwAWfh/ynqHlYC9kNqKfxNl3IhzR8=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ perl zlib bzip2 popt ];
 

--- a/pkgs/development/libraries/libslirp/default.nix
+++ b/pkgs/development/libraries/libslirp/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-avUbgXPPV3IhUwZyARxCvctbVlLqDKWmMhAjdVBA3jY=";
   };
 
+  outputs = [ "out" "dev" ];
+
   separateDebugInfo = true;
 
   nativeBuildInputs = [ meson ninja pkg-config ];

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-J6qvq///A/tr+/vNRVCwCc80/VHKWQTYF6Mt1I+dBCU=";
   };
 
-  outputs = [ "out" "dev" ];
-
   postPatch = let
     toDisable = [
       "getnameinfo_basic" "udp_send_hang_loop" # probably network-dependent
@@ -81,6 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
     in lib.optionalString (finalAttrs.finalPackage.doCheck) ''
       sed '/${tdRegexp}/d' -i test/test-list.h
     '';
+
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ automake autoconf libtool pkg-config ];
 

--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -15,10 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5eH0yu4KAd4q7ibjE4gH1tPKK45nKHlm0f79ZeH9iUM=";
   };
 
-  outputs = [
-    "out"
-    "man"
-  ];
+  outputs = [ "out" "man" ];
 
   configureFlags = [
     "--enable-hashes=${enableHashes}"

--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5eH0yu4KAd4q7ibjE4gH1tPKK45nKHlm0f79ZeH9iUM=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   configureFlags = [
     "--enable-hashes=${enableHashes}"

--- a/pkgs/development/libraries/lzo/default.nix
+++ b/pkgs/development/libraries/lzo/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0wm04519pd3g8hqpjqhfr72q8qmbiwqaxcs3cndny9h86aa95y60";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   configureFlags = lib.optional (!stdenv.hostPlatform.isStatic) "--enable-shared" ;
 

--- a/pkgs/development/libraries/lzo/default.nix
+++ b/pkgs/development/libraries/lzo/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0wm04519pd3g8hqpjqhfr72q8qmbiwqaxcs3cndny9h86aa95y60";
   };
 
+  outputs = [ "out" "doc" ];
+
   configureFlags = lib.optional (!stdenv.hostPlatform.isStatic) "--enable-shared" ;
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   pname = "polkit";
   version = "123";
 
-  outputs = [ "bin" "dev" "out" ]; # small man pages in $bin
+  outputs = [ "bin" "dev" "out" "man" ]; # small man pages in $bin
 
   # Tarballs do not contain subprojects.
   src = fetchFromGitLab {

--- a/pkgs/development/libraries/popt/default.nix
+++ b/pkgs/development/libraries/popt/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   doCheck = false; # fails
 

--- a/pkgs/development/libraries/popt/default.nix
+++ b/pkgs/development/libraries/popt/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   doCheck = false; # fails
 
   meta = with lib; {

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -30,6 +30,8 @@ mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
       --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
   '';
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ autoreconfHook buildPackages.which buildPackages.stdenv.cc buildProtobuf ];
 
   buildInputs = [ zlib ];

--- a/pkgs/development/libraries/protobufc/default.nix
+++ b/pkgs/development/libraries/protobufc/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-pmqZYFREPgSrWPekymTglhtAv6gQR1gP3dOl3hqjYig=";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [ protobuf zlib ];

--- a/pkgs/development/libraries/rabbitmq-c/default.nix
+++ b/pkgs/development/libraries/rabbitmq-c/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-4tSZ+eaLZAkSmFsGnIrRXNvn3xA/4sTKyYZ3hPUMcd0=";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openssl popt xmlto ];
 

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-zZwnhBt6WTLJiXZR4guGxwHddAVWmJsByllvz6PUmgo=";
   };
 
-  outputs = [ "bin" "dev" "out" ];
+  outputs = [ "bin" "dev" "out" "man" ];
   separateDebugInfo = stdenv.isLinux;
 
   buildInputs = [ zlib ] ++ lib.optionals interactive [ readline ncurses ];

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-hez55GXiD5j5lQpS6aQR4UMgvFVfolfYdpe356mx2KY=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [
     pkg-config
     python3

--- a/pkgs/development/libraries/ti-rpc/default.nix
+++ b/pkgs/development/libraries/ti-rpc/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     name = "${pname}-${version}.tar.gz";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   KRB5_CONFIG = "${libkrb5.dev}/bin/krb5-config";
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-75yiKVZrR1vcCwKp4tDO4A9JB0KDM0MXPJ1N85kAaRk=";
   };
 
-  outputs = [ "out" "man" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [
     autoreconfHook autoconf-archive pkg-config doxygen perl

--- a/pkgs/development/libraries/xxHash/default.nix
+++ b/pkgs/development/libraries/xxHash/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-kofPs01jb189LUjYHHt+KxDifZQWl0Hm779711mvWtI=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/development/libraries/yajl/default.nix
+++ b/pkgs/development/libraries/yajl/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./cmake-shared-static-fix.patch
   ];
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ cmake ];
 
   doCheck = true;

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   strictDeps = true;
-  outputs = [ "out" "dev" ]
+  outputs = [ "out" "dev" "man" ]
     ++ lib.optional splitStaticOutput "static";
   setOutputFlags = false;
   outputDoc = "dev"; # single tiny man3 page

--- a/pkgs/development/tools/misc/lsof/default.nix
+++ b/pkgs/development/tools/misc/lsof/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     sed -i 's|lcurses|lncurses|g' Configure
   '';
 
+  outputs = [ "out" "man" ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ nukeReferences perl which ];
   buildInputs = [ ncurses ];

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-9ANtPuTY4ijewb7/8PbkbYpA6eVw4AaOOdd+YuLIvcI=";
   };
 
+  outputs = [ "out" "man" ];
+
   strictDeps = true;
 
   setupHook = [ ./setup-hook.sh ];

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-9ANtPuTY4ijewb7/8PbkbYpA6eVw4AaOOdd+YuLIvcI=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   strictDeps = true;
 

--- a/pkgs/development/tools/misc/patchelf/unstable.nix
+++ b/pkgs/development/tools/misc/patchelf/unstable.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
       --replace "set-rpath-library.sh" ""
   '';
 
+  outputs = [ "out" "man" ];
+
   setupHook = [ ./setup-hook.sh ];
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/tools/misc/patchelf/unstable.nix
+++ b/pkgs/development/tools/misc/patchelf/unstable.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       --replace "set-rpath-library.sh" ""
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   setupHook = [ ./setup-hook.sh ];
 

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-IJAgHho/8yhG9P5CHBFjsV9EC7OOMTVdCfgtOUmSKvc=";
   };
 
+  outputs = [ "out" "man" ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl ];
 

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -116,7 +116,7 @@ let
       (lib.withFeature withPython "python")
     ];
 
-    outputs = [ "out" "man" ] ++ lib.optional withPython "python";
+    outputs = [ "out" "dev" "man" ] ++ lib.optional withPython "python";
 
     postInstall = lib.optionalString withPython ''
       mkdir -p $python/lib

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -116,7 +116,7 @@ let
       (lib.withFeature withPython "python")
     ];
 
-    outputs = [ "out" ] ++ lib.optional withPython "python";
+    outputs = [ "out" "man" ] ++ lib.optional withPython "python";
 
     postInstall = lib.optionalString withPython ''
       mkdir -p $python/lib
@@ -134,6 +134,8 @@ let
     format = "other";
 
     src = apparmor-sources;
+
+    outputs = [ "out" "man" ];
 
     strictDeps = true;
 
@@ -192,6 +194,8 @@ let
 
     src = apparmor-sources;
 
+    outputs = [ "out" "man" ];
+
     nativeBuildInputs = [
       pkg-config
       libapparmor
@@ -219,6 +223,8 @@ let
     version = apparmor-version;
 
     src = apparmor-sources;
+
+    outputs = [ "out" "man" ];
 
     nativeBuildInputs = [ bison flex which ];
 

--- a/pkgs/os-specific/linux/bridge-utils/default.nix
+++ b/pkgs/os-specific/linux/bridge-utils/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = {

--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-De+quFvT6kb/xFq0H7DQrVTQWuLPqn5QPehtTxK8gWE=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook docutils pkg-config ];
 
   buildInputs = [ libkrb5 keyutils pam talloc python3 ];

--- a/pkgs/os-specific/linux/cpufrequtils/default.nix
+++ b/pkgs/os-specific/linux/cpufrequtils/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
       -i Makefile
   '';
 
+  outputs = [ "out" "man" ];
+
   buildInputs = [ stdenv.cc.libc.linuxHeaders libtool gettext ];
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     "CROSS_COMPILE=${stdenv.hostPlatform.config}-"
   ]);
 
-  outputs = [ "out" "dev" "man" ];
+  outputs = [ "out" "man" ];
 
   preBuild = ''
     # No idea why but configure scripts break otherwise.

--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-eddnNe6OJRluKnIpZM+Wg/WglYFQNTeISyVrATicwHM=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   makeFlags = [
     "prefix=$(out)"

--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-eddnNe6OJRluKnIpZM+Wg/WglYFQNTeISyVrATicwHM=";
   };
 
+  outputs = [ "out" "man" ];
+
   makeFlags = [
     "prefix=$(out)"
     "CC=${stdenv.cc.targetPrefix}cc"

--- a/pkgs/os-specific/linux/dmraid/default.nix
+++ b/pkgs/os-specific/linux/dmraid/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     NIX_CFLAGS_COMPILE+=" -D_GNU_SOURCE"
   '';
 
+  outputs = [ "out" "man" ];
+
   preConfigure = "cd */";
 
   buildInputs = [ lvm2 ];

--- a/pkgs/os-specific/linux/dmraid/default.nix
+++ b/pkgs/os-specific/linux/dmraid/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     NIX_CFLAGS_COMPILE+=" -D_GNU_SOURCE"
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   preConfigure = "cd */";
 

--- a/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
@@ -11,13 +11,15 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-xoGMEcGMwDDVX/g/ZLK62P7vSF53QvhPlKYdgRpiWL0=";
   };
 
+  outputs = [ "out" "doc" ];
+
   installPhase = ''
     runHook preInstall
 
     install -D -m644 ipw2200-bss.fw     $out/lib/firmware/ipw2200-bss.fw
     install -D -m644 ipw2200-ibss.fw    $out/lib/firmware/ipw2200-ibss.fw
     install -D -m644 ipw2200-sniffer.fw $out/lib/firmware/ipw2200-sniffer.fw
-    install -D -m644 LICENSE.ipw2200-fw $out/share/doc/intel2200BGFirmware/LICENSE
+    install -D -m644 LICENSE.ipw2200-fw $doc/share/doc/intel2200BGFirmware/LICENSE
 
     runHook postInstall
   '';

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     then [ meson ninja pkg-config ]
     else [ autoreconfHook gettext ];
 
-  outputs = [ "out" ] ++ lib.optional isFuse3 "common";
+  outputs = [ "out" "man" ] ++ lib.optional isFuse3 "common";
 
   mesonFlags = lib.optionals isFuse3 [
     "-Dudevrulesdir=/udev/rules.d"
@@ -65,8 +65,8 @@ in stdenv.mkDerivation rec {
     '' + (if isFuse3 then ''
       # The configure phase will delete these files (temporary workaround for
       # ./fuse3-install_man.patch)
-      install -D -m444 doc/fusermount3.1 $out/share/man/man1/fusermount3.1
-      install -D -m444 doc/mount.fuse3.8 $out/share/man/man8/mount.fuse3.8
+      install -D -m444 doc/fusermount3.1 $man/share/man/man1/fusermount3.1
+      install -D -m444 doc/mount.fuse3.8 $man/share/man/man8/mount.fuse3.8
     '' else ''
       substituteInPlace util/mount.fuse.c --replace '"su"' '"${shadow.su}/bin/su"'
       sed -e 's@CONFIG_RPATH=/usr/share/gettext/config.rpath@CONFIG_RPATH=${gettext}/share/gettext/config.rpath@' -i makeconf.sh

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     then [ meson ninja pkg-config ]
     else [ autoreconfHook gettext ];
 
-  outputs = [ "out" "man" ] ++ lib.optional isFuse3 "common";
+  outputs = [ "out" "dev" "man" ] ++ lib.optional isFuse3 "common";
 
   mesonFlags = lib.optionals isFuse3 [
     "-Dudevrulesdir=/udev/rules.d"

--- a/pkgs/os-specific/linux/hdparm/default.nix
+++ b/pkgs/os-specific/linux/hdparm/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-0Ukp+RDQYJMucX6TgkJdR8LnFEI1pTcT1VqU995TWks=";
   };
 
+  outputs = [ "out" "man" ];
+
   makeFlags = [
     "sbindir=${placeholder "out"}/sbin"
     "manprefix=${placeholder "out"}"

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       --replace "CC := gcc" "CC ?= $CC"
   '';
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   makeFlags = [
     "PREFIX=$(out)"

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-sERY8ZKuXiY85cXdNWOm4byiNU7mOVIeA55dgQJHdoE=";
   };
 
-  outputs = [ "out" "apparmor" ];
+  outputs = [ "out" "apparmor" "man" ];
 
   # We don't have the required permissions inside the build sandbox:
   # /build/source/build/ping/ping: socket: Operation not permitted

--- a/pkgs/os-specific/linux/iw/default.nix
+++ b/pkgs/os-specific/linux/iw/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-8We76UfdU7uevAwdzvXbatc6wdYITyxvk3bFw2DMTU4=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libnl ];
 

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -24,10 +24,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-UZ+NCHrsyn4KM80IS++SwGbrGXMWZmU9zHDJ1xqkCSY=";
   };
 
-  # vlock is moved into its own output, since it depends on pam. This
-  # reduces closure size for most use cases.
-  outputs = [ "out" "vlock" "dev" ];
-
   configureFlags = [
     "--enable-optional-progs"
     "--enable-libkeymap"
@@ -72,6 +68,10 @@ stdenv.mkDerivation rec {
         --replace /usr/bin/tty ${coreutils}/bin/tty
     done
   '';
+
+  # vlock is moved into its own output, since it depends on pam. This
+  # reduces closure size for most use cases.
+  outputs = [ "out" "vlock" "dev" "man" ];
 
   buildInputs = [ check pam ];
   NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isStatic "-laudit";

--- a/pkgs/os-specific/linux/kexec-tools/default.nix
+++ b/pkgs/os-specific/linux/kexec-tools/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   hardeningDisable = [ "format" "pic" "relro" "pie" ];
 
   # Prevent kexec-tools from using uname to detect target, which is wrong in

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
     hash = "sha256-FNR015/AoYBbi7Eb1M2TXH3yxUuddKICCu+ot10CdeQ=";
   };
 
-  outputs = [ "out" "dev" "lib" ] ++ lib.optional withDevdoc "devdoc";
+  outputs = [ "out" "dev" "lib" "man" ] ++ lib.optional withDevdoc "devdoc";
 
   strictDeps = true;
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/libaio/default.nix
+++ b/pkgs/os-specific/linux/libaio/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
       --replace "-Werror" ""
   '';
 
+  outputs = [ "out" "dev" ];
+
   makeFlags = [
     "prefix=${placeholder "out"}"
   ] ++ lib.optional stdenv.hostPlatform.isStatic "ENABLE_SHARED=0";

--- a/pkgs/os-specific/linux/libatasmart/default.nix
+++ b/pkgs/os-specific/linux/libatasmart/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "138gvgdwk6h4ljrjsr09pxk1nrki4b155hqdzyr8mlk3bwsfmw31";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/os-specific/linux/libatasmart/default.nix
+++ b/pkgs/os-specific/linux/libatasmart/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "138gvgdwk6h4ljrjsr09pxk1nrki4b155hqdzyr8mlk3bwsfmw31";
   };
 
+  outputs = [ "out" "doc" ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ udev ];

--- a/pkgs/os-specific/linux/lksctp-tools/default.nix
+++ b/pkgs/os-specific/linux/lksctp-tools/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "05da6c2v3acc18ndvmkrag6x5lf914b7s0xkkr6wkvrbvd621sqs";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   meta = with lib; {
     description = "Linux Kernel Stream Control Transmission Protocol Tools";

--- a/pkgs/os-specific/linux/lksctp-tools/default.nix
+++ b/pkgs/os-specific/linux/lksctp-tools/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "05da6c2v3acc18ndvmkrag6x5lf914b7s0xkkr6wkvrbvd621sqs";
   };
 
+  outputs = [ "out" "man" ];
+
   meta = with lib; {
     description = "Linux Kernel Stream Control Transmission Protocol Tools";
     homepage = "https://lksctp.sourceforge.net/";

--- a/pkgs/os-specific/linux/lm-sensors/default.nix
+++ b/pkgs/os-specific/linux/lm-sensors/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     substituteInPlace prog/sensors/Module.mk --replace 'lib/$(LIBSHBASENAME)' ""
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ bison flex which ];
   # bash is required for correctly replacing the shebangs in all tools for cross-compilation.

--- a/pkgs/os-specific/linux/lm-sensors/default.nix
+++ b/pkgs/os-specific/linux/lm-sensors/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     substituteInPlace prog/sensors/Module.mk --replace 'lib/$(LIBSHBASENAME)' ""
   '';
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ bison flex which ];
   # bash is required for correctly replacing the shebangs in all tools for cross-compilation.
   buildInputs = [ bash perl ]

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./no-self-references.patch ];
 
+  outputs = [ "out" "man" ];
+
   makeFlags = [
     "NIXOS=1" "INSTALL=install" "BINDIR=$(out)/sbin"
     "SYSTEMD_DIR=$(out)/lib/systemd/system"

--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-smJDWlJB6Jv6UcPKvVEzdTlS96e3uT8y4Iy52W9YDWk=";
   };
 
+  outputs = [ "out" "man" ];
+
   preBuild =
     ''
       cp ${./config.h} config.h

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-o8MEzZugYSOe4EdPmvuTipu5nYm5YCRvZvDDoKheFM0=";
   };
 
-  outputs = [ "out" "doc" "man" ];
+  outputs = [ "out" "dev" "doc" "man" ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-o8MEzZugYSOe4EdPmvuTipu5nYm5YCRvZvDDoKheFM0=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config bison flex

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-o8MEzZugYSOe4EdPmvuTipu5nYm5YCRvZvDDoKheFM0=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     touch ChangeLog
   '' else null;
 
-  outputs = [ "out" "doc" "man" /* "modules" */ ];
+  outputs = [ "out" "dev" "doc" "man" /* "modules" */ ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   # autoreconfHook269 is needed for `suid-wrapper-path.patch` above.

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "doc" "man" ];
+  outputs = [ "out" "dev" "doc" "man" ];
 
   buildInputs = [ ncurses ]
     ++ lib.optional withSystemd systemd;

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   buildInputs = [ ncurses ]
     ++ lib.optional withSystemd systemd;

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   buildInputs = [ ncurses ]
     ++ lib.optional withSystemd systemd;
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/os-specific/linux/sdparm/default.nix
+++ b/pkgs/os-specific/linux/sdparm/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xMnvr9vrZi4vlxJwfsSQkyvU0BC7ESmueplSZUburb4=";
   };
 
+  outputs = [ "out" "man" ];
+
   meta = with lib; {
     homepage = "http://sg.danny.cz/sg/sdparm.html";
     description = "A utility to access SCSI device parameters";

--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -80,6 +80,8 @@ stdenv.mkDerivation {
     touch gnu-efi/inc/ia32/gnu/stubs-32.h
   '';
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [
     nasm
     perl

--- a/pkgs/os-specific/linux/sysstat/default.nix
+++ b/pkgs/os-specific/linux/sysstat/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-ELmSzWnJ8vGwGPwY/5MFp/2gQhMXMjNG4bHtCplfQSc=";
   };
 
+  outputs = [ "out" "man" ];
+
   buildInputs = [ gettext ];
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/sysstat/default.nix
+++ b/pkgs/os-specific/linux/sysstat/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-ELmSzWnJ8vGwGPwY/5MFp/2gQhMXMjNG4bHtCplfQSc=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   buildInputs = [ gettext ];
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -402,7 +402,9 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tools test src/!(rpm|kernel-install|ukify) src/kernel-install/test-kernel-install.sh
   '';
 
-  outputs = [ "out" "dev" ] ++ (lib.optional (!buildLibsOnly) "man");
+  outputs = [ "out" "dev" ]
+    ++ (lib.optional (!buildLibsOnly) "man")
+    ++ (lib.optional withDocumentation "doc");
 
   nativeBuildInputs =
     [

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation rec {
   # the greater util-linux toolset.
   # Compatibility is maintained by symlinking the binaries from the
   # smaller outputs in the bin output.
-  outputs = [ "bin" "dev" "out" "lib" "man" ] ++ lib.optionals stdenv.isLinux [ "mount" ] ++ [ "login" ] ++ lib.optionals stdenv.isLinux [ "swap" ];
+  outputs = [ "bin" "dev" "out" "lib" "doc" "man" ] ++ lib.optionals stdenv.isLinux [ "mount" ] ++ [ "login" ] ++ lib.optionals stdenv.isLinux [ "swap" ];
+
   separateDebugInfo = true;
 
   postPatch = ''

--- a/pkgs/os-specific/linux/wireless-tools/default.nix
+++ b/pkgs/os-specific/linux/wireless-tools/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0qscyd44jmhs4k32ggp107hlym1pcyjzihiai48xs7xzib4wbndb";
   };
 
+  outputs = [ "out" "man" ];
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "CC:=$(CC)"

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
       ${optionalString withPcsclite "-I${lib.getDev pcsclite}/include/PCSC/"}"
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   buildInputs = [ openssl libnl ]
     ++ optional dbusSupport dbus

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -104,6 +104,8 @@ stdenv.mkDerivation rec {
       ${optionalString withPcsclite "-I${lib.getDev pcsclite}/include/PCSC/"}"
   '';
 
+  outputs = [ "out" "man" ];
+
   buildInputs = [ openssl libnl ]
     ++ optional dbusSupport dbus
     ++ optional withReadline readline

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -196,7 +196,9 @@ let
       done
     '';
 
-    outputs = [ "out" ] ++ optionals buildUser [ "dev" ];
+    outputs = [ "out" ]
+      ++ optional buildUser "dev"
+      ++ optional (!buildKernel) "man";
 
     passthru = {
       inherit enableMail latestCompatibleLinuxPackages kernelModuleAttribute;

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     substituteInPlace src/prog/gpm-root.y --replace __sigemptyset sigemptyset
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [ automake autoconf libtool flex bison texinfo ];
   buildInputs = [ ncurses ];

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     substituteInPlace src/prog/gpm-root.y --replace __sigemptyset sigemptyset
   '';
 
-  outputs = [ "out" "info" "man" ];
+  outputs = [ "out" "dev" "info" "man" ];
 
   nativeBuildInputs = [ automake autoconf libtool flex bison texinfo ];
   buildInputs = [ ncurses ];

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/prog/gpm-root.y --replace __sigemptyset sigemptyset
   '';
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ automake autoconf libtool flex bison texinfo ];
   buildInputs = [ ncurses ];
 

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
     inherit hash;
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   cmakeFlags = [
     "-DMARIADB_UNIX_ADDR=/run/mysqld/mysqld.sock"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -184,7 +184,7 @@ self: super:
   });
 
   libXtst = super.libXtst.overrideAttrs (attrs: {
-    outputs = [ "out" "man" ];
+    outputs = [ "out" "doc" "man" ];
     meta = attrs.meta // {
       pkgConfigModules = [ "xtst" ];
     };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -172,7 +172,7 @@ self: super:
   });
 
   libXau = super.libXau.overrideAttrs (attrs: {
-    outputs = [ "out" "dev" ];
+    outputs = [ "out" "dev" "man" ];
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ xorg.xorgproto ];
   });
 
@@ -184,6 +184,7 @@ self: super:
   });
 
   libXtst = super.libXtst.overrideAttrs (attrs: {
+    outputs = [ "out" "man" ];
     meta = attrs.meta // {
       pkgConfigModules = [ "xtst" ];
     };
@@ -197,19 +198,22 @@ self: super:
   });
 
   libXxf86vm = super.libXxf86vm.overrideAttrs (attrs: {
-    outputs = [ "out" "dev" ];
+    outputs = [ "out" "dev" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });
   libXxf86dga = super.libXxf86dga.overrideAttrs (attrs: {
+    outputs = [ "out" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });
   libXxf86misc = super.libXxf86misc.overrideAttrs (attrs: {
+    outputs = [ "out" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });
   libdmx = super.libdmx.overrideAttrs (attrs: {
+    outputs = [ "out" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });
@@ -225,6 +229,7 @@ self: super:
   listres = addMainProgram super.listres { };
 
   xdpyinfo = super.xdpyinfo.overrideAttrs (attrs: {
+    outputs = [ "out" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
     preConfigure = attrs.preConfigure or ""
@@ -277,7 +282,7 @@ self: super:
   });
 
   libXcomposite = super.libXcomposite.overrideAttrs (attrs: {
-    outputs = [ "out" "dev" ];
+    outputs = [ "out" "dev" "man" ];
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ xorg.libXfixes ];
   });
 
@@ -329,7 +334,7 @@ self: super:
   });
 
   libXinerama = super.libXinerama.overrideAttrs (attrs: {
-    outputs = [ "out" "dev" ];
+    outputs = [ "out" "dev" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });
@@ -922,6 +927,7 @@ self: super:
   });
 
   xauth = super.xauth.overrideAttrs (attrs: {
+    outputs = [ "out" "man" ];
     doCheck = false; # fails
     preConfigure = attrs.preConfigure or ""
     # missing transitive dependencies
@@ -1056,6 +1062,7 @@ self: super:
   });
 
   xpr = addMainProgram super.xpr { };
+
   xprop = addMainProgram super.xprop { };
 
   xrdb = super.xrdb.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -184,7 +184,7 @@ self: super:
   });
 
   libXtst = super.libXtst.overrideAttrs (attrs: {
-    outputs = [ "out" "doc" "man" ];
+    outputs = [ "out" "dev" "doc" "man" ];
     meta = attrs.meta // {
       pkgConfigModules = [ "xtst" ];
     };
@@ -203,7 +203,7 @@ self: super:
       ++ malloc0ReturnsNullCrossFlag;
   });
   libXxf86dga = super.libXxf86dga.overrideAttrs (attrs: {
-    outputs = [ "out" "man" ];
+    outputs = [ "out" "dev" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });
@@ -213,7 +213,7 @@ self: super:
       ++ malloc0ReturnsNullCrossFlag;
   });
   libdmx = super.libdmx.overrideAttrs (attrs: {
-    outputs = [ "out" "man" ];
+    outputs = [ "out" "dev" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });

--- a/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "03r6hpb5fy4yaakqm3lbf4xcvd408r44jgpv4lnzl9asp4sb9qc0";
   };
 
+  outputs = [ "out" "doc" ];
+
   strictDeps = true;
   buildInputs = [ zsh ];
 

--- a/pkgs/tools/archivers/cpio/default.nix
+++ b/pkgs/tools/archivers/cpio/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-k3YQuXwymh7JJoVT+3gAN7z/8Nz/6XJevE/ZwaqQdds=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/tools/archivers/cpio/default.nix
+++ b/pkgs/tools/archivers/cpio/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-k3YQuXwymh7JJoVT+3gAN7z/8Nz/6XJevE/ZwaqQdds=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   separateDebugInfo = true;

--- a/pkgs/tools/archivers/gnutar/default.nix
+++ b/pkgs/tools/archivers/gnutar/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     substituteInPlace src/system.c --replace '_(' 'N_('
   '';
 
-  outputs = [ "out" "info" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = lib.optional stdenv.isDarwin autoreconfHook;
   # Add libintl on Darwin specifically as it fails to link (or skip)

--- a/pkgs/tools/archivers/unzip/default.nix
+++ b/pkgs/tools/archivers/unzip/default.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation rec {
       sha256 = "67ab260ae6adf8e7c5eda2d1d7846929b43562943ec4aff629bd7018954058b1";
     });
 
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ bzip2 ];
   buildInputs = [ bzip2 ] ++ lib.optional enableNLS libnatspec;

--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     substituteInPlace unix/Makefile --replace 'CC = cc' ""
   '';
 
+  outputs = [ "out" "man" ];
+
   hardeningDisable = [ "format" ];
 
   makefile = "unix/Makefile";

--- a/pkgs/tools/backup/dar/default.nix
+++ b/pkgs/tools/backup/dar/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-d88BwbovhbAn72y5pVd4No+hVydXbtZYHZpdtpo4RGY=";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ which ];
 

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = lib.optional staticOnly "-DBUILD_SHARED_LIBS=OFF";
 
-  outputs = [ "out" "dev" "lib" ];
+  outputs = [ "out" "dev" "lib" "man" ];
 
   doCheck = true;
 

--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   # TODO(@Ericson2314): Separate binaries and libraries
-  outputs = [ "bin" "out" "dev" ];
+  outputs = [ "bin" "out" "dev" "man" ];
 
   buildInputs = lib.optional doCheck valgrind;
 

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     ''
   );
 
-  outputs = [ "bin" "dev" ]
+  outputs = [ "bin" "dev" "doc" ]
     ++ lib.optional stdenv.hostPlatform.isUnix "man"
     ++ [ "out" ];
 

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-Ors2xXRrVTf8Cq3BYnSVSfJy/nyGjT5BGLSNpxOcHR4=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ util-linux ];
 

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-JNx7l08KV7oOyoD5dEC4QN+oWw8cssAb39l2WaSAsgA=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-JNx7l08KV7oOyoD5dEC4QN+oWw8cssAb39l2WaSAsgA=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [
     pkg-config
   ] ++ [

--- a/pkgs/tools/filesystems/dosfstools/default.nix
+++ b/pkgs/tools/filesystems/dosfstools/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ]
     ++ lib.optional stdenv.isDarwin libiconv;
 

--- a/pkgs/tools/filesystems/dosfstools/default.nix
+++ b/pkgs/tools/filesystems/dosfstools/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ]
     ++ lib.optional stdenv.isDarwin libiconv;

--- a/pkgs/tools/filesystems/exfat/default.nix
+++ b/pkgs/tools/filesystems/exfat/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-5m8fiItEOO6piR132Gxq6SHOPN1rAFTuTVE+UI0V00k=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ fuse ];
 

--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-zNG1F//+BTBzlEc6qNVixyuCB6PMZD5Kf8pVK0ePYiA=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libselinux libuuid ];
 

--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-zNG1F//+BTBzlEc6qNVixyuCB6PMZD5Kf8pVK0ePYiA=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libselinux libuuid ];

--- a/pkgs/tools/filesystems/fuse-overlayfs/default.nix
+++ b/pkgs/tools/filesystems/fuse-overlayfs/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-ngpC1KtUsIJOfpJ9dSqZn9XhKkJSpp2/6RBz/RlZ+A0=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [ fuse3 ];

--- a/pkgs/tools/filesystems/gpart/default.nix
+++ b/pkgs/tools/filesystems/gpart/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     owner = "baruch";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   enableParallelBuilding = true;

--- a/pkgs/tools/filesystems/gpart/default.nix
+++ b/pkgs/tools/filesystems/gpart/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "baruch";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/tools/filesystems/jfsutils/default.nix
+++ b/pkgs/tools/filesystems/jfsutils/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libuuid ];
 

--- a/pkgs/tools/filesystems/mtools/default.nix
+++ b/pkgs/tools/filesystems/mtools/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   patches = lib.optional stdenv.isDarwin ./UNUSED-darwin.patch;
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   # fails to find X on darwin
   configureFlags = lib.optional stdenv.isDarwin "--without-x";

--- a/pkgs/tools/filesystems/mtools/default.nix
+++ b/pkgs/tools/filesystems/mtools/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   patches = lib.optional stdenv.isDarwin ./UNUSED-darwin.patch;
 
+  outputs = [ "out" "man" ];
+
   # fails to find X on darwin
   configureFlags = lib.optional stdenv.isDarwin "--without-x";
 

--- a/pkgs/tools/filesystems/nilfs-utils/default.nix
+++ b/pkgs/tools/filesystems/nilfs-utils/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-XqViUvPj2BHO3bGs9xBO3VpRq9XqnwBptHvMwBOntqo=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ libuuid libselinux ];

--- a/pkgs/tools/filesystems/nilfs-utils/default.nix
+++ b/pkgs/tools/filesystems/nilfs-utils/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-XqViUvPj2BHO3bGs9xBO3VpRq9XqnwBptHvMwBOntqo=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/tools/filesystems/reiserfsprogs/default.nix
+++ b/pkgs/tools/filesystems/reiserfsprogs/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-DpW2f6d0ajwtWRRem5wv60pr5ShT6DtJexgurlCOYuM=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libuuid e2fsprogs acl ];
 

--- a/pkgs/tools/filesystems/sshfs-fuse/common.nix
+++ b/pkgs/tools/filesystems/sshfs-fuse/common.nix
@@ -22,6 +22,8 @@ in stdenv.mkDerivation rec {
 
   inherit patches;
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ meson pkg-config ninja docutils makeWrapper ];
   buildInputs = [ fuse glib ];
   nativeCheckInputs = [ which python3Packages.pytest ];

--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-wxhoQYv79Jo6nEf8cM3/3p2W9P8AUb0EoIgeZlRkgQQ=";
   };
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" "man" ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [

--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation {
     hash = "sha256-o7SPK/G31cW/rrLwV3UJOTq6EBHl6AEE/GdeKGlHdyg=";
   };
 
+  outputs = [ "out" "man" ];
+
   preBuild = lib.optionalString (conf != null)
     "cp ${writeText "config.def.h" conf} config.def.h";
 

--- a/pkgs/tools/misc/bc/default.nix
+++ b/pkgs/tools/misc/bc/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "62adfca89b0a1c0164c2cdca59ca210c1d44c3ffc46daf9931cf4942664cb02a";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   configureFlags = [ "--with-readline" ];
 

--- a/pkgs/tools/misc/bc/default.nix
+++ b/pkgs/tools/misc/bc/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "62adfca89b0a1c0164c2cdca59ca210c1d44c3ffc46daf9931cf4942664cb02a";
   };
 
+  outputs = [ "out" "man" ];
+
   configureFlags = [ "--with-readline" ];
 
   # As of 1.07 cross-compilation is quite complicated as the build system wants

--- a/pkgs/tools/misc/ccze/default.nix
+++ b/pkgs/tools/misc/ccze/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-LVwmbrq78mZcAEuAqjXTqLE5we83H9mcMPtxQx2Tn/c=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoconf ];
 
   buildInputs = [ ncurses pcre ];

--- a/pkgs/tools/misc/ccze/default.nix
+++ b/pkgs/tools/misc/ccze/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-LVwmbrq78mZcAEuAqjXTqLE5we83H9mcMPtxQx2Tn/c=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ autoconf ];
 

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -81,7 +81,8 @@ stdenv.mkDerivation rec {
     sed '2i echo Skipping cut huge range test && exit 77' -i ./tests/cut/cut-huge-range.sh
   '');
 
-  outputs = [ "out" "info" ];
+  outputs = [ "out" "info" ] ++ optional (!minimal) "man";
+
   separateDebugInfo = true;
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/dvtm/dvtm.nix
+++ b/pkgs/tools/misc/dvtm/dvtm.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
     cp ${builtins.toFile "config.h" customConfig} ./config.h
   '';
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ ncurses ];
   buildInputs = [ ncurses ];
 

--- a/pkgs/tools/misc/ethtool/default.nix
+++ b/pkgs/tools/misc/ethtool/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     && (stdenv.hostPlatform.libc != "musl")
     && stdenv.hostPlatform == stdenv.buildPlatform;
 
-  outputs = [ "out" "info" "locate"];
+  outputs = [ "out" "info" "locate" "man" ];
 
   configureFlags = [
     # "sort" need not be on the PATH as a run-time dep, so we need to tell

--- a/pkgs/tools/misc/grc/default.nix
+++ b/pkgs/tools/misc/grc/default.nix
@@ -27,6 +27,8 @@ buildPythonApplication rec {
       --replace "^([/\w\.]+\/)" "^([/\w\.\-]+\/)"
   '';
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''

--- a/pkgs/tools/misc/lnav/default.nix
+++ b/pkgs/tools/misc/lnav/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  outputs = [ "out" "man" ];
+
   strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [

--- a/pkgs/tools/misc/most/default.nix
+++ b/pkgs/tools/misc/most/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-lFWuuPgm+oOFyFDcIr8PIs+QabPDQj+6S/LG9iJtmQM=";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "doc" "man" ];
 
   makeFlags = [
     "DOC_DIR=${placeholder "doc"}/share/doc/most"

--- a/pkgs/tools/misc/ms-sys/default.nix
+++ b/pkgs/tools/misc/ms-sys/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
   # TODO: Remove with next release, see https://sourceforge.net/p/ms-sys/patches/8/
   patches = [ ./manpages-without-build-timestamps.patch ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ gettext ];
 
   enableParallelBuilding = true;

--- a/pkgs/tools/misc/riemann-c-client/default.nix
+++ b/pkgs/tools/misc/riemann-c-client/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-FIhTT57g2uZBaH3EPNxNUNJn9n+0ZOhI6WMyF+xIr/Q=";
   };
 
-  outputs = [ "bin" "dev" "out" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   nativeBuildInputs = [ autoreconfHook check pkg-config ];
   buildInputs = [ file protobufc ]

--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     "--enable-rxvt_osc"
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [
     autoreconfHook
   ];

--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     "--enable-rxvt_osc"
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/tools/misc/screenfetch/default.nix
+++ b/pkgs/tools/misc/screenfetch/default.nix
@@ -29,11 +29,13 @@ in stdenv.mkDerivation rec {
     sha256 = "04l8aqr474pb115nagn9f6y48jw92n1qfszgw7dbhgl4mpn95lcr";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     install -Dm 0755 screenfetch-dev $out/bin/screenfetch
-    install -Dm 0644 screenfetch.1 $out/share/man/man1/screenfetch.1
+    install -Dm 0644 screenfetch.1 $man/share/man/man1/screenfetch.1
     install -Dm 0644 -t $out/share/doc/screenfetch CHANGELOG COPYING README.mkdn TODO
 
     # Fix all of the dependencies of screenfetch

--- a/pkgs/tools/misc/screenfetch/default.nix
+++ b/pkgs/tools/misc/screenfetch/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
     sha256 = "04l8aqr474pb115nagn9f6y48jw92n1qfszgw7dbhgl4mpn95lcr";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1iwg04rhmdhijmlk5hfl8wvv83115lzb65if6cc1glkkfva8jfjp";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ expat libaio boost ];

--- a/pkgs/tools/misc/time/default.nix
+++ b/pkgs/tools/misc/time/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+6zwyB5iQp3z4zvaTO44dWYE8Y4B2XczjiMwaj47Uh4=";
   };
 
+  outputs = [ "out" "info" ];
+
   meta = {
     description = "Tool that runs programs and summarizes the system resources they use";
     longDescription = ''

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-tNC5XCA8dShaTIff15mQz8v+YK9sZkRNLCX5qnlpxx4=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     udev

--- a/pkgs/tools/networking/fping/default.nix
+++ b/pkgs/tools/networking/fping/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-HuUmjAY9dmRq8rRCYFLn2BpCtlfmp32OfT0uYP10Cf4=";
   };
 
+  outputs = [ "out" "man" ];
+
   configureFlags = [ "--enable-ipv6" "--enable-ipv4" ];
 
   meta = with lib; {

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-h2l9YKMeELXLhqnwZR4ex77pgyDQSMBzlDGqw9V2T7Y=";
   };
 
-  outputs = [ "out" "apparmor" "man" ];
+  outputs = [ "out" "apparmor" "info" "man" ];
 
   patches = [
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-h2l9YKMeELXLhqnwZR4ex77pgyDQSMBzlDGqw9V2T7Y=";
   };
 
-  outputs = ["out" "apparmor"];
+  outputs = [ "out" "apparmor" "man" ];
 
   patches = [
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3

--- a/pkgs/tools/networking/iperf/3.nix
+++ b/pkgs/tools/networking/iperf/3.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     "--with-openssl=${openssl.dev}"
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   patches = lib.optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {

--- a/pkgs/tools/networking/mtr/default.nix
+++ b/pkgs/tools/networking/mtr/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional (!withGtk) "--without-gtk";
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [ ncurses jansson ]

--- a/pkgs/tools/networking/ookla-speedtest/default.nix
+++ b/pkgs/tools/networking/ookla-speedtest/default.nix
@@ -38,12 +38,14 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
+  outputs = [ "out" "man" ];
+
   dontBuild = true;
   dontConfigure = true;
 
   installPhase = ''
     install -D speedtest $out/bin/speedtest
-    install -D speedtest.5 $out/share/man/man5/speedtest.5
+    install -D speedtest.5 $man/share/man/man5/speedtest.5
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/openresolv/default.nix
+++ b/pkgs/tools/networking/openresolv/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-rpfzAIzuiO+QTFhN+tHND+OQOyX/GUPvLLX3CSSwqA4=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ makeWrapper ];
 
   configurePhase =

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation {
       substituteInPlace Makefile.in --replace '$(INSTALL) -m 4711' '$(INSTALL) -m 0711'
     '';
 
+  outputs = [ "out" "man" ];
+
   strictDeps = true;
   nativeBuildInputs = [ autoreconfHook pkg-config ]
     # This is not the same as the libkrb5 from the inputs! pkgs.libkrb5 is
@@ -158,7 +160,7 @@ stdenv.mkDerivation {
     # Install ssh-copy-id, it's very useful.
     cp contrib/ssh-copy-id $out/bin/
     chmod +x $out/bin/ssh-copy-id
-    cp contrib/ssh-copy-id.1 $out/share/man/man1/
+    cp contrib/ssh-copy-id.1 $man/share/man/man1/
   '';
 
   installTargets = [ "install-nokeys" ];

--- a/pkgs/tools/networking/openssh/copyid.nix
+++ b/pkgs/tools/networking/openssh/copyid.nix
@@ -1,11 +1,12 @@
 { runCommand, openssh }:
 
 runCommand "ssh-copy-id-${openssh.version}" {
+  outputs = [ "out" "man" ];
   meta = openssh.meta // {
     description = "A tool to copy SSH public keys to a remote machine";
     priority = (openssh.meta.priority or 0) - 1;
   };
 } ''
   install -Dm 755 {${openssh},$out}/bin/ssh-copy-id
-  install -Dm 644 {${openssh},$out}/share/man/man1/ssh-copy-id.1.gz
+  install -Dm 644 {${openssh.man},$man}/share/man/man1/ssh-copy-id.1.gz
 ''

--- a/pkgs/tools/networking/slirp4netns/default.nix
+++ b/pkgs/tools/networking/slirp4netns/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-6kfL0ZjXzcyZl3remLi25RMLWCpg+a8EHC1M5LJE4a4=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [ glib libcap libseccomp libslirp ];

--- a/pkgs/tools/networking/socat/default.nix
+++ b/pkgs/tools/networking/socat/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
       --replace /sbin/ifconfig ifconfig
   '';
 
+  outputs = [ "out" "man" ];
+
   buildInputs = [ openssl readline ];
 
   hardeningEnable = [ "pie" ];

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     patchShebangs tests
   '';
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = lib.optional (stdenv.hostPlatform.isStatic) [ pkg-config ];
 
   nativeCheckInputs = [ perl ];

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-qXUyRohUxhwt5IykFw3oVP07yVyAQ7sM+w/iZgWWZiQ=";
   };
 
-  outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB
+  outputs = [ "out" "lib" "dev" "man" ];
 
   nativeBuildInputs =
     lib.optionals withMakeWrapper [ makeWrapper ]

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     ./remove-runtime-dep-on-openssl-headers.patch
   ];
 
+  outputs = [ "out" "man" ];
+
   preConfigure = ''
     patchShebangs doc
 

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     ./remove-runtime-dep-on-openssl-headers.patch
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   preConfigure = ''
     patchShebangs doc

--- a/pkgs/tools/security/ccrypt/default.nix
+++ b/pkgs/tools/security/ccrypt/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0kx4a5mhmp73ljknl2lcccmw9z3f5y8lqw0ghaymzvln1984g75i";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ perl ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-Zd8zLkFlvXTbeInEkNFyHgcAiOsX4WwF6hf5juSQvbY=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "man" "doc" ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation {
   pname = "gnupg1compat";
   version = gnupg.version;
 
+  outputs = [ "out" "man" ];
+
   builder = writeScript "gnupg1compat-builder" ''
     PATH=${coreutils}/bin
     # First symlink all top-level dirs

--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   pname = "gnupg1compat";
   version = gnupg.version;
 
-  outputs = [ "out" "info" "man" ];
+  outputs = [ "out" "doc" "info" "man" ];
 
   builder = writeScript "gnupg1compat-builder" ''
     PATH=${coreutils}/bin

--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   pname = "gnupg1compat";
   version = gnupg.version;
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   builder = writeScript "gnupg1compat-builder" ''
     PATH=${coreutils}/bin

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-Z+vgFsqQ+naIzmejh+vYLGJh6ViX23sj3yT/M1voW8Y=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config texinfo ];

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-Z+vgFsqQ+naIzmejh+vYLGJh6ViX23sj3yT/M1voW8Y=";
   };
 
-  outputs = [ "out" "info" "man" ];
+  outputs = [ "out" "doc" "info" "man" ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config texinfo ];

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-Z+vgFsqQ+naIzmejh+vYLGJh6ViX23sj3yT/M1voW8Y=";
   };
 
+  outputs = [ "out" "man" ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config texinfo ];
   buildInputs = [

--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation {
   pname = "mkpasswd";
   inherit (whois) version src patches;
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ perl pkg-config ];
   buildInputs = [ libxcrypt ];
 

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -57,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
       installFlags="sudoers_uid=$(id -u) sudoers_gid=$(id -g) sysconfdir=$out/etc rundir=$TMPDIR/dummy vardir=$TMPDIR/dummy DESTDIR=/"
     '';
 
+  outputs = [ "out" "man" ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ groff ];
   buildInputs = [ pam ];

--- a/pkgs/tools/system/ddrescue/default.nix
+++ b/pkgs/tools/system/ddrescue/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZibAenyhzB0DytCVhSLFJ5sVYiLTLDQugRF8/vrrEME=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [ lzip ];
 

--- a/pkgs/tools/system/ddrescue/default.nix
+++ b/pkgs/tools/system/ddrescue/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZibAenyhzB0DytCVhSLFJ5sVYiLTLDQugRF8/vrrEME=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ lzip ];
 
   doCheck = true; # not cross;

--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-DYYQGALEn2+mRHgqCJsA7OQCF7xirIgQlWexZ9uoKcg=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ efivar popt ];

--- a/pkgs/tools/system/gptfdisk/default.nix
+++ b/pkgs/tools/system/gptfdisk/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
       "/usr/local/Cellar/ncurses/6.2/lib/libncurses.dylib" "${ncurses.out}/lib/libncurses.dylib"
   '';
 
+  outputs = [ "out" "man" ];
+
   buildPhase = lib.optionalString stdenv.isDarwin "make -f Makefile.mac";
   buildInputs = [ libuuid popt icu ncurses ];
 

--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-qDhQkzY2zj2yxbgFUXwE0MGEgAFOsAhnapUuetO9WTw=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ]
     ++ lib.optional stdenv.isLinux pkg-config
   ;

--- a/pkgs/tools/system/inxi/default.nix
+++ b/pkgs/tools/system/inxi/default.nix
@@ -31,6 +31,8 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-/EutIHQGLiRcRD/r8LJYG7oJBb7EAhR5cn6QiC7zMOc=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ perl ];
 

--- a/pkgs/tools/system/ioping/default.nix
+++ b/pkgs/tools/system/ioping/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "man" ];
+
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {

--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     "--with-uncompress-command=${gzip}/bin/gunzip"
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ popt ] ++ lib.optionals aclSupport [ acl ];
 

--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-I4ouJxZnMOU6F/4Hv60ingf6ObYYEX5ZRLbX7an7sOk=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ which zlib ]

--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-I4ouJxZnMOU6F/4Hv60ingf6ObYYEX5ZRLbX7an7sOk=";
   };
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ which zlib ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ IOKit ]

--- a/pkgs/tools/system/sg3_utils/default.nix
+++ b/pkgs/tools/system/sg3_utils/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-1itsPPIDkPpzVwRDkAhBZtJfHZMqETXEULaf5cKD13M=";
   };
 
+  outputs = [ "out" "man" ];
+
   meta = with lib; {
     homepage = "https://sg.danny.cz/sg/";
     description = "Utilities that send SCSI commands to devices";

--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
     "--without-update-smart-drivedb"
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit ApplicationServices ];
   enableParallelBuilding = true;

--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     "--without-update-smart-drivedb"
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit ApplicationServices ];

--- a/pkgs/tools/system/testdisk/default.nix
+++ b/pkgs/tools/system/testdisk/default.nix
@@ -33,6 +33,8 @@ assert enableQt -> qwt != null;
 
   enableParallelBuilding = true;
 
+  outputs = [ "out" "man" ];
+
   buildInputs = [
     ncurses
     libuuid

--- a/pkgs/tools/system/testdisk/default.nix
+++ b/pkgs/tools/system/testdisk/default.nix
@@ -33,7 +33,7 @@ assert enableQt -> qwt != null;
 
   enableParallelBuilding = true;
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "doc" "man" ];
 
   buildInputs = [
     ncurses

--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-aPz1ROUeAKDmMjEtAaL2AguF54/CbIYWpL4Qovv2ftQ=";
   };
 
+  outputs = [ "out" "man" ];
+
   preConfigure = ''
     makeFlagsArray+=(${systemFlags})
   '';

--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-9KJFuUEks3fYtJZGv0IfkVXTaqdhS26/g3BdP/x26q0=";
   };
 
+  outputs = [ "out" "man" ];
+
   strictDeps = true;
   enableParallelBuilding = true;
 

--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-9KJFuUEks3fYtJZGv0IfkVXTaqdhS26/g3BdP/x26q0=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "info" "man" ];
 
   strictDeps = true;
   enableParallelBuilding = true;

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-kOXpPMck5OvhLt6A3xY0Bjx6hVaSaFkZv+YLVWyb0J4=";
   };
 
-  outputs = [ "out" "info" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [ (lib.getBin xz) ];
   /* If no explicit coreutils is given, use the one from stdenv. */

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pie" ];
 
   # When we do build separate interactive version, it makes sense to always include man.
-  outputs = [ "out" "info" ]
+  outputs = [ "out" "dev" "info" ]
     ++ lib.optional (!interactive) "man";
 
   # no-pma fix

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   '' else null;
 
   nativeCheckInputs = [ perl glibcLocales ];
-  outputs = [ "out" "info" ]; # the man pages are rather small
+  outputs = [ "out" "info" "man" ]; # the man pages are rather small
 
   buildInputs = [ pcre2 libiconv ];
 

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     ./CVE-2019-13638-and-CVE-2018-20969.patch
   ];
 
+  outputs = [ "out" "man" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=";
   };
 
-  outputs = [ "out" "info" ];
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [ perl ];
   preConfigure = "patchShebangs ./build-aux/help2man";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4763,6 +4763,7 @@ with self; {
       url = "mirror://cpan/authors/id/R/RU/RURBAN/Cpanel-JSON-XS-4.37.tar.gz";
       hash = "sha256-wkFhWg4X/3Raqoa79Gam4pzSQFFeZfBqegUBe2GebUs=";
     };
+    outputs = [ "out" "man" ];
     meta = {
       description = "CPanel fork of JSON::XS, fast and correct serializing";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -7272,6 +7273,7 @@ with self; {
       url = "mirror://cpan/authors/id/T/TI/TIMB/DBI-1.643.tar.gz";
       hash = "sha256-iiuZPbVgosNzwXTul2pRAn3XgOx2auF2IMIDk9LoNvo=";
     };
+    outputs = [ "out" "man" ];
     postInstall = lib.optionalString (perl ? crossVersion) ''
       mkdir -p $out/${perl.libPrefix}/cross_perl/${perl.version}/DBI
       cat > $out/${perl.libPrefix}/cross_perl/${perl.version}/DBI.pm <<EOF
@@ -13499,6 +13501,7 @@ with self; {
       url = "mirror://cpan/authors/id/M/ML/MLEHMANN/JSON-XS-4.03.tar.gz";
       hash = "sha256-UVU29F8voafojIgkUzdY0BIdJnq5y0U6G1iHyKVrkGg=";
     };
+    outputs = [ "out" "man" ];
     propagatedBuildInputs = [ TypesSerialiser ];
     buildInputs = [ CanaryStability ];
     meta = {
@@ -14699,6 +14702,8 @@ with self; {
       substituteInPlace Makefile.PL --replace 'if has_module' 'if 0; #'
     '';
     doCheck = !stdenv.isDarwin;
+    outputs = [ "out" "man" ];
+
     nativeCheckInputs = [ HTTPDaemon TestFatal TestNeeds TestRequiresInternet ];
     meta = {
       description = "The World-Wide Web library for Perl";
@@ -23321,6 +23326,7 @@ with self; {
       url = "mirror://cpan/authors/id/R/RO/ROSCH/String-ShellQuote-1.04.tar.gz";
       hash = "sha256-5gY2UDjOINZG0lXIBe/90y+GR18Y1DynVFWwDk2G3TU=";
     };
+    outputs = [ "out" "man" ];
     doCheck = !stdenv.isDarwin;
     meta = {
       description = "Quote strings for passing through the shell";


### PR DESCRIPTION
###### Description of changes
Reduce netboot image size by splitting output to doc/info/man.
Additionals to PR https://github.com/NixOS/nixpkgs/pull/170460

Some manuals are not removed from the netboot image for an unclear reason:
```
ls ./image/*-man
./image/37kmfxlc9qw06f3v2033wljpyxdwrh5r-perl-5.34.1-man:
./image/b7jbssdlv7am8d8ccbk4lfl25myjbij1-sudo-1.9.10-man:
./image/f8g5wybwqvjpnxmfqx32dfdxfjr9msk9-jemalloc-5.2.1-man:
./image/gra95scbdx5jrvagfjbg74w9gns5iwdn-nix-2.8.0-man:
./image/k8bcn13ad5fw1n1jdrd8f6yr4nr1prl6-smartmontools-7.2-man:
```
cc @SuperSandro2000
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
