### PR TITLE
tree-sitter: update grammars to fix nvim-treesitter for vim syntax

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9572,8 +9572,8 @@
     githubId = 14816024;
     name = "oxalica";
     keys = [{
-      longkeyid = "rsa4096/0xCED392DE0C483D00";
-      fingerprint = "5CB0 E9E5 D5D5 71F5 7F54  0FEA CED3 92DE 0C48 3D00";
+      longkeyid = "ed25519/0x7571654CF88E31C2";
+      fingerprint = "F90F FD6D 585C 2BA1 F13D  E8A9 7571 654C F88E 31C2";
     }];
   };
   oxij = {

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -166,6 +166,6 @@ rustPlatform.buildRustPackage {
       * Dependency-free so that the runtime library (which is written in pure C) can be embedded in any application
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ Profpatsch ];
+    maintainers = with maintainers; [ Profpatsch oxalica ];
   };
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "5b6ae1f88e741b9ed738891ad1362fb9f2041671",
-  "date": "2022-03-23T15:50:46-04:00",
-  "path": "/nix/store/n5kjbimssqrwz7h99gq83935432dpm5s-tree-sitter-c-sharp",
-  "sha256": "1yp1lyzay7hxlgca2r5yigpdy80vli4f48k2bm3h2rpa99fczmrb",
+  "rev": "fcb2b6f7cb8ab8584d390aa266b0d2df7cbd1fd5",
+  "date": "2022-05-01T16:44:38+01:00",
+  "path": "/nix/store/5kwbva55mi975kqkjrw3jya98cb8i07d-tree-sitter-c-sharp",
+  "sha256": "0xdbh1n1mnglfxn16can69c3sr4ibc37v85vh7ckljcjgqhikfi9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/usernobody14/tree-sitter-dart",
-  "rev": "6a25376685d1d47968c2cef06d4db8d84a70025e",
-  "date": "2021-06-04T09:39:40-06:00",
-  "path": "/nix/store/vdygn1702kn92k222kygk9i50h10z9km-tree-sitter-dart",
-  "sha256": "0z06sphmgjggx5j2rjfy3f85fh1m9s79sql8a7d4kvsamz9rwakl",
+  "rev": "f95876f0ed3ef207bbd3c5c41987bc2e9cecfc97",
+  "date": "2022-05-07T10:16:06-07:00",
+  "path": "/nix/store/aad6q85ni1rp22jkc0n8mhlhjq7pm794-tree-sitter-dart",
+  "sha256": "0iaa37g5z927dvlxla0nidl9n2hvpsw97b5ffi7w1hq9d4m6rc7i",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elixir-lang/tree-sitter-elixir",
-  "rev": "ec1c4cac1b2f0290c53511a72fbab17c47815d2b",
-  "date": "2022-04-18T23:16:26+02:00",
-  "path": "/nix/store/2jmkl3lxq6cy0cg4wjf3hgjciw0xsm0y-tree-sitter-elixir",
-  "sha256": "0xiprldyfqpx5fil1b1kbnpj57n7j15j3m8dhibhif7azbd1z1y3",
+  "rev": "5d0c1bfcdf8aaad225525acad930a972b319a675",
+  "date": "2022-04-28T11:17:48-05:00",
+  "path": "/nix/store/a3vks004yjn7pb80nppdyq0k18wm3myc-tree-sitter-elixir",
+  "sha256": "1iff2gk6r6qa13imizxawc4hjwwwsnvhvhafcwab2q2476gk82mz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "c8fed1f0847a65a04a4b8cb7655f5f416e0742ca",
-  "date": "2022-03-29T10:06:48+02:00",
-  "path": "/nix/store/f9vy5q9p3rf2dcp7zdw9708j138ibi36-tree-sitter-go",
-  "sha256": "0yi8h1q39hsdxp9053by9xkl53wn229fhwjrrzml7k8y95qgnsyd",
+  "rev": "372d3241b099e189406475a9445cbb29dac2e054",
+  "date": "2022-04-28T20:49:46+02:00",
+  "path": "/nix/store/ylm4blh7lw1ac3ym9i69gbbs1cc5vmcs-tree-sitter-go",
+  "sha256": "0cmw37lgpfrw82kg9mcx7kgxnnvdydagbwckqv418zbh2xv881jf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "ed976b81b00ce7b72b99bca75e7a616cc526220c",
-  "date": "2022-03-20T00:05:14+01:00",
-  "path": "/nix/store/wzkfkix4q3vcrlsj2v4q32ihw0vdp1li-tree-sitter-haskell",
-  "sha256": "19g5f59gh6s4xpphrppmrqlh0nfld0q8zffy85pkby4gd6xh73zm",
+  "rev": "ff5c879d9b75f4e6930d7f687d458f707945ad78",
+  "date": "2022-05-07T17:45:16+02:00",
+  "path": "/nix/store/2pnp7kazxg1sp0anf4by99f27d7z0p64-tree-sitter-haskell",
+  "sha256": "0aa960150wli4hnv64jrl4gqvlgchc3y44bx4d7i53ygn9cdkl12",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-html",
-  "rev": "161a92474a7bb2e9e830e48e76426f38299d99d1",
-  "date": "2021-08-17T11:20:56-07:00",
-  "path": "/nix/store/pv8x73j4sbngsqplwfm73jlpwc31mc17-tree-sitter-html",
-  "sha256": "1gwvgwk0py09pp65vnga522l5r16dvgwxsc76fg66y07k2i63cfk",
+  "rev": "29f53d8f4f2335e61bf6418ab8958dac3282077a",
+  "date": "2022-05-06T09:01:49-07:00",
+  "path": "/nix/store/w5dy2r99rbzpmg0icwil5j9cp37l9hkk-tree-sitter-html",
+  "sha256": "0wadphmgndj4vq9mg258624pj0klspbpcx8qlc6f8by5xbshvkmz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "e7cb801ef57f74db5c4ebe14df74de852bb451b5",
-  "date": "2022-04-16T15:36:51+02:00",
-  "path": "/nix/store/55br93464adchwwjwdqjai8ppykwh098-tree-sitter-java",
-  "sha256": "0w27xk9j7mm9gr5aiwcv6cgfvzfnps0l9b09mwfqxhndh7j96vfn",
+  "rev": "39a11c8330d0b2ad75310456c378396785f79a4e",
+  "date": "2022-04-28T20:50:54+02:00",
+  "path": "/nix/store/w2hi6yvm3z4cy3bignphb9c2gf6fpnnq-tree-sitter-java",
+  "sha256": "0im81m2wb35n7rgmraf7p5ql6lvr7m9y4krgmkvgqkxnbkw7zcr0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-latex",
-  "rev": "8c5d90e78fa58ee6acab465ffa9a53e8b7b2c69c",
-  "date": "2022-04-23T15:10:18+02:00",
-  "path": "/nix/store/qpc37mjsl75qnmyzbkw6azphwzfdr9n9-tree-sitter-latex",
-  "sha256": "1xq5g34g9sqshhpprakc4k5lrlgg1n8vb7d7nfrx4ilrz5s0kks1",
+  "rev": "3b370b5ca3948312738b4f27b2a12e4bb58907a2",
+  "date": "2022-05-11T20:22:05+02:00",
+  "path": "/nix/store/l1nja32pv92awd5jnksi3wfd29mqxvkd-tree-sitter-latex",
+  "sha256": "0a4ks4ng02qivxr7h1izhc55791czba2r82ngi7a9l0smdxa9yv7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "d24196f9b3e5af6fcb2ec2a0b6cbc5c06f58b85e",
-  "date": "2022-03-30T11:47:57+02:00",
-  "path": "/nix/store/rdac46kl274bdd18bdrdh33s71sin7xd-tree-sitter-markdown",
-  "sha256": "07i3zwjla74s61w39fqfmb5a61dw6xlgfagh70p1rpvyrpxsywds",
+  "rev": "6d112e7a9c1694504bb78ee0b92dcd509625e0df",
+  "date": "2022-04-26T12:23:01+02:00",
+  "path": "/nix/store/598nrwznzg37r9pskrmzwnhrw3f4knnw-tree-sitter-markdown",
+  "sha256": "03d601dp65p30c88p0r6rx13wlkbg1q3ch11wfn4sa2rhba8zpyk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "fab7af32a2719091df5b222f98099c566859de78",
-  "date": "2022-04-07T16:00:06-04:00",
-  "path": "/nix/store/b17cvbkdvv7d3dzbi58lgrqsnhvh79d8-tree-sitter-org",
-  "sha256": "0jz69wm1ay84zkslbcp4l906ay7l4jd3bi1k1ivclpx493pg8ia7",
+  "rev": "aeacac619457a187bb202b9dfc58541232ed4a25",
+  "date": "2022-05-02T16:54:48-04:00",
+  "path": "/nix/store/y06b3jf6mfgbx4ar9l8crd7r5vljln92-tree-sitter-org",
+  "sha256": "03g52pbnv859wy3sdbr0i440il98idj6zg0q12g7ccxxmwblwxig",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "3c17a28da38afac41332d3ce79bbd8951867f346",
-  "date": "2022-03-29T09:09:35-07:00",
-  "path": "/nix/store/7dmygp3gi9ch00mf59d7g2l8k6f2pl81-tree-sitter-php",
-  "sha256": "06xc4y67pl96h1gfh9zg4yxdgqj5mv7md28m78gix8sk1h011irq",
+  "rev": "6be89d517d550a47b067b23d0f89a364091b41ca",
+  "date": "2022-05-04T13:05:38-04:00",
+  "path": "/nix/store/pd19zya0sng7dahwgkamk51s1mprg9hf-tree-sitter-php",
+  "sha256": "18yrmvxajcg7m8xqpdkdllm9grs4m9pp4y058ky6q3drq7cx0v1m",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pug.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pug.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/zealot128/tree-sitter-pug",
-  "rev": "5875f9a7d94836708119b0a1102bb5792e8bf673",
-  "date": "2021-07-13T22:48:45+02:00",
-  "path": "/nix/store/3bwj01nmxkd4cmvjyrfv2a6wq07hbqig-tree-sitter-pug",
-  "sha256": "1sjw632yidi8dq34g1nqmld9861j40qnrlg4c8w478kl8hmhnvmb",
+  "rev": "63e214905970e75f065688b1e8aa90823c3aacdc",
+  "date": "2022-05-05T14:29:30+02:00",
+  "path": "/nix/store/8nwqja3ff6cmy06sgxx6wzlbg7qx6x1r-tree-sitter-pug",
+  "sha256": "1r3zhz4adfpg2ihlbdfx4nb9svv6apnlahgfqqzmacj3bm8r3wmp",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ql",
-  "rev": "8e7fd7e638d4a0ec7a792ee16b19dbc6407aa810",
-  "date": "2021-06-02T18:46:47+02:00",
-  "path": "/nix/store/yhyi9y09shv1fm87gka43vnv9clvyd92-tree-sitter-ql",
-  "sha256": "0x5f9989ymqvw3g8acckyk4j7zpmnc667qishbgly9icl9rkmv7w",
+  "rev": "b2c2364e833cc9f1afa243ac367f1475330fef63",
+  "date": "2022-05-04T13:16:04-04:00",
+  "path": "/nix/store/8c01j930llm5wacj2727k8igwwyhbcz4-tree-sitter-ql",
+  "sha256": "1a4k4rmyqqcj94y57sf2h27bbkn921p1ifl2xwcqpmk6dr6n5bbr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "0509e440ae042db6483984b3a56b3c5f24b5d9b9",
-  "date": "2022-03-09T12:11:47+01:00",
-  "path": "/nix/store/9jrsqsrql5wlbzmqna111w4a02hf75z2-tree-sitter-rust",
-  "sha256": "1r8n8441b8bppizlzh4xw7yy3amz4apfxpqxm8hw0n3j3iwnw4pz",
+  "rev": "9a6d980afbb9864405426f1b3905fbcd459871ca",
+  "date": "2022-05-09T16:14:09-07:00",
+  "path": "/nix/store/h5zks31j4xj7vw5ygqhbml0ydsly7l6z-tree-sitter-rust",
+  "sha256": "0hmamkb2hqrp67b756ckifbwdbr0yw7qr2m8farh0bg7rbi5c6z1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "ec6047f531e7d4c13787d4ff208b94a84de34165",
-  "date": "2022-03-27T09:48:17+02:00",
-  "path": "/nix/store/70sghy226gl3s1b2p0zjhplb6zjy777g-tree-sitter-scala",
-  "sha256": "0yjl8hwdm1pkihfgfbg19z5j0v3cp64a2pa59maws1i231fm5bsw",
+  "rev": "8599058ef292e82203a1b23d10734dcbaf4d1b5c",
+  "date": "2022-05-09T16:17:13-07:00",
+  "path": "/nix/store/q802q124fq79wwr6m4xfcdmgw6fzjigw-tree-sitter-scala",
+  "sha256": "0i6qkgyv722jwma2rs0nf02jzl5dvml5m1whb7580qnza95x7py1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "5268e0ec901e33ad7142ee31b580269a94fba042",
-  "date": "2022-04-16T20:12:40+02:00",
-  "path": "/nix/store/rw6cjm4vj4yihlfmrxa2vc81lr3x59rn-tree-sitter-viml",
-  "sha256": "0vga1bivzkr00brzvv309hx7sqvg7y2kf6vx0s8hv9r56x6nm54s",
+  "rev": "4b9d2dda6de64fe5abc9bf96b5727ba73ed08515",
+  "date": "2022-05-07T11:41:23+02:00",
+  "path": "/nix/store/zm2pfjv3fn2qg6iy1s03mn5kjawsy3qg-tree-sitter-viml",
+  "sha256": "0p7fj5vvxxz4d43j91zwv3h8df4m4c26w9gq2qx561vjh5w1q7fn",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`tree-sitter-vim` is outdated and older than `nvim-treesitter`'s queries, causing highlighting failures.
After the update, `:checkhealth nvim-treesitter` reports no errors and the highlighting works well.

