### PR TITLE
aravis: 0.6.4 -> 0.8.21, add myself as maintainer

### DIFF
--- a/pkgs/development/libraries/aravis/default.nix
+++ b/pkgs/development/libraries/aravis/default.nix
@@ -1,85 +1,76 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, gtk-doc, intltool
-, audit, glib, libusb1, libxml2
-, wrapGAppsHook
-, gstreamer
-, gst-plugins-base
-, gst-plugins-good
-, gst-plugins-bad
-, libnotify
-, gnome
-, gtk3
-, enableUsb ? true
-, enablePacketSocket ? true
-, enableViewer ? true
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, gi-docgen
+, glib
+, libxml2
+, gobject-introspection
+
 , enableGstPlugin ? true
-, enableCppTest ? false
+, enableViewer ? true
+, gst_all_1
+, gtk3
+, wrapGAppsHook
+
+, enableUsb ? true
+, libusb1
+
+, enablePacketSocket ? true
 , enableFastHeartbeat ? false
-, enableAsan ? false
 }:
 
-let
-  gstreamerAtLeastVersion1 =
-    lib.all
-      (pkg: pkg != null && lib.versionAtLeast (lib.getVersion pkg) "1.0")
-      [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ];
-in
-  assert enableViewer -> enableGstPlugin;
-  assert enableViewer -> gstreamerAtLeastVersion1;
+assert enableGstPlugin -> gst_all_1 != null;
+assert enableViewer -> enableGstPlugin;
+assert enableViewer -> gtk3 != null;
+assert enableViewer -> wrapGAppsHook != null;
 
-  stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
+  pname = "aravis";
+  version = "0.8.21";
 
-    pname = "aravis";
-    version = "0.6.4";
+  src = fetchFromGitHub {
+    owner = "AravisProject";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-z4fuo8tVyHf2Bw73ZfAEpAYmzbr9UIzEWPC5f95wnD8=";
+  };
 
-    src = fetchFromGitHub {
-      owner = "AravisProject";
-      repo = pname;
-      rev= "ARAVIS_${builtins.replaceStrings ["."] ["_"] version}";
-      sha256 = "18fnliks661kzc3g8v08hcaj18hjid8b180d6s9gwn0zgv4g374w";
-    };
+  outputs = [ "bin" "dev" "out" "lib" ];
 
-    outputs = [ "bin" "dev" "out" "lib" ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gi-docgen
+  ] ++ lib.optional enableViewer wrapGAppsHook;
 
-    nativeBuildInputs = [
-      autoreconfHook
-      pkg-config
-      intltool
-      gtk-doc
-    ] ++ lib.optional enableViewer wrapGAppsHook;
+  buildInputs =
+    [ glib libxml2 gobject-introspection ]
+    ++ lib.optional enableUsb libusb1
+    ++ lib.optionals (enableViewer || enableGstPlugin) (with gst_all_1; [ gstreamer gst-plugins-base (gst-plugins-good.override { gtkSupport = true; }) gst-plugins-bad ])
+    ++ lib.optionals (enableViewer) [ gtk3 ];
 
-    buildInputs =
-      [ glib libxml2 ]
-      ++ lib.optional enableUsb libusb1
-      ++ lib.optional enablePacketSocket audit
-      ++ lib.optionals (enableViewer || enableGstPlugin) [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ]
-      ++ lib.optionals (enableViewer) [ libnotify gtk3 gnome.adwaita-icon-theme ];
+  mesonFlags = [
+  ] ++ lib.optional enableFastHeartbeat "-Dfast-heartbeat=enabled"
+  ++ lib.optional (!enableGstPlugin) "-Dgst-plugin=disabled"
+  ++ lib.optional (!enableViewer) "-Dviewer=disabled"
+  ++ lib.optional (!enableUsb) "-Dviewer=disabled"
+  ++ lib.optional (!enablePacketSocket) "-Dpacket-socket=disabled";
 
-    preAutoreconf = "./autogen.sh";
+  doCheck = true;
 
-    configureFlags =
-      lib.optional enableUsb "--enable-usb"
-        ++ lib.optional enablePacketSocket "--enable-packet-socket"
-        ++ lib.optional enableViewer "--enable-viewer"
-        ++ lib.optional enableGstPlugin
-        (if gstreamerAtLeastVersion1 then "--enable-gst-plugin" else "--enable-gst-0.10-plugin")
-        ++ lib.optional enableCppTest "--enable-cpp-test"
-        ++ lib.optional enableFastHeartbeat "--enable-fast-heartbeat"
-        ++ lib.optional enableAsan "--enable-asan";
-
-    postPatch = ''
-        ln -s ${gtk-doc}/share/gtk-doc/data/gtk-doc.make .
-      '';
-
-    doCheck = true;
-
-    meta = {
-      description = "Library for video acquisition using GenICam cameras";
-      longDescription = ''
-        Implements the gigabit ethernet and USB3 protocols used by industrial cameras.
-      '';
-      homepage = "https://aravisproject.github.io/docs/aravis-0.5";
-      license = lib.licenses.lgpl2;
-      maintainers = [];
-      platforms = lib.platforms.unix;
-    };
-  }
+  meta = {
+    description = "Library for video acquisition using GenICam cameras";
+    longDescription = ''
+      Implements the gigabit ethernet and USB3 protocols used by industrial cameras.
+    '';
+    # the documentation is the best working homepage that's not the Github repo
+    homepage = "https://aravisproject.github.io/docs/aravis-0.8";
+    license = lib.licenses.lgpl2;
+    maintainers = with lib.maintainers; [ tpw_rules ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16519,9 +16519,7 @@ with pkgs;
 
   aprutil = callPackage ../development/libraries/apr-util { };
 
-  aravis = callPackage ../development/libraries/aravis {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad;
-  };
+  aravis = callPackage ../development/libraries/aravis { };
 
   arb = callPackage ../development/libraries/arb {};
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This upgrades Aravis to a supported version. I've tested both the viewer (though it has problems rendering on some desktop environments) and the GStreamer plugin with a handful of USB3 Vision cameras. I have not been able to test with GigE Vision cameras.

I've also added myself as a maintainer as there were none and I have both the need of this program and (some of) the necessary hardware to properly test it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
