### PR TITLE
strictDeps fixes and xcbutilerrors add dev output

### DIFF
--- a/pkgs/applications/window-managers/sway/bg.nix
+++ b/pkgs/applications/window-managers/sway/bg.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-Lt/hn/K+CjcmU3Bs5wChiZq0VGNcraH4tSVYsmYnKjc=";
   };
 
+  strictDeps = true;
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
   buildInputs = [ wayland wayland-protocols cairo gdk-pixbuf ];

--- a/pkgs/applications/window-managers/sway/contrib.nix
+++ b/pkgs/applications/window-managers/sway/contrib.nix
@@ -10,6 +10,7 @@
 , slurp
 , grim
 , jq
+, bash
 
 , python3Packages
 }:
@@ -27,8 +28,9 @@ grimshot = stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" ];
 
+  strictDeps = true;
   nativeBuildInputs = [ makeWrapper installShellFiles ];
-
+  buildInputs = [ bash ];
   installPhase = ''
     installManPage contrib/grimshot.1
 

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
     ./sway-config-nixos-paths.patch
   ];
 
+  strictDeps = true;
   depsBuildBuild = [
     pkg-config
   ];

--- a/pkgs/applications/window-managers/sway/idle.nix
+++ b/pkgs/applications/window-managers/sway/idle.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "06iq12p4438d6bv3jlqsf01wjaxrzlnj1bnicn41kad563aq41xl";
   };
 
+  strictDeps = true;
   nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
   buildInputs = [ wayland wayland-protocols ]
                 ++ lib.optionals systemdSupport [ systemd ];

--- a/pkgs/applications/window-managers/sway/lock-effects.nix
+++ b/pkgs/applications/window-managers/sway/lock-effects.nix
@@ -8,6 +8,7 @@
 , scdoc
 , wayland
 , wayland-protocols
+, wayland-scanner
 , libxkbcommon
 , cairo
 , gdk-pixbuf
@@ -36,7 +37,8 @@ stdenv.mkDerivation rec {
     sed -iE "s/version: '1\.3',/version: '${version}',/" meson.build
   '';
 
-  nativeBuildInputs = [ meson ninja pkg-config scdoc ];
+  strictDeps = true;
+  nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner];
   buildInputs = [ wayland wayland-protocols libxkbcommon cairo gdk-pixbuf pam ];
 
   mesonFlags = [

--- a/pkgs/applications/window-managers/sway/lock-fancy.nix
+++ b/pkgs/applications/window-managers/sway/lock-fancy.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, coreutils, grim, gawk, jq, swaylock
-, imagemagick, getopt, fontconfig, wmctrl, makeWrapper
+, imagemagick, getopt, fontconfig, wmctrl, makeWrapper, bash
 }:
 
 let
@@ -30,7 +30,9 @@ in stdenv.mkDerivation rec {
       --replace "/usr/share" "$out/share"
   '';
 
+  strictDeps = true;
   nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 

--- a/pkgs/applications/window-managers/sway/lock.nix
+++ b/pkgs/applications/window-managers/sway/lock.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , meson, ninja, pkg-config, scdoc, wayland-scanner
 , wayland, wayland-protocols, libxkbcommon, cairo, gdk-pixbuf, pam
 }:
@@ -14,6 +14,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VVGgidmSQWKxZNx9Cd6z52apxpxVfmX3Ut/G9kzfDcY=";
   };
 
+  patches = [
+    # remove once when updating to 1.7
+    # https://github.com/swaywm/swaylock/pull/235
+    (fetchpatch {
+      url = "https://github.com/swaywm/swaylock/commit/5a1e6ad79aa7d79b32d36cda39400f3e889b8f8f.diff";
+      sha256 = "sha256-ZcZVImUzvng7sluC6q2B5UL8sVunLe4PIfc+tyw48RQ=";
+    })
+  ];
+
+  strictDeps = true;
+  depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
   buildInputs = [ wayland wayland-protocols libxkbcommon cairo gdk-pixbuf pam ];
 

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -37,6 +37,7 @@ in symlinkJoin {
   paths = (optional withBaseWrapper baseWrapper)
     ++ [ sway ];
 
+  strictDeps = true;
   nativeBuildInputs = [ makeWrapper ]
     ++ (optional withGtkWrapper wrapGAppsHook);
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -351,6 +351,10 @@ self: super:
     outputs = [ "out" "dev" ];
   });
 
+  xcbutilerrors = super.xcbutilerrors.overrideAttrs (attrs: {
+    outputs = [ "out" "dev" ]; # mainly to get rid of propagating others
+  });
+
   xcbutilcursor = super.xcbutilcursor.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ];
     meta = attrs.meta // { maintainers = [ lib.maintainers.lovek323 ]; };


### PR DESCRIPTION
verified with https://github.com/Artturin/diffing/
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
