### PR TITLE
libnvidia-container: 1.5.0 -> 1.9.0

### DIFF
--- a/pkgs/applications/virtualization/libnvidia-container/inline-c-struct.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/inline-c-struct.patch
@@ -1,0 +1,14 @@
+diff --git a/src/nvcgo.c b/src/nvcgo.c
+index 98789a3..47ad02b 100644
+--- a/src/nvcgo.c
++++ b/src/nvcgo.c
+@@ -33,7 +33,8 @@
+ void nvcgo_program_1(struct svc_req *, register SVCXPRT *);
+ 
+ static struct nvcgo_ext {
+-        struct nvcgo;
++        struct rpc rpc;
++        struct libnvcgo api;
+         bool initialized;
+         void *dl_handle;
+ } global_nvcgo_context;

--- a/pkgs/applications/virtualization/libnvidia-container/modprobe.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/modprobe.patch
@@ -1,6 +1,6 @@
-diff -ruN nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c
---- nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c	2020-07-09 17:06:05.000000000 +0000
-+++ nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c	2020-08-18 12:43:03.223871514 +0000
+diff -ruN nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c
+--- nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c	2020-07-09 17:06:05.000000000 +0000
++++ nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c	2020-08-18 12:43:03.223871514 +0000
 @@ -840,10 +840,10 @@
      return mknod_helper(major, minor_num, vgpu_dev_name, NV_PROC_REGISTRY_PATH);
  }
@@ -16,9 +16,9 @@ diff -ruN nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c nvidia-m
  {
      char field[32];
      FILE *fp;
-diff -ruN nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h
---- nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h	2020-07-09 17:06:05.000000000 +0000
-+++ nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h	2020-08-18 12:43:44.227745050 +0000
+diff -ruN nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h
+--- nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h	2020-07-09 17:06:05.000000000 +0000
++++ nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h	2020-08-18 12:43:44.227745050 +0000
 @@ -81,6 +81,7 @@
  int nvidia_nvswitch_get_file_state(int minor);
  int nvidia_cap_mknod(const char* cap_file_path, int *minor);


### PR DESCRIPTION
###### Description of changes

This PR bumps `libnvidia-container` from 1.5.0 to 1.9.0.

This bump includes the changes from 1.8.0, which allow support for cgroupv2 when building go-based NVC.

I've tested this change on my desktop which has an NVIDIA GeForce RTX 2080 SUPER GPU with both docker and podman:

## Tests

### list GPUs

#### docker

```
$ docker run --runtime nvidia --rm nvidia/cuda:11.6.1-base-ubi7 nvidia-smi --list-gpus
GPU 0: NVIDIA GeForce RTX 2080 SUPER (UUID: GPU-16efc9cd-6886-5c12-52f8-2bef887747d9)
```

#### podman

```
$ podman run --runtime nvidia --rm nvidia/cuda:11.6.1-base-ubi7 nvidia-smi --list-gpus
GPU 0: NVIDIA GeForce RTX 2080 SUPER (UUID: GPU-16efc9cd-6886-5c12-52f8-2bef887747d9)
```

### list GPUs from tensorflow

#### docker

```
$ docker run -e TF_CPP_MIN_LOG_LEVEL=1 -e LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu --runtime nvidia --rm tensorflow/tensorflow:2.8.0-gpu python -c 'import tensorflow as tf

devices = tf.config.list_physical_devices("GPU")
assert devices, "no GPU devices found"

print("\n".join(map(repr, devices)))
'
PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')
```

#### podman

```
$ podman run -e TF_CPP_MIN_LOG_LEVEL=1 -e LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu --runtime nvidia --rm tensorflow/tensorflow:2.8.0-gpu python -c 'import tensorflow as tf

devices = tf.config.list_physical_devices("GPU")
assert devices, "no GPU devices found"

print("\n".join(map(repr, devices)))
'
PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
