### PR TITLE
gcc12, gfortran12, gnat12: init at 12.1.0

### DIFF
--- a/pkgs/development/compilers/gcc/12/Added-mcf-thread-model-support-from-mcfgthread.patch
+++ b/pkgs/development/compilers/gcc/12/Added-mcf-thread-model-support-from-mcfgthread.patch
@@ -1,0 +1,306 @@
+From 86f2f767ddffd9f7c6f1470b987ae7b0d251b988 Mon Sep 17 00:00:00 2001
+From: Liu Hao <lh_mouse@126.com>
+Date: Wed, 25 Apr 2018 21:54:19 +0800
+Subject: [PATCH] Added 'mcf' thread model support from mcfgthread.
+
+Signed-off-by: Liu Hao <lh_mouse@126.com>
+---
+ config/gthr.m4                          |  1 +
+ gcc/config.gcc                          |  3 +++
+ gcc/config/i386/mingw-mcfgthread.h      |  1 +
+ gcc/config/i386/mingw-w64.h             |  2 +-
+ gcc/config/i386/mingw32.h               | 11 ++++++++++-
+ gcc/configure                           |  2 +-
+ gcc/configure.ac                        |  2 +-
+ libatomic/configure.tgt                 |  2 +-
+ libgcc/config.host                      |  6 ++++++
+ libgcc/config/i386/gthr-mcf.h           |  1 +
+ libgcc/config/i386/t-mingw-mcfgthread   |  2 ++
+ libgcc/configure                        |  1 +
+ libstdc++-v3/configure                  |  1 +
+ libstdc++-v3/libsupc++/atexit_thread.cc | 18 ++++++++++++++++++
+ libstdc++-v3/libsupc++/guard.cc         | 23 +++++++++++++++++++++++
+ libstdc++-v3/src/c++11/thread.cc        |  9 +++++++++
+ 16 files changed, 80 insertions(+), 5 deletions(-)
+ create mode 100644 gcc/config/i386/mingw-mcfgthread.h
+ create mode 100644 libgcc/config/i386/gthr-mcf.h
+ create mode 100644 libgcc/config/i386/t-mingw-mcfgthread
+
+diff --git a/config/gthr.m4 b/config/gthr.m4
+index 7b29f1f3327..82e21fe1709 100644
+--- a/config/gthr.m4
++++ b/config/gthr.m4
+@@ -21,6 +21,7 @@ case $1 in
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ AC_SUBST(thread_header)
+ ])
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 46a9029acec..112c24e95a3 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -1758,6 +1758,9 @@ i[34567]86-*-mingw* | x86_64-*-mingw*)
+ 	if test x$enable_threads = xposix ; then
+ 		tm_file="${tm_file} i386/mingw-pthread.h"
+ 	fi
++	if test x$enable_threads = xmcf ; then
++		tm_file="${tm_file} i386/mingw-mcfgthread.h"
++	fi
+ 	tm_file="${tm_file} i386/mingw32.h"
+ 	# This makes the logic if mingw's or the w64 feature set has to be used
+ 	case ${target} in
+diff --git a/gcc/config/i386/mingw-mcfgthread.h b/gcc/config/i386/mingw-mcfgthread.h
+new file mode 100644
+index 00000000000..ec381a7798f
+--- /dev/null
++++ b/gcc/config/i386/mingw-mcfgthread.h
+@@ -0,0 +1 @@
++#define TARGET_USE_MCFGTHREAD 1
+diff --git a/gcc/config/i386/mingw-w64.h b/gcc/config/i386/mingw-w64.h
+index 484dc7a9e9f..a15bbeea500 100644
+--- a/gcc/config/i386/mingw-w64.h
++++ b/gcc/config/i386/mingw-w64.h
+@@ -48,7 +48,7 @@ along with GCC; see the file COPYING3.  If not see
+ 		 "%{mwindows:-lgdi32 -lcomdlg32} " \
+      "%{fvtable-verify=preinit:-lvtv -lpsapi; \
+         fvtable-verify=std:-lvtv -lpsapi} " \
+-		 "-ladvapi32 -lshell32 -luser32 -lkernel32"
++		 LIB_MCFGTHREAD "-ladvapi32 -lshell32 -luser32 -lkernel32"
+ 
+ #undef SPEC_32
+ #undef SPEC_64
+diff --git a/gcc/config/i386/mingw32.h b/gcc/config/i386/mingw32.h
+index 0612b87199a..76cea94f3b7 100644
+--- a/gcc/config/i386/mingw32.h
++++ b/gcc/config/i386/mingw32.h
+@@ -32,6 +32,14 @@ along with GCC; see the file COPYING3.  If not see
+ 	 | MASK_STACK_PROBE | MASK_ALIGN_DOUBLE \
+ 	 | MASK_MS_BITFIELD_LAYOUT)
+ 
++#ifndef TARGET_USE_MCFGTHREAD
++#define CPP_MCFGTHREAD()  ((void)0)
++#define LIB_MCFGTHREAD     ""
++#else
++#define CPP_MCFGTHREAD()  (builtin_define("__USING_MCFGTHREAD__"))
++#define LIB_MCFGTHREAD     " -lmcfgthread "
++#endif
++
+ /* See i386/crtdll.h for an alternative definition. _INTEGRAL_MAX_BITS
+    is for compatibility with native compiler.  */
+ #define EXTRA_OS_CPP_BUILTINS()					\
+@@ -50,6 +58,7 @@ along with GCC; see the file COPYING3.  If not see
+ 	  builtin_define_std ("WIN64");				\
+ 	  builtin_define ("_WIN64");				\
+ 	}							\
++	CPP_MCFGTHREAD();	\
+     }								\
+   while (0)
+ 
+@@ -93,7 +102,7 @@ along with GCC; see the file COPYING3.  If not see
+ 		 "%{mwindows:-lgdi32 -lcomdlg32} " \
+      "%{fvtable-verify=preinit:-lvtv -lpsapi; \
+         fvtable-verify=std:-lvtv -lpsapi} " \
+-                 "-ladvapi32 -lshell32 -luser32 -lkernel32"
++                 LIB_MCFGTHREAD "-ladvapi32 -lshell32 -luser32 -lkernel32"
+ 
+ /* Weak symbols do not get resolved if using a Windows dll import lib.
+    Make the unwind registration references strong undefs.  */
+diff --git a/gcc/configure b/gcc/configure
+index 6121e163259..52f0e00efe6 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -11693,7 +11693,7 @@ case ${enable_threads} in
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32)
++  single | tpf | vxworks | win32 | mcf)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index b066cc609e1..4ecdba88de7 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -1612,7 +1612,7 @@ case ${enable_threads} in
+     target_thread_file='single'
+     ;;
+   aix | dce | lynx | mipssde | posix | rtems | \
+-  single | tpf | vxworks | win32)
++  single | tpf | vxworks | win32 | mcf)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
+index ea8c34f8c71..23134ad7363 100644
+--- a/libatomic/configure.tgt
++++ b/libatomic/configure.tgt
+@@ -145,7 +145,7 @@ case "${target}" in
+   *-*-mingw*)
+ 	# OS support for atomic primitives.
+         case ${target_thread_file} in
+-          win32)
++          win32 | mcf)
+             config_path="${config_path} mingw"
+             ;;
+           posix)
+diff --git a/libgcc/config.host b/libgcc/config.host
+index 11b4acaff55..9fbd38650bd 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -737,6 +737,9 @@ i[34567]86-*-mingw*)
+ 	  posix)
+ 	    tmake_file="i386/t-mingw-pthread $tmake_file"
+ 	    ;;
++	  mcf)
++	    tmake_file="i386/t-mingw-mcfgthread $tmake_file"
++	    ;;
+ 	esac
+ 	# This has to match the logic for DWARF2_UNWIND_INFO in gcc/config/i386/cygming.h
+ 	if test x$ac_cv_sjlj_exceptions = xyes; then
+@@ -761,6 +764,9 @@ x86_64-*-mingw*)
+ 	  posix)
+ 	    tmake_file="i386/t-mingw-pthread $tmake_file"
+ 	    ;;
++	  mcf)
++	    tmake_file="i386/t-mingw-mcfgthread $tmake_file"
++	    ;;
+ 	esac
+ 	# This has to match the logic for DWARF2_UNWIND_INFO in gcc/config/i386/cygming.h
+ 	if test x$ac_cv_sjlj_exceptions = xyes; then
+diff --git a/libgcc/config/i386/gthr-mcf.h b/libgcc/config/i386/gthr-mcf.h
+new file mode 100644
+index 00000000000..5ea2908361f
+--- /dev/null
++++ b/libgcc/config/i386/gthr-mcf.h
+@@ -0,0 +1 @@
++#include <mcfgthread/gthread.h>
+diff --git a/libgcc/config/i386/t-mingw-mcfgthread b/libgcc/config/i386/t-mingw-mcfgthread
+new file mode 100644
+index 00000000000..4b9b10e32d6
+--- /dev/null
++++ b/libgcc/config/i386/t-mingw-mcfgthread
+@@ -0,0 +1,2 @@
++SHLIB_PTHREAD_CFLAG =
++SHLIB_PTHREAD_LDFLAG = -lmcfgthread
+diff --git a/libgcc/configure b/libgcc/configure
+index b2f3f870844..eff889dc3b3 100644
+--- a/libgcc/configure
++++ b/libgcc/configure
+@@ -5451,6 +5451,7 @@ case $target_thread_file in
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 
+ 
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index ba094be6f15..979a5ab9ace 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -15187,6 +15187,7 @@ case $target_thread_file in
+     tpf)	thread_header=config/s390/gthr-tpf.h ;;
+     vxworks)	thread_header=config/gthr-vxworks.h ;;
+     win32)	thread_header=config/i386/gthr-win32.h ;;
++    mcf)	thread_header=config/i386/gthr-mcf.h ;;
+ esac
+ 
+ 
+diff --git a/libstdc++-v3/libsupc++/atexit_thread.cc b/libstdc++-v3/libsupc++/atexit_thread.cc
+index de920d714c6..665fb74bd6b 100644
+--- a/libstdc++-v3/libsupc++/atexit_thread.cc
++++ b/libstdc++-v3/libsupc++/atexit_thread.cc
+@@ -25,6 +25,22 @@
+ #include <cstdlib>
+ #include <new>
+ #include "bits/gthr.h"
++
++#ifdef __USING_MCFGTHREAD__
++
++#include <mcfgthread/gthread.h>
++namespace __cxxabiv1 {
++extern "C" int
++__cxa_thread_atexit (void (_GLIBCXX_CDTOR_CALLABI *dtor)(void *),
++				 void *obj, void *dso_handle)
++  _GLIBCXX_NOTHROW
++{
++  return ::_MCFCRT_AtThreadExit((void (*)(_MCFCRT_STD intptr_t))dtor, (_MCFCRT_STD intptr_t)obj) ? 0 : -1;
++  (void)dso_handle;
++}
++}
++#else // __USING_MCFGTHREAD__
++
+ #ifdef _GLIBCXX_THREAD_ATEXIT_WIN32
+ #define WIN32_LEAN_AND_MEAN
+ #include <windows.h>
+@@ -167,3 +183,5 @@ __cxxabiv1::__cxa_thread_atexit (void (*dtor)(void *), void *obj, void */*dso_ha
+ }
+ 
+ #endif /* _GLIBCXX_HAVE___CXA_THREAD_ATEXIT_IMPL */
++
++#endif // __USING_MCFGTHREAD__
+diff --git a/libstdc++-v3/libsupc++/guard.cc b/libstdc++-v3/libsupc++/guard.cc
+index 3a2ec3ad0d6..8b4cc96199b 100644
+--- a/libstdc++-v3/libsupc++/guard.cc
++++ b/libstdc++-v3/libsupc++/guard.cc
+@@ -28,6 +28,27 @@
+ #include <cxxabi.h>
+ #include <exception>
+ #include <new>
++
++#ifdef __USING_MCFGTHREAD__
++
++#include <mcfgthread/gthread.h>
++
++namespace __cxxabiv1 {
++
++extern "C" int __cxa_guard_acquire(__guard *g){
++	return ::_MCFCRT_WaitForOnceFlagForever((::_MCFCRT_OnceFlag *)g) == ::_MCFCRT_kOnceResultInitial;
++}
++extern "C" void __cxa_guard_abort(__guard *g) throw() {
++	::_MCFCRT_SignalOnceFlagAsAborted((::_MCFCRT_OnceFlag *)g);
++}
++extern "C" void __cxa_guard_release(__guard *g) throw() {
++	::_MCFCRT_SignalOnceFlagAsFinished((::_MCFCRT_OnceFlag *)g);
++}
++
++}
++
++#else // __USING_MCFGTHREAD__
++
+ #include <ext/atomicity.h>
+ #include <ext/concurrence.h>
+ #include <bits/atomic_lockfree_defines.h>
+@@ -425,3 +446,5 @@ namespace __cxxabiv1
+ #endif
+   }
+ }
++
++#endif
+diff --git a/libstdc++-v3/src/c++11/thread.cc b/libstdc++-v3/src/c++11/thread.cc
+index 8238817c2e9..0c6a1f85f6f 100644
+--- a/libstdc++-v3/src/c++11/thread.cc
++++ b/libstdc++-v3/src/c++11/thread.cc
+@@ -55,6 +55,15 @@ static inline int get_nprocs()
+ #elif defined(_GLIBCXX_USE_SC_NPROC_ONLN)
+ # include <unistd.h>
+ # define _GLIBCXX_NPROCS sysconf(_SC_NPROC_ONLN)
++#elif defined(_WIN32)
++# include <windows.h>
++static inline int get_nprocs()
++{
++  SYSTEM_INFO sysinfo;
++  GetSystemInfo(&sysinfo);
++  return (int)sysinfo.dwNumberOfProcessors;
++}
++# define _GLIBCXX_NPROCS get_nprocs()
+ #else
+ # define _GLIBCXX_NPROCS 0
+ #endif
+-- 
+2.17.0
+

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -1,0 +1,294 @@
+{ lib, stdenv, targetPackages, fetchurl, fetchpatch, noSysDirs
+, langC ? true, langCC ? true, langFortran ? false
+, langAda ? false
+, langObjC ? stdenv.targetPlatform.isDarwin
+, langObjCpp ? stdenv.targetPlatform.isDarwin
+, langGo ? false
+, reproducibleBuild ? true
+, profiledCompiler ? false
+, langJit ? false
+, staticCompiler ? false
+, enableShared ? !stdenv.targetPlatform.isStatic
+, enableLTO ? !stdenv.hostPlatform.isStatic
+, texinfo ? null
+, perl ? null # optional, for texi2pod (then pod2man)
+, gmp, mpfr, libmpc, gettext, which, patchelf
+, libelf                      # optional, for link-time optimizations (LTO)
+, isl ? null # optional, for the Graphite optimization framework.
+, zlib ? null
+, gnatboot ? null
+, enableMultilib ? false
+, enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, name ? "gcc"
+, libcCross ? null
+, threadsCross ? null # for MinGW
+, crossStageStatic ? false
+, # Strip kills static libs of other archs (hence no cross)
+  stripped ? stdenv.hostPlatform.system == stdenv.buildPlatform.system
+          && stdenv.targetPlatform.system == stdenv.hostPlatform.system
+, gnused ? null
+, cloog # unused; just for compat with gcc4, as we override the parameter on some places
+, buildPackages
+}:
+
+# LTO needs libelf and zlib.
+assert libelf != null -> zlib != null;
+
+# Make sure we get GNU sed.
+assert stdenv.hostPlatform.isDarwin -> gnused != null;
+
+# The go frontend is written in c++
+assert langGo -> langCC;
+assert langAda -> gnatboot != null;
+
+# threadsCross is just for MinGW
+assert threadsCross != null -> stdenv.targetPlatform.isWindows;
+
+# profiledCompiler builds inject non-determinism in one of the compilation stages.
+# If turned on, we can't provide reproducible builds anymore
+assert reproducibleBuild -> profiledCompiler == false;
+
+with lib;
+with builtins;
+
+let majorVersion = "12";
+    version = "${majorVersion}.1.0";
+
+    inherit (stdenv) buildPlatform hostPlatform targetPlatform;
+
+    patches =
+         optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
+      ++ optional noSysDirs ../gcc-12-no-sys-dirs.patch
+      ++ optional noSysDirs ../no-sys-dirs-riscv.patch
+      ++ [
+        ../gnat-cflags-11.patch
+        ../gcc-12-gfortran-driving.patch
+        ../ppc-musl.patch
+      ] ++ optional (stdenv.isDarwin && stdenv.isAarch64) (fetchpatch {
+        url = "https://github.com/fxcoudert/gcc/compare/releases/gcc-11.1.0...gcc-11.1.0-arm-20210504.diff";
+        sha256 = "sha256-JqCGJAfbOxSmkNyq49aFHteK/RFsCSLQrL9mzUCnaD0=";
+      })
+
+      # Obtain latest patch with ../update-mcfgthread-patches.sh
+      ++ optional (!crossStageStatic && targetPlatform.isMinGW) ./Added-mcf-thread-model-support-from-mcfgthread.patch;
+
+    /* Cross-gcc settings (build == host != target) */
+    crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+    stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
+    crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-${stageNameAddon}-";
+
+in
+
+stdenv.mkDerivation ({
+  pname = "${crossNameAddon}${name}${if stripped then "" else "-debug"}";
+  inherit version;
+
+  builder = ../builder.sh;
+
+  src = fetchurl {
+    url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.xz";
+    sha256 = "sha256-Yv1jSInzHAK2SvLEaPBktHrRynhBHEWr5qxLX43RnHs=";
+  };
+
+  inherit patches;
+
+  outputs = [ "out" "man" "info" ] ++ lib.optional (!langJit) "lib";
+  setOutputFlags = false;
+  NIX_NO_SELF_RPATH = true;
+
+  libc_dev = stdenv.cc.libc_dev;
+
+  hardeningDisable = [ "format" "pie" ];
+
+  postPatch = ''
+    configureScripts=$(find . -name configure)
+    for configureScript in $configureScripts; do
+      patchShebangs $configureScript
+    done
+  ''
+  # This should kill all the stdinc frameworks that gcc and friends like to
+  # insert into default search paths.
+  + lib.optionalString hostPlatform.isDarwin ''
+    substituteInPlace gcc/config/darwin-c.c \
+      --replace 'if (stdinc)' 'if (0)'
+
+    substituteInPlace libgcc/config/t-slibgcc-darwin \
+      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name ''${!outputLib}/lib/\$(SHLIB_INSTALL_NAME)"
+
+    substituteInPlace libgfortran/configure \
+      --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
+  ''
+  + (
+    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+      # On NixOS, use the right path to the dynamic linker instead of
+      # `/lib/ld*.so'.
+      let
+        libc = if libcCross != null then libcCross else stdenv.cc.libc;
+      in
+        (
+        '' echo "fixing the \`GLIBC_DYNAMIC_LINKER', \`UCLIBC_DYNAMIC_LINKER', and \`MUSL_DYNAMIC_LINKER' macros..."
+           for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h
+           do
+             grep -q _DYNAMIC_LINKER "$header" || continue
+             echo "  fixing \`$header'..."
+             sed -i "$header" \
+                 -e 's|define[[:blank:]]*\([UCG]\+\)LIBC_DYNAMIC_LINKER\([0-9]*\)[[:blank:]]"\([^\"]\+\)"$|define \1LIBC_DYNAMIC_LINKER\2 "${libc.out}\3"|g' \
+                 -e 's|define[[:blank:]]*MUSL_DYNAMIC_LINKER\([0-9]*\)[[:blank:]]"\([^\"]\+\)"$|define MUSL_DYNAMIC_LINKER\1 "${libc.out}\2"|g'
+           done
+        ''
+        + lib.optionalString (targetPlatform.libc == "musl")
+        ''
+            sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
+        ''
+        )
+    else "")
+      + lib.optionalString targetPlatform.isAvr ''
+            makeFlagsArray+=(
+               '-s' # workaround for hitting hydra log limit
+               'LIMITS_H_TEST=false'
+            )
+          '';
+
+  inherit noSysDirs staticCompiler crossStageStatic
+    libcCross crossMingw;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ texinfo which gettext ]
+    ++ (optional (perl != null) perl)
+    ++ (optional langAda gnatboot)
+    ;
+
+  # For building runtime libs
+  depsBuildTarget =
+    (
+      if hostPlatform == buildPlatform then [
+        targetPackages.stdenv.cc.bintools # newly-built gcc will be used
+      ] else assert targetPlatform == hostPlatform; [ # build != host == target
+        stdenv.cc
+      ]
+    )
+    ++ optional targetPlatform.isLinux patchelf;
+
+  buildInputs = [
+    gmp mpfr libmpc libelf
+    targetPackages.stdenv.cc.bintools # For linking code at run-time
+  ] ++ (optional (isl != null) isl)
+    ++ (optional (zlib != null) zlib)
+    # The builder relies on GNU sed (for instance, Darwin's `sed' fails with
+    # "-i may not be used with stdin"), and `stdenvNative' doesn't provide it.
+    ++ (optional hostPlatform.isDarwin gnused)
+    ;
+
+  depsTargetTarget = optional (!crossStageStatic && threadsCross != null) threadsCross;
+
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+
+  preConfigure = import ../common/pre-configure.nix {
+    inherit lib;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
+  };
+
+  dontDisableStatic = true;
+
+  configurePlatforms = [ "build" "host" "target" ];
+
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      lib
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
+
+      gmp mpfr libmpc libelf isl
+
+      enableLTO
+      enableMultilib
+      enablePlugin
+      enableShared
+
+      langC
+      langCC
+      langFortran
+      langAda
+      langGo
+      langObjC
+      langObjCpp
+      langJit
+      ;
+  };
+
+  targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
+
+  buildFlags = optional
+    (targetPlatform == hostPlatform && hostPlatform == buildPlatform)
+    (if profiledCompiler then "profiledbootstrap" else "bootstrap");
+
+  dontStrip = !stripped;
+
+  installTargets = optional stripped "install-strip";
+
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
+
+  # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
+  # library headers and binaries, regarless of the language being compiled.
+  #
+  # Likewise, the LTO code doesn't find zlib.
+  #
+  # Cross-compiling, we need gcc not to read ./specs in order to build the g++
+  # compiler (after the specs for the cross-gcc are created). Having
+  # LIBRARY_PATH= makes gcc read the specs from ., and the build breaks.
+
+  CPATH = optionals (targetPlatform == hostPlatform) (makeSearchPathOutput "dev" "include" ([]
+    ++ optional (zlib != null) zlib
+  ));
+
+  LIBRARY_PATH = optionals (targetPlatform == hostPlatform) (makeLibraryPath (optional (zlib != null) zlib));
+
+  inherit
+    (import ../common/extra-target-flags.nix {
+      inherit lib stdenv crossStageStatic libcCross threadsCross;
+    })
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
+    ;
+
+  passthru = {
+    inherit langC langCC langObjC langObjCpp langAda langFortran langGo version;
+    isGNU = true;
+  };
+
+  enableParallelBuilding = true;
+  inherit enableShared enableMultilib;
+
+  inherit (stdenv) is64bit;
+
+  meta = {
+    homepage = "https://gcc.gnu.org/";
+    license = lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
+    description = "GNU Compiler Collection, version ${version}"
+      + (if stripped then "" else " (with debugging info)");
+
+    longDescription = ''
+      The GNU Compiler Collection includes compiler front ends for C, C++,
+      Objective-C, Fortran, OpenMP for C/C++/Fortran, and Ada, as well as
+      libraries for these languages (libstdc++, libgomp,...).
+
+      GCC development is a part of the GNU Project, aiming to improve the
+      compiler used in the GNU system including the GNU/Linux variant.
+    '';
+
+    maintainers = lib.teams.gcc.members;
+
+    platforms = lib.platforms.unix;
+  };
+}
+
+// optionalAttrs (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt" && crossStageStatic) {
+  makeFlags = [ "all-gcc" "all-target-libgcc" ];
+  installTargets = "install-gcc install-target-libgcc";
+}
+
+// optionalAttrs (enableMultilib) { dontMoveLib64 = true; }
+)

