### PR TITLE
freetalk: pull pending fix for -fno-common toolchains

### DIFF
--- a/pkgs/applications/networking/instant-messengers/freetalk/default.nix
+++ b/pkgs/applications/networking/instant-messengers/freetalk/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , guile, pkg-config, glib, loudmouth, gmp, libidn, readline, libtool
 , libunwind, ncurses, curl, jansson, texinfo
 , automake, autoconf }:
@@ -12,6 +12,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "09jwk2i8qd8c7wrn9xbqcwm32720dwxis22kf3jpbg8mn6w6i757";
   };
+
+  patches = [
+    # Pull pending patch for -fno-common tuulchain support:
+    #   https://github.com/GNUFreetalk/freetalk/pull/39
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/GNUFreetalk/freetalk/commit/f04d6bc8422be44cdf51b29c9a4310f20a18775a.patch";
+      sha256 = "1zjm56cdibnqabgcwl2bx79dj6dmqjf40zghqwwb0lfi60v1njqf";
+    })
+  ];
 
   preConfigure = ''
     ./autogen.sh


### PR DESCRIPTION
Without the change build on -fno-common toolchains like clamng-13 fails as:

    $ nix build --impure --expr 'with import ./. {}; freetalk.override { stdenv = clang13Stdenv; }' -L
    ...
    ld: more.o:src/./more.h:15: multiple definition of `cin'; primitives.o:src/./more.h:15: first defined here
    ld: more.o:src/./more.h:14: multiple definition of `initial_settings'; primitives.o:src/./more.h:14: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
