### PR TITLE
pythonPackages.virt-backup: init 0.5.4

### DIFF
--- a/pkgs/development/python-modules/virt-backup/default.nix
+++ b/pkgs/development/python-modules/virt-backup/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, appdirs
+, arrow
+, buildPythonPackage
+, deepdiff
+, fetchFromGitHub
+, fetchpatch
+, libvirt
+, lxml
+, packaging
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+, zstandard
+}:
+
+buildPythonPackage rec {
+  pname = "virt-backup";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "aruhier";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-YZQi0OLyZa4pD4aLCkoHVW7s+bWMD/9tMPwChL0+U8U=";
+  };
+
+  disabled = pythonOlder "3.5";
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"pytest-cov", ' "" \
+      --replace "'pytest-runner', " ""
+  '';
+
+  checkInputs = [
+    deepdiff
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    appdirs
+    arrow
+    libvirt
+    lxml
+    packaging
+    pyyaml
+    zstandard
+  ];
+
+  pythonImportsCheck = [ "virt_backup" ];
+
+  disabledTestPaths = [
+    "tests/test_unsupported.py"
+  ];
+
+  meta = with lib; {
+    description = "Do external backup of your KVM guests, managed by libvirt, using the BlockCommit feature";
+    homepage = "https://github.com/aruhier/virt-backup";
+    maintainers = with maintainers; [ rhoriguchi ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10776,6 +10776,8 @@ in {
 
   vine = callPackage ../development/python-modules/vine { };
 
+  virt-backup = callPackage ../development/python-modules/virt-backup { };
+
   virtkey = callPackage ../development/python-modules/virtkey { };
 
   virtual-display = callPackage ../development/python-modules/virtual-display { };


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
