### PR TITLE
python310Packages.mysql-connector: 8.0.24 -> 8.0.29

### DIFF
--- a/pkgs/development/python-modules/mysql-connector/default.nix
+++ b/pkgs/development/python-modules/mysql-connector/default.nix
@@ -1,16 +1,24 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python }:
+{ lib
+, buildPythonPackage
+, django
+, dnspython
+, fetchFromGitHub
+, protobuf
+, pythonOlder
+}:
 
-let
-  py = python;
-in buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "mysql-connector";
-  version = "8.0.24";
+  version = "8.0.29";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "mysql";
     repo = "mysql-connector-python";
     rev = version;
-    sha256 = "1zb5wf65rnpbk0lw31i4piy0bq09hqa62gx7bh241zc5310zccc7";
+    hash = "sha256-X0qiXNYkNoR00ESUdByPj4dPnEnjLyopm25lm1JvkAk=";
   };
 
   patches = [
@@ -22,16 +30,19 @@ in buildPythonPackage rec {
     ./0001-Revert-Fix-MacOS-wheels-platform-tag.patch
   ];
 
-  propagatedBuildInputs = with py.pkgs; [ protobuf dnspython ];
+  propagatedBuildInputs = [
+    dnspython
+    protobuf
+  ];
 
-  # Tests are failing (TODO: unknown reason)
-  # TypeError: __init__() missing 1 required positional argument: 'string'
-  # But the library should be working as expected.
+  pythonImportsCheck = [
+    "mysql"
+  ];
+
+  # Tests require a running MySQL instance
   doCheck = false;
 
-  pythonImportsCheck = [ "mysql" ];
-
-  meta = {
+  meta = with lib; {
     description = "A MySQL driver";
     longDescription = ''
       A MySQL driver that does not depend on MySQL C client libraries and
@@ -39,7 +50,7 @@ in buildPythonPackage rec {
     '';
     homepage = "https://github.com/mysql/mysql-connector-python";
     changelog = "https://raw.githubusercontent.com/mysql/mysql-connector-python/${version}/CHANGES.txt";
-    license = [ lib.licenses.gpl2Only ];
-    maintainers = with lib.maintainers; [ neosimsim turion ];
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ neosimsim turion ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/mysql/mysql-connector-python/blob/master/CHANGES.txt
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
