### PR TITLE
python3Packages.pydyf: fix failing tests

### DIFF
--- a/pkgs/development/python-modules/pydyf/default.nix
+++ b/pkgs/development/python-modules/pydyf/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , isPy3k
 , pytestCheckHook
@@ -18,6 +19,15 @@ buildPythonPackage rec {
     pname = "pydyf";
     sha256 = "sha256-Hi9d5IF09QXeAlp9HnzwG73ZQiyoq5RReCvwDuF4YCw=";
   };
+
+  patches = [
+    # Fix tests for Ghostscript 9.56
+    # Remove after v0.1.3 has been released
+    (fetchpatch {
+      url = "https://github.com/CourtBouillon/pydyf/commit/d4c34823f1d15368753c9c26f7acc7a24fc2d979.patch";
+      sha256 = "sha256-2hHZW/q5CbStbpSJYbm3b23qKXANEb5jbPGQ83uHC+Q=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \


### PR DESCRIPTION
###### Description of changes

Some tests were failing with the latest Ghostscript version. It's fixed upstream but no new version has been released, so for now we just apply that fix.

https://github.com/CourtBouillon/pydyf/commit/d4c34823f1d15368753c9c26f7acc7a24fc2d979

Fixes https://github.com/NixOS/nixpkgs/issues/172259 @samuela 

ZHF #172160 

Should be backported to release-22.05

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
