### PR TITLE
rocm: * -> 5.1.1

### DIFF
--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -31,13 +31,13 @@
 let
   hip = stdenv.mkDerivation rec {
     pname = "hip";
-    version = "5.0.2";
+    version = "5.1.1";
 
     src = fetchFromGitHub {
       owner = "ROCm-Developer-Tools";
       repo = "HIP";
       rev = "rocm-${version}";
-      hash = "sha256-w023vBLJaiFbRdvz9UfZLPasRjk3VqM9zwctCIJ5hGU=";
+      hash = "sha256-/kIZrbzq1u1pIs1jlmRYZNUGteqVQTI4TlXsHsVIUKE=";
     };
 
     # - fix bash paths
@@ -102,13 +102,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "hip";
-  version = "5.0.2";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
     repo = "hipamd";
     rev = "rocm-${version}";
-    hash = "sha256-hhTwKG0wDpbIBI8S61AhdNldX+STO8C66xi2EzmJSBs=";
+    hash = "sha256-TuCMRJb6G/bhD8hG6Ot7MIkgBoShjVboeXrlGh9eYpQ=";
   };
 
   nativeBuildInputs = [ cmake python3 makeWrapper perl ];

--- a/pkgs/development/compilers/llvm/rocm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, buildPackages, fetchFromGitHub, callPackage, wrapCCWith, overrideCC }:
 
 let
-  version = "5.0.2";
+  version = "5.1.1";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "llvm-project";
     rev = "rocm-${version}";
-    hash = "sha256-wPzwbeQUFE6RAytrz5lBa6UUPoVL0UeMyY3qa4M6W6M=";
+    hash = "sha256-5SGIWiyfHvfwIUc4bhdWrlhBfK5ssA7tm5r3zKdr3kg=";
   };
 in rec {
   clang = wrapCCWith rec {
@@ -52,12 +52,10 @@ in rec {
   };
 
   lld = callPackage ./lld.nix {
-    inherit llvm version;
-    src = "${src}/lld";
+    inherit llvm src version;
   };
 
   llvm = callPackage ./llvm {
-    inherit version;
-    src = "${src}/llvm";
+    inherit src version;
   };
 }

--- a/pkgs/development/compilers/llvm/rocm/lld.nix
+++ b/pkgs/development/compilers/llvm/rocm/lld.nix
@@ -3,6 +3,7 @@
 , cmake
 , libxml2
 , llvm
+, ninja
 
 , version
 , src
@@ -11,15 +12,17 @@
 stdenv.mkDerivation rec {
   inherit version src;
 
+  sourceRoot = "${src.name}/lld";
+
   pname = "lld";
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ninja ];
 
   buildInputs = [ libxml2 llvm ];
 
   outputs = [ "out" "dev" ];
 
-  cmakeFlags = [ "-DLLVM_MAIN_SRC_DIR=${llvm.src}" ];
+  cmakeFlags = [ "-DLLVM_MAIN_SRC_DIR=${src}/llvm" ];
 
   postInstall = ''
     moveToOutput include "$dev"

--- a/pkgs/development/compilers/llvm/rocm/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm/default.nix
@@ -28,6 +28,8 @@ in stdenv.mkDerivation rec {
 
   pname = "rocm-llvm";
 
+  sourceRoot = "${src.name}/llvm";
+
   outputs = [ "out" "python" ]
     ++ lib.optional enableSharedLibraries "lib";
 

--- a/pkgs/development/libraries/rocclr/default.nix
+++ b/pkgs/development/libraries/rocclr/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , writeScript
 , rocm-comgr
 }:
@@ -14,6 +15,16 @@ stdenv.mkDerivation rec {
     rev = "rocm-${version}";
     hash = "sha256-SFWEGKffhuiTE7ICbkElVV5cldXu4Xbwvjb6LiNmijA=";
   };
+
+  patches = [
+    # Enable support for gfx8 again
+    # See the upstream issue: https://github.com/RadeonOpenCompute/ROCm/issues/1659
+    # And the arch patch: https://github.com/rocm-arch/rocm-arch/pull/742
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/John-Gee/rocm-arch/d6812d308fee3caf2b6bb01b4d19fe03a6a0e3bd/rocm-opencl-runtime/enable-gfx800.patch";
+      hash = "sha256-59jFDIIsTTZcNns9RyMVWPRUggn/bSlAGrky4quu8B4=";
+    })
+  ];
 
   prePatch = ''
     substituteInPlace device/comgrctx.cpp \

--- a/pkgs/development/libraries/rocm-opencl-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-opencl-runtime";
-  version = "5.0.2";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-OpenCL-Runtime";
     rev = "rocm-${version}";
-    hash = "sha256-ovYwElZGRKySH1mWFIISxuNNxCjaqoe9oCvqYZGdfq0=";
+    hash = "sha256-O7q3uTjspO/rZ2+8+g7pRfBXsCRaEr4DZxEqABHbOeY=";
   };
 
   nativeBuildInputs = [ cmake rocm-cmake ];
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DAMD_OPENCL_PATH=${src}"
     "-DROCCLR_PATH=${rocclr}"
+    "-DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm/opencl"
   ];
 
   dontStrip = true;

--- a/pkgs/development/libraries/rocm-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-runtime/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-runtime";
-  version = "5.1.0";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCR-Runtime";
     rev = "rocm-${version}";
-    hash = "sha256-MGm7YmnoFNk7VsxsbsUgSD9Y5r1OBm6Ycg3wXNme8EI=";
+    hash = "sha256-IP5ylfUXOFkw9+Frfh+tNaZ83ozAbOK9kO2AzFVzzWk=";
   };
 
   sourceRoot = "source/src";


### PR DESCRIPTION
###### Description of changes

Update rocm packages to 5.1.1. Some have already been updated by r-ryantm.

I also added a patch to rocclr that re-enables support for gfx8 hardware.
The patch has been floating around for a while and I think it’s applied
for some distributions.

I tested some OpenCL examples on gfx8 and gfx10 and it's both working with this patch.

Builds are on the `flakebi` cachix, so you can use
```bash
cachix use flakebi
nix-build rocm-opencl-icd
nix-build hip
```
and skip building llvm.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
