### PR TITLE
envoy: fix sha256 for x86_64-linux/aarch64-linux

### DIFF
--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -86,7 +86,7 @@ buildBazelPackage rec {
   fetchAttrs = {
     sha256 = {
       x86_64-linux = "sha256-23Z6SbKnbah/NCrdMrXhrNFFASd/8xRH3fSyIE++heA=";
-      aarch64-linux = "1ijv4arw67nprykn2wkn4ji8fbr284mc7p74zxfsky772s42yy9j";
+      aarch64-linux = "sha256-dMOu0HYUIUJ+XEtctjaZZ1jGGQq+cHbay8+KwR5XqP0=";
     }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -85,7 +85,7 @@ buildBazelPackage rec {
 
   fetchAttrs = {
     sha256 = {
-      x86_64-linux = "0k2cna0vjzc8z7jvxdlcw741vacil8daczppv32bslw17af65vq6";
+      x86_64-linux = "sha256-23Z6SbKnbah/NCrdMrXhrNFFASd/8xRH3fSyIE++heA=";
       aarch64-linux = "1ijv4arw67nprykn2wkn4ji8fbr284mc7p74zxfsky772s42yy9j";
     }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     dontUseCmakeConfigure = true;


### PR DESCRIPTION
###### Description of changes

Fix sha256 for envoy, so it starts building again.

SInce it's such a big package, it might take a while to build (and I might kill it before it's done). But at least it starts building now rather than reporting a hash mismatch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ZHF: https://github.com/NixOS/nixpkgs/issues/172160
