### PR TITLE
wlogout: support cross-compilation

### DIFF
--- a/pkgs/tools/wayland/wlogout/default.nix
+++ b/pkgs/tools/wayland/wlogout/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     sha256 = "cTscfx+erHVFHwwYpN7pADQWt5sq75sQSyXSP/H8kOs=";
   };
 
+  depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [
     gtk3

--- a/pkgs/tools/wayland/wlogout/default.nix
+++ b/pkgs/tools/wayland/wlogout/default.nix
@@ -10,6 +10,11 @@
 , wayland
 , wayland-protocols
 , gtk-layer-shell
+# gtk-layer-shell fails to cross-compile due to a hard dependency
+# on gobject-introspection.
+# Disable it when cross-compiling since it's an optional dependency.
+# This disables transparency support.
+, withGtkLayerShell ? (stdenv.buildPlatform == stdenv.hostPlatform)
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +35,7 @@ stdenv.mkDerivation rec {
     libxkbcommon
     wayland
     wayland-protocols
+  ] ++ lib.optionals withGtkLayerShell [
     gtk-layer-shell
   ];
 

--- a/pkgs/tools/wayland/wlogout/default.nix
+++ b/pkgs/tools/wayland/wlogout/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     sha256 = "cTscfx+erHVFHwwYpN7pADQWt5sq75sQSyXSP/H8kOs=";
   };
 
+  strictDeps = true;
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

Targeting staging-next due to gtk3 cross fixes which aren't merged yet (currently in staging-next).
Could also be applied to master, but won't compile there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

