### PR TITLE
commit: init at 3.2.0

### DIFF
--- a/pkgs/applications/editors/commit/always-use-latest.patch
+++ b/pkgs/applications/editors/commit/always-use-latest.patch
@@ -1,0 +1,32 @@
+By default, commit displays something along of "git config core.editors /nix/store/[...]/bin/re.sonny.Commit"
+as command to set it as git editor. Since this would break on upgrades, just use the non-versioned binary
+diff --git a/src/welcome.js b/src/welcome.js
+index c410e2d..62e46ba 100644
+--- a/src/welcome.js
++++ b/src/welcome.js
+@@ -70,24 +70,7 @@ export default function Welcome({ application }) {
+ }
+ 
+ function getCommand() {
+-  const FLATPAK_ID = GLib.getenv("FLATPAK_ID");
+-  const { programInvocationName } = system;
+-
+-  if (FLATPAK_ID) {
+-    return `flatpak run --file-forwarding ${FLATPAK_ID} @@`;
+-  }
+-
+-  // re.sonny.Commit
+-  if (programInvocationName === GLib.path_get_basename(programInvocationName)) {
+-    return programInvocationName;
+-  }
+-
+-  // ./re.sonny.commit
+-  // /home/sonny/re.sonny.Commit
+-  return GLib.canonicalize_filename(
+-    programInvocationName,
+-    GLib.get_current_dir(),
+-  );
++  return "re.sonny.Commit";
+ }
+ 
+ function getRange(key) {

--- a/pkgs/applications/editors/commit/default.nix
+++ b/pkgs/applications/editors/commit/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, lib
+, desktop-file-utils
+, meson
+, ninja
+, gettext
+, pkg-config
+, gtk4
+, gtksourceview5
+, gobject-introspection
+, wrapGAppsHook4
+, fetchFromGitHub
+, gjs
+, libadwaita
+}:
+
+stdenv.mkDerivation rec {
+  pname = "commit";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sonnyp";
+    repo = "Commit";
+    rev = "v${version}";
+    hash = "sha256-nnjHuE7MzCuoPfCb4MA00BIzLPbhgR6mbeWYagmNjME=";
+  };
+
+  patches = [
+    ./always-use-latest.patch
+  ];
+
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gjs
+    gtk4
+    gtksourceview5
+    libadwaita
+    gobject-introspection
+  ];
+
+  postPatch = ''
+    substituteInPlace src/re.sonny.Commit \
+      --replace "/usr/bin/env -S gjs" ${gjs}/bin/gjs
+  '';
+
+
+  dontPatchShebangs = true;
+
+  meta = with lib; {
+    homepage = "https://commit.sonny.re/";
+    description = "Commit message editor";
+    maintainers = [ maintainers.Cogitri ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35152,6 +35152,8 @@ with pkgs;
 
   mmark = callPackage ../tools/typesetting/mmark { };
 
+  commit = callPackage ../applications/editors/commit { };
+
   wire-desktop = callPackage ../applications/networking/instant-messengers/wire-desktop { };
 
   teseq = callPackage ../applications/misc/teseq {  };


### PR DESCRIPTION
###### Description of changes

Commit is a handy commit message editor for git.
https://github.com/sonnyp/Commit

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
