### PR TITLE
mold: wrap with ld-wrapper

### DIFF
--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -35,8 +35,7 @@ stdenv.mkDerivation rec {
   wrapperName = "MOLD_WRAPPER";
   coreutils_bin = lib.getBin coreutils;
   postInstall = let
-    targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
-                                          (stdenv.targetPlatform.config + "-");
+    targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
   in ''
     mkdir -p $out/nix-support
 

--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -31,9 +31,14 @@ stdenv.mkDerivation rec {
   LTO = 1;
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
+  # The next three variables are substituted into the script scaffold below.
+  # add-flags.sh; add-hardening.sh; ld-wrapper.sh; utils.bash
   suffixSalt = lib.replaceStrings ["-" "."] ["_" "_"] stdenv.targetPlatform.config;
+  # utils.bash
   wrapperName = "MOLD_WRAPPER";
+  # ld-wrapper.sh; utils.bash
   coreutils_bin = lib.getBin coreutils;
+
   postInstall = let
     targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
   in ''


### PR DESCRIPTION
###### Description of changes

Wrapping mold so it can find libraries from the nix build environment.

See #24744 for additional context. The situation with lld is very similar, but mold was easier to fix.

Demo:
```
$ printf '#include <iostream>\nint main(){std::cout << "Woo!\\\n";}\n' \
  | c++ -B$(nix build --print-out-paths .#mold)/bin -x c++ - \
  && readelf -p .comment a.out \
  && ./a.out

String dump of section '.comment':
  [     0]  GCC: (GNU) 10.3.0
  [    12]  mold 1.2.1 (compatible with GNU ld)
  [    37]  GCC: (GNU) 8.3.0

Woo!
```

- [ ] check in a `nix-shell` with additional dependencies
- [ ] verify that this doesn't involuntarily break linking when used with rust

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
