### PR TITLE
tinystatus: init at unstable-2021-07-09

### DIFF
--- a/pkgs/tools/networking/tinystatus/default.nix
+++ b/pkgs/tools/networking/tinystatus/default.nix
@@ -1,0 +1,58 @@
+{ lib, stdenvNoCC, makeWrapper, netcat, curl, unixtools, coreutils, mktemp
+, findutils, gnugrep, fetchFromGitHub, gawk, gnused }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "tinystatus";
+  version = "unstable-2021-07-09";
+
+  src = fetchFromGitHub {
+    owner = "bderenzo";
+    repo = "tinystatus";
+    rev = "fc128adf240261ac99ea3e3be8d65a92eda52a73";
+    sha256 = "sha256-FvQwibm6F10l9/U3RnNTGu+C2JjHOwbv62VxXAfI7/s=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  runtimeInputs = [
+    curl
+    netcat
+    unixtools.ping
+    coreutils
+    mktemp
+    findutils
+    gnugrep
+    gawk
+    gnused
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 tinystatus $out/bin/tinystatus
+    wrapProgram $out/bin/tinystatus \
+      --set PATH "${lib.makeBinPath runtimeInputs}"
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preCheck
+
+    cat <<EOF >test.csv
+    ping, 0, testing, this.should.fail.example.com
+    EOF
+
+    $out/bin/tinystatus test.csv | grep Disrupted
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A static HTML status page generator written in pure shell";
+    homepage = "https://github.com/bderenzo/tinystatus";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8671,6 +8671,8 @@ with pkgs;
 
   tinyssh = callPackage ../tools/networking/tinyssh { };
 
+  tinystatus = callPackage ../tools/networking/tinystatus { };
+
   opensshPackages = dontRecurseIntoAttrs (callPackage ../tools/networking/openssh {});
 
   openssh = opensshPackages.openssh.override {


### PR DESCRIPTION
###### Description of changes

This initializes a simple posix compliant shell script called tinystatus, which generates the static html for a status page that looks like https://lab.bdro.fr/tinystatus/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
