### PR TITLE
dsf2flac: unstable-2018-01-02 → unstable-2021-07-31

### DIFF
--- a/pkgs/applications/audio/dsf2flac/default.nix
+++ b/pkgs/applications/audio/dsf2flac/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dsf2flac";
-  version = "unstable-2018-01-02";
+  version = "unstable-2021-07-31";
 
   src = fetchFromGitHub {
     owner = "hank";
     repo = pname;
-    rev = "b0cf5aa6ddc60df9bbfeed25548e443c99f5cb16";
-    sha256 = "15j5f82v7lgs0fkgyyynl82cb1rsxyr9vw3bpzra63nacbi9g8lc";
+    rev = "6b109cd276ec7c7901f96455c77cf2d2ebfbb181";
+    sha256 = "sha256-VlXfywgYhI2QuGQvpD33BspTTgT0jOKUV3gENq4HiBU=";
   };
 
   buildInputs = [ boost flac id3lib taglib zlib ];
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "A DSD to FLAC transcoding tool";
     homepage = "https://github.com/hank/dsf2flac";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ dmrauh ];
-    platforms = with platforms; linux;
+    maintainers = with maintainers; [ artemist ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates dsf2flac to the latest version to fix the build as part of ZHF (#172160). It previously failed due to incompatibilities with current versions of boost

###### Things done
Update to latest version and set platforms to only x86_64-linux, as it fails on aarch64-linux


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
