### PR TITLE
goku: fix download url

### DIFF
--- a/pkgs/os-specific/darwin/goku/default.nix
+++ b/pkgs/os-specific/darwin/goku/default.nix
@@ -1,13 +1,21 @@
-{lib, stdenv, fetchurl }:
+{ lib
+, stdenv
+, fetchurl
+, unzip
+}:
 
 stdenv.mkDerivation rec {
   pname = "goku";
   version = "0.5.1";
 
   src = fetchurl {
-    url = "https://github.com/yqrashawn/GokuRakuJoudo/releases/download/v${version}/goku.tar.gz";
+    url = "https://github.com/yqrashawn/GokuRakuJoudo/releases/download/v${version}/goku.zip";
     sha256 = "7c9304a5b4265575ca154bc0ebc04fcf812d14981775966092946cf82f65c782";
   };
+
+  nativeBuildInputs = [
+    unzip
+  ];
 
   sourceRoot = ".";
 


### PR DESCRIPTION
I accidentally merged the PR even though the url was not correct.
Fixup for https://github.com/NixOS/nixpkgs/pull/168863.

Closes https://github.com/NixOS/nixpkgs/issues/172154

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (produces a darwin binary, as expected)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
