### PR TITLE
opendungeons: fix compilation

### DIFF
--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0xf7gkpy8ll1h59wyaljf0hr8prg7p4ixz80mxqwcnm9cglpgn63";
   };
 
-  patches = [ ./cmakepaths.patch ];
+  patches = [
+    ./cmakepaths.patch
+    ./fix_link_date_time.patch
+  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ ogre cegui boost sfml openal ois ];

--- a/pkgs/games/opendungeons/fix_link_date_time.patch
+++ b/pkgs/games/opendungeons/fix_link_date_time.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f8ff3c2..689c463 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -538,7 +538,7 @@ endif()
+ #This has to cover the versions not already known by CMake
+ set(Boost_ADDITIONAL_VERSIONS 1.47 1.47.0 1.47.1 1.55.0)
+ 
+-set(OD_BOOST_COMPONENTS system filesystem locale program_options thread)
++set(OD_BOOST_COMPONENTS system date_time filesystem locale program_options thread)
+ 
+ if(BUILD_TESTING AND OD_BUILD_TESTING)
+     set(OD_BOOST_COMPONENTS ${OD_BOOST_COMPONENTS} unit_test_framework)


### PR DESCRIPTION
###### Description of changes

Added a patch to the CMakeFile that fix compilation. I'm nor really sure why it fix it, or why it stopped compiling to start with, but it seems to work correctly ( and meet this error, that seems to just be some issue with the game https://github.com/OpenDungeons/OpenDungeons/issues/1311 )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
