### PR TITLE
darkstat: Fix build on darwin

### DIFF
--- a/pkgs/tools/networking/darkstat/default.nix
+++ b/pkgs/tools/networking/darkstat/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libpcap, zlib }:
+{ lib, stdenv, fetchpatch, fetchurl, libpcap, zlib }:
 
 stdenv.mkDerivation rec {
   version = "3.0.719";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "${meta.homepage}/${pname}-${version}.tar.bz2";
     sha256 = "1mzddlim6dhd7jhr4smh0n2fa511nvyjhlx76b03vx7phnar1bxf";
   };
+
+  patches = [
+    # Avoid multiple definitions of CLOCK_REALTIME on macOS 11,
+    # see https://github.com/emikulic/darkstat/pull/2
+    (fetchpatch {
+       url = "https://github.com/emikulic/darkstat/commit/d2fd232e1167dee6e7a2d88b9ab7acf2a129f697.diff";
+       sha256 = "0z5mpyc0q65qb6cn4xcrxl0vx21d8ibzaam5kjyrcw4icd8yg4jb";
+    })
+  ];
 
   buildInputs = [ libpcap zlib ];
 


### PR DESCRIPTION
###### Description of changes

ZHF: #172160

On recent macOS the build fails with:
```
now.c:33:16: error: typedef redefinition with different types ('int' vs 'enum clockid_t')
   typedef int clockid_t;
               ^
/nix/store/4df4jhlj71vblmxhrr7dkkqpak8a42c8-Libsystem-1238.60.2/include/time.h:171:3: note: previous definition is here
} clockid_t;
  ^
now.c:34:11: warning: 'CLOCK_REALTIME' macro redefined [-Wmacro-redefined]
          ^
/nix/store/4df4jhlj71vblmxhrr7dkkqpak8a42c8-Libsystem-1238.60.2/include/time.h:154:9: note: previous definition is here
        ^
now.c:35:11: warning: 'CLOCK_MONOTONIC' macro redefined [-Wmacro-redefined]
          ^
/nix/store/4df4jhlj71vblmxhrr7dkkqpak8a42c8-Libsystem-1238.60.2/include/time.h:156:9: note: previous definition is here
        ^
2 warnings and 1 error generated.
```

See upstream PR: https://github.com/emikulic/darkstat/pull/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
