### PR TITLE
Fix broken CMake-generated pkg-config files

### DIFF
--- a/pkgs/applications/misc/maliit-framework/default.nix
+++ b/pkgs/applications/misc/maliit-framework/default.nix
@@ -55,6 +55,24 @@ mkDerivation rec {
     wayland-protocols
   ];
 
+  # https://github.com/maliit/framework/issues/106
+  postPatch = ''
+    substituteInPlace common/maliit-framework.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace maliit-glib/maliit-glib.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace src/maliit-plugins.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_DATADIR@ @CMAKE_INSTALL_FULL_DATADIR@
+    substituteInPlace src/maliit-server.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_DATADIR@ @CMAKE_INSTALL_FULL_DATADIR@
+  '';
+
   preConfigure = ''
     cmakeFlags+="-DQT5_PLUGINS_INSTALL_DIR=$out/$qtPluginPrefix"
   '';

--- a/pkgs/applications/misc/maliit-framework/default.nix
+++ b/pkgs/applications/misc/maliit-framework/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , lib
 , fetchFromGitHub
+, fetchpatch
 
 , at-spi2-atk
 , at-spi2-core
@@ -32,6 +33,15 @@ mkDerivation rec {
     sha256 = "138jyvw130kmrldksbk4l38gvvahh3x51zi4vyplad0z5nxmbazb";
   };
 
+  # in master post 2.2.1, see https://github.com/maliit/framework/issues/106
+  patches = [
+    (fetchpatch {
+      name = "fix-pkg-config.patch";
+      url = "https://github.com/maliit/framework/commit/1e20a4a5113f1c092295f5a5f04ab6e584f6fcff.patch";
+      sha256 = "0h7jfqnqvjka626wx2z2g150rch4air7q3zbq59gcb12g7x6gfyn";
+    })
+  ];
+
   buildInputs = [
     at-spi2-atk
     at-spi2-core
@@ -54,24 +64,6 @@ mkDerivation rec {
     pkg-config
     wayland-protocols
   ];
-
-  # https://github.com/maliit/framework/issues/106
-  postPatch = ''
-    substituteInPlace common/maliit-framework.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-    substituteInPlace maliit-glib/maliit-glib.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-    substituteInPlace src/maliit-plugins.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_DATADIR@ @CMAKE_INSTALL_FULL_DATADIR@
-    substituteInPlace src/maliit-server.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_DATADIR@ @CMAKE_INSTALL_FULL_DATADIR@
-  '';
 
   preConfigure = ''
     cmakeFlags+="-DQT5_PLUGINS_INSTALL_DIR=$out/$qtPluginPrefix"

--- a/pkgs/applications/radio/openwebrx/default.nix
+++ b/pkgs/applications/radio/openwebrx/default.nix
@@ -47,6 +47,13 @@ let
       soapysdr-with-plugins
     ];
 
+    # https://github.com/jketterl/owrx_connector/issues/15
+    postPatch = ''
+      substituteInPlace src/lib/owrx-connector.pc.in \
+        --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+        --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    '';
+
     meta = with lib; {
       homepage = "https://github.com/jketterl/owrx_connector";
       description = "A set of connectors that are used by OpenWebRX to interface with SDR hardware";

--- a/pkgs/applications/radio/openwebrx/default.nix
+++ b/pkgs/applications/radio/openwebrx/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, buildPythonPackage, buildPythonApplication, fetchFromGitHub
-, pkg-config, cmake, setuptools
+, fetchpatch, pkg-config, cmake, setuptools
 , rtl-sdr, soapysdr-with-plugins, csdr, direwolf
 }:
 
@@ -42,17 +42,19 @@ let
       pkg-config
     ];
 
+    # in master post 0.5.0, see https://github.com/jketterl/owrx_connector/issues/15
+    patches = [
+      (fetchpatch {
+        name = "fix-pkg-config.patch";
+        url = "https://github.com/jketterl/owrx_connector/commit/d42ca00f3dc6870a460b9b91e6fab3c5ed171928.patch";
+        sha256 = "0rcss9djdn7agankn82vwnlacf16d2iqgwlr8iq3rgirzxsvp04p";
+      })
+    ];
+
     buildInputs = [
       rtl-sdr
       soapysdr-with-plugins
     ];
