### PR TITLE
tilemaker: init at 2.2.0

### DIFF
--- a/pkgs/applications/misc/tilemaker/default.nix
+++ b/pkgs/applications/misc/tilemaker/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, buildPackages, cmake, installShellFiles
+, boost, lua, protobuf, rapidjson, shapelib, sqlite, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "tilemaker";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "systemed";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-st6WDCk1RZ2lbfrudtcD+zenntyTMRHrIXw3nX5FHOU=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/tilemaker.cpp \
+      --replace "config.json" "$out/share/tilemaker/config-openmaptiles.json" \
+      --replace "process.lua" "$out/share/tilemaker/process-openmaptiles.lua"
+  '';
+
+  nativeBuildInputs = [ cmake installShellFiles ];
+
+  buildInputs = [ boost lua protobuf rapidjson shapelib sqlite zlib ];
+
+  cmakeFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+    "-DPROTOBUF_PROTOC_EXECUTABLE=${buildPackages.protobuf}/bin/protoc";
+
+  postInstall = ''
+    installManPage ../docs/man/tilemaker.1
+    install -Dm644 ../resources/* -t $out/share/tilemaker
+  '';
+
+  meta = with lib; {
+    description = "Make OpenStreetMap vector tiles without the stack";
+    homepage = "https://tilemaker.org/";
+    license = licenses.free; # FTWPL
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29934,6 +29934,8 @@ with pkgs;
 
   tig = callPackage ../applications/version-management/git-and-tools/tig { };
 
+  tilemaker = callPackage ../applications/misc/tilemaker { };
+
   timbreid = callPackage ../applications/audio/pd-plugins/timbreid {
     fftw = fftwSinglePrec;
   };


### PR DESCRIPTION
###### Description of changes
[**Tilemaker**](https://tilemaker.org/) - make OpenStreetMap vector tiles without the stack.
[![Packaging status](https://repology.org/badge/tiny-repos/tilemaker.svg)](https://repology.org/project/tilemaker/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
