### PR TITLE
spyder: fix build

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -288,7 +288,7 @@ self: super: {
         ps: with ps; [
           pyflakes
           pytest
-          python-language-server
+          black
         ]
       ))
 

--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
 
   disabledTests = [
     "test_multiple_workspaces"
+    "test_option_overrides_dmypy"
   ];
 
   checkInputs = [ pytestCheckHook mock ];

--- a/pkgs/development/python-modules/python-lsp-black/default.nix
+++ b/pkgs/development/python-modules/python-lsp-black/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "python-lsp-black";
-  version = "1.1.0";
+  version = "1.2.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "python-lsp";
     repo = "python-lsp-black";
     rev = "v${version}";
-    sha256 = "sha256-WIQf1oz3b1PLIcXfQsu4hQ58nfp7l3J7zkcWNT6RbUY=";
+    sha256 = "sha256-qNA6Bj1VI0YEtRuvcMQZGWakQNNrJ2PqhozrLmQHPAg=";
   };
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -20,6 +20,7 @@
 , pythonOlder
 , rope
 , setuptools
+, setuptools-scm
 , stdenv
 , ujson
 , yapf
@@ -36,7 +37,8 @@
 
 buildPythonPackage rec {
   pname = "python-lsp-server";
-  version = "1.3.3";
+  version = "1.4.1";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -44,13 +46,18 @@ buildPythonPackage rec {
     owner = "python-lsp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-F8f9NAjPWkm01D/KwFH0oA6nQ3EF4ZVCCckZTL4A35Y=";
+    sha256 = "sha256-rEfjxHw2NIVIa8RepxLPiXkRFhcGWLzm6w43n60zkFE=";
   };
 
   postPatch = ''
     substituteInPlace setup.cfg \
       --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
-      --replace "--cov pylsp --cov test" ""
+      --replace "--cov pylsp --cov test" "" \
+      --replace "mccabe>=0.6.0,<0.7.0" "mccabe"
+  '';
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
   '';
 
   propagatedBuildInputs = [
@@ -58,6 +65,7 @@ buildPythonPackage rec {
     pluggy
     python-lsp-jsonrpc
     setuptools
+    setuptools-scm
     ujson
   ] ++ lib.optional withAutopep8 autopep8
   ++ lib.optional withFlake8 flake8
@@ -79,10 +87,7 @@ buildPythonPackage rec {
   # pyqt5 is broken on aarch64-darwin
   ++ lib.optionals (!stdenv.isDarwin || !stdenv.isAarch64) [ pyqt5 ];
 
-  disabledTests = [
-    # pytlint output changed
-    "test_lint_free_pylint"
-  ] ++ lib.optional (!withPycodestyle) "test_workspace_loads_pycodestyle_config"
+  disabledTests = lib.optional (!withPycodestyle) "test_workspace_loads_pycodestyle_config"
   # pyqt5 is broken on aarch64-darwin
   ++ lib.optional (stdenv.isDarwin && stdenv.isAarch64) "test_pyqt_completion";
 

--- a/pkgs/development/python-modules/qstylizer/default.nix
+++ b/pkgs/development/python-modules/qstylizer/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, inflection
+, pbr
+, tinycss2
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "qstylizer";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "blambright";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-iEMxBpS9gOPubd9O8zpVmR5B7+UZJFkPuOtikO1a9v0=";
+  };
+
+  nativeBuildInputs = [
+    pbr
+  ];
+
+  propagatedBuildInputs = [
+    inflection
+    tinycss2
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  preBuild = ''
+    export PBR_VERSION=${version}
+  '';
+
+  meta = with lib; {
+    description = "Qt stylesheet generation utility for PyQt/PySide ";
+    homepage = "https://github.com/blambright/qstylizer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/python-modules/spyder-kernels/default.nix
+++ b/pkgs/development/python-modules/spyder-kernels/default.nix
@@ -18,6 +18,10 @@ buildPythonPackage rec {
     pyzmq
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "ipython>=7.31.1,<8" "ipython"
+  '';
+
   # No tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -1,16 +1,54 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, makeDesktopItem, intervaltree,
-  jedi, pycodestyle, psutil, rope, numpy, scipy, matplotlib, pylint,
-  keyring, numpydoc, qtconsole, qtawesome, nbconvert, mccabe, pyopengl,
-  cloudpickle, pygments, spyder-kernels, qtpy, pyzmq, chardet, qdarkstyle,
-  watchdog, python-language-server, pyqtwebengine, atomicwrites, pyxdg,
-  diff-match-patch, three-merge, pyls-black, pyls-spyder, flake8, textdistance
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, makeDesktopItem
+, atomicwrites
+, chardet
+, cloudpickle
+, cookiecutter
+, diff-match-patch
+, flake8
+, intervaltree
+, jedi
+, jellyfish
+, keyring
+, matplotlib
+, mccabe
+, nbconvert
+, numpy
+, numpydoc
+, psutil
+, pygments
+, pylint
+, pyls-spyder
+, pyopengl
+, pyqtwebengine
+, python-lsp-black
+, python-lsp-server
+, pyxdg
+, pyzmq
+, pycodestyle
+, qdarkstyle
+, qstylizer
+, qtawesome
+, qtconsole
+, qtpy
+, rope
+, Rtree
+, scipy
+, spyder-kernels
+, textdistance
+, three-merge
+, watchdog
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "spyder";
   version = "5.3.0";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -20,11 +58,44 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
 
   propagatedBuildInputs = [
-    intervaltree jedi pycodestyle psutil rope numpy scipy matplotlib pylint keyring
-    numpydoc qtconsole qtawesome nbconvert mccabe pyopengl cloudpickle spyder-kernels
-    pygments qtpy pyzmq chardet pyqtwebengine qdarkstyle watchdog python-language-server
-    atomicwrites pyxdg diff-match-patch three-merge pyls-black pyls-spyder
-    flake8 textdistance
+    atomicwrites
+    chardet
+    cloudpickle
+    cookiecutter
+    diff-match-patch
+    flake8
+    intervaltree
+    jedi
+    jellyfish
+    keyring
+    matplotlib
+    mccabe
+    nbconvert
+    numpy
+    numpydoc
+    psutil
+    pygments
+    pylint
+    pyls-spyder
+    pyopengl
+    pyqtwebengine
+    python-lsp-black
+    python-lsp-server
+    pyxdg
+    pyzmq
+    pycodestyle
+    qdarkstyle
+    qstylizer
+    qtawesome
+    qtconsole
+    qtpy
+    rope
+    Rtree
+    scipy
+    spyder-kernels
+    textdistance
+    three-merge
+    watchdog
   ];
 
   # There is no test for spyder
@@ -44,13 +115,8 @@ buildPythonPackage rec {
     # remove dependency on pyqtwebengine
     # this is still part of the pyqt 5.11 version we have in nixpkgs
     sed -i /pyqtwebengine/d setup.py
-    # The major version bump in watchdog is due to changes in supported
-    # platforms, not API break.
-    # https://github.com/gorakhargosh/watchdog/issues/761#issuecomment-777001518
     substituteInPlace setup.py \
-      --replace "pyqt5<5.13" "pyqt5" \
-      --replace "parso==0.7.0" "parso" \
-      --replace "watchdog>=0.10.3,<2.0.0" "watchdog>=0.10.3,<3.0.0"
+      --replace "ipython>=7.31.1,<8.0.0" "ipython"
   '';
 
   postInstall = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8774,6 +8774,8 @@ in {
 
   qscintilla = self.qscintilla-qt5;
 
+  qstylizer = callPackage ../development/python-modules/qstylizer { };
+
   qt5reactor = callPackage ../development/python-modules/qt5reactor { };
 
   qtawesome = callPackage ../development/python-modules/qtawesome { };


### PR DESCRIPTION
###### Description of changes

Fix build of ``spyder`` on ``master``. See #171613.
* Updates ``python3Packages.python-lsp-black 1.1.0 -> 1.2.1``
* Update ``python3Packages.python-lsp-server 1.3.3 -> 1.4.1``
* Fix build of ``python3Packages.spyder-kernels``
* Init ``python3Packages.qstylizer at 0.2.1`` (required by spyder)
* Remove reference to broken (no longer maintained) ``python3Packages.python-language-server``.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
