### PR TITLE
firejail: Fix opengl support for various apps

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -47,6 +47,12 @@ stdenv.mkDerivation rec {
     # Upstream fix https://github.com/netblue30/firejail/pull/5131
     # Upstream hopefully fixed in later versions > 0.9.68
    ./whitelist-nix-profile.patch
+
+    # Fix OpenGL support for various applications including Firefox
+    # Issue: https://github.com/NixOS/nixpkgs/issues/55191
+    # Upstream fix: https://github.com/netblue30/firejail/pull/5132
+    # Hopefully fixed upstream in version > 0.9.68
+    ./fix-opengl-support.patch
   ];
 
   prePatch = ''

--- a/pkgs/os-specific/linux/firejail/fix-opengl-support.patch
+++ b/pkgs/os-specific/linux/firejail/fix-opengl-support.patch
@@ -1,0 +1,7 @@
+--- a/etc/inc/whitelist-run-common.inc.org	2022-05-07 11:27:32.264849186 +0200
++++ b/etc/inc/whitelist-run-common.inc	2022-05-07 11:27:55.577778211 +0200
+@@ -13,3 +13,4 @@
+ whitelist /run/systemd/resolve/resolv.conf
+ whitelist /run/systemd/resolve/stub-resolv.conf
+ whitelist /run/udev/data
++whitelist /run/opengl-driver	# NixOS


### PR DESCRIPTION
###### Description of changes

Fixes opengl support for various apps including Firefox, see https://github.com/NixOS/nixpkgs/issues/55191 

Upstream fix https://github.com/netblue30/firejail/pull/5132 but would be cool to merge this too since it could take a while for a new upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
