### PR TITLE
cmake: add check-pc-files hook to check broken pc files

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , fetchFromGitHub
 , fixDarwinDylibNames
 , abseil-cpp
@@ -113,14 +112,6 @@ stdenv.mkDerivation rec {
   patches = [
     # patch to fix python-test
     ./darwin.patch
-    # in master post 8.0.0, see https://github.com/apache/arrow/pull/13182
-    (fetchpatch {
-      name = "fix-pkg-config.patch";
-      stripLen = 1;
-      excludes = [ "src/arrow/engine/arrow-substrait.pc.in" ]; # for < 8.0.0
-      url = "https://github.com/apache/arrow/commit/a242eb17362c0352fc3291213542c48abfe18669.patch";
-      sha256 = "15gz13f8q75l7d4z5blyvxd805hwfcvrbrxs2kbfal9vcbnirycx";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
 , alsaSupport ? !stdenv.isDarwin, alsa-lib
 , dbusSupport ? !stdenv.isDarwin, dbus
 , pipewireSupport ? !stdenv.isDarwin, pipewire
@@ -21,11 +21,6 @@ stdenv.mkDerivation rec {
     # this will make it find its own data files (e.g. HRTF profiles)
     # without any other configuration
     ./search-out.patch
-    # merged after 1.22.0 in https://github.com/kcat/openal-soft/pull/696
-    (fetchpatch {
-      url = "https://github.com/kcat/openal-soft/commit/0bf2abae9b2121c3bc5a56dab30eca308136bc29.patch";
-      sha256 = "1fhjjy7nrhrj3a0wlmsqpf8h3ss6s487vz5jrhamyv04nbcahn20";
-    })
   ];
   postPatch = ''
     substituteInPlace core/helpers.cpp \

--- a/pkgs/development/libraries/orcania/default.nix
+++ b/pkgs/development/libraries/orcania/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchpatch, fetchFromGitHub, cmake, check, subunit }:
+{ lib, stdenv, fetchFromGitHub, cmake, check, subunit }:
 stdenv.mkDerivation rec {
   pname = "orcania";
   version = "2.3.0";
@@ -9,15 +9,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-QAq/6MGVj+iBHLElHuqokF1v3LU1TZ9hVVJE1s3y6f0=";
   };
-
-  # in master post 2.2.2, see https://github.com/babelouest/orcania/issues/27
-  patches = [
-    (fetchpatch {
-      name = "fix-pkg-config.patch";
-      url = "https://github.com/babelouest/orcania/commit/4eac7d5ff76bb3bec8250fef300b723c8891552a.patch";
-      sha256 = "01bsxay1ca8d08ac3ddcqyvjwgz5mgs68jz5y3gzq4qnzl3q1i54";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/tools/build-managers/cmake/check-pc-files-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/check-pc-files-hook.sh
@@ -1,0 +1,18 @@
+cmakePcfileCheckPhase() {
+    while IFS= read -rd $'\0' file; do
+        grepout=$(grep --line-number '}//nix/store' "$file" || true)
+        if [ -n "$grepout" ]; then
+            {
+            echo "Broken paths found in a .pc file! $file"
+            echo "The following lines have issues (specifically '//' in paths)."
+            echo "$grepout"
+            echo "It is very likely that paths are being joined improperly."
+            echo 'ex: "${prefix}/@CMAKE_INSTALL_LIBDIR@" should be "@CMAKE_INSTALL_FULL_LIBDIR@"'
+            echo "Please see https://github.com/NixOS/nixpkgs/issues/144170 for more details."
+            exit 1
+            } 1>&2
+        fi
+    done < <(find "${!outputDev}" -iname "*.pc" -print0)
+}
+
+postFixupHooks+=(cmakePcfileCheckPhase)

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -61,13 +61,15 @@ stdenv.mkDerivation rec {
   outputs = [ "out" ] ++ lib.optionals buildDocs [ "man" "info" ];
   setOutputFlags = false;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ./setup-hook.sh
+    ./check-pc-files-hook.sh
+  ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs = [
+  nativeBuildInputs = setupHooks ++ [
     pkg-config
-    setupHook
   ]
   ++ lib.optionals buildDocs [ texinfo ]
   ++ lib.optionals qt5UI [ wrapQtAppsHook ];


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/pull/172150

test by building `seexpr`

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
