### PR TITLE
gnss-sdr: 0.0.16 → 0.0.17

### DIFF
--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -21,13 +21,13 @@
 
 gnuradio.pkgs.mkDerivation rec {
   pname = "gnss-sdr";
-  version = "0.0.16";
+  version = "0.0.17";
 
   src = fetchFromGitHub {
     owner = "gnss-sdr";
     repo = "gnss-sdr";
     rev = "v${version}";
-    sha256 = "sha256-ODe4k6PDGtDX11FrbggEbN3tc4UtATaItUIpCKl4JjM=";
+    sha256 = "sha256-0aAjkrVAswoRL/KANBSZ5Jq4Y9VwOHZKUKLpXDdKtk8=";
   };
 
   patches = [
@@ -35,11 +35,6 @@ gnuradio.pkgs.mkDerivation rec {
     # cpu_features which is bundled in the source. NOTE: Perhaps this patch
     # should be sent upstream.
     ./fix_libcpu_features_install_path.patch
-    # Fixes a compilation issue, should be removed on next release.
-    (fetchpatch {
-      url = "https://github.com/gnss-sdr/gnss-sdr/commit/8a42967c854e575f2dd9ee7ca81a2522eebb864b.patch";
-      sha256 = "sha256-W8BwC08QVtW0LUj5Q+j28aYG+713s+vQIzsWyrNUs1Q=";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/radio/gnss-sdr/fix_libcpu_features_install_path.patch
+++ b/pkgs/applications/radio/gnss-sdr/fix_libcpu_features_install_path.patch
@@ -1,6 +1,6 @@
---- a/CMakeLists.txt	1970-01-01 08:00:01.000000000 +0800
-+++ b/CMakeLists.txt	2022-02-16 20:41:53.725290020 +0800
-@@ -1214,7 +1214,7 @@
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -1210,7 +1210,7 @@ if(NOT VOLKGNSSSDR_FOUND)
              BINARY_DIR ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/build
              CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
                  -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
@@ -9,16 +9,16 @@
              DOWNLOAD_COMMAND ""
              UPDATE_COMMAND ""
              PATCH_COMMAND ""
-@@ -1247,7 +1247,7 @@
-                 )
-                 set(VOLK_GNSSSDR_BUILD_BYPRODUCTS
-                     ${VOLK_GNSSSDR_BUILD_BYPRODUCTS}
--                    ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
-+                    ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/lib/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
-                 )
+@@ -1248,7 +1248,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+                     )
+                     set(VOLK_GNSSSDR_BUILD_BYPRODUCTS
+                         ${VOLK_GNSSSDR_BUILD_BYPRODUCTS}
+-                        ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
++                        ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/lib/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
+                     )
+                 endif()
              endif()
-             ExternalProject_Add(volk_gnsssdr_module
-@@ -1256,7 +1256,7 @@
+@@ -1261,7 +1261,7 @@ if(NOT VOLKGNSSSDR_FOUND)
                  BINARY_DIR ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/build
                  CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
                      -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
@@ -27,7 +27,7 @@
                  DOWNLOAD_COMMAND ""
                  UPDATE_COMMAND ""
                  PATCH_COMMAND ""
-@@ -1271,7 +1271,7 @@
+@@ -1280,7 +1280,7 @@ if(NOT VOLKGNSSSDR_FOUND)
                  BINARY_DIR ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/build
                  CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
                      -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
@@ -36,9 +36,9 @@
                  DOWNLOAD_COMMAND ""
                  UPDATE_COMMAND ""
                  PATCH_COMMAND ""
-@@ -1310,7 +1310,7 @@
+@@ -1319,7 +1319,7 @@ if(NOT VOLKGNSSSDR_FOUND)
          if(CMAKE_VERSION VERSION_GREATER 3.0 AND SUPPORTED_CPU_FEATURES_ARCH)
-             if(NOT CpuFeatures_FOUND)
+             if(NOT CPUFEATURES_FOUND AND ENABLE_CPUFEATURES)
                  set_target_properties(Volkgnsssdr::volkgnsssdr PROPERTIES
 -                    INTERFACE_LINK_LIBRARIES ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
 +                    INTERFACE_LINK_LIBRARIES ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/lib/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/gnss-sdr/gnss-sdr/releases/tag/v0.0.17)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).