### PR TITLE
opentyrian: 2.1.20130907 -> 2.1.20220318

### DIFF
--- a/pkgs/games/opentyrian/default.nix
+++ b/pkgs/games/opentyrian/default.nix
@@ -1,35 +1,43 @@
-{ lib, stdenv, fetchurl, fetchzip, SDL, SDL_net }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchzip
+, SDL2
+, SDL2_net
+, pkg-config
+}:
 
 stdenv.mkDerivation rec {
   pname = "opentyrian";
-  version = "2.1.20130907";
+  version = "2.1.20220318";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/opentyrian/opentyrian/get/${version}.tar.gz";
-    sha256 = "1jnrkq616pc4dhlbd4n30d65vmn25q84w6jfv9383l9q20cqf2ph";
+  src = fetchFromGitHub {
+    owner = "opentyrian";
+    repo = "opentyrian";
+    rev = "v${version}";
+    sha256 = "01z1zxpps4ils0bnwazl9lmqdbfhfd8fkacahnh6kqyczavg40xg";
   };
 
   data = fetchzip {
-    url = "http://sites.google.com/a/camanis.net/opentyrian/tyrian/tyrian21.zip";
+    url = "https://camanis.net/tyrian/tyrian21.zip";
     sha256 = "1biz6hf6s7qrwn8ky0g6p8w7yg715w7yklpn6258bkks1s15hpdb";
   };
 
-  buildInputs = [SDL SDL_net];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ SDL2 SDL2_net ];
 
-  patchPhase = "
-    substituteInPlace src/file.c --replace /usr/share $out/share
-  ";
-  buildPhase = "make release";
-  installPhase = "
-    mkdir -p $out/bin
-    cp ./opentyrian $out/bin
-    mkdir -p $out/share/opentyrian/data
-    cp -r $data/* $out/share/opentyrian/data
-  ";
+  enableParallelBuilding = true;
+
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  postInstall = ''
+    mkdir -p $out/share/games/tyrian
+    cp -r $data/* $out/share/games/tyrian/
+  '';
 
   meta = {
     description = ''Open source port of the game "Tyrian"'';
-    homepage = "https://bitbucket.org/opentyrian/opentyrian";
+    homepage = "https://github.com/opentyrian/opentyrian";
     # This does not account of Tyrian data.
     # license = lib.licenses.gpl2;
   };


### PR DESCRIPTION
Updated homepage url and download url to github.
Updated assets URL.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
