### PR TITLE
php81Packages.php-parallel-lint: fix the build

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -2299,6 +2299,14 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>phpPackages.box</literal> package has been
+          updated from 2.7.5 to 3.16.0. See the
+          <link xlink:href="https://github.com/box-project/box/blob/master/UPGRADE.md#from-27-to-30">upgrade
+          guide</link> for more details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>zrepl</literal> package has been updated from
           0.4.0 to 0.5:
         </para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -827,6 +827,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `vscode-extensions.ionide.ionide-fsharp` package has been updated to 6.0.0 and now requires .NET 6.0.
 
+- The `phpPackages.box` package has been updated from 2.7.5 to 3.16.0. See the [upgrade guide](https://github.com/box-project/box/blob/master/UPGRADE.md#from-27-to-30) for more details.
+
 - The `zrepl` package has been updated from 0.4.0 to 0.5:
 
   - The RPC protocol version was bumped; all zrepl daemons in a setup must be updated and restarted before replication can resume.

--- a/pkgs/development/php-packages/box/default.nix
+++ b/pkgs/development/php-packages/box/default.nix
@@ -1,14 +1,14 @@
 { mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "box";
-  version = "2.7.5";
+  version = "3.16.0";
 in
 mkDerivation {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://github.com/box-project/box2/releases/download/${version}/box-${version}.phar";
-    sha256 = "1zmxdadrv0i2l8cz7xb38gnfmfyljpsaz2nnkjzqzksdmncbgd18";
+    url = "https://github.com/box-project/box/releases/download/${version}/box.phar";
+    sha256 = "sha256-9QjijzCdfpWjGb3NXxPc+7GOuRy3psrJtpvHeZ14vfk=";
   };
 
   dontUnpack = true;
@@ -27,7 +27,7 @@ mkDerivation {
   meta = with lib; {
     description = "An application for building and managing Phars";
     license = licenses.mit;
-    homepage = "https://box-project.github.io/box2/";
+    homepage = "https://github.com/box-project/box";
     maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
   };
 }

--- a/pkgs/development/php-packages/php-parallel-lint/default.nix
+++ b/pkgs/development/php-packages/php-parallel-lint/default.nix
@@ -1,16 +1,16 @@
 { mkDerivation, fetchFromGitHub, makeWrapper, lib, php }:
 let
   pname = "php-parallel-lint";
-  version = "1.0.0";
+  version = "1.3.2";
 in
 mkDerivation {
   inherit pname version;
 
   src = fetchFromGitHub {
-    owner = "JakubOnderka";
+    owner = "php-parallel-lint";
     repo = "PHP-Parallel-Lint";
     rev = "v${version}";
-    sha256 = "16nv8yyk2z3l213dg067l6di4pigg5rd8yswr5xgd18jwbys2vnw";
+    sha256 = "sha256-pTHH19HwqyOj5pSmH7l0JlntNVtMdu4K9Cl+qyrrg9U=";
   };
 
   nativeBuildInputs = [
@@ -38,7 +38,7 @@ mkDerivation {
   meta = with lib; {
     description = "Tool to check syntax of PHP files faster than serial check with fancier output";
     license = licenses.bsd2;
-    homepage = "https://github.com/JakubOnderka/PHP-Parallel-Lint";
+    homepage = "https://github.com/php-parallel-lint/PHP-Parallel-Lint";
     maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
   };
 }


### PR DESCRIPTION
###### Description of changes

The goal was to fix the build of the `php81Packages.php-parallel-lint` but in order to do so Box and php-parallel-lint have been updated to their latest versions on new upstream repositories.

ZHF: https://github.com/NixOS/nixpkgs/issues/172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>php74Packages.box</li>
    <li>php74Packages.php-parallel-lint</li>
    <li>php80Packages.box</li>
    <li>php80Packages.php-parallel-lint</li>
    <li>php81Packages.box</li>
    <li>php81Packages.php-parallel-lint</li>
  </ul>
</details>

@NixOS/nixos-release-managers