### PR TITLE
runc: fix CVE-2022-29162

### DIFF
--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -12,6 +12,7 @@
 , makeWrapper
 , procps
 , nixosTests
+, fetchpatch
 }:
 
 buildGoModule rec {
@@ -27,6 +28,15 @@ buildGoModule rec {
 
   vendorSha256 = null;
   outputs = [ "out" "man" ];
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/opencontainers/runc/security/advisories/GHSA-f3fp-gc8g-vw66
+      name = "CVE-2022-29162.patch";
+      url = "https://github.com/opencontainers/runc/commit/364ec0f1b4fa188ad96049c590ecb42fa70ea165.patch";
+      sha256 = "sha256-NXnM3XO+rMXIC57Gh9ovOxkfXCTsuv9MAXi2CajFurs=";
+    })
+  ];
 
   nativeBuildInputs = [ go-md2man installShellFiles makeWrapper pkg-config which ];
 


### PR DESCRIPTION
###### Description of changes
See also #172625 

https://github.com/opencontainers/runc/security/advisories/GHSA-f3fp-gc8g-vw66

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] NixOS test `podman.nix`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
