### PR TITLE
yersinia: init at 0.8.2

### DIFF
--- a/pkgs/tools/security/yersinia/default.nix
+++ b/pkgs/tools/security/yersinia/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkg-config, fetchpatch
+, ncurses, libpcap, libnet
+# alpha version of GTK interface
+, withGtk ? false, gtk2
+# enable remote admin interface
+, enableAdmin ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yersinia";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "tomac";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06yfpf9iyi525rly1ychsihzvw3sas8kp0nxxr99xkwiqp5dc78b";
+  };
+
+  patches = [
+    # ncurses-6.3 support, included in next release
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/tomac/yersinia/commit/d91bbf6f475e7ea39f131b77ce91b2de9646d5ca.patch";
+      sha256 = "fl1pZKWA+nLtBm9+3FBFqaeuVZjszQCNkNl6Cf++BAI=";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ libpcap libnet ncurses ]
+    ++ lib.optional withGtk gtk2;
+
+  autoreconfPhase = "./autogen.sh";
+
+  configureFlags = [
+    "--with-pcap-includes=${libpcap}/include"
+    "--with-libnet-includes=${libnet}/include"
+  ]
+  ++ lib.optional (!enableAdmin) "--disable-admin"
+  ++ lib.optional (!withGtk) "--disable-gtk";
+
+  makeFlags = [ "LDFLAGS=-lncurses" ];
+
+  meta = with lib; {
+    description = "A framework for layer 2 attacks";
+    homepage = "https://github.com/tomac/yersinia";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ vdot0x23 ];
+    # INSTALL and FAQ in this package seem a little outdated
+    # so not sure, but it could work on openbsd, illumos, and freebsd
+    # if you have a machine to test with, feel free to add these
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33369,6 +33369,8 @@ with pkgs;
 
   yarGen = callPackage ../tools/security/yarGen { };
 
+  yersinia = callPackage ../tools/security/yersinia { };
+
   yaxg = callPackage ../tools/graphics/yaxg {};
 
   yuzu-mainline = import ../misc/emulators/yuzu {


### PR DESCRIPTION
###### Description of changes
Add https://github.com/tomac/yersinia helping us become hackers #81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
