### PR TITLE
k3s: 1.23.5+k3s1 -> 1.23.6+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -46,17 +46,15 @@ with lib;
 # Those pieces of software we entirely ignore upstream's handling of, and just
 # make sure they're in the path if desired.
 let
-  k3sVersion = "1.23.5+k3s1";     # k3s git tag
-  k3sCommit = "313aaca547f030752788dce696fdf8c9568bc035"; # k3s git commit at the above version
-  k3sRepoSha256 = "0vk72609cyyh64irp14jp2zspnxw34jm710cbwgklx0ch6kiz88d";
-  k3sVendorSha256 = "sha256-d7kQsJi/eQbaTUDglp3gFpc5Im6CyD9coKeM3kMrbjI=";
-
-  k3sServerVendorSha256 = "sha256-E3USXNuXY0lzZH+t3O7BOQ8rKNNQ6avOMItgOEi1cEg=";
+  k3sVersion = "1.23.6+k3s1";     # k3s git tag
+  k3sCommit = "418c3fa858b69b12b9cefbcff0526f666a6236b9"; # k3s git commit at the above version
+  k3sRepoSha256 = "0fmw491dn5mpi058mr7sij51i5m4qg2grx30cnl3h2v4s0sdkx2i";
+  k3sVendorSha256 = "sha256-iHg5ySMaiSWXs98YGmxPwdZr4zdBIFma12dNEuf30Hs=";
 
   # taken from ./manifests/traefik.yaml, extracted from '.spec.chart' https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/download#L9
   # The 'patch' and 'minor' versions are currently hardcoded as single digits only, so ignore the trailing two digits. Weird, I know.
-  traefikChartVersion = "10.14.1";
-  traefikChartSha256 = "09a6cialx7nrh7nwi1gkkh8zcsasxcgb52dyx0r8bjq9ng29simj";
+  traefikChartVersion = "10.19.3";
+  traefikChartSha256 = "04zg5li957svgscdmkzmzjkwljaljyav68rzxmhakkwgav6q9058";
 
   # taken from ./scripts/version.sh VERSION_ROOT https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/version.sh#L47
   k3sRootVersion = "0.11.0";
@@ -68,8 +66,8 @@ let
 
   # taken from go.mod, the 'github.com/containerd/containerd' line
   # run `grep github.com/containerd/containerd go.mod | head -n1 | awk '{print $4}'`
-  containerdVersion = "1.5.10-k3s1";
-  containerdSha256 = "1ff2sfaqpjimq7w0lprci6ibyi6v65ap6b9sr6b0j12gqr2sqwa5";
+  containerdVersion = "1.5.11-k3s2";
+  containerdSha256 = "16132snvrg8r0vwm6c0lz0q6fx686s2ix53nm3aka9a83xs75vf2";
 
   # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
   criCtlVersion = "1.22.0-k3s1";
@@ -175,7 +173,7 @@ let
     version = k3sVersion;
 
     src = k3sRepo;
-    vendorSha256 = k3sServerVendorSha256;
+    vendorSha256 = k3sVendorSha256;
 
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libseccomp ];
@@ -223,7 +221,6 @@ buildGoModule rec {
   version = k3sVersion;
 
   src = k3sRepo;
-  proxyVendor = true;
   vendorSha256 = k3sVendorSha256;
 
   patches = [

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -81,19 +81,6 @@ setKV containerdSha256 ${CONTAINERD_SHA256}
 
 setKV criCtlVersion ${CRI_CTL_VERSION}
 
-setKV k3sServerVendorSha256 "0000000000000000000000000000000000000000000000000000"
-
-set +e
-K3S_SERVER_VENDOR_SHA256=$(nix-build ${NIXPKGS_ROOT} --no-out-link -A k3s 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
-set -e
-
-if [ -n "${K3S_SERVER_VENDOR_SHA256:-}" ]; then
-    setKV k3sServerVendorSha256 ${K3S_SERVER_VENDOR_SHA256}
-else
-    echo "Update failed. K3S_SERVER_VENDOR_SHA256 is empty."
-    exit 1
-fi
-
 set +e
 K3S_VENDOR_SHA256=$(nix-prefetch -I nixpkgs=${NIXPKGS_ROOT} "{ sha256 }: (import ${NIXPKGS_ROOT}. {}).k3s.go-modules.overrideAttrs (_: { vendorSha256 = sha256; })")
 set -e


### PR DESCRIPTION
###### Description of changes

This updates k3s.

This one's done by hand rather than via the update bot since the
upstream repo ended up in a state where `go mod download` didn't work,
and we had `proxyVendor` set (which causes a `go mod download`).

Deleting `proxyVendor` works now though, and I didn't actually fully
understand why it was needed before, so I've removed that. Which
unblocks the update.

The actual update was done via `./update.sh` after removing
`proxyVendor` and the `k3sServerVendorSha256` variables.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - `nix-build -A nixosTests.k3s-single-node-docker` and `nix-build -A nixosTests.k3s-single-node` both worked
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).