### PR TITLE
Don't allow user paths in `linkFarm`

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -477,7 +477,7 @@ rec {
       cd $out
       ${lib.concatMapStrings (x: ''
           mkdir -p "$(dirname ${lib.escapeShellArg x.name})"
-          ln -s ${lib.escapeShellArg x.path} ${lib.escapeShellArg x.name}
+          ln -s ${lib.escapeShellArg (builtins.storePath x.path)} ${lib.escapeShellArg x.name}
       '') entries}
     '';
 


### PR DESCRIPTION
```nix
let pkgs = import ./. {}; in
pkgs.linkFarm "test" [
  { name = "foo"; path = ./README.md; }
]
```

The nix code above generates this result: (`nix build -f test.nix`)

```
lrwxrwxrwx 1 root root 31 Jan  1  1970 /nix/store/98mdz626n99w0467q4r203q154bnnli9-test/foo -> /home/juloo/w/nixpkgs/README.md
```

I have been living with such derivations for a while before noticing the hard way. With this patch, this is now an error:

```
error: path '/home/juloo/w/nixpkgs/README.md' is not in the Nix store

       at /home/juloo/w/nixpkgs/pkgs/build-support/trivial-builders.nix:480:39:

          479|           mkdir -p "$(dirname ${lib.escapeShellArg x.name})"
          480|           ln -s ${lib.escapeShellArg (builtins.storePath x.path)} ${lib.escapeShellArg x.na
me}
             |                                       ^
          481|       '') entries}
(use '--show-trace' to show detailed location information)
```

I realise this might be a breaking change, I can think of other solutions:

- Copy link destination to the store with `builtins.path`.
- Keep the error above but continue to allow absolute paths.
- Keep the old behavior but document it clearly. The current
  documentation almost sound like the paths would be copied to the store
  automatically.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
