### PR TITLE
batman-adv: 2022.0 -> 2022.1

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -16,19 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = cfg.sha256.${pname};
   };
 
-  patches = [
-    #  batman-adv: make mc_forwarding atomic
-    (fetchpatch {
-      url = "https://git.open-mesh.org/batman-adv.git/blobdiff_plain/c142c00f6b1a2ad5f5d74202fb1249e6a6575407..56db7c0540e733a1f063ccd6bab1b537a80857eb:/net/batman-adv/multicast.c";
-      hash = "sha256-2zXg8mZ3/iK9E/kyn+wHSrlLq87HuK72xuXojQ9KjkI=";
-    })
-    #  batman-adv: compat: Add atomic mc_fowarding support for stable kernels
-    (fetchpatch {
-      url = "https://git.open-mesh.org/batman-adv.git/blobdiff_plain/f07a0c37ab278fb6a9e95cad89429b1282f1ab59..350adcaec82fbaa358a2406343b6130ac8dad126:/net/batman-adv/multicast.c";
-      hash = "sha256-r/Xp5bmDo9GVfAF6bn2Xq+cOq5ddQe+D5s/h37uI6bM=";
-    })
-  ];
-
   nativeBuildInputs = kernel.moduleBuildDependencies;
   makeFlags = kernel.makeFlags ++ [
     "KERNELPATH=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"

--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,9 +1,9 @@
 {
-  version = "2022.0";
+  version = "2022.1";
 
   sha256 = {
-    batman-adv = "sha256-STOHBbwgdwmshNdmaI5wJXEAnIJ8CjIHiOpR+4h3FKo=";
-    alfred = "sha256-q7odrGHsz81jKeczHQVV/syTd2D7NsbPVc5sHXUc/Zg=";
-    batctl = "sha256-iTlm+aLWpQch3hJM5i2l096cIOBVdspIK8VwTMWm9z0=";
+    batman-adv = "sha256-bQQdNTCr1LJJq/Wpb8Ki4kFDG/lEO1R/2yWi2P0ymkA=";
+    alfred = "sha256-OgrCuybgyz8nMtSHNmmgoi6YJej5qOerrJhjY/J1CX8=";
+    batctl = "sha256-h+iak4lxuGJCJoG7NBBOmytLZRLR0WXelTYw3zjWGmg=";
   };
 }


### PR DESCRIPTION
###### Description of changes

<s>Release notes are not out yet</s>
https://www.open-mesh.org/news/108


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
