### PR TITLE
ripser: 1.0.0 -> 1.2.1

### DIFF
--- a/pkgs/applications/science/math/ripser/default.nix
+++ b/pkgs/applications/science/math/ripser/default.nix
@@ -1,5 +1,4 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub
-, assembleReductionMatrix ? false
+{ lib, stdenv, fetchFromGitHub
 , useCoefficients ? false
 , indicateProgress ? false
 , useGoogleHashmap ? false, sparsehash ? null
@@ -14,7 +13,7 @@ assert useGoogleHashmap -> sparsehash != null;
 
 let
   inherit (lib) optional;
-  version = "1.0";
+  version = "1.2.1";
 in
 stdenv.mkDerivation {
   pname = "ripser";
@@ -23,25 +22,17 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Ripser";
     repo = "ripser";
-    rev = "f69c6af6ca6883dd518c48faf41cf8901c379598";
-    sha256 = "1mw2898s7l29hgajsaf75bs9bjn2sn4g2mvmh41a602jpwp9r0rz";
+    rev = "v${version}";
+    sha256 = "sha256-BxmkPQ/nl5cF+xwQMTjXnLgkLgdmT/39y7Kzl2wDfpE=";
   };
-
-  #Patch from dev branch to make compilation work.
-  #Will be removed when it gets merged into master.
-  patches = [(fetchurl {
-    url = "https://github.com/Ripser/ripser/commit/dc78d8ce73ee35f3828f0aad67a4e53620277ebf.patch";
-    sha256 = "1y93aqpqz8fm1cxxrf90dhh67im3ndkr8dnxgbw5y96296n4r924";
-  })];
 
   buildInputs = optional useGoogleHashmap sparsehash;
 
   buildFlags = [
     "-std=c++11"
-    "-Ofast"
+    "-O3"
     "-D NDEBUG"
   ]
-  ++ optional assembleReductionMatrix "-D ASSEMBLE_REDUCTION_MATRIX"
   ++ optional useCoefficients "-D USE_COEFFICIENTS"
   ++ optional indicateProgress "-D INDICATE_PROGRESS"
   ++ optional useGoogleHashmap "-D USE_GOOGLE_HASHMAP"


### PR DESCRIPTION
###### Description of changes

](https://github.com/Ripser/ripser/releases/tag/v1.0.1
https://github.com/Ripser/ripser/releases/tag/v1.1
https://github.com/Ripser/ripser/releases/tag/v1.2
https://github.com/Ripser/ripser/releases/tag/v1.2.1

ZHF: https://github.com/NixOS/nixpkgs/issues/172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>ripser</li>
  </ul>
</details>

@NixOS/nixos-release-managers

