### PR TITLE
jpegrescan: 2016-06-01 -> 2019-03-27

### DIFF
--- a/pkgs/applications/graphics/jpegrescan/default.nix
+++ b/pkgs/applications/graphics/jpegrescan/default.nix
@@ -1,15 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, libjpeg_turbo, perl, perlPackages }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, perl, perlPackages, libjpeg_original }:
 
 stdenv.mkDerivation rec {
   pname = "jpegrescan";
-  date = "2016-06-01";
-  name = "${pname}-${date}";
+  version = "unstable-2019-03-27";
+
+  dontBuild = true;
+  dontConfigure = true;
 
   src = fetchFromGitHub {
     owner = "kud";
     repo = pname;
-    rev = "e5e39cd972b48ccfb2cba4da6855c511385c05f9";
-    sha256 = "0jbx1vzkzif6yjx1fnsm7fjsmq166sh7mn22lf01ll7s245nmpdp";
+    rev = "3a7de06feabeb3c3235c3decbe2557893c1abe51";
+    sha256 = "0cnl46z28lkqc5x27b8rpghvagahivrqcfvhzcsv9w1qs8qbd6dm";
   };
 
   patchPhase = ''
@@ -23,24 +25,23 @@ stdenv.mkDerivation rec {
     mv jpegrescan $out/bin
     chmod +x $out/bin/jpegrescan
 
-    wrapProgram $out/bin/jpegrescan --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/jpegrescan \
+      --prefix PATH : "${libjpeg_original}/bin:" \
+      --prefix PERL5LIB : $PERL5LIB
   '';
 
   propagatedBuildInputs = [ perlPackages.FileSlurp ];
 
-  nativeBuildInputs = [
-    makeWrapper
-  ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [
-    perl libjpeg_turbo
-  ];
+  buildInputs = [ perl ];
 
   meta = with lib; {
-    description = "losslessly shrink any JPEG file";
+    description = "Losslessly shrink any JPEG file";
     homepage = "https://github.com/kud/jpegrescan";
     license = licenses.publicDomain;
-    maintainers = [ maintainers.ramkromberg ];
+    maintainers = with maintainers; [ ramkromberg ];
     platforms = platforms.all;
+    mainProgram = "jpegrescan";
   };
 }


### PR DESCRIPTION
###### Description of changes

1. Updated.
2. Hard ``$PATH`` using ``libjpeg_original``: When I originally packaged this script I wanted to leave it up to the user to decide between different ``jpegtran`` implementations so I didn't hard code the library ``$PATH``. However, after all these years,
    1. I've seen ``mozjpeg``'s ``jpegtran`` output corrupted jpegs enough times to rule it out completely.
    2. That, while ``libjpeg_turbo`` is faster in many other use cases, with this particular script there's no meaningful difference (used ``time libjpeg in.jpeg out.jpeg`` on multiple occasions with the different ``jpegtran``). e.g. even for a 130MB jpeg, the difference in time was negligible.
    3. That ``libjpeg_original`` produces slightly smaller file sizes (0.1-0.5%) even without the controversial and generally unsupported arithmetic coding flag.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