-
-    # https://github.com/jketterl/owrx_connector/issues/15
-    postPatch = ''
-      substituteInPlace src/lib/owrx-connector.pc.in \
-        --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-        --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-    '';
 
     meta = with lib; {
       homepage = "https://github.com/jketterl/owrx_connector";

--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -35,6 +35,13 @@ in stdenv.mkDerivation {
     "-DCMAKE_BUILD_TYPE=Release"
   ] ++ lib.optional usePython "-DUSE_PYTHON_CONFIG=ON";
 
+  # https://github.com/pothosware/SoapySDR/issues/352
+  postPatch = ''
+    substituteInPlace lib/SoapySDR.in.pc \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   postFixup = lib.optionalString (lib.length extraPackages != 0) ''
     # Join all plugins via symlinking
     for i in ${toString extraPackages}; do

--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , mkDerivation
+, fetchpatch
 , fetchFromGitHub
 , cmake
 , pkg-config
@@ -21,6 +22,14 @@ mkDerivation rec {
     rev = version;
     sha256 = "vzppKTDwADBG5pOaluT858cWCKFFRaSbHz2Qhe6799E=";
   };
+
+  patches = [
+    # https://github.com/lxqt/lxqt-build-tools/pull/76
+    (fetchpatch {
+      url = "https://github.com/lxqt/lxqt-build-tools/pull/76/commits/fa9672b671ede3f46b004f81580f9afb50fedf00.patch";
+      sha256 = "0dl7n1afcc6ky9vd9lpc65p9grpszpql7lfjq2vlzlilixnv8xv1";
+    })
+  ];
 
   postPatch = ''
     # Nix clang on darwin identifies as 'Clang', not 'AppleClang'

--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -24,8 +24,9 @@ mkDerivation rec {
   };
 
   patches = [
-    # https://github.com/lxqt/lxqt-build-tools/pull/76
+    # in master post 0.11.0, see https://github.com/lxqt/lxqt-build-tools/pull/76
     (fetchpatch {
+      name = "fix-pkg-config.patch";
       url = "https://github.com/lxqt/lxqt-build-tools/pull/76/commits/fa9672b671ede3f46b004f81580f9afb50fedf00.patch";
       sha256 = "0dl7n1afcc6ky9vd9lpc65p9grpszpql7lfjq2vlzlilixnv8xv1";
     })

--- a/pkgs/development/compilers/seexpr/default.nix
+++ b/pkgs/development/compilers/seexpr/default.nix
@@ -27,6 +27,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libGLU libpng zlib qt4 python3Packages.pyqt4 python3Packages.boost bison flex ];
 
+  # https://github.com/wdas/SeExpr/issues/106
+  postPatch = ''
+    substituteInPlace src/build/seexpr2.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description = "Embeddable expression evaluation engine from Disney Animation";
     homepage = "https://wdas.github.io/SeExpr/";

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -143,6 +143,16 @@ stdenv.mkDerivation rec {
     patchShebangs build-support/
     substituteInPlace "src/arrow/vendored/datetime/tz.cpp" \
       --replace 'discover_tz_dir();' '"${tzdata}/share/zoneinfo";'
+
+    # https://issues.apache.org/jira/browse/ARROW-16585
+    substituteInPlace src/parquet/parquet.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace src/plasma/plasma.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_BINDIR@ @CMAKE_INSTALL_FULL_BINDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+    substituteInPlace src/plasma/PlasmaConfig.cmake.in \
+      --replace @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@ @CMAKE_INSTALL_FULL_BINDIR@
   '';
 
   cmakeFlags = [

--- a/pkgs/development/libraries/audio/libkeyfinder/default.nix
+++ b/pkgs/development/libraries/audio/libkeyfinder/default.nix
@@ -22,6 +22,13 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  # https://github.com/mixxxdj/libkeyfinder/issues/21
+  postPatch = ''
+    substituteInPlace packaging/libkeyfinder.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "Musical key detection for digital audio (C++ library)";
     homepage = "https://mixxxdj.github.io/libkeyfinder/";

--- a/pkgs/development/libraries/audio/libkeyfinder/default.nix
+++ b/pkgs/development/libraries/audio/libkeyfinder/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fftw, catch2 }:
+{ lib, stdenv, fetchpatch, fetchFromGitHub, cmake, fftw, catch2 }:
 
 stdenv.mkDerivation rec {
   pname = "libkeyfinder";
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7w/Wc9ncLinbnM2q3yv5DBtFoJFAM2e9xAUTsqvE9mg=";
   };
 
+  # in main post 2.2.6, see https://github.com/mixxxdj/libkeyfinder/issues/21
+  patches = [
+    (fetchpatch {
+      name = "fix-pkg-config";
+      url = "https://github.com/mixxxdj/libkeyfinder/commit/4e1a5022d4c91e3ecfe9be5c3ac7cc488093bd2e.patch";
+      sha256 = "08llmgp6r11bq5s820j3fs9bgriaibkhq8r3v2av064w66mwp48x";
+    })
+  ];
+
   # needed for finding libkeyfinder.so to link it into keyfinder-tests executable
   cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
 
@@ -21,13 +30,6 @@ stdenv.mkDerivation rec {
   checkInputs = [ catch2 ];
 
   doCheck = true;
-
-  # https://github.com/mixxxdj/libkeyfinder/issues/21
-  postPatch = ''
-    substituteInPlace packaging/libkeyfinder.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-  '';
 
   meta = with lib; {
     description = "Musical key detection for digital audio (C++ library)";

--- a/pkgs/development/libraries/bcg729/default.nix
+++ b/pkgs/development/libraries/bcg729/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace '$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR}
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR}
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/bcg729/default.nix
+++ b/pkgs/development/libraries/bcg729/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR}
+  '';
+
   meta = with lib; {
     description = "Opensource implementation of both encoder and decoder of the ITU G729 Annex A/B speech codec";
     homepage = "https://linphone.org/technical-corner/bcg729";

--- a/pkgs/development/libraries/cglm/default.nix
+++ b/pkgs/development/libraries/cglm/default.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/recp/cglm/issues/249
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/recp/cglm";
     description = "Highly Optimized Graphics Math (glm) for C";

--- a/pkgs/development/libraries/cm256cc/default.nix
+++ b/pkgs/development/libraries/cm256cc/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost ];
 
+  # https://github.com/f4exb/cm256cc/issues/16
+  postPatch = ''
+    substituteInPlace libcm256cc.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description = "Fast GF(256) Cauchy MDS Block Erasure Codec in C++";
     homepage = "https://github.com/f4exb/cm256cc";

--- a/pkgs/development/libraries/cxxopts/default.nix
+++ b/pkgs/development/libraries/cxxopts/default.nix
@@ -31,6 +31,12 @@ stdenv.mkDerivation rec {
   # Conflict on case-insensitive filesystems.
   dontUseCmakeBuildDir = true;
 
+  # https://github.com/jarro2783/cxxopts/issues/332
+  postPatch = ''
+    substituteInPlace packaging/pkgconfig.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/jarro2783/cxxopts";
     description = "Lightweight C++ GNU-style option parser library";

--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -18,6 +18,20 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace library/rt/backendmanager.cpp --subst-var out
+
+    # https://sourceforge.net/p/drumstick/bugs/39/
+    substituteInPlace drumstick-alsa.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace drumstick-file.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace drumstick-rt.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace drumstick-widgets.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -24,6 +24,17 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace cmake/FindOpenJPEG.cmake --replace openjpeg-2.1 ${openjpeg.incDir}
+
+    # https://github.com/ecmwf/ecbuild/issues/40
+    substituteInPlace cmake/ecbuild_config.h.in \
+      --replace @CMAKE_INSTALL_PREFIX@/@INSTALL_LIB_DIR@ @eccodes_FULL_INSTALL_LIB_DIR@ \
+      --replace @CMAKE_INSTALL_PREFIX@/@INSTALL_BIN_DIR@ @eccodes_FULL_INSTALL_BIN_DIR@
+    substituteInPlace cmake/pkg-config.pc.in \
+      --replace '$'{prefix}/@INSTALL_LIB_DIR@ @eccodes_FULL_INSTALL_LIB_DIR@ \
+      --replace '$'{prefix}/@INSTALL_INCLUDE_DIR@ @eccodes_FULL_INSTALL_INCLUDE_DIR@ \
+      --replace '$'{prefix}/@INSTALL_BIN_DIR@ @eccodes_FULL_INSTALL_BIN_DIR@
+    substituteInPlace cmake/ecbuild_install_project.cmake \
+      --replace '$'{CMAKE_INSTALL_PREFIX}/'$'{INSTALL_INCLUDE_DIR} '$'{'$'{PROJECT_NAME}_FULL_INSTALL_INCLUDE_DIR}
   '';
 
   nativeBuildInputs = [ cmake gfortran perl ];

--- a/pkgs/development/libraries/entt/default.nix
+++ b/pkgs/development/libraries/entt/default.nix
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/skypjack/entt/issues/890
+  postPatch = ''
+    substituteInPlace cmake/in/entt.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/skypjack/entt";
     description = "A header-only, tiny and easy to use library for game programming and much more written in modern C++";

--- a/pkgs/development/libraries/ffmpegthumbnailer/default.nix
+++ b/pkgs/development/libraries/ffmpegthumbnailer/default.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ ffmpeg libpng libjpeg ];
   cmakeFlags = [ "-DENABLE_THUMBNAILER=ON" ];
 
+  # https://github.com/dirkvdb/ffmpegthumbnailer/issues/215
+  postPatch = ''
+    substituteInPlace libffmpegthumbnailer.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib;  {
     homepage = "https://github.com/dirkvdb/ffmpegthumbnailer";
     description = "A lightweight video thumbnailer";

--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
   postPatch = ''
     cp -r ${gtest.src} googletest
     chmod -R u+w googletest
+
+    # https://github.com/google/benchmark/issues/1396
+    substituteInPlace cmake/benchmark.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   doCheck = true;

--- a/pkgs/development/libraries/geos/default.nix
+++ b/pkgs/development/libraries/geos/default.nix
@@ -14,10 +14,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/libgeos/geos/issues/608
   postPatch = ''
-    substituteInPlace tools/geos-config.in \
-      --replace "@libdir@" "@prefix@/lib" \
-      --replace "@includedir@" "@prefix@/include"
+    substituteInPlace tools/CMakeLists.txt \
+      --replace '$\{exec_prefix\}/$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '$\{prefix\}/$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/geos/default.nix
+++ b/pkgs/development/libraries/geos/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , cmake }:
 
 stdenv.mkDerivation rec {
@@ -12,14 +13,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ULvFmaw4a0wrOWLcxBHwBAph8gSq7066ciXs3Qz0VxU=";
   };
 
-  nativeBuildInputs = [ cmake ];
-
   # https://github.com/libgeos/geos/issues/608
-  postPatch = ''
-    substituteInPlace tools/CMakeLists.txt \
-      --replace '$\{exec_prefix\}/$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
-      --replace '$\{prefix\}/$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
-  '';
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/libgeos/geos/commit/11faa4db672ed61d64fd8a6f1a59114f5b5f2406.patch";
+      sha256 = "1mvyg633xm21wd0ap7v7hd1kqmh2yh03shd81dvrzmdxdb02n050";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     description = "C++ port of the Java Topology Suite (JTS)";

--- a/pkgs/development/libraries/getdns/default.nix
+++ b/pkgs/development/libraries/getdns/default.nix
@@ -27,6 +27,13 @@ in rec {
 
     buildInputs = [ libidn2 openssl unbound ];
 
+    # https://github.com/getdnsapi/getdns/issues/517
+    postPatch = ''
+      substituteInPlace getdns.pc.in \
+        --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+        --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    '';
+
     postInstall = "rm -r $out/share/doc";
 
     meta = with lib;

--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -42,6 +42,14 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace external/googleapis/CMakeLists.txt \
       --replace "https://github.com/googleapis/googleapis/archive/\''${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz" "file://${googleapis}"
+
+    # https://github.com/googleapis/google-cloud-cpp/issues/8992
+    for file in external/googleapis/config.pc.in google/cloud/{,*/}config.pc.in; do
+      substituteInPlace "$file" \
+        --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+        --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
+        --replace '$'{prefix}/@CMAKE_INSTALL_BINDIR@ @CMAKE_INSTALL_FULL_BINDIR@
+    done
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -85,6 +85,7 @@
 , srt
 , vo-aacenc
 , libfreeaptx
+, zxing-cpp
 , VideoToolbox
 , AudioToolbox
 , AVFoundation
@@ -172,6 +173,7 @@ stdenv.mkDerivation rec {
     srt
     vo-aacenc
     libfreeaptx
+    zxing-cpp
   ] ++ lib.optionals enableZbar [
     zbar
   ] ++ lib.optionals faacSupport [
@@ -259,7 +261,6 @@ stdenv.mkDerivation rec {
     "-Dwasapi=disabled" # not packaged in nixpkgs as of writing / no Windows support
     "-Dwasapi2=disabled" # not packaged in nixpkgs as of writing / no Windows support
     "-Dwpe=disabled" # required `wpe-webkit` library not packaged in nixpkgs as of writing
-    "-Dzxing=disabled" # required `zxing-cpp` library not packaged in nixpkgs as of writing
     "-Disac=disabled" # depends on `webrtc-audio-coding-1` not compatible with 0.3
     "-Dgs=disabled" # depends on `google-cloud-cpp`
     "-Donnx=disabled" # depends on `libonnxruntime` not packaged in nixpkgs as of writing

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
@@ -1,10 +1,15 @@
-{ mkDerivation, lib, cmake, pkg-config }:
+{ mkDerivation, lib, fetchpatch, cmake, pkg-config }:
 
 mkDerivation {
   pname = "extra-cmake-modules";
 
   patches = [
     ./nix-lib-path.patch
+    # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/268
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/extra-cmake-modules/-/commit/5862a6f5b5cd7ed5a7ce2af01e44747c36318220.patch";
+      sha256 = "10y36fc3hnpmcsmjgfxn1rp4chj5yrhgghj7m8gbmcai1q5jr0xj";
+    })
   ];
 
   outputs = [ "out" ];  # this package has no runtime components

--- a/pkgs/development/libraries/libargs/default.nix
+++ b/pkgs/development/libraries/libargs/default.nix
@@ -13,6 +13,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/Taywee/args/issues/108
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '$'{CMAKE_INSTALL_LIBDIR_ARCHIND} '$'{CMAKE_INSTALL_LIBDIR}
+    substituteInPlace packaging/pkgconfig.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "A simple header-only C++ argument parser library";
     homepage = "https://github.com/Taywee/args";

--- a/pkgs/development/libraries/libbaseencode/default.nix
+++ b/pkgs/development/libraries/libbaseencode/default.nix
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/paolostivanin/libbaseencode/issues/25
+  postPatch = ''
+    substituteInPlace baseencode.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "Library written in C for encoding and decoding data using base32 or base64 (RFC-4648)";
     homepage = "https://github.com/paolostivanin/libbaseencode";

--- a/pkgs/development/libraries/libbaseencode/default.nix
+++ b/pkgs/development/libraries/libbaseencode/default.nix
@@ -2,23 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "libbaseencode";
-  version = "1.0.12";
+  version = "1.0.14";
 
   src = fetchFromGitHub {
     owner = "paolostivanin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-TKmM2BPzas9qbWI8n63lfR8OvsSj+BKC12NXpfe9aow=";
+    sha256 = "sha256-cSiinuIc/qONuy9ZVsmsF4DiN1VUL43ZAXffCiIGgkY=";
   };
 
   nativeBuildInputs = [ cmake ];
-
-  # https://github.com/paolostivanin/libbaseencode/issues/25
-  postPatch = ''
-    substituteInPlace baseencode.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-  '';
 
   meta = with lib; {
     description = "Library written in C for encoding and decoding data using base32 or base64 (RFC-4648)";

--- a/pkgs/development/libraries/libbtbb/default.nix
+++ b/pkgs/development/libraries/libbtbb/default.nix
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/greatscottgadgets/libbtbb/issues/63
+  postPatch = ''
+    substituteInPlace lib/libbtbb.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "Bluetooth baseband decoding library";
     homepage = "https://github.com/greatscottgadgets/libbtbb";

--- a/pkgs/development/libraries/libcork/default.nix
+++ b/pkgs/development/libraries/libcork/default.nix
@@ -16,14 +16,20 @@ stdenv.mkDerivation rec {
     sha256 = "152gqnmr6wfmflf5l6447am4clmg3p69pvy3iw7yhaawjqa797sk";
   };
 
-  # N.B. We need to create this file, otherwise it tries to use git to
-  # determine the package version, which we do not want.
-  #
-  # N.B. We disable tests by force, since their build is broken.
   postPatch = ''
+    # N.B. We need to create this file, otherwise it tries to use git to
+    # determine the package version, which we do not want.
     echo "${version}" > .version-stamp
     echo "${version}" > .commit-stamp
+
+    # N.B. We disable tests by force, since their build is broken.
     sed -i '/add_subdirectory(tests)/d' ./CMakeLists.txt
+
+    # https://github.com/dcreager/libcork/issues/173
+    substituteInPlace cmake/FindCTargets.cmake \
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR} \
+      --replace '\$'{datarootdir}/'$'{base_docdir} '$'{CMAKE_INSTALL_FULL_DOCDIR}
   '';
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/libraries/libcotp/default.nix
+++ b/pkgs/development/libraries/libcotp/default.nix
@@ -14,6 +14,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ libbaseencode libgcrypt ];
   nativeBuildInputs = [ cmake pkg-config ];
 
+  # https://github.com/paolostivanin/libcotp/issues/32
+  postPatch = ''
+    substituteInPlace cotp.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "C library that generates TOTP and HOTP";
     homepage = "https://github.com/paolostivanin/libcotp";

--- a/pkgs/development/libraries/libcotp/default.nix
+++ b/pkgs/development/libraries/libcotp/default.nix
@@ -2,24 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "libcotp";
-  version = "1.2.4";
+  version = "1.2.6";
 
   src = fetchFromGitHub {
     owner = "paolostivanin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-PN0kd0CP2zrkuPTdaS3TdsdEl+Gy6CecrDSh0Bd7mRk=";
+    sha256 = "sha256-AMLnUFLDL592zcbVN8yaQeOJQWDLUUG+6aKh4paPGlE=";
   };
 
   buildInputs = [ libbaseencode libgcrypt ];
   nativeBuildInputs = [ cmake pkg-config ];
-
-  # https://github.com/paolostivanin/libcotp/issues/32
-  postPatch = ''
-    substituteInPlace cotp.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-  '';
 
   meta = with lib; {
     description = "C library that generates TOTP and HOTP";

--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -27,6 +27,13 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_PREFIX="
   ];
 
+  # https://github.com/Matroska-Org/libebml/issues/97
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     description = "Extensible Binary Meta Language library";
     homepage = "https://dl.matroska.org/downloads/libebml/";

--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
       sha256 = "1yd6rsds03kwx5jki4hihd2bpfh26g5l1pi82qzaqzarixdxwzvl";
       excludes = [ "ChangeLog" ];
     })
+    # in master post 1.4.2, see https://github.com/Matroska-Org/libebml/issues/97
+    (fetchpatch {
+      name = "fix-pkg-config.patch";
+      url = "https://github.com/Matroska-Org/libebml/commit/42fbae35d291b737f2bb4ad5d643fd0d48537a88.patch";
+      sha256 = "020qp4a3l60mcm4n310ynxbbv5qlpmybb9xy10pjvx4brp83pmy3";
+    })
   ];
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -26,13 +32,6 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=YES"
     "-DCMAKE_INSTALL_PREFIX="
   ];
