### PR TITLE
xvkbd: 3.9 -> 4.1

### DIFF
--- a/pkgs/tools/X11/xvkbd/default.nix
+++ b/pkgs/tools/X11/xvkbd/default.nix
@@ -1,24 +1,27 @@
-{ lib, stdenv, fetchurl, imake, libXt, libXaw, libXtst
-, libXi, libXpm, xorgproto, gccmakedep, Xaw3d }:
+{ lib, stdenv, fetchurl, libXt, libXaw, libXtst
+, libXi, libXpm, pkg-config, xorgproto, Xaw3d }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "xvkbd";
-  version = "3.9";
+  version = "4.1";
   src = fetchurl {
-    url = "http://t-sato.in.coocan.jp/xvkbd/xvkbd-3.9.tar.gz";
-    sha256 = "17csj6x5zm3g67izfwhagkal1rbqzpw09lqmmlyrjy3vzgfkf75q";
+    url = "http://t-sato.in.coocan.jp/xvkbd/xvkbd-${version}.tar.gz";
+    sha256 = "1x5yldv9y99cw5hzzs73ygdn1z80zns9hz0baa355r711zghfbcm";
   };
 
-  nativeBuildInputs = [ imake gccmakedep ];
+  nativeBuildInputs = [ pkg-config ] ;
   buildInputs = [ libXt libXaw libXtst xorgproto libXi Xaw3d libXpm ];
-  installTargets = [ "install" "install.man" ];
+
   makeFlags = [
-    "BINDIR=${placeholder "out"}/bin"
-    "CONFDIR=${placeholder "out"}/etc/X11"
-    "LIBDIR=${placeholder "out"}/lib/X11"
-    "XAPPLOADDIR=${placeholder "out"}/etc/X11/app-defaults"
-    "MANPATH=${placeholder "out"}/man"
+    # avoid default libXt location
+    "appdefaultdir=${placeholder "out"}/share/X11/app-defaults"
+    "datarootdir=${placeholder "out"}/share"
   ];
+
+  preInstall = ''
+    # workaround absence of libXt in $DESTDIR location.
+    mkdir -p $out/share/X11
+  '';
 
   meta = with lib; {
     description = "Virtual keyboard for X window system";


### PR DESCRIPTION
Upstream moved from imake to autoconf.
Also fixes build against gcc-10 -fno-common.

Changes: http://t-sato.in.coocan.jp/xvkbd/ChangeLog

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
