### PR TITLE
Seafile WebDAV extension (dependencies, package, and integration to seafile service)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4392,6 +4392,12 @@
     githubId = 74379;
     name = "Florian Pester";
   };
+  flyx = {
+    email = "contact@flyx.org";
+    github = "flyx";
+    githubId = 791710;
+    name = "Felix Krause";
+  };
   fmthoma = {
     email = "f.m.thoma@googlemail.com";
     github = "fmthoma";

--- a/pkgs/applications/networking/seafdav/default.nix
+++ b/pkgs/applications/networking/seafdav/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, python3
+, makeWrapper
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "seafdav";
+  version = "9.0.7";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seafdav";
+    rev = "v${version}-server";
+    sha256 = "0jdspxz9cakpx0vipqsqf02llz3w02fjid3kff0kclz9apmyvx55";
+  };
+
+  dontBuild = true; # $out will contain Python sources, no build necessary
+
+  doCheck = false; # disabled because it requires a ccnet environment
+
+  propagatedBuildInputs = with python3.pkgs; [
+    defusedxml
+    future
+    jinja2
+    json5
+    pysearpc
+    python-pam
+    pyyaml
+    six
+    lxml
+    seaserv
+    seafobj
+    sqlalchemy
+    gunicorn
+  ];
+
+  installPhase = ''
+    cp -dr --no-preserve='ownership' . $out/
+    cp ${./seafdav.py} $out/seafdav.py
+  '';
+
+  passthru = {
+    python = python3;
+    pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
+  };
+
+  meta = with lib; {
+    description = "Seafile WebDAV Server";
+    homepage = "https://github.com/haiwen/seafdav";
+    license = licenses.mit;
+    maintainers = with maintainers; [ flyx ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/seafdav/seafdav.py
+++ b/pkgs/applications/networking/seafdav/seafdav.py
@@ -1,0 +1,24 @@
+# This is a WSGI application that can be run via GUnicorn.
+#
+# It is unclear why Seafile does not provide this script with seafdav,
+# when a similar script does exist for seahub. The existing server_cli
+# script is not as flexible since it is a Python script that launches
+# GUnicorn (or other WSGI servers) instead of being a consumable
+# WSGI application. For example, server_cli isn't able to bind to a
+# unix socket.
+
+from wsgidav.default_conf import DEFAULT_CONFIG
+from wsgidav.wsgidav_app import WsgiDAVApp
+from wsgidav.server.server_cli import _loadSeafileSettings
+
+import copy, logging
+
+config = copy.deepcopy(DEFAULT_CONFIG)
+
+logging.info("share_name = %s", config.get("share_name"))
+
+# gets us data from seafdav.conf,
+# and sets up the general Seafile configuration.
+_loadSeafileSettings(config)
+
+application = WsgiDAVApp(config)

--- a/pkgs/development/python-modules/seafobj/default.nix
+++ b/pkgs/development/python-modules/seafobj/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, boto3
+, coverage
+, future
+, mock
+, nose
+, python
+}:
+buildPythonPackage rec {
+  pname = "seafobj";
+  version = "9.0.7";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seafobj";
+    rev = "v${version}-server";
+    sha256 = "04vn75x4yx3lcvll69q4q0g4gbqlc4w7047x7hxan1zramjmdxfg";
+  };
+
+  dontBuild = true; # $out will contain Python sources, no build necessary
+
+  checkInputs = [ coverage mock nose boto3 ];
+
+  checkPhase = ''
+    runHook preCheck
+    PYTHONPATH=$PYTHONPATH:seafobj ${python.interpreter} run_test.py --storage fs
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    dest="$out/${python.sitePackages}"
+    mkdir -p $dest
+    cp -dr --no-preserve='ownership' seafobj $dest/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/haiwen/seafobj";
+    description = "Python library for accessing seafile data model";
+    maintainers = with maintainers; [ flyx ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30300,6 +30300,8 @@ with pkgs;
   scribus_1_5 = libsForQt5.callPackage ../applications/office/scribus/default.nix { };
   scribus = scribus_1_5;
 
+  seafdav = callPackage ../applications/networking/seafdav { };
+
   seafile-client = libsForQt5.callPackage ../applications/networking/seafile-client { };
 
   seahub = callPackage ../applications/networking/seahub { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9679,6 +9679,8 @@ in {
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };
 
+  seafobj = callPackage ../development/python-modules/seafobj { };
+
   seaserv = toPythonModule (pkgs.seafile-server.override {
     python3 = self.python;
   });


### PR DESCRIPTION
###### Description of changes

This adds the Python library `seafobj` and the Python WSGI application `seafdav`, both of which belong with the [Seafile](https://manual.seafile.com/extension/webdav/) server. Version is `8.0.8` which is not the most recent one, but conforms to the current versions of existing `seafile-server` and `seahub` packages.

`seafdav` provides a WebDAV interface to a running `seafile-server`. `seafobj` is a dependency of `seafdav`.

The `nixos/seafile` service has been extended to provide options for automatically starting the WebDAV extension alongside the server. I opted to not allow freeform settings since the existing settings are already confusing – some are consumed by `seafdav` itself, some by the script `server_cli` (which my setup doesn't use), and some only when using Seafile's own management script `seafile.sh` (which isn't viable for NixOS). I wanted to clearly communicate which values are actually relevant.

I reviewed the relevant code (mainly [server_cli.py](https://github.com/haiwen/seafdav/blob/master/wsgidav/server/server_cli.py)) to learn how the settings are used, and then added and used a simpler WSGI application setup script for the service setup. This enables a service setup very similar to the one of `seahub`, which also is a WSGI application. This should be easier to maintain than running the `server_cli.py` script provided from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ping @schmittlauch @greizgh (maintainers of the other Seafile packages)