### PR TITLE
gfold: 3.0.0 -> 4.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gfold/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gfold/default.nix
@@ -1,28 +1,43 @@
-{ lib, fetchFromGitHub, gitMinimal, makeWrapper, rustPlatform }:
+{ fetchFromGitHub
+, gitMinimal
+, gfold
+, lib
+, libiconv
+, makeWrapper
+, rustPlatform
+, Security
+, stdenv
+, testVersion
+}:
 
-rustPlatform.buildRustPackage rec {
+let
   pname = "gfold";
-  version = "3.0.0";
+  version = "4.0.0";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "nickgerace";
     repo = pname;
     rev = version;
-    sha256 = "0ss6vfrc6h3jlh5qilh82psd3vdnfawf1wl4cf64mfm4hm9dda63";
+    sha256 = "1yh5173qhi9bd41zss9k21nm0xnr2sa918kvlyr5xvzhq47rrwz5";
   };
 
-  cargoSha256 = "09ywwgxm8l1p0jypp65zpqryjnb2g4gririf1dmqb9148dsj29x2";
+  cargoSha256 = "sha256-o2fMIlj+veTmhfqi7BVpxr3520SOwWLmVS2UU83EVjo=";
 
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  postInstall = ''
-    wrapProgram "$out/bin/gfold" --prefix PATH : "${gitMinimal}/bin"
-  '';
+  passthru.tests.version = testVersion {
+    package = gfold;
+    command = "gfold --version";
+    inherit version;
+  };
 
   meta = with lib; {
-    inherit (src.meta) homepage;
     description =
-      "A tool to help keep track of your Git repositories, written in Rust";
+      "CLI tool to help keep track of your Git repositories, written in Rust";
+    homepage = "https://github.com/nickgerace/gfold";
     license = licenses.asl20;
     maintainers = [ maintainers.shanesveller ];
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6161,7 +6161,9 @@ with pkgs;
 
   gfbgraph = callPackage ../development/libraries/gfbgraph { };
 
-  gfold = callPackage ../applications/version-management/git-and-tools/gfold { };
+  gfold = callPackage ../applications/version-management/git-and-tools/gfold {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   ggobi = callPackage ../tools/graphics/ggobi { };
 


### PR DESCRIPTION
###### Description of changes

No intermediate non-RC versions were published between 3.0.0 and 4.0.0.

https://github.com/nickgerace/gfold/blob/4.0.0/CHANGELOG.md

Specific callouts:

> Added:
>> [git2-rs](https://github.com/rust-lang/git2-rs), which replaces git subcommand usage
>>    Even though git subcommands were used over git2-rs to reduce binary size, significant speed increases could only be achieved by using the latter
>
> Removed
>> `git` subcommand usage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