-
-  # https://github.com/Matroska-Org/libebml/issues/97
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
-      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
-  '';
 
   meta = with lib; {
     description = "Extensible Binary Meta Language library";

--- a/pkgs/development/libraries/libebur128/default.nix
+++ b/pkgs/development/libraries/libebur128/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ speexdsp ];
 
+  # https://github.com/jiixyj/libebur128/issues/121
+  postPatch = ''
+    substituteInPlace ebur128/libebur128.pc.cmake \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description = "Implementation of the EBU R128 loudness standard";
     homepage = "https://github.com/jiixyj/libebur128";

--- a/pkgs/development/libraries/libiio/cmake-fix-libxml2-find-package.patch
+++ b/pkgs/development/libraries/libiio/cmake-fix-libxml2-find-package.patch
@@ -1,13 +1,13 @@
 diff --color -ur a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	2021-05-30 13:46:22.256040282 +0200
-+++ b/CMakeLists.txt	2021-05-30 14:15:42.530181216 +0200
-@@ -333,7 +333,7 @@
- # So, try first to find the CMake module provided by libxml2 package, then fallback
- # on the CMake's FindLibXml2.cmake module (which can lack some definition, especially
- # in static build case).
--find_package(LibXml2 QUIET NO_MODULE)
-+find_package(LibXml2 QUIET MODULE)
- if(DEFINED LIBXML2_VERSION_STRING)
- 	set(LIBXML2_FOUND ON)
- 	set(LIBXML2_INCLUDE_DIR ${LIBXML2_INCLUDE_DIRS})
+--- a/CMakeLists.txt	2022-06-02 02:57:01.503340155 +0300
++++ b/CMakeLists.txt	2022-06-02 02:54:33.726941188 +0300
+@@ -378,7 +378,7 @@
+ 	# So, try first to find the CMake module provided by libxml2 package, then fallback
+ 	# on the CMake's FindLibXml2.cmake module (which can lack some definition, especially
+ 	# in static build case).
+-	find_package(LibXml2 QUIET NO_MODULE)
++	find_package(LibXml2 QUIET MODULE)
+ 	if(DEFINED LIBXML2_VERSION_STRING)
+ 		set(LIBXML2_FOUND ON)
+ 		set(LIBXML2_INCLUDE_DIR ${LIBXML2_INCLUDE_DIRS})
 Seulement dans b: good.patch

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -6,13 +6,15 @@
 , libxml2
 , python
 , libusb1
