### PR TITLE
spirv-llvm-translator: fix duplicate makeFlags merge

### DIFF
--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ lit ];
 
-  makeFlags = [ "llvm-spirv" ];
-
   cmakeFlags = [
     "-DLLVM_INCLUDE_TESTS=ON"
     "-DLLVM_DIR=${llvm_11.dev}"


### PR DESCRIPTION
See
https://github.com/NixOS/nixpkgs/pull/171656#issuecomment-1119263828

there was a conflict with #162603 and a GitHub Action did a bad merge in 4cab9ae#diff-1aeab0da45b3afb6688d321042021a2ebad96758fc495d92aaadb50cc9aa22c7R28, adding a second makeFlags and breaking the build.