### PR TITLE
nixos/pleroma: fix release cookie generator

### DIFF
--- a/nixos/modules/services/networking/pleroma.nix
+++ b/nixos/modules/services/networking/pleroma.nix
@@ -118,10 +118,10 @@ in {
         # Better be safe than sorry migration-wise.
         ExecStartPre =
           let preScript = pkgs.writers.writeBashBin "pleromaStartPre" ''
-            if [ ! -f /var/lib/pleroma/.cookie ]
+            if [ ! -f /var/lib/pleroma/.cookie ] || [ ! -s /var/lib/pleroma/.cookie ]
             then
               echo "Creating cookie file"
-              dd if=/dev/urandom bs=1 count=16 | hexdump -e '16/1 "%02x"' > /var/lib/pleroma/.cookie
+              dd if=/dev/urandom bs=1 count=16 | ${pkgs.hexdump}/bin/hexdump -e '16/1 "%02x"' > /var/lib/pleroma/.cookie
             fi
             ${cfg.package}/bin/pleroma_ctl migrate
           '';


### PR DESCRIPTION
b9cfbcafdf0ca9573de1cdc06137c020e70e44a8 introduced a bug: hexdump was
not present in the path, we hence ended up generating empty release
cookies. This is a security issue.

This issue was fixed part of 71d9048f72e4ec7afffbcd562f14d53714110522
which has since been reverted by
96aaf29234d4dd39d3fcd49452039269f4730f4f.

Re-introducing the cookie generation fix and forcing the rotation of
the empty cookies.

Cc: @yu-re-ka 