### PR TITLE
lib: add forSystems

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -62,7 +62,7 @@ let
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
 
-    inherit (self.flakes) callLocklessFlake;
+    inherit (self.flakes) callLocklessFlake forSystems;
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isString length

--- a/lib/flakes.nix
+++ b/lib/flakes.nix
@@ -19,4 +19,24 @@ rec {
     in
     self;
 
+  /* Generates an attrset for the given list of system strings and instantiates
+    nixpkgs from a given flake. The system architecture string for each set is
+    available via the 'system' argument. The instantiated nixpkgs set is available
+    via the 'pkgs' argument.
+
+    Type: forSystems :: [String] -> Flake -> ( String -> AttrSet -> t ) -> AttrSet
+
+    Example:
+      nixpkgs.lib.forSystems
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
+        (builtins.getFlake "github:nixos/nixpkgs")
+        (system: pkgs: { x = pkgs.hello; })
+
+      The example will return:
+        { aarch64-darwin = { ... }; aarcH64-linux = { ... }; x86_64-darwin = { ... }; x86_64-linux = { ... }; }
+  */
+  legacyPackagesForSystems = systems: flake: f:
+    lib.genAttrs systems
+    (system: f system flake.legacyPackages.${system});
+
 }


### PR DESCRIPTION
###### Description of changes

This adds a function `lib.forSystems` which is similar to `forAllSystems` from the [c-hello flake template](https://github.com/NixOS/templates/blob/6296caa969420047c3de8b336f481106cf7af6f8/c-hello/flake.nix#L20)

Co-authored-by: Justin Restivo <justin@restivo.me>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
