### PR TITLE
python39Packages.clickgen: 1.1.9 -> 1.2.0, mark as broken on darwin

### DIFF
--- a/pkgs/development/python-modules/clickgen/default.nix
+++ b/pkgs/development/python-modules/clickgen/default.nix
@@ -1,5 +1,8 @@
 { lib
+, stdenv
 , buildPythonPackage
+, pythonOlder
+, pythonAtLeast
 , fetchFromGitHub
 , pillow
 , libX11
@@ -11,26 +14,38 @@
 
 buildPythonPackage rec {
   pname = "clickgen";
-  version = "1.1.9";
+  version = "1.2.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8" || pythonAtLeast "3.10";
 
   src = fetchFromGitHub {
     owner = "ful1e5";
     repo = "clickgen";
     rev = "v${version}";
-    sha256 = "108f3sbramd3hhs4d84s3i3lbwllfrkvjakjq4gdmbw6xpilvm0l";
+    sha256 = "sha256-01c8SVy+J004dq5KCUe62w7i/xUTxTfl/IpvUtGQgw0=";
   };
 
   buildInputs = [ libXcursor libX11 libpng ];
 
   propagatedBuildInputs = [ pillow ];
 
-  pythonImportsCheck = [ "clickgen" ];
+  checkInputs = [ pytestCheckHook ];
 
-  postInstall = ''
-    install -m644 clickgen/xcursorgen.so $out/${python.sitePackages}/clickgen/xcursorgen.so
+  postBuild = ''
+    # Needs to build xcursorgen.so
+    cd src/xcursorgen
+    make
+    cd ../..
   '';
 
-  checkInputs = [ pytestCheckHook ];
+  postInstall = ''
+    install -m644 src/xcursorgen/xcursorgen.so $out/${python.sitePackages}/clickgen/xcursorgen.so
+    # Copying scripts directory needed by clickgen script at $out/bin/
+    cp -R src/clickgen/scripts $out/${python.sitePackages}/clickgen/scripts
+  '';
+
+  pythonImportsCheck = [ "clickgen" ];
 
   meta = with lib; {
     homepage = "https://github.com/ful1e5/clickgen";
@@ -41,5 +56,6 @@ buildPythonPackage rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ AdsonCicilioti ];
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/clickgen/default.nix
+++ b/pkgs/development/python-modules/clickgen/default.nix
@@ -56,6 +56,8 @@ buildPythonPackage rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ AdsonCicilioti ];
+    # fails with:
+    # ld: unknown option: -zdefs
     broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

ZHF: #172160 

The failing builds are related to Darwin. ~~I will set this PR as a draft and see the ofborg results first before merging~~ As I don't know how to fix this on Darwin, I will mark it as broken (it cannot build `xcursorgen.so`, which is needed for the tests and its functionality):

```
       > Processing ./clickgen-1.2.0-py3-none-any.whl
       > Requirement already satisfied: Pillow>=8.1.1 in /nix/store/7xkw1qqviqkjlx2s77dribzm10bj4aj2-python3.9-pillow-9.1.0/lib/python3.9/site-packages (from clickgen==1.2.0) (9.1.0)
       > Installing collected packages: clickgen
       > Successfully installed clickgen-1.2.0
       > /private/tmp/nix-build-python3.9-clickgen-1.2.0.drv-0/source
       > clang -Wextra -Wall   -Wl,-zdefs -shared -o xcursorgen.so -fPIC  xcursorgen.c -lX11 -lXcursor -lpng -lz
       > ld: unknown option: -zdefs
       > clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
       > make: *** [Makefile:9: xcursorgen.so] Error 1
       For full logs, run 'nix log /nix/store/1w5j8xvwknp388ymlhhp9pgv5hika2zh-python3.9-clickgen-1.2.0.drv'.
```

If someone with a darwin machine wants to figure out how to build `xcursorgen.so`, feel free to do so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
