### PR TITLE
catclock: 2015-10-04 -> 2021-11-15

### DIFF
--- a/pkgs/applications/misc/catclock/default.nix
+++ b/pkgs/applications/misc/catclock/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, xlibsWrapper, motif }:
+{ stdenv, lib, fetchFromGitHub, xlibsWrapper, motif
+, withAudioTracking ? false, libpulseaudio, aubio }:
 
 stdenv.mkDerivation {
   pname = "catclock";
-  version = "unstable-2015-10-04";
+  version = "unstable-2021-11-15";
 
   src = fetchFromGitHub {
     owner = "BarkyTheDog";
     repo = "catclock";
-    rev = "d20b8825b38477a144e8a2a4bbd4779adb3620ac";
-    sha256 = "0fiv9rj8p8mifv24cxljdrrmh357q70zmzdci9bpbxnhs1gdpr63";
+    rev = "b2f277974b5a80667647303cabf8a89d6d6a4290";
+    sha256 = "0ls02j9waqg155rj6whisqm7ppsdabgkrln92n4rmkgnwv25hdbi";
   };
 
   preInstall = ''
@@ -17,14 +18,15 @@ stdenv.mkDerivation {
     cp xclock.man $out/share/man/man1/xclock.1
   '';
 
-  makeFlags = [
-    "DESTINATION=$(out)/bin/"
-  ];
+  makeFlags = [ "DESTINATION=$(out)/bin/" ]
+    ++ lib.optional withAudioTracking "WITH_TEMPO_TRACKER=1";
 
-  buildInputs = [ xlibsWrapper motif ];
+  buildInputs = [ xlibsWrapper motif ]
+    ++ lib.optionals withAudioTracking [ libpulseaudio aubio ];
 
   meta = with lib; {
     homepage = "http://codefromabove.com/2014/05/catclock/";
+    description = "Analog / Digital / Cat clock for X";
     license = with licenses; mit;
     maintainers = with maintainers; [ ramkromberg ];
     mainProgram = "xclock";


### PR DESCRIPTION
###### Description of changes

updated and executed on my x86_64-linux. 
added an optional override for the tempo tracking feature though it's off by default.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).