### PR TITLE
add "check cherry-picks" github action

### DIFF
--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -1,0 +1,24 @@
+name: "Check cherry-picks"
+on:
+  pull_request_target:
+    branches:
+     - 'release-*'
+     - 'staging-*'
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'NixOS'
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        filter: blob:none
+    - name: Check cherry-picks
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        ./maintainers/scripts/check-cherry-picks.sh "$BASE_SHA" "$HEAD_SHA"

--- a/maintainers/scripts/check-cherry-picks.sh
+++ b/maintainers/scripts/check-cherry-picks.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Find alleged cherry-picks
+
+set -e
+
+if [ $# != "2" ] ; then
+  echo "usage: check-cherry-picks.sh base_rev head_rev"
+  exit 2
+fi
+
+PICKABLE_BRANCHES=${PICKABLE_BRANCHES:-master staging release-??.?? staging-??.??}
+problem=0
+
+while read new_commit_sha ; do
+  if [ "$GITHUB_ACTIONS" = 'true' ] ; then
+    echo "::group::Commit $new_commit_sha"
+  else
+    echo "================================================="
+  fi
+  git rev-list --max-count=1 --format=medium "$new_commit_sha"
+  echo "-------------------------------------------------"
+
+  original_commit_sha=$(
+    git rev-list --max-count=1 --format=format:%B "$new_commit_sha" \
+    | grep -Ei -m1 "cherry.*[0-9a-f]{40}" \
+    | grep -Eoi -m1 '[0-9a-f]{40}'
+  )
+  if [ "$?" != "0" ] ; then
+    echo "  ? Couldn't locate original commit hash in message"
+    [ "$GITHUB_ACTIONS" = 'true' ] && echo ::endgroup::
+    continue
+  fi
+
+  set -f # prevent pathname expansion of patterns
+  for branch_pattern in $PICKABLE_BRANCHES ; do
+    set +f # re-enable pathname expansion
+
+    while read -r picked_branch ; do
+      if git merge-base --is-ancestor "$original_commit_sha" "$picked_branch" ; then
+        echo "  ✔ $original_commit_sha present in branch $picked_branch"
+
+        range_diff_common='git range-diff
+          --no-notes
+          --creation-factor=100
+          '"$original_commit_sha~..$original_commit_sha"'
+          '"$new_commit_sha~..$new_commit_sha"'
+        '
+
+        if $range_diff_common --no-color | grep -E '^ {4}[+-]{2}' > /dev/null ; then
+          if [ "$GITHUB_ACTIONS" = 'true' ] ; then
+            echo ::endgroup::
+            echo -n "::warning ::"
+          else
+            echo -n "  ⚠ "
+          fi
+          echo "Difference between $new_commit_sha and original $original_commit_sha may warrant inspection:"
+
+          $range_diff_common --color
+
+          problem=1
+        else
+          echo "  ✔ $original_commit_sha highly similar to $new_commit_sha"
+          $range_diff_common --color
+          [ "$GITHUB_ACTIONS" = 'true' ] && echo ::endgroup::
+        fi
+
+        # move on to next commit
+        continue 3
+      fi
+    done <<< "$(
+      git for-each-ref \
+      --format="%(refname)" \
+      "refs/remotes/origin/$branch_pattern"
+    )"
+  done
+
+  if [ "$GITHUB_ACTIONS" = 'true' ] ; then
+    echo ::endgroup::
+    echo -n "::error ::"
+  else
+    echo -n "  ✘ "
+  fi
+  echo "$original_commit_sha not found in any pickable branch"
+
+  problem=1
+done <<< "$(
+  git rev-list \
+    -E -i --grep="cherry.*[0-9a-f]{40}" --reverse \
+    "$1..$2"
+)"
+
+exit $problem


### PR DESCRIPTION
###### Description of changes
The intention being to catch commits which declare themselves as cherry-picks, but either:

 - don't refer to a commit in the master or staging branches
 - are significantly altered from their original commit

Determining the latter is not an exact science, but the heuristic of looking for differences in only the added or removed lines seems to work quite well. Still, this should be considered an assistant for reviewers rather than a hard failure. Unfortunately github workflows don't have a way of raising a gentle warning instead of a failure. My real interest here is catching trojan horse commits, as I realized I'm a lot less thorough reviewing commits that are cherry-picks, and it would probably be a lot easier to slip something past a reviewer by claiming it to be a cherry-pick of something innocent.

An example run of this workflow is visible here https://github.com/risicle/nixpkgs/runs/6342603972?check_suite_focus=true where I ran it against a release-21.11 branch which I had made random cherry-picks (and phoney cherry-picks) to give it a bit of a torture test.

You'll see that the formatting of the output also leaves something to be desired due to the limitations of github actions' "group" commands. Ideally we'd be able to choose which groups (i.e. the ones containing problems) are initially expanded, but that's not possible. So the error output is printed _after_ a commit's "group". Ugly, I know, but the alternative leaves the reader to go digging for the issues in all the collapsed groups.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
