### PR TITLE
CODEOWNERS: rename Gabriel439 to Gabriella439

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -192,8 +192,8 @@
 /nixos/tests/knot.nix @mweinelt
 
 # Dhall
-/pkgs/development/dhall-modules      @Gabriel439 @Profpatsch @ehmry
-/pkgs/development/interpreters/dhall @Gabriel439 @Profpatsch @ehmry
+/pkgs/development/dhall-modules      @Gabriella439 @Profpatsch @ehmry
+/pkgs/development/interpreters/dhall @Gabriella439 @Profpatsch @ehmry
 
 # Idris
 /pkgs/development/idris-modules @Infinisil


### PR DESCRIPTION
See https://github.com/Gabriel439:

Hi, there! 👋🏼

I renamed my GitHub account from @Gabriel439 to @Gabriella439, so if you got here from an old profile link you can visit my new profile here:

    @Gabriella439

I created this placeholder account so that:

    … people who visit old links to my profile can find my new profile
    … other people cannot impersonate my old handle
    … GitHub continues to redirect old links to my repositories indefinitely

