### PR TITLE
icloudpd: init at 1.7.2

### DIFF
--- a/pkgs/applications/misc/icloudpd/default.nix
+++ b/pkgs/applications/misc/icloudpd/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, click
+, piexif
+, pyicloud
+, python-dateutil
+, requests
+, schema
+, tqdm
+, pytestCheckHook
+, vcrpy
+, mock
+, freezegun
+}:
+
+buildPythonApplication rec {
+  pname = "icloudpd";
+  version = "1.7.2";
+
+  src = fetchFromGitHub {
+    owner = "icloud-photos-downloader";
+    repo = "icloud_photos_downloader";
+    rev = "v${version}";
+    sha256 = "aRF8M3w39CNjEvFGX3PgKQq3PxLUCLcVz+H/Q/t0YKk=";
+  };
+
+  propagatedBuildInputs = [
+    click
+    piexif
+    pyicloud
+    python-dateutil
+    requests
+    schema
+    tqdm
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    vcrpy
+    mock
+    freezegun
+  ];
+
+  postPatch = ''
+    # Unpin dependencies.
+    # Also unfork pyicloud https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/179
+    substituteInPlace requirements.txt \
+      --replace 'pyicloud_ipd==' 'pyicloud>=' \
+      --replace 'click==' 'click>=' \
+      --replace 'python_dateutil==' 'python_dateutil>=' \
+      --replace 'schema==' 'schema>=' \
+      --replace 'tqdm==' 'tqdm>='
+
+    # Use non-forked version.
+    sed -i 's/pyicloud_ipd/pyicloud/g' $(grep -lr pyicloud_ipd)
+
+    # Update API to classes renamed in 0.9.4
+    # https://github.com/picklepete/pyicloud/releases/tag/0.9.4
+    sed -i 's/PyiCloudAPIResponseError/PyiCloudAPIResponseException/g' $(grep -lr PyiCloudAPIResponseError)
+    sed -i 's/NoStoredPasswordAvailable/PyiCloudNoStoredPasswordAvailableException/g' $(grep -lr NoStoredPasswordAvailable)
+  '';
+
+  preCheck = ''
+    # Tests try to create ~/.pyicloud
+    export HOME="$(mktemp -d)"
+  '';
+
+  # Too broken.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Command-line tool to download photos and videos from iCloud";
+    homepage = "https://github.com/icloud-photos-downloader/icloud_photos_downloader";
+    changelog = "https://github.com/icloud-photos-downloader/icloud_photos_downloader/raw/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7032,6 +7032,8 @@ with pkgs;
 
   deco = callPackage ../applications/misc/deco { };
 
+  icloudpd = python3Packages.callPackage ../applications/misc/icloudpd { };
+
   icoutils = callPackage ../tools/graphics/icoutils { };
 
   idutils = callPackage ../tools/misc/idutils { };


### PR DESCRIPTION
###### Description of changes

iCloud Photos Downloader

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
