### PR TITLE
sony-headphones-client: fix build

### DIFF
--- a/pkgs/applications/audio/sony-headphones-client/default.nix
+++ b/pkgs/applications/audio/sony-headphones-client/default.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-Wno-dev" ];
 
+  postPatch = ''
+    substituteInPlace Constants.h \
+      --replace "UNKNOWN = -1" "// UNKNOWN removed since it doesn't fit in char"
+  '';
+
   installPhase = ''
     runHook preInstall
     install -Dm755 -t $out/bin SonyHeadphonesClient


### PR DESCRIPTION
###### Description of changes

I tried fixing the build for sony-headphones-client, but ran into a different issue after fixing the first build failure.

Deferring to @Stunkymonkey to check the other build failures.

<details><summary>Build log</summary>

```
SonyHeadphonesClient> unpacking sources
SonyHeadphonesClient> unpacking source archive /nix/store/w91kp6wliwwmim8yddmalyhzbrdn7x3c-source
SonyHeadphonesClient> source root is ./source/Client
SonyHeadphonesClient> patching sources
SonyHeadphonesClient> configuring
SonyHeadphonesClient> fixing cmake files...
SonyHeadphonesClient> cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/share/doc/SonyHeadphonesClient -DCMAKE_INSTALL_INFODIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/include -DCMAKE_INSTALL_SBINDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/bg35nfwn6zd616facdywiysgpprfvsji-gcc-wrapper-11.3.0/bin/strip -DCMAKE_RANLIB=/nix/store/rs684lgm8k7akkgbisb49z4vpxxc2zns-binutils-2.38/bin/ranlib -DCMAKE_AR=/nix/store/rs684lgm8k7akkgbisb49z4vpxxc2zns-binutils-2.38/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/7r9y2y3rcshywainnrr3d123c58bj92d-SonyHeadphonesClient-1.2 -Wno-dev
SonyHeadphonesClient> -- The C compiler identification is GNU 11.3.0
SonyHeadphonesClient> -- The CXX compiler identification is GNU 11.3.0
SonyHeadphonesClient> -- Detecting C compiler ABI info
SonyHeadphonesClient> -- Detecting C compiler ABI info - done
SonyHeadphonesClient> -- Check for working C compiler: /nix/store/bg35nfwn6zd616facdywiysgpprfvsji-gcc-wrapper-11.3.0/bin/gcc - skipped
SonyHeadphonesClient> -- Detecting C compile features
SonyHeadphonesClient> -- Detecting C compile features - done
SonyHeadphonesClient> -- Detecting CXX compiler ABI info
SonyHeadphonesClient> -- Detecting CXX compiler ABI info - done
SonyHeadphonesClient> -- Check for working CXX compiler: /nix/store/bg35nfwn6zd616facdywiysgpprfvsji-gcc-wrapper-11.3.0/bin/g++ - skipped
SonyHeadphonesClient> -- Detecting CXX compile features
SonyHeadphonesClient> -- Detecting CXX compile features - done
SonyHeadphonesClient> -- Looking for pthread.h
SonyHeadphonesClient> -- Looking for pthread.h - found
SonyHeadphonesClient> -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
SonyHeadphonesClient> -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
SonyHeadphonesClient> -- Found Threads: TRUE
SonyHeadphonesClient> -- Found PkgConfig: /nix/store/shgkj0lsgs0swgvrzz81dwykz6a519mf-pkg-config-wrapper-0.29.2/bin/pkg-config (found version "0.29.2")
SonyHeadphonesClient> -- Found DBUS: /nix/store/lfzy9f42awiqfvk053v6132rh34kbwq1-dbus-1.12.20-dev/include/dbus-1.0;/nix/store/kis1qxl8jp36yj9liqc9lz74jjid301v-dbus-1.12.20-lib/lib/dbus-1.0/include
SonyHeadphonesClient> -- Found GLEW: /nix/store/n00dnmqmf8v63l9qbnyd0198xi2hgqyf-glew-2.2.0-dev/lib/cmake/glew/glew-config.cmake
SonyHeadphonesClient> -- Found OpenGL: /nix/store/mzx6j2y1nk1bfdbahf10yjflcq23p2bk-libGL-1.4.0/lib/libOpenGL.so
SonyHeadphonesClient> -- Configuring done
SonyHeadphonesClient> -- Generating done
SonyHeadphonesClient> CMake Warning:
SonyHeadphonesClient>   Manually-specified variables were not used by the project:
SonyHeadphonesClient>     BUILD_TESTING
SonyHeadphonesClient>     CMAKE_EXPORT_NO_PACKAGE_REGISTRY
SonyHeadphonesClient>     CMAKE_INSTALL_BINDIR
SonyHeadphonesClient>     CMAKE_INSTALL_DOCDIR
SonyHeadphonesClient>     CMAKE_INSTALL_INCLUDEDIR
SonyHeadphonesClient>     CMAKE_INSTALL_INFODIR
SonyHeadphonesClient>     CMAKE_INSTALL_LIBDIR
SonyHeadphonesClient>     CMAKE_INSTALL_LIBEXECDIR
SonyHeadphonesClient>     CMAKE_INSTALL_LOCALEDIR
SonyHeadphonesClient>     CMAKE_INSTALL_MANDIR
SonyHeadphonesClient>     CMAKE_INSTALL_OLDINCLUDEDIR
SonyHeadphonesClient>     CMAKE_INSTALL_SBINDIR
SonyHeadphonesClient>     CMAKE_POLICY_DEFAULT_CMP0025
SonyHeadphonesClient> 
SonyHeadphonesClient> -- Build files have been written to: /build/source/Client/build
SonyHeadphonesClient> cmake: enabled parallel building
SonyHeadphonesClient> building
SonyHeadphonesClient> build flags: -j8 -l8 SHELL=/nix/store/07ln9bxp9k8nds669r24fsywf4d1jlly-bash-5.1-p16/bin/bash
SonyHeadphonesClient> [  5%] Building CXX object CMakeFiles/SonyHeadphonesClient.dir/BluetoothWrapper.cpp.o
SonyHeadphonesClient> [ 11%] Building CXX object CMakeFiles/SonyHeadphonesClient.dir/imgui/imgui_tables.cpp.o
SonyHeadphonesClient> [ 17%] Building CXX object CMakeFiles/SonyHeadphonesClient.dir/imgui/imgui_widgets.cpp.o
SonyHeadphonesClient> /build/source/Client/imgui/imgui_widgets.cpp: In function 'bool ImGui::CollapsingHeader(const char*, bool*, ImGuiTreeNodeFlags)':
SonyHeadphonesClient> /build/source/Client/imgui/imgui_widgets.cpp:5970:54: warning: bitwise operation between different enumeration types 'ImGuiTreeNodeFlags_' and 'ImGuiTreeNodeFlagsPrivate_' is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-enum-enum-conversion-Wdeprecated-enum-enum-conversion8;;]
SonyHeadphonesClient>  5970 |         flags |= ImGuiTreeNodeFlags_AllowItemOverlap | ImGuiTreeNodeFlags_ClipLabelForTrailingButton;
SonyHeadphonesClient>       |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SonyHeadphonesClient> [ 23%] Building CXX object CMakeFiles/SonyHeadphonesClient.dir/CascadiaCodeFont.cpp.o
SonyHeadphonesClient> [ 29%] Building CXX object CMakeFiles/SonyHeadphonesClient.dir/linux/DBusHelper.cpp.o
SonyHeadphonesClient> [ 35%] Building CXX object CMakeFiles/SonyHeadphonesClient.dir/linux/LinuxBluetoothConnector.cpp.o
SonyHeadphonesClient> [ 41%] Building CXX object CMakeFiles/SonyHeadphonesClient.dir/linux/LinuxGUI.cpp.o
SonyHeadphonesClient> In file included from /build/source/Client/CrossPlatformGUI.h:10,
SonyHeadphonesClient>                  from /build/source/Client/linux/LinuxGUI.cpp:10:
SonyHeadphonesClient> /build/source/Client/SingleInstanceFuture.h:15:33: error: expected unqualified-id before ')' token
SonyHeadphonesClient>    15 |         SingleInstanceFuture<T>() = default;
SonyHeadphonesClient>       |                                 ^
SonyHeadphonesClient> /build/source/Client/SingleInstanceFuture.h:21:48: error: invalid declarator before 'other'
SonyHeadphonesClient>    21 |         SingleInstanceFuture<T>(std::future<T> other);
SonyHeadphonesClient>       |                                                ^~~~~
SonyHeadphonesClient> /build/source/Client/SingleInstanceFuture.h:21:47: error: expected ')' before 'other'
SonyHeadphonesClient>    21 |         SingleInstanceFuture<T>(std::future<T> other);
SonyHeadphonesClient>       |                                ~              ^~~~~~
SonyHeadphonesClient>       |                                               )
SonyHeadphonesClient> /build/source/Client/SingleInstanceFuture.h:48:8: error: no declaration matches 'SingleInstanceFuture<T>::SingleInstanceFuture(std::future<_Res>)'
SonyHeadphonesClient>    48 | inline SingleInstanceFuture<T>::SingleInstanceFuture(std::future<T> other) : std::future<T>(std::move(other)) {}
SonyHeadphonesClient>       |        ^~~~~~~~~~~~~~~~~~~~~~~
SonyHeadphonesClient> /build/source/Client/SingleInstanceFuture.h:48:8: note: no functions named 'SingleInstanceFuture<T>::SingleInstanceFuture(std::future<_Res>)'
SonyHeadphonesClient> /build/source/Client/SingleInstanceFuture.h:12:7: note: 'class SingleInstanceFuture<T>' defined here
SonyHeadphonesClient>    12 | class SingleInstanceFuture : public std::future<T>
SonyHeadphonesClient>       |       ^~~~~~~~~~~~~~~~~~~~
SonyHeadphonesClient> make[2]: *** [CMakeFiles/SonyHeadphonesClient.dir/build.make:244: CMakeFiles/SonyHeadphonesClient.dir/linux/LinuxGUI.cpp.o] Error 1
SonyHeadphonesClient> make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/SonyHeadphonesClient.dir/all] Error 2
SonyHeadphonesClient> make: *** [Makefile:91: all] Error 2
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ZHF: https://github.com/NixOS/nixpkgs/issues/172160
