### PR TITLE
siesta: fix build for gcc/gfortran-10/11

### DIFF
--- a/pkgs/applications/science/chemistry/siesta/default.nix
+++ b/pkgs/applications/science/chemistry/siesta/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ blas lapack ]
     ++ lib.optionals useMpi [ mpi scalapack ];
 
-  enableParallelBuilding = true;
+  enableParallelBuilding = false;  # Started making trouble with gcc-11
 
   # Must do manualy becuase siesta does not do the regular
   # ./configure; make; make install
@@ -35,17 +35,23 @@ stdenv.mkDerivation rec {
     cp gfortran.make arch.make
   '';
 
-  preBuild = if useMpi then ''
+  preBuild = ''
+    # See https://gitlab.com/siesta-project/siesta/-/commit/a10bf1628e7141ba263841889c3503c263de1582
+    # This may be fixed in the next release.
     makeFlagsArray=(
+        FFLAGS="-fallow-argument-mismatch"
+    )
+    '' + (if useMpi then ''
+    makeFlagsArray+=(
         CC="mpicc" FC="mpifort"
         FPPFLAGS="-DMPI" MPI_INTERFACE="libmpi_f90.a" MPI_INCLUDE="."
         COMP_LIBS="" LIBS="-lblas -llapack -lscalapack"
     );
   '' else ''
-    makeFlagsArray=(
+    makeFlagsArray+=(
       COMP_LIBS="" LIBS="-lblas -llapack"
     );
-  '';
+  '');
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Description of changes
FIx broken build due to gcc/gfortran-10/11 update.
ZHF: https://github.com/NixOS/nixpkgs/issues/172160


###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
