### PR TITLE
wmfs: fix build on -fno-common toolchain

### DIFF
--- a/pkgs/applications/window-managers/wmfs/default.nix
+++ b/pkgs/applications/window-managers/wmfs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub,
+{ lib, stdenv, fetchFromGitHub, fetchpatch,
   libX11, libXinerama, libXrandr, libXpm, libXft, imlib2 }:
 stdenv.mkDerivation {
   pname = "wmfs";
@@ -11,6 +11,17 @@ stdenv.mkDerivation {
     sha256 = "1m7dsmmlhq2qipim659cp9aqlriz1cwrrgspl8baa5pncln0gd5c";
     rev = "b7b8ff812d28c79cb22a73db2739989996fdc6c2";
   };
+
+  patches = [
+    # Pull patch pending upstream inclusion to fix build on
+    # -fno-common toolchain like upstream gcc-10:
+    #  https://github.com/xorg62/wmfs/pull/104
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/xorg62/wmfs/commit/e4ec12618f4689d791892ebb49df9610a25d24d3.patch";
+      sha256 = "0qvwry9sikvr85anzha9x4gcx0r2ckwdxqw2in2l6bl9z9d9c0w2";
+    })
+  ];
 
   buildInputs = [
     imlib2


### PR DESCRIPTION
Without the change build fails on -fno-common tollchains as:

    $ nix build --impure --expr 'with import ~/nm {}; wmfs.override { stdenv = clang13Stdenv; }'
    ...
    ld: src/log.o:(.bss+0x0): multiple definition of `W'; src/barwin.o:(.bss+0x0): first defined here
    ld: src/wmfs.o:(.bss+0x0): multiple definition of `W'; src/barwin.o:(.bss+0x0): first defined here
    ld: src/wmfs.o:(.bss+0x10): multiple definition of `event_handle'; src/client.o:(.bss+0x10): first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
