### PR TITLE
vtk_9: Try to use external dependencies

### DIFF
--- a/pkgs/development/libraries/adios2/default.nix
+++ b/pkgs/development/libraries/adios2/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, perl
+, pkg-config
+, libffi
+, pugixml
+, nlohmann_json
+, libyamlcpp
+, atl
+, dill
+# , ffs
+# , enet
+# , evpath
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ADIOS2";
+  version = "2.8.0";
+
+  src = fetchFromGitHub {
+    owner = "ornladios";
+    repo = "ADIOS2";
+    rev = "v${version}";
+    sha256 = "IiOmufc9WgCLlGEOyPber79Q/GHkJrRGlhg3eVdZ2FU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    perl
+    pkg-config
+  ];
+
+  buildInputs = [
+    libffi
+    pugixml
+    nlohmann_json
+    libyamlcpp
+    atl
+    dill
+    # ffs
+    # enet
+    # evpath
+  ];
+
+  cmakeFlags = [
+    "-DADIOS2_USE_EXTERNAL_DEPENDENCIES=ON"
+    "-DADIOS2_USE_EXTERNAL_ATL=ON"
+    "-DADIOS2_USE_EXTERNAL_DILL=ON"
+    # The following break build:
+    # "-DADIOS2_USE_EXTERNAL_FFS=ON"
+    # "-DADIOS2_USE_EXTERNAL_EVPATH=ON"
+    # "-DADIOS2_USE_EXTERNAL_ENET=ON"
+
+    # Does not handle absolute paths in libdir
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+
+    # Slow
+    "-DADIOS2_BUILD_EXAMPLES=OFF"
+  ];
+
+  postPatch = ''
+    patchShebangs cmake/install/post/generate-adios2-config.sh.in
+  '';
+
+  meta = with lib; {
+    description = "Adaptable Input/Output System";
+    homepage = "https://adios2.readthedocs.io/";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/atl/default.nix
+++ b/pkgs/development/libraries/atl/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "atl";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "GTkorvo";
+    repo = "atl";
+    rev = "v${version}";
+    sha256 = "kbFyO4nl8v4vW8pmbdfrXWHbw7ZYhaXj46svhGU8LYg=";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+
+    # Does not handle absolute paths
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  meta = with lib; {
+    description = "Library for the creation and manipulation of lists of name/value pairs using an efficient binary representation";
+    homepage = "https://github.com/GTkorvo/atl";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/atl/default.nix
+++ b/pkgs/development/libraries/atl/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "kbFyO4nl8v4vW8pmbdfrXWHbw7ZYhaXj46svhGU8LYg=";
   };
 
+  nativeBuildInputs = [
+    cmake
+  ];
+
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
 

--- a/pkgs/development/libraries/cgns/default.nix
+++ b/pkgs/development/libraries/cgns/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, hdf5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "CGNS";
+  version = "4.3.0";
+
+  outputs = [ "bin" "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "CGNS";
+    repo = "CGNS";
+    rev = "v${version}";
+    sha256 = "bVvauoZPOZiU9eudaZXtsEp1nTua4ydiDhOnTY8PL0o=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    hdf5
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+    "-DCGNS_BUILD_TESTING=ON"
+    "-DCGNS_ENABLE_TESTS=ON"
+  ];
+
+  doCheck = true;
+
+  postInstall = ''
+    moveToOutput bin "''${!outputBin}"
+  '';
+
+  meta = with lib; {
+    description = "Standard for recording and recovering computer data associated with the numerical solution of fluid dynamics equations";
+    homepage = "https://cgns.github.io/";
+    license = licenses.zlib;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/dill/default.nix
+++ b/pkgs/development/libraries/dill/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, perl
+, libffi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dill";
+  version = "2.4.1";
+
+  src = fetchFromGitHub {
+    owner = "GTkorvo";
+    repo = "dill";
+    rev = "v${version}";
+    sha256 = "NiRVHAQzGDVs5Mc6kwDpbJQJoSs90qohFF5UR8huFRs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    perl
+  ];
+
+  propagatedBuildInputs = [
+    libffi
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+
+    # Does not handle absolute paths
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  meta = with lib; {
+    description = "Instruction-level code generation, register allocation and simple optimizations for generating executable code directly into memory regions";
+    homepage = "https://github.com/GTkorvo/dill";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/diy/default.nix
+++ b/pkgs/development/libraries/diy/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, cmake
+, openmpi
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "diy";
+  version = "unstable-2022-01-04";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.kitware.com";
+    owner = "diatomic";
+    repo = "diy";
+    rev = "9246b0bd09368455e8604063a44fe7a93088d789";
+    sha256 = "/rKuwRSEcw9AkyfBAhbYF9z//i/iJ/ZoHtLDzJCurEY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    openmpi
+  ];
+
+  cmakeFlags = [
+    # Slow
+    "-Dbuild_examples=OFF"
+    # Fails to build with “size of array 'altStackMem' is not an integral constant-expression”
+    "-Dbuild_tests=OFF"
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater {
+      url = "https://gitlab.kitware.com/diatomic/diy.git";
+    };
+  };
+
+  meta = with lib; {
+    description = "Data-parallel out-of-core library";
+    homepage = "https://gitlab.kitware.com/diatomic/diy";
+    license = licenses.bsd3; # Actually BSD-3-Clause-LBNL
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/diy/default.nix
+++ b/pkgs/development/libraries/diy/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.kitware.com/diatomic/diy";
     license = licenses.bsd3; # Actually BSD-3-Clause-LBNL
     platforms = platforms.unix;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ jtojnar ];
   };
 }

--- a/pkgs/development/libraries/evpath/default.nix
+++ b/pkgs/development/libraries/evpath/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, perl
+, pkg-config
+, atl
+, ffs
+, dill
+}:
+
+stdenv.mkDerivation rec {
+  pname = "evpath";
+  version = "4.5.0";
+
+  src = fetchFromGitHub {
+    owner = "GTkorvo";
+    repo = "evpath";
+    rev = "v${version}";
+    sha256 = "vx6H7u0bezxSr+QoX1JueFgVSh7uL93jFzFLfsv9ufw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    perl
+    pkg-config
+  ];
+
+  buildInputs = [
+    dill
+  ];
+
+  propagatedBuildInputs = [
+    atl
+    ffs
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+
+    # Does not handle absolute paths
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  meta = with lib; {
+    description = "Event transport middleware layer";
+    homepage = "https://github.com/GTkorvo/evpath";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/exodusII/default.nix
+++ b/pkgs/development/libraries/exodusII/default.nix
@@ -10,7 +10,7 @@ let
   fortranSupport = false;
 in
 stdenv.mkDerivation rec {
-  pname = "exodus";
+  pname = "exodusII";
   version = "2022-01-27";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/exprtk/default.nix
+++ b/pkgs/development/libraries/exprtk/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "exprtk";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "ArashPartow";
+    repo = "exprtk";
+    rev = version;
+    sha256 = "5/k+y3gNJeggfwXmtAVqmaiV+BXX+WKtWwZWcQSrQDM=";
+  };
+
+  # There are just extremely-slow-to-build examples and benchmarks.
+  dontBuild = true;
+
+  # No install target.
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt "$out/include" exprtk.hpp
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "C++ Mathematical Expression Parsing And Evaluation Library";
+    homepage = "https://www.partow.net/programming/exprtk/index.html";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/ffs/default.nix
+++ b/pkgs/development/libraries/ffs/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, bison
+, flex
+, perl
+, atl
+, dill
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ffs";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "GTkorvo";
+    repo = "ffs";
+    rev = "v${version}";
+    sha256 = "WTrlqzpBmIHEstWXnhKopKT2UWOkdzGF/7lpB1foPVo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    bison
+    flex
+    perl
+  ];
+
+  buildInputs = [
+    atl
+    dill
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+
+    # Does not handle absolute paths
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  meta = with lib; {
+    description = "Middleware library for highly efficient binary data communication";
+    homepage = "https://github.com/GTkorvo/ffs";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/fides/default.nix
+++ b/pkgs/development/libraries/fides/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, cmake
+, adios2
+, vtk-m
+, rapidjson
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fides";
+  version = "1.1.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.kitware.com";
+    owner = "vtk";
+    repo = "fides";
+    rev = "v${version}";
+    sha256 = "oquvV6kyb4b3j0oAKYxUtfjatrZp+7j07y4B1UeMKlA=";
+  };
+
+  patches = [
+    # Fix missing header includes.
+    (fetchpatch {
+      url = "https://gitlab.kitware.com/vtk/fides/-/commit/eb7cd4567e5805f52a657ce70e2596aaa9e735f6.patch";
+      sha256 = "gh5WJCIOvBgy8Y+bes/oCnvlALnRRhHqnZLSENfv5vk=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    adios2
+    vtk-m
+    rapidjson
+  ];
+
+  cmakeFlags = [
+    "-DFIDES_USE_EXTERNAL_RAPIDJSON=ON"
+  ];
+
+  dontUseCmakeBuildDir = true;
+
+  preConfigure = ''
+    # VTK-m does not install targets when `CMAKE_BINARY_DIR=/build/source/build`, thinking it is building itself.
+    # https://gitlab.kitware.com/vtk/vtk-m/-/blob/3b8ead6cb2444fcf50e8f5a5d188d08095ecb95a/CMake/VTKmConfig.cmake.in#L109
+    mkdir -p _build
+    cd _build
+    cmakeDir=..
+  '';
+
+  meta = with lib; {
+    description = "Library that enables interoperable analysis and visualization services with ADIOS2-enabled simulations";
+    homepage = "https://gitlab.kitware.com/vtk/fides";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -49,7 +49,7 @@ in
   };
 
   fmt_8 = generic {
-    version = "8.0.1";
-    sha256 = "1mnvxqsan034d2jiqnw2yvkljl7lwvhakmj5bscwp1fpkn655bbw";
+    version = "8.1.1";
+    sha256 = "leb2800CwdZMJRWF5b1Y9ocK0jXpOX/nwo95icDf308=";
   };
 }

--- a/pkgs/development/libraries/ioss/default.nix
+++ b/pkgs/development/libraries/ioss/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, netcdf
+, exodusII
+, zoltan
+}:
+
+let
+  fortranSupport = false;
+in
+stdenv.mkDerivation rec {
+  pname = "ioss";
+  version = "2022-01-27";
+
+  src = fetchFromGitHub {
+    owner = "gsjaardema";
+    repo = "seacas";
+    rev = "v${version}";
+    sha256 = "mHTRUK+48icF9EzUUO6TPZEHqq/gAhKmqqXOXQ4s6Jo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    netcdf
+    exodusII
+    zoltan
+  ];
+
+  cmakeFlags = [
+    "-DSEACASProj_ENABLE_SEACASIoss:BOOL=ON"
+    "-DSEACASProj_ENABLE_SEACASExodus:BOOL=OFF"
+    "-DSEACASProj_ENABLE_Zoltan:BOOL=OFF"
+    "-DBUILD_SHARED_LIBS:BOOL=ON"
+    "-DSEACASProj_ENABLE_Fortran:BOOL=${lib.boolToString fortranSupport}"
+  ];
+
+  meta = with lib; {
+    description = "Sierra IO System";
+    homepage = "https://github.com/gsjaardema/seacas";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/pegtl/default.nix
+++ b/pkgs/development/libraries/pegtl/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "PEGTL";
+  version = "3.2.5";
+
+  src = fetchFromGitHub {
+    owner = "taocpp";
+    repo = "PEGTL";
+    rev = version;
+    sha256 = "6BfWN8IsfAJxlhkFs8yCK0o2OfLI/acGXY+349MY9CY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Parsing Expression Grammar Template Library";
+    homepage = "https://github.com/taocpp/PEGTL";
+    license = licenses.boost;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/seacas-exodus/default.nix
+++ b/pkgs/development/libraries/seacas-exodus/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, netcdf
+, hdf5
+}:
+
+let
+  fortranSupport = false;
+in
+stdenv.mkDerivation rec {
+  pname = "exodus";
+  version = "2022-01-27";
+
+  src = fetchFromGitHub {
+    owner = "gsjaardema";
+    repo = "seacas";
+    rev = "v${version}";
+    sha256 = "mHTRUK+48icF9EzUUO6TPZEHqq/gAhKmqqXOXQ4s6Jo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    netcdf
+    hdf5
+  ];
+
+  cmakeFlags = [
+    "-DSEACASProj_ENABLE_SEACASExodus:BOOL=ON"
+    "-DSEACASExodus_ENABLE_STATIC:BOOL=OFF"
+    "-DSEACASProj_ENABLE_SEACASExodus_for:BOOL=${lib.boolToString fortranSupport}"
+    "-DSEACASProj_ENABLE_SEACASExoIIv2for32:BOOL=${lib.boolToString fortranSupport}"
+    "-DSEACASProj_ENABLE_Fortran:BOOL=${lib.boolToString fortranSupport}"
+  ];
+
+  meta = with lib; {
+    description = "Finite Element Data Model";
+    homepage = "https://github.com/gsjaardema/seacas";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/verdict/default.nix
+++ b/pkgs/development/libraries/verdict/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "verdict";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "sandialabs";
+    repo = "verdict";
+    rev = version;
+    sha256 = "GvCL1yxYIvZWgIf3QSSCsKDhzDTAttB7t7uUGVXponM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Compute quality functions of 2 and 3-dimensional regions";
+    homepage = "https://github.com/sandialabs/verdict";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/vtk-m/default.nix
+++ b/pkgs/development/libraries/vtk-m/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, cmake
+# , diy
+}:
+
+stdenv.mkDerivation rec {
+  pname = "VTK-m";
+  version = "1.7.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.kitware.com";
+    owner = "vtk";
+    repo = "vtk-m";
+    rev = "v${version}";
+    sha256 = "kkHc2ny+KjzgfaehoulaUfetx5y/dezyHd93mULElxs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    # diy
+  ];
+
+  cmakeFlags = [
+    # Currently not supported:
+    # "-DVTKM_USE_EXTERNAL_DIY:BOOL=ON"
+  ];
+
+  meta = with lib; {
+    description = "A toolkit of scientific visualization algorithms for emerging processor architectures";
+    homepage = "https://m.vtk.org/";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/zoltan/default.nix
+++ b/pkgs/development/libraries/zoltan/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+let
+  fortranSupport = false;
+in
+stdenv.mkDerivation rec {
+  pname = "Zoltan";
+  version = "2022-01-27";
+
+  src = fetchFromGitHub {
+    owner = "gsjaardema";
+    repo = "seacas";
+    rev = "v${version}";
+    sha256 = "mHTRUK+48icF9EzUUO6TPZEHqq/gAhKmqqXOXQ4s6Jo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    # TODO: Package pympi separately?
+  ];
+
+  cmakeFlags = [
+    "-DSEACASProj_ENABLE_Zoltan:BOOL=ON"
+    "-DBUILD_SHARED_LIBS:BOOL=ON"
+    "-DSEACASProj_ENABLE_Fortran:BOOL=${lib.boolToString fortranSupport}"
+  ];
+
+  meta = with lib; {
+    description = "Toolkit for Load-balancing, Partitioning, Ordering and Coloring";
+    homepage = "https://github.com/gsjaardema/seacas";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -14,6 +14,7 @@
 , libcap_ng
 , libqb
 , libseccomp
+, pegtl
 , polkit
 , protobuf
 , audit
@@ -51,6 +52,7 @@ stdenv.mkDerivation rec {
     libcap_ng
     libqb
     libseccomp
+    pegtl
     polkit
     protobuf
     audit
@@ -60,7 +62,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-bundled-catch"
-    "--with-bundled-pegtl"
     "--with-dbus"
     "--with-polkit"
   ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16566,6 +16566,8 @@ with pkgs;
     aspell = aspell.override { searchNixProfiles = false; };
   };
 
+  atl = callPackage ../development/libraries/atl { };
+
   attr = callPackage ../development/libraries/attr { };
 
   at-spi2-core = callPackage ../development/libraries/at-spi2-core { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4567,6 +4567,8 @@ with pkgs;
 
   cfdg = callPackage ../tools/graphics/cfdg { };
 
+  cgns = callPackage ../development/libraries/cgns { };
+
   cglm = callPackage ../development/libraries/cglm { };
 
   cgreen = callPackage ../development/libraries/cgreen { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16486,6 +16486,8 @@ with pkgs;
 
   activemq = callPackage ../development/libraries/apache-activemq { };
 
+  adios2 = callPackage ../development/libraries/adios2 { };
+
   adns = callPackage ../development/libraries/adns { };
 
   adslib = callPackage ../development/libraries/adslib { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17160,6 +17160,8 @@ with pkgs;
   fftwFloat = fftwSinglePrec; # the configure option is just an alias
   fftwLongDouble = fftw.override { precision = "long-double"; };
 
+  fides = callPackage ../development/libraries/fides { };
+
   filter-audio = callPackage ../development/libraries/filter-audio {};
 
   filtron = callPackage ../servers/filtron {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20054,6 +20054,8 @@ with pkgs;
 
   pe-parse = callPackage ../development/libraries/pe-parse { };
 
+  pegtl = callPackage ../development/libraries/pegtl { };
+
   inherit (callPackage ../development/libraries/physfs {
     inherit (darwin.apple_sdk.frameworks) Foundation Carbon;
   })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16978,6 +16978,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };
 
+  diy = callPackage ../development/libraries/diy { };
+
   dlib = callPackage ../development/libraries/dlib { };
 
   doctest = callPackage ../development/libraries/doctest { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17066,6 +17066,8 @@ with pkgs;
 
   exiv2 = callPackage ../development/libraries/exiv2 { };
 
+  exodusII = callPackage ../development/libraries/exodusII { };
+
   expat = callPackage ../development/libraries/expat { };
 
   exprtk = callPackage ../development/libraries/exprtk { };
@@ -20500,8 +20502,6 @@ with pkgs;
   };
 
   sblim-sfcc = callPackage ../development/libraries/sblim-sfcc {};
-
-  seacas-exodus = callPackage ../development/libraries/seacas-exodus { };
 
   selinux-sandbox = callPackage ../os-specific/linux/selinux-sandbox { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21288,6 +21288,8 @@ with pkgs;
 
   zita-resampler = callPackage ../development/libraries/audio/zita-resampler { };
 
+  zoltan = callPackage ../development/libraries/zoltan { };
+
   zz = callPackage ../development/compilers/zz { };
 
   zziplib = callPackage ../development/libraries/zziplib { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21048,6 +21048,8 @@ with pkgs;
   vtk = vtk_8;
   vtkWithQt5 = vtk_8_withQt5;
 
+  vtk-m = callPackage ../development/libraries/vtk-m { };
+
   vulkan-extension-layer = callPackage ../tools/graphics/vulkan-extension-layer { };
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { inherit (darwin) moltenvk; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16968,6 +16968,8 @@ with pkgs;
 
   dclib = callPackage ../development/libraries/dclib { };
 
+  dill = callPackage ../development/libraries/dill { };
+
   dillo = callPackage ../applications/networking/browsers/dillo {
     fltk = fltk13;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20499,6 +20499,8 @@ with pkgs;
 
   sblim-sfcc = callPackage ../development/libraries/sblim-sfcc {};
 
+  seacas-exodus = callPackage ../development/libraries/seacas-exodus { };
+
   selinux-sandbox = callPackage ../os-specific/linux/selinux-sandbox { };
 
   seasocks = callPackage ../development/libraries/seasocks { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17062,6 +17062,8 @@ with pkgs;
 
   expat = callPackage ../development/libraries/expat { };
 
+  exprtk = callPackage ../development/libraries/exprtk { };
+
   eventlog = callPackage ../development/libraries/eventlog { };
 
   faac = callPackage ../development/libraries/faac { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20999,6 +20999,8 @@ with pkgs;
 
   vcg = callPackage ../development/libraries/vcg { };
 
+  verdict = callPackage ../development/libraries/verdict { };
+
   vid-stab = callPackage ../development/libraries/vid-stab {
     inherit (llvmPackages) openmp;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17076,6 +17076,8 @@ with pkgs;
 
   eventlog = callPackage ../development/libraries/eventlog { };
 
+  evpath = callPackage ../development/libraries/evpath { };
+
   faac = callPackage ../development/libraries/faac { };
 
   faad2 = callPackage ../development/libraries/faad2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11921,7 +11921,9 @@ with pkgs;
 
   zerofree = callPackage ../tools/filesystems/zerofree { };
 
-  zfp = callPackage ../tools/compression/zfp {};
+  zfp = callPackage ../tools/compression/zfp {
+    pythonPackages = python3Packages;
+  };
 
   zfs-autobackup = callPackage ../tools/backup/zfs-autobackup { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17989,6 +17989,8 @@ with pkgs;
 
   ios-cross-compile = callPackage ../development/compilers/ios-cross-compile/9.2.nix {};
 
+  ioss = callPackage ../development/libraries/ioss { };
+
   ip2location-c = callPackage ../development/libraries/ip2location-c { };
 
   irrlicht = if !stdenv.isDarwin then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17107,6 +17107,8 @@ with pkgs;
 
   fflas-ffpack = callPackage ../development/libraries/fflas-ffpack { };
 
+  ffs = callPackage ../development/libraries/ffs { };
+
   forge = callPackage ../development/libraries/forge {
     cudatoolkit = buildPackages.cudatoolkit_11;
   };


### PR DESCRIPTION
###### Description of changes

Trying to make it build faster by not rebuilding the world.

Currently failing on

```
/build/VTK-9.1.0/IO/IOSS/vtkIOSSReader.cxx: In member function 'Ioss::Region* vtkIOSSReader::vtkInternals::GetRegion(const string&, int)':
/build/VTK-9.1.0/IO/IOSS/vtkIOSSReader.cxx:1304:38: error: 'MPI_COMM_WORLD' was not declared in this scope
 1304 |       dbasename, Ioss::READ_RESTART, MPI_COMM_WORLD, properties));
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
