### PR TITLE
jemalloc: 5.2.1 -> 5.3.0

### DIFF
--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
 # then stops downstream builds (mariadb in particular) from detecting it. This
 # option should remove the prefix and give us a working jemalloc.
@@ -13,20 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "jemalloc";
-  version = "5.2.1";
+  version = "5.3.0";
 
   src = fetchurl {
     url = "https://github.com/jemalloc/jemalloc/releases/download/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "1xl7z0vwbn5iycg7amka9jd6hxd8nmfk7nahi4p9w2bnw9f0wcrl";
+    sha256 = "sha256-LbgtHnEZ3z5xt2QCGbbf6EeJvAU3mDw7esT3GJrs/qo=";
   };
-
-  patches = [
-    # workaround https://github.com/jemalloc/jemalloc/issues/2091
-    (fetchpatch {
-      url = "https://github.com/jemalloc/jemalloc/commit/3b4a03b92b2e415415a08f0150fdb9eeb659cd52.diff";
-      sha256 = "sha256-6AYtADREhfj93ZLk9xnXtjc6vHDU0EKLLOvLd6YdJeI=";
-    })
-  ];
 
   # see the comment on stripPrefix
   configureFlags = []
@@ -40,6 +31,8 @@ stdenv.mkDerivation rec {
       "je_cv_thp=no"
     ]
   ;
+
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-Wno-error=array-bounds";
 
   doCheck = true;
 

--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -12,7 +12,6 @@
 , curl
 , flex
 , gnutls
-, jemalloc
 , libconfig
 , libdaemon
 , libev
@@ -99,7 +98,6 @@ stdenv.mkDerivation rec {
     ${lib.concatMapStringsSep "\n"
       (x: ''replace_dep "${x.f}" "${x.p.src}" "${x.p.pname or (builtins.parseDrvName x.p.name).name}" "${x.p.name}"'') [
         { f = "curl"; p = curl; }
-        { f = "jemalloc"; p = jemalloc; }
         { f = "libconfig"; p = libconfig; }
         { f = "libdaemon"; p = libdaemon; }
         { f = "libev"; p = libev; }

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -112,7 +112,7 @@
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
  lz4: lz4/lz4/liblz4.a
  
-@@ -148,16 +112,12 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib.a
+@@ -148,16 +112,14 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib.a
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a: 
@@ -124,8 +124,8 @@
  libdaemon: libdaemon/libdaemon/libdaemon/.libs/libdaemon.a
  
  jemalloc/jemalloc/lib/libjemalloc.a:
--	cd jemalloc && rm -rf jemalloc-5.2.0
--	cd jemalloc && tar -jxf jemalloc-5.2.0.tar.bz2
+ 	cd jemalloc && rm -rf jemalloc-5.2.0
+ 	cd jemalloc && tar -jxf jemalloc-5.2.0.tar.bz2
  	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue823.520.patch
  	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue2358.patch
  	cd jemalloc/jemalloc && ./configure ${MYJEOPT}


### PR DESCRIPTION
https://github.com/jemalloc/jemalloc/releases/tag/5.3.0

The patch is part of the release, but the issue is still open, hope a darwin user can confirm it still builds for them?

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