+, avahi
+, libaio
 , runtimeShell
 , lib
 }:
 
 stdenv.mkDerivation rec {
   pname = "libiio";
-  version = "0.21";
+  version = "0.23";
 
   outputs = [ "out" "lib" "dev" "python" ];
 
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "analogdevicesinc";
     repo = "libiio";
     rev = "v${version}";
-    sha256 = "0psw67mzysdb8fkh8xpcwicm7z94k8plkcc8ymxyvl6inshq0mc7";
+    sha256 = "0awny9zb43dcnxa5jpxay2zxswydblnbn4x6vi5mlw1r48pzhjf8";
   };
 
   # Revert after https://github.com/NixOS/nixpkgs/issues/125008 is
@@ -37,6 +39,8 @@ stdenv.mkDerivation rec {
     python
     libxml2
     libusb1
+    avahi
+    libaio
   ] ++ lib.optional python.isPy3k python.pkgs.setuptools;
 
   cmakeFlags = [

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -50,6 +50,11 @@ stdenv.mkDerivation rec {
 
     substituteInPlace libiio.rules.cmakein \
       --replace /bin/sh ${runtimeShell}
+
+    # https://github.com/analogdevicesinc/libiio/issues/848
+    substituteInPlace libiio.pc.cmakein \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   postInstall = ''

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -50,11 +50,6 @@ stdenv.mkDerivation rec {
 
     substituteInPlace libiio.rules.cmakein \
       --replace /bin/sh ${runtimeShell}
-
-    # https://github.com/analogdevicesinc/libiio/issues/848
-    substituteInPlace libiio.pc.cmakein \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   postInstall = ''

--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -109,6 +109,16 @@ stdenv.mkDerivation rec {
     # "-DJPEGXL_ENABLE_PLUGINS=ON"
   ];
 
+  # https://github.com/libjxl/libjxl/issues/1400
+  postPatch = ''
+    substituteInPlace lib/jxl/libjxl.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace lib/threads/libjxl_threads.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isRiscV "-latomic";
 
   doCheck = !stdenv.hostPlatform.isi686;

--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -32,6 +32,13 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # present in master, see https://github.com/libjxl/libjxl/pull/1403
+    (fetchpatch {
+      name = "prefixless-pkg-config.patch";
+      url = "https://github.com/libjxl/libjxl/commit/0b906564bfbfd8507d61c5d6a447f545f893227c.patch";
+      sha256 = "1g5c6lrsmgxb9j64pjy8lbdgbvw834m5jyfivy9ppmd8iiv0kkq4";
+    })
+
     # present in master, remove after 0.7?
     (fetchpatch {
       name = "fix-link-lld-macho.patch";
@@ -108,16 +115,6 @@ stdenv.mkDerivation rec {
     # * the `gimp` one, which allows GIMP to load jpeg-xl files
     # "-DJPEGXL_ENABLE_PLUGINS=ON"
   ];
-
-  # https://github.com/libjxl/libjxl/issues/1400
-  postPatch = ''
-    substituteInPlace lib/jxl/libjxl.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-    substituteInPlace lib/threads/libjxl_threads.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-  '';
 
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isRiscV "-latomic";
 

--- a/pkgs/development/libraries/libmatroska/default.nix
+++ b/pkgs/development/libraries/libmatroska/default.nix
@@ -21,6 +21,13 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_PREFIX="
   ];
 
+  # https://github.com/Matroska-Org/libmatroska/issues/62
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     description = "A library to parse Matroska files";
     homepage = "https://matroska.org/";

--- a/pkgs/development/libraries/libmatroska/default.nix
+++ b/pkgs/development/libraries/libmatroska/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config
 , libebml }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "01dg12ndxfdqgjx5v2qy4mff6xjdxglywyg82sr3if5aw6rp3dji";
   };
 
+  # in master post 1.6.3, see https://github.com/Matroska-Org/libmatroska/issues/62
+  patches = [
+    (fetchpatch {
+      name = "fix-pkg-config.patch";
+      url = "https://github.com/Matroska-Org/libmatroska/commit/53f6ea573878621871bca5f089220229fcb33a3b.patch";
+      sha256 = "1lcxl3n32kk5x4aa4ja7p68km7qb2bwscavpv7qdmbhp3w5ia0mk";
+    })
+  ];
+
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [ libebml ];
@@ -20,13 +29,6 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=YES"
     "-DCMAKE_INSTALL_PREFIX="
   ];
-
-  # https://github.com/Matroska-Org/libmatroska/issues/62
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
-      --replace '\$\{prefix\}/$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
-  '';
 
   meta = with lib; {
     description = "A library to parse Matroska files";

--- a/pkgs/development/libraries/libmodule/default.nix
+++ b/pkgs/development/libraries/libmodule/default.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
+  # https://github.com/FedeDP/libmodule/issues/7
+  postPatch = ''
+    substituteInPlace Extra/libmodule.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "C simple and elegant implementation of an actor library";
     homepage = "https://github.com/FedeDP/libmodule";

--- a/pkgs/development/libraries/libnats-c/default.nix
+++ b/pkgs/development/libraries/libnats-c/default.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
   separateDebugInfo = true;
   outputs = [ "out" "dev" ];
 
+  # https://github.com/nats-io/nats.c/issues/542
+  postPatch = ''
+    substituteInPlace src/libnats.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description = "C API for the NATS messaging system";
     homepage    = "https://github.com/nats-io/nats.c";

--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -20,6 +20,13 @@ mkDerivation rec {
     "-DQuotient_ENABLE_E2EE=OFF"
   ];
 
+  # https://github.com/quotient-im/libQuotient/issues/551
+  postPatch = ''
+    substituteInPlace Quotient.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "A Qt5 library to write cross-platform clients for Matrix";
     homepage = "https://matrix.org/docs/projects/sdk/quotient";

--- a/pkgs/development/libraries/libsurvive/default.nix
+++ b/pkgs/development/libraries/libsurvive/default.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
+  # https://github.com/cntools/libsurvive/issues/272
+  postPatch = ''
+    substituteInPlace survive.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description = "Open Source Lighthouse Tracking System";
     homepage = "https://github.com/cntools/libsurvive";

--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -25,6 +25,18 @@ in stdenv.mkDerivation {
   buildInputs = [ boostPython openssl zlib python ncurses ]
     ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ];
 
+  # https://github.com/arvidn/libtorrent/issues/6865
+  postPatch = ''
+    substituteInPlace cmake/Modules/GeneratePkgConfig.cmake \
+      --replace @CMAKE_INSTALL_PREFIX@/'$<'1: '$<'1:
+    substituteInPlace cmake/Modules/GeneratePkgConfig/target-compile-settings.cmake.in \
+      --replace 'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")' \
+                'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")
+                 set(_INSTALL_FULL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@")'
+    substituteInPlace cmake/Modules/GeneratePkgConfig/pkg-config.cmake.in \
+      --replace '$'{prefix}/@_INSTALL_LIBDIR@ @_INSTALL_FULL_LIBDIR@
+  '';
+
   postInstall = ''
     moveToOutput "include" "$dev"
     moveToOutput "lib/${python.libPrefix}" "$python"

--- a/pkgs/development/libraries/libtsm/default.nix
+++ b/pkgs/development/libraries/libtsm/default.nix
@@ -15,6 +15,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
+  # https://github.com/Aetf/libtsm/issues/20
+  postPatch = ''
+    substituteInPlace etc/libtsm.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "Terminal-emulator State Machine";
     homepage = "http://www.freedesktop.org/wiki/Software/kmscon/libtsm/";

--- a/pkgs/development/libraries/libunarr/default.nix
+++ b/pkgs/development/libraries/libunarr/default.nix
@@ -11,6 +11,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/selmf/unarr/issues/23
+  postPatch = ''
+    substituteInPlace pkg-config.pc.cmake \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/selmf/unarr";
     description = "A lightweight decompression library with support for rar, tar and zip archives";

--- a/pkgs/development/libraries/libzra/default.nix
+++ b/pkgs/development/libraries/libzra/default.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # in submodule dev as of 1.4.7
+  postPatch = ''
+    (cd submodule/zstd && patch -Np1 < ${./fix-pkg-config.patch})
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/zraorg/ZRA";
     description = "Library for ZStandard random access";

--- a/pkgs/development/libraries/libzra/fix-pkg-config.patch
+++ b/pkgs/development/libraries/libzra/fix-pkg-config.patch
@@ -1,0 +1,150 @@
+From 7be7e35d61d8d499599623502a35460d410de114 Mon Sep 17 00:00:00 2001
+From: Alexander Shpilkin <ashpilkin@gmail.com>
+Date: Thu, 26 May 2022 16:03:27 +0300
+Subject: [PATCH] Squashed commit of the following:
+
+commit 9aacb9d5da65a64c3845937a6f9eede329d43989
+Author: W. Felix Handte <w@felixhandte.com>
+Date:   Tue Dec 8 20:46:02 2020 -0500
+
+    Apply Same Strategy to CMake
+
+    (cherry picked from commit a75f9ce3e924564ab358c2c1aa95b6268383ec42)
+
+commit e21b7ad0d98d1322ea92f99fcd1f85e2d6b6f6b7
+Author: W. Felix Handte <w@felixhandte.com>
+Date:   Tue Dec 8 20:10:05 2020 -0500
+
+    Avoid Use of Regexes in Building Package-Config File
+
+    (cherry picked from commit b521183c74795bd9bdd9bdebe74af01cae4d3d43)
+---
+ build/cmake/lib/CMakeLists.txt | 29 ++++++++++++++++++++++++----
+ lib/Makefile                   | 35 ++++++++++++++++------------------
+ lib/libzstd.pc.in              |  6 +++---
+ 3 files changed, 44 insertions(+), 26 deletions(-)
+
+diff --git a/build/cmake/lib/CMakeLists.txt b/build/cmake/lib/CMakeLists.txt
+index 32ae7525..466c2c7b 100644
+--- a/build/cmake/lib/CMakeLists.txt
++++ b/build/cmake/lib/CMakeLists.txt
+@@ -137,12 +137,33 @@ endif ()
+ if (UNIX)
+     # pkg-config
+     set(PREFIX "${CMAKE_INSTALL_PREFIX}")
+-    set(LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+-    set(INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
++    set(EXEC_PREFIX "\\$$\{prefix}")
++    set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
++    set(INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+     set(VERSION "${zstd_VERSION}")
++
++    string(LENGTH "${PREFIX}" PREFIX_LENGTH)
++    string(SUBSTRING "${LIBDIR}" 0 ${PREFIX_LENGTH} LIBDIR_PREFIX)
++    string(SUBSTRING "${LIBDIR}" ${PREFIX_LENGTH} -1 LIBDIR_SUFFIX)
++    string(SUBSTRING "${INCLUDEDIR}" 0 ${PREFIX_LENGTH} INCLUDEDIR_PREFIX)
++    string(SUBSTRING "${INCLUDEDIR}" ${PREFIX_LENGTH} -1 INCLUDEDIR_SUFFIX)
++
++    if ("${INCLUDEDIR_PREFIX}" STREQUAL "${PREFIX}")
++        set(INCLUDEDIR_PREFIX "\\$$\{prefix}")
++    endif()
++    if ("${LIBDIR_PREFIX}" STREQUAL "${PREFIX}")
++        set(LIBDIR_PREFIX "\\$$\{exec_prefix}")
++    endif()
++
+     add_custom_target(libzstd.pc ALL
+-            ${CMAKE_COMMAND} -DIN="${LIBRARY_DIR}/libzstd.pc.in" -DOUT="libzstd.pc"
+-            -DPREFIX="${PREFIX}" -DLIBDIR="${LIBDIR}" -DINCLUDEDIR="${INCLUDEDIR}" -DVERSION="${VERSION}"
++            ${CMAKE_COMMAND}
++            -DIN="${LIBRARY_DIR}/libzstd.pc.in"
++            -DOUT="libzstd.pc"
++            -DPREFIX="${PREFIX}"
++            -DEXEC_PREFIX="${EXEC_PREFIX}"
++            -DINCLUDEDIR="${INCLUDEDIR_PREFIX}${INCLUDEDIR_SUFFIX}"
++            -DLIBDIR="${LIBDIR_PREFIX}${LIBDIR_SUFFIX}"
++            -DVERSION="${VERSION}"
+             -P "${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig.cmake"
+             COMMENT "Creating pkg-config file")
+ 
+diff --git a/lib/Makefile b/lib/Makefile
+index 4a9ab799..2893ec21 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -257,6 +257,8 @@ ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD Ne
+ 
+ all: libzstd.pc
+ 
++HAS_EXPLICIT_EXEC_PREFIX := $(if $(or $(EXEC_PREFIX),$(exec_prefix)),1,)
++
+ DESTDIR     ?=
+ # directory variables : GNU conventions prefer lowercase
+ # see https://www.gnu.org/prep/standards/html_node/Makefile-Conventions.html
+@@ -270,24 +272,17 @@ LIBDIR      ?= $(libdir)
+ includedir  ?= $(PREFIX)/include
+ INCLUDEDIR  ?= $(includedir)
+ 
+-PCLIBDIR ?= $(shell echo "$(LIBDIR)" | sed -n $(SED_ERE_OPT) -e "s@^$(EXEC_PREFIX)(/|$$)@@p")
+-PCINCDIR ?= $(shell echo "$(INCLUDEDIR)" | sed -n $(SED_ERE_OPT) -e "s@^$(PREFIX)(/|$$)@@p")
++PCINCDIR := $(patsubst $(PREFIX)%,%,$(INCLUDEDIR))
++PCLIBDIR := $(patsubst $(EXEC_PREFIX)%,%,$(LIBDIR))
+ 
+-ifeq (,$(PCLIBDIR))
+-# Additional prefix check is required, since the empty string is technically a
+-# valid PCLIBDIR
+-ifeq (,$(shell echo "$(LIBDIR)" | sed -n $(SED_ERE_OPT) -e "\\@^$(EXEC_PREFIX)(/|$$)@ p"))
+-$(error configured libdir ($(LIBDIR)) is outside of prefix ($(PREFIX)), can't generate pkg-config file)
+-endif
+-endif
++# If we successfully stripped off a prefix, we'll add a reference to the
++# relevant pc variable.
++PCINCPREFIX := $(if $(findstring $(INCLUDEDIR),$(PCINCDIR)),,$${prefix})
++PCLIBPREFIX := $(if $(findstring $(LIBDIR),$(PCLIBDIR)),,$${exec_prefix})
+ 
+-ifeq (,$(PCINCDIR))
+-# Additional prefix check is required, since the empty string is technically a
+-# valid PCINCDIR
+-ifeq (,$(shell echo "$(INCLUDEDIR)" | sed -n $(SED_ERE_OPT) -e "\\@^$(PREFIX)(/|$$)@ p"))
+-$(error configured includedir ($(INCLUDEDIR)) is outside of exec_prefix ($(EXEC_PREFIX)), can't generate pkg-config file)
+-endif
+-endif
++# If no explicit EXEC_PREFIX was set by the caller, write it out as a reference
++# to PREFIX, rather than as a resolved value.
++PCEXEC_PREFIX := $(if $(HAS_EXPLICIT_EXEC_PREFIX),$(EXEC_PREFIX),$${prefix})
+ 
+ ifneq (,$(filter $(shell uname),FreeBSD NetBSD DragonFly))
+ PKGCONFIGDIR ?= $(PREFIX)/libdata/pkgconfig
+@@ -308,9 +303,11 @@ INSTALL_DATA    ?= $(INSTALL) -m 644
+ libzstd.pc:
+ libzstd.pc: libzstd.pc.in
+ 	@echo creating pkgconfig
+-	$(Q)@sed $(SED_ERE_OPT) -e 's|@PREFIX@|$(PREFIX)|' \
+-          -e 's|@LIBDIR@|$(PCLIBDIR)|' \
+-          -e 's|@INCLUDEDIR@|$(PCINCDIR)|' \
++	$(Q)@sed $(SED_ERE_OPT) \
++	        -e 's|@PREFIX@|$(PREFIX)|' \
++	        -e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
++          -e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \
++          -e 's|@LIBDIR@|$(PCLIBPREFIX)$(PCLIBDIR)|' \
+           -e 's|@VERSION@|$(VERSION)|' \
+           $< >$@
+ 
+diff --git a/lib/libzstd.pc.in b/lib/libzstd.pc.in
+index 8ec0235a..8465c977 100644
+--- a/lib/libzstd.pc.in
++++ b/lib/libzstd.pc.in
+@@ -3,9 +3,9 @@
+ #   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+ 
+ prefix=@PREFIX@
+-exec_prefix=${prefix}
+-includedir=${prefix}/@INCLUDEDIR@
+-libdir=${exec_prefix}/@LIBDIR@
++exec_prefix=@EXEC_PREFIX@
++includedir=@INCLUDEDIR@
++libdir=@LIBDIR@
+ 
+ Name: zstd
+ Description: fast lossless compression algorithm library
+-- 
+2.36.0
+

--- a/pkgs/development/libraries/mysocketw/default.nix
+++ b/pkgs/development/libraries/mysocketw/default.nix
@@ -24,7 +24,11 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = ''
+    # https://github.com/RigsOfRods/socketw/issues/16
+    substituteInPlace SocketW.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/Makefile \
         --replace -Wl,-soname, -Wl,-install_name,$out/lib/
   '';

--- a/pkgs/development/libraries/nanomsg/default.nix
+++ b/pkgs/development/libraries/nanomsg/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/nanomsg/nanomsg/issues/1082
+  postPatch = ''
+    substituteInPlace src/pkgconfig.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description= "Socket library that provides several common communication patterns";
     homepage = "https://nanomsg.org/";

--- a/pkgs/development/libraries/notcurses/default.nix
+++ b/pkgs/development/libraries/notcurses/default.nix
@@ -44,6 +44,22 @@ stdenv.mkDerivation rec {
     lib.optional (qrcodegenSupport) "-DUSE_QRCODEGEN=ON"
     ++ lib.optional (!multimediaSupport) "-DUSE_MULTIMEDIA=none";
 
+  # https://github.com/dankamongmen/notcurses/issues/2661
+  postPatch = ''
+    substituteInPlace tools/notcurses-core.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace tools/notcurses-ffi.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace tools/notcurses++.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace tools/notcurses.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/dankamongmen/notcurses";
     description = "Blingful TUIs and character graphics";

--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  postPatch = ''
+    substituteInPlace olm.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     description = "Implements double cryptographic ratchet and Megolm ratchet";
     homepage = "https://gitlab.matrix.org/matrix-org/olm";

--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "OpenAL alternative";
-    homepage = "https://kcat.strangesoft.net/openal.html";
+    homepage = "https://openal-soft.org/";
     license = licenses.lgpl2;
     maintainers = with maintainers; [ftrvxmtrx];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
     # this will make it find its own data files (e.g. HRTF profiles)
     # without any other configuration
     ./search-out.patch
-    # https://github.com/kcat/openal-soft/pull/696
+    # merged after 1.22.0 in https://github.com/kcat/openal-soft/pull/696
     (fetchpatch {
-      url = "https://github.com/kcat/openal-soft/commit/61a32d2d447a48993bf7c8feeb4fe4b3e0ed8036.patch";
+      url = "https://github.com/kcat/openal-soft/commit/0bf2abae9b2121c3bc5a56dab30eca308136bc29.patch";
       sha256 = "1fhjjy7nrhrj3a0wlmsqpf8h3ss6s487vz5jrhamyv04nbcahn20";
     })
   ];

--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config
 , alsaSupport ? !stdenv.isDarwin, alsa-lib
 , dbusSupport ? !stdenv.isDarwin, dbus
 , pipewireSupport ? !stdenv.isDarwin, pipewire
@@ -17,9 +17,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Y2KhPkwtG6tBzUhSqwV2DVnOjZwxPihidLKahjaIvyU=";
   };
 
-  # this will make it find its own data files (e.g. HRTF profiles)
-  # without any other configuration
-  patches = [ ./search-out.patch ];
+  patches = [
+    # this will make it find its own data files (e.g. HRTF profiles)
+    # without any other configuration
+    ./search-out.patch
+    # https://github.com/kcat/openal-soft/pull/696
+    (fetchpatch {
+      url = "https://github.com/kcat/openal-soft/commit/61a32d2d447a48993bf7c8feeb4fe4b3e0ed8036.patch";
+      sha256 = "1fhjjy7nrhrj3a0wlmsqpf8h3ss6s487vz5jrhamyv04nbcahn20";
+    })
+  ];
   postPatch = ''
     substituteInPlace core/helpers.cpp \
       --replace "@OUT@" $out

--- a/pkgs/development/libraries/opencolorio/default.nix
+++ b/pkgs/development/libraries/opencolorio/default.nix
@@ -39,6 +39,13 @@ stdenv.mkDerivation rec {
   # TODO Investigate this: Python and GPU tests fail to load libOpenColorIO.so.2.0
   # doCheck = true;
 
+  # https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1649
+  postPatch = ''
+    substituteInPlace src/OpenColorIO/CMakeLists.txt \
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR} \
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR}
+  '';
+
   meta = with lib; {
     homepage = "https://opencolorio.org";
     description = "A color management framework for visual effects and animation";

--- a/pkgs/development/libraries/opendht/default.nix
+++ b/pkgs/development/libraries/opendht/default.nix
@@ -59,6 +59,13 @@ stdenv.mkDerivation rec {
     "-DOPENDHT_PUSH_NOTIFICATIONS=ON"
   ];
 
+  # https://github.com/savoirfairelinux/opendht/issues/612
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   outputs = [ "out" "lib" "dev" "man" ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/openxr-loader/default.nix
+++ b/pkgs/development/libraries/openxr-loader/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "layers" ];
 
+  # https://github.com/KhronosGroup/OpenXR-SDK-Source/issues/305
+  postPatch = ''
+    substituteInPlace src/loader/openxr.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   postInstall = ''
     mkdir -p "$layers/share"
     mv "$out/share/openxr" "$layers/share"

--- a/pkgs/development/libraries/orcania/default.nix
+++ b/pkgs/development/libraries/orcania/default.nix
@@ -18,6 +18,13 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  # https://github.com/babelouest/orcania/issues/27
+  postPatch = ''
+    substituteInPlace liborcania.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   preCheck = ''
     export LD_LIBRARY_PATH="$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
     export DYLD_FALLBACK_LIBRARY_PATH="$(pwd):$DYLD_FALLBACK_LIBRARY_PATH"

--- a/pkgs/development/libraries/orcania/default.nix
+++ b/pkgs/development/libraries/orcania/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, check, subunit }:
+{ lib, stdenv, fetchpatch, fetchFromGitHub, cmake, check, subunit }:
 stdenv.mkDerivation rec {
   pname = "orcania";
   version = "2.2.2";
@@ -10,6 +10,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-lrc4VEqmCp/P/h0+5/ix6tx4pjfkLy9BLBZtKYLlyGI=";
   };
 
+  # in master post 2.2.2, see https://github.com/babelouest/orcania/issues/27
+  patches = [
+    (fetchpatch {
+      name = "fix-pkg-config.patch";
+      url = "https://github.com/babelouest/orcania/commit/4eac7d5ff76bb3bec8250fef300b723c8891552a.patch";
+      sha256 = "01bsxay1ca8d08ac3ddcqyvjwgz5mgs68jz5y3gzq4qnzl3q1i54";
+    })
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   checkInputs = [ check subunit ];
@@ -17,13 +26,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DBUILD_ORCANIA_TESTING=on" ];
 
   doCheck = true;
-
-  # https://github.com/babelouest/orcania/issues/27
-  postPatch = ''
-    substituteInPlace liborcania.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-  '';
 
   preCheck = ''
     export LD_LIBRARY_PATH="$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"

--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -22,6 +22,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-zMP+WzC65BFz8g8mF5t7toqxmxCJePysd6WJuqpe8yg=";
   };
 
+  # https://github.com/OSGeo/PROJ/issues/3206
+  postPatch = ''
+    # NB will not apply once https://github.com/OSGeo/PROJ/pull/3150 is released
+    substituteInPlace cmake/ProjUtilities.cmake \
+      --replace '$\{exec_prefix\}/$'{PROJ_LIB_SUBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '$\{prefix\}/$'{PROJ_INCLUDE_SUBDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR} \
+      --replace '$\{prefix\}/$'{CMAKE_INSTALL_DATAROOTDIR} '$'{CMAKE_INSTALL_FULL_DATAROOTDIR}
+    substituteInPlace cmake/project-config.cmake.in \
+      --replace '$'{_ROOT}/@INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
+      --replace '$'{_ROOT}/@LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{_ROOT}/@BINDIR@ @CMAKE_INSTALL_FULL_BINDIR@
+  '';
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/libraries/prometheus-cpp/default.nix
+++ b/pkgs/development/libraries/prometheus-cpp/default.nix
@@ -32,6 +32,19 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  # https://github.com/jupp0r/prometheus-cpp/issues/587
+  postPatch = ''
+    substituteInPlace cmake/prometheus-cpp-core.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace cmake/prometheus-cpp-pull.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace cmake/prometheus-cpp-push.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   postInstall = ''
     mkdir -p $dev/lib/pkgconfig
     substituteAll ${./prometheus-cpp.pc.in} $dev/lib/pkgconfig/prometheus-cpp.pc

--- a/pkgs/development/libraries/prometheus-cpp/default.nix
+++ b/pkgs/development/libraries/prometheus-cpp/default.nix
@@ -32,19 +32,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  # https://github.com/jupp0r/prometheus-cpp/issues/587
-  postPatch = ''
-    substituteInPlace cmake/prometheus-cpp-core.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-    substituteInPlace cmake/prometheus-cpp-pull.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-    substituteInPlace cmake/prometheus-cpp-push.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
-  '';
-
   postInstall = ''
     mkdir -p $dev/lib/pkgconfig
     substituteAll ${./prometheus-cpp.pc.in} $dev/lib/pkgconfig/prometheus-cpp.pc

--- a/pkgs/development/libraries/prometheus-cpp/default.nix
+++ b/pkgs/development/libraries/prometheus-cpp/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "prometheus-cpp";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "jupp0r";
     repo = pname;
     rev = "v${version}";
-    sha256 = "L6CXRup3kU1lY5UnwPbaOwEtCeAySNmFCPmHwsk6cRE=";
+    sha256 = "F8paJhptEcOMtP0FCJ3ragC4kv7XSVPiZheM5UZChno=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/rabbitmq-c/default.nix
+++ b/pkgs/development/libraries/rabbitmq-c/default.nix
@@ -14,6 +14,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openssl popt xmlto ];
 
+  # https://github.com/alanxz/rabbitmq-c/issues/733
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     description = "RabbitMQ C AMQP client library";
     homepage = "https://github.com/alanxz/rabbitmq-c";

--- a/pkgs/development/libraries/recastnavigation/default.nix
+++ b/pkgs/development/libraries/recastnavigation/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     cp ${catch}/include/catch/catch.hpp Tests/catch.hpp
+
+    # https://github.com/recastnavigation/recastnavigation/issues/524
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
   '';
 
   doCheck = true;

--- a/pkgs/development/libraries/reproc/default.nix
+++ b/pkgs/development/libraries/reproc/default.nix
@@ -22,6 +22,16 @@ stdenv.mkDerivation rec {
     "-DREPROC_TEST=ON"
   ];
 
+  # https://github.com/DaanDeMeyer/reproc/issues/81
+  postPatch = ''
+    substituteInPlace reproc++/reproc++.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace reproc/reproc.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/DaanDeMeyer/reproc";
     description = "A cross-platform (C99/C++11) process library";

--- a/pkgs/development/libraries/rinutils/default.nix
+++ b/pkgs/development/libraries/rinutils/default.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   pname = "rinutils";
-  version = "0.10.0";
+  version = "0.10.1";
 
   meta = with lib; {
     homepage = "https://github.com/shlomif/rinutils";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/shlomif/${pname}/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-cNifCoRk+PSU8zcEt8k5bn/KOS6Kr6pEZXEMGjiemAY=";
+    sha256 = "sha256-MewljOmd57u+efMzjOcwSNrEVCUEXrK9DWvZLRuLmvs=";
   };
 
   nativeBuildInputs = [ cmake perl ];

--- a/pkgs/development/libraries/rinutils/default.nix
+++ b/pkgs/development/libraries/rinutils/default.nix
@@ -18,4 +18,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake perl ];
+
+  # https://github.com/shlomif/rinutils/issues/5
+  postPatch = ''
+    substituteInPlace librinutils.pc.in \
+      --replace '$'{exec_prefix}/@RINUTILS_INSTALL_MYLIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
 }

--- a/pkgs/development/libraries/rinutils/default.nix
+++ b/pkgs/development/libraries/rinutils/default.nix
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake perl ];
 
   # https://github.com/shlomif/rinutils/issues/5
+  # (variable was unused at time of writing)
   postPatch = ''
     substituteInPlace librinutils.pc.in \
-      --replace '$'{exec_prefix}/@RINUTILS_INSTALL_MYLIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+      --replace '$'{exec_prefix}/@RINUTILS_INSTALL_MYLIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
   '';
 }

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -26,6 +26,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libdrm numactl ];
 
+  # https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/issues/75
+  postPatch = ''
+    substituteInPlace libhsakmt.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   postInstall = ''
     cp -r $src/include $out
   '';

--- a/pkgs/development/libraries/sentencepiece/default.nix
+++ b/pkgs/development/libraries/sentencepiece/default.nix
@@ -24,6 +24,13 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" ];
 
+  # https://github.com/google/sentencepiece/issues/754
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/google/sentencepiece";
     description = "Unsupervised text tokenizer for Neural Network-based text generation";

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -30,6 +30,12 @@ let
         # spdlog <1.4 is header only, no need to split libraries and headers
         ++ lib.optional (lib.versionAtLeast version "1.4") "dev";
 
+      # https://github.com/gabime/spdlog/issues/2380
+      postPatch = lib.optionalString (lib.versionAtLeast version "1.4.1") ''
+        substituteInPlace cmake/spdlog.pc.in \
+          --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+      '';
+
       postInstall = ''
         mkdir -p $out/share/doc/spdlog
         cp -rv ../example $out/share/doc/spdlog

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fmt_8 }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, fmt_8 }:
 
 let
   generic = { version, sha256 }:
