### PR TITLE
gittyup: init at 1.1.0

### DIFF
--- a/pkgs/applications/version-management/gittyup/default.nix
+++ b/pkgs/applications/version-management/gittyup/default.nix
@@ -1,0 +1,117 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmark
+, mount
+, http-parser
+, perl
+, cmake
+, qtbase
+, qttools
+, git
+, git-lfs
+, ninja
+, libssh2
+, libgit2
+, pkg-config
+, libsecret
+, libgnome-keyring
+, pcre
+, wrapQtAppsHook
+, makeDesktopItem
+}:
+stdenv.mkDerivation rec {
+  pname = "gittyup";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Murmele";
+    repo = "Gittyup";
+    rev = "gittyup_v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-WJzw1uFCE5dyI1F0FEzww05zCsYPEgeXBz+HogTYX9w=";
+  };
+
+  nativeBuildInputs = [
+    cmark
+    mount
+    http-parser
+    perl
+    cmake
+    qttools
+    ninja
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    git
+    git-lfs
+    libssh2
+    libgit2
+    libsecret
+    libgnome-keyring
+    pcre
+  ];
+
+  cmakeFlage = [
+    "-W no-dev"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_PREFIX_PATH=${qtbase}"
+    "-DENABLE_REPRODUCIBLE_BUILDS=ON"
+    "-DBUILD_SHARED_LIBS=OFF"
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = "Gittyup";
+    exec = "gittyup";
+    icon = pname;
+    type = "Application";
+    comment = meta.description;
+    desktopName = "Gittyup";
+    genericName = "Text Editor";
+    categories = [ "GNOME" "GTK" "Application" "Development" ];
+    startupNotify = true;
+    terminal = false;
+  };
+
+  postInstall = ''
+    # Move all created files to subdirectory
+    shopt -s extglob
+    mkdir -p $out/temp
+    mv $out/!(temp) $out/temp
+    mkdir -p $out/lib
+    mv $out/temp $out/lib/gittyup
+
+    # Remove unnecessary files
+    rm -rf "$out/lib/gittyup/"*.so.*
+    rm -rf "$out/lib/gittyup/Plugins"
+    rm -rf "$out/lib/gittyup/lib"
+    rm -rf "$out/lib/gittyup/lib64"
+    rm -rf "$out/lib/gittyup/include"
+    rm -rf "$out/lib/gittyup/share"
+
+    # Move the executable to the correct location
+    install -d "$out/bin"
+    ln -s $out/lib/gittyup/Gittyup "$out/bin/gittyup"
+    chmod 0755 "$out/bin/gittyup"
+
+    # Install the gittyup icons
+    install -Dm644 $src/rsrc/Gittyup.iconset/gittyup_logo.svg "$out/share/icons/hicolor/scalable/apps/${pname}.svg"
+    for s in 16x16 32x32 64x64 128x128 256x256 512x512; do
+      install -Dm0644 "$src/rsrc/Gittyup.iconset/icon_$s.png" "$out/share/icons/hicolor/$s/apps/${pname}.png"
+    done
+
+    # Create desktop item, so we can pick it from the KDE/GNOME menu
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  meta = with lib; {
+    description = "A graphical Git client designed to help you understand and manage your source code history";
+    homepage = "https://github.com/Murmele/Gittyup";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zebreus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6376,6 +6376,8 @@ with pkgs;
 
   gitty = callPackage ../applications/version-management/git-and-tools/gitty { };
 
+  gittyup = libsForQt5.callPackage ../applications/version-management/gittyup { };
+
   gitui = callPackage ../applications/version-management/git-and-tools/gitui {
     inherit (darwin.apple_sdk.frameworks) Security AppKit;
   };


### PR DESCRIPTION
###### Description of changes
[Gittyup](https://github.com/Murmele/Gittyup) is a graphical Git client designed to help you understand and manage your source code history.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
