### PR TITLE
curl: 7.83.0 -> 7.83.1

### DIFF
--- a/pkgs/tools/networking/curl/7.83.1-quiche-support-ca-fallback.patch
+++ b/pkgs/tools/networking/curl/7.83.1-quiche-support-ca-fallback.patch
@@ -1,0 +1,51 @@
+diff --git a/lib/vquic/quiche.c b/lib/vquic/quiche.c
+index bfdc966a85ea..e4bea4d677be 100644
+--- a/lib/vquic/quiche.c
++++ b/lib/vquic/quiche.c
+@@ -201,23 +201,31 @@ static SSL_CTX *quic_ssl_ctx(struct Curl_easy *data)
+ 
+   {
+     struct connectdata *conn = data->conn;
+-    const char * const ssl_cafile = conn->ssl_config.CAfile;
+-    const char * const ssl_capath = conn->ssl_config.CApath;
+-
+     if(conn->ssl_config.verifypeer) {
+-      SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
+-      /* tell OpenSSL where to find CA certificates that are used to verify
+-         the server's certificate. */
+-      if(!SSL_CTX_load_verify_locations(ssl_ctx, ssl_cafile, ssl_capath)) {
+-        /* Fail if we insist on successfully verifying the server. */
+-        failf(data, "error setting certificate verify locations:"
+-              "  CAfile: %s CApath: %s",
+-              ssl_cafile ? ssl_cafile : "none",
+-              ssl_capath ? ssl_capath : "none");
+-        return NULL;
++      const char * const ssl_cafile = conn->ssl_config.CAfile;
++      const char * const ssl_capath = conn->ssl_config.CApath;
++      if(ssl_cafile || ssl_capath) {
++        SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
++        /* tell OpenSSL where to find CA certificates that are used to verify
++           the server's certificate. */
++        if(!SSL_CTX_load_verify_locations(ssl_ctx, ssl_cafile, ssl_capath)) {
++          /* Fail if we insist on successfully verifying the server. */
++          failf(data, "error setting certificate verify locations:"
++                "  CAfile: %s CApath: %s",
++                ssl_cafile ? ssl_cafile : "none",
++                ssl_capath ? ssl_capath : "none");
++          return NULL;
++        }
++        infof(data, " CAfile: %s", ssl_cafile ? ssl_cafile : "none");
++        infof(data, " CApath: %s", ssl_capath ? ssl_capath : "none");
+       }
+-      infof(data, " CAfile: %s", ssl_cafile ? ssl_cafile : "none");
+-      infof(data, " CApath: %s", ssl_capath ? ssl_capath : "none");
++#ifdef CURL_CA_FALLBACK
++      else {
++        /* verifying the peer without any CA certificates won't work so
++           use openssl's built-in default as fallback */
++        SSL_CTX_set_default_verify_paths(ssl_ctx);
++      }
++#endif
+     }
+   }
+   return ssl_ctx;

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -62,18 +62,21 @@ assert zstdSupport -> zstd != null;
 
 stdenv.mkDerivation rec {
   pname = "curl";
-  version = "7.83.0";
+  version = "7.83.1";
 
   src = fetchurl {
     urls = [
       "https://curl.haxx.se/download/${pname}-${version}.tar.bz2"
       "https://github.com/curl/curl/releases/download/${lib.replaceStrings ["."] ["_"] pname}-${version}/${pname}-${version}.tar.bz2"
     ];
-    sha256 = "sha256-JHx+x1IcQljmVjTlKScNIU/jKWmXHMy3KEXnqkaDH5Y=";
+    sha256 = "sha256-9Tmjb7RKgmDsXZd+Tg290u7intkPztqpvDyfeKETv/A=";
   };
 
   patches = [
     ./7.79.1-darwin-no-systemconfiguration.patch
+    # quiche: support ca-fallback
+    # https://github.com/curl/curl/commit/fdb5e21b4dd171a96cf7c002ee77bb08f8e58021
+    ./7.83.1-quiche-support-ca-fallback.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
@@ -141,8 +144,7 @@ stdenv.mkDerivation rec {
     ] ++ lib.optionals stdenv.isDarwin [
       # Disable default CA bundle, use NIX_SSL_CERT_FILE or fallback to nss-cacert from the default profile.
       # Without this curl might detect /etc/ssl/cert.pem at build time on macOS, causing curl to ignore NIX_SSL_CERT_FILE.
-      # https://github.com/curl/curl/issues/8696 - fallback is not supported by HTTP3
-      (if http3Support then "--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt" else "--without-ca-bundle")
+      "--without-ca-bundle"
       "--without-ca-path"
     ];
 


### PR DESCRIPTION
###### Description of changes
Update curl to 7.83.1 version.
Add support ca-fallback in HTTP3 protocol - https://github.com/curl/curl/commit/fdb5e21b4dd171a96cf7c002ee77bb08f8e58021


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
