### PR TITLE
ArchiSteamFarm: fix aarch64 build

### DIFF
--- a/pkgs/applications/misc/ArchiSteamFarm/deps-aarch64-linux.nix
+++ b/pkgs/applications/misc/ArchiSteamFarm/deps-aarch64-linux.nix
@@ -76,7 +76,7 @@
   (fetchNuGet { pname = "Microsoft.Extensions.Primitives"; version = "5.0.0"; sha256 = "0swqcknyh87ns82w539z1mvy804pfwhgzs97cr3nwqk6g5s42gd6"; })
   (fetchNuGet { pname = "Microsoft.NET.Test.Sdk"; version = "17.0.0"; sha256 = "0bknyf5kig5icwjxls7pcn51x2b2qf91dz9qv67fl70v6cczaz2r"; })
   (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "6.0.4"; sha256 = "1zm9q9yvglsn5w786c9cjdfj1a8z4sipmvn9rhg3ps23rllxwmcc"; })
-  (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "6.0.4"; sha256 = "0g1vw0wr88zlfpdg2gz8c0mriasci1kzvjia4nj19j7b0zaga7f0"; })
+  (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "6.0.4"; sha256 = "1x1g3jhd57z1w3js7f6qa72vwvvjayvxzc2xxcqyscm9xy1fb3d4"; })
   (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-arm64"; version = "6.0.4"; sha256 = "08mrvb71kldzla2j7v10ifxrc6bwsrd4bms2rqfb7rmx00qs6yj0"; })
   (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "6.0.4"; sha256 = "0vgjwpy55mf6x22a634cdidckyq5hi941i9p10jqyrbnc637frv2"; })
   (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "6.0.4"; sha256 = "1qasm6j25lmcc4xn7f7s3jli1pypz1kfnj7j9dkjlx9mc8r356zp"; })


### PR DESCRIPTION
###### Description of changes

ZHF: #172160

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
