### PR TITLE
pypiserver: 1.4.2 -> 1.5.0, add SuperSandro2000 as maintainer, add to…

### DIFF
--- a/pkgs/development/python-modules/pypiserver/default.nix
+++ b/pkgs/development/python-modules/pypiserver/default.nix
@@ -1,7 +1,6 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-, httpx
 , passlib
 , pytestCheckHook
 , setuptools

--- a/pkgs/development/python-modules/pypiserver/default.nix
+++ b/pkgs/development/python-modules/pypiserver/default.nix
@@ -1,15 +1,24 @@
-{ buildPythonPackage, fetchFromGitHub, lib, passlib, pytestCheckHook, setuptools
-, setuptools-git, twine, webtest }:
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, httpx
+, passlib
+, pytestCheckHook
+, setuptools
+, setuptools-git
+, twine
+, webtest
+}:
 
 buildPythonPackage rec {
   pname = "pypiserver";
-  version = "1.4.2";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1z5rsmqgin98m6ihy1ww42fxxr6jb4hzldn8vlc9ssv7sawdz8vz";
+    sha256 = "sha256-BK5vQsaWIMOnUqyeofAWJC1nQJPsTvmzl9i2893JCDI=";
   };
 
   nativeBuildInputs = [ setuptools-git ];
@@ -20,13 +29,23 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
-  checkInputs = [ passlib pytestCheckHook twine webtest ];
+  checkInputs = [
+    passlib
+    pytestCheckHook
+    twine
+    webtest
+  ];
 
-  # These tests try to use the network
   disabledTests = [
-    "test_pipInstall_openOk"
-    "test_pipInstall_authedOk"
+    # fails to install the package
     "test_hash_algos"
+    "test_pip_install_authed_succeeds"
+    "test_pip_install_open_succeeds"
+  ];
+
+  disabledTestPaths = [
+    # requires docker service running
+    "docker/test_docker.py"
   ];
 
   pythonImportsCheck = [ "pypiserver" ];
@@ -35,6 +54,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pypiserver/pypiserver";
     description = "Minimal PyPI server for use with pip/easy_install";
     license = with licenses; [ mit zlib ];
-    maintainers = [ maintainers.austinbutler ];
+    maintainers = with maintainers; [ austinbutler SuperSandro2000 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22454,6 +22454,8 @@ with pkgs;
 
   pypolicyd-spf = python3.pkgs.callPackage ../servers/mail/pypolicyd-spf { };
 
+  pypiserver = with python3Packages; toPythonApplication pypiserver;
+
   qpid-cpp = callPackage ../servers/amqp/qpid-cpp { };
 
   qremotecontrol-server = callPackage ../servers/misc/qremotecontrol-server { };


### PR DESCRIPTION
…p-level entry

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
