### PR TITLE
emscriptenStdenv: create writable cache directory

### DIFF
--- a/pkgs/development/em-modules/generic/default.nix
+++ b/pkgs/development/em-modules/generic/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, emscripten, python2 }:
+{ pkgs, lib, emscripten, python3 }:
 
 { buildInputs ? [], nativeBuildInputs ? []
 
@@ -12,8 +12,8 @@ pkgs.stdenv.mkDerivation (
 
   pname = "emscripten-${lib.getName args}";
   version = lib.getVersion args;
-  buildInputs = [ emscripten python2 ] ++ buildInputs;
-  nativeBuildInputs = [ emscripten python2 ] ++ nativeBuildInputs;
+  buildInputs = [ emscripten python3 ] ++ buildInputs;
+  nativeBuildInputs = [ emscripten python3 ] ++ nativeBuildInputs;
 
   # fake conftest results with emscripten's python magic
   EMCONFIGURE_JS=2;
@@ -25,6 +25,9 @@ pkgs.stdenv.mkDerivation (
 
     emconfigure ./configure --prefix=$out
 
+    mkdir -p .emscriptencache
+    export EM_CACHE=$(pwd)/.emscriptencache
+
     runHook postConfigure
   '';
 
@@ -32,6 +35,7 @@ pkgs.stdenv.mkDerivation (
     runHook preBuild
 
     HOME=$TMPDIR
+
     emmake make
 
     runHook postBuild

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -14,6 +14,8 @@ rec {
       propagatedBuildInputs = [ zlib ];
       configurePhase = ''
         HOME=$TMPDIR
+        mkdir -p .emscriptencache
+        export EM_CACHE=$(pwd)/.emscriptencache
         emcmake cmake . $cmakeFlags -DCMAKE_INSTALL_PREFIX=$out -DCMAKE_INSTALL_INCLUDEDIR=$dev/include
       '';
       checkPhase = ''
@@ -54,6 +56,8 @@ rec {
       autoreconfPhase = "echo autoreconfPhase not used...";
       configurePhase = ''
         HOME=$TMPDIR
+        mkdir -p .emscriptencache
+        export EM_CACHE=$(pwd)/.emscriptencache
         emconfigure ./configure --prefix=$out --without-python
       '';
       checkPhase = ''
@@ -102,6 +106,8 @@ rec {
       sed -e "s/\$(JSONC_LDFLAGS) \$(ZLIB_LDFLAGS) \$(LIBXML20_LDFLAGS)/\$(JSONC_LDFLAGS) \$(LIBXML20_LDFLAGS) \$(ZLIB_LDFLAGS) /g" -i Makefile.emEnv
       # https://gitlab.com/odfplugfest/xmlmirror/issues/11
       sed -e "s/-o fastXmlLint.js/-s EXTRA_EXPORTED_RUNTIME_METHODS='[\"ccall\", \"cwrap\"]' -o fastXmlLint.js/g" -i Makefile.emEnv
+      mkdir -p .emscriptencache
+      export EM_CACHE=$(pwd)/.emscriptencache
     '';
 
     buildPhase = ''
@@ -137,16 +143,6 @@ rec {
       buildInputs = old.buildInputs ++ [ pkg-config ];
       # we need to reset this setting!
       NIX_CFLAGS_COMPILE="";
-      configurePhase = ''
-        # FIXME: Some tests require writing at $HOME
-        HOME=$TMPDIR
-        runHook preConfigure
-
-        #export EMCC_DEBUG=2
-        emconfigure ./configure --prefix=$out --shared
-
-        runHook postConfigure
-      '';
       dontStrip = true;
       outputs = [ "out" ];
       buildPhase = ''
@@ -161,7 +157,7 @@ rec {
         echo "Compiling a custom test"
         set -x
         emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 test/example.c -DZ_SOLO \
-        -L. libz.so.${old.version} -I . -o example.js
+        -L. libz.a -I . -o example.js
 
         echo "Using node to execute the test"
         ${pkgs.nodejs}/bin/node ./example.js


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In the `configurePhase` of `emscriptenStdenv`, create a subdirectory that can be used for the internal emscripten cache. Fixes #139943 and #170621.

Issue broke zlib with the update to 3.0 in #149083.

Additionally this modified the derivation for `zlib` to just use the `emscriptenStdenv` configure phase, and then adds the same changes to the other derivations that make larger modifications.

@arximboldi @busti 
@qknight @matthewbauer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
