### PR TITLE
bicon: unstable-2018-09-10 ->  unstable-2020-06-04

### DIFF
--- a/pkgs/applications/misc/bicon/default.nix
+++ b/pkgs/applications/misc/bicon/default.nix
@@ -1,23 +1,34 @@
 { lib, stdenv
-  , fetchFromGitHub
-  , autoreconfHook
-  , pkg-config
-  , perl
-  , fribidi
-  , kbd
-  , xkbutils
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, pkg-config
+, perl
+, fribidi
+, kbd
+, xkbutils
 }:
 
 stdenv.mkDerivation rec {
   pname = "bicon";
-  version = "unstable-2018-09-10";
+  version = "unstable-2020-06-04";
 
   src = fetchFromGitHub {
     owner = "behdad";
     repo = pname;
-    rev = "38725c062a83ab19c4e4b4bc20eb9535561aa76c";
-    sha256 = "0hdslrci8pq300f3rrjsvl5psfrxdwyxf9g2m5g789sr049dksnq";
+    rev = "64ae10c94b94a573735a2c2b1502334b86d3b1f7";
+    sha256 = "0ixsf65j4dbdl2aazjc2j0hiagbp6svvfwfmyivha0i1k5yx12v1";
   };
+
+  patches = [
+    # Fix build on clang-13. Pull the change pending upstream
+    # inclusion: https://github.com/behdad/bicon/pull/29
+    (fetchpatch {
+      name = "clang.patch";
+      url = "https://github.com/behdad/bicon/commit/20f5a79571f222f96e07d7c0c5e76e2c9ff1c59a.patch";
+      sha256 = "0l1dm7w52k57nv3lvz5pkbwp021mlsk3csyalxi90np1lx5sqbd1";
+    })
+  ];
 
   buildInputs = [ fribidi kbd xkbutils perl ];
   nativeBuildInputs = [ autoreconfHook pkg-config ];


### PR DESCRIPTION
Without the update build fails on -fno-common toolchains as:

    $ nix build --impure --expr 'with import ./. {}; bicon.override { stdenv = clang13Stdenv; }'
    ...
    ld: bicon_bin-bicon_read.o:/build/source/bicon/bicon_read.c:37:
      multiple definition of `bicon_options'; bicon_bin-bicon.o:/build/source/bicon/./bicon_read.h:4: first defined here

While at it pulled in pending fix for clang compatibility.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
