### PR TITLE
tsm-client: 8.1.14.0 -> 8.1.15.0 & fix patching rpath with autoPatchelf

### DIFF
--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -107,10 +107,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.14.0";
+    version = "8.1.15.0";
     src = fetchurl {
       url = mkSrcUrl version;
-      sha256 = "1iczc4w8rwzqnw01r89kwxcdr7pnwh3nqr3a0q8ncrxrhsy3qwn0";
+      hash = "sha512-K98irjGvN2QejwbOoRhnHkYdFX3ZQ8hv+v2Gb2/pnr9AE1uj6h0lEXQu2cOEHbk7jMtGwpglzofCF7yUyT/tcw==";
     };
     inherit meta passthru;
 

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -160,6 +160,16 @@ let
         ln --symbolic --force --no-target-directory "$out/$(cut -b 7- <<< "$target")" "$link"
       done
     '';
+
+    # since 7b9fd5d1c9802131ca0a01ff08a3ff64379d2df4
+    # autopatchelf misses to add $out/lib to rpath;
+    # we have to call autopatchelf manually as it would
+    # run too late and overwrite our rpath otherwise
+    dontAutoPatchelf = true;
+    postFixup = ''
+      autoPatchelf $out
+      patchelf --add-rpath $out/lib $out/lib/*
+    '';
   };
 
   binPath = lib.makeBinPath ([ acl gnugrep procps ]


### PR DESCRIPTION
###### Description of changes

**Edit**

Besides the changes described below, this pull request updates `tsm-client` to 8.1.15.0.  According to IBM's security bulletins

* https://www.ibm.com/support/pages/node/6596379 (CVE-2021-35550, CVE-2021-35603)
* https://www.ibm.com/support/pages/node/6596741 (CVE-2022-22478, CVE-2022-22474)
* https://www.ibm.com/support/pages/node/6596399 (CVE-2022-0778)

this update fixes several security vulnerabilities, including an "unspecified vulnerability in Java SE related to the JSSE component [which] could allow an unauthenticated attacker to obtain sensitive information resulting in a high confidentiality impact".

With this update, both automated tests pass, and I also tested the binary with a real TSM server and uploaded files successfully.

**End of Edit**

The new `autoPatchelf` from https://github.com/NixOS/nixpkgs/pull/149731 broke `tsm-client` (discovered with git-bisect).  Strangely, `tsm-client` still built fine, but when used, the command line program `dsmc` just said

> error while loading shared libraries: libtsmxerces-depdom.so.28: cannot open shared object file: No such file or directory

Output of `ldd $out/dsmc`

> ```
> linux-vdso.so.1 (0x00007ffd89f70000)
> libgsk8ssl_64.so => /nix/store/i21g0x44g336ag8rkx0dgndb9v4w2xhk-tsm-client-8.1.13.3-unwrapped/local/ibm/gsk8_64/lib64/libgsk8ssl_64.so (0x0000791c8eb34000)
> libgsk8iccs_64.so => /nix/store/i21g0x44g336ag8rkx0dgndb9v4w2xhk-tsm-client-8.1.13.3-unwrapped/local/ibm/gsk8_64/lib64/libgsk8iccs_64.so (0x0000791c8e9b7000)
> libgsk8km_64.so => /nix/store/i21g0x44g336ag8rkx0dgndb9v4w2xhk-tsm-client-8.1.13.3-unwrapped/local/ibm/gsk8_64/lib64/libgsk8km_64.so (0x0000791c8e791000)
> libxmlutil-8.1.13.0.so => /nix/store/i21g0x44g336ag8rkx0dgndb9v4w2xhk-tsm-client-8.1.13.3-unwrapped/opt/tivoli/tsm/client/api/bin64/libxmlutil-8.1.13.0.so (0x0000791c8e675000)
> libcrypt.so.1 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libcrypt.so.1 (0x0000791c8e639000)
> libpthread.so.0 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libpthread.so.0 (0x0000791c8e619000)
> libdl.so.2 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libdl.so.2 (0x0000791c8e614000)
> libstdc++.so.6 => /nix/store/ndnqiz3nnifj1blhg9q626xlmkqq1nmh-gcc-10.3.0-lib/lib/libstdc++.so.6 (0x0000791c8e43f000)
> libgpfs.so => /nix/store/i21g0x44g336ag8rkx0dgndb9v4w2xhk-tsm-client-8.1.13.3-unwrapped/opt/tivoli/tsm/client/api/bin64/libgpfs.so (0x0000791c8e22a000)
> libdmapi.so => /nix/store/i21g0x44g336ag8rkx0dgndb9v4w2xhk-tsm-client-8.1.13.3-unwrapped/opt/tivoli/tsm/client/api/bin64/libdmapi.so (0x0000791c8e020000)
> librt.so.1 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/librt.so.1 (0x0000791c8e015000)
> libm.so.6 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libm.so.6 (0x0000791c8ded4000)
> libgcc_s.so.1 => /nix/store/ndnqiz3nnifj1blhg9q626xlmkqq1nmh-gcc-10.3.0-lib/lib/libgcc_s.so.1 (0x0000791c8deba000)
> libc.so.6 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libc.so.6 (0x0000791c8dce5000)
> libgsk8cms_64.so => /nix/store/i21g0x44g336ag8rkx0dgndb9v4w2xhk-tsm-client-8.1.13.3-unwrapped/local/ibm/gsk8_64/lib64/libgsk8cms_64.so (0x0000791c8d78d000)
> /nix/store/4s21k8k7p1mfik0b33r2spq5hq7774k1-glibc-2.33-108/lib/ld-linux-x86-64.so.2 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib64/ld-linux-x86-64.so.2 (0x0000791c8f074000)
> libtsmxerces-depdom.so.28 => not found
> libtsmxerces-c.so.28 => not found
> ```

Output of `ldd $out/lib/libtsmxerces-depdom.so.28`

> ```
> linux-vdso.so.1 (0x00007fff69388000)
> libpthread.so.0 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libpthread.so.0 (0x000078f150454000)
> libtsmxerces-c.so.28 => not found
> libstdc++.so.6 => /nix/store/ndnqiz3nnifj1blhg9q626xlmkqq1nmh-gcc-10.3.0-lib/lib/libstdc++.so.6 (0x000078f15027f000)
> libm.so.6 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libm.so.6 (0x000078f15013e000)
> libgcc_s.so.1 => /nix/store/ndnqiz3nnifj1blhg9q626xlmkqq1nmh-gcc-10.3.0-lib/lib/libgcc_s.so.1 (0x000078f150124000)
> libc.so.6 => /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib/libc.so.6 (0x000078f14ff4d000)
> /nix/store/qjgj2642srlbr59wwdihnn66sw97ming-glibc-2.33-123/lib64/ld-linux-x86-64.so.2 (0x000078f150601000)
> ```

I've been studying the sources of the old and new `autoPatchelf` script, and I found out that the new one treats two shared libraries differently from the old one, but I failed to understand why that happens.

Anyway, this pull request fixes the issue by directly adding `$out/lib` to the rpath of all shared libraries in that directory.

Informing the author of the new `autoPatchelf` @layus : I can't tell if the issue that gets fixed here is a bug in the new `autoPatchelf`, or a bug in my `tsm-client` build recipe (or in `tsm-client` itself) that was just "hidden" and now got uncovered.  If you suspect a bug in `autoPatchelf`, you might want to take a closer look.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Besides two automated tests, I also tested the result with a real tsm server, successfully.