### PR TITLE
buildCrystalPackage: enable strictDeps

### DIFF
--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -72,16 +72,17 @@ stdenv.mkDerivation (mkDerivationArgs // {
 
   PREFIX = placeholder "out";
 
-  buildInputs = args.buildInputs or [ ] ++ [ crystal ]
-    ++ lib.optional (format != "crystal") shards;
+  strictDeps = true;
+  buildInputs = args.buildInputs or [ ] ++ [ crystal ];
 
   nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
+    crystal
     git
     installShellFiles
     removeReferencesTo
     pkg-config
     which
-  ];
+  ] ++ lib.optional (format != "crystal") shards;
 
   buildPhase = args.buildPhase or (lib.concatStringsSep "\n" ([
     "runHook preBuild"

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -145,9 +145,10 @@ let
         export CRYSTAL_CACHE_DIR=$TMP
       '';
 
-      buildInputs = commonBuildInputs extraBuildInputs;
 
+      strictDeps = true;
       nativeBuildInputs = [ binary makeWrapper which pkg-config llvmPackages.llvm ];
+      buildInputs = commonBuildInputs extraBuildInputs;
 
       makeFlags = [
         "CRYSTAL_CONFIG_VERSION=${version}"

--- a/pkgs/development/tools/oq/default.nix
+++ b/pkgs/development/tools/oq/default.nix
@@ -18,7 +18,8 @@ crystal.buildCrystalPackage rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jq libxml2 ];
+  buildInputs = [ libxml2 ];
+  checkInputs = [ jq ];
 
   format = "shards";
 

--- a/pkgs/development/tools/scry/default.nix
+++ b/pkgs/development/tools/scry/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, crystal, coreutils, makeWrapper }:
+{ lib, fetchFromGitHub, crystal, coreutils, makeWrapper, bash }:
 
 crystal.buildCrystalPackage rec {
   pname = "scry";
@@ -19,6 +19,7 @@ crystal.buildCrystalPackage rec {
   format = "shards";
 
   nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
 
   shardsFile = ./shards.nix;
 

--- a/pkgs/tools/misc/kakoune-cr/default.nix
+++ b/pkgs/tools/misc/kakoune-cr/default.nix
@@ -1,4 +1,4 @@
-{ lib, crystal, fetchFromGitHub, fetchurl, jq }:
+{ lib, crystal, fetchFromGitHub, fetchurl, jq, bash }:
 let
   icon = fetchurl {
     url = "https://github.com/mawww/kakoune/raw/master/doc/kakoune_logo.svg";
@@ -16,6 +16,7 @@ crystal.buildCrystalPackage rec {
     hash = "sha256-xFrxbnZl/49vGKdkESPa6LpK0ckq4Jv5GNLL/G0qA1w=";
   };
 
+  buildInputs = [ bash ];
   propagatedUserEnvPkgs = [ jq ];
 
   format = "shards";


### PR DESCRIPTION
it improves package correctness and keeps cross-compilation in good
health
there aren't many uses of buildCrystalPackage in nixpkgs yet so imo its
safe to turn it on

python builder, rust build, go builder, and others all turn it on

changes verified with [diffing](https://github.com/Artturin/diffing)
###### Description of changes


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
