### PR TITLE
Remove stdenv adapter cruft

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -149,25 +149,15 @@ rec {
   });
 
 
-  /* Return a modified stdenv that builds packages with GCC's coverage
-     instrumentation.  The coverage note files (*.gcno) are stored in
-     $out/.build, along with the source code of the package, to enable
-     programs like lcov to produce pretty-printed reports.
-  */
+  # remove after 22.05 and before 22.11
   addCoverageInstrumentation = stdenv:
+    builtins.trace "'addCoverageInstrumentation' adapter is deprecated and will be removed before 22.11"
     overrideInStdenv stdenv [ pkgs.enableGCOVInstrumentation pkgs.keepBuildTree ];
 
 
-  /* Replace the meta.maintainers field of a derivation.  This is useful
-     when you want to fork to update some packages without disturbing other
-     developers.
-
-     e.g.:  in all-packages.nix:
-
-     # remove all maintainers.
-     defaultStdenv = replaceMaintainersField allStdenvs.stdenv pkgs [];
-  */
+  # remove after 22.05 and before 22.11
   replaceMaintainersField = stdenv: pkgs: maintainers:
+    builtins.trace "'replaceMaintainersField' adapter is deprecated and will be removed before 22.11"
     stdenv.override (old: {
       mkDerivationFromStdenv = overrideMkDerivationResult (pkg:
         lib.recursiveUpdate pkg { meta.maintainers = maintainers; });
@@ -193,22 +183,9 @@ rec {
     });
 
 
-  /* Abort if the license predicate is not verified for a derivation
-     declared with mkDerivation.
-
-     One possible predicate to avoid all non-free packages can be achieved
-     with the following function:
-
-     isFree = license: with builtins;
-       if license == null then true
-       else if isList license then lib.all isFree license
-       else license != "non-free" && license != "unfree";
-
-     This adapter can be defined on the defaultStdenv definition.  You can
-     use it by patching the all-packages.nix file or by using the override
-     feature of ~/.config/nixpkgs/config.nix .
-  */
+  # remove after 22.05 and before 22.11
   validateLicenses = licensePred: stdenv:
+    builtins.trace "'validateLicenses' adapter is deprecated and will be removed before 22.11"
     stdenv.override (old: {
       mkDerivationFromStdenv = overrideMkDerivationResult (pkg:
         let


### PR DESCRIPTION
See commit msgs
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
