### PR TITLE
gtkdialog: pull gentoo patch for -fno-common toolchains

### DIFF
--- a/pkgs/development/tools/misc/gtkdialog/default.nix
+++ b/pkgs/development/tools/misc/gtkdialog/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, gtk2, pkg-config }:
+{lib, stdenv, fetchurl, fetchpatch, gtk2, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "gtkdialog";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/${pname}/${pname}-${version}.tar.gz";
     sha256 = "ff89d2d7f1e6488e5df5f895716ac1d4198c2467a2a5dc1f51ab408a2faec38e";
   };
+  patches = [
+    # Pull Gentoo patch for -fno-common toolchain fix.
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/x11-misc/gtkdialog/files/gtkdialog-0.8.3-fno-common.patch?id=98692e4c4ad494b88c4902ca1ab3e6541190bbe8";
+      sha256 = "1mh01krzpfy7lbbqx3xm71xsiqqgg67w4snv794wspfqkk2hicvz";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gtk2 ];


### PR DESCRIPTION
Without the change build fails on -fno-common toolchains like upstream
gcc-10:

    $ nix build -L --impure --expr 'with import ./. {}; gtkdialog.overrideAttrs (oa: {   NIX_CFLAGS_COMPILE = (oa.NIX_CFLAGS_COMPILE or []) ++ ["-fno-common"]; })'
    ...
    ld: widget_window.o:/build/gtkdialog-0.8.3/src/gtkdialog.h:43:
      multiple definition of `function_signals_block'; gtkdialog.o:/build/gtkdialog-0.8.3/src/gtkdialog.h:43: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
