### PR TITLE
kmod: build devdoc

### DIFF
--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, lib, fetchurl, autoreconfHook, pkg-config
+{ stdenv, lib, fetchzip, autoconf, automake, docbook_xml_dtd_42
+, docbook_xml_dtd_43, docbook_xsl, gtk-doc, libtool, pkg-config
 , libxslt, xz, zstd, elf-header
+, withDevdoc ? stdenv.hostPlatform == stdenv.buildPlatform
 , withStatic ? stdenv.hostPlatform.isStatic
 }:
 
@@ -11,21 +13,35 @@ in stdenv.mkDerivation rec {
   pname = "kmod";
   version = "29";
 
-  src = fetchurl {
-    url = "mirror://kernel/linux/utils/kernel/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0am54mi5rk72g5q7k6l6f36gw3r9vwgjmyna43ywcjhqmakyx00b";
+  # autogen.sh is missing from the release tarball,
+  # and we need to run it to regenerate gtk_doc.make,
+  # because the version in the release tarball is broken.
+  # Possibly this will be fixed in kmod 30?
+  # https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/commit/.gitignore?id=61a93a043aa52ad62a11ba940d4ba93cb3254e78
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/snapshot/kmod-${version}.tar.gz";
+    sha256 = "sha256-7O5VdBd8rBZdIERPE+2zkjj5POvSurwlV2EpWmkFUD0=";
   };
 
-  outputs = [ "out" "dev" "lib" ];
+  outputs = [ "out" "dev" "lib" ] ++ lib.optional withDevdoc "devdoc";
 
-  nativeBuildInputs = [ autoreconfHook pkg-config libxslt ];
+  nativeBuildInputs = [
+    autoconf automake docbook_xsl libtool libxslt pkg-config
+
+    docbook_xml_dtd_42 # for the man pages
+  ] ++ lib.optionals withDevdoc [ docbook_xml_dtd_43 gtk-doc ];
   buildInputs = [ xz zstd ] ++ lib.optional stdenv.isDarwin elf-header;
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   configureFlags = [
     "--sysconfdir=/etc"
     "--with-xz"
     "--with-zstd"
     "--with-modulesdirs=${modulesDirs}"
+    (lib.enableFeature withDevdoc "gtk-doc")
   ] ++ lib.optional withStatic "--enable-static";
 
   patches = [ ./module-dir.patch ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Switch from autoreconfHook to running autogen.sh ourselves so that gtkdocize gets run.  The `GTK_DOC_CHECK` autoconf macro isn't cross-friendly, so we have to disable it when cross-compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
