### PR TITLE
hstr: 2.3 -> 2.5

### DIFF
--- a/pkgs/applications/misc/hstr/default.nix
+++ b/pkgs/applications/misc/hstr/default.nix
@@ -1,26 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, readline, ncurses
+{ lib, stdenv, fetchFromGitHub, readline, ncurses
 , autoreconfHook, pkg-config, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "hstr";
-  version = "2.3";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner  = "dvorka";
     repo   = "hstr";
     rev    = version;
-    sha256 = "1chmfdi1dwg3sarzd01nqa82g65q7wdr6hrnj96l75vikwsg986y";
+    sha256 = "sha256-qIMnU+gRR3HPAOrrrduN68R5E8ZJKROfZ0sEHL0E4XU=";
   };
-
-  patches = [
-    # pull pending upstream inclusion fix for ncurses-6.3:
-    #  https://github.com/dvorka/hstr/pull/435
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://github.com/dvorka/hstr/commit/7fbd852c464ae3cfcd2f4fed9c62a21fb84c5439.patch";
-      sha256 = "15f0ja4bsh4jnchcg0ray8ijpdraag7k07ss87a6ymfs1rg6i0jr";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ readline ncurses gettext ];


### PR DESCRIPTION


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/dvorka/hstr/releases/tag/2.4
https://github.com/dvorka/hstr/releases/tag/2.5
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
