### PR TITLE
python3Packages.github3_py: update list of dependencies

### DIFF
--- a/pkgs/development/python-modules/github3_py/default.nix
+++ b/pkgs/development/python-modules/github3_py/default.nix
@@ -1,41 +1,50 @@
 { lib
-, pythonOlder
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
-, betamax
-, pytest
-, betamax-matchers
-, unittest2
-, mock
 , requests
 , uritemplate
 , python-dateutil
-, jwcrypto
-, pyopenssl
-, ndg-httpsclient
-, pyasn1
+, pyjwt
+, pytestCheckHook
+, betamax
+, betamax-matchers
 }:
 
 buildPythonPackage rec {
   pname = "github3.py";
   version = "3.2.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-Cbcr4Ul9NGsJaM3oNgoNavedwgbQFJpjzT7IbGXDd8w=";
   };
 
-  checkInputs = [ betamax pytest betamax-matchers ]
-    ++ lib.optional (pythonOlder "3") unittest2
-    ++ lib.optional (pythonOlder "3.3") mock;
-  propagatedBuildInputs = [ requests uritemplate python-dateutil jwcrypto pyopenssl ndg-httpsclient pyasn1 ];
+  propagatedBuildInputs = [
+    requests
+    uritemplate
+    python-dateutil
+    pyjwt
+  ];
 
-  postPatch = ''
-    sed -i -e 's/unittest2 ==0.5.1/unittest2>=0.5.1/' setup.py
+  checkInputs = [
+    pytestCheckHook
+    betamax
+    betamax-matchers
+  ];
+
+  # Solves "__main__.py: error: unrecognized arguments: -nauto"
+  preCheck = ''
+    rm tox.ini
   '';
 
-  # TODO: only disable the tests that require network
-  doCheck = false;
+  disabledTests = [
+    # FileNotFoundError: [Errno 2] No such file or directory: 'tests/id_rsa.pub'
+    "test_delete_key"
+  ];
 
   meta = with lib; {
     homepage = "https://github3py.readthedocs.org/en/master/";
@@ -43,5 +52,4 @@ buildPythonPackage rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ pSub ];
   };
-
 }


### PR DESCRIPTION
###### Description of changes

ZHF: #172160

[According to Hydra](https://hydra.nixos.org/build/176039191/nixlog/2), this package does not build because of a missing dependency. After checking the repo, some of the dependencies used weren't needed and others were missing. Also enabled tests and added a Python version constraint.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
