### PR TITLE
intel-graphics-compiler: follow-ups

### DIFF
--- a/pkgs/development/compilers/intel-graphics-compiler/default.nix
+++ b/pkgs/development/compilers/intel-graphics-compiler/default.nix
@@ -56,17 +56,17 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace ./external/SPIRV-Tools/CMakeLists.txt \
-            --replace '$'''{SPIRV-Tools_DIR}../../..' \
-                      '${spirv-tools}' \
-            --replace 'SPIRV-Headers_INCLUDE_DIR "/usr/include"' \
-                      'SPIRV-Headers_INCLUDE_DIR "${spirv-headers}/include"' \
-            --replace 'set_target_properties(SPIRV-Tools' \
-                      'set_target_properties(SPIRV-Tools-shared' \
-            --replace 'IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools' \
-                      'IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools-shared'
-          substituteInPlace ./IGC/AdaptorOCL/igc-opencl.pc.in \
-            --replace '/@CMAKE_INSTALL_INCLUDEDIR@' "/include" \
-            --replace '/@CMAKE_INSTALL_LIBDIR@' "/lib"
+      --replace '$'''{SPIRV-Tools_DIR}../../..' \
+                '${spirv-tools}' \
+      --replace 'SPIRV-Headers_INCLUDE_DIR "/usr/include"' \
+                'SPIRV-Headers_INCLUDE_DIR "${spirv-headers}/include"' \
+      --replace 'set_target_properties(SPIRV-Tools' \
+                'set_target_properties(SPIRV-Tools-shared' \
+      --replace 'IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools' \
+                'IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools-shared'
+    substituteInPlace ./IGC/AdaptorOCL/igc-opencl.pc.in \
+      --replace '/@CMAKE_INSTALL_INCLUDEDIR@' "/include" \
+      --replace '/@CMAKE_INSTALL_LIBDIR@' "/lib"
   '';
 
   # Handholding the braindead build script

--- a/pkgs/development/compilers/intel-graphics-compiler/default.nix
+++ b/pkgs/development/compilers/intel-graphics-compiler/default.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation rec {
     "-Wno-dev"
     "-DVC_INTRINSICS_SRC=${vc_intrinsics_src}"
     "-DIGC_OPTION__SPIRV_TOOLS_MODE=Prebuilds"
-    "-DINSTALL_SPIRVDLL=0"
     "-DCCLANG_BUILD_PREBUILDS=ON"
     "-DCCLANG_BUILD_PREBUILDS_DIR=${prebuilds}"
     "-DIGC_PREFERRED_LLVM_VERSION=${getVersion llvm}"

--- a/pkgs/development/compilers/intel-graphics-compiler/default.nix
+++ b/pkgs/development/compilers/intel-graphics-compiler/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   # https://github.com/intel/intel-graphics-compiler/issues/98
   doCheck = false;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./external/SPIRV-Tools/CMakeLists.txt \
       --replace '$'''{SPIRV-Tools_DIR}../../..' \
                 '${spirv-tools}' \

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -34,12 +34,6 @@ stdenv.mkDerivation rec {
     "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
   ];
 
-  prePatch = ''
-    substituteInPlace ./test/CMakeLists.txt \
-      --replace 'SPIRV-Tools' 'SPIRV-Tools-shared'
-  '';
-
-
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;
 

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-/vUyL6Wh8hykoGz1QmT1F7lfGDEmG4U3iqmqrJxizOg=";
   };
 
-  nativeBuildInputs = [ pkg-config cmake llvm_11.dev ];
+  nativeBuildInputs = [ pkg-config cmake llvm_11.dev spirv-tools ];
 
-  buildInputs = [ spirv-headers spirv-tools llvm_11 ];
+  buildInputs = [ spirv-headers llvm_11 ];
 
   checkInputs = [ lit ];
 


### PR DESCRIPTION
###### Description of changes
Addresses some review comments that came in after I merged #171656

- spirv-llvm-translator: move spirv-tools to nativeBuildInputs
- intel-graphics-compiler: reindent
- spirv-llvm-translator: remove prePatch since we don't run tests
- intel-graphics-compiler: remove INSTALL_SPIRVDLL
- intel-graphics-compiler: move substitutes to postPatch

cc. @calbrecht @wentasah

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
