### PR TITLE
directx-shader-compiler: 1.6.2106 -> 1.6.2112

### DIFF
--- a/pkgs/tools/graphics/directx-shader-compiler/default.nix
+++ b/pkgs/tools/graphics/directx-shader-compiler/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, cmake, python3, git }:
+{ lib, stdenv, fetchFromGitHub, cmake, ninja, python3, git }:
 
 stdenv.mkDerivation rec {
   pname = "directx-shader-compiler";
-  version = "1.6.2106";
+  version = "1.6.2112";
 
   # Put headers in dev, there are lot of them which aren't necessary for
   # using the compiler binary.
@@ -12,20 +12,13 @@ stdenv.mkDerivation rec {
     owner = "microsoft";
     repo = "DirectXShaderCompiler";
     rev = "v${version}";
-    sha256 = "6kQgAESYiQ06LkiGTfDBYwd/ORLSm1W+BcO+OUp4yXY=";
-    # We rely on the side effect of leaving the .git directory here for the
-    # version-grabbing functionality of the build system.
+    hash = "sha256-+oh7oWJCE0CLehnqpE2J9aIfMFbtfLAKwI9ETmCg/TA=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake git python3 ];
+  nativeBuildInputs = [ cmake git ninja python3 ];
 
-  configurePhase = ''
-    # Requires some additional flags to cmake from a file in the repo
-    additionalCMakeFlags=$(< utils/cmake-predefined-config-params)
-    cmakeFlags="$additionalCMakeFlags''${cmakeFlags:+ $cmakeFlags}"
-    cmakeConfigurePhase
-  '';
+  cmakeFlags = [ "-C../cmake/caches/PredefinedParams.cmake" ];
 
   # The default install target installs heaps of LLVM stuff.
   #
@@ -45,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/microsoft/DirectXShaderCompiler";
     platforms = with platforms; linux ++ darwin;
     license = licenses.ncsa;
-    maintainers = with maintainers; [ expipiplus1 ];
+    maintainers = with maintainers; [ expipiplus1 Flakebi ];
   };
 }


### PR DESCRIPTION
###### Description of changes

The glibc update broke compiling dxc. Update and fix compilation.

- Use ninja because it's faster and fixes compilation (uhm, yes, no idea
  why)
- Remove the comment about using submodules only for .git, they are
  actually used for SPIR-V
- The way default CMake flags are passed changed
- Add myself as maintainer (I also did the update before this one)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
