### PR TITLE
Fix wrapper arguments escaping

### DIFF
--- a/pkgs/applications/graphics/image_optim/default.nix
+++ b/pkgs/applications/graphics/image_optim/default.nix
@@ -51,7 +51,7 @@ bundlerApp {
 
   postBuild = ''
     wrapProgram $out/bin/image_optim \
-      --prefix PATH : ${makeBinPath optionalDepsPath}
+      --prefix PATH : ${lib.escapeShellArg (makeBinPath optionalDepsPath)}
   '';
 
   passthru.updateScript = bundlerUpdateScript "image_optim";

--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
 
   preFixup = optionalString (tiffSupport || jpgSupport) ''
     gappsWrapperArgs+=(
-      --prefix PATH : ${runtimePath}
+      --prefix PATH : ${lib.escapeShellArg runtimePath}
     )
   '';
 

--- a/pkgs/applications/networking/instant-messengers/chatty/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatty/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix PURPLE_PLUGIN_PATH : ${pidgin.makePluginPath plugins}
+      --prefix PURPLE_PLUGIN_PATH : ${lib.escapeShellArg (pidgin.makePluginPath plugins)}
       ${lib.concatMapStringsSep " " (p: p.wrapArgs or "") plugins}
     )
   '';

--- a/pkgs/applications/networking/p2p/tremc/default.nix
+++ b/pkgs/applications/networking/p2p/tremc/default.nix
@@ -44,7 +44,7 @@ python3Packages.buildPythonApplication rec {
   dontBuild = true;
   doCheck = false;
 
-  makeWrapperArgs = ["--prefix PATH : ${wrapperPath}"];
+  makeWrapperArgs = ["--prefix PATH : ${lib.escapeShellArg wrapperPath}"];
 
   installPhase = ''
     make DESTDIR=$out install

--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
       --add-flags "-cp $out/share/java/jameica.jar:$out/share/jameica-${version}/* ${
         lib.optionalString stdenv.isDarwin ''-Xdock:name="Jameica" -XstartOnFirstThread''
       } de.willuhn.jameica.Main" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
+      --prefix LD_LIBRARY_PATH : ${lib.escapeShellArg (lib.makeLibraryPath buildInputs)} \
       --chdir "$out/share/java/"
   '';
 

