### PR TITLE
python3Packages.eventlet: disable failing test

### DIFF
--- a/pkgs/development/python-modules/eventlet/default.nix
+++ b/pkgs/development/python-modules/eventlet/default.nix
@@ -59,6 +59,8 @@ buildPythonPackage rec {
     "test_patcher_existing_locks_locked"
     # broken with pyopenssl 22.0.0
     "test_sendall_timeout"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    "test_fork_after_monkey_patch"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
It's failing on aarch64: https://hydra.nixos.org/build/176121677/nixlog/2
Unclear if it's an actual failure or not, but disabling should help
downstream packages to build again.

Only fails on python39Packages, as far as I can tell.

Build is untested, since I don't have an aarch64 machine available for easy building.
Cross-compilation fails when compiling cffi so isn't useful either (and it wouldn't run the tests anyway).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux (needs to be done to verify if this fixes the build)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ZHF: https://github.com/NixOS/nixpkgs/issues/172160