### PR TITLE
salt: 3004.1 - bugfixes

### DIFF
--- a/pkgs/tools/admin/salt/0001-Fix-Jinja2-3.1.0.patch
+++ b/pkgs/tools/admin/salt/0001-Fix-Jinja2-3.1.0.patch
@@ -1,0 +1,38 @@
+From 0a763a13ef55964395dff60283ececc16f957792 Mon Sep 17 00:00:00 2001
+From: Derek Kulinski <d@kulinski.us>
+Date: Sun, 8 May 2022 01:30:39 -0700
+Subject: [PATCH] Fix Jinja2 3.1.0
+
+---
+ salt/utils/jinja.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index 0cb70bf64a..322c2f7f46 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -25,10 +25,11 @@ import salt.utils.json
+ import salt.utils.stringutils
+ import salt.utils.url
+ import salt.utils.yaml
+-from jinja2 import BaseLoader, Markup, TemplateNotFound, nodes
++from jinja2 import BaseLoader, TemplateNotFound, nodes
+ from jinja2.environment import TemplateModule
+ from jinja2.exceptions import TemplateRuntimeError
+ from jinja2.ext import Extension
++from markupsafe import Markup
+ from salt.exceptions import TemplateError
+ from salt.utils.decorators.jinja import jinja_filter, jinja_global, jinja_test
+ from salt.utils.odict import OrderedDict
+@@ -706,7 +707,7 @@ def method_call(obj, f_name, *f_args, **f_kwargs):
+     return getattr(obj, f_name, lambda *args, **kwargs: None)(*f_args, **f_kwargs)
+ 
+ 
+-@jinja2.contextfunction
++@jinja2.pass_context
+ def show_full_context(ctx):
+     return salt.utils.data.simple_types_filter(
+         {key: value for key, value in ctx.items()}
+-- 
+2.35.1
+

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -57,6 +57,7 @@ python3.pkgs.buildPythonApplication rec {
     # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=259279
     # https://github.com/saltstack/salt/pull/61163
     substituteInPlace "requirements/zeromq.txt" \
+      --replace 'pyzmq<=20.0.0 ; python_version < "3.6"' "" \
       --replace 'pyzmq>=17.0.0,<22.0.0 ; python_version < "3.9"' 'pyzmq>=17.0.0 ; python_version < "3.9"' \
       --replace 'pyzmq>19.0.2,<22.0.0 ; python_version >= "3.9"' 'pyzmq>19.0.2 ; python_version >= "3.9"'
   '';

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -6,30 +6,16 @@
 , extraInputs ? []
 }:
 
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-      # Incompatible with pyzmq 22
-      pyzmq = super.pyzmq.overridePythonAttrs (oldAttrs: rec {
-        version = "21.0.2";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "CYwTxhmJE8KgaQI1+nTS5JFhdV9mtmO+rsiWUVVMx5w=";
-        };
-      });
-   };
-  };
-in
-py.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "salt";
   version = "3004.1";
 
-  src = py.pkgs.fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
     hash = "sha256-fzRKJDJkik8HjapazMaNzf/hCVzqE+wh5QQTVg8Ewpg=";
   };
 
-  propagatedBuildInputs = with py.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     distro
     jinja2
     markupsafe
@@ -39,17 +25,45 @@ py.pkgs.buildPythonApplication rec {
     pyyaml
     pyzmq
     requests
-    tornado
   ] ++ extraInputs;
 
-  patches = [ ./fix-libcrypto-loading.patch ];
+  patches = [
+    ./fix-libcrypto-loading.patch
+
+    # Bug in 3004.1: https://github.com/saltstack/salt/pull/61856
+    ./0001-Fix-Jinja2-3.1.0.patch
+  ];
 
   postPatch = ''
     substituteInPlace "salt/utils/rsax931.py" \
       --subst-var-by "libcrypto" "${lib.getLib openssl}/lib/libcrypto.so"
     substituteInPlace requirements/base.txt \
       --replace contextvars ""
+
+    # Don't require optional dependencies on Darwin, let's use
+    # `extraInputs` like on any other platform
+    echo -n > "requirements/darwin.txt"
+
+    # Bug in 3004.1: https://github.com/saltstack/salt/pull/61839
+    substituteInPlace "salt/utils/entrypoints.py" \
+      --replace 'if sys.version_info >= (3, 10):' 'if False:'
+
+    # Bug in 3004.1: https://github.com/saltstack/salt/issues/61865
+    substituteInPlace "salt/transport/tcp.py" \
+      --replace 'payload = self.pack_publish(package)' 'package = self.pack_publish(package)'
+
+    # 3004.1: requirement of pyzmq was restricted to <22.0.0; looks like that req was incorrect
+    # https://github.com/saltstack/salt/commit/070597e525bb7d56ffadede1aede325dfb1b73a4
+    # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=259279
+    # https://github.com/saltstack/salt/pull/61163
+    substituteInPlace requirements/zeromq.txt \
+      --replace 'pyzmq>=17.0.0,<22.0.0 ; python_version < "3.9"' 'pyzmq>=17.0.0 ; python_version < "3.9"'
+    substituteInPlace requirements/zeromq.txt \
+      --replace 'pyzmq>19.0.2,<22.0.0 ; python_version >= "3.9"' 'pyzmq>19.0.2 ; python_version >= "3.9"'
   '';
+
+  # Don't fix dependencies on Darwin
+  USE_STATIC_REQUIREMENTS = "0";
 
   # The tests fail due to socket path length limits at the very least;
   # possibly there are more issues but I didn't leave the test suite running

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -56,13 +56,12 @@ python3.pkgs.buildPythonApplication rec {
     # https://github.com/saltstack/salt/commit/070597e525bb7d56ffadede1aede325dfb1b73a4
     # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=259279
     # https://github.com/saltstack/salt/pull/61163
-    substituteInPlace requirements/zeromq.txt \
-      --replace 'pyzmq>=17.0.0,<22.0.0 ; python_version < "3.9"' 'pyzmq>=17.0.0 ; python_version < "3.9"'
-    substituteInPlace requirements/zeromq.txt \
+    substituteInPlace "requirements/zeromq.txt" \
+      --replace 'pyzmq>=17.0.0,<22.0.0 ; python_version < "3.9"' 'pyzmq>=17.0.0 ; python_version < "3.9"' \
       --replace 'pyzmq>19.0.2,<22.0.0 ; python_version >= "3.9"' 'pyzmq>19.0.2 ; python_version >= "3.9"'
   '';
 
-  # Don't fix dependencies on Darwin
+  # Don't use fixed dependencies on Darwin
   USE_STATIC_REQUIREMENTS = "0";
 
   # The tests fail due to socket path length limits at the very least;


### PR DESCRIPTION


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Contains following fixes:

- crashes with Jinja2 3.1.0 (in nixpkgs)
- crashes on Python 3.10+
- TCP transport broken
- doesn't build on Darwin
- doesn't work with pyzmq 22.3.0 (in nixpkgs)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
