### PR TITLE
radicle-cli: init at 0.6.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/radicle-cli/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/radicle-cli/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, cmake
+, installShellFiles
+, asciidoctor
+, DarwinTools
+, openssl
+, libusb1
+, AppKit
+, openssh
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "radicle-cli";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "radicle-dev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-LS6zYpMg0LanRL2M8ioGG8Ys07TPT/3hP7geEGehwxg=";
+  };
+
+  cargoSha256 = "sha256-o7ahnV7NnvzKxXb7HdNqKcxekshOtKanYKb0Sy15mhs=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    installShellFiles
+    asciidoctor
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    DarwinTools
+  ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libusb1
+    AppKit
+  ];
+
+  postInstall = ''
+    for f in $(find . -name '*.adoc'); do
+      mf=''${f%.*}
+      asciidoctor --doctype manpage --backend manpage $f -o $mf
+      installManPage $mf
+    done
+  '';
+
+  checkInputs = [ openssh ];
+  preCheck = ''
+    eval $(ssh-agent)
+  '';
+
+  meta = {
+    description = "Command-line tooling for Radicle, a decentralized code collaboration network";
+    homepage = "https://radicle.xyz";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ amesgen ];
+    platforms = lib.platforms.unix;
+    mainProgram = "rad";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23129,6 +23129,10 @@ with pkgs;
 
   radicale = radicale3;
 
+  radicle-cli = callPackage ../applications/version-management/git-and-tools/radicle-cli {
+    inherit (darwin) DarwinTools;
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
   radicle-upstream = callPackage ../applications/version-management/git-and-tools/radicle-upstream {};
 
   rake = callPackage ../development/tools/build-managers/rake { };


### PR DESCRIPTION
###### Description of changes

Closes #170543

radicle-cli vendors zlib and libgit2. I see no simple way to patch this just in nixpkgs, but if devendoring is very desired, creating upstream PRs to create a `vendor` feature in all relevant transitive dependencies should be possible (but tedious). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