Also add me as maintainer and update keys (can be verified [via GitHub](https://github.com/oxalica.gpg)).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>tree-sitter-grammars.tree-sitter-c-sharp</li>
    <li>tree-sitter-grammars.tree-sitter-dart</li>
    <li>tree-sitter-grammars.tree-sitter-elixir</li>
    <li>tree-sitter-grammars.tree-sitter-go</li>
    <li>tree-sitter-grammars.tree-sitter-haskell</li>
    <li>tree-sitter-grammars.tree-sitter-html</li>
    <li>tree-sitter-grammars.tree-sitter-java</li>
    <li>tree-sitter-grammars.tree-sitter-latex</li>
    <li>tree-sitter-grammars.tree-sitter-markdown</li>
    <li>tree-sitter-grammars.tree-sitter-org-nvim</li>
    <li>tree-sitter-grammars.tree-sitter-php</li>
    <li>tree-sitter-grammars.tree-sitter-pug</li>
    <li>tree-sitter-grammars.tree-sitter-ql</li>
    <li>tree-sitter-grammars.tree-sitter-rust</li>
    <li>tree-sitter-grammars.tree-sitter-scala</li>
    <li>tree-sitter-grammars.tree-sitter-vim</li>
  </ul>
</details>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Tested via `neovim`
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
