### PR TITLE
python310Packages.ciscoconfparse: 1.6.36 -> 1.6.40

### DIFF
--- a/pkgs/development/python-modules/ciscoconfparse/default.nix
+++ b/pkgs/development/python-modules/ciscoconfparse/default.nix
@@ -1,24 +1,27 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
-, poetry-core
-, passlib
 , dnspython
+, fetchFromGitHub
 , loguru
-, toml
+, passlib
+, poetry-core
 , pytestCheckHook
+, pythonOlder
+, toml
 }:
 
 buildPythonPackage rec {
   pname = "ciscoconfparse";
-  version = "1.6.36";
+  version = "1.6.40";
   format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "mpenning";
     repo = pname;
     rev = version;
-    sha256 = "sha256-nIuuqAxz8eHEQRuH8nfYVQ+vGMmcDcARJLizoI5Mty8=";
+    hash = "sha256-2j1AlCIwTxIjotZ0fSt1zhsgPfJTqJukZ6KQvh74NJ8=";
   };
 
   postPatch = ''
@@ -45,17 +48,19 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # Tests require network access
     "test_dns_lookup"
     "test_reverse_dns_lookup"
   ];
 
-  pythonImportsCheck = [ "ciscoconfparse" ];
+  pythonImportsCheck = [
+    "ciscoconfparse"
+  ];
 
   meta = with lib; {
-    description =
-      "Parse, Audit, Query, Build, and Modify Cisco IOS-style configurations";
+    description = "Parse, Audit, Query, Build, and Modify Cisco IOS-style configurations";
     homepage = "https://github.com/mpenning/ciscoconfparse";
     license = licenses.gpl3Only;
-    maintainers = [ maintainers.astro ];
+    maintainers = with maintainers; [ astro ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/mpenning/ciscoconfparse/blob/main/CHANGES.md#version-1640
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
