### PR TITLE
babeld: 1.11 -> 1.12

### DIFF
--- a/pkgs/tools/networking/babeld/default.nix
+++ b/pkgs/tools/networking/babeld/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "babeld";
-  version = "1.11";
+  version = "1.12";
 
   src = fetchurl {
     url = "https://www.irif.fr/~jch/software/files/${pname}-${version}.tar.gz";
-    sha256 = "sha256-mTFa6vLqIH8XfBaFX/o0/DVK8bWYjAcODy/KOg1ND6U=";
+    sha256 = "sha256-gy7wgMOA/2wNcVxr+IrCL8rofcDwRWbmC+zbjYce/7k=";
   };
 
   preBuild = ''

--- a/pkgs/tools/networking/babeld/default.nix
+++ b/pkgs/tools/networking/babeld/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "babeld";
-  version = "1.12";
+  version = "1.12.1";
 
   src = fetchurl {
     url = "https://www.irif.fr/~jch/software/files/${pname}-${version}.tar.gz";
-    sha256 = "sha256-gy7wgMOA/2wNcVxr+IrCL8rofcDwRWbmC+zbjYce/7k=";
+    sha256 = "sha256-mrWdesdB82MN8j+cO2fGApTYs0q2IjmPm4l3OoeOyx4=";
   };
 
   preBuild = ''


### PR DESCRIPTION
5 May 2022: babeld-1.12
  * Implement v4-via-v6 routing (RFC 9229), which allows a router with
    IPv4 addresses only to route IPv4.  Thanks to Théophile Bastian.
  * Enable extended Netlink acks when available.
    Thanks to Toke Høyland-Jørgensen.
  * Fix restoring of interface configuration to avoid unbounded memory
    consumption.  Thanks to andrew-hoff.
  * Fix handling of deny filters in the install chain.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
