### PR TITLE
hydra: fix evaluation with aliases disabled

### DIFF
--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -36,7 +36,7 @@ let
         CatalystPluginSessionStateCookie
         CatalystPluginSessionStoreFastMmap
         CatalystPluginStackTrace
-        CatalystPluginUnicodeEncoding
+        CatalystRuntime
         CatalystTraitForRequestProxyBase
         CatalystViewDownload
         CatalystViewJSON


### PR DESCRIPTION
###### Description of changes
Follow-up on #172242 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Checked that hydra still evaluates to the same derivation as before
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
