### PR TITLE
medusa: pull upstream fix for fno-common toolchains

### DIFF
--- a/pkgs/tools/security/medusa/default.nix
+++ b/pkgs/tools/security/medusa/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, freerdp, openssl, libssh2 }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, freerdp, openssl, libssh2 }:
 
 stdenv.mkDerivation rec {
   pname = "medusa-unstable";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "292193b3995444aede53ff873899640b08129fc7";
     sha256 = "0njlz4fqa0165wdmd5y8lfnafayf3c4la0r8pf3hixkdwsss1509";
   };
+
+  patches = [
+    # Pull upstream fix for -fno-common tollchains like gcc-10:
+    #  https://github.com/jmk-foofus/medusa/pull/36
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/jmk-foofus/medusa/commit/a667656ad085b3eb95309932666c250d97a92767.patch";
+      sha256 = "01marqqhjd3qwar3ymp50y1h2im5ilgpaxk7wrc2kcxgmzvbdfxc";
+    })
+  ];
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
Without the chanhe build fails on -fno-common tollchains as:

    $ nix build -L --impure --expr 'with import ./. {}; medusa.overrideAttrs (oa: {   NIX_CFLAGS_COMPILE = (["-fno-common"] ++ [oa.NIX_CFLAGS_COMPILE or ""]); })'
    ...
    ld: ../medusa-trace.o:/build/source/src/modsrc/../medusa.h:69:
      multiple definition of `iErrorLevel'; cvs.o:/build/source/src/modsrc/../medusa.h:69: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
