### PR TITLE
python3Packages.sanic: fix build on aarch64

### DIFF
--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -125,15 +125,14 @@ buildPythonPackage rec {
     "test_raw_headers"
     # noisy_exceptions sometimes missing from sanic stdout
     "test_noisy_exceptions"
-    # test fail on aarch64
   ] ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    # test fail on aarch64
     "test_tls_wrong_options"
     "test_cookie_expires"
     "test_gunicorn_worker"
     "test_gunicorn_worker_no_logs"
     "test_gunicorn_worker_with_logs"
   ];
-
 
   disabledTestPaths = [
     # unable to create async loop

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -126,15 +126,13 @@ buildPythonPackage rec {
     # noisy_exceptions sometimes missing from sanic stdout
     "test_noisy_exceptions"
     # test fail on aarch64
-  ] ++ (if stdenv.hostPlatform.system == "aarch64-linux"
-  then [
+  ] ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
     "test_tls_wrong_options"
     "test_cookie_expires"
     "test_gunicorn_worker"
     "test_gunicorn_worker_no_logs"
     "test_gunicorn_worker_with_logs"
-  ]
-  else [ ]);
+  ];
 
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   disabled = pythonOlder "3.7" ||
-    pythonAtLeast "3.10";  # see GHSA-7p79-6x2v-5h88
+    pythonAtLeast "3.10"; # see GHSA-7p79-6x2v-5h88
 
   src = fetchFromGitHub {
     owner = "sanic-org";
@@ -125,7 +125,17 @@ buildPythonPackage rec {
     "test_raw_headers"
     # noisy_exceptions sometimes missing from sanic stdout
     "test_noisy_exceptions"
-  ];
+    # test fail on aarch64
+  ] ++ (if stdenv.hostPlatform.system == "aarch64-linux"
+  then [
+    "test_tls_wrong_options"
+    "test_cookie_expires"
+    "test_gunicorn_worker"
+    "test_gunicorn_worker_no_logs"
+    "test_gunicorn_worker_with_logs"
+  ]
+  else [ ]);
+
 
   disabledTestPaths = [
     # unable to create async loop


### PR DESCRIPTION
###### Description of changes

Sanic fails to build on aarch64

```
nix-build --argstr system aarch64-linux --no-link -A python3Packages.sanic
[...]
=========================== short test summary info ============================
FAILED test_cli.py::test_tls_wrong_options[cmd0] - assert -9 == 1
FAILED test_cli.py::test_tls_wrong_options[cmd1] - assert -9 == 1
FAILED test_cli.py::test_tls_wrong_options[cmd2] - assert -9 == 1
FAILED test_cookies.py::test_cookie_expires[expires0] - KeyError: 'test'
FAILED test_worker.py::test_gunicorn_worker - urllib.error.URLError: <urlopen...
FAILED test_worker.py::test_gunicorn_worker_no_logs - urllib.error.URLError: ...
FAILED test_worker.py::test_gunicorn_worker_with_logs - urllib.error.URLError...
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
