### PR TITLE
python310Packages.automat: adopt, run tests

### DIFF
--- a/pkgs/development/python-modules/automat/default.nix
+++ b/pkgs/development/python-modules/automat/default.nix
@@ -1,26 +1,50 @@
-{ lib, buildPythonPackage, fetchPypi,
-  m2r, setuptools-scm, six, attrs }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, attrs
+, m2r
+, pytest-benchmark
+, pytestCheckHook
+, setuptools-scm
+, six
+}:
 
-buildPythonPackage rec {
+let automat = buildPythonPackage rec {
   version = "20.2.0";
-  pname = "Automat";
+  pname = "automat";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "Automat";
+    inherit version;
     sha256 = "7979803c74610e11ef0c0d68a2942b152df52da55336e0c9d58daf1831cbdf33";
   };
 
-  buildInputs = [ m2r setuptools-scm ];
-  propagatedBuildInputs = [ six attrs ];
+  nativeBuildInputs = [
+    m2r
+    setuptools-scm
+  ];
 
-  # Some tests require twisetd, but twisted requires Automat to build.
-  # this creates a circular dependency.
+  propagatedBuildInputs = [
+    six
+    attrs
+  ];
+
+  checkInputs = [
+    pytest-benchmark
+    pytestCheckHook
+  ];
+
+  # escape infinite recursion with twisted
   doCheck = false;
+
+  passthru.tests = {
+    check = automat.overridePythonAttrs (_: { doCheck = true; });
+  };
 
   meta = with lib; {
     homepage = "https://github.com/glyph/Automat";
     description = "Self-service finite-state machines for the programmer on the go";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
-}
+}; in automat


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
