### PR TITLE
open-policy-agent: 0.38.1 -> 0.40.0

### DIFF
--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
@@ -6,15 +7,17 @@
 , enableWasmEval ? false
 }:
 
+assert enableWasmEval && stdenv.isDarwin -> builtins.throw "building with wasm on darwin is failing in nixpkgs";
+
 buildGoModule rec {
   pname = "open-policy-agent";
-  version = "0.38.1";
+  version = "0.40.0";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
     rev = "v${version}";
-    sha256 = "sha256-x8mSlZ2X0DdkhaW5QXs5axERJkwARu8tHueQHXfamXM=";
+    sha256 = "sha256-rLfo2SUlxL6QFc2v+nxFnbyYcfy7i3OFhGt6ZAUteHY=";
   };
   vendorSha256 = null;
 
@@ -35,12 +38,13 @@ buildGoModule rec {
     # Feed in all but the e2e tests for testing
     # This is because subPackages above limits what is built to just what we
     # want but also limits the tests
+    # Also avoid wasm tests on darwin due to wasmtime-go build issues
     getGoDirs() {
-      go list ./... | grep -v e2e
+      go list ./... | grep -v -e e2e ${lib.optionalString stdenv.isDarwin "-e wasm"}
     }
-
-    # Remove test case that fails on < go1.17
-    rm test/cases/testdata/cryptox509parsecertificates/test-cryptox509parsecertificates-0123.yaml
+    '' + lib.optionalString stdenv.isDarwin ''
+    # resolve "too many open files" errors during the tests on darwin
+    ulimit -n 1024
   '';
 
   postInstall = ''
@@ -66,6 +70,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
+    mainProgram = "opa";
     homepage = "https://www.openpolicyagent.org";
     changelog = "https://github.com/open-policy-agent/opa/blob/v${version}/CHANGELOG.md";
     description = "General-purpose policy engine";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump open-policy-agent to `0.40.0`

set the `mainProgram` to `opa` for `nix run`

Also fixes the builds on darwin (https://hydra.nixos.org/build/176050231)

ZHF: #172160

![image](https://user-images.githubusercontent.com/9866621/167684210-adc21f41-a6e7-4f2d-9293-72b31b811ccb.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
