### PR TITLE
bwa: pull upstream fix for -fno-common tollchains

### DIFF
--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, zlib }:
+{ lib, stdenv, fetchurl, fetchpatch, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "bwa";
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/bio-bwa/${pname}-${version}.tar.bz2";
     sha256 = "1zfhv2zg9v1icdlq4p9ssc8k01mca5d1bd87w71py2swfi74s6yy";
   };
+
+  patches = [
+    # Pull upstream patch for -fno-common toolchain support like upstream
+    # gcc-10: https://github.com/lh3/bwa/pull/267
+    (fetchpatch {
+      name  = "fno-common.patch";
+      url = "https://github.com/lh3/bwa/commit/2a1ae7b6f34a96ea25be007ac9d91e57e9d32284.patch";
+      sha256 = "1lihfxai6vcshv5vr3m7yhk833bdivkja3gld6ilwrc4z28f6wqy";
+    })
+  ];
 
   buildInputs = [ zlib ];
 


### PR DESCRIPTION
Without the change build fails on -fno-common toolchains like upstream
gcc-10 as:

    $ nix build -L --impure --expr 'with import ./. {}; bwa.overrideAttrs (oa: {   NIX_CFLAGS_COMPILE = (oa.NIX_CFLAGS_COMPILE or "") + "-fno-common"; })'
    ...
    ld: ./libbwa.a(rope.o):/build/bwa-0.7.17/rle.h:33:
      multiple definition of `rle_auxtab'; ./libbwa.a(bwtindex.o):/build/bwa-0.7.17/rle.h:33: first defined here
    ld: ./libbwa.a(rle.o):/build/bwa-0.7.17/rle.h:33:
      multiple definition of `rle_auxtab'; ./libbwa.a(bwtindex.o):/build/bwa-0.7.17/rle.h:33: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
