### PR TITLE
ipmitool: fix build on -fno-common toolchains

### DIFF
--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -24,6 +24,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/ipmitool/ipmitool/commit/e824c23316ae50beb7f7488f2055ac65e8b341f2.patch";
       sha256 = "sha256-X7MnoX2fzByRpRY4p33xetT+V2aehlQ/qU+aeaqtTUY=";
     })
+    # Pull upstream patch to support upstream gcc-10:
+    #   https://github.com/ipmitool/ipmitool/pull/180
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/ipmitool/ipmitool/commit/51c7e0822f531469cf860dfa5d010c87b284b747.patch";
+      sha256 = "sha256-5UszUdVw3s2S5RCm5Exq4mqDqiYcN62in1O5+TZu9YA=";
+    })
   ];
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
Without the change build fails on toolchains like clang-13 which
switch to -fno-common by default:

    $ nix build --impure --expr 'with import ./. {}; ipmitool.override { stdenv = clang13Stdenv; }'
    ...
    ld: ../lib/.libs/libipmitool.a(ipmi_hpmfwupg.o):/build/ipmitool-1.8.18/lib/../include/ipmitool/ipmi_hpmfwupg.h:803:
      multiple definition of `gVersionInfo'; ipmitool.o:/build/ipmitool-1.8.18/src/../include/ipmitool/ipmi_hpmfwupg.h:803: first defined here

Pull upstream fix to move definition to .c file.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
