### PR TITLE
wolfram-engine: infinite loop on `WolframKernel`; `wolframscript` available in package but not installed

### DIFF
--- a/pkgs/applications/science/math/wolfram-engine/default.nix
+++ b/pkgs/applications/science/math/wolfram-engine/default.nix
@@ -112,8 +112,12 @@ stdenv.mkDerivation rec {
 
     # Fix library paths
     cd $out/libexec/${dirName}/Executables
-    for path in MathKernel WolframKernel math mcc wolfram; do
+    for path in MathKernel math mcc wolfram; do
       makeWrapper $out/libexec/${dirName}/Executables/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
+    done
+
+    for path in WolframKernel wolframscript; do
+      makeWrapper $out/libexec/${dirName}/SystemFiles/Kernel/Binaries/Linux-x86-64/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
     done
 
     # ... and xkeyboard config path for Qt


### PR DESCRIPTION
### Describe the bug
The derivation `wolfram-engine` installs executables by `makeWrapper`:

https://github.com/NixOS/nixpkgs/blob/76b29a450007df2912e8190be178ae6b5d220731/pkgs/applications/science/math/wolfram-engine/default.nix#L113-L117

Here `WolframKernel` in `.../Executables` is wrapped and linked to `$out/bin`. However, the generated wrapper basically just calls the wrapped (also a bash script); and the wrapped one under `Executables` just calls itself, leading to an infinite cycle. I suspect this is because the install script copies `WolframKernel` from somewhere, possibly `bin`, but I have no idea at all.

Now there is a proper working (binary) file also named `WolframKernel` under `.../SystemFiles/Kernel/Binaries/Linux-x86-64`. We can consider wrapping it instead...

Also under `SystemFiles/Kernel/Binaries/Linux-x86-64` there's a `wolframscript` binary available, which isn't processed by the derivation now, so it would be nice to get this to `$out/bin` too.


### Steps To Reproduce
Steps to reproduce the behavior:
1. `nix shell nixpkgs#wolfram-engine` (first `nix-store --add-fixed` the install package)
2. `WolframKernel` should spawn a bash process and hang. Check `cat $(which WolframKernel)`.
3. `wolframscript` is not put under `$PATH`. But it's available at `$(nix path-info nixpkgs#wolfram-engine)/libexec/WolframEngine/SystemFiles/Kernel/Binaries/Linux-x86-64/wolframscript`.


### Expected behavior
`WolframKernel` should not get stuck. `wolframscript` should be installed.


### Additional context
I did a quick hack by removing `WolframKernel` from the part of script aforementioned, and just appended another for-loop `mkWrapper` invocation:

```bash
# Fix library paths
cd $out/libexec/${dirName}/Executables
for path in MathKernel math mcc wolfram; do
  makeWrapper $out/libexec/${dirName}/Executables/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
done

for path in WolframKernel wolframscript; do
  makeWrapper $out/libexec/${dirName}/SystemFiles/Kernel/Binaries/Linux-x86-64/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
done
```

And it seems this is enough for properly introducing `wolframscript` and fixing `WolframKernel`'s non-terminating wrapper. I figured this could be cleaned up a bit and made prettier, so I decided to ask for the maintainer's help first instead of submitting a PR now.


### Notify maintainers
<!--
Please @ people who are in the `meta.maintainers` list of the offending package or module.
If in doubt, check `git blame` for whoever last touched something.
-->
@fedeinthemix

### Metadata
Please run `nix-shell -p nix-info --run "nix-info -m"` and paste the result.

```console
% nix run nix-info -- -m
 - system: `"x86_64-linux"`
 - host os: `Linux 5.17.3, NixOS, 22.05 (Quokka), 22.05.20220424.87d34a6`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.8.0pre20220411_f7276bc`
 - channels(root): `""`
 - channels(hex): `""`
 - nixpkgs: `/home/hex/nix-configs`
```
