### PR TITLE
libpulseaudio: fix build on x86_64-darwin

### DIFF
--- a/pkgs/servers/pulseaudio/0001-Make-gio-2.0-optional-when-gsettings-is-disabled.patch
+++ b/pkgs/servers/pulseaudio/0001-Make-gio-2.0-optional-when-gsettings-is-disabled.patch
@@ -1,0 +1,26 @@
+From 72f3fe059f031f24c5ad026cb2fc16318f227c09 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 16:29:58 +0900
+Subject: [PATCH 1/8] Make gio-2.0 optional when gsettings is disabled
+
+Derived from https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/654
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index d7e468cab..f7adf1413 100644
+--- a/meson.build
++++ b/meson.build
+@@ -614,7 +614,7 @@ if dbus_dep.found()
+   cdata.set('HAVE_DBUS', 1)
+ endif
+ 
+-gio_dep = dependency('gio-2.0', version : '>= 2.26.0')
++gio_dep = dependency('gio-2.0', version : '>= 2.26.0', required : false)
+ if get_option('gsettings').enabled()
+   assert(gio_dep.found(), 'GSettings support needs glib I/O library (GIO)')
+   cdata.set('HAVE_GSETTINGS', 1)
+-- 
+2.35.1
+

--- a/pkgs/servers/pulseaudio/0002-Ignore-SCM_CREDS-on-macOS.patch
+++ b/pkgs/servers/pulseaudio/0002-Ignore-SCM_CREDS-on-macOS.patch
@@ -1,0 +1,27 @@
+From 39bef695f783614e6175477417298ddf37e2ac13 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 16:58:43 +0900
+Subject: [PATCH 2/8] Ignore SCM_CREDS on macOS
+
+It was added for FreeBSD support, but also enables the
+unsupported[citation needed] feature on macOS.
+---
+ src/pulsecore/creds.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pulsecore/creds.h b/src/pulsecore/creds.h
+index b599b569c..b5b1c9f37 100644
+--- a/src/pulsecore/creds.h
++++ b/src/pulsecore/creds.h
+@@ -34,7 +34,7 @@
+ typedef struct pa_creds pa_creds;
+ typedef struct pa_cmsg_ancil_data pa_cmsg_ancil_data;
+ 
+-#if defined(SCM_CREDENTIALS) || defined(SCM_CREDS)
++#if defined(SCM_CREDENTIALS) || (defined(SCM_CREDS) && !defined(__APPLE__))
+ 
+ #define HAVE_CREDS 1
+ 
+-- 
+2.35.1
+

--- a/pkgs/servers/pulseaudio/0003-Disable-z-nodelete-on-darwin.patch
+++ b/pkgs/servers/pulseaudio/0003-Disable-z-nodelete-on-darwin.patch
@@ -1,0 +1,26 @@
+From 3f1abb55f4eb985fd0715b2b2ca45dcce3a56824 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 17:06:50 +0900
+Subject: [PATCH 3/8] Disable `-z nodelete` on darwin
+
+Not supported[citation needed].
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index f7adf1413..d4bece11a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -404,7 +404,7 @@ cdata.set('MESON_BUILD', 1)
+ # so we request the nodelete flag to be enabled.
+ # On other systems, we don't really know how to do that, but it's welcome if somebody can tell.
+ # Windows doesn't support this flag.
+-if host_machine.system() != 'windows'
++if host_machine.system() != 'windows' and host_machine.system() != 'darwin'
+   nodelete_link_args = ['-Wl,-z,nodelete']
+ else
+   nodelete_link_args = []
+-- 
+2.35.1
+

--- a/pkgs/servers/pulseaudio/0004-Prefer-clock_gettime.patch
+++ b/pkgs/servers/pulseaudio/0004-Prefer-clock_gettime.patch
@@ -1,0 +1,57 @@
+From 0bd3b613ac3bf16a73b3223fa1b961da3a0db1b2 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 17:12:52 +0900
+Subject: [PATCH 4/8] Prefer clock_gettime
+
+Available in darwin since 10.12 (released in 2016).
+---
+ src/pulsecore/core-rtclock.c | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/src/pulsecore/core-rtclock.c b/src/pulsecore/core-rtclock.c
+index 2c2e28631..a08d4b391 100644
+--- a/src/pulsecore/core-rtclock.c
++++ b/src/pulsecore/core-rtclock.c
+@@ -65,19 +65,7 @@ pa_usec_t pa_rtclock_age(const struct timeval *tv) {
+ 
+ struct timeval *pa_rtclock_get(struct timeval *tv) {
+ 
+-#if defined(OS_IS_DARWIN)
+-    uint64_t val, abs_time = mach_absolute_time();
+-    Nanoseconds nanos;
+-
+-    nanos = AbsoluteToNanoseconds(*(AbsoluteTime *) &abs_time);
+-    val = *(uint64_t *) &nanos;
+-
+-    tv->tv_sec = val / PA_NSEC_PER_SEC;
+-    tv->tv_usec = (val % PA_NSEC_PER_SEC) / PA_NSEC_PER_USEC;
+-
+-    return tv;
+-
+-#elif defined(HAVE_CLOCK_GETTIME)
++#if defined(HAVE_CLOCK_GETTIME)
+     struct timespec ts;
+ 
+ #ifdef CLOCK_MONOTONIC
+@@ -109,6 +97,18 @@ struct timeval *pa_rtclock_get(struct timeval *tv) {
+ 
+         return tv;
+     }
++#elif defined(OS_IS_DARWIN)
++    uint64_t val, abs_time = mach_absolute_time();
++    Nanoseconds nanos;
++
++    nanos = AbsoluteToNanoseconds(*(AbsoluteTime *) &abs_time);
++    val = *(uint64_t *) &nanos;
++
++    tv->tv_sec = val / PA_NSEC_PER_SEC;
++    tv->tv_usec = (val % PA_NSEC_PER_SEC) / PA_NSEC_PER_USEC;
++
++    return tv;
++
+ #endif /* HAVE_CLOCK_GETTIME */
+ 
+     return pa_gettimeofday(tv);
+-- 
+2.35.1
+

--- a/pkgs/servers/pulseaudio/0005-Include-poll-posix.c-on-darwin.patch
+++ b/pkgs/servers/pulseaudio/0005-Include-poll-posix.c-on-darwin.patch
@@ -1,0 +1,24 @@
+From 8dee473920d3a331b73a415b37e7e0b01f014110 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 17:22:23 +0900
+Subject: [PATCH 5/8] Include poll-posix.c on darwin
+
+---
+ src/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/meson.build b/src/meson.build
+index e2860811b..5bd68cb12 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -182,6 +182,7 @@ if host_machine.system() == 'windows'
+ else
+   libpulsecommon_sources += [
+     'pulsecore/mutex-posix.c',
++    'pulsecore/poll-posix.c',
+     'pulsecore/semaphore-posix.c',
+     'pulsecore/thread-posix.c'
+   ]
+-- 
+2.35.1
+

--- a/pkgs/servers/pulseaudio/0006-Only-use-version-script-on-GNU-ish-linkers.patch
+++ b/pkgs/servers/pulseaudio/0006-Only-use-version-script-on-GNU-ish-linkers.patch
@@ -1,0 +1,29 @@
+From 419258112b9d90d149ebbd5c657a36d8532b78a2 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 17:31:36 +0900
+Subject: [PATCH 6/8] Only use version-script on GNU-ish linkers
+
+---
+ src/pulse/meson.build | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/pulse/meson.build b/src/pulse/meson.build
+index c2128e087..a5e47867e 100644
+--- a/src/pulse/meson.build
++++ b/src/pulse/meson.build
+@@ -74,7 +74,11 @@ run_target('update-map-file',
+   command : [ join_paths(meson.source_root(), 'scripts/generate-map-file.sh'), 'map-file',
+               [ libpulse_headers, 'simple.h', join_paths(meson.build_root(), 'src', 'pulse', 'version.h') ] ])
+ 
+-versioning_link_args = '-Wl,-version-script=' + join_paths(meson.source_root(), 'src', 'pulse', 'map-file')
++if meson.get_compiler('c').get_linker_id().startswith('ld.')
++  versioning_link_args = '-Wl,-version-script=' + join_paths(meson.source_root(), 'src', 'pulse', 'map-file')
++else
++  versioning_link_args = []
++endif
+ 
+ libpulse = shared_library('pulse',
+   libpulse_sources,
+-- 
+2.35.1
+

--- a/pkgs/servers/pulseaudio/0007-Adapt-undefined-link-args-per-linker.patch
+++ b/pkgs/servers/pulseaudio/0007-Adapt-undefined-link-args-per-linker.patch
@@ -1,0 +1,44 @@
+From 6f132be835d5acb5db4301ea1818601504e47fae Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 17:41:34 +0900
+Subject: [PATCH 7/8] Adapt undefined link args per linker
+
+TODO: Why is this required? Isn't it default?
+---
+ src/modules/meson.build | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/modules/meson.build b/src/modules/meson.build
+index be72c3b9b..0163b583f 100644
+--- a/src/modules/meson.build
++++ b/src/modules/meson.build
+@@ -293,6 +293,17 @@ all_modules += [
+ # FIXME: meson doesn't support multiple RPATH arguments currently
+ rpath_dirs = join_paths(privlibdir) + ':' + join_paths(modlibexecdir)
+ 
++if meson.get_compiler('c').get_linker_id().startswith('ld.')
++  no_undefined_link_args = [ '-Wl,--no-undefined' ]
++elif meson.get_compiler('c').get_linker_id() == 'ld64'
++  # TODO: is this required? is this not default?
++  no_undefined_link_args = [ '-Wl,-undefined,error' ]
++else
++  # TODO: what platforms is this? what flag do they use?
++  no_undefined_link_args = []
++endif
++
++
+ foreach m : all_modules
+   name = m[0]
+   sources = m[1]
+@@ -310,7 +321,7 @@ foreach m : all_modules
+     install_rpath : rpath_dirs,
+     install_dir : modlibexecdir,
+     dependencies : [thread_dep, libpulse_dep, libpulsecommon_dep, libpulsecore_dep, libintl_dep, platform_dep, platform_socket_dep] + extra_deps,
+-    link_args : [nodelete_link_args, '-Wl,--no-undefined' ],
++    link_args : [nodelete_link_args, no_undefined_link_args ],
+     link_with : extra_libs,
+     name_prefix : '',
+     implicit_include_directories : false)
+-- 
+2.35.1
+

--- a/pkgs/servers/pulseaudio/0008-Use-correct-semaphore-on-darwin.patch
+++ b/pkgs/servers/pulseaudio/0008-Use-correct-semaphore-on-darwin.patch
@@ -1,0 +1,31 @@
+From 1a840b6e517004c902dfbea3d358b344c9588978 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 19 Apr 2022 17:49:08 +0900
+Subject: [PATCH 8/8] Use correct semaphore on darwin
+
+---
+ src/meson.build | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index 5bd68cb12..041e2fab4 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -183,9 +183,13 @@ else
+   libpulsecommon_sources += [
+     'pulsecore/mutex-posix.c',
+     'pulsecore/poll-posix.c',
+-    'pulsecore/semaphore-posix.c',
+     'pulsecore/thread-posix.c'
+   ]
++  if host_machine.system() == 'darwin'
++    libpulsecommon_sources += [ 'pulsecore/semaphore-osx.c' ]
++  else
++    libpulsecommon_sources += [ 'pulsecore/semaphore-posix.c' ]
++  endif
+ endif
+ # FIXME: Do SIMD things
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Mostly work thanks to @thefloweringash. I did a rebase and disabled the tests on darwin (the only thing that was failing from his branch).

Substitute https://github.com/NixOS/nixpkgs/pull/172230.
ZHF: https://github.com/NixOS/nixpkgs/issues/172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
