### PR TITLE
python3Packages.limits: fix input tarball non-reproducibility

### DIFF
--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -26,7 +26,13 @@ buildPythonPackage rec {
     owner = "alisaifee";
     repo = pname;
     rev = version;
-    hash = "sha256-4Njai0LT72U9Ra4pgHU0ZjF9oZexbijUgLFYaZi/LgE=";
+    # Upstream uses versioneer, which relies on git attributes substitution.
+    # This leads to non-reproducible archives on github. Remove the substituted
+    # file here, and recreate it later based on our version info.
+    extraPostFetch = ''
+      rm "$out/limits/_version.py"
+    '';
+    hash = "sha256-ja+YbRHCcZ5tFnoofdR44jbkkdDroVUdKeDOt6yE0LI=";
   };
 
   propagatedBuildInputs = [
@@ -53,6 +59,9 @@ buildPythonPackage rec {
     # redis-py-cluster doesn't support redis > 4
     substituteInPlace tests/conftest.py \
       --replace "import rediscluster" ""
+
+    # Recreate _version.py, deleted at fetch time due to non-reproducibility.
+    echo 'def get_versions(): return {"version": "${version}"}' > limits/_version.py
   '';
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes

Fixes regression from last bump (22f5d327101db), it looks like the
release tarball was changed upstream.

Tested: `nix-build . -A home-assistant` now passes on staging-next.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
