### PR TITLE
nixos/hadoop: init HBase submodule

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -128,6 +128,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://hbase.apache.org/">HBase
+          cluster</link>, a distributed, scalable, big data store.
+          Available as
+          <link xlink:href="options.html#opt-services.hadoop.hbase.enable">services.hadoop.hbase</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/leetronics/infnoise">infnoise</link>,
           a hardware True Random Number Generator dongle. Available as
           <link xlink:href="options.html#opt-services.infnoise.enable">services.infnoise</link>.
@@ -250,6 +258,14 @@
           <link xlink:href="https://www.barco.com/de/support/knowledge-base/4380-can-i-use-linux-os-with-clickshare-base-units">According
           to Barco</link> many of their base unit models can be used
           with Google Chrome and the Google Cast extension.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>services.hbase</literal> has been renamed to
+          <literal>services.hbase-standalone</literal>. For production
+          HBase clusters, use <literal>services.hadoop.hbase</literal>
+          instead.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -56,6 +56,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [dragonflydb](https://dragonflydb.io/), a modern replacement for Redis and Memcached. Available as [services.dragonflydb](#opt-services.dragonflydb.enable).
 
+- [HBase cluster](https://hbase.apache.org/), a distributed, scalable, big data store. Available as [services.hadoop.hbase](options.html#opt-services.hadoop.hbase.enable).
+
 - [infnoise](https://github.com/leetronics/infnoise), a hardware True Random Number Generator dongle.
   Available as [services.infnoise](options.html#opt-services.infnoise.enable).
 
@@ -97,6 +99,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The Barco ClickShare driver/client package `pkgs.clickshare-csc1` and the option `programs.clickshare-csc1.enable` have been removed,
   as it requires `qt4`, which reached its end-of-life 2015 and will no longer be supported by nixpkgs.
   [According to Barco](https://www.barco.com/de/support/knowledge-base/4380-can-i-use-linux-os-with-clickshare-base-units) many of their base unit models can be used with Google Chrome and the Google Cast extension.
+
+- `services.hbase` has been renamed to `services.hbase-standalone`.
+  For production HBase clusters, use `services.hadoop.hbase` instead.
 
 - PHP 7.4 is no longer supported due to upstream not supporting this
   version for the entire lifecycle of the 22.11 release.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -357,7 +357,7 @@
   ./services/databases/dgraph.nix
   ./services/databases/firebird.nix
   ./services/databases/foundationdb.nix
-  ./services/databases/hbase.nix
+  ./services/databases/hbase-standalone.nix
   ./services/databases/influxdb.nix
   ./services/databases/influxdb2.nix
   ./services/databases/memcached.nix

--- a/nixos/modules/services/cluster/hadoop/conf.nix
+++ b/nixos/modules/services/cluster/hadoop/conf.nix
@@ -33,6 +33,7 @@ pkgs.runCommand "hadoop-conf" {} (with cfg; ''
   mkdir -p $out/
   cp ${siteXml "core-site.xml" (coreSite // coreSiteInternal)}/* $out/
   cp ${siteXml "hdfs-site.xml" (hdfsSiteDefault // hdfsSite // hdfsSiteInternal)}/* $out/
+  cp ${siteXml "hbase-site.xml" (hbaseSiteDefault // hbaseSite // hbaseSiteInternal)}/* $out/
   cp ${siteXml "mapred-site.xml" (mapredSiteDefault // mapredSite)}/* $out/
   cp ${siteXml "yarn-site.xml" (yarnSiteDefault // yarnSite // yarnSiteInternal)}/* $out/
   cp ${siteXml "httpfs-site.xml" httpfsSite}/* $out/

--- a/nixos/modules/services/cluster/hadoop/conf.nix
+++ b/nixos/modules/services/cluster/hadoop/conf.nix
@@ -41,5 +41,5 @@ pkgs.runCommand "hadoop-conf" {} (with cfg; ''
   cp ${pkgs.writeTextDir "hadoop-user-functions.sh" userFunctions}/* $out/
   cp ${pkgs.writeTextDir "hadoop-env.sh" hadoopEnv}/* $out/
   cp ${log4jProperties} $out/log4j.properties
-  ${lib.concatMapStringsSep "\n" (dir: "cp -r ${dir}/* $out/") extraConfDirs}
+  ${lib.concatMapStringsSep "\n" (dir: "cp -f -r ${dir}/* $out/") extraConfDirs}
 '')

--- a/nixos/modules/services/cluster/hadoop/default.nix
+++ b/nixos/modules/services/cluster/hadoop/default.nix
@@ -5,7 +5,7 @@ let
 in
 with lib;
 {
-  imports = [ ./yarn.nix ./hdfs.nix ];
+  imports = [ ./yarn.nix ./hdfs.nix ./hbase.nix ];
 
   options.services.hadoop = {
     coreSite = mkOption {

--- a/nixos/modules/services/cluster/hadoop/hbase.nix
+++ b/nixos/modules/services/cluster/hadoop/hbase.nix
@@ -1,0 +1,200 @@
+{ config, lib, pkgs, ...}:
+
+with lib;
+let
+  cfg = config.services.hadoop;
+  hadoopConf = "${import ./conf.nix { inherit cfg pkgs lib; }}/";
+  mkIfNotNull = x: mkIf (x != null) x;
+in
+{
+  options.services.hadoop = {
+
+    gatewayRole.enableHbaseCli = mkOption {
+      description = "Whether to enable HBase CLI tools";
+      default = false;
+      type = types.bool;
+    };
+
+    hbaseSiteDefault = mkOption {
+      default = {
+        "hbase.regionserver.ipc.address" = "0.0.0.0";
+        "hbase.master.ipc.address" = "0.0.0.0";
+        "hbase.master.info.bindAddress" = "0.0.0.0";
+        "hbase.regionserver.info.bindAddress" = "0.0.0.0";
+
+        "hbase.cluster.distributed" = "true";
+      };
+      type = types.attrsOf types.anything;
+      description = ''
+        Default options for hbase-site.xml
+      '';
+    };
+    hbaseSite = mkOption {
+      default = {};
+      type = with types; attrsOf anything;
+      example = literalExpression ''
+      '';
+      description = ''
+        Additional options and overrides for hbase-site.xml
+        <link xlink:href="https://github.com/apache/hbase/blob/rel/2.4.11/hbase-common/src/main/resources/hbase-default.xml"/>
+      '';
+    };
+    hbaseSiteInternal = mkOption {
+      default = {};
+      type = with types; attrsOf anything;
+      internal = true;
+      description = ''
+        Internal option to add configs to hbase-site.xml based on module options
+      '';
+    };
+
+    hbase = {
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.hbase;
+        defaultText = literalExpression "pkgs.hbase";
+        description = "HBase package";
+      };
+
+      rootdir = mkOption {
+        description = ''
+          This option will set "hbase.rootdir" in hbase-site.xml and determine
+          the directory shared by region servers and into which HBase persists.
+          The URL should be 'fully-qualified' to include the filesystem scheme.
+          If a core-site.xml is provided, the FS scheme defaults to the value
+          of "fs.defaultFS".
+
+          Filesystems other than HDFS (like S3, QFS, Swift) are also supported.
+        '';
+        type = types.str;
+        example = "hdfs://nameservice1/hbase";
+        default = "/hbase";
+      };
+      zookeeperQuorum = mkOption {
+        description = ''
+          This option will set "hbase.zookeeper.quorum" in hbase-site.xml.
+          Comma separated list of servers in the ZooKeeper ensemble.
+        '';
+        type = with types; nullOr commas;
+        example = "zk1.internal,zk2.internal,zk3.internal";
+        default = null;
+      };
+      master = {
+        enable = mkEnableOption "HBase Master";
+        initHDFS = mkEnableOption "initialization of the hbase directory on HDFS";
+
+        openFirewall = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Open firewall ports for HBase master.
+          '';
+        };
+      };
+      regionServer = {
+        enable = mkEnableOption "HBase RegionServer";
+
+        overrideHosts = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Remove /etc/hosts entries for "127.0.0.2" and "::1" defined in nixos/modules/config/networking.nix
+            Regionservers must be able to resolve their hostnames to their IP addresses, through PTR records
+            or /etc/hosts entries.
+
+          '';
+        };
+
+        openFirewall = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Open firewall ports for HBase master.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.hbase.master.enable {
+      services.hadoop.gatewayRole = {
+        enable = true;
+        enableHbaseCli = mkDefault true;
+      };
+
+      systemd.services.hbase-master = {
+        description = "HBase master";
+        wantedBy = [ "multi-user.target" ];
+
+        preStart = mkIf cfg.hbase.master.initHDFS ''
+          HADOOP_USER_NAME=hdfs ${cfg.package}/bin/hdfs --config ${hadoopConf} dfsadmin -safemode wait
+          HADOOP_USER_NAME=hdfs ${cfg.package}/bin/hdfs --config ${hadoopConf} dfs -mkdir -p ${cfg.hbase.rootdir}
+          HADOOP_USER_NAME=hdfs ${cfg.package}/bin/hdfs --config ${hadoopConf} dfs -chown hbase ${cfg.hbase.rootdir}
+        '';
+
+        serviceConfig = {
+          User = "hbase";
+          SyslogIdentifier = "hbase-master";
+          ExecStart = "${cfg.hbase.package}/bin/hbase --config ${hadoopConf} " +
+                      "master start";
+          Restart = "always";
+        };
+      };
+
+      services.hadoop.hbaseSiteInternal."hbase.rootdir" = cfg.hbase.rootdir;
+
+      networking.firewall.allowedTCPPorts = (mkIf cfg.hbase.master.openFirewall [
+        16000 16010
+      ]);
+
+    })
+
+    (mkIf cfg.hbase.regionServer.enable {
+      services.hadoop.gatewayRole = {
+        enable = true;
+        enableHbaseCli = mkDefault true;
+      };
+
+      systemd.services.hbase-regionserver = {
+        description = "HBase RegionServer";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          User = "hbase";
+          SyslogIdentifier = "hbase-regionserver";
+          ExecStart = "${cfg.hbase.package}/bin/hbase --config /etc/hadoop-conf/ " +
+                      "regionserver start";
+          Restart = "always";
+        };
+      };
+
+      services.hadoop.hbaseSiteInternal."hbase.rootdir" = cfg.hbase.rootdir;
+
+      networking = {
+        firewall.allowedTCPPorts = (mkIf cfg.hbase.regionServer.openFirewall [
+          16020 16030
+        ]);
+        hosts = mkIf cfg.hbase.regionServer.overrideHosts {
+          "127.0.0.2" = mkForce [ ];
+          "::1" = mkForce [ ];
+        };
+      };
+    })
+
+    (mkIf cfg.gatewayRole.enable {
+
+      environment.systemPackages = mkIf cfg.gatewayRole.enableHbaseCli [ cfg.hbase.package ];
+
+      services.hadoop.hbaseSiteInternal = with cfg.hbase; {
+        "hbase.zookeeper.quorum" = mkIfNotNull zookeeperQuorum;
+      };
+
+      users.users.hbase = {
+        description = "Hadoop HBase user";
+        group = "hadoop";
+        isSystemUser = true;
+      };
+    })
+  ];
+}

--- a/nixos/modules/services/cluster/hadoop/hbase.nix
+++ b/nixos/modules/services/cluster/hadoop/hbase.nix
@@ -9,11 +9,7 @@ in
 {
   options.services.hadoop = {
 
-    gatewayRole.enableHbaseCli = mkOption {
-      description = "Whether to enable HBase CLI tools";
-      default = false;
-      type = types.bool;
-    };
+    gatewayRole.enableHbaseCli = mkEnableOption "HBase CLI tools";
 
     hbaseSiteDefault = mkOption {
       default = {

--- a/nixos/modules/services/cluster/hadoop/hdfs.nix
+++ b/nixos/modules/services/cluster/hadoop/hdfs.nix
@@ -158,8 +158,8 @@ in
         50010 # datanode.address
         50020 # datanode.ipc.address
       ];
-      extraConfig.services.hadoop.hdfsSiteInternal."dfs.datanode.data.dir" = let d = cfg.hdfs.datanode.dataDirs; in
-        if (d!= null) then (concatMapStringsSep "," (x: "["+x.type+"]file://"+x.path) cfg.hdfs.datanode.dataDirs) else d;
+      extraConfig.services.hadoop.hdfsSiteInternal."dfs.datanode.data.dir" = mkIf (cfg.hdfs.datanode.dataDirs!= null)
+        (concatMapStringsSep "," (x: "["+x.type+"]file://"+x.path) cfg.hdfs.datanode.dataDirs);
     })
 
     (hadoopServiceConfig {

--- a/nixos/modules/services/cluster/hadoop/yarn.nix
+++ b/nixos/modules/services/cluster/hadoop/yarn.nix
@@ -178,18 +178,18 @@ in
 
       services.hadoop.gatewayRole.enable = true;
 
-      services.hadoop.yarnSiteInternal = with cfg.yarn.nodemanager; {
-        "yarn.nodemanager.local-dirs" = localDir;
+      services.hadoop.yarnSiteInternal = with cfg.yarn.nodemanager; mkMerge [ ({
+        "yarn.nodemanager.local-dirs" = mkIf (localDir!= null) (concatStringsSep "," localDir);
         "yarn.scheduler.maximum-allocation-vcores" = resource.maximumAllocationVCores;
         "yarn.scheduler.maximum-allocation-mb" = resource.maximumAllocationMB;
         "yarn.nodemanager.resource.cpu-vcores" = resource.cpuVCores;
         "yarn.nodemanager.resource.memory-mb" = resource.memoryMB;
-      } // mkIf useCGroups {
+      }) (mkIf useCGroups {
         "yarn.nodemanager.linux-container-executor.cgroups.hierarchy" = "/hadoop-yarn";
         "yarn.nodemanager.linux-container-executor.resources-handler.class" = "org.apache.hadoop.yarn.server.nodemanager.util.CgroupsLCEResourcesHandler";
         "yarn.nodemanager.linux-container-executor.cgroups.mount" = "true";
         "yarn.nodemanager.linux-container-executor.cgroups.mount-path" = "/run/wrappers/yarn-nodemanager/cgroup";
-      };
+      })];
 
       networking.firewall.allowedTCPPortRanges = [
         (mkIf (cfg.yarn.nodemanager.openFirewall) {from = 1024; to = 65535;})

--- a/nixos/modules/services/databases/hbase-standalone.nix
+++ b/nixos/modules/services/databases/hbase-standalone.nix
@@ -32,6 +32,10 @@ let
 
 in {
 
+  imports = [
+    (mkRenamedOptionModule [ "services" "hbase" ] [ "services" "hbase-standalone" ])
+  ];
+
   ###### interface
 
   options = {

--- a/nixos/modules/services/databases/hbase.nix
+++ b/nixos/modules/services/databases/hbase.nix
@@ -3,8 +3,8 @@
 with lib;
 
 let
-  cfg = config.services.hbase;
-  opt = options.services.hbase;
+  cfg = config.services.hbase-standalone;
+  opt = options.services.hbase-standalone;
 
   buildProperty = configAttr:
     (builtins.concatStringsSep "\n"
@@ -35,16 +35,12 @@ in {
   ###### interface
 
   options = {
+    services.hbase-standalone = {
 
-    services.hbase = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Whether to run HBase.
-        '';
-      };
+      enable = mkEnableOption ''
+        HBase master in standalone mode with embedded regionserver and zookeper.
+        Do not use this configuration for production nor for evaluating HBase performance.
+      '';
 
       package = mkOption {
         type = types.package;
@@ -108,12 +104,11 @@ in {
       };
 
     };
-
   };
 
   ###### implementation
 
-  config = mkIf config.services.hbase.enable {
+  config = mkIf cfg.enable {
 
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}' - ${cfg.user} ${cfg.group} - -"

--- a/nixos/tests/hadoop/default.nix
+++ b/nixos/tests/hadoop/default.nix
@@ -4,4 +4,5 @@
   all = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop.nix { inherit package; };
   hdfs = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hdfs.nix { inherit package; };
   yarn = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./yarn.nix { inherit package; };
+  hbase = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hbase.nix { inherit package; };
 }

--- a/nixos/tests/hadoop/hbase.nix
+++ b/nixos/tests/hadoop/hbase.nix
@@ -1,0 +1,84 @@
+# Test a minimal hbase cluster
+{ pkgs, ... }:
+import ../make-test-python.nix ({ hadoop ? pkgs.hadoop, hbase ? pkgs.hbase, ... }:
+with pkgs.lib;
+{
+  name = "hadoop-hbase";
+
+  nodes = let
+    coreSite = {
+      "fs.defaultFS" = "hdfs://namenode:8020";
+    };
+    defOpts = {
+      enable = true;
+      openFirewall = true;
+    };
+    zookeeperQuorum = "zookeeper";
+    in {
+    zookeeper = { ... }: {
+      services.zookeeper.enable = true;
+      networking.firewall.allowedTCPPorts = [ 2181 ];
+    };
+    namenode = { ... }: {
+      services.hadoop = {
+        hdfs = {
+          namenode = defOpts // { formatOnInit = true; };
+        };
+        inherit coreSite;
+      };
+    };
+    datanode = { ... }: {
+      virtualisation.diskSize = 8192;
+      services.hadoop = {
+        hdfs.datanode = defOpts;
+        inherit coreSite;
+      };
+    };
+
+    master = { ... }:{
+      services.hadoop = {
+        inherit coreSite;
+        hbase = {
+          inherit zookeeperQuorum;
+          master = defOpts // { initHDFS = true; };
+        };
+      };
+    };
+    regionserver = { ... }:{
+      services.hadoop = {
+        inherit coreSite;
+        hbase = {
+          inherit zookeeperQuorum;
+          regionServer = defOpts;
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    # wait for HDFS cluster
+    namenode.wait_for_unit("hdfs-namenode")
+    namenode.wait_for_unit("network.target")
+    namenode.wait_for_open_port(8020)
+    namenode.wait_for_open_port(9870)
+    datanode.wait_for_unit("hdfs-datanode")
+    datanode.wait_for_unit("network.target")
+    datanode.wait_for_open_port(9864)
+    datanode.wait_for_open_port(9866)
+    datanode.wait_for_open_port(9867)
+
+    # wait for ZK
+    zookeeper.wait_for_unit("zookeeper")
+    zookeeper.wait_for_open_port(2181)
+
+    # wait for HBase to start up
+    master.wait_for_unit("hbase-master")
+    regionserver.wait_for_unit("hbase-regionserver")
+
+    assert "1 active master, 0 backup masters, 1 servers" in master.succeed("echo status | HADOOP_USER_NAME=hbase hbase shell -n")
+    regionserver.wait_until_succeeds("echo \"create 't1','f1'\" | HADOOP_USER_NAME=hbase hbase shell -n")
+    assert "NAME => 'f1'" in regionserver.succeed("echo \"describe 't1'\" | HADOOP_USER_NAME=hbase hbase shell -n")
+  '';
+})

--- a/nixos/tests/hadoop/hbase.nix
+++ b/nixos/tests/hadoop/hbase.nix
@@ -14,7 +14,7 @@ with pkgs.lib;
       openFirewall = true;
     };
     zookeeperQuorum = "zookeeper";
-    in {
+  in {
     zookeeper = { ... }: {
       services.zookeeper.enable = true;
       networking.firewall.allowedTCPPorts = [ 2181 ];

--- a/nixos/tests/hadoop/yarn.nix
+++ b/nixos/tests/hadoop/yarn.nix
@@ -19,7 +19,7 @@ import ../make-test-python.nix ({ package, ... }: {
           enable = true;
           openFirewall = true;
         };
-        yarnSite = options.services.hadoop.yarnSite.default // {
+        yarnSite = {
           "yarn.resourcemanager.hostname" = "resourcemanager";
           "yarn.nodemanager.log-dirs" = "/tmp/userlogs";
         };

--- a/nixos/tests/hbase.nix
+++ b/nixos/tests/hbase.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, lib, package ? pkgs.hbase, ... }:
 {
-  name = "hbase";
+  name = "hbase-standalone";
 
   meta = with lib.maintainers; {
     maintainers = [ illustris ];
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, lib, package ? pkgs.hbase, ... }:
 
   nodes = {
     hbase = { pkgs, ... }: {
-      services.hbase = {
+      services.hbase-standalone = {
         enable = true;
         inherit package;
         # Needed for standalone mode in hbase 2+

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -51,7 +51,8 @@ let
           makeWrapper "$n" "$out/bin/$(basename $n)"\
             --set-default JAVA_HOME ${jdk.home}\
             --set-default HADOOP_HOME $out/lib/${untarDir}\
-            --set-default HADOOP_CONF_DIR /etc/hadoop-conf/\
+            --run "test -d /etc/hadoop-conf && export HADOOP_CONF_DIR=\''${HADOOP_CONF_DIR-'/etc/hadoop-conf/'}"\
+            --set-default HADOOP_CONF_DIR $out/lib/${untarDir}/etc/hadoop/\
             --prefix PATH : "${makeBinPath [ bash coreutils which]}"\
             --prefix JAVA_LIBRARY_PATH : "${makeLibraryPath buildInputs}"
         done

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -26,13 +26,13 @@ with lib;
 assert elem stdenv.system [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
 
 let
-  common = { pname, versions, untarDir ? "${pname}-${version}", hash, jdk, openssl ? null, nativeLibs ? [ ], libPatches ? "", tests }:
+  common = { pname, platformAttrs, untarDir ? "${pname}-${version}", jdk, openssl ? null, nativeLibs ? [ ], libPatches ? "", tests }:
     stdenv.mkDerivation rec {
       inherit pname jdk libPatches untarDir openssl;
-      version = versions.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+      version = platformAttrs.${stdenv.system}.version or (throw "Unsupported system: ${stdenv.system}");
       src = fetchurl {
         url = "mirror://apache/hadoop/common/hadoop-${version}/hadoop-${version}" + optionalString stdenv.isAarch64 "-aarch64" + ".tar.gz";
-        hash = hash.${stdenv.system};
+        inherit (platformAttrs.${stdenv.system}) hash;
       };
       doCheck = true;
 
@@ -63,7 +63,7 @@ let
 
       passthru = { inherit tests; };
 
-      meta = {
+      meta = recursiveUpdate {
         homepage = "https://hadoop.apache.org/";
         description = "Framework for distributed processing of large data sets across clusters of computers";
         license = licenses.asl20;
@@ -81,8 +81,8 @@ let
           computers, each of which may be prone to failures.
         '';
         maintainers = with maintainers; [ illustris ];
-        platforms = attrNames hash;
-      };
+        platforms = attrNames platformAttrs;
+      } (attrByPath [ stdenv.system "meta" ] {} platformAttrs);
     };
 in
 {
@@ -90,19 +90,20 @@ in
   # https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Java+Versions
   hadoop_3_3 = common rec {
     pname = "hadoop";
-    versions = rec {
-      x86_64-linux = "3.3.3";
-      x86_64-darwin = x86_64-linux;
-      aarch64-linux = "3.3.1";
-      aarch64-darwin = aarch64-linux;
+    platformAttrs = rec {
+        x86_64-linux = {
+          version = "3.3.3";
+          hash = "sha256-+nHGG7qkJxKa7wn+wCizTdVCxlrZD9zOxefvk9g7h2Q=";
+        };
+        x86_64-darwin = x86_64-linux;
+        aarch64-linux = {
+          version = "3.3.1";
+          hash = "sha256-v1Om2pk0wsgKBghRD2wgTSHJoKd3jkm1wPKAeDcKlgI=";
+          meta.knownVulnerabilities = [ "CVE-2021-37404" "CVE-2021-33036" ];
+        };
+        aarch64-darwin = aarch64-linux;
     };
-    untarDir = "${pname}-${version}";
-    hash = rec {
-      x86_64-linux = "sha256-+nHGG7qkJxKa7wn+wCizTdVCxlrZD9zOxefvk9g7h2Q=";
-      x86_64-darwin = x86_64-linux;
-      aarch64-linux = "sha256-v1Om2pk0wsgKBghRD2wgTSHJoKd3jkm1wPKAeDcKlgI=";
-      aarch64-darwin = aarch64-linux;
-    };
+    untarDir = "${pname}-${platformAttrs.${stdenv.system}.version}";
     jdk = jdk11_headless;
     inherit openssl;
     # TODO: Package and add Intel Storage Acceleration Library
@@ -123,8 +124,10 @@ in
   };
   hadoop_3_2 = common rec {
     pname = "hadoop";
-    versions.x86_64-linux = "3.2.3";
-    hash.x86_64-linux = "sha256-Q2/a1LcKutpJoGySB0qlCcYE2bvC/HoG/dp9nBikuNU=";
+    platformAttrs.x86_64-linux = {
+      version = "3.2.3";
+      hash = "sha256-Q2/a1LcKutpJoGySB0qlCcYE2bvC/HoG/dp9nBikuNU=";
+    };
     jdk = jdk8_headless;
     # not using native libs because of broken openssl_1_0_2 dependency
     # can be manually overriden
@@ -132,8 +135,10 @@ in
   };
   hadoop2 = common rec {
     pname = "hadoop";
-    versions.x86_64-linux = "2.10.2";
-    hash.x86_64-linux = "sha256-xhA4zxqIRGNhIeBnJO9dLKf/gx/Bq+uIyyZwsIafEyo=";
+    platformAttrs.x86_64-linux = {
+      version = "2.10.2";
+      hash = "sha256-xhA4zxqIRGNhIeBnJO9dLKf/gx/Bq+uIyyZwsIafEyo=";
+    };
     jdk = jdk8_headless;
     tests = nixosTests.hadoop2;
   };

--- a/pkgs/servers/hbase/default.nix
+++ b/pkgs/servers/hbase/default.nix
@@ -21,7 +21,9 @@ let common = { version, hash, jdk ? jdk11_headless, tests }:
     installPhase = ''
       mkdir -p $out
       cp -R * $out
-      wrapProgram $out/bin/hbase --set-default JAVA_HOME ${jdk.home}
+      wrapProgram $out/bin/hbase --set-default JAVA_HOME ${jdk.home} \
+        --run "test -d /etc/hadoop-conf && export HBASE_CONF_DIR=\''${HBASE_CONF_DIR-'/etc/hadoop-conf/'}" \
+        --set-default HBASE_CONF_DIR "$out/conf/"
     '';
 
     passthru = { inherit tests; };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Init Hbase submodule and tests for Hadoop
- allow easier overriding of conf dir env variables for Hadoop and HBase
- cleanup and minor bugfixes for Hadoop

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
