### PR TITLE
arrow-cpp: add cuda support

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -231,8 +231,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     "-DCMAKE_SKIP_BUILD_RPATH=OFF" # needed for tests
     "-DCMAKE_INSTALL_RPATH=@loader_path/../lib" # needed for tools executables
-  ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF"
-  ++ lib.optional enableS3 "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp}/include/aws/core/Aws.h";
+  ] ++ lib.optionals (!stdenv.isx86_64) [ "-DARROW_USE_SIMD=OFF" ]
+  ++ lib.optionals enableS3 [ "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp}/include/aws/core/Aws.h" ];
 
   doInstallCheck = true;
   ARROW_TEST_DATA = lib.optionalString doInstallCheck "${arrow-testing}/data";
@@ -255,7 +255,7 @@ stdenv.mkDerivation rec {
       ];
     in
     lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
-  installCheckInputs = [ perl which sqlite ] ++ lib.optional enableS3 minio;
+  installCheckInputs = [ perl which sqlite ] ++ lib.optionals enableS3 [ minio ];
 
   postBuild = lib.optionalString (doInstallCheck && cudaSupport) ''
     for file in ./*/arrow-{cuda,flight}-test ./*/plasma-*-tests; do

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -11,6 +11,7 @@
 , fsspec
 , hypothesis
 , numpy
+, numba
 , pandas
 , pytestCheckHook
 , pytest-lazy-fixture
@@ -35,7 +36,8 @@ buildPythonPackage rec {
   sourceRoot = "apache-arrow-${version}/python";
 
   nativeBuildInputs = [ cmake cython pkg-config setuptools-scm ];
-  propagatedBuildInputs = [ numpy six cloudpickle scipy fsspec cffi ];
+  propagatedBuildInputs = [ numpy six cloudpickle scipy fsspec cffi ]
+    ++ lib.optionals _arrow-cpp.cudaSupport [ numba ];
   checkInputs = [
     hypothesis
     pandas
@@ -45,6 +47,7 @@ buildPythonPackage rec {
 
   PYARROW_BUILD_TYPE = "release";
 
+  PYARROW_WITH_CUDA = zero_or_one _arrow-cpp.cudaSupport;
   PYARROW_WITH_DATASET = zero_or_one true;
   PYARROW_WITH_FLIGHT = zero_or_one _arrow-cpp.enableFlight;
   PYARROW_WITH_HDFS = zero_or_one true;


### PR DESCRIPTION
- arrow-cpp: add cuda support
- python3Packages.pyarrow: add cuda support

###### Description of changes

This PR adds optional cuda support for `arrow-cpp` and
`python3Packages.pyarrow`.

It depends on #171874.

Because the sandbox requires an option `extra-sandbox-paths` set correctly to
run the tests (and a GPU of course) and because a few cuda-unrelated tests appear
to link transitively to libcuda, we can't run any tests that link to libcuda during
build. See https://github.com/NixOS/nix/issues/4489 for details.

I successfully performed some rudimentary operations with `pyarrow` and things appear
to be working:

Fire up `ipython` from a shell:

```
nix-shell -p '((import ./. {}).python3.withPackages(p: with p; [ pyarrow pandas numpy ipython ]))' --run ipython
```

Then, in `ipython`:

```
In [1]: import pyarrow as pa, pyarrow.cuda as cu, pandas as pd, numpy as np

In [2]: df = pd.DataFrame(dict(a=list("aabbc"), b=[1, 2, 3, 4, 5]))

In [3]: t = pa.Table.from_pandas(df)

In [4]: ctx = cu.Context()

In [5]: batch, = t.to_batches()

In [6]: buf = cu.serialize_record_batch(batch, ctx)

In [7]: buf
Out[7]: <pyarrow._cuda.CudaBuffer at 0x7fb1135a8040>

In [8]: buf.to_numba()
Out[8]: <numba.cuda.cudadrv.driver.MemoryPointer at 0x7faff1c95730>

In [9]: num = buf.to_numba()

In [10]: num.context.device
Out[10]: <numba.cuda.cudadrv.devices._DeviceContextManager at 0x7faff1c95640>

In [11]: num.context.device.name
Out[11]: b'NVIDIA GeForce RTX 2080 SUPER'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
