### PR TITLE
SDL2: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -49,6 +49,7 @@
 , audiofile
 , libiconv
 , withStatic ? false
+, buildPackages
 }:
 
 # NOTE: When editing this expression see if the same change applies to
@@ -75,6 +76,15 @@ stdenv.mkDerivation rec {
     # This patch + the setup-hook will ensure that `sdl2-config --cflags` works correctly.
     ./find-headers.patch
   ];
+
+  postPatch = ''
+    # Fix running wayland-scanner for the build platform when cross-compiling.
+    # See comment here: https://github.com/libsdl-org/SDL/issues/4860#issuecomment-1119003545
+    substituteInPlace configure \
+      --replace '$(WAYLAND_SCANNER)' "${buildPackages.wayland-scanner}/bin/wayland-scanner"
+  '';
+
+  strictDeps = true;
 
   depsBuildBuild = [ pkg-config ];
 

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -22,6 +22,7 @@
 , waylandSupport ? stdenv.isLinux && !stdenv.hostPlatform.isAndroid
 , wayland
 , wayland-protocols
+, wayland-scanner
 , drmSupport ? stdenv.isLinux && !stdenv.hostPlatform.isAndroid
 , libdrm
 , mesa
@@ -49,7 +50,6 @@
 , audiofile
 , libiconv
 , withStatic ? false
-, buildPackages
 }:
 
 # NOTE: When editing this expression see if the same change applies to
@@ -81,14 +81,14 @@ stdenv.mkDerivation rec {
     # Fix running wayland-scanner for the build platform when cross-compiling.
     # See comment here: https://github.com/libsdl-org/SDL/issues/4860#issuecomment-1119003545
     substituteInPlace configure \
-      --replace '$(WAYLAND_SCANNER)' "${buildPackages.wayland-scanner}/bin/wayland-scanner"
+      --replace '$(WAYLAND_SCANNER)' 'wayland-scanner'
   '';
 
   strictDeps = true;
 
   depsBuildBuild = [ pkg-config ];
 
-  nativeBuildInputs = [ pkg-config ] ++ optionals waylandSupport [ wayland ];
+  nativeBuildInputs = [ pkg-config ] ++ optionals waylandSupport [ wayland wayland-scanner ];
 
   propagatedBuildInputs = dlopenPropagatedBuildInputs;
 


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
