### PR TITLE
mujmap: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3662,6 +3662,12 @@
     githubId = 103082;
     name = "Ed Brindley";
   };
+  elizagamedev = {
+    email = "eliza@eliza.sh";
+    github = "elizagamedev";
+    githubId = 4576666;
+    name = "Eliza Velasquez";
+  };
   elliot = {
     email = "hack00mind@gmail.com";
     github = "Eliot00";

--- a/pkgs/applications/networking/mujmap/default.nix
+++ b/pkgs/applications/networking/mujmap/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Bridge for synchronizing email and tags between JMAP and notmuch";
     homepage = "https://github.com/elizagamedev/mujmap/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ elizagamedev ];
     mainProgram = "mujmap";
   };

--- a/pkgs/applications/networking/mujmap/default.nix
+++ b/pkgs/applications/networking/mujmap/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, notmuch
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mujmap";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "elizagamedev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-G5CPH6CmQtw7pegBR6B/WBOZXUvFzEPBBvgqYEIF2OI=";
+  };
+
+  cargoSha256 = "sha256-nrLorxdJdQvCG8WhfsvHtWizrkzD38XqgeNyksKbvN4=";
+
+  buildInputs = [ notmuch ];
+  propagatedUserEnvPkgs = [ notmuch ];
+
+  meta = with lib; {
+    description = "Bridge for synchronizing email and tags between JMAP and notmuch";
+    homepage = "https://github.com/elizagamedev/mujmap/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ elizagamedev ];
+    mainProgram = "mujmap";
+  };
+}

--- a/pkgs/applications/networking/mujmap/default.nix
+++ b/pkgs/applications/networking/mujmap/default.nix
@@ -2,6 +2,8 @@
 , fetchFromGitHub
 , rustPlatform
 , notmuch
+, stdenv
+, Security
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -17,8 +19,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-nrLorxdJdQvCG8WhfsvHtWizrkzD38XqgeNyksKbvN4=";
 
-  buildInputs = [ notmuch ];
-  propagatedUserEnvPkgs = [ notmuch ];
+  buildInputs = [
+    notmuch
+  ] ++ lib.optional stdenv.isDarwin Security;
 
   meta = with lib; {
     description = "Bridge for synchronizing email and tags between JMAP and notmuch";

--- a/pkgs/applications/networking/mujmap/default.nix
+++ b/pkgs/applications/networking/mujmap/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mujmap";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "elizagamedev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-G5CPH6CmQtw7pegBR6B/WBOZXUvFzEPBBvgqYEIF2OI=";
+    sha256 = "sha256-O5CbLgs+MkATPtess0gocgPB9kwD8FMR/urwm6jo2rA=";
   };
 
-  cargoSha256 = "sha256-nrLorxdJdQvCG8WhfsvHtWizrkzD38XqgeNyksKbvN4=";
+  cargoSha256 = "sha256-nOZ+HnzXhVp+tLrNMZO1NmZIhIqlWz0fRMbHVIQkOxI=";
 
   buildInputs = [
     notmuch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7782,7 +7782,9 @@ with pkgs;
 
   mtail = callPackage ../servers/monitoring/mtail { };
 
-  mujmap = callPackage ../applications/networking/mujmap {};
+  mujmap = callPackage ../applications/networking/mujmap {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   multitail = callPackage ../tools/misc/multitail { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7782,6 +7782,8 @@ with pkgs;
 
   mtail = callPackage ../servers/monitoring/mtail { };
 
+  mujmap = callPackage ../applications/networking/mujmap {};
+
   multitail = callPackage ../tools/misc/multitail { };
 
   mx-puppet-discord = callPackage ../servers/mx-puppet-discord { };


### PR DESCRIPTION
-------

###### Description of changes

[mujmap](https://github.com/elizagamedev/mujmap) is an email synchronization tool that I've recently published. As a NixOS user, I would like to take ownership of this package in nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->