@@ -12,6 +12,13 @@ let
         rev    = "v${version}";
         inherit sha256;
       };
+
+      # in master post 1.10.0, see https://github.com/gabime/spdlog/issues/2380
+      patches = lib.optional (lib.versionAtLeast version "1.4.1") (fetchpatch {
+        name = "fix-pkg-config.patch";
+        url = "https://github.com/gabime/spdlog/commit/afb69071d5346b84e38fbcb0c8c32eddfef02a55.patch";
+        sha256 = "0cab2bbv8zyfhrhfvcyfwf5p2fddlq5hs2maampn5w18f6jhvk6q";
+      });
 
       nativeBuildInputs = [ cmake ];
       # spdlog <1.3 uses a bundled version of fmt
@@ -29,12 +36,6 @@ let
       outputs = [ "out" "doc" ]
         # spdlog <1.4 is header only, no need to split libraries and headers
         ++ lib.optional (lib.versionAtLeast version "1.4") "dev";
-
-      # https://github.com/gabime/spdlog/issues/2380
-      postPatch = lib.optionalString (lib.versionAtLeast version "1.4.1") ''
-        substituteInPlace cmake/spdlog.pc.in \
-          --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
-      '';
 
       postInstall = ''
         mkdir -p $out/share/doc/spdlog

