### PR TITLE
ocamlPackages.easy-format: 1.3.2 → 1.3.3

### DIFF
--- a/pkgs/development/ocaml-modules/easy-format/default.nix
+++ b/pkgs/development/ocaml-modules/easy-format/default.nix
@@ -1,12 +1,22 @@
-{ lib, fetchurl, buildDunePackage }:
+{ lib, fetchurl, ocaml, buildDunePackage }:
+
+let params =
+  if lib.versionAtLeast ocaml.version "4.08" then {
+    version = "1.3.3";
+    sha256 = "sha256:05n4mm1yz33h9gw811ivjw7x4m26lpmf7kns9lza4v6227lwmz7a";
+  } else {
+    version = "1.3.2";
+    sha256 = "sha256:09hrikx310pac2sb6jzaa7k6fmiznnmhdsqij1gawdymhawc4h1l";
+  };
+in
 
 buildDunePackage rec {
   pname = "easy-format";
-  version = "1.3.2";
+  inherit (params) version;
 
   src = fetchurl {
     url = "https://github.com/ocaml-community/easy-format/releases/download/${version}/easy-format-${version}.tbz";
-    sha256 = "sha256:09hrikx310pac2sb6jzaa7k6fmiznnmhdsqij1gawdymhawc4h1l";
+    inherit (params) sha256;
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

Compatibility with future OCaml: https://github.com/ocaml-community/easy-format/blob/1.3.3/CHANGES.md#133-2022-04-27

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
