### PR TITLE
rbspy: 0.11.1 -> 0.12.1

### DIFF
--- a/pkgs/development/tools/rbspy/default.nix
+++ b/pkgs/development/tools/rbspy/default.nix
@@ -1,17 +1,31 @@
-{ stdenv, rustPlatform, fetchFromGitHub, lib}:
+{ stdenv, rustPlatform, fetchFromGitHub, lib, ruby, which}:
 rustPlatform.buildRustPackage rec {
   pname = "rbspy";
-  version = "0.11.1";
+  version = "0.12.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-9BeQHwwnirK5Wquj6Tal8yCU/NXZGaPjXZe3cy5m98s=";
+    sha256 = "FnUUX7qQWVZMHtWvneTLzBL1YYwF8v4e1913Op4Lvbw=";
   };
 
-  cargoSha256 = "sha256-DHdfv6210wAkL9vXxLr76ejFWU/eV/q3lmgsYa5Rn54=";
+  cargoSha256 = "98vmUoWSehX/9rMlHNSvKHJvJxW99pOhS08FI3OeLGo=";
   doCheck = true;
+
+  # Tests in initialize.rs rely on specific PIDs being queried and attaching
+  # tracing to forked processes, which don't work well with the isolated build.
+  preCheck = ''
+    substituteInPlace src/core/process.rs \
+      --replace /usr/bin/which '${which}/bin/which'
+    substituteInPlace src/sampler/mod.rs \
+      --replace /usr/bin/which '${which}/bin/which'
+    substituteInPlace src/core/initialize.rs \
+      --replace 'fn test_initialize_with_disallowed_process(' '#[ignore] fn test_initialize_with_disallowed_process(' \
+      --replace 'fn test_get_exec_trace(' '#[ignore] fn test_get_exec_trace(' \
+  '';
+
+  nativeBuildInputs = [ ruby which ];
 
   meta = with lib; {
     broken = (stdenv.isLinux && stdenv.isAarch64);


### PR DESCRIPTION
###### Description of changes

Update rbspy.

Changes:

```
0.12.1

    Add --force-version flag for testing with pre-release or custom Ruby versions (https://github.com/rbspy/rbspy/pull/357)
    Fix CLI bug when using the summary-by-line format (https://github.com/rbspy/rbspy/issues/361)
    Improve library examples (https://github.com/rbspy/rbspy/pull/358) and help text

0.12.0

    Add support for Ruby 2.6.10, 2.7.6, 3.0.4, and 3.1.2
    Use directories crate to find OS-appropriate cache directory
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
