### PR TITLE
vyper: relax semantic-version dependency

### DIFF
--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -1,6 +1,19 @@
-{ lib, buildPythonPackage, fetchPypi, writeText, asttokens
-, pycryptodome, pytest-xdist, pytest-cov, recommonmark, semantic-version, sphinx
-, sphinx_rtd_theme, pytest-runner, setuptools-scm }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pythonAtLeast
+, pythonRelaxDepsHook
+, writeText
+, asttokens
+, pycryptodome
+, recommonmark
+, semantic-version
+, sphinx
+, sphinx_rtd_theme
+, pytest-runner
+, setuptools-scm
+}:
 
 let
   sample-contract = writeText "example.vy" ''
@@ -10,18 +23,27 @@ let
     def __init__(foo: address):
         self.count = 1
   '';
-in
 
+in
 buildPythonPackage rec {
   pname = "vyper";
   version = "0.3.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7" || pythonAtLeast "3.10";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-fXug5v3zstz19uexMWokHBVsfcl2ZCdIOIXKeLVyh/Q=";
   };
 
-  nativeBuildInputs = [ pytest-runner setuptools-scm ];
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    pytest-runner
+    setuptools-scm
+  ];
+
+  pythonRelaxDeps = [ "semantic-version" ];
 
   propagatedBuildInputs = [
     asttokens


### PR DESCRIPTION
###### Description of changes

ZHF: #172160

[According to Hydra](https://hydra.nixos.org/build/176105448/nixlog/2), `vyper` is looking for `semantic-version==2.8.5`, but it is on `2.9.0` on nixpkgs. As indicated by @thiagokokada, it is now using `pythonRelaxDepsHook` to handle this.

Note that upstream already has a new version, but this PR will focus on fixing the build error (if I update the package version, I get a lot of errors and right now I can't focus my time on fixing them). I will open #172349 to consider updating `vyper` to a new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
