### PR TITLE
libreoffice-qt: fix build

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -121,13 +121,10 @@ in (mkDrv rec {
       'GPGMEPP_CFLAGS=-I${gpgme.dev}/include/gpgme++'
   '' + lib.optionalString kdeIntegration ''
       substituteInPlace configure.ac \
-        --replace kcoreaddons_version.h KCoreAddons/kcoreaddons_version.h \
         --replace '$QT5INC'             ${qtbase.dev}/include \
         --replace '$QT5LIB'             ${qtbase.out}/lib \
         --replace '-I$qt5_incdir '      '-I${qtx11extras.dev}/include '\
         --replace '-L$qt5_libdir '      '${libs [ qtbase qtx11extras ]} ' \
-        --replace '$KF5INC'             ${kcoreaddons.dev}/include \
-        --replace '$KF5LIB'             ${kcoreaddons.out}/lib \
         --replace '$kf5_incdir/KCore'   ${inc kcoreaddons "KCore"} \
         --replace '$kf5_incdir/KI18n'   ${inc ki18n "KI18n"} \
         --replace '$kf5_incdir/KConfig' ${inc kconfig "KConfig"} \

--- a/pkgs/applications/office/libreoffice/src-fresh/override.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/override.nix
@@ -1,6 +1,11 @@
-{ lib, kdeIntegration, ... }:
+{ lib, kdeIntegration, kio ? null, ... }:
 attrs:
 {
+  postPatch = attrs.postPatch + lib.optionalString kdeIntegration ''
+    substituteInPlace configure.ac \
+      --replace '$KF5INC' ${kio.dev}/include \
+      --replace '$KF5LIB' ${kio.out}/lib
+  '';
   postConfigure = attrs.postConfigure + ''
     sed -e '/CPPUNIT_TEST(Import_Export_Import);/d' -i './sw/qa/inc/swmodeltestbase.hxx'
     sed -e '/CPPUNIT_ASSERT(!bRTL);/d' -i './vcl/qa/cppunit/text.cxx'

--- a/pkgs/applications/office/libreoffice/src-still/override.nix
+++ b/pkgs/applications/office/libreoffice/src-still/override.nix
@@ -1,6 +1,12 @@
-{ lib, kdeIntegration, commonsLogging, ... }:
+{ lib, kdeIntegration, commonsLogging, kcoreaddons ? null, ... }:
 attrs:
 {
+  postPatch = attrs.postPatch + lib.optionalString kdeIntegration ''
+    substituteInPlace configure.ac \
+      --replace kcoreaddons_version.h KCoreAddons/kcoreaddons_version.h \
+      --replace '$KF5INC'             ${kcoreaddons.dev}/include \
+      --replace '$KF5LIB'             ${kcoreaddons.out}/lib
+  '';
   postConfigure = attrs.postConfigure + ''
     sed -e '/CPPUNIT_TEST(Import_Export_Import);/d' -i './sw/qa/inc/swmodeltestbase.hxx'
     sed -e '/CPPUNIT_ASSERT_EQUAL(11148L, pOleObj->GetLogicRect().getWidth());/d ' -i sc/qa/unit/subsequent_filters-test.cxx


### PR DESCRIPTION
###### Description of changes

Libreoffice 7.3 configure now checks for KFileWidget instead of kcoreaddons ([commit](https://cgit.freedesktop.org/libreoffice/core/commit/configure.ac?id=5fd5e42bf28a7910321c6b6d76257e7386839fbc)).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
