### PR TITLE
dieharder: init at 3.31.1

### DIFF
--- a/pkgs/tools/security/dieharder/default.nix
+++ b/pkgs/tools/security/dieharder/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchurl, gsl
+, dieharder, testers }:
+
+stdenv.mkDerivation rec {
+  pname = "dieharder";
+  version = "3.31.1";
+
+  src = fetchurl {
+    url = "http://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-${version}.tgz";
+    hash = "sha256-bP8P+DlMVTVJrHQzNZzPyVX7JnlCYDFGIN+l5M1Lcn8=";
+  };
+
+  patches = [
+    # Include missing stdint.h header
+    ./stdint.patch
+  ];
+
+  buildInputs = [ gsl ];
+
+  passthru = {
+    tests.version = testers.testVersion { package = dieharder; };
+  };
+
+  meta = with lib; {
+    description = "A Random Number Generator test suite";
+    homepage = "https://webhome.phy.duke.edu/~rgb/General/dieharder.php";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ zhaofengli ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/dieharder/stdint.patch
+++ b/pkgs/tools/security/dieharder/stdint.patch
@@ -1,0 +1,10 @@
+--- a/include/dieharder/libdieharder.h	2011-10-14 15:41:37.000000000 +0200
++++ b/include/dieharder/libdieharder.h	2015-03-27 16:34:40.978860858 +0100
+@@ -13,6 +13,7 @@
+ #include <stdlib.h>
+ #include <stdarg.h>
+ #include <string.h>
++#include <stdint.h>
+ #include <sys/time.h>
+ 
+ /* This turns on uint macro in c99 */

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3238,6 +3238,8 @@ with pkgs;
 
   dibbler = callPackage ../tools/networking/dibbler { };
 
+  dieharder = callPackage ../tools/security/dieharder { };
+
   diesel-cli = callPackage ../development/tools/diesel-cli {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[dieharder](https://webhome.phy.duke.edu/~rgb/General/dieharder.php) is a Random Number Generator test suite.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
