### PR TITLE
esptool: 3.3 -> 3.3.1

### DIFF
--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -2,19 +2,27 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "esptool";
-  version = "3.3";
+  version = "3.3.1";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    sha256 = "sha256-CmGie+M3AboOk8X+LkRhIxTRQZgDlklouzmz8kiIZuI=";
+    hash = "sha256-9WmiLji7Zoad5WIzgkpvkI9t96sfdkCtFh6zqVxF7qo=";
   };
 
-  checkInputs = with python3.pkgs;
-    [ flake8 flake8-future-import flake8-import-order openssl ];
-  propagatedBuildInputs = with python3.pkgs;
-    [ pyserial pyaes ecdsa reedsolo bitstring cryptography ];
+  postPatch = ''
+    substituteInPlace test/test_imagegen.py \
+      --replace "sys.executable, ESPTOOL_PY" "ESPTOOL_PY"
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    bitstring
+    cryptography
+    ecdsa
+    pyserial
+    reedsolo
+  ];
 
   # wrapPythonPrograms will overwrite esptool.py with a bash script,
   # but espefuse.py tries to import it. Since we don't add any binary paths,
@@ -26,6 +34,23 @@ python3.pkgs.buildPythonApplication rec {
         echo "Patching $f"
         patchPythonScript "$f"
     done
+  '';
+
+  checkInputs = with python3.pkgs; [
+    pyelftools
+  ];
+
+  # tests mentioned in `.github/workflows/test_esptool.yml`
+  checkPhase = ''
+    runHook preCheck
+
+    export ESPTOOL_PY=$out/bin/esptool.py
+    ${python3.interpreter} test/test_imagegen.py
+    ${python3.interpreter} test/test_espsecure.py
+    ${python3.interpreter} test/test_merge_bin.py
+    ${python3.interpreter} test/test_modules.py
+
+    runHook postCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
https://github.com/espressif/esptool/releases/tag/v3.3.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
