### PR TITLE
gnu-efi: 3.0.11 -> 3.0.14

### DIFF
--- a/pkgs/development/libraries/gnu-efi/default.nix
+++ b/pkgs/development/libraries/gnu-efi/default.nix
@@ -1,23 +1,16 @@
-{ lib, stdenv, buildPackages, fetchurl, fetchpatch, pciutils }:
+{ lib, stdenv, buildPackages, fetchurl, pciutils
+, gitUpdater }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "gnu-efi";
-  version = "3.0.11";
+  version = "3.0.14";
 
   src = fetchurl {
     url = "mirror://sourceforge/gnu-efi/${pname}-${version}.tar.bz2";
-    sha256 = "1ffnc4xbzfggs37ymrgfx76j56kk2644c081ivhr2bjkla9ag3gj";
+    sha256 = "tztkOg1Wl9HzltdDFEjoht2AVmh4lXjj4aKCd8lShDU=";
   };
-
-  patches = [
-    # Fix build on armv6l
-    (fetchpatch {
-      url = "https://sourceforge.net/p/gnu-efi/patches/_discuss/thread/25bb273a18/9c4d/attachment/0001-Fix-ARCH-on-armv6-and-other-32-bit-ARM-platforms.patch";
-      sha256 = "0pj03h20g2bbz6fr753bj1scry6919h57l1h86z3b6q7hqfj0b4r";
-    })
-  ];
 
   buildInputs = [ pciutils ];
 
@@ -28,6 +21,12 @@ stdenv.mkDerivation rec {
     "HOSTCC=${buildPackages.stdenv.cc.targetPrefix}cc"
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
+
+  passthru.updateScript = gitUpdater {
+    inherit pname version;
+    # No nicer place to find latest release.
+    url = "https://git.code.sf.net/p/gnu-efi/code";
+  };
 
   meta = with lib; {
     description = "GNU EFI development toolchain";


### PR DESCRIPTION
Dropped upstreamed patch for armv6 support.
Added updater script.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
