### PR TITLE
python3Packages.gidgethub: set format to flit

### DIFF
--- a/pkgs/development/python-modules/gidgethub/default.nix
+++ b/pkgs/development/python-modules/gidgethub/default.nix
@@ -2,21 +2,20 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, setuptools
-, pytest-runner
-, pytest
-, pytest-asyncio
-, twisted
-, treq
-, tornado
-, aiohttp
 , uritemplate
 , pyjwt
+, pytestCheckHook
+, aiohttp
+, httpx
+, importlib-resources
+, pytest-asyncio
+, pytest-tornasync
 }:
 
 buildPythonPackage rec {
   pname = "gidgethub";
   version = "5.1.0";
+  format = "flit";
 
   disabled = pythonOlder "3.6";
 
@@ -25,20 +24,25 @@ buildPythonPackage rec {
     sha256 = "sha256-kNGTb6mA2XBaljYvpOWaKFEks3NigsiPgmdIgSMKTiU=";
   };
 
-  nativeBuildInputs = [ setuptools pytest-runner ];
-  checkInputs = [ pytest pytest-asyncio twisted treq tornado aiohttp ];
   propagatedBuildInputs = [
     uritemplate
     pyjwt
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "extras_require=extras_require," "extras_require=None,"
-  '';
+  checkInputs = [
+    pytestCheckHook
+    aiohttp
+    httpx
+    importlib-resources
+    pytest-asyncio
+    pytest-tornasync
+  ];
 
-  # requires network (reqests github.com)
-  doCheck = false;
+  disabledTests = [
+    # Require internet connection
+    "test__request"
+    "test_get"
+  ];
 
   meta = with lib; {
     description = "An async GitHub API library";


### PR DESCRIPTION
###### Description of changes

ZHF: #172160 

[According to Hydra](https://hydra.nixos.org/build/176087546/nixlog/2), this package is failing to build because it is looking for a setup.py file. As indicated by @thiagokokada, I added the `flit` format to it. Plus, enabled tests (disabling the ones that require internet connection) and fixed the dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
