### PR TITLE
rapidsvn: fix the build

### DIFF
--- a/pkgs/applications/version-management/rapidsvn/default.nix
+++ b/pkgs/applications/version-management/rapidsvn/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, wxGTK, subversion, apr, aprutil, python2 }:
+{ lib, stdenv, fetchurl, wxGTK, subversion, apr, aprutil, python3, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "rapidsvn";
@@ -9,13 +9,28 @@ stdenv.mkDerivation rec {
     sha256 = "1bmcqjc12k5w0z40k7fkk8iysqv4fw33i80gvcmbakby3d4d4i4p";
   };
 
-  buildInputs = [ wxGTK subversion apr aprutil python2 ];
+  buildInputs = [ wxGTK subversion apr aprutil python3 ];
+
+  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];
 
   configureFlags = [ "--with-svn-include=${subversion.dev}/include"
     "--with-svn-lib=${subversion.out}/lib" ];
 
   patches = [
     ./fix-build.patch
+    # Python 3 compatibility patches
+    (fetchpatch {
+      url = "https://github.com/RapidSVN/RapidSVN/pull/44/commits/2e26fd5d6a413d6c3a055c17ac4840b95d1537e9.patch";
+      hash = "sha256-8acABzscgZh1bfAt35KHfU+nfaiO7P1b+lh34Bj0REI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/RapidSVN/RapidSVN/pull/44/commits/92927af764f92b3731333ed3dba637f98611167a.patch";
+      hash = "sha256-4PdShGcfFwxjdI3ygbnKFAa8l9dGERq/xSl54WisgKM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/RapidSVN/RapidSVN/pull/44/commits/3e375f11d94cb8faddb8b7417354a9fb51f304ec.patch";
+      hash = "sha256-BUpCMEH7jctOLtJktDUE52bxexfLemLItZ0IgdAnq9g=";
+    })
   ];
 
   meta = {
@@ -23,5 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "http://rapidsvn.tigris.org/";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.viric ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

Moved back to C++14 where dynamic exception specifications are deprecated but still present.

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>rapidsvn</li>
  </ul>
</details>

@NixOS/nixos-release-managers