### PR TITLE
xnee: pull fix pending upstream inclusion for -fno-common toolchain s…

### DIFF
--- a/pkgs/tools/X11/xnee/default.nix
+++ b/pkgs/tools/X11/xnee/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, lib, stdenv, libX11, xorgproto, libXext, libXtst
+{ fetchurl, fetchpatch, lib, stdenv, libX11, xorgproto, libXext, libXtst
 , gtk2, libXi, pkg-config, texinfo }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,17 @@ stdenv.mkDerivation rec {
     sha256 = "04n2lac0vgpv8zsn7nmb50hf3qb56pmj90dmwnivg09gyrf1x92j";
   };
 
-  patchPhase =
+  patches = [
+    # Pull fix pending upstream inclusion for -fno-common
+    # toolchain support: https://savannah.gnu.org/bugs/?58810
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://savannah.gnu.org/bugs/download.php?file_id=49534";
+      sha256 = "04j2cjy2yaiigg31a6k01vw0fq19yj3zpriikkjcz9q4ab4m5gh2";
+    })
+  ];
+
+  postPatch =
     '' for i in `find cnee/test -name \*.sh`
        do
          sed -i "$i" -e's|/bin/bash|${stdenv.shell}|g ; s|/usr/bin/env bash|${stdenv.shell}|g'


### PR DESCRIPTION
…upport

Without the change build fails as:

    $ nix build -L --impure --expr 'with import ./. {}; xnee.overrideAttrs (oa: {   NIX_CFLAGS_COMPILE = (oa.NIX_CFLAGS_COMPILE or "") + "-fno-common"; })'
    ...
    ld: .libs/xnee_xinput.o:/build/xnee-3.19/libxnee/src/../include/libxnee/xnee_internal.h:117:
      multiple definition of `xnee_mode';

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
