### PR TITLE
{adl,opn}plug: 1.0.2 -> unstable-2021-12-17, fix Darwin, fix Linux de…

### DIFF
--- a/pkgs/applications/audio/adlplug/default.nix
+++ b/pkgs/applications/audio/adlplug/default.nix
@@ -13,11 +13,22 @@
 , libXinerama
 , libXext
 , libXcursor
-, libobjc
+, Foundation
 , Cocoa
+, Carbon
 , CoreServices
+, ApplicationServices
+, CoreAudio
+, CoreMIDI
+, AudioToolbox
+, Accelerate
+, CoreImage
+, IOKit
+, AudioUnit
+, QuartzCore
 , WebKit
 , DiscRecording
+, CoreAudioKit
 
   # Enabling JACK requires a JACK server at runtime, no fallback mechanism
 , withJack ? false, jack
@@ -35,24 +46,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "${lib.strings.toLower type}plug";
-  version = "1.0.2";
+  version = "unstable-2021-12-17";
 
   src = fetchFromGitHub {
     owner = "jpcima";
     repo = "ADLplug";
-    rev = "v${version}";
+    rev = "a488abedf1783c61cb4f0caa689f1b01bf9aa17d";
     fetchSubmodules = true;
-    sha256 = "0mqx4bzri8s880v7jwd24nb93m5i3aklqld0b3h0hjnz0lh2qz0f";
+    sha256 = "1a5zw0rglqgc5wq1n0s5bxx7y59dsg6qy02236fakl34bvbk60yz";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/jpcima/ADLplug/83636c55bec1b86cabf634b9a6d56d07f00ecc61/resources/patch/juce-gcc9.patch";
-      sha256 = "15hkdb76n9lgjsrpczj27ld9b4804bzrgw89g95cj4sc8wwkplyy";
-      extraPrefix = "thirdparty/JUCE/";
-      stripLen = 1;
-    })
-  ];
 
   cmakeFlags = [
     "-DADLplug_CHIP=${chip}"
@@ -61,7 +63,22 @@ stdenv.mkDerivation rec {
   ];
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [
+    # "fp.h" file not found
     "-isystem ${CoreServices}/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/Headers"
+  ]);
+
+  NIX_LDFLAGS = toString (lib.optionals stdenv.hostPlatform.isDarwin [
+    # Framework that JUCE needs which don't get linked properly
+    "-framework CoreAudioKit"
+    "-framework QuartzCore"
+    "-framework AudioToolbox"
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # JUCE dlopen's these at runtime
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
   ]);
 
   nativeBuildInputs = [
@@ -81,11 +98,22 @@ stdenv.mkDerivation rec {
     libXext
     libXcursor
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    libobjc
+    Foundation
     Cocoa
+    Carbon
     CoreServices
+    ApplicationServices
+    CoreAudio
+    CoreMIDI
+    AudioToolbox
+    Accelerate
+    CoreImage
+    IOKit
+    AudioUnit
+    QuartzCore
     WebKit
     DiscRecording
+    CoreAudioKit
   ] ++ lib.optional withJack jack;
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/applications/audio/adlplug/default.nix
+++ b/pkgs/applications/audio/adlplug/default.nix
@@ -117,9 +117,13 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional withJack jack;
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir $out/Applications
+    mkdir -p $out/{Applications,Library/Audio/Plug-Ins/{VST,Components}}
+
     mv $out/bin/${mainProgram}.app $out/Applications/
     ln -s $out/{Applications/${mainProgram}.app/Contents/MacOS,bin}/${mainProgram}
+
+    mv vst2/${mainProgram}.vst $out/Library/Audio/Plug-Ins/VST/
+    mv au/${mainProgram}.component $out/Library/Audio/Plug-Ins/Components/
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -986,8 +986,7 @@ with pkgs;
   addlicense = callPackage ../tools/misc/addlicense { };
 
   adlplug = callPackage ../applications/audio/adlplug {
-    inherit (darwin) libobjc;
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices WebKit DiscRecording;
+    inherit (darwin.apple_sdk.frameworks) Foundation Cocoa Carbon CoreServices ApplicationServices CoreAudio CoreMIDI AudioToolbox Accelerate CoreImage IOKit AudioUnit QuartzCore WebKit DiscRecording CoreAudioKit;
     jack = libjack2;
   };
   opnplug = adlplug.override {


### PR DESCRIPTION
> …pendencies

###### Description of changes

- Last release was in 2020, bumping to latest master.
- Fix Darwin build, which has been failing on CI for awhile
- Fix JUCE insisting on `dlopen`ing some X11 libraries, which can cause problems in some JUCE applications
- Install audio plugins on Darwin

###### ~~TODO:~~

~~- Only tested JACK-less standalone~~
~~- None of the plugin builds (LV2, VST2, AU) get installed on Darwin. I don't use them myself, dunno where they need to go for Darwin stuff to pick them up (especially AU which is Darwin-specific).~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  Also tested the VST2 plugin on Darwin in `bespokesynth-with-vst2`
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
