### PR TITLE
zeroc-ice: 3.7.6 -> 3.7.7

### DIFF
--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -1,9 +1,7 @@
 { stdenv, lib, fetchFromGitHub
 , bzip2, expat, libedit, lmdb, openssl
-, darwin, libiconv, Security
 , python3 # for tests only
 , cpp11 ? false
-, fetchpatch
 }:
 
 let
@@ -24,36 +22,16 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "zeroc-ice";
-  version = "3.7.6";
+  version = "3.7.7";
 
   src = fetchFromGitHub {
     owner = "zeroc-ice";
     repo = "ice";
     rev = "v${version}";
-    sha256 = "0zc8gmlzl2f38m1fj6pv2vm8ka7fkszd6hx2lb8gfv65vn3m4sk4";
+    sha256 = "sha256-h455isEmnRyoasXhh1UaA5PICcEEM8/C3IJf5yHRl5g=";
   };
 
-  patches = [
-    # Fixes for openssl 3.0 / glibc-2.34.
-    (fetchpatch {
-      url = "https://github.com/zeroc-ice/ice/commit/7204b31a082a10cd481c1f31dbb6184ec699160d.patch";
-      sha256 = "sha256-RN8kQrvWRu1oXB7UV7DkYbZ8A0VyJYGArx6ikovwefo=";
-    })
-    (fetchpatch {
-      url = "https://github.com/zeroc-ice/ice/commit/358e7fea00383d55d1c19d38a3bbb64aca803aeb.patch";
-      sha256 = "sha256-ntrTO6qHB7dw398BRdAyJQUfVYW3iEfzUaBYoWWOEDs=";
-    })
-  ];
-
-  buildInputs = [ zeroc_mcpp bzip2 expat libedit lmdb openssl ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.cctools libiconv Security ];
-
-  NIX_CFLAGS_COMPILE = "-Wno-error=class-memaccess -Wno-error=deprecated-copy";
-
-  prePatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace Make.rules.Darwin \
-        --replace xcrun ""
-  '';
+  buildInputs = [ zeroc_mcpp bzip2 expat libedit lmdb openssl ];
 
   preBuild = ''
     makeFlagsArray+=(
@@ -97,7 +75,6 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];
-    # no match for 'operator!='
-    broken = true;
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30892,9 +30892,7 @@ with pkgs;
 
   zerobin = callPackage ../applications/networking/zerobin { };
 
-  zeroc-ice = callPackage ../development/libraries/zeroc-ice {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
+  zeroc-ice = callPackage ../development/libraries/zeroc-ice {};
 
   zeroc-ice-cpp11 = zeroc-ice.override { cpp11 = true; };
 


### PR DESCRIPTION
###### Description of changes

Fixes build of itself and Mumble. Upstream changelog is not interesting: https://doc.zeroc.com/ice/latest/release-notes/new-features-in-ice-3-7#id-.NewFeaturesinIce3.7v3.7-NewFeaturesIntroducedinIce3.7.7

This is strictly an improvement from it being marked broken on all platforms.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