--- a/pkgs/development/libraries/spirv-headers/default.nix
+++ b/pkgs/development/libraries/spirv-headers/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/KhronosGroup/SPIRV-Headers/issues/282
+  postPatch = ''
+    substituteInPlace SPIRV-Headers.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     inherit (src.meta) homepage;
     description = "Machine-readable components of the Khronos SPIR-V Registry";

--- a/pkgs/development/libraries/tdlib/default.nix
+++ b/pkgs/development/libraries/tdlib/default.nix
@@ -15,6 +15,16 @@ stdenv.mkDerivation rec {
   buildInputs = [ gperf openssl readline zlib ];
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/tdlib/td/issues/1974
+  postPatch = ''
+    substituteInPlace CMake/GeneratePkgConfig.cmake \
+      --replace 'function(generate_pkgconfig' \
+                'include(GNUInstallDirs)
+                 function(generate_pkgconfig' \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     description = "Cross-platform library for building Telegram clients";
     homepage = "https://core.telegram.org/tdlib/";

--- a/pkgs/development/libraries/tinyobjloader/default.nix
+++ b/pkgs/development/libraries/tinyobjloader/default.nix
@@ -16,6 +16,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/tinyobjloader/tinyobjloader/issues/336
+  postPatch = ''
+    substituteInPlace tinyobjloader.pc.in \
+      --replace '$'{prefix}/@TINYOBJLOADER_LIBRARY_DIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@TINYOBJLOADER_INCLUDE_DIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/tinyobjloader/tinyobjloader";
     description = "Tiny but powerful single file wavefront obj loader";

--- a/pkgs/development/libraries/usrsctp/default.nix
+++ b/pkgs/development/libraries/usrsctp/default.nix
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/sctplab/usrsctp/issues/662
+  postPatch = ''
+    substituteInPlace usrsctplib/CMakeLists.txt \
+      --replace '$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/sctplab/usrsctp";
     description = "A portable SCTP userland stack";

--- a/pkgs/development/libraries/wildmidi/default.nix
+++ b/pkgs/development/libraries/wildmidi/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace CMakeLists.txt \
       --replace /etc/wildmidi $out/etc
+    # https://github.com/Mindwerks/wildmidi/issues/236
+    substituteInPlace src/wildmidi.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   postInstall = ''

--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -46,6 +46,12 @@ in stdenv.mkDerivation {
       ];
     in "-${builtins.concatStringsSep ":" filteredTests}";
 
+  # https://github.com/xtensor-stack/xsimd/issues/748
+  postPatch = ''
+    substituteInPlace xsimd.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description = "C++ wrappers for SIMD intrinsics";
     homepage = "https://github.com/xtensor-stack/xsimd";

--- a/pkgs/development/libraries/xtensor/default.nix
+++ b/pkgs/development/libraries/xtensor/default.nix
@@ -26,6 +26,12 @@ stdenv.mkDerivation rec {
   checkInputs = [ gtest ];
   checkTarget = "xtest";
 
+  # https://github.com/xtensor-stack/xtensor/issues/2542
+  postPatch = ''
+    substituteInPlace xtensor.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   meta = with lib; {
     description = "Multi-dimensional arrays with broadcasting and lazy computing.";
     homepage = "https://github.com/xtensor-stack/xtensor";

--- a/pkgs/development/libraries/zxing-cpp/default.nix
+++ b/pkgs/development/libraries/zxing-cpp/default.nix
@@ -26,6 +26,17 @@ stdenv.mkDerivation rec {
     "-DBUILD_BLACKBOX_TESTS=OFF"
   ];
 
+  # https://github.com/nu-book/zxing-cpp/issues/335
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'configure_file(zxing.pc.in' \
+                'include(GNUInstallDirs)
+                 configure_file(zxing.pc.in'
+    substituteInPlace zxing.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/nu-book/zxing-cpp";
     description = "C++ port of zxing (a Java barcode image processing library)";

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -15,6 +15,21 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DSPIRV-Headers_SOURCE_DIR=${spirv-headers.src}" ];
 
+  # https://github.com/KhronosGroup/SPIRV-Tools/issues/3905
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '-P ''${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake' \
+                '-DCMAKE_INSTALL_FULL_LIBDIR=''${CMAKE_INSTALL_FULL_LIBDIR}
+                 -DCMAKE_INSTALL_FULL_INCLUDEDIR=''${CMAKE_INSTALL_FULL_INCLUDEDIR}
+                 -P ''${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake'
+    substituteInPlace cmake/SPIRV-Tools.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    substituteInPlace cmake/SPIRV-Tools-shared.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   meta = with lib; {
     inherit (src.meta) homepage;
     description = "The SPIR-V Tools project provides an API and commands for processing SPIR-V modules";

--- a/pkgs/development/web/cog/default.nix
+++ b/pkgs/development/web/cog/default.nix
@@ -53,6 +53,12 @@ stdenv.mkDerivation rec {
     "-DCOG_USE_WEBKITGTK=ON"
   ];
 
+  # https://github.com/Igalia/cog/issues/438
+  postPatch = ''
+    substituteInPlace core/cogcore.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   # not ideal, see https://github.com/WebPlatformForEmbedded/libwpe/issues/59
   preFixup = ''
     wrapProgram $out/bin/cog \

--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -52,6 +52,10 @@ python.pkgs.buildPythonApplication rec {
 
     substituteAll ${./absolute-ausyscall.patch} ./absolute-ausyscall.patch
     patch -p1 < absolute-ausyscall.patch
+
+    # https://github.com/iovisor/bcc/issues/3996
+    substituteInPlace src/cc/libbcc.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
   '';
 
   postInstall = ''

--- a/pkgs/os-specific/linux/powercap/default.nix
+++ b/pkgs/os-specific/linux/powercap/default.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=On"
   ];
 
+  # https://github.com/powercap/powercap/issues/8
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   meta = with lib; {
     description = "Tools and library to read/write to the Linux power capping framework (sysfs interface)";
     license = licenses.bsd3;

--- a/pkgs/os-specific/linux/powercap/default.nix
+++ b/pkgs/os-specific/linux/powercap/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "powercap";
@@ -11,18 +11,20 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VvepbABc7daRE0/sJqsCb+m2my8O3B1ICXywBqsjSO8=";
   };
 
+  # in master post 0.6.0, see https://github.com/powercap/powercap/issues/8
+  patches = [
+    (fetchpatch {
+      name = "fix-pkg-config.patch";
+      url = "https://github.com/powercap/powercap/commit/278dceb51635686e343edfc357b6020533fff299.patch";
+      sha256 = "0h62j63xdn0iqyx4xbia6hlmdjn45camb82z4vv6sb37x9sph7rg";
+    })
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=On"
   ];
-
-  # https://github.com/powercap/powercap/issues/8
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
-      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
-  '';
 
   meta = with lib; {
     description = "Tools and library to read/write to the Linux power capping framework (sysfs interface)";

--- a/pkgs/tools/bluetooth/obexftp/default.nix
+++ b/pkgs/tools/bluetooth/obexftp/default.nix
@@ -15,6 +15,13 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ openobex ];
 
+  # https://sourceforge.net/p/openobex/bugs/66/
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
+  '';
+
   # There's no such thing like "bluetooth" library; possibly they meant "bluez" but it links correctly without this.
   postFixup = ''
     sed -i 's,^Requires: bluetooth,Requires:,' $out/lib/pkgconfig/obexftp.pc

--- a/pkgs/tools/bluetooth/openobex/default.nix
+++ b/pkgs/tools/bluetooth/openobex/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     sed -i "s!/lib/udev!$out/lib/udev!" udev/CMakeLists.txt
     sed -i "/if ( PKGCONFIG_UDEV_FOUND )/,/endif ( PKGCONFIG_UDEV_FOUND )/d" udev/CMakeLists.txt
+    # https://sourceforge.net/p/openobex/bugs/66/
+    substituteInPlace CMakeLists.txt \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
+      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
     '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -22,6 +22,26 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DWITH_STATIC=OFF"  "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON" ];
 
+  postPatch = ''
+    # https://github.com/shadowsocks/shadowsocks-libev/issues/2901
+    substituteInPlace CMakeLists.txt \
+      --replace '# pkg-config' \
+                '# pkg-config
+                 include(GNUInstallDirs)'
+    substituteInPlace cmake/shadowsocks-libev.pc.cmake \
+      --replace @prefix@ @CMAKE_INSTALL_PREFIX@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_BINDIR@ @CMAKE_INSTALL_FULL_BINDIR@ \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_FULL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_DATAROOTDIR@ @CMAKE_INSTALL_FULL_DATAROOTDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_MANDIR@ @CMAKE_INSTALL_FULL_MANDIR@
+
+    # https://github.com/dcreager/libcork/issues/173 but needs a different patch (yay vendoring)
+    substituteInPlace libcork/src/libcork.pc.in \
+      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+  '';
+
   postInstall = ''
     cp lib/* $out/lib
   '';

--- a/pkgs/tools/package-management/libdnf/default.nix
+++ b/pkgs/tools/package-management/libdnf/default.nix
@@ -41,11 +41,15 @@ stdenv.mkDerivation rec {
     cp ${libsolv}/share/cmake/Modules/FindLibSolv.cmake cmake/modules/
   '';
 
-  # See https://github.com/NixOS/nixpkgs/issues/107428
   postPatch = ''
+    # See https://github.com/NixOS/nixpkgs/issues/107428
     substituteInPlace CMakeLists.txt \
       --replace "enable_testing()" "" \
       --replace "add_subdirectory(tests)" ""
+
+    # https://github.com/rpm-software-management/libdnf/issues/1518
+    substituteInPlace libdnf/libdnf.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
   '';
 
   cmakeFlags = [

--- a/pkgs/tools/security/rnp/default.nix
+++ b/pkgs/tools/security/rnp/default.nix
@@ -42,6 +42,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" ];
 
+  # https://github.com/rnpgp/rnp/issues/1835
+  postPatch = ''
+    substituteInPlace cmake/librnp.pc.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+  '';
+
   preConfigure = ''
     echo "v${version}" > version.txt
   '';

--- a/pkgs/tools/security/rnp/default.nix
+++ b/pkgs/tools/security/rnp/default.nix
@@ -5,6 +5,7 @@
 , bzip2
 , cmake
 , fetchFromGitHub
+, fetchpatch
 , gnupg
 , gtest
 , json_c
@@ -24,6 +25,15 @@ stdenv.mkDerivation rec {
     sha256 = "u0etVslTBF9fBqnpVBofYsm0uC/eR6gO3lhwzqua5Qw=";
   };
 
+  # in master post 0.16.0, see https://github.com/rnpgp/rnp/issues/1835
+  patches = [
+    (fetchpatch {
+      name = "fix-pkg-config.patch";
+      url = "https://github.com/rnpgp/rnp/commit/de9856c94ea829cad277800ee03ec52e30993d8e.patch";
+      sha256 = "1vd83fva7lhmvqnvsrifqb2zdhfrbx84lf3l9i0hcph0k8h3ddx9";
+    })
+  ];
+
   buildInputs = [ zlib bzip2 json_c botan2 ];
 
   cmakeFlags = [
@@ -41,12 +51,6 @@ stdenv.mkDerivation rec {
   # checkInputs = [ gtest python3 ];
 
   outputs = [ "out" "lib" "dev" ];
-
-  # https://github.com/rnpgp/rnp/issues/1835
-  postPatch = ''
-    substituteInPlace cmake/librnp.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
-  '';
 
   preConfigure = ''
     echo "v${version}" > version.txt


### PR DESCRIPTION
###### Description of changes

Fixes #167528 and several other cases of similarly broken pkg-config files generated with CMake. The case of zxing-cpp was discussed in review comments of #172046.

I tried to patch things in such a way that the build won’t break even once an upstream fix is in place.

Upstream bugs: https://github.com/jiixyj/libebur128/issues/121, https://github.com/libjxl/libjxl/issues/1400, https://github.com/kcat/openal-soft/pull/696, https://github.com/sctplab/usrsctp/issues/662, https://github.com/Mindwerks/wildmidi/issues/236, https://github.com/nu-book/zxing-cpp/issues/335, https://github.com/KhronosGroup/SPIRV-Tools/issues/3905, [openobex#66](https://sourceforge.net/p/openobex/bugs/66/), https://github.com/dirkvdb/ffmpegthumbnailer/issues/215, https://github.com/Matroska-Org/libmatroska/issues/62, [extra-cmake-modules!268](https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/268), https://github.com/Matroska-Org/libebml/issues/97.

I only patched things that I found by grepping the Nix store on my machine, so it’s probable there are many more cases of this problem in CMake build systems. Someone who has access to a full build of Nixpkgs should probably make a systematic review (`rg -g '*.pc' '}//nix' /nix/store` will probably find most cases).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
