### PR TITLE
envoy: fix builds for x86_64-linux and aarch64-linux

### DIFF
--- a/pkgs/servers/http/envoy/bump-brotli.patch
+++ b/pkgs/servers/http/envoy/bump-brotli.patch
@@ -1,0 +1,15 @@
+diff --git a/bazel/repository_locations.bzl b/bazel/repository_locations.bzl
+index 454c54b0ef..2ac0623cf0 100644
+--- a/bazel/repository_locations.bzl
++++ b/bazel/repository_locations.bzl
+@@ -510,8 +510,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
+         project_url = "https://brotli.org",
+         # Use the dev branch of brotli to resolve compilation issues.
+         # TODO(rojkov): Remove when brotli > 1.0.9 is released.
+-        version = "0cd2e3926e95e7e2930f57ae3f4885508d462a25",
+-        sha256 = "93810780e60304b51f2c9645fe313a6e4640711063ed0b860cfa60999dd256c5",
++        version = "27dd7265403d8e8fed99a854b9c3e1db7d79525f",
++        sha256 = "e71238b12e30233bdf25997132b29ae49639a69f33fdef3ae18a47abfc0d5e4c",
+         strip_prefix = "brotli-{version}",
+         urls = ["https://github.com/google/brotli/archive/{version}.tar.gz"],
+         use_category = ["dataplane_ext"],

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -12,6 +12,9 @@
 , python3
 , linuxHeaders
 , nixosTests
+
+# v8 (upstream default), wavm, wamr, wasmtime, disabled
+, wasmRuntime ? "wamr"
 }:
 
 let
@@ -31,7 +34,7 @@ buildBazelPackage rec {
   src = fetchFromGitHub {
     owner = "envoyproxy";
     repo = "envoy";
-    inherit (srcVer) rev ;
+    inherit (srcVer) rev;
     hash = "sha256:11mm72zmb479ss585jzqzhklyyqmdadnvr91ghzvjxc0j2a1hrr4";
 
     extraPostFetch = ''
@@ -58,6 +61,13 @@ buildBazelPackage rec {
       url = "https://github.com/envoyproxy/envoy/commit/68448aae7a78a3123097b6ea96016b270457e7b8.patch";
       sha256 = "123kv3x37p8fgfp29jhw5xg5js5q5ipibs8hsm7gzfd5bcllnpfh";
     })
+
+    # fix issues with brotli and GCC 11.2.0+ (-Werror=vla-parameter)
+    ./bump-brotli.patch
+
+    # fix linux-aarch64 WAMR builds
+    # (upstream WAMR only detects aarch64 on Darwin, not Linux)
+    ./fix-aarch64-wamr.patch
   ];
 
   nativeBuildInputs = [
@@ -75,8 +85,8 @@ buildBazelPackage rec {
 
   fetchAttrs = {
     sha256 = {
-      x86_64-linux = "0f7mls2zrpjjvbz6pgkzrvr55bv05xn2l76j9i1r0cf367qqfkz8";
-      aarch64-linux = "1l3ls47z20xrw6x9qps5jm7vq50xb1acv9gczfdrj9hw6jybgwgg";
+      x86_64-linux = "0k2cna0vjzc8z7jvxdlcw741vacil8daczppv32bslw17af65vq6";
+      aarch64-linux = "1ijv4arw67nprykn2wkn4ji8fbr284mc7p74zxfsky772s42yy9j";
     }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;
@@ -128,6 +138,11 @@ buildBazelPackage rec {
     "--cxxopt=-Wno-maybe-uninitialized"
     "--cxxopt=-Wno-uninitialized"
     "--cxxopt=-Wno-error=type-limits"
+
+    "--define=wasm=${wasmRuntime}"
+  ];
+  bazelFetchFlags = [
+    "--define=wasm=${wasmRuntime}"
   ];
 
   passthru.tests = {

--- a/pkgs/servers/http/envoy/fix-aarch64-wamr.patch
+++ b/pkgs/servers/http/envoy/fix-aarch64-wamr.patch
@@ -1,0 +1,38 @@
+diff --git a/bazel/envoy_build_system.bzl b/bazel/envoy_build_system.bzl
+index f48ebe7056..1e5cc5d663 100644
+--- a/bazel/envoy_build_system.bzl
++++ b/bazel/envoy_build_system.bzl
+@@ -102,6 +102,7 @@ def envoy_cmake(
+         pdb_name = "",
+         cmake_files_dir = "$BUILD_TMPDIR/CMakeFiles",
+         generate_crosstool_file = False,
++        generate_args = [],
+         **kwargs):
+     cache_entries.update({"CMAKE_BUILD_TYPE": "Bazel"})
+     cache_entries_debug = dict(cache_entries)
+@@ -131,7 +132,7 @@ def envoy_cmake(
+             "@envoy//bazel:dbg_build": cache_entries_debug,
+             "//conditions:default": cache_entries,
+         }),
+-        generate_args = ["-GNinja"],
++        generate_args = ["-GNinja"] + generate_args,
+         targets = ["", "install"],
+         # TODO: Remove install target and make this work
+         install = False,
+diff --git a/bazel/foreign_cc/BUILD b/bazel/foreign_cc/BUILD
+index 4d3a281669..b4716dfe2e 100644
+--- a/bazel/foreign_cc/BUILD
++++ b/bazel/foreign_cc/BUILD
+@@ -394,6 +394,12 @@ envoy_cmake(
+         "WAMR_BUILD_LIBC_WASI": "0",
+         "WAMR_BUILD_TAIL_CALL": "1",
+     },
++    generate_args = select({
++        "//conditions:default": [],
++        "@platforms//cpu:aarch64": [
++            "-DWAMR_BUILD_TARGET=AARCH64",
++        ],
++    }),
+     lib_source = "@com_github_wamr//:all",
+     out_static_libs = ["libvmlib.a"],
+     tags = ["skip_on_windows"],


### PR DESCRIPTION
* Bumps brotli version to incorporate a fix for some GCC warnings which
  get promoted to errors.
* Switches from wee8 to WAMR because it's easier to make it build
  sensibly on a range of GCC versions that aren't just "whatever ships
  with Ubuntu LTS".
* Adds a patch for WAMR's build in Envoy because it won't build properly
  under Linux aarch64, since WAMR doesn't detect aarch64 unless it's on
  macOS.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
