### PR TITLE
rt-tests: init at 2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10122,6 +10122,12 @@
     githubId = 81340136;
     name = "polykernel";
   };
+  poelzi = {
+    email = "nix@poelzi.org";
+    github = "poelzi";
+    githubId = 66107;
+    name = "Daniel Poelzleithner";
+  };
   polyrod = {
     email = "dc1mdp@gmail.com";
     github = "polyrod";

--- a/pkgs/os-specific/linux/rt-tests/default.nix
+++ b/pkgs/os-specific/linux/rt-tests/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchurl, pkgs }:
+
+stdenv.mkDerivation rec {
+  pname = "rt-tests";
+  version = "2.3";
+
+  src = fetchurl {
+    url = "https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot/${pname}-${version}.tar.gz";
+    sha256 = "Q+rNdpRdsmW2gcsrfwg12EzpvO6qlEP/Mb/OWQMNmr8=";
+  };
+
+  buildInputs = with pkgs;[ numactl python3 makeWrapper];
+  makeFlags = [ "prefix=$(out)" "DESTDIR=" "PYLIB=$(out)/lib/python" ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/determine_maximum_mpps.sh" --prefix PATH : $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git;
+    description = "Suite of real-time tests - cyclictest, hwlatdetect, pip_stress, pi_stress, pmqtest, ptsematest, rt-migrate-test, sendme, signaltest, sigwaittest, svsematest";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ poelzi ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/os-specific/linux/rt-tests/default.nix
+++ b/pkgs/os-specific/linux/rt-tests/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, lib, fetchurl, pkgs }:
+{ stdenv
+, lib
+, makeWrapper
+, fetchurl
+, numactl
+, python3
+}:
 
 stdenv.mkDerivation rec {
   pname = "rt-tests";
@@ -9,8 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "Q+rNdpRdsmW2gcsrfwg12EzpvO6qlEP/Mb/OWQMNmr8=";
   };
 
-  buildInputs = with pkgs;[ numactl python3 makeWrapper];
-  makeFlags = [ "prefix=$(out)" "DESTDIR=" "PYLIB=$(out)/lib/python" ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ numactl python3 ];
+
+  makeFlags = [ "prefix=$(out)" "DESTDIR=" "PYLIB=$(out)/${pkgs.python3.sitePackages}" ];
 
   postInstall = ''
     wrapProgram "$out/bin/determine_maximum_mpps.sh" --prefix PATH : $out/bin

--- a/pkgs/os-specific/linux/rt-tests/default.nix
+++ b/pkgs/os-specific/linux/rt-tests/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ numactl python3 ];
 
-  makeFlags = [ "prefix=$(out)" "DESTDIR=" "PYLIB=$(out)/${pkgs.python3.sitePackages}" ];
+  makeFlags = [ "prefix=$(out)" "DESTDIR=" "PYLIB=$(out)/${python3.sitePackages}" ];
 
   postInstall = ''
     wrapProgram "$out/bin/determine_maximum_mpps.sh" --prefix PATH : $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23661,6 +23661,8 @@ with pkgs;
 
   rtkit = callPackage ../os-specific/linux/rtkit { };
 
+  rt-tests = callPackage ../os-specific/linux/rt-tests { };
+
   rt5677-firmware = callPackage ../os-specific/linux/firmware/rt5677 { };
 
   rtl8192su-firmware = callPackage ../os-specific/linux/firmware/rtl8192su-firmware { };


### PR DESCRIPTION
###### Description of changes
Add realtime tests suite

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
