### PR TITLE
python3.pkgs.moku: init at 2.3

### DIFF
--- a/pkgs/development/python-modules/moku/default.nix
+++ b/pkgs/development/python-modules/moku/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, zeroconf
+, requests
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "moku";
+  version = "2.3";
+
+  /*
+
+  Pypi's webpage <https://pypi.org/project/moku/> lists
+  https://github.com/liquidinstruments/moku/archive/${version}.tar.gz as the
+  download link, but that repository doesn't exist from some reason :/. When
+  packaging this, I didn't find any mention of a git repo of the sources. Note
+  that the pymoku <https://github.com/liquidinstruments/pymoku> repo holds the
+  sources of the legacy API package.
+
+  */
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-EzVcECjJyrr2NLQkG0Yp/jYBMnsEP1/FnS5O3UplszI=";
+  };
+  /*
+
+  Note: If you run `moku download` and encounter the error:
+
+  [Errno 13] Permission denied: '/nix/store/.../lib/python 3.9/site-packages/moku/data'
+
+  Then use the $MOKU_DATA_PATH environment variable to control where the
+  downloaded files will go to. It is undocumented upstream and there's no
+  repository to contribute such documentation unfortunately. Also there is no
+  suitable default value for this on Nix systems, so there's no patch we can
+  apply locally to make the situation better.
+
+  */
+
+  propagatedBuildInputs = [
+    zeroconf
+    requests
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "moku"
+  ];
+
+  meta = with lib; {
+    description = "Python scripting interface to the Liquid Instruments Moku";
+    homepage = "https://apis.liquidinstruments.com/starting-python.html";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5337,6 +5337,8 @@ in {
 
   mohawk = callPackage ../development/python-modules/mohawk { };
 
+  moku = callPackage ../development/python-modules/moku { };
+
   monero = callPackage ../development/python-modules/monero { };
 
   mongomock = callPackage ../development/python-modules/mongomock { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