--- a/pkgs/development/compilers/gcc/gcc-12-gfortran-driving.patch
+++ b/pkgs/development/compilers/gcc/gcc-12-gfortran-driving.patch
@@ -1,0 +1,20 @@
+This patch fixes interaction with Libtool.
+See <http://thread.gmane.org/gmane.comp.gcc.patches/258777>, for details.
+
+--- a/gcc/fortran/gfortranspec.cc
++++ b/gcc/fortran/gfortranspec.cc
+@@ -461,8 +461,15 @@ For more information about these matters, see the file named COPYING\n\n"));
+     {
+       fprintf (stderr, _("Driving:"));
+       for (i = 0; i < g77_newargc; i++)
++	{
++	  if (g77_new_decoded_options[i].opt_index == OPT_l)
++	    /* Make sure no white space is inserted after `-l'.  */
++	    fprintf (stderr, " -l%s",
++		     g77_new_decoded_options[i].canonical_option[1]);
++	  else
+ 	fprintf (stderr, " %s",
+ 		 g77_new_decoded_options[i].orig_option_with_args_text);
++	}
+       fprintf (stderr, "\n");
+     }

--- a/pkgs/development/compilers/gcc/gcc-12-no-sys-dirs.patch
+++ b/pkgs/development/compilers/gcc/gcc-12-no-sys-dirs.patch
@@ -1,0 +1,26 @@
+--- a/gcc/cppdefault.cc	2013-01-10 21:38:27.000000000 +0100
++++ b/gcc/cppdefault.cc	2014-08-18 16:20:32.893944536 +0200
+@@ -35,6 +35,8 @@
+ # undef CROSS_INCLUDE_DIR
+ #endif
+ 
++#undef LOCAL_INCLUDE_DIR
++
+ const struct default_include cpp_include_defaults[]
+ #ifdef INCLUDE_DEFAULTS
+ = INCLUDE_DEFAULTS;
+--- a/gcc/gcc.cc	2014-03-23 12:30:57.000000000 +0100
++++ b/gcc/gcc.cc	2014-08-18 13:19:32.689201690 +0200
+@@ -1162,10 +1162,10 @@
+ /* Default prefixes to attach to command names.  */
+ 
+ #ifndef STANDARD_STARTFILE_PREFIX_1
+-#define STANDARD_STARTFILE_PREFIX_1 "/lib/"
++#define STANDARD_STARTFILE_PREFIX_1 ""
+ #endif
+ #ifndef STANDARD_STARTFILE_PREFIX_2
+-#define STANDARD_STARTFILE_PREFIX_2 "/usr/lib/"
++#define STANDARD_STARTFILE_PREFIX_2 ""
+ #endif
+ 
+ #ifdef CROSS_DIRECTORY_STRUCTURE  /* Don't use these prefixes for a cross compiler.  */

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12510,6 +12510,7 @@ with pkgs;
   gcc9Stdenv = overrideCC gccStdenv buildPackages.gcc9;
   gcc10Stdenv = overrideCC gccStdenv buildPackages.gcc10;
   gcc11Stdenv = overrideCC gccStdenv buildPackages.gcc11;
