### PR TITLE
ena: 2.5.0 -> 2.7.1 & nixos/amazon-image: default to 5.15 kernel 

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -37,12 +37,10 @@ in
       { assertion = cfg.efi -> cfg.hvm;
         message = "EC2 instances using EFI must be HVM instances.";
       }
-      { assertion = versionOlder config.boot.kernelPackages.kernel.version "5.15";
-        message = "ENA driver fails to build with kernel >= 5.15";
+      { assertion = versionOlder config.boot.kernelPackages.kernel.version "5.17";
+        message = "ENA driver fails to build with kernel >= 5.17";
       }
     ];
-
-    boot.kernelPackages = pkgs.linuxKernel.packages.linux_5_10;
 
     boot.growPartition = cfg.hvm;
 

--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
-  version = "2.5.0";
+  version = "2.7.1";
   name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
     rev = "ena_linux_${version}";
-    sha256 = "sha256-uOf/1624UtjaZtrk7XyQpeUGdTNVDnzZJZMgU86i+SM=";
+    sha256 = "sha256-JkGzmmsAmLvL9e+bg58H79GNHgsqydK/79VoWEq5/Mc=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.linux;
-    broken = kernel.kernelAtLeast "5.15";
+    broken = kernel.kernelAtLeast "5.17";
   };
 }


### PR DESCRIPTION
###### Description of changes

This bumps the ENA driver, and removes a change that overrode the default kernel for the amazon-image to 5.10. Since the default is 5.15 for nixos as a whole, and 5.15 now works, we can let the amazon-image use the default.

 This update is supposed to give us support for the 5.17 kernel according to the
 2.7.0 release notes here: https://github.com/amzn/amzn-drivers/releases/tag/ena_linux_2.7.0

 Unfortunately, in practice, it does not build with `linuxPackages_5_17`,
 so I left that marked as broken.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
    Manually tested this by booting an ec2 instance and `nixos-rebuild switch`ing through `linuxPackages_5_15` and `5_10` with this change pulled in. I verified the network kept working, including after a reboot, after each kernel version update.
    My methodology was basically to boot the default nixos ami and do `nix-channel --add "https://github.com/euank/nixpkgs/archive/856c922b33c5c3f7de6b55872887077ece431854.tar.gz" nixos && nix-channel --update`, and swap through each kernel version in `configuration.nix`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).