### PR TITLE
wrapFirefox: move back into $out

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -219,6 +219,8 @@ let
           ln -sfT "$target" "$out/$l"
         done
 
+        cd "$out"
+
         # create the wrapper
 
         executablePrefix="$out/bin"


### PR DESCRIPTION
```
error: builder for '/nix/store/jnr69pl8m1b7a2sgf1lxr3wmydn4ivn1-librewolf-100.0-2.drv' failed with exit code 1;
       last 1 log lines:
       > /nix/store/crpnj8ssz0va2q0p5ibv9i6k6n52gcya-stdenv-linux/setup: line 1470: .tmp.json: Permission denied
       For full logs, run 'nix log /nix/store/jnr69pl8m1b7a2sgf1lxr3wmydn4ivn1-librewolf-100.0-2.drv'.
error: 1 dependencies of derivation '/nix/store/yr7586cjwydr330hnw61zgb05cdnslwz-system-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/h4980r5lv493kjkhg5ivil6pwllssyff-nixos-system-teff-22.05.20220509.2a3aac4.drv' failed to build
$ nix log /nix/store/jnr69pl8m1b7a2sgf1lxr3wmydn4ivn1-librewolf-100.0-2.drv                                                                                                                                                  
/nix/store/crpnj8ssz0va2q0p5ibv9i6k6n52gcya-stdenv-linux/setup: line 1470: .tmp.json: Permission denied
```

Broken by https://github.com/NixOS/nixpkgs/pull/171985. I did look at the code after removing that `cd`, but apparently not close enough.

Built `firefox-bin` with a dummy `extraPoliciesFiles`.