### PR TITLE
gimx: fix build

### DIFF
--- a/pkgs/games/gimx/default.nix
+++ b/pkgs/games/gimx/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, curl, libusb1, xorg, libxml2
-, ncurses5, bluez, libmhash, gimxPDP ? false }:
+, ncurses5, bluez, libmhash, gimxPdpGamepad ? false }:
 
 let
   gimx-config = fetchFromGitHub {
@@ -11,14 +11,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "gimx";
-  version = "8.0";
+  version = "unstable-2021-08-31";
 
   src = fetchFromGitHub {
     owner = "matlo";
     repo = "GIMX";
-    rev = "v${version}";
+    rev = "58d2098dce75ed4c90ae649460d3a7a150f4ef0a";
     fetchSubmodules = true;
-    sha256 = "0265gg6q7ymg76fb4pjrfdwjd280b3zzry96qy92w0h411slph85";
+    sha256 = "05kdv2qqr311c2p76hdlgvrq7b04vcpps5c80zn8b8l7p831ilgz";
   };
 
   patches = [ ./conf.patch ];
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
     xorg.libX11 xorg.libXi xorg.libXext
   ];
 
-  postPatch = lib.optionals gimxPDP ''
+  postPatch = lib.optionals gimxPdpGamepad ''
     substituteInPlace ./shared/gimxcontroller/include/x360.h \
       --replace "0x045e" "0x0e6f" --replace "0x028e" "0x0213"
     substituteInPlace ./loader/firmware/EMU360.hex \
@@ -60,10 +60,6 @@ in stdenv.mkDerivation rec {
     cp -r ${./custom} $out/share/custom
 
     makeWrapper $out/bin/gimx $out/bin/gimx-dualshock4 \
-      --set GIMXCONF 1 --add-flags "--nograb" --add-flags "-p /dev/ttyUSB0" \
-      --add-flags "-c $out/share/config/Dualshock4.xml"
-
-    makeWrapper $out/bin/gimx $out/bin/gimx-dualshock4-noff \
       --set GIMXCONF 1 --add-flags "--nograb" --add-flags "-p /dev/ttyUSB0" \
       --add-flags "-c $out/share/custom/Dualshock4.xml"
 


### PR DESCRIPTION
###### Description of changes
#172160

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
