### PR TITLE
firejail: Fix resolve binary paths in user environment

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -37,9 +37,16 @@ stdenv.mkDerivation rec {
     # Adds the /nix directory when using an overlay.
     # Required to run any programs under this mode.
     ./mount-nix-dir-on-overlay.patch
+
     # By default fbuilder hardcodes the firejail binary to the install path.
     # On NixOS the firejail binary is a setuid wrapper available in $PATH.
     ./fbuilder-call-firejail-on-path.patch
+
+    # NixOS specific whitelist to resolve binary paths in user environment
+    # Fixes https://github.com/NixOS/nixpkgs/issues/170784
+    # Upstream fix https://github.com/netblue30/firejail/pull/5131
+    # Upstream hopefully fixed in later versions > 0.9.68
+   ./whitelist-nix-profile.patch
   ];
 
   prePatch = ''

--- a/pkgs/os-specific/linux/firejail/whitelist-nix-profile.patch
+++ b/pkgs/os-specific/linux/firejail/whitelist-nix-profile.patch
@@ -1,0 +1,9 @@
+--- a/etc/inc/whitelist-common.inc.org	2022-05-06 13:57:17.294206339 +0200
++++ b/etc/inc/whitelist-common.inc	2022-05-06 13:58:00.108655548 +0200
+@@ -83,3 +83,6 @@
+ whitelist ${HOME}/.kde4/share/config/oxygenrc
+ whitelist ${HOME}/.kde4/share/icons
+ whitelist ${HOME}/.local/share/qt5ct
++
++# NixOS specific to resolve binary paths
++whitelist ${HOME}/.nix-profile


### PR DESCRIPTION
###### Description of changes

This PR fixes running firejail from the command line where it couldn't find executables because ~/.nix-profile is not whitelisted, see https://github.com/NixOS/nixpkgs/issues/170784

@raskin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
