### PR TITLE
fltk: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/fltk/common.nix
+++ b/pkgs/development/libraries/fltk/common.nix
@@ -37,7 +37,7 @@
 , doxygen
 , graphviz
 
-, withExamples ? true
+, withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform)
 , withShared ? true
 }:
 
@@ -139,6 +139,7 @@ stdenv.mkDerivation rec {
 
     # Examples & Tests
     "-DFLTK_BUILD_EXAMPLES=${onOff withExamples}"
+    "-DFLTK_BUILD_TEST=${onOff withExamples}"
 
     # Docs
     "-DOPTION_BUILD_HTML_DOCUMENTATION=${onOff withDocs}"


### PR DESCRIPTION
Disabling building tests when cross-compiling, since it gives a build fail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

