### PR TITLE
latencytop: fix hardcoded path to /bin/mount

### DIFF
--- a/pkgs/os-specific/linux/latencytop/default.nix
+++ b/pkgs/os-specific/linux/latencytop/default.nix
@@ -1,10 +1,16 @@
-{ lib, stdenv, fetchurl, ncurses, glib, pkg-config, gtk2 }:
+{ lib, stdenv, fetchurl, ncurses, glib, pkg-config, gtk2, util-linux }:
 
 stdenv.mkDerivation rec {
   pname = "latencytop";
   version = "0.5";
 
-  patchPhase = "sed -i s,/usr,$out, Makefile";
+  postPatch = ''
+    sed -i s,/usr,$out, Makefile
+
+    # Fix #171609
+    substituteInPlace fsync.c --replace /bin/mount ${util-linux}/bin/mount
+  '';
+
   preInstall = "mkdir -p $out/sbin";
 
   src = fetchurl {


### PR DESCRIPTION
###### Description of changes

Fixes #171609.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).