### PR TITLE
SDL_compat: init at 1.2.52

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -672,7 +672,7 @@ in
     license = "MAME";
 
     extraBuildInputs = [ libpng SDL ];
-    SDL_CONFIG = "${SDL.dev}/bin/sdl-config";
+    SDL_CONFIG = "${lib.getDev SDL}/bin/sdl-config";
     dontAddPrefix = true;
     configurePlatforms = [ ];
     makeFlags = lib.optional stdenv.hostPlatform.isAarch64 [ "platform=aarch64" ];

--- a/pkgs/development/guile-modules/guile-sdl/default.nix
+++ b/pkgs/development/guile-modules/guile-sdl/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
   buildInputs = [
-    SDL.dev
+    (lib.getDev SDL)
     SDL_image
     SDL_mixer
     SDL_ttf

--- a/pkgs/development/libraries/SDL_compat/default.nix
+++ b/pkgs/development/libraries/SDL_compat/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, SDL2
+, libGLSupported ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms
+, openglSupport ? libGLSupported
+, libGL
+, libGLU
+}:
+
+let
+  inherit (lib) optionals makeLibraryPath;
+
+in
+stdenv.mkDerivation rec {
+  pname = "SDL_compat";
+  version = "1.2.52";
+
+  src = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "sdl12-compat";
+    rev = "release-" + version;
+    hash = "sha256-PDGlMI8q74JaqMQ5oX9Zt5CEr7frFQWECbuwq5g25eg=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  propagatedBuildInputs = [ SDL2 ]
+    ++ optionals openglSupport [ libGL libGLU ];
+
+  enableParallelBuilding = true;
+
+  setupHook = ../SDL/setup-hook.sh;
+
+  postFixup = ''
+    for lib in $out/lib/*.so* ; do
+      if [[ -L "$lib" ]]; then
+        patchelf --set-rpath "$(patchelf --print-rpath $lib):${makeLibraryPath propagatedBuildInputs}" "$lib"
+      fi
+    done
+  '';
+
+  meta = with lib; {
+    description = "A cross-platform multimedia library - build SDL 1.2 applications against 2.0";
+    homepage = "https://www.libsdl.org/";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/smpeg/default.nix
+++ b/pkgs/development/libraries/smpeg/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/smpeg-config \
       --prefix PATH ":" "${pkg-config}/bin" \
-      --prefix PKG_CONFIG_PATH ":" "${SDL.dev}/lib/pkgconfig"
+      --prefix PKG_CONFIG_PATH ":" "${lib.getDev SDL}/lib/pkgconfig"
   '';
 
   NIX_LDFLAGS = "-lX11";

--- a/pkgs/games/brogue/default.nix
+++ b/pkgs/games/brogue/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     sed -i Makefile -e 's,LIBTCODDIR=.*,LIBTCODDIR=${libtcod},g' \
-                    -e 's,sdl-config,${SDL.dev}/bin/sdl-config,g'
+                    -e 's,sdl-config,${lib.getDev SDL}/bin/sdl-config,g'
     sed -i src/platform/tcod-platform.c -e "s,fonts/font,$out/share/brogue/fonts/font,g"
     make clean
     rm -rf src/libtcod*

--- a/pkgs/games/gargoyle/default.nix
+++ b/pkgs/games/gargoyle/default.nix
@@ -6,7 +6,7 @@ let
   jamenv = ''
     unset AR
   '' + (if stdenv.isDarwin then ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL.dev}/include/SDL"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${lib.getDev SDL}/include/SDL"
     export GARGLKINI="$out/Applications/Gargoyle.app/Contents/Resources/garglk.ini"
   '' else ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/libexec/gargoyle"

--- a/pkgs/games/hyperrogue/default.nix
+++ b/pkgs/games/hyperrogue/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0bijgbqpc867pq8lbwwvcnc713gm51mmz625xb5br0q2qw09nkyh";
   };
 
-  CPPFLAGS = "-I${SDL.dev}/include/SDL";
+  CPPFLAGS = "-I${lib.getDev SDL}/include/SDL";
 
   buildInputs = [ autoreconfHook SDL SDL_ttf SDL_gfx SDL_mixer libpng glew ];
 

--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   ;
 
   # To avoid problems finding SDL_types.h.
-  configureFlags = [ "CFLAGS=-I${SDL.dev}/include/SDL" ];
+  configureFlags = [ "CFLAGS=-I${lib.getDev SDL}/include/SDL" ];
 
   meta = with lib; {
     description = "Quick tactics game";

--- a/pkgs/games/meritous/default.nix
+++ b/pkgs/games/meritous/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   prePatch = ''
     substituteInPlace Makefile \
       --replace "CPPFLAGS +=" "CPPFLAGS += -DSAVES_IN_HOME -DDATADIR=\\\"$out/share/meritous\\\"" \
-      --replace sld-config ${SDL.dev}/bin/sdl-config
+      --replace sld-config ${lib.getDev SDL}/bin/sdl-config
     substituteInPlace src/audio.c \
       --replace "filename[64]" "filename[256]"
   '';

--- a/pkgs/games/openxcom/default.nix
+++ b/pkgs/games/openxcom/default.nix
@@ -1,26 +1,38 @@
-{lib, stdenv, fetchFromGitHub, cmake, libGLU, libGL, zlib, openssl, libyamlcpp, boost
-, SDL, SDL_image, SDL_mixer, SDL_gfx }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libGLU
+, libGL
+, zlib
+, openssl
+, libyamlcpp
+, boost
+, SDL
+, SDL_image
+, SDL_mixer
+, SDL_gfx
+}:
 
-let version = "1.0.0.2019.10.18"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "openxcom";
-  inherit version;
+  version = "1.0.0.2019.10.18";
+
   src = fetchFromGitHub {
     owner = "OpenXcom";
     repo = "OpenXcom";
     rev = "f9853b2cb8c8f741ac58707487ef493416d890a3";
-    sha256 = "0kbfawj5wsp1mwfcm5mwpkq6s3d13pailjm5w268gqpxjksziyq0";
+    hash = "sha256-APv49ZT94oeM4KVKGtUdoQ1t8Ly8lsocr+FqXiRXbk0=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ SDL SDL_gfx SDL_image SDL_mixer boost libyamlcpp libGLU libGL openssl zlib ];
 
-  meta = {
+  meta = with lib; {
     description = "Open source clone of UFO: Enemy Unknown";
     homepage = "https://openxcom.org";
-    maintainers = [ lib.maintainers.cpages ];
-    platforms = lib.platforms.linux;
-    license = lib.licenses.gpl3;
+    maintainers = with maintainers; [ cpages ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
   };
-
 }

--- a/pkgs/games/pokerth/default.nix
+++ b/pkgs/games/pokerth/default.nix
@@ -59,7 +59,7 @@ mkDerivation rec {
     "pokerth.pro"
   ];
 
-  NIX_CFLAGS_COMPILE = "-I${SDL.dev}/include/SDL";
+  NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL}/include/SDL";
 
   meta = with lib; {
     homepage = "https://www.pokerth.net";

--- a/pkgs/games/quantumminigolf/default.nix
+++ b/pkgs/games/quantumminigolf/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   preBuild = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL.dev}/include/SDL -I${SDL_ttf}/include/SDL"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${lib.getDev SDL}/include/SDL -I${SDL_ttf}/include/SDL"
 
     sed -re 's@"(gfx|fonts|tracks)/@"'"$out"'/share/quantumminigolf/\1/@g' -i *.cpp
   '';

--- a/pkgs/games/rili/default.nix
+++ b/pkgs/games/rili/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  CPPFLAGS = "-I${SDL.dev}/include -I${SDL.dev}/include/SDL -I${SDL_mixer}/include";
+  CPPFLAGS = "-I${lib.getDev SDL}/include -I${lib.getDev SDL}/include/SDL -I${SDL_mixer}/include";
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ SDL SDL_mixer ];

--- a/pkgs/games/wargus/stratagus.nix
+++ b/pkgs/games/wargus/stratagus.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     zlib bzip2 libpng
     lua5_1 toluapp
-    SDL.dev SDL_image SDL_mixer libGL
+    (lib.getDev SDL) SDL_image SDL_mixer libGL
   ];
   cmakeFlags = [
     "-DCMAKE_CXX_FLAGS=-Wno-error=format-overflow"

--- a/pkgs/games/zaz/default.nix
+++ b/pkgs/games/zaz/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
   buildInputs = [
-    SDL.dev
+    (lib.getDev SDL)
     SDL_image
     mesa
     libtheora
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   # Fix SDL include problems
-  NIX_CFLAGS_COMPILE="-I${SDL.dev}/include/SDL -I${SDL_image}/include/SDL";
+  NIX_CFLAGS_COMPILE="-I${lib.getDev SDL}/include/SDL -I${SDL_image}/include/SDL";
   # Fix linking errors
   makeFlags = [
     "ZAZ_LIBS+=-lSDL"

--- a/pkgs/tools/graphics/quirc/default.nix
+++ b/pkgs/tools/graphics/quirc/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   buildInputs = [ SDL SDL_gfx libjpeg libpng opencv ];
 
   makeFlags = [ "PREFIX=$(out)" ];
-  NIX_CFLAGS_COMPILE = "-I${SDL.dev}/include/SDL -I${SDL_gfx}/include/SDL";
+  NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL}/include/SDL -I${SDL_gfx}/include/SDL";
 
   # Disable building of linux-only demos on darwin systems
   patches = lib.optionals stdenv.isDarwin [ ./0001-dont-build-demos.patch ];

--- a/pkgs/tools/video/mjpegtools/default.nix
+++ b/pkgs/tools/video/mjpegtools/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libdv libjpeg libpng ]
               ++ lib.optionals (!withMinimal) [ gtk2 libX11 SDL SDL_gfx ];
 
-  NIX_CFLAGS_COMPILE = lib.optionalString (!withMinimal) "-I${SDL.dev}/include/SDL";
+  NIX_CFLAGS_COMPILE = lib.optionalString (!withMinimal) "-I${lib.getDev SDL}/include/SDL";
 
   postPatch = ''
     sed -i -e '/ARCHFLAGS=/s:=.*:=:' configure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20418,12 +20418,16 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
-  SDL = callPackage ../development/libraries/SDL ({
+  SDL_classic = callPackage ../development/libraries/SDL ({
     inherit (darwin.apple_sdk.frameworks) OpenGL CoreAudio CoreServices AudioUnit Kernel Cocoa GLUT;
   } // lib.optionalAttrs stdenv.hostPlatform.isAndroid {
     # libGLU doesn’t work with Android’s SDL
     libGLU = null;
   });
+
+  SDL_compat = callPackage ../development/libraries/SDL_compat { };
+
+  SDL = SDL_classic;
 
   SDL_audiolib = callPackage ../development/libraries/SDL_audiolib { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31968,7 +31968,7 @@ with pkgs;
 
   opentyrian = callPackage ../games/opentyrian { };
 
-  openxcom = callPackage ../games/openxcom { };
+  openxcom = callPackage ../games/openxcom { SDL = SDL_compat; };
 
   openxray = callPackage ../games/openxray { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32072,7 +32072,7 @@ with pkgs;
 
   rocksndiamonds = callPackage ../games/rocksndiamonds { };
 
-  rott = callPackage ../games/rott { };
+  rott = callPackage ../games/rott { SDL = SDL_compat; };
 
   rott-shareware = rott.override {
     buildShareware = true;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -330,7 +330,7 @@ let
 
     installPhase = "./Build install --prefix $out";
 
-    SDL_INST_DIR = pkgs.SDL.dev;
+    SDL_INST_DIR = lib.getDev pkgs.SDL;
     buildInputs = [ pkgs.SDL ArchiveExtract ArchiveZip TextPatch ];
     propagatedBuildInputs = [ CaptureTiny FileShareDir FileWhich ];
 


### PR DESCRIPTION
- SDL_compat: init at 1.2.52
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev
- tree-wide: SDL may not have a .dev

###### Description of changes

SDL_compat as a compatibility library that allows using SDL2 for applications otherwise only supporting SDL 1.2

There are a few changes here:

1. introduce SDL_compat
2. rename legacy SDL to SDL_classic (how upstream refers to it)
3. since SDL_compat doesn't have a dev output, change all `SDL.dev` references to `lib.getDev SDL`
4. point `SDL` at `SDL_compat`
   
Items 1 to 3 are non-controversial and do not affect anything else.

Item 4 does cause breakage for some packages, so we need at least an overview before we make that switch.

I have tested this with `openxcom` which launches properly using the compat library.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
