### PR TITLE
matrix-recorder: use nodejs-14

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-recorder/composition.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-recorder/composition.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-12_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-14_x"}:
 
 let
   nodeEnv = import ./node-env.nix {

--- a/pkgs/applications/networking/instant-messengers/matrix-recorder/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-recorder/default.nix
@@ -6,13 +6,13 @@
   postInstall = ''
     mkdir "$out/bin"
     echo '#!/bin/sh' >> "$out/bin/matrix-recorder"
-    echo "'${pkgs.nodejs-12_x}/bin/node'" \
+    echo "'${pkgs.nodejs-14_x}/bin/node'" \
          "'$out/lib/node_modules/matrix-recorder/matrix-recorder.js'" \
          '"$@"' >> "$out/bin/matrix-recorder"
     echo '#!/bin/sh' >> "$out/bin/matrix-recorder-to-html"
     echo 'cd "$1"' >> "$out/bin/matrix-recorder-to-html"
     echo "test -d templates/ || ln -sfT '$out/lib/node_modules/matrix-recorder/templates' templates" >> "$out/bin/matrix-recorder-to-html"
-    echo "'${pkgs.nodejs-12_x}/bin/node'" \
+    echo "'${pkgs.nodejs-14_x}/bin/node'" \
          "'$out/lib/node_modules/matrix-recorder/recorder-to-html.js'" \
          '.' >> "$out/bin/matrix-recorder-to-html"
     chmod a+x "$out/bin/matrix-recorder"


### PR DESCRIPTION
###### Description of changes

Brute-force replace Node.JS 12 with Node.JS 14

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
