### PR TITLE
netcoredbg: 1.2.0-825 -> 2.0.0-895

### DIFF
--- a/pkgs/development/tools/misc/netcoredbg/default.nix
+++ b/pkgs/development/tools/misc/netcoredbg/default.nix
@@ -1,7 +1,7 @@
 { lib, clangStdenv, stdenvNoCC, cmake, fetchFromGitHub, dotnetCorePackages, buildDotnetModule }:
 let
   pname = "netcoredbg";
-  version = "1.2.0-825";
+  version = "2.0.0-895";
 
   # according to CMakeLists.txt, this should be 3.1 even when building for .NET 5
   coreclr-version = "3.1.19";
@@ -12,18 +12,19 @@ let
     sha256 = "o1KafmXqNjX9axr6sSxPKrfUX0e+b/4ANiVQt4T2ybw=";
   };
 
-  dotnet-sdk = dotnetCorePackages.sdk_5_0;
+  dotnet-sdk = dotnetCorePackages.sdk_6_0;
 
   src = fetchFromGitHub {
     owner = "Samsung";
     repo = pname;
     rev = version;
-    sha256 = "JQhDI1+bVbOIFNkXixZnFB/5+dzqCbInR0zJvykcFCg=";
+    sha256 = "sha256-zOfChuNjD6py6KD1AmN5DgCGxD2YNH9gTyageoiN8PU=";
   };
 
   unmanaged = clangStdenv.mkDerivation rec {
     inherit src pname version;
 
+    patches = [ ./limits.patch ];
     nativeBuildInputs = [ cmake dotnet-sdk ];
 
     hardeningDisable = [ "strictoverflow" ];

--- a/pkgs/development/tools/misc/netcoredbg/limits.patch
+++ b/pkgs/development/tools/misc/netcoredbg/limits.patch
@@ -1,0 +1,12 @@
+diff --git a/src/debugger/frames.cpp b/src/debugger/frames.cpp
+index 534936b..21366f9 100644
+--- a/src/debugger/frames.cpp
++++ b/src/debugger/frames.cpp
+@@ -9,6 +9,7 @@
+ #include "utils/platform.h"
+ #include "utils/logger.h"
+ #include "utils/torelease.h"
++#include <limits>
+ 
+ namespace netcoredbg
+ {


### PR DESCRIPTION
###### Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/172160
Failed build: https://hydra.nixos.org/build/173937987/nixlog/1/tail

Build failed with complaint about unknown std::numeric_limits constant, because on older gcc versions <limits> header was implicitly included and now it does not (https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes) 

###### Things done

Added a small patch with <limits> include and also bumped versions of netcoredb and dotnet-sdk.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ping https://github.com/orgs/NixOS/teams/nixos-release-managers