### PR TITLE
Add `lmathx` and `lmpfrlib` Lua packages

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -22,6 +22,7 @@ ldoc,https://github.com/stevedonovan/LDoc.git,,,,,
 lgi,,,,,,
 linenoise,https://github.com/hoelzro/lua-linenoise.git,,,,,
 ljsyscall,,,,,lua5_1,lblasc
+lmathx,,,,,lua5_3,alexshpilkin
 lpeg,,,,,,vyp
 lpeg_patterns,,,,,,
 lpeglabel,,,,,,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -23,6 +23,7 @@ lgi,,,,,,
 linenoise,https://github.com/hoelzro/lua-linenoise.git,,,,,
 ljsyscall,,,,,lua5_1,lblasc
 lmathx,,,,,lua5_3,alexshpilkin
+lmpfrlib,,,,,lua5_3,alexshpilkin
 lpeg,,,,,,vyp
 lpeg_patterns,,,,,,
 lpeglabel,,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -659,6 +659,31 @@ buildLuarocksPackage {
   };
 }) {};
 
+lmathx = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
+  pname = "lmathx";
+  version = "20150624-1";
+  knownRockspec = (fetchurl {
+    url    = "https://luarocks.org/lmathx-20150624-1.rockspec";
+    sha256 = "181wzsj1mxjyia43y8zwaydxahnl7a70qzcgc8jhhgic7jyi9pgv";
+  }).outPath;
+  src = fetchurl {
+    url    = "http://www.tecgraf.puc-rio.br/~lhf/ftp/lua/5.3/lmathx.tar.gz";
+    sha256 = "1r0ax3lq4xx6469aqc6qlfl3jynlghzhl5j65mpdj0kyzv4nknzf";
+  };
+
+  propagatedBuildInputs = [ lua ];
+
+  meta = {
+    homepage = "http://www.tecgraf.puc-rio.br/~lhf/ftp/lua/#lmathx";
+    description = "C99 extensions for the math library";
+    maintainers = with lib.maintainers; [ alexshpilkin ];
+    license.fullName = "Public domain";
+  };
+}) {};
+
 lpeg = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
 , fetchurl, lua
 }:

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -684,6 +684,32 @@ buildLuarocksPackage {
   };
 }) {};
 
+lmpfrlib = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
+  pname = "lmpfrlib";
+  version = "20170112-2";
+  knownRockspec = (fetchurl {
+    url    = "https://luarocks.org/lmpfrlib-20170112-2.rockspec";
+    sha256 = "1x7qiwmk5b9fi87fn7yvivdsis8h9fk9r3ipqiry5ahx72vzdm7d";
+  }).outPath;
+  src = fetchurl {
+    url    = "http://www.circuitwizard.de/lmpfrlib/lmpfrlib.c";
+    sha256 = "00d32cwvk298k3vyrjkdmfjgc69x1fwyks3hs7dqr2514zdhgssm";
+  };
+
+  disabled = with lua; (luaOlder "5.3") || (luaAtLeast "5.5");
+  propagatedBuildInputs = [ lua ];
+
+  meta = {
+    homepage = "http://www.circuitwizard.de/lmpfrlib/lmpfrlib.html";
+    description = "Lua API for the GNU MPFR library";
+    maintainers = with lib.maintainers; [ alexshpilkin ];
+    license.fullName = "LGPL";
+  };
+}) {};
+
 lpeg = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
 , fetchurl, lua
 }:

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -129,6 +129,38 @@ with prev;
     '';
   });
 
+  lmathx = prev.lib.overrideLuarocks prev.lmathx (drv:
+    if luaAtLeast "5.1" && luaOlder "5.2" then {
+      version = "20120430.51-1";
+      knownRockspec = (pkgs.fetchurl {
+        url    = "https://luarocks.org/lmathx-20120430.51-1.rockspec";
+        sha256 = "148vbv2g3z5si2db7rqg5bdily7m4sjyh9w6r3jnx3csvfaxyhp0";
+      }).outPath;
+      src = pkgs.fetchurl {
+        url    = "https://web.tecgraf.puc-rio.br/~lhf/ftp/lua/5.1/lmathx.tar.gz";
+        sha256 = "0sa553d0zlxhvpsmr4r7d841f16yq4wr3fg7i07ibxkz6yzxax51";
+      };
+    } else
+    if luaAtLeast "5.2" && luaOlder "5.3" then {
+      version = "20120430.52-1";
+      knownRockspec = (pkgs.fetchurl {
+        url    = "https://luarocks.org/lmathx-20120430.52-1.rockspec";
+        sha256 = "14rd625sipakm72wg6xqsbbglaxyjba9nsajsfyvhg0sz8qjgdya";
+      }).outPath;
+      src = pkgs.fetchurl {
+        url    = "http://www.tecgraf.puc-rio.br/~lhf/ftp/lua/5.2/lmathx.tar.gz";
+        sha256 = "19dwa4z266l2njgi6fbq9rak4rmx2fsx1s0p9sl166ar3mnrdwz5";
+      };
+    } else
+    {
+      disabled = luaOlder "5.1" || luaAtLeast "5.5";
+      # works fine with 5.4 as well
+      postConfigure = ''
+        substituteInPlace ''${rockspecFilename} \
+          --replace 'lua ~> 5.3' 'lua >= 5.3, < 5.5'
+      '';
+    });
+
   lrexlib-gnu = prev.lib.overrideLuarocks prev.lrexlib-gnu (drv: {
     buildInputs = [
       pkgs.gnulib

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -161,6 +161,16 @@ with prev;
       '';
     });
 
+  lmpfrlib = prev.lib.overrideLuarocks prev.lmpfrlib (drv: {
+    externalDeps = [
+      { name = "GMP"; dep = pkgs.gmp; }
+      { name = "MPFR"; dep = pkgs.mpfr; }
+    ];
+    unpackPhase = ''
+      cp $src $(stripHash $src)
+    '';
+  });
+
   lrexlib-gnu = prev.lib.overrideLuarocks prev.lrexlib-gnu (drv: {
     buildInputs = [
       pkgs.gnulib


### PR DESCRIPTION
###### Description of changes

This adds two numerics-related Lua packages:

- [`lmathx`][1] by Luiz Henrique de Figueiredo, which exposes additional mathematics functions from libm;
- [`lmpfrlib`][2] by Hartmut Henkel, which provides a binding to the widely-used [GNU MPFR][3] mulitprecision floating point library.

One thing worthy of mention is that the `lmathx` upstream provides, and the LuaRocks repository describes, three separate and somewhat different tarballs for Lua 5.1 (thus also -JIT), 5.2, and 5.3. While I could extract the differences into patches, I thought it simpler to just select the appropriate definitions by hand depending on the version of luaPackages being evaluated. This results in a fairly unpleasant if-then-else ladder, though.

[1]: https://web.tecgraf.puc-rio.br/~lhf/ftp/lua/#lmathx
[2]: http://www.circuitwizard.de/lmpfrlib/lmpfrlib.html
[3]: https://www.mpfr.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - The interactive shell part is surprisingly useless when adding packages for several Luas at once, unfortunately, because only one can survive due to conflicts; thus for the interactive part I also entered the appropriate `nix shell --expr` incantations manually
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Lua modules, in this case
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
