### PR TITLE
python3Packages.prox-tv: ignore known MacOS failure

### DIFF
--- a/pkgs/development/python-modules/prox-tv/default.nix
+++ b/pkgs/development/python-modules/prox-tv/default.nix
@@ -6,6 +6,7 @@
 , fetchFromGitHub
 , nose
 , numpy
+, stdenv
 }:
 
 buildPythonPackage {
@@ -27,6 +28,11 @@ buildPythonPackage {
     numpy
     cffi
   ];
+
+  # this test is known to fail on darwin
+  checkPhase = ''
+    nosetests ${lib.optionalString stdenv.isDarwin " --exclude=test_tv2_1d"}
+  '';
 
   propagatedNativeBuildInputs = [ cffi ];
 


### PR DESCRIPTION
###### Description of changes

prox-tv seems to intermittently fail on darwin. this issue is [known](https://github.com/albarji/proxTV#notes-on-mac-os-x) [upstream](https://github.com/albarji/proxTV/blob/master/prox_tv/prox_tv_test.py#L88)
I'm a bit stuck there, as I don't have access to a darwin system :(
I've at least tested it does not break on linux

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
