### PR TITLE
imlib2: add explicit svg & heif support-disabling (fixing darwin build)

### DIFF
--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -5,6 +5,10 @@
 , libid3tag, librsvg, libheif
 , freetype , bzip2, pkg-config
 , x11Support ? true, xlibsWrapper ? null
+# Compilation error on Darwin with librsvg. For more information see:
+# https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
+, svgSupport ? !stdenv.isDarwin
+, heifSupport ? !stdenv.isDarwin
 }:
 
 let
@@ -21,11 +25,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libjpeg libtiff giflib libpng libwebp
-    bzip2 freetype libid3tag libheif
+    bzip2 freetype libid3tag
   ] ++ optional x11Support xlibsWrapper
-  # Compilation error on Darwin with librsvg. For more information see:
-  # https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
-  ++ optional (!stdenv.isDarwin) librsvg;
+    ++ optional heifSupport libheif
+    ++ optional svgSupport librsvg;
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -34,6 +37,8 @@ stdenv.mkDerivation rec {
   # Do not build amd64 assembly code on Darwin, because it fails to compile
   # with unknow directive errors
   configureFlags = optional stdenv.isDarwin "--enable-amd64=no"
+    ++ optional (!svgSupport) "--without-svg"
+    ++ optional (!heifSupport) "--without-heif"
     ++ optional (!x11Support) "--without-x";
 
   outputs = [ "bin" "out" "dev" ];


### PR DESCRIPTION
###### Description of changes
...instead of just `buildInput` omission. Darwin still fails to build with svg support, but `librsvg` being accidentally included in one of the existing dependencies will cause support to be enabled. Oops.

See https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1120151120

cc @vcunat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
