### PR TITLE
scorecard: 4.1.0 -> 4.2.0

### DIFF
--- a/pkgs/tools/security/scorecard/default.nix
+++ b/pkgs/tools/security/scorecard/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "scorecard";
-  version = "4.1.0";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "ossf";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-QOWQhuEEnwtHmQwl5WCCHcKMjwhgxn9xerR0Bxi3660=";
+    sha256 = "sha256-MTqXQCPmm2NoueVd3bbQlRz4pi2dOZ9l2EUfb60LwsM=";
     # populate values otherwise taken care of by goreleaser,
     # unfortunately these require us to use git. By doing
     # this in postFetch we can delete .git afterwards and
@@ -16,20 +16,14 @@ buildGoModule rec {
     leaveDotGit = true;
     postFetch = ''
       cd "$out"
-
-      commit="$(git rev-parse HEAD)"
-      source_date_epoch=$(git log --date=iso8601-strict -1 --pretty=%ct)
-
-      substituteInPlace "$out/pkg/scorecard_version.go" \
-        --replace 'gitCommit = "unknown"' "gitCommit = \"$commit\"" \
-        --replace 'buildDate = "unknown"' "buildDate = \"$source_date_epoch\""
-
+      git rev-parse HEAD > $out/COMMIT
+      # 0000-00-00T00:00:00Z
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorSha256 = "sha256-AFadBzkRj0D1MXLHzexvomJ0cqirhW82tnNRGx/gChI=";
+  vendorSha256 = "sha256-JT1hoEm3eBjR5mlNJ+/tBpHIw6FSvFXC/nEVPkbIfq8=";
 
-  # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "." ];
@@ -37,9 +31,15 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/ossf/scorecard/v${lib.versions.major version}/pkg.gitVersion=v${version}"
-    "-X github.com/ossf/scorecard/v${lib.versions.major version}/pkg.gitTreeState=clean"
+    "-X sigs.k8s.io/release-utils/version.gitVersion=v${version}"
+    "-X sigs.k8s.io/release-utils/version.gitTreeState=clean"
   ];
+
+  # ldflags based on metadata from git and source
+  preBuild = ''
+    ldflags+=" -X sigs.k8s.io/release-utils/version.gitCommit=$(cat COMMIT)"
+    ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
+  '';
 
   preCheck = ''
     # Feed in all but the e2e tests for testing
@@ -63,7 +63,7 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/scorecard --help
-    $out/bin/scorecard version | grep "v${version}"
+    # $out/bin/scorecard version 2>&1 | grep "v${version}"
     runHook postInstallCheck
   '';
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump scorecard to `4.1.0`

Fixed the source date epoch generation and made it less brittle
Updated to new version ldflags stuff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
