### PR TITLE
victoriametrics: 1.59.0 -> 1.77.0

### DIFF
--- a/pkgs/servers/nosql/victoriametrics/default.nix
+++ b/pkgs/servers/nosql/victoriametrics/default.nix
@@ -16,6 +16,8 @@ buildGoModule rec {
   postPatch = ''
     # main module (github.com/VictoriaMetrics/VictoriaMetrics) does not contain package
     # github.com/VictoriaMetrics/VictoriaMetrics/app/vmui/packages/vmui/web
+    #
+    # This appears to be some of test server for development purposes only.
     rm -f app/vmui/packages/vmui/web/{go.mod,main.go}
   '';
 

--- a/pkgs/servers/nosql/victoriametrics/default.nix
+++ b/pkgs/servers/nosql/victoriametrics/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "VictoriaMetrics";
-  version = "1.76.1";
+  version = "1.77.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-4cgSJi53EGK6YUwO4HlhNs4T07US94A/sPZi2QCx0aw=";
+    sha256 = "sha256-Ike3yO93q/bna/cnHv1sg+gR7iS9cVmNzLViBsfFdVs=";
   };
 
   vendorSha256 = null;

--- a/pkgs/servers/nosql/victoriametrics/default.nix
+++ b/pkgs/servers/nosql/victoriametrics/default.nix
@@ -2,16 +2,22 @@
 
 buildGoModule rec {
   pname = "VictoriaMetrics";
-  version = "1.59.0";
+  version = "1.76.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2i9rmk9aAnjTJY+w/NKJOaLX+tpkt3vG07iLCsSGzdU=";
+    sha256 = "sha256-4cgSJi53EGK6YUwO4HlhNs4T07US94A/sPZi2QCx0aw=";
   };
 
   vendorSha256 = null;
+
+  postPatch = ''
+    # main module (github.com/VictoriaMetrics/VictoriaMetrics) does not contain package
+    # github.com/VictoriaMetrics/VictoriaMetrics/app/vmui/packages/vmui/web
+    rm -f app/vmui/packages/vmui/web/{go.mod,main.go}
+  '';
 
   ldflags = [ "-s" "-w" "-X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${version}" ];
 
@@ -21,7 +27,7 @@ buildGoModule rec {
     homepage = "https://victoriametrics.com/";
     description = "fast, cost-effective and scalable time series database, long-term remote storage for Prometheus";
     license = licenses.asl20;
-    maintainers = [ maintainers.yorickvp ];
+    maintainers = with maintainers; [ yorickvp ivan ];
     changelog = "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v${version}";
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
###### Description of changes

This fixes grafana + VictoriaMetrics on NixOS master; victoriametrics 1.59.0 somehow resulted in mostly empty charts and `ExemplarQueryResult: decode slice: expect [ or n, but found \u0000` in the log.

https://docs.victoriametrics.com/CHANGELOG.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I made sure that this works with my grafana in production; I tested victoriametrics's HTTP server and confirmed that vmui was functional; I checked the systemd journal for the victoriametrics unit and didn't see anything broken.

cc maintainer @yorickvP 