### PR TITLE
powerdevil: drop ddcutil dependency

### DIFF
--- a/pkgs/desktops/plasma-5/powerdevil.nix
+++ b/pkgs/desktops/plasma-5/powerdevil.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules, kdoctools,
   bluez-qt, kactivities, kauth, kconfig, kdbusaddons,
   kglobalaccel, ki18n, kidletime, kio, knotifyconfig, kwayland, libkscreen,
-  ddcutil, networkmanager-qt, plasma-workspace, qtx11extras, solid, udev
+  networkmanager-qt, plasma-workspace, qtx11extras, solid, udev
 }:
 
 mkDerivation {
@@ -13,9 +13,5 @@ mkDerivation {
     kconfig kdbusaddons knotifyconfig solid udev bluez-qt kactivities kauth
     kglobalaccel ki18n kio kidletime kwayland libkscreen
     networkmanager-qt plasma-workspace qtx11extras
-    ddcutil
-  ];
-  cmakeFlags = [
-    "-DHAVE_DDCUTIL=On"
   ];
 }


### PR DESCRIPTION
###### Description of changes

This is kind of a weird one, because ddcutil is not _obviously broken_ from an end user perspective, but it is very broken conceptually, and it can lead to lots of interesting side effects. Basically, what ddcutil does is it tries to talk [DDC](https://en.wikipedia.org/wiki/Display_Data_Channel) to a display over an I2C bus. The problems with that are:

1. DDC is a legacy protocol that modern displays implement in increasingly broken ways.
2. Poking random I2C buses from userspace requires special permissions and can lead to [explosions](https://gitlab.freedesktop.org/drm/amd/-/issues/1470).
3. The ddcutil integration in Powerdevil is [very](https://github.com/rockowitz/ddcutil/issues/205), [very](https://github.com/rockowitz/ddcutil/issues/228) broken, [effectively unmaintained](https://invent.kde.org/plasma/powerdevil/-/commits/master/daemon/backends/upower/ddcutilbrightness.cpp) and even [upstream recommends not using it](https://invent.kde.org/plasma/powerdevil/-/blob/ce15edd227737f718e2f4474ae3ac2e0f6162beb/CMakeLists.txt#L80=).
4. Most modern GPU drivers expose native brightness controls in sysfs, which PowerDevil natively supports.

Might be release note worthy, but I decided to throw it out there first and see how people feel about it.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
