### PR TITLE
Hydra updates 2

### DIFF
--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -9,6 +9,8 @@
 , foreman
 , python3
 , libressl
+, cacert
+, glibcLocales
 }:
 
 with stdenv;
@@ -22,19 +24,19 @@ let
     name = "hydra-perl-deps";
     paths = with perlPackages; lib.closePropagation
       [ ModulePluggable
+        AuthenSASL
         CatalystActionREST
         CatalystAuthenticationStoreDBIxClass
+        CatalystAuthenticationStoreLDAP
         CatalystDevel
-        CatalystDispatchTypeRegex
         CatalystPluginAccessLog
         CatalystPluginAuthorizationRoles
         CatalystPluginCaptcha
         CatalystPluginPrometheusTiny
         CatalystPluginSessionStateCookie
         CatalystPluginSessionStoreFastMmap
-        CatalystPluginSmartURI
         CatalystPluginStackTrace
-        CatalystRuntime
+        CatalystPluginUnicodeEncoding
         CatalystTraitForRequestProxyBase
         CatalystViewDownload
         CatalystViewJSON
@@ -52,8 +54,10 @@ let
         EmailMIME
         EmailSender
         FileSlurper
+        FileWhich
         IOCompress
         IPCRun
+        IPCRun3
         JSON
         JSONMaybeXS
         JSONXS
@@ -75,16 +79,18 @@ let
         StringCompareConstantTime
         SysHostnameLong
         TermSizeAny
+        TermReadKey
         Test2Harness
+        TestMore
         TestPostgreSQL
         TextDiff
         TextTable
+        UUID4Tiny
         XMLSimple
         YAML
         nix
         nix.perl-bindings
         git
-        boehmgc
       ];
   };
 in stdenv.mkDerivation rec {
@@ -110,7 +116,9 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config mdbook autoconf automake ];
 
   checkInputs = [
+    cacert
     foreman
+    glibcLocales
     python3
     libressl.nc
   ];

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -149,7 +149,7 @@ in stdenv.mkDerivation rec {
         wrapProgram $i \
             --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
             --prefix PATH ':' $out/bin:$hydraPath \
-            --set HYDRA_RELEASE ${version} \
+            --set-default HYDRA_RELEASE ${version} \
             --set HYDRA_HOME $out/libexec/hydra \
             --set NIX_RELEASE ${nix.name or "unknown"}
     done

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -2,15 +2,18 @@
 
 {
   hydra-unstable = callPackage ./common.nix {
-    version = "2021-08-11";
+    version = "2021-12-17";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "9bce425c3304173548d8e822029644bb51d35263";
-      sha256 = "sha256-tGzwKNW/odtAYcazWA9bPVSmVXMGKfXsqCA1UYaaxmU=";
+      rev = "e1e5fafdff63c1e1595d2edb8c9854710211a0d7";
+      sha256 = "sha256-JPkw3heasqX9iWju7BWjKDsyoS+HmLIKM2ibwHq5+Ko=";
     };
-    patches = [ ./eval.patch ];
-    nix = nixVersions.unstable;
+    patches = [
+      ./eval.patch
+      ./missing-std-string.patch
+    ];
+    nix = nixVersions.nix_2_4;
 
     tests = {
       basic = nixosTests.hydra.hydra-unstable;

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -1,19 +1,23 @@
-{ fetchFromGitHub, callPackage, nixVersions, nixosTests }:
+{ lib, fetchFromGitHub, callPackage, nixVersions, nixosTests, fetchpatch }:
 
 {
   hydra-unstable = callPackage ./common.nix {
-    version = "2021-12-17";
+    version = "2022-02-07";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "e1e5fafdff63c1e1595d2edb8c9854710211a0d7";
-      sha256 = "sha256-JPkw3heasqX9iWju7BWjKDsyoS+HmLIKM2ibwHq5+Ko=";
+      rev = "517dce285a851efd732affc084c7083aed2e98cd";
+      sha256 = "sha256-abWhd/VLNse3Gz7gcVbFANJLAhHV4nbOKjhVDmq/Zmg=";
     };
     patches = [
       ./eval.patch
       ./missing-std-string.patch
+      (fetchpatch {
+        url = "https://github.com/NixOS/hydra/commit/5ae26aa7604f714dcc73edcb74fe71ddc8957f6c.patch";
+        sha256 = "sha256-wkbWo8SFbT3qwVxwkKQWpQT5Jgb1Bb51yiLTlFdDN/I=";
+      })
     ];
-    nix = nixVersions.nix_2_4;
+    nix = nixVersions.nix_2_6;
 
     tests = {
       basic = nixosTests.hydra.hydra-unstable;

--- a/pkgs/development/tools/misc/hydra/missing-std-string.patch
+++ b/pkgs/development/tools/misc/hydra/missing-std-string.patch
@@ -1,0 +1,61 @@
+diff --git a/src/hydra-eval-jobs/hydra-eval-jobs.cc b/src/hydra-eval-jobs/hydra-eval-jobs.cc
+index acffe1d..53f2630 100644
+--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
++++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
+@@ -63,7 +63,7 @@ struct MyArgs : MixEvalArgs, MixCommonArgs
+ 
+ static MyArgs myArgs;
+ 
+-static std::string queryMetaStrings(EvalState & state, DrvInfo & drv, const string & name, const string & subAttribute)
++static std::string queryMetaStrings(EvalState & state, DrvInfo & drv, const std::string & name, const std::string & subAttribute)
+ {
+     Strings res;
+     std::function<void(Value & v)> rec;
+@@ -186,7 +186,7 @@ static void worker(
+                     for (auto & i : context)
+                         if (i.at(0) == '!') {
+                             size_t index = i.find("!", 1);
+-                            job["constituents"].push_back(string(i, index + 1));
++                            job["constituents"].push_back(std::string(i, index + 1));
+                         }
+ 
+                     state.forceList(*a->value, *a->pos);
+diff --git a/src/hydra-queue-runner/hydra-queue-runner.cc b/src/hydra-queue-runner/hydra-queue-runner.cc
+index 62eb572..a957bef 100644
+--- a/src/hydra-queue-runner/hydra-queue-runner.cc
++++ b/src/hydra-queue-runner/hydra-queue-runner.cc
+@@ -87,7 +87,7 @@ void State::parseMachines(const std::string & contents)
+     }
+ 
+     for (auto line : tokenizeString<Strings>(contents, "\n")) {
+-        line = trim(string(line, 0, line.find('#')));
++        line = trim(std::string(line, 0, line.find('#')));
+         auto tokens = tokenizeString<std::vector<std::string>>(line);
+         if (tokens.size() < 3) continue;
+         tokens.resize(8);
+diff --git a/src/libhydra/db.hh b/src/libhydra/db.hh
+index 7d5bdc5..00e8f40 100644
+--- a/src/libhydra/db.hh
++++ b/src/libhydra/db.hh
+@@ -18,7 +18,7 @@ struct Connection : pqxx::connection
+         std::string upper_prefix = "DBI:Pg:";
+ 
+         if (hasPrefix(s, lower_prefix) || hasPrefix(s, upper_prefix)) {
+-            return concatStringsSep(" ", tokenizeString<Strings>(string(s, lower_prefix.size()), ";"));
++            return concatStringsSep(" ", tokenizeString<Strings>(std::string(s, lower_prefix.size()), ";"));
+         }
+ 
+         throw Error("$HYDRA_DBI does not denote a PostgreSQL database");
+diff --git a/src/libhydra/hydra-config.hh b/src/libhydra/hydra-config.hh
+index bc989f7..1688c27 100644
+--- a/src/libhydra/hydra-config.hh
++++ b/src/libhydra/hydra-config.hh
+@@ -17,7 +17,7 @@ struct HydraConfig
+         if (hydraConfigFile && pathExists(*hydraConfigFile)) {
+ 
+             for (auto line : tokenizeString<Strings>(readFile(*hydraConfigFile), "\n")) {
+-                line = trim(string(line, 0, line.find('#')));
++                line = trim(std::string(line, 0, line.find('#')));
+ 
+                 auto eq = line.find('=');
+                 if (eq == std::string::npos) continue;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19055,6 +19055,21 @@ let
     };
   };
 
+  ReadonlyX = buildPerlModule {
+    pname = "ReadonlyX";
+    version = "1.04";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SA/SANKO/ReadonlyX-1.04.tar.gz";
+      sha256 = "81bb97dba93ac6b5ccbce04a42c3590eb04557d75018773ee18d5a30fcf48188";
+    };
+    buildInputs = [ ModuleBuildTiny TestFatal ];
+    meta = {
+      homepage = "https://github.com/sanko/readonly";
+      description = "Faster facility for creating read-only scalars, arrays, hashes";
+      license = lib.licenses.artistic2;
+    };
+  };
+
   ReadonlyXS = buildPerlPackage {
     pname = "Readonly-XS";
     version = "1.05";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24476,6 +24476,19 @@ let
     };
   };
 
+  UUID4Tiny = buildPerlPackage {
+    pname = "UUID4-Tiny";
+    version = "0.002";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/C/CV/CVLIBRARY/UUID4-Tiny-0.002.tar.gz";
+      sha256 = "e7535b31e386d432dec7adde214348389e1d5cf753e7ed07f1ae04c4360840cf";
+    };
+    meta = {
+      description = "Cryptographically secure v4 UUIDs for Linux x64";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   UUIDTiny = buildPerlPackage {
     pname = "UUID-Tiny";
     version = "1.04";


### PR DESCRIPTION
###### Description of changes

First batch of hydra updates, picked and rebased from https://github.com/NixOS/nixpkgs/pull/160202.

Since tests are now enabled, this gives some confidence in that everything's working ok.

TBD are some other changes in the other PR, but let's get this in first to get started.

Note that the latest version of hydra in this patchset doesn't work with nix_2_4 or nix_2_8 (test failures), so I picked nix_2_6 (others may or may not work too). Hopefully we can update that when we update hydra again.

cc @lheckemann @dasJ 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<s>Running the nixos test for hydra now...</s> ofborg did that for me, success on x86_64-linux

ZHF: https://github.com/NixOS/nixpkgs/issues/172160 (fixes the hydra build: https://hydra.nixos.org/build/176040460/nixlog/2)