### PR TITLE
factorio-experimental: 1.1.57 -> 1.1.59

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.57.tar.xz",
+        "name": "factorio_alpha_x64-1.1.59.tar.xz",
         "needsAuth": true,
-        "sha256": "0sazpljdkknv74dqhrv5gxi7s50bfccynqk7xhsr4awl2gdkys0v",
+        "sha256": "0qwq3mjsmhb119pvbfznpncw898z4zs2if4fd7p6rqfz0wip93qk",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.57/alpha/linux64",
-        "version": "1.1.57"
+        "url": "https://factorio.com/get-download/1.1.59/alpha/linux64",
+        "version": "1.1.59"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.1.57.tar.xz",
@@ -20,12 +20,12 @@
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.57.tar.xz",
+        "name": "factorio_demo_x64-1.1.59.tar.xz",
         "needsAuth": false,
-        "sha256": "1lwrz0ix7iycampjh87ki8vg3pkk753873vmrfiyrmh3hchvbj34",
+        "sha256": "1nddk8184kgq4ni0y9j2l8sa3szvcbsq9l90b35l9jb6sqflgki0",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.57/demo/linux64",
-        "version": "1.1.57"
+        "url": "https://factorio.com/get-download/1.1.59/demo/linux64",
+        "version": "1.1.59"
       },
       "stable": {
         "name": "factorio_demo_x64-1.1.57.tar.xz",
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.57.tar.xz",
+        "name": "factorio_headless_x64-1.1.59.tar.xz",
         "needsAuth": false,
-        "sha256": "1y65wppfzfpad6g6kvdd8srd9sq71dh1dpqia5b3x6pnwk5xsqdm",
+        "sha256": "1p5wyki6wxnvnp7zqjjw9yggiy0p78rx49wmq3q7kq0mxfz054dg",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.57/headless/linux64",
-        "version": "1.1.57"
+        "url": "https://factorio.com/get-download/1.1.59/headless/linux64",
+        "version": "1.1.59"
       },
       "stable": {
         "name": "factorio_headless_x64-1.1.57.tar.xz",


### PR DESCRIPTION
###### Description of changes

Factorio experimental is 1.1.59

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
