### PR TITLE
beancount-language-server: refactor -> 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10188,6 +10188,12 @@
     githubId = 10473184;
     name = "Jia Xiaodong";
   };
+  polarmutex = {
+    email = "brian@brianryall.xyz";
+    github = "polarmutex";
+    githubId = 115141;
+    name = "Brian Ryall";
+  };
   polendri = {
     email = "paul@ijj.li";
     github = "polendri";

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -35,7 +35,6 @@
 , "awesome-lint"
 , "balanceofsatoshis"
 , "bash-language-server"
-, "beancount-langserver"
 , "bower"
 , "bower2nix"
 , "browserify"

--- a/pkgs/development/tools/beancount-language-server/default.nix
+++ b/pkgs/development/tools/beancount-language-server/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "beancount-language-server";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "polarmutex";
+    repo = "beancount-language-server";
+    rev = "v${version}";
+    sha256 = "sha256-CkwNxamkErRo3svJNth2F8NSqlJNX+1S/srKu6Z+mX4=";
+  };
+
+  cargoSha256 = "sha256-NTUs9ADTn+KoE08FikRHrdptZkrUqnjVIlcr8RtDvic=";
+
+  doInstallCheck = true;
+  postInstallCheck = ''
+    $out/bin/beancount-language-server --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A Language Server Protocol (LSP) for beancount files";
+    homepage = "https://github.com/polarmutex/beancount-language-server";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ polarmutex ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31334,6 +31334,8 @@ with pkgs;
 
   beancount = with python3.pkgs; toPythonApplication beancount;
 
+  beancount-language-server = callPackage ../development/tools/beancount-language-server {};
+
   bean-add = callPackage ../applications/office/beancount/bean-add.nix { };
 
   bench = haskell.lib.compose.justStaticExecutables haskellPackages.bench;


### PR DESCRIPTION
###### Description of changes

fixes: #171138

This PR does the following:
-  removes the npm version of the beancount-language-server tool which has been deprecated
- adds the new refactored rust version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
