### PR TITLE
installation-cd: add more guest tools to NixOS graphical installation base

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -35,8 +35,13 @@ with lib;
   # Enable sound in graphical iso's.
   hardware.pulseaudio.enable = true;
 
-  # Spice guest additions
+  # VM guest additions to improve host-guest interaction
   services.spice-vdagentd.enable = true;
+  services.qemuGuest.enable = true;
+  virtualisation.virtualbox.guest.enable = true;
+  virtualisation.vmware.guest.enable = true;
+  virtualisation.hypervGuest.enable = true;
+  services.xe-guest-utilities.enable = true;
 
   # Enable plymouth
   boot.plymouth.enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -36,12 +36,14 @@ with lib;
   hardware.pulseaudio.enable = true;
 
   # VM guest additions to improve host-guest interaction
-  services.spice-vdagentd.enable = true;
-  services.qemuGuest.enable = true;
-  virtualisation.virtualbox.guest.enable = true;
-  virtualisation.vmware.guest.enable = true;
-  virtualisation.hypervGuest.enable = true;
-  services.xe-guest-utilities.enable = true;
+  services.spice-vdagentd.enable = mkDefault true;
+  services.qemuGuest.enable = mkDefault true;
+  virtualisation.vmware.guest.enable = mkDefault true;
+  virtualisation.hypervGuest.enable = mkDefault true;
+  services.xe-guest-utilities.enable = mkDefault true;
+  # The VirtualBox guest additions rely on an out-of-tree kernel module
+  # which lags behind kernel releases, potentially causing broken builds.
+  virtualisation.virtualbox.guest.enable = mkDefault false;
 
   # Enable plymouth
   boot.plymouth.enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -36,14 +36,14 @@ with lib;
   hardware.pulseaudio.enable = true;
 
   # VM guest additions to improve host-guest interaction
-  services.spice-vdagentd.enable = mkDefault true;
-  services.qemuGuest.enable = mkDefault true;
-  virtualisation.vmware.guest.enable = mkDefault true;
-  virtualisation.hypervGuest.enable = mkDefault true;
-  services.xe-guest-utilities.enable = mkDefault true;
+  services.spice-vdagentd.enable = true;
+  services.qemuGuest.enable = true;
+  virtualisation.vmware.guest.enable = true;
+  virtualisation.hypervGuest.enable = true;
+  services.xe-guest-utilities.enable = true;
   # The VirtualBox guest additions rely on an out-of-tree kernel module
   # which lags behind kernel releases, potentially causing broken builds.
-  virtualisation.virtualbox.guest.enable = mkDefault false;
+  virtualisation.virtualbox.guest.enable = false;
 
   # Enable plymouth
   boot.plymouth.enable = true;


### PR DESCRIPTION
###### Description of changes

This change adds more guest tools to the graphical live installer, to make it nicer to use with the following agents:
- spice (was there previously)
- qemu
- Virtualbox
- VMware
- HyperV
- Xe

This is done to improve the user experience for those who test the NixOS live media in a VM.