### PR TITLE
pwndbg: add glibc debug symbols to debug dirs

### DIFF
--- a/pkgs/development/tools/misc/pwndbg/default.nix
+++ b/pkgs/development/tools/misc/pwndbg/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , makeWrapper
 , gdb
+, glibc # for debug symbols that pwndbg uses for heap commands
 }:
 
 let
@@ -40,7 +41,8 @@ in stdenv.mkDerivation rec {
     chmod +x $out/share/pwndbg/gdbinit.py
     makeWrapper ${gdb}/bin/gdb $out/bin/pwndbg \
       --add-flags "-q -x $out/share/pwndbg/gdbinit.py" \
-      --set NIX_PYTHONPATH ${pythonPath}
+      --set NIX_PYTHONPATH ${pythonPath} \
+      --prefix NIX_DEBUG_INFO_DIRS : ${glibc.debug}/lib/debug
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Currently, pwndbg doesn't have any sensible debug info paths set up:
```
pwndbg> show debug-file-directory
The directory where separate debug symbols are searched for is "/nix/store/5xm7rggy43c6gm7rj6nara2l6lbkyc5j-gdb-11.2/lib/debug:/usr/lib/debug".
```
In fact, both of those paths don't exist.

If a program is built on NixOS and someone wants to debug it with pwndbg, the heap commands like `heap` or `vis_heap_chunks` won't work:
```
pwndbg> heap
/home/git/.cache/pwndbg/typeinfo/x86-64_struct-malloc_state.cc:3:21: error: aggregate ‘malloc_state foo’ has incomplete type and cannot be defined
    3 | struct malloc_state foo;
      |                     ^~~
Exception occurred: heap: No struct type named malloc_state. (<class 'gdb.error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
```

This PR fixes this by prepending the current glibc debug symbols to the `NIX_DEBUG_INFO_DIRS`. This doesn't work if the binary uses a different glibc buid (this has to be still configured manually) but at least the basic functionality is fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
