### PR TITLE
 waylandpp: 0.2.10 -> 1.0.0 

### DIFF
--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchFromGitHub
 , cmake
+, makeFontsConf
 , pkg-config
 , pugixml
 , wayland
@@ -32,10 +33,18 @@ stdenv.mkDerivation rec {
     "-DWAYLAND_SCANNERPP=${buildPackages.waylandpp}/bin/wayland-scanner++"
   ];
 
+  # Complains about not being able to find the fontconfig config file otherwise
+  FONTCONFIG_FILE = optional docSupport (makeFontsConf { fontDirectories = [ ]; });
+
   nativeBuildInputs = [ cmake pkg-config ] ++ optionals docSupport [ doxygen graphviz ];
   buildInputs = [ pugixml wayland libGL libffi ];
 
   outputs = [ "bin" "dev" "lib" "out" ] ++ optionals docSupport [ "doc" "devman" ];
+
+  # Resolves the warning "Fontconfig error: No writable cache directories"
+  preBuild = ''
+    export XDG_CACHE_HOME="$(mktemp -d)"
+  '';
 
   meta = with lib; {
     description = "Wayland C++ binding";

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -18,13 +18,13 @@ assert docSupport -> doxygen != null;
 with lib;
 stdenv.mkDerivation rec {
   pname = "waylandpp";
-  version = "0.2.10";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "NilsBrause";
     repo = pname;
     rev = version;
-    sha256 = "sha256-5/u6tp7/E4tjSfX+QJFmcUYdnyOgl9rB79PDE/SJH1o=";
+    hash = "sha256-Dw2RnLLyhykikHps1in+euHksO+ERbATbfmbUFOJklg=";
   };
 
   cmakeFlags = [

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -9,11 +9,9 @@
 , libffi
 , buildPackages
 , docSupport ? true
-, doxygen ? null
-, graphviz ? null
+, doxygen
+, graphviz
 }:
-
-assert docSupport -> doxygen != null;
 
 stdenv.mkDerivation rec {
   pname = "waylandpp";

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -15,7 +15,6 @@
 
 assert docSupport -> doxygen != null;
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "waylandpp";
   version = "1.0.0";
@@ -34,12 +33,12 @@ stdenv.mkDerivation rec {
   ];
 
   # Complains about not being able to find the fontconfig config file otherwise
-  FONTCONFIG_FILE = optional docSupport (makeFontsConf { fontDirectories = [ ]; });
+  FONTCONFIG_FILE = lib.optional docSupport (makeFontsConf { fontDirectories = [ ]; });
 
-  nativeBuildInputs = [ cmake pkg-config ] ++ optionals docSupport [ doxygen graphviz ];
+  nativeBuildInputs = [ cmake pkg-config ] ++ lib.optionals docSupport [ doxygen graphviz ];
   buildInputs = [ pugixml wayland libGL libffi ];
 
-  outputs = [ "bin" "dev" "lib" "out" ] ++ optionals docSupport [ "doc" "devman" ];
+  outputs = [ "bin" "dev" "lib" "out" ] ++ lib.optionals docSupport [ "doc" "devman" ];
 
   # Resolves the warning "Fontconfig error: No writable cache directories"
   preBuild = ''
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Wayland C++ binding";
     homepage = "https://github.com/NilsBrause/waylandpp/";
-    license = with licenses; [ bsd2 hpnd ];
-    maintainers = with maintainers; [ minijackson ];
+    license = with lib.licenses; [ bsd2 hpnd ];
+    maintainers = with lib.maintainers; [ minijackson ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Changes: https://github.com/NilsBrause/waylandpp/releases/tag/1.0.0

Despite the major version, there are only ABI breaking changes in this release. Since the reason for the major change is only for adding Wayland Server support, I don't think it warrants a release note entry.

The only reverse-dependency that I know of is kodi-wayland (confirmed by nix-review) and it seems to work fine.

Also some minor changes to silence the Fontconfig warnings in the build logs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