--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -42,7 +42,7 @@ in stdenv.mkDerivation {
     done
     # Needed for at least the remote plugin server
     for file in $out/bin/*; do
-        wrapProgram "$file" --prefix SOAPY_SDR_PLUGIN_PATH : ${extraPackagesSearchPath}
+        wrapProgram "$file" --prefix SOAPY_SDR_PLUGIN_PATH : ${lib.escapeShellArg extraPackagesSearchPath}
     done
   '';
 

--- a/pkgs/applications/science/electronics/qucs-s/default.nix
+++ b/pkgs/applications/science/electronics/qucs-s/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     # Make custom kernels avaible from qucs-s
-    gappsWrapperArgs+=(--prefix PATH ":" ${lib.makeBinPath kernels})
+    gappsWrapperArgs+=(--prefix PATH ":" ${lib.escapeShellArg (lib.makeBinPath kernels)})
   '';
 
   QTDIR=qt4;

--- a/pkgs/applications/video/vdr/wrapper.nix
+++ b/pkgs/applications/video/vdr/wrapper.nix
@@ -17,7 +17,7 @@ in symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/vdr \
       --add-flags "-L $out/lib/vdr --localedir=$out/share/locale" \
-      --prefix XINE_PLUGIN_PATH ":" ${makeXinePluginPath requiredXinePlugins}
+      --prefix XINE_PLUGIN_PATH ":" ${lib.escapeShellArg (makeXinePluginPath requiredXinePlugins)}
   '';
 
   meta = with vdr.meta; {

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -76,5 +76,5 @@ in runCommand podman.name {
   ln -s ${podman-unwrapped}/share $out/share
   makeWrapper ${podman-unwrapped}/bin/podman $out/bin/podman \
     --set CONTAINERS_HELPER_BINARY_DIR ${helpersBin}/bin \
-    --prefix PATH : ${binPath}
+    --prefix PATH : ${lib.escapeShellArg binPath}
 ''

--- a/pkgs/applications/window-managers/i3/blocks-gaps.nix
+++ b/pkgs/applications/window-managers/i3/blocks-gaps.nix
@@ -28,17 +28,21 @@ stdenv.mkDerivation rec {
   buildInputs = optional (contains_any scripts perlscripts) perl;
   nativeBuildInputs = [ makeWrapper ];
 
-  postFixup = ''
+  postFixup = optionalString (elem "bandwidth" scripts) ''
     wrapProgram $out/libexec/i3blocks/bandwidth \
-      --prefix PATH : ${makeBinPath (optional (elem "bandwidth" scripts) iproute2)}
+      --prefix PATH : ${makeBinPath [ iproute2 ]}
+  '' + optionalString (elem "battery" scripts) ''
     wrapProgram $out/libexec/i3blocks/battery \
-      --prefix PATH : ${makeBinPath (optional (elem "battery" scripts) acpi)}
+      --prefix PATH : ${makeBinPath [ acpi ]}
+  '' + optionalString (elem "cpu_usage" scripts) ''
     wrapProgram $out/libexec/i3blocks/cpu_usage \
-      --prefix PATH : ${makeBinPath (optional (elem "cpu_usage" scripts) sysstat)}
+      --prefix PATH : ${makeBinPath [ sysstat ]}
+  '' + optionalString (elem "iface" scripts) ''
     wrapProgram $out/libexec/i3blocks/iface \
-      --prefix PATH : ${makeBinPath (optional (elem "iface" scripts) iproute2)}
+      --prefix PATH : ${makeBinPath [ iproute2 ]}
+  '' + optionalString (elem "volume" scripts) ''
     wrapProgram $out/libexec/i3blocks/volume \
-      --prefix PATH : ${makeBinPath (optional (elem "volume" scripts) alsa-utils)}
+      --prefix PATH : ${makeBinPath [ alsa-utils ]}
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/hunspell/wrapper.nix
+++ b/pkgs/development/libraries/hunspell/wrapper.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   name = (appendToName "with-dicts" hunspell).name;
   nativeBuildInputs = [ makeWrapper ];
   buildCommand = ''
-    makeWrapper ${hunspell.bin}/bin/hunspell $out/bin/hunspell --prefix DICPATH : ${searchPath}
+    makeWrapper ${hunspell.bin}/bin/hunspell $out/bin/hunspell --prefix DICPATH : ${lib.escapeShellArg searchPath}
   '';
   meta = removeAttrs hunspell.meta ["outputsToInstall"];
 }

--- a/pkgs/development/libraries/nuspell/wrapper.nix
+++ b/pkgs/development/libraries/nuspell/wrapper.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   name = (appendToName "with-dicts" nuspell).name;
   nativeBuildInputs = [ makeWrapper ];
   buildCommand = ''
-    makeWrapper ${nuspell}/bin/nuspell $out/bin/nuspell --prefix DICPATH : ${searchPath}
+    makeWrapper ${nuspell}/bin/nuspell $out/bin/nuspell --prefix DICPATH : ${lib.escapeShellArg searchPath}
   '';
   meta = removeAttrs nuspell.meta ["outputsToInstall"];
 }

--- a/pkgs/development/tools/continuous-integration/hci/default.nix
+++ b/pkgs/development/tools/continuous-integration/hci/default.nix
@@ -12,7 +12,7 @@ let
           ${o.postInstall or ""}
           mkdir -p $out/libexec
           mv $out/bin/hci $out/libexec
-          makeWrapper $out/libexec/hci $out/bin/hci --prefix PATH : ${makeBinPath bundledBins}
+          makeWrapper $out/libexec/hci $out/bin/hci --prefix PATH : ${lib.escapeShellArg (makeBinPath bundledBins)}
         '';
       })
       (addBuildDepends [ makeWrapper ] (justStaticExecutables haskellPackages.hercules-ci-cli));

--- a/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
@@ -12,7 +12,7 @@ let
           ${o.postInstall or ""}
           mkdir -p $out/libexec
           mv $out/bin/hercules-ci-agent $out/libexec
-          makeWrapper $out/libexec/hercules-ci-agent $out/bin/hercules-ci-agent --prefix PATH : ${makeBinPath bundledBins}
+          makeWrapper $out/libexec/hercules-ci-agent $out/bin/hercules-ci-agent --prefix PATH : ${lib.escapeShellArg (makeBinPath bundledBins)}
         '';
       })
       (addBuildDepends [ makeWrapper ] (justStaticExecutables haskellPackages.hercules-ci-agent));

--- a/pkgs/development/tools/misc/sqitch/default.nix
+++ b/pkgs/development/tools/misc/sqitch/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   '';
   dontStrip = true;
   postFixup = ''
-    wrapProgram $out/bin/sqitch --prefix PERL5LIB : ${perlPackages.makeFullPerlPath modules}
+    wrapProgram $out/bin/sqitch --prefix PERL5LIB : ${lib.escapeShellArg (perlPackages.makeFullPerlPath modules)}
   '';
 
   meta = {

--- a/pkgs/servers/misc/navidrome/default.nix
+++ b/pkgs/servers/misc/navidrome/default.nix
@@ -32,9 +32,9 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  postFixup = ''
+  postFixup = optionalString ffmpegSupport ''
     wrapProgram $out/bin/navidrome \
-      --prefix PATH : ${makeBinPath (optional ffmpegSupport ffmpeg)}
+      --prefix PATH : ${makeBinPath [ ffmpeg ]}
   '';
 
   passthru.tests.navidrome = nixosTests.navidrome;

--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -47,7 +47,7 @@ buildGoModule rec {
       --set PUFFER_PANEL_EMAIL_TEMPLATES $out/share/pufferpanel/templates/emails.json \
       --set GIN_MODE release \
       --set PUFFER_PANEL_WEB_FILES $out/share/pufferpanel/www \
-      --prefix PATH : ${lib.makeBinPath pathDeps}
+      --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath pathDeps)}
   '';
 
   meta = with lib; {

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
@@ -20,7 +20,7 @@ symlinkJoin {
   postBuild = ''
     for i in bin/emoji-picker libexec/ibus-{setup,engine}-typing-booster; do
       wrapProgram "$out/$i" \
-        --prefix NIX_HUNSPELL_DIRS : ${hunspellDirs}
+        --prefix NIX_HUNSPELL_DIRS : ${lib.escapeShellArg hunspellDirs}
     done
 
     sed -i -e "s,${typing-booster},$out," $out/share/ibus/component/typing-booster.xml


### PR DESCRIPTION
Some packages invoke `makeWrapper` like this:

```
wrapProgram foo --prefix PATH : ${bins}
```

The lack of escaping is a problem in cases where `bins` might be an empty string. The problem is becoming more apparent with https://github.com/NixOS/nixpkgs/pull/164163 merged, because `makeWrapper` used to silently do nothing if the third argument to `--prefix` is missing, while `makeBinaryWrapper` fails.

This PR fixes all instances of this pattern I could find where `bins` has a chance of being empty (hence leaving alone statically okay cases like `--prefix PATH : ${lib.makeBinPath [ hello ]}`).

ZHF https://github.com/NixOS/nixpkgs/issues/172160