### PR TITLE
python3Packages.nbconvert: clean up

### DIFF
--- a/pkgs/development/python-modules/jupyter-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyter-sphinx/default.nix
@@ -5,6 +5,7 @@
 , sphinx
 , ipywidgets
 , pythonOlder
+, nbconvert
 }:
 
 buildPythonPackage rec {
@@ -17,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "37fc9408385c45326ac79ca0452fbd7ae2bf0e97842d626d2844d4830e30aaf2";
   };
 
-  propagatedBuildInputs = [ nbformat sphinx ipywidgets ];
+  propagatedBuildInputs = [ nbconvert nbformat sphinx ipywidgets ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/jupyter_server/default.nix
+++ b/pkgs/development/python-modules/jupyter_server/default.nix
@@ -10,6 +10,7 @@
 , jinja2
 , tornado
 , pyzmq
+, ipykernel
 , ipython_genutils
 , traitlets
 , jupyter_core
@@ -62,6 +63,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    ipykernel
     pytestCheckHook
     pytest-tornasync
     requests

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -1,25 +1,19 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, pytestCheckHook
-, glibcLocales
-, entrypoints
+{ beautifulsoup4
 , bleach
+, buildPythonPackage
+, defusedxml
+, fetchPypi
+, ipywidgets
+, jinja2
+, jupyterlab-pygments
+, lib
+, markupsafe
 , mistune
 , nbclient
-, jinja2
-, pygments
-, traitlets
-, jupyter_core
-, jupyterlab-pygments
-, nbformat
-, ipykernel
 , pandocfilters
-, tornado
-, jupyter-client
-, defusedxml
+, pyppeteer
+, pytestCheckHook
 , tinycss2
-, beautifulsoup4
 }:
 
 buildPythonPackage rec {
@@ -42,37 +36,38 @@ buildPythonPackage rec {
     substituteAllInPlace ./nbconvert/exporters/templateexporter.py
   '';
 
-  checkInputs = [ pytestCheckHook glibcLocales ];
-
   propagatedBuildInputs = [
-    entrypoints bleach mistune jinja2 pygments traitlets
-    jupyter_core nbformat ipykernel pandocfilters tornado jupyter-client
-    defusedxml tinycss2 beautifulsoup4
-    nbclient
+    beautifulsoup4
+    bleach
+    defusedxml
+    jinja2
     jupyterlab-pygments
+    markupsafe
+    mistune
+    nbclient
+    pandocfilters
+    tinycss2
   ];
 
-  # disable preprocessor tests for ipython 7
-  # see issue https://github.com/jupyter/nbconvert/issues/898
   preCheck = ''
-    export LC_ALL=en_US.UTF-8
-    HOME=$(mktemp -d)
+    export HOME=$(mktemp -d)
   '';
 
-  pytestFlagsArray = [
-    "--ignore=nbconvert/preprocessors/tests/test_execute.py"
-    # can't resolve template paths within sandbox
-    "--ignore=nbconvert/tests/base.py"
-    "--ignore=nbconvert/tests/test_nbconvertapp.py"
+  checkInputs = [
+    ipywidgets
+    pyppeteer
+    pytestCheckHook
   ];
 
+  pytestFlagsArray = [
+    # DeprecationWarning: Support for bleach <5 will be removed in a future version of nbconvert
+    "-W ignore::DeprecationWarning"
+  ];
 
   disabledTests = [
+    # Attempts network access (Failed to establish a new connection: [Errno -3] Temporary failure in name resolution)
     "test_export"
-    "test_webpdf_without_chromium"
-    #"test_cell_tag_output"
-    #"test_convert_from_stdin"
-    #"test_convert_full_qualified_name"
+    "test_webpdf_with_chromium"
   ];
 
   # Some of the tests use localhost networking.

--- a/pkgs/development/python-modules/pweave/default.nix
+++ b/pkgs/development/python-modules/pweave/default.nix
@@ -7,6 +7,7 @@
 , nbconvert
 , markdown
 , isPy3k
+, ipykernel
 }:
 
 buildPythonPackage rec {
@@ -21,7 +22,7 @@ buildPythonPackage rec {
   disabled = !isPy3k;
 
   buildInputs = [ mock pkgs.glibcLocales ];
-  propagatedBuildInputs = [ matplotlib nbconvert markdown ];
+  propagatedBuildInputs = [ ipykernel matplotlib nbconvert markdown ];
 
   # fails due to trying to run CSS as test
   doCheck = false;

--- a/pkgs/development/python-modules/widgetsnbextension/default.nix
+++ b/pkgs/development/python-modules/widgetsnbextension/default.nix
@@ -8,13 +8,20 @@
 buildPythonPackage rec {
   pname = "widgetsnbextension";
   version = "3.6.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-6Ep6n8ubrz1XEG4YSnOJqPjrk1v3QaXrnWCqGMwCmoA=";
+    hash = "sha256-6Ep6n8ubrz1XEG4YSnOJqPjrk1v3QaXrnWCqGMwCmoA=";
   };
 
-  propagatedBuildInputs = [ notebook ];
+  # setup.py claims to require notebook, but the source doesn't have any imports
+  # in it.
+  postPatch = ''
+    substituteInPlace setup.py --replace "'notebook>=4.4.1'," ""
+  '';
+
+  propagatedBuildInputs = [ ];
 
   # No tests in archive
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

General clean up of the nbconvert derivation. In particular, I found that the set of disabled tests could be made smaller, leading to better test coverage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
