### PR TITLE
python310Packages.ldaptor: adopt, use twisted.extras-require.tls, mark broken

### DIFF
--- a/pkgs/development/python-modules/ldaptor/default.nix
+++ b/pkgs/development/python-modules/ldaptor/default.nix
@@ -3,17 +3,18 @@
 , fetchPypi
 , twisted
 , passlib
-, pyopenssl
 , pyparsing
 , service-identity
+, six
 , zope_interface
-, isPy3k
+, pythonOlder
 , python
 }:
 
 buildPythonPackage rec {
   pname = "ldaptor";
   version = "21.2.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -21,18 +22,27 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    twisted passlib pyopenssl pyparsing service-identity zope_interface
+    passlib
+    pyparsing
+    six
+    twisted
+    zope_interface
+  ] ++ twisted.extras-require.tls;
+
+  checkInputs = [
+    twisted
   ];
 
-  disabled = !isPy3k;
-
   checkPhase = ''
-    ${python.interpreter} -m twisted.trial ldaptor
+    trial -j$NIX_BUILD_CORES ldaptor
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A Pure-Python Twisted library for LDAP";
     homepage = "https://github.com/twisted/ldaptor";
-    license = lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+    # tests hang or fail with "no space left on device"
+    broken = true;
   };
 }


### PR DESCRIPTION


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
