### PR TITLE
python310Packages.twisted: adopt, run tests

### DIFF
--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -27,6 +27,19 @@
 , setuptools
 , typing-extensions
 , zope_interface
+
+# for passthru.tests
+, cassandra-driver
+, klein
+, magic-wormhole
+, scrapy
+, treq
+, txaio
+, txamqp
+, txrequests
+, txtorcon
+, thrift
+, nixosTests
 }:
 
 buildPythonPackage rec {
@@ -123,6 +136,21 @@ buildPythonPackage rec {
     # race conditions when running in paralell
     ${python.interpreter} -m twisted.trial twisted
   '';
+
+  passthru.tests = {
+    inherit
+      cassandra-driver
+      klein
+      magic-wormhole
+      scrapy
+      treq
+      txaio
+      txamqp
+      txrequests
+      txtorcon
+      thrift;
+    inherit (nixosTests) buildbot matrix-synapse;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/twisted/twisted";

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -1,32 +1,36 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
 , python
-, zope_interface
-, incremental
-, automat
-, constantly
-, hyperlink
-, pyhamcrest
+, appdirs
 , attrs
+, automat
+, bcrypt
+, constantly
+, contextvars
+, cryptography
+, git
+, glibcLocales
+, h2
+, hyperlink
+, idna
+, incremental
+, priority
+, pyasn1
+, pyhamcrest
+, pynacl
 , pyopenssl
+, pyserial
 , service-identity
 , setuptools
-, idna
 , typing-extensions
-, pyasn1
-, cryptography
-, appdirs
-, bcrypt
-, pynacl
-, pyserial
-, h2
-, priority
-, contextvars
+, zope_interface
 }:
+
 buildPythonPackage rec {
-  pname = "Twisted";
+  pname = "twisted";
   version = "22.4.0";
 
   disabled = pythonOlder "3.6";
@@ -34,12 +38,22 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "Twisted";
+    inherit version;
     extension = "tar.gz";
     sha256 = "sha256-oEeZD1ffrh4L0rffJSbU8W3NyEN3TcEIt4xS8qXxNoA=";
   };
 
-  propagatedBuildInputs = [ zope_interface incremental automat constantly hyperlink pyhamcrest attrs setuptools typing-extensions ];
+  propagatedBuildInputs = [
+    attrs
+    automat
+    constantly
+    hyperlink
+    incremental
+    setuptools
+    typing-extensions
+    zope_interface
+  ];
 
   passthru.extras-require = rec {
     tls = [ pyopenssl service-identity idna ];
@@ -50,26 +64,65 @@ buildPythonPackage rec {
     contextvars = lib.optionals (pythonOlder "3.7") [ contextvars ];
   };
 
-  # Patch t.p._inotify to point to libc. Without this,
-  # twisted.python.runtime.platform.supportsINotify() == False
-  postPatch = lib.optionalString stdenv.isLinux ''
+  postPatch = ''
+    echo 'ListingTests.test_localeIndependent.skip = "Timezone issue"'>> src/twisted/conch/test/test_cftp.py
+    echo 'ListingTests.test_newFile.skip = "Timezone issue"'>> src/twisted/conch/test/test_cftp.py
+    echo 'ListingTests.test_newSingleDigitDayOfMonth.skip = "Timezone issue"'>> src/twisted/conch/test/test_cftp.py
+    echo 'ListingTests.test_oldFile.skip = "Timezone issue"'>> src/twisted/conch/test/test_cftp.py
+    echo 'ListingTests.test_oldSingleDigitDayOfMonth.skip = "Timezone issue"'>> src/twisted/conch/test/test_cftp.py
+
+    echo 'PTYProcessTestsBuilder_AsyncioSelectorReactorTests.test_openFileDescriptors.skip = "invalid syntax"'>> src/twisted/internet/test/test_process.py
+    echo 'PTYProcessTestsBuilder_SelectReactorTests.test_openFileDescriptors.skip = "invalid syntax"'>> src/twisted/internet/test/test_process.py
+    echo 'PTYProcessTestsBuilder_PollReactorTests.test_openFileDescriptors.skip = "invalid syntax"'>> src/twisted/internet/test/test_process.py
+
+    echo 'UNIXTestsBuilder_AsyncioSelectorReactorTests.test_sendFileDescriptorTriggersPauseProducing.skip = "sendFileDescriptor producer was not paused"'>> src/twisted/internet/test/test_unix.py
+    echo 'UNIXTestsBuilder_PollReactorTests.test_sendFileDescriptorTriggersPauseProducing.skip = "sendFileDescriptor producer was not paused"'>> src/twisted/internet/test/test_unix.py
+    echo 'UNIXTestsBuilder_SelectReactorTests.test_sendFileDescriptorTriggersPauseProducing.skip = "sendFileDescriptor producer was not paused"'>> src/twisted/internet/test/test_unix.py
+
+    echo 'FileObserverTests.test_getTimezoneOffsetEastOfUTC.skip = "mktime argument out of range"'>> src/twisted/test/test_log.py
+    echo 'FileObserverTests.test_getTimezoneOffsetWestOfUTC.skip = "mktime argument out of range"'>> src/twisted/test/test_log.py
+    echo 'FileObserverTests.test_getTimezoneOffsetWithoutDaylightSavingTime.skip = "tuple differs, values not"'>> src/twisted/test/test_log.py
+
+    echo 'MulticastTests.test_joinLeave.skip = "No such device"'>> src/twisted/test/test_udp.py
+    echo 'MulticastTests.test_loopback.skip = "No such device"'>> src/twisted/test/test_udp.py
+    echo 'MulticastTests.test_multicast.skip = "Reactor was unclean"'>> src/twisted/test/test_udp.py
+    echo 'MulticastTests.test_multiListen.skip = "No such device"'>> src/twisted/test/test_udp.py
+
+    echo 'DomishExpatStreamTests.test_namespaceWithWhitespace.skip = "syntax error: line 1, column 0"'>> src/twisted/words/test/test_domish.py
+
+    # not packaged
+    substituteInPlace src/twisted/test/test_failure.py \
+      --replace "from cython_test_exception_raiser import raiser  # type: ignore[import]" "raiser = None"
+  '' + lib.optionalString stdenv.isLinux ''
+    echo 'PTYProcessTestsBuilder_EPollReactorTests.test_openFileDescriptors.skip = "invalid syntax"'>> src/twisted/internet/test/test_process.py
+    echo 'UNIXTestsBuilder_EPollReactorTests.test_sendFileDescriptorTriggersPauseProducing.skip = "sendFileDescriptor producer was not paused"'>> src/twisted/internet/test/test_unix.py
+
+    # Patch t.p._inotify to point to libc. Without this,
+    # twisted.python.runtime.platform.supportsINotify() == False
     substituteInPlace src/twisted/python/_inotify.py --replace \
       "ctypes.util.find_library(\"c\")" "'${stdenv.glibc.out}/lib/libc.so.6'"
   '';
 
-  # Generate Twisted's plug-in cache.  Twisted users must do it as well.  See
+  # Generate Twisted's plug-in cache. Twisted users must do it as well. See
   # http://twistedmatrix.com/documents/current/core/howto/plugin.html#auto3
-  # and http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=477103 for
-  # details.
+  # and http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=477103 for details.
   postFixup = ''
     $out/bin/twistd --help > /dev/null
   '';
 
+  checkInputs = [
+    git
+    glibcLocales
+    pyhamcrest
+  ] ++ passthru.extras.conch
+  ++ passthru.extras.tls;
+
   checkPhase = ''
-    ${python.interpreter} -m unittest discover -s src/twisted/test
+    export SOURCE_DATE_EPOCH=315532800
+    export PATH=$out/bin:$PATH
+    # race conditions when running in paralell
+    ${python.interpreter} -m twisted.trial twisted
   '';
-  # Tests require network
-  doCheck = false;
 
   meta = with lib; {
     homepage = "https://github.com/twisted/twisted";
@@ -79,6 +132,6 @@ buildPythonPackage rec {
       and licensed under the MIT license.
     '';
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -28,7 +28,7 @@
 , typing-extensions
 , zope_interface
 
-# for passthru.tests
+  # for passthru.tests
 , cassandra-driver
 , klein
 , magic-wormhole
@@ -45,10 +45,9 @@
 buildPythonPackage rec {
   pname = "twisted";
   version = "22.4.0";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
-
-  format = "setuptools";
 
   src = fetchPypi {
     pname = "Twisted";
@@ -67,15 +66,6 @@ buildPythonPackage rec {
     typing-extensions
     zope_interface
   ];
-
-  passthru.extras-require = rec {
-    tls = [ pyopenssl service-identity idna ];
-    conch = [ pyasn1 cryptography appdirs bcrypt ];
-    conch_nacl = conch ++ [ pynacl ];
-    serial = [ pyserial ];
-    http2 = [ h2 priority ];
-    contextvars = lib.optionals (pythonOlder "3.7") [ contextvars ];
-  };
 
   postPatch = ''
     echo 'ListingTests.test_localeIndependent.skip = "Timezone issue"'>> src/twisted/conch/test/test_cftp.py
@@ -127,8 +117,8 @@ buildPythonPackage rec {
     git
     glibcLocales
     pyhamcrest
-  ] ++ passthru.extras.conch
-  ++ passthru.extras.tls;
+  ] ++ passthru.extras-require.conch
+  ++ passthru.extras-require.tls;
 
   checkPhase = ''
     export SOURCE_DATE_EPOCH=315532800
@@ -137,19 +127,29 @@ buildPythonPackage rec {
     ${python.interpreter} -m twisted.trial twisted
   '';
 
-  passthru.tests = {
-    inherit
-      cassandra-driver
-      klein
-      magic-wormhole
-      scrapy
-      treq
-      txaio
-      txamqp
-      txrequests
-      txtorcon
-      thrift;
-    inherit (nixosTests) buildbot matrix-synapse;
+  passthru = {
+    extras-require = {
+      conch = [ appdirs bcrypt cryptography pyasn1 ];
+      contextvars = lib.optionals (pythonOlder "3.7") [ contextvars ];
+      http2 = [ h2 priority ];
+      serial = [ pyserial ];
+      tls = [ idna pyopenssl service-identity ];
+    };
+
+    tests = {
+      inherit
+        cassandra-driver
+        klein
+        magic-wormhole
+        scrapy
+        treq
+        txaio
+        txamqp
+        txrequests
+        txtorcon
+        thrift;
+      inherit (nixosTests) buildbot matrix-synapse;
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
