### PR TITLE
spidermonkey_91: remove platform restriction

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -122,6 +122,6 @@ stdenv.mkDerivation rec {
     homepage = "https://spidermonkey.dev/";
     license = licenses.mpl20;
     maintainers = with maintainers; [ lostnet ];
-    platforms = platforms.all;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -120,6 +120,6 @@ stdenv.mkDerivation rec {
     homepage = "https://spidermonkey.dev/";
     license = licenses.mpl20;
     maintainers = with maintainers; [ lostnet ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     perl
     pkg-config
     python3
-    rust-cbindgen
     rustc
     rustc.llvmPackages.llvm # for llvm-objdump
     which

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -12,6 +12,7 @@
 , rust-cbindgen
 , rustc
 , which
+, xcbuildHook
 , zip
 
 # runtime
@@ -43,7 +44,12 @@ stdenv.mkDerivation rec {
     rustc.llvmPackages.llvm # for llvm-objdump
     which
     zip
+<<<<<<< HEAD
   ];
+=======
+    m4
+  ] ++ lib.optionals stdenv.isDarwin [ xcbuildHook ];
+>>>>>>> a199edf1da3 (xcbuild needed on darwin)
 
   buildInputs = [
     icu

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -12,7 +12,7 @@
 , rust-cbindgen
 , rustc
 , which
-, xcbuildHook
+, xcbuild
 , zip
 
 # runtime
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     rustc.llvmPackages.llvm # for llvm-objdump
     which
     zip
-  ] ++ lib.optionals stdenv.isDarwin [ xcbuildHook libobjc ];
+  ] ++ lib.optionals stdenv.isDarwin [ xcbuild libobjc ];
 
   buildInputs = [
     icu

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -45,16 +45,7 @@ stdenv.mkDerivation rec {
     rustc.llvmPackages.llvm # for llvm-objdump
     which
     zip
-<<<<<<< HEAD
-  ];
-=======
-    m4
-<<<<<<< HEAD
-  ] ++ lib.optionals stdenv.isDarwin [ xcbuildHook ];
->>>>>>> a199edf1da3 (xcbuild needed on darwin)
-=======
   ] ++ lib.optionals stdenv.isDarwin [ xcbuildHook libobjc ];
->>>>>>> c29bd5ea4b3 (add libobjc)
 
   buildInputs = [
     icu

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -17,6 +17,7 @@
 
 # runtime
 , icu
+, libobjc
 , nspr
 , readline
 , zlib
@@ -48,8 +49,12 @@ stdenv.mkDerivation rec {
   ];
 =======
     m4
+<<<<<<< HEAD
   ] ++ lib.optionals stdenv.isDarwin [ xcbuildHook ];
 >>>>>>> a199edf1da3 (xcbuild needed on darwin)
+=======
+  ] ++ lib.optionals stdenv.isDarwin [ xcbuildHook libobjc ];
+>>>>>>> c29bd5ea4b3 (add libobjc)
 
   buildInputs = [
     icu

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -5,6 +5,7 @@
 # build time
 , buildPackages
 , cargo
+, libiconv
 , m4
 , perl
 , pkg-config
@@ -45,7 +46,7 @@ stdenv.mkDerivation rec {
     rustc.llvmPackages.llvm # for llvm-objdump
     which
     zip
-  ] ++ lib.optionals stdenv.isDarwin [ xcbuild libobjc ];
+  ] ++ lib.optionals stdenv.isDarwin [ xcbuild libobjc libiconv ];
 
   buildInputs = [
     icu

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14625,7 +14625,9 @@ with pkgs;
   sparkleshare = callPackage ../applications/version-management/sparkleshare { };
 
   spidermonkey_78 = callPackage ../development/interpreters/spidermonkey/78.nix { };
-  spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix { };
+  spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix {
+    inherit (darwin) libobjc;
+  };
 
   ssm-agent = callPackage ../applications/networking/cluster/ssm-agent { };
   ssm-session-manager-plugin = callPackage ../applications/networking/cluster/ssm-session-manager-plugin { };


### PR DESCRIPTION
###### Description of changes

Try removing the platform restriction on spidermonkey to build it and couchdb3 on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
