### PR TITLE
nixos/redmine: Rework module

### DIFF
--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -249,6 +249,13 @@ in
           default = false;
           description = "Allows exporting Gant diagrams as PDF.";
         };
+
+        minimagick_font_path = mkOption {
+          type = types.str;
+          default = "";
+          description = "";
+          example = "/run/current-system/sw/share/X11/fonts/LiberationSans-Regular.ttf";
+        };
       };
     };
   };
@@ -269,6 +276,9 @@ in
       { assertion = cfg.database.createLocally -> cfg.database.host == "localhost";
         message = "services.redmine.database.host must be set to localhost if services.redmine.database.createLocally is set to true";
       }
+      { assertion = cfg.components.imagemagick -> cfg.components.minimagick_font_path != "";
+        message = "services.redmine.components.minimagick_font_path must be configured with a path to a font file if services.redmine.components.imagemagick is set to true.";
+      }
     ];
 
     services.redmine.settings = {
@@ -280,6 +290,7 @@ in
         scm_bazaar_command = if cfg.components.breezy then "${pkgs.breezy}/bin/bzr" else "";
         imagemagick_convert_command = if cfg.components.imagemagick then "${pkgs.imagemagick}/bin/convert" else "";
         gs_command = if cfg.components.ghostscript then "${pkgs.ghostscript}/bin/gs" else "";
+        minimagick_font_path = "${cfg.components.minimagick_font_path}";
       };
     };
 

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -243,6 +243,12 @@ in
           default = false;
           description = "Allows exporting Gant diagrams as PNG.";
         };
+
+        ghostscript = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Allows exporting Gant diagrams as PDF.";
+        };
       };
     };
   };
@@ -272,6 +278,7 @@ in
         scm_git_command = if cfg.components.git then "${pkgs.git}/bin/git" else "";
         scm_cvs_command = if cfg.components.cvs then "${pkgs.cvs}/bin/cvs" else "";
         scm_bazaar_command = if cfg.components.breezy then "${pkgs.breezy}/bin/bzr" else "";
+        gs_command = if cfg.components.ghostscript then "${pkgs.ghostscript}/bin/gs" else "";
       };
     };
 
@@ -339,7 +346,8 @@ in
       ++ optional cfg.components.git git
       ++ optional cfg.components.cvs cvs
       ++ optional cfg.components.breezy breezy
-      ++ optional cfg.components.imagemagick imagemagick;
+      ++ optional cfg.components.imagemagick imagemagick
+      ++ optional cfg.components.ghostscript ghostscript;
 
       preStart = ''
         rm -rf "${cfg.stateDir}/plugins/"*

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -234,7 +234,6 @@ in
         scm_git_command = "${pkgs.git}/bin/git";
         scm_cvs_command = "${pkgs.cvs}/bin/cvs";
         scm_bazaar_command = "${pkgs.breezy}/bin/bzr";
-        scm_darcs_command = "${pkgs.darcs}/bin/darcs";
       };
     };
 
@@ -299,7 +298,6 @@ in
         imagemagick
         breezy
         cvs
-        darcs
         git
         mercurial
         subversion

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -278,6 +278,7 @@ in
         scm_git_command = if cfg.components.git then "${pkgs.git}/bin/git" else "";
         scm_cvs_command = if cfg.components.cvs then "${pkgs.cvs}/bin/cvs" else "";
         scm_bazaar_command = if cfg.components.breezy then "${pkgs.breezy}/bin/bzr" else "";
+        imagemagick_convert_command = if cfg.components.imagemagick then "${pkgs.imagemagick}/bin/convert" else "";
         gs_command = if cfg.components.ghostscript then "${pkgs.ghostscript}/bin/gs" else "";
       };
     };

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -206,6 +206,44 @@ in
           description = "Create the database and database user locally.";
         };
       };
+
+      components = {
+        subversion = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Subversion integration.";
+        };
+
+        mercurial = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Mercurial integration.";
+        };
+
+        git = mkOption {
+          type = types.bool;
+          default = false;
+          description = "git integration.";
+        };
+
+        cvs = mkOption {
+          type = types.bool;
+          default = false;
+          description = "cvs integration.";
+        };
+
+        breezy = mkOption {
+          type = types.bool;
+          default = false;
+          description = "bazaar integration.";
+        };
+
+        imagemagick = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Allows exporting Gant diagrams as PNG.";
+        };
+      };
     };
   };
 
@@ -229,11 +267,11 @@ in
 
     services.redmine.settings = {
       production = {
-        scm_subversion_command = "${pkgs.subversion}/bin/svn";
-        scm_mercurial_command = "${pkgs.mercurial}/bin/hg";
-        scm_git_command = "${pkgs.git}/bin/git";
-        scm_cvs_command = "${pkgs.cvs}/bin/cvs";
-        scm_bazaar_command = "${pkgs.breezy}/bin/bzr";
+        scm_subversion_command = if cfg.components.subversion then "${pkgs.subversion}/bin/svn" else "";
+        scm_mercurial_command = if cfg.components.mercurial then "${pkgs.mercurial}/bin/hg" else "";
+        scm_git_command = if cfg.components.git then "${pkgs.git}/bin/git" else "";
+        scm_cvs_command = if cfg.components.cvs then "${pkgs.cvs}/bin/cvs" else "";
+        scm_bazaar_command = if cfg.components.breezy then "${pkgs.breezy}/bin/bzr" else "";
       };
     };
 
@@ -295,13 +333,14 @@ in
       environment.REDMINE_LANG = "en";
       environment.SCHEMA = "${cfg.stateDir}/cache/schema.db";
       path = with pkgs; [
-        imagemagick
-        breezy
-        cvs
-        git
-        mercurial
-        subversion
-      ];
+      ]
+      ++ optional cfg.components.subversion subversion
+      ++ optional cfg.components.mercurial mercurial
+      ++ optional cfg.components.git git
+      ++ optional cfg.components.cvs cvs
+      ++ optional cfg.components.breezy breezy
+      ++ optional cfg.components.imagemagick imagemagick;
+
       preStart = ''
         rm -rf "${cfg.stateDir}/plugins/"*
         rm -rf "${cfg.stateDir}/public/themes/"*


### PR DESCRIPTION
###### Description of changes

* [nixos/redmine: Drop darcs integration](https://github.com/NixOS/nixpkgs/pull/171930/commits/3be58b2afc2369c777f987359c0843e219e78590)
* [nixos/redmine: Make optional components configurable](https://github.com/NixOS/nixpkgs/pull/171930/commits/92b1cf8b4ccc16e42b04d518f9d23de42cc97c07)
* [nixos/redmine: Add PDF export support for gant](https://github.com/NixOS/nixpkgs/pull/171930/commits/4d23eae938b33fd9cf5ad046d18fb0266b3ca8de)
* [nixos/redmine: Configure imagemagick_convert_command](https://github.com/NixOS/nixpkgs/pull/171930/commits/66ef66fc6215fa22f1f216d00ae258db93fe9441)
* [nixos/redmine: Fix PNG generation of Gant diagrams](https://github.com/NixOS/nixpkgs/pull/171930/commits/562bc5c2a9c4479b11e454d2ac75fccd13e043b9)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).