### PR TITLE
libgcc: downgrade to 11.2.0 on x86_64-darwin

### DIFF
--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -1,11 +1,22 @@
-{ lib, stdenvNoLibs, buildPackages
+{ lib, fetchurl, stdenvNoLibs, buildPackages
 , gcc, glibc
 , libiberty
 }:
 
-stdenvNoLibs.mkDerivation rec {
+with
+  # Avoid issues on x86_64-darwin, and on aarch64-darwin it's 11.2.0 anyway.
+  if stdenvNoLibs.isDarwin then rec {
+    version = "11.2.0";
+    src = fetchurl {
+      url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.xz";
+      sha256 = "sha256-0I7cU2tUw3KhAQ/2YZ3SdMDxYDqkkhK6IPeqLNo2+os=";
+    };
+  } else {
+    inherit (gcc.cc) src version;
+  };
+stdenvNoLibs.mkDerivation {
   pname = "libgcc";
-  inherit (gcc.cc) src version;
+  inherit src version;
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
https://hydra.nixos.org/build/175546330

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] no rebuild x86_64-linux
  - [x] no rebuild aarch64-linux
  - [ ] x86_64-darwin
  - [x] no rebuild aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
