### PR TITLE
infnoise: unstable-2019-08-12 -> 0.3.2, nixos/infnoise: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -40,12 +40,19 @@
   </section>
   <section xml:id="sec-release-22.11-new-services">
     <title>New Services</title>
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para>
           <link xlink:href="https://github.com/jollheef/appvm">appvm</link>,
           Nix based app VMs. Available as
           <link xlink:href="options.html#opt-virtualisation.appvm.enable">virtualisation.appvm</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/leetronics/infnoise">infnoise</link>,
+          a hardware True Random Number Generator dongle. Available as
+          <link xlink:href="options.html#opt-services.infnoise.enable">services.infnoise</link>.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -25,6 +25,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [appvm](https://github.com/jollheef/appvm), Nix based app VMs. Available as [virtualisation.appvm](options.html#opt-virtualisation.appvm.enable).
 
+- [infnoise](https://github.com/leetronics/infnoise), a hardware True Random Number Generator dongle.
+  Available as [services.infnoise](options.html#opt-services.infnoise.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-22.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -981,6 +981,7 @@
   ./services/security/hologram-server.nix
   ./services/security/hologram-agent.nix
   ./services/security/kanidm.nix
+  ./services/security/infnoise.nix
   ./services/security/munge.nix
   ./services/security/nginx-sso.nix
   ./services/security/oauth2_proxy.nix

--- a/nixos/modules/services/security/infnoise.nix
+++ b/nixos/modules/services/security/infnoise.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.infnoise;
+in {
+  options = {
+    services.infnoise = {
+      enable = mkEnableOption "the Infinite Noise TRNG driver";
+
+      fillDevRandom = mkOption {
+        description = ''
+          Whether to run the infnoise driver as a daemon to refill /dev/random.
+
+          If disabled, you can use the `infnoise` command-line tool to
+          manually obtain randomness.
+        '';
+        type = types.bool;
+        default = true;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.infnoise ];
+
+    services.udev.extraRules = ''
+      SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", SYMLINK+="infnoise", TAG+="systemd", GROUP="dialout", MODE="0664", ENV{SYSTEMD_WANTS}="infnoise.service"
+    '';
+
+    systemd.services.infnoise = mkIf cfg.fillDevRandom {
+      description = "Infinite Noise TRNG driver";
+
+      bindsTo = [ "dev-infnoise.device" ];
+      after = [ "dev-infnoise.device" ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.infnoise}/bin/infnoise --dev-random --debug";
+        Restart = "always";
+        User = "infnoise";
+        DynamicUser = true;
+        SupplementaryGroups = [ "dialout" ];
+        DeviceAllow = [ "/dev/infnoise" ];
+        DevicePolicy = "closed";
+        PrivateNetwork = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true; # only reads entropy pool size and watermark
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+      };
+    };
+  };
+}

--- a/pkgs/misc/drivers/infnoise/default.nix
+++ b/pkgs/misc/drivers/infnoise/default.nix
@@ -37,9 +37,6 @@ stdenv.mkDerivation rec {
     longDescription = ''
       The Infinite Noise TRNG is a USB key hardware true random number generator.
       It can either provide rng for userland applications, or provide rng for the OS entropy.
-      Add the following to your system configuration for plug and play support, adding to the OS entropy:
-      systemd.packages = [ pkgs.infnoise ];
-      services.udev.packages = [ pkgs.infnoise ];
     '';
     license = licenses.cc0;
     maintainers = with maintainers; [ StijnDW zhaofengli ];

--- a/pkgs/misc/drivers/infnoise/default.nix
+++ b/pkgs/misc/drivers/infnoise/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libftdi
+{ lib, stdenv, fetchFromGitHub, fetchpatch, libftdi
 , infnoise, testers }:
 
 stdenv.mkDerivation rec {
@@ -12,18 +12,27 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-9MKG1InkV+yrQPBTgi2gZJ3y9Fokb6WbxuAnM7n7FyA=";
   };
 
-  # Patch makefile so we can set defines from the command line instead of it depending on .git
-  patches = [ ./makefile.patch ];
+  patches = [
+    # Patch makefile so we can set defines from the command line instead of it depending on .git
+    ./makefile.patch
+
+    # Fix getc return type
+    (fetchpatch {
+      url = "https://github.com/leetronics/infnoise/commit/7ed7014e14253311c07e530c8f89f1c8f4705c2b.patch";
+      sha256 = "sha256-seB/fJaxQ/rXJp5iPtnobXXOccQ2KUAk6HFx31dhOhs=";
+    })
+  ];
+
   GIT_COMMIT = src.rev;
   GIT_VERSION = version;
   GIT_DATE = "2019-08-12";
 
   buildInputs = [ libftdi ];
 
-  sourceRoot = "source/software";
   makefile = "Makefile.linux";
   makeFlags = [ "PREFIX=$(out)" ];
   postPatch = ''
+    cd software
     substituteInPlace init_scripts/infnoise.service --replace "/usr/local" "$out"
   '';
 

--- a/pkgs/misc/drivers/infnoise/default.nix
+++ b/pkgs/misc/drivers/infnoise/default.nix
@@ -36,6 +36,12 @@ stdenv.mkDerivation rec {
     substituteInPlace init_scripts/infnoise.service --replace "/usr/local" "$out"
   '';
 
+  postInstall = ''
+    make -C tools
+    find ./tools/ -executable -type f -exec \
+      sh -c "install -Dm755 {} $out/bin/infnoise-\$(basename {})" \;
+  '';
+
   passthru = {
     tests.version = testers.testVersion { package = infnoise; };
   };

--- a/pkgs/misc/drivers/infnoise/default.nix
+++ b/pkgs/misc/drivers/infnoise/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, libftdi }:
+{ lib, stdenv, fetchFromGitHub, libftdi
+, infnoise, testers }:
 
 stdenv.mkDerivation rec {
   pname = "infnoise";
-  version = "unstable-2019-08-12";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
-    owner = "13-37-org";
+    owner = "leetronics";
     repo = "infnoise";
-    rev = "132683d4b5ce0902468b666cba63baea36e97f0c";
-    sha256 = "1dzfzinyvhyy9zj32kqkl19fyhih6sy8r5sa3qahbbr4c30k7flp";
+    rev = "e80ddd78085abf3d06df2e0d8c08fd33dade78eb";
+    sha256 = "sha256-9MKG1InkV+yrQPBTgi2gZJ3y9Fokb6WbxuAnM7n7FyA=";
   };
 
   # Patch makefile so we can set defines from the command line instead of it depending on .git
@@ -26,8 +27,12 @@ stdenv.mkDerivation rec {
     substituteInPlace init_scripts/infnoise.service --replace "/usr/local" "$out"
   '';
 
+  passthru = {
+    tests.version = testers.testVersion { package = infnoise; };
+  };
+
   meta = with lib; {
-    homepage = "https://github.com/13-37-org/infnoise";
+    homepage = "https://github.com/leetronics/infnoise";
     description = "Driver for the Infinite Noise TRNG";
     longDescription = ''
       The Infinite Noise TRNG is a USB key hardware true random number generator.
@@ -37,7 +42,7 @@ stdenv.mkDerivation rec {
       services.udev.packages = [ pkgs.infnoise ];
     '';
     license = licenses.cc0;
-    maintainers = with maintainers; [ StijnDW ];
+    maintainers = with maintainers; [ StijnDW zhaofengli ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/drivers/infnoise/makefile.patch
+++ b/pkgs/misc/drivers/infnoise/makefile.patch
@@ -1,7 +1,7 @@
 diff --git a/software/Makefile.linux b/software/Makefile.linux
 index db48aa5..df8b3d2 100644
---- a/Makefile.linux
-+++ b/Makefile.linux
+--- a/software/Makefile.linux
++++ b/software/Makefile.linux
 @@ -1,6 +1,6 @@
 -GIT_VERSION := $(shell git --no-pager describe --tags --always)
 -GIT_COMMIT  := $(shell git rev-parse --verify HEAD)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR updates infnoise to the latest stable release and adds a NixOS module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
