### PR TITLE
python310Packages.oscrypto: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/oscrypto/default.nix
+++ b/pkgs/development/python-modules/oscrypto/default.nix
@@ -1,24 +1,25 @@
 { lib
 , stdenv
-, buildPythonPackage
 , asn1crypto
-, fetchPypi
+, buildPythonPackage
+, fetchFromGitHub
 , openssl
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "oscrypto";
-  version = "1.2.1";
+  version = "1.3.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1546si2bdgkqnbvv4mw1hr4mhh6bq39d9z4wxgv1m7fq6miclb3x";
-  };
+  disabled = pythonOlder "3.7";
 
-  testSources = fetchPypi {
-    inherit version;
-    pname = "oscrypto_tests";
-    sha256 = "1ha68dsrbx6mlra44x0n81vscn17pajbl4yg7cqkk7mq1zfmjwks";
+  src = fetchFromGitHub {
+    owner = "wbond";
+    repo = pname;
+    rev = version;
+    hash = "sha256-CmDypmlc/kb6ONCUggjT1Iqd29xNSLRaGh5Hz36dvOw=";
   };
 
   propagatedBuildInputs = [
@@ -26,21 +27,26 @@ buildPythonPackage rec {
     openssl
   ];
 
-  preCheck = ''
-    tar -xf ${testSources}
-    mv oscrypto_tests-${version} tests
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-    # remove tests that require network
-    sed -e '/TLSTests/d' -e '/TrustListTests/d' -i tests/__init__.py
-  '';
-
-  pythonImportsCheck = [ "oscrypto" ];
+  pythonImportsCheck = [
+    "oscrypto"
+  ];
 
   doCheck = !stdenv.isDarwin;
+
+  disabledTests = [
+    # Tests require network access
+    "TLSTests"
+    "TrustListTests"
+  ];
 
   meta = with lib; {
     description = "Encryption library for Python";
     homepage = "https://github.com/wbond/oscrypto";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/wbond/oscrypto/blob/master/changelog.md#130

- switch to `pytestCheckHook`
- remove test module by using GitHub 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
