### PR TITLE
fpc: 3.2.0 -> unstable-2022-05-09

### DIFF
--- a/pkgs/development/compilers/fpc/patches/0001-mark-paths-for-substitution-in-postPatch.patch
+++ b/pkgs/development/compilers/fpc/patches/0001-mark-paths-for-substitution-in-postPatch.patch
@@ -1,34 +1,23 @@
-diff --git a/fpcsrc/compiler/systems/t_linux.pas b/fpcsrc/compiler/systems/t_linux.pas
-index a7398fb9..8e46fec0 100644
---- a/fpcsrc/compiler/systems/t_linux.pas
-+++ b/fpcsrc/compiler/systems/t_linux.pas
-@@ -135,13 +135,13 @@ begin
-       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib64',true);
-       { /lib64 should be the really first, so add it before everything else }
-       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib',true);
--      LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib64',true);
+From e902698a4ff414fff1a1086a60e40387aa561dd4 Mon Sep 17 00:00:00 2001
+From: superherointj <5861043+superherointj@users.noreply.github.com>
+Date: Mon, 9 May 2022 12:01:18 -0300
+Subject: [PATCH] fpc: mark paths for substitution in postPatch
+
+
+diff --git a/compiler/systems/t_linux.pas b/compiler/systems/t_linux.pas
+index febd93d8ac..dc03f02b52 100644
+--- a/compiler/systems/t_linux.pas
++++ b/compiler/systems/t_linux.pas
+@@ -126,6 +126,8 @@ procedure SetupLibrarySearchPath;
+ begin
+   if not Dontlinkstdlibpath Then
+     begin
 +      LibrarySearchPath.AddLibraryPath(sysrootpath,'=@syslibpath@',true);
- {$else}
- {$ifdef powerpc64}
-       if target_info.abi<>abi_powerpc_elfv2 then
--        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib64;=/usr/lib64;=/usr/X11R6/lib64',true)
-+        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/@syslibpath@;=/usr/lib64;=/usr/X11R6/lib64',true)
-       else
--        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib64;=/usr/lib/powerpc64le-linux-gnu;=/usr/X11R6/powerpc64le-linux-gnu',true);
-+        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/@syslibpath@;=/usr/lib/powerpc64le-linux-gnu;=/usr/X11R6/powerpc64le-linux-gnu',true);
- {$else powerpc64}
-       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib;=/usr/lib;=/usr/X11R6/lib',true);
- {$endif powerpc64}
-@@ -164,7 +164,7 @@ begin
-       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/i386-linux-gnu',true);
- {$endif i386}
- {$ifdef aarch64}
--      LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/aarch64-linux-gnu',true);
-+      LibrarySearchPath.AddLibraryPath(sysrootpath,'=@syslibpath@',true);
- {$endif aarch64}
- {$ifdef powerpc}
-       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/powerpc-linux-gnu',true);
-@@ -185,53 +185,53 @@ begin
++
+ {$ifdef x86_64}
+       { some linuxes might not have the lib64 variants (Arch, LFS }
+       { don't use PathExists checks, as we need to take sysroots and
+@@ -210,65 +212,65 @@ procedure SetupLibrarySearchPath;
  end;
  
  {$ifdef m68k}
@@ -94,8 +83,23 @@ index a7398fb9..8e46fec0 100644
 +  const defdynlinker='@dynlinker-prefix@/lib64/ld-linux.so.2';
  {$endif sparc64}
  
+ {$ifdef riscv32}
+-  const defdynlinker='/lib32/ld.so.1';
++  const defdynlinker='@dynlinker-prefix@/lib32/ld.so.1';
+ {$endif riscv32}
  
-@@ -266,9 +266,9 @@ begin
+ {$ifdef riscv64}
+-  const defdynlinker='/lib/ld-linux-riscv64-lp64d.so.1';
++  const defdynlinker='@dynlinker-prefix@/lib/ld-linux-riscv64-lp64d.so.1';
+ {$endif riscv64}
+ 
+ {$ifdef xtensa}
+-  const defdynlinker='/lib/ld.so.1';
++  const defdynlinker='@dynlinker-prefix@/lib/ld.so.1';
+ {$endif xtensa}
+ 
+ 
+@@ -303,9 +305,9 @@ procedure SetupDynlinker(out DynamicLinker:string;out libctype:TLibcType);
        libctype:=uclibc;
      end
  {$ifdef i386}
@@ -107,3 +111,6 @@ index a7398fb9..8e46fec0 100644
        libctype:=glibc2;
      end
  {$endif i386}
+-- 
+2.36.0
+


### PR DESCRIPTION
fpc: 3.2.0 -> unstable-2022-05-09

Why `unstable-2022-05-09` instead of `3.2.2`?
The patch I got is for master. On the anticipation of a new release soon (it's been almost an year), the patch is ready for it.

I'll keep an eye on this package. I'm not currently using `fpc` for myself. But still, I don't like seeing it breaking/outdated.

Pending build for `fpc.aarch64-linux`:
* Test for ZeroHour: [fpc.aarch64-linux](https://hydra.nixos.org/build/176125413)

This PR seems to be breaking many packages for aarch64:

* lazarus-gtk2-2.0.12 (very important)
* lazarus-qt5-2.0.12
* lazpaint
* ddrescueview-0.4alpha4
* cudatext-1.163.0
* goverlay-0.7.1
* xidel-0.9.8

Need to better assess this.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