+  gcc12Stdenv = overrideCC gccStdenv buildPackages.gcc12;
 
   # This is not intended for use in nixpkgs but for providing a faster-running
   # compiler to nixpkgs users by building gcc with reproducibility-breaking
@@ -12705,7 +12706,19 @@ with pkgs;
     isl = if !stdenv.isDarwin then isl_0_20 else null;
   }));
 
-  gcc_latest = gcc11;
+  gcc12 = lowPrio (wrapCC (callPackage ../development/compilers/gcc/12 {
+    inherit noSysDirs;
+
+    reproducibleBuild = true;
+    profiledCompiler = false;
+
+    libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then libcCross else null;
+    threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else null;
+
+    isl = if !stdenv.isDarwin then isl_0_20 else null;
+  }));
+
+  gcc_latest = gcc12;
 
   # Use the same GCC version as the one from stdenv by default
   gfortran = wrapCC (gcc.cc.override {
@@ -12773,6 +12786,14 @@ with pkgs;
   });
 
   gfortran11 = wrapCC (gcc11.cc.override {
+    name = "gfortran";
+    langFortran = true;
+    langCC = false;
+    langC = false;
+    profiledCompiler = false;
+  });
+
+  gfortran12 = wrapCC (gcc12.cc.override {
     name = "gfortran";
     langFortran = true;
     langCC = false;
@@ -12867,6 +12888,22 @@ with pkgs;
          && stdenv.buildPlatform == stdenv.hostPlatform
       then buildPackages.gnat6
       else buildPackages.gnat11;
+  });
+
+  gnat12 = wrapCC (gcc12.cc.override {
+    name = "gnat";
+    langC = true;
+    langCC = false;
+    langAda = true;
+    profiledCompiler = false;
+    # As per upstream instructions building a cross compiler
+    # should be done with a (native) compiler of the same version.
+    # If we are cross-compiling GNAT, we may as well do the same.
+    gnatboot =
+      if stdenv.hostPlatform == stdenv.targetPlatform
+         && stdenv.buildPlatform == stdenv.hostPlatform
+      then buildPackages.gnat6
+      else buildPackages.gnat12;
   });
 
   gnatboot = wrapCC (callPackage ../development/compilers/gnatboot { });


### PR DESCRIPTION
A copy of gcc11 with minor patch changes:
- follow .c/.cc rename upstream
- made patches unconditional

Changes: https://www.gnu.org/software/gcc/gcc-12/changes.html

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
