### PR TITLE
[staging-next] gnome: fix compilation with gcc 11.3.0

### DIFF
--- a/pkgs/desktops/gnome/apps/cheese/default.nix
+++ b/pkgs/desktops/gnome/apps/cheese/default.nix
@@ -80,6 +80,8 @@ stdenv.mkDerivation rec {
     pipewire # PipeWire provides a gstreamer plugin for using PipeWire for video
   ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=overlength-strings";
+
   postPatch = ''
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py

--- a/pkgs/desktops/gnome/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-maps/default.nix
@@ -69,6 +69,8 @@ stdenv.mkDerivation rec {
     webkitgtk
   ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=overlength-strings";
+
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file
     patchShebangs meson_post_install.py

--- a/pkgs/desktops/gnome/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-music/default.nix
@@ -76,6 +76,8 @@ python3.pkgs.buildPythonApplication rec {
     gst-plugins-ugly
   ]);
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=overlength-strings";
+
   pythonPath = with python3.pkgs; [
     pycairo
     dbus-python

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -175,6 +175,8 @@ stdenv.mkDerivation rec {
     pythonEnv
   ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=overlength-strings";
+
   mesonFlags = [
     "-Dgtk_doc=true"
   ];

--- a/pkgs/desktops/gnome/core/totem/default.nix
+++ b/pkgs/desktops/gnome/core/totem/default.nix
@@ -77,6 +77,8 @@ stdenv.mkDerivation rec {
     xvfb-run
   ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=overlength-strings";
+
   mesonFlags = [
     # TODO: https://github.com/NixOS/nixpkgs/issues/36468
     "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"


### PR DESCRIPTION
A new warning (`-Werror=overlength-strings`) is causing issues due to
a recent gcc version upgrade

Targetting: #171497

(Unbreaking)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
