### PR TITLE
nixos/_1password{,-gui}: use a static gid

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -667,6 +667,27 @@ in
       # uid. Users and groups with the same name should have equal
       # uids and gids. Also, don't use gids above 399!
 
+      # For exceptional cases where you really need a gid above 399, leave a
+      # comment stating why.
+      #
+      # Also, avoid the following GID ranges:
+      #
+      #  1000 - 29999: user accounts (see ../config/update-users-groups.pl)
+      # 30000 - 31000: nixbld users (the upper limit is arbitrarily chosen)
+      # 61184 - 65519: systemd DynamicUser (see systemd.exec(5))
+      #         65535: the error return sentinel value when uid_t was 16 bits
+      #
+      # 100000 - 6653600: subgid allocated for user namespaces
+      #                   (see ../config/update-users-groups.pl)
+      #       4294967294: unauthenticated user in some NFS implementations
+      #       4294967295: error return sentinel value
+      #
+      # References:
+      # https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes
+
+      onepassword = 31001; # 1Password requires that its GID be larger than 1000
+      onepassword-cli = 31002; # 1Password requires that its GID be larger than 1000
+
       users = 100;
       nixbld = 30000;
       nogroup = 65534;

--- a/nixos/modules/programs/_1password-gui.nix
+++ b/nixos/modules/programs/_1password-gui.nix
@@ -8,18 +8,15 @@ let
 
 in
 {
+  imports = [
+    (mkRemovedOptionModule [ "programs" "_1password-gui" "gid" ] ''
+      A preallocated GID will be used instead.
+    '')
+  ];
+
   options = {
     programs._1password-gui = {
       enable = mkEnableOption "the 1Password GUI application";
-
-      gid = mkOption {
-        type = types.addCheck types.int (x: x >= 1000);
-        example = literalExpression "5000";
-        description = ''
-          The gid to assign to the onepassword group, which is needed for browser integration.
-          It must be 1000 or greater.
-        '';
-      };
 
       polkitPolicyOwners = mkOption {
         type = types.listOf types.str;
@@ -44,7 +41,7 @@ in
     in
     mkIf cfg.enable {
       environment.systemPackages = [ package ];
-      users.groups.onepassword.gid = cfg.gid;
+      users.groups.onepassword.gid = config.ids.gids.onepassword;
 
       security.wrappers = {
         "1Password-BrowserSupport" = {

--- a/nixos/modules/programs/_1password.nix
+++ b/nixos/modules/programs/_1password.nix
@@ -8,18 +8,15 @@ let
 
 in
 {
+  imports = [
+    (mkRemovedOptionModule [ "programs" "_1password" "gid" ] ''
+      A preallocated GID will be used instead.
+    '')
+  ];
+
   options = {
     programs._1password = {
       enable = mkEnableOption "the 1Password CLI tool";
-
-      gid = mkOption {
-        type = types.addCheck types.int (x: x >= 1000);
-        example = literalExpression "5001";
-        description = ''
-          The gid to assign to the onepassword-cli group, which is needed for integration with the 1Password GUI.
-          It must be 1000 or greater.
-        '';
-      };
 
       package = mkPackageOption pkgs "1Password CLI" {
         default = [ "_1password" ];
@@ -29,7 +26,7 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
-    users.groups.onepassword-cli.gid = cfg.gid;
+    users.groups.onepassword-cli.gid = config.ids.gids.onepassword-cli;
 
     security.wrappers = {
       "op" = {


### PR DESCRIPTION
###### Description of changes

The current 1Password module requires that users explicitly pick a GID for its setuid/setgid binaries. Looking at the original [PR](https://github.com/NixOS/nixpkgs/pull/165479), this seems to be because 1Password requires that the GID be greater than 1000 and NixOS has a policy stated in [ids.nix](https://github.com/NixOS/nixpkgs/blob/5656d7f92aa8264eb06ba68ad94c87ac5b5312e8/nixos/modules/misc/ids.nix#L662-L664) that disallows registering a static GID greater than 399.

However there are 2 problems with the current approach:

* There are certain GID ranges that should avoided. It would be better to centralize that knowledge in the NixOS code rather than requiring users to tiptoe through those pitfalls.
* Exposing the GID option in the module could lead to confusions. I initially wondered whether I needed to add my own user account to the `onepassword` group in order to use this module.

For these reasons, I think it's worth creating an exception to the stated policy.

As part of this change, I listed the GIDs that should be avoided when registering a new static GID in a code comment.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
