### PR TITLE
gnome.atomix: pull upstream fix for -fno-common toolchains

### DIFF
--- a/pkgs/desktops/gnome/games/atomix/default.nix
+++ b/pkgs/desktops/gnome/games/atomix/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, wrapGAppsHook, python3
+{ lib, stdenv, fetchurl, fetchpatch
+, meson, ninja, pkg-config, wrapGAppsHook, python3
 , gettext, gnome, glib, gtk3, libgnome-games-support, gdk-pixbuf }:
 
 stdenv.mkDerivation rec {
@@ -10,8 +11,23 @@ stdenv.mkDerivation rec {
     sha256 = "0h909a4mccf160hi0aimyicqhq2b0gk1dmqp7qwf87qghfrw6m00";
   };
 
+  patches = [
+    # Pull upstream fix for -fno-common toolchains like gcc-10:
+    #  https://gitlab.gnome.org/GNOME/atomix/-/merge_requests/2
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://gitlab.gnome.org/GNOME/atomix/-/commit/be7f44f1945a569494d46c60eaf6e7b39b2bb48b.patch";
+      sha256 = "0nrwl6kb1als9mxd5s0la45z63xwshqlnxqjaax32w8yrl6kz7l8";
+    })
+  ];
+
   nativeBuildInputs = [ meson ninja pkg-config gettext wrapGAppsHook python3 ];
   buildInputs = [ glib gtk3 gdk-pixbuf libgnome-games-support gnome.adwaita-icon-theme ];
+
+  # When building with clang ceil() is not inlined:
+  # ld: src/libatomix.a.p/canvas_helper.c.o: undefined reference to symbol 'ceil@@GLIBC_2.2.5'
+  #  https://gitlab.gnome.org/GNOME/atomix/-/merge_requests/3
+  NIX_LDFLAGS = "-lm";
 
   postPatch = ''
     chmod +x meson_post_install.py


### PR DESCRIPTION
Without the change build on -fno-common toolchains fails as:

    $ nix build --impure --expr 'with import ~/nm {}; gnome.atomix.override { stdenv = clang13Stdenv; }'
    ld: src/libatomix.a.p/canvas_helper.c.o: undefined reference to symbol 'ceil@@GLIBC_2.2.5'
    ld: /nix/store/m4g6lswi75b739cpdx8wfxlfmcazyks9-glibc-2.34-115/lib/libm.so.6: error adding symbols: DSO missing from command line

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
