### PR TITLE
nodePackages.prisma: package tests to validate binary interop

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -339,6 +339,12 @@ let
           --set PRISMA_INTROSPECTION_ENGINE_BINARY ${prisma-engines}/bin/introspection-engine \
           --set PRISMA_FMT_BINARY ${prisma-engines}/bin/prisma-fmt
       '';
+
+      passthru.tests = {
+        simple-execution = pkgs.callPackage ./package-tests/prisma.nix {
+          inherit (self) prisma;
+        };
+      };
     };
 
     pulp = super.pulp.override {

--- a/pkgs/development/node-packages/package-tests/prisma.nix
+++ b/pkgs/development/node-packages/package-tests/prisma.nix
@@ -1,0 +1,56 @@
+{ lib, pkgs, runCommand, prisma }:
+
+let
+  inherit (prisma) packageName;
+  prismaMajorVersion = lib.versions.majorMinor prisma.version;
+  enginesMajorVersion = lib.versions.majorMinor pkgs.prisma-engines.version;
+in
+
+runCommand "${packageName}-tests" {
+  nativeBuildInputs = with pkgs; [ prisma sqlite-interactive ];
+  meta.timeout = 60;
+}
+  ''
+    mkdir $out
+    cd $out
+
+    if [ "${prismaMajorVersion}" != "${enginesMajorVersion}" ]; then
+      echo "nodePackages.prisma in version ${prismaMajorVersion} and prisma-engines in ${enginesMajorVersion}. Major versions must match."
+      exit 1
+    fi
+
+    # Ensure CLI runs
+    prisma --help > /dev/null
+
+    # Init a new project
+    prisma init > /dev/null
+
+    # Create a simple data model
+    cat << EOF > prisma/schema.prisma
+    datasource db {
+      provider = "sqlite"
+      url      = "file:test.db"
+    }
+
+    generator js {
+      provider = "prisma-client-js"
+    }
+
+    model A {
+      id Int    @id @default(autoincrement())
+      b  String @default("foo")
+    }
+    EOF
+
+    # Format
+    prisma format > /dev/null
+
+    # Create the database
+    prisma db push --skip-generate > /dev/null
+
+    # The database file should exist and be a SQLite database
+    sqlite3 prisma/test.db "SELECT id, b FROM A" > /dev/null
+
+    # Introspect the database
+    prisma db pull > /dev/null
+  ''


### PR DESCRIPTION
###### Description of changes

Adding package tests for Prisma

- Testing `prisma --help`
- Testing to format a data model with `prisma --format` (WASM interop)
- Testing to create a database schema with SQLite (binary interop, migration-engine)
- Testing to read a schema from the database (binary interop, introspection-engine)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
