### PR TITLE
Revert "glib: remove build references from cross compiles"

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -169,9 +169,6 @@ stdenv.mkDerivation rec {
       -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
   '' + optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     cp -r ${buildPackages.glib.devdoc} $devdoc
-
-    # Remove references to build dependencies from closure
-    rm $dev/bin/*
   '';
 
   checkInputs = [ tzdata desktop-file-utils shared-mime-info ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#138580