### PR TITLE
nixos/tests/boot: fix intermittent biosUsb failure

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -114,8 +114,15 @@ in {
       cdrom = "${iso}/iso/${iso.isoName}";
     };
 
-    biosUsb = makeBootTest "bios-usb" {
+    biosUsb = let
+      # disable the TSC timer to prevent https://github.com/NixOS/nixpkgs/issues/170803
+      seabiosNoTSC = pkgs.seabios.override {
+        csm = false;
+        tsc = false;
+      };
+    in makeBootTest "bios-usb" {
       usb = "${iso}/iso/${iso.isoName}";
+      bios = "${seabiosNoTSC}/bios.bin";
     };
 
     biosNetboot = makeNetbootTest "bios" {};


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/15690, fixes https://github.com/NixOS/nixpkgs/issues/104642, fixes https://github.com/NixOS/nixpkgs/issues/170803 🤞

Based on our observations in https://github.com/NixOS/nixpkgs/issues/170803, the issue doesn't seem to occur when using the ACPI PM timer instead of the TSC timer, so we use a patched seabios for the biosUsb test with `CONFIG_TSC_TIMER` disabled.

Note that the bug is reported upstream https://mail.coreboot.org/hyperkitty/list/seabios@seabios.org/thread/OUTHT5ISSQJGXPNTUPY3O5E5EPZJCHM3/