### PR TITLE
Settle on convention of version name for snapshot builds

### DIFF
--- a/pkgs/applications/audio/fmsynth/default.nix
+++ b/pkgs/applications/audio/fmsynth/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, gtkmm2, lv2, lvtk, pkg-config }:
 stdenv.mkDerivation {
-  pname = "fmsynth-unstable";
-  version = "2015-02-07";
+  pname = "fmsynth";
+  version = "unstable-2015-02-07";
   src = fetchFromGitHub {
     owner = "Themaister";
     repo = "libfmsynth";

--- a/pkgs/applications/audio/pd-plugins/gem/default.nix
+++ b/pkgs/applications/audio/pd-plugins/gem/default.nix
@@ -14,8 +14,8 @@
  }:
 
 stdenv.mkDerivation rec {
-  pname = "gem-unstable";
-  version = "2020-09-22";
+  pname = "gem";
+  version = "unstable-2020-09-22";
 
   src = fetchFromGitHub {
     owner = "umlaeute";

--- a/pkgs/applications/audio/spotifywm/default.nix
+++ b/pkgs/applications/audio/spotifywm/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, spotify, xorg, runtimeShell }:
 stdenv.mkDerivation {
-  pname = "spotifywm-unstable";
-  version = "2016-11-28";
+  pname = "spotifywm";
+  version = "unstable-2016-11-28";
 
   src = fetchFromGitHub {
     owner  = "dasJ";

--- a/pkgs/applications/editors/deadpixi-sam/default.nix
+++ b/pkgs/applications/editors/deadpixi-sam/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, freetype, libX11, libXi, libXt, libXft }:
 
 stdenv.mkDerivation rec {
-  pname = "deadpixi-sam-unstable";
-  version = "2020-07-14";
+  pname = "deadpixi-sam";
+  version = "unstable-2020-07-14";
 
   src = fetchFromGitHub {
     owner = "deadpixi";

--- a/pkgs/applications/graphics/hello-wayland/default.nix
+++ b/pkgs/applications/graphics/hello-wayland/default.nix
@@ -3,8 +3,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "hello-wayland-unstable";
-  version = "2020-07-27";
+  pname = "hello-wayland";
+  version = "unstable-2020-07-27";
 
   src = fetchFromGitHub {
     owner = "emersion";

--- a/pkgs/applications/misc/dmenu/wayland.nix
+++ b/pkgs/applications/misc/dmenu/wayland.nix
@@ -4,8 +4,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "dmenu-wayland-unstable";
-  version = "2020-07-06";
+  pname = "dmenu-wayland";
+  version = "unstable-2020-07-06";
 
   src = fetchFromGitHub {
     owner = "nyyManni";

--- a/pkgs/applications/misc/volnoti/default.nix
+++ b/pkgs/applications/misc/volnoti/default.nix
@@ -3,8 +3,8 @@
 , dbus-glib, autoreconfHook, wrapGAppsHook }:
 
 stdenv.mkDerivation {
-  pname = "volnoti-unstable";
-  version = "2013-09-23";
+  pname = "volnoti";
+  version = "unstable-2013-09-23";
 
   src = fetchFromGitHub {
     owner = "davidbrazdil";

--- a/pkgs/applications/networking/cluster/prow/default.nix
+++ b/pkgs/applications/networking/cluster/prow/default.nix
@@ -1,8 +1,8 @@
 { buildGoModule, fetchFromGitHub, lib }:
 
 buildGoModule rec {
-  pname = "prow-unstable";
-  version = "2020-04-01";
+  pname = "prow";
+  version = "unstable-2020-04-01";
   rev = "32e3b5ce7695fb622381421653db436cb57b47c5";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, pidgin, json-glib, glib, http-parser, sqlite, olm, libgcrypt } :
 
 stdenv.mkDerivation rec {
-  pname = "purple-matrix-unstable";
-  version = "2019-06-06";
+  pname = "purple-matrix";
+  version = "unstable-2019-06-06";
 
   src = fetchFromGitHub {
     owner = "matrix-org";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-slack/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, pidgin, pkg-config }:
 
 stdenv.mkDerivation {
-  pname = "purple-slack-unstable";
-  version = "2020-09-22";
+  pname = "purple-slack";
+  version = "unstable-2020-09-22";
 
   src = fetchFromGitHub {
     owner = "dylex";

--- a/pkgs/applications/networking/mailreaders/hasmail/default.nix
+++ b/pkgs/applications/networking/mailreaders/hasmail/default.nix
@@ -9,8 +9,8 @@
 }:
 
 buildGoModule rec {
-  pname = "hasmail-unstable";
-  version = "2019-08-24";
+  pname = "hasmail";
+  version = "unstable-2019-08-24";
 
   src = fetchFromGitHub {
     owner = "jonhoo";

--- a/pkgs/applications/networking/mkchromecast/default.nix
+++ b/pkgs/applications/networking/mkchromecast/default.nix
@@ -27,8 +27,8 @@ let packages = [
 
 in
 python3Packages.buildPythonApplication rec {
-  pname = "mkchromecast-unstable";
-  version = "2020-10-17";
+  pname = "mkchromecast";
+  version = "unstable-2020-10-17";
 
   src = fetchFromGitHub rec {
     owner = "muammar";

--- a/pkgs/applications/networking/p2p/storrent/default.nix
+++ b/pkgs/applications/networking/p2p/storrent/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
-  pname = "storrent-unstable";
-  version = "2021-10-10";
+  pname = "storrent";
+  version = "unstable-2021-10-10";
 
   src = fetchFromGitHub {
     owner = "jech";

--- a/pkgs/applications/science/biology/platypus/default.nix
+++ b/pkgs/applications/science/biology/platypus/default.nix
@@ -3,8 +3,8 @@
 let python = python27.withPackages (ps: with ps; [ cython ]);
 
 in stdenv.mkDerivation {
-  pname = "platypus-unstable";
-  version = "2018-07-22";
+  pname = "platypus";
+  version = "unstable-2018-07-22";
 
   src = fetchFromGitHub {
     owner = "andyrimmer";

--- a/pkgs/applications/science/logic/drat-trim/default.nix
+++ b/pkgs/applications/science/logic/drat-trim/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "drat-trim-unstable";
-  version = "2020-06-05";
+  pname = "drat-trim";
+  version = "unstable-2020-06-05";
 
   src = fetchFromGitHub {
     owner = "marijnheule";

--- a/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "git-appraise-unstable";
-  version = "2018-02-26";
+  pname = "git-appraise";
+  version = "unstable-2018-02-26";
   rev = "2414523905939525559e4b2498c5597f86193b61";
 
   goPackagePath = "github.com/google/git-appraise";

--- a/pkgs/applications/video/xscast/default.nix
+++ b/pkgs/applications/video/xscast/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, ffmpeg, imagemagick, dzen2, xorg }:
 
 stdenv.mkDerivation {
-  pname = "xscast-unstable";
-  version = "2016-07-26";
+  pname = "xscast";
+  version = "unstable-2016-07-26";
 
   src = fetchFromGitHub {
     owner = "KeyboardFire";

--- a/pkgs/applications/window-managers/sway/lock-fancy.nix
+++ b/pkgs/applications/window-managers/sway/lock-fancy.nix
@@ -15,8 +15,8 @@ let
     wmctrl
   ];
 in stdenv.mkDerivation rec {
-  pname = "swaylock-fancy-unstable";
-  version = "2021-10-11";
+  pname = "swaylock-fancy";
+  version = "unstable-2021-10-11";
 
   src = fetchFromGitHub {
     owner = "Big-B";

--- a/pkgs/data/documentation/nginx-doc/default.nix
+++ b/pkgs/data/documentation/nginx-doc/default.nix
@@ -7,8 +7,8 @@
 # In other words, documentation does not necessary matches capabilities of
 # $out/bin/nginx, but we have no better options.
 stdenv.mkDerivation {
-  pname = "nginx-doc-unstable";
-  version = "2022-05-05";
+  pname = "nginx-doc";
+  version = "unstable-2022-05-05";
   src = fetchhg {
     url = "https://hg.nginx.org/nginx.org";
     rev = "a3aee2697d4e";

--- a/pkgs/data/documentation/scheme-manpages/default.nix
+++ b/pkgs/data/documentation/scheme-manpages/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "scheme-manpages-unstable";
-  version = "2022-04-21";
+  pname = "scheme-manpages";
+  version = "unstable-2022-04-21";
 
   src = fetchFromGitHub {
     owner = "schemedoc";

--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -13,8 +13,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "shared-mime-info-unstable";
-  version = "2021-12-03";
+  pname = "shared-mime-info";
+  version = "unstable-2021-12-03";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/compilers/wcc/default.nix
+++ b/pkgs/development/compilers/wcc/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, capstone, libbfd, libelf, libiberty, readline }:
 
 stdenv.mkDerivation {
-  pname = "wcc-unstable";
-  version = "2018-04-05";
+  pname = "wcc";
+  version = "unstable-2018-04-05";
 
   src = fetchFromGitHub {
     owner = "endrazine";

--- a/pkgs/development/libraries/SDL_gpu/default.nix
+++ b/pkgs/development/libraries/SDL_gpu/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, cmake, SDL2, libGLU }:
 
 stdenv.mkDerivation {
-  pname = "SDL_gpu-unstable";
-  version = "2019-01-24";
+  pname = "SDL_gpu";
+  version = "unstable-2019-01-24";
 
   src = fetchFromGitHub {
     owner = "grimfang4";

--- a/pkgs/development/libraries/cxx-prettyprint/default.nix
+++ b/pkgs/development/libraries/cxx-prettyprint/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "cxx-prettyprint-unstable";
-  version = "2016-04-30";
+  pname = "cxx-prettyprint";
+  version = "unstable-2016-04-30";
   rev = "9ab26d228f2960f50b38ad37fe0159b7381f7533";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -14,8 +14,8 @@
 }:
 
 mkDerivation {
-  pname = "libfive-unstable";
-  version = "2020-02-15";
+  pname = "libfive";
+  version = "unstable-2020-02-15";
 
   src = fetchFromGitHub {
     owner = "libfive";

--- a/pkgs/development/libraries/liblastfm/default.nix
+++ b/pkgs/development/libraries/liblastfm/default.nix
@@ -3,8 +3,8 @@
 , darwin }:
 
 stdenv.mkDerivation rec {
-  pname = "liblastfm-unstable";
-  version = "2019-08-23";
+  pname = "liblastfm";
+  version = "unstable-2019-08-23";
 
   src = fetchFromGitHub {
     owner = "lastfm";

--- a/pkgs/development/libraries/openexrid-unstable/default.nix
+++ b/pkgs/development/libraries/openexrid-unstable/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, re2, openfx, zlib, ilmbase, libGLU, libGL, openexr }:
 
 stdenv.mkDerivation {
-  pname = "openexrid-unstable";
-  version = "2017-09-17";
+  pname = "openexrid";
+  version = "unstable-2017-09-17";
 
   src = fetchFromGitHub {
     owner = "MercenariesEngineering";

--- a/pkgs/development/libraries/optparse-bash/default.nix
+++ b/pkgs/development/libraries/optparse-bash/default.nix
@@ -8,8 +8,8 @@
 }:
 
 stdenvNoCC.mkDerivation {
-  pname = "optparse-bash-unstable";
-  version = "2021-06-13";
+  pname = "optparse-bash";
+  version = "unstable-2021-06-13";
 
   src = fetchFromGitHub {
     owner = "nk412";

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp, fetchpatch }:
 
 stdenv.mkDerivation {
-  version = "2018-11-24";
-  pname = "qmltermwidget-unstable";
+  version = "unstable-2018-11-24";
+  pname = "qmltermwidget";
 
   src = fetchFromGitHub {
     repo = "qmltermwidget";

--- a/pkgs/development/libraries/sonic/default.nix
+++ b/pkgs/development/libraries/sonic/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, fftw, installShellFiles }:
 
 stdenv.mkDerivation {
-  pname = "sonic-unstable";
-  version = "2020-12-27";
+  pname = "sonic";
+  version = "unstable-2020-12-27";
 
   src = fetchFromGitHub {
     owner = "waywardgeek";

--- a/pkgs/development/libraries/tl-expected/default.nix
+++ b/pkgs/development/libraries/tl-expected/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
-  pname = "tl-expected-unstable";
-  version = "2019-11-11"; # 5 commits ahead of version 1.0.0
+  pname = "tl-expected";
+  version = "unstable-2019-11-11"; # 5 commits ahead of version 1.0.0
 
   src = fetchFromGitHub {
     owner = "TartanLlama";

--- a/pkgs/development/libraries/unibilium/default.nix
+++ b/pkgs/development/libraries/unibilium/default.nix
@@ -1,9 +1,9 @@
 { stdenv, lib, fetchFromGitHub, libtool, pkg-config, perl, ncurses }:
 
 stdenv.mkDerivation rec {
-  pname = "unibilium-unstable";
+  pname = "unibilium";
 
-  version = "20190811";
+  version = "unstable-20190811";
 
   src = fetchFromGitHub {
     owner = "neovim";

--- a/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
+++ b/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
@@ -2,8 +2,8 @@
 , xorg, gnum4, libxcb, gperf }:
 
 stdenv.mkDerivation {
-  pname = "xcb-util-cursor-0.1.1-3-unstable";
-  version = "2017-04-05";
+  pname = "xcb-util-cursor-0.1.1-3";
+  version = "unstable-2017-04-05";
 
   src = fetchgit {
     url    = "http://anongit.freedesktop.org/git/xcb/util-cursor.git";

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -18,7 +18,7 @@
 rec {
   re2c = stdenv.mkDerivation rec {
     pname = "re2c";
-    version = "1.0.3";
+    version = "unstable-1.0.3";
     sourceRoot = "${src.name}/re2c";
     src = fetchFromGitHub {
       owner = "skvadrik";
@@ -33,8 +33,8 @@ rec {
   };
 
   py-yajl = python27Packages.buildPythonPackage rec {
-    pname = "oil-pyyajl-unstable";
-    version = "2019-12-05";
+    pname = "oil-pyyajl";
+    version = "unstable-2019-12-05";
     src = fetchFromGitHub {
       owner = "oilshell";
       repo = "py-yajl";
@@ -52,8 +52,8 @@ rec {
     This creates one without disturbing upstream too much.
   */
   oildev = python27Packages.buildPythonPackage rec {
-    pname = "oildev-unstable";
-    version = "2021-07-14";
+    pname = "oildev";
+    version = "unstable-2021-07-14";
 
     src = fetchFromGitHub {
       owner = "oilshell";

--- a/pkgs/development/mobile/adb-sync/default.nix
+++ b/pkgs/development/mobile/adb-sync/default.nix
@@ -3,8 +3,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "adb-sync-unstable";
-  version = "2019-01-01";
+  pname = "adb-sync";
+  version = "unstable-2019-01-01";
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/development/perl-modules/ham/default.nix
+++ b/pkgs/development/perl-modules/ham/default.nix
@@ -1,8 +1,8 @@
 { lib, buildPerlPackage, fetchFromGitHub, makeWrapper, openssh, GitRepository, URI, XMLMini }:
 
 buildPerlPackage {
-  pname = "ham-unstable";
-  version = "2020-09-09";
+  pname = "ham";
+  version = "unstable-2020-09-09";
 
   src = fetchFromGitHub {
     owner = "kernkonzept";

--- a/pkgs/development/python-modules/openant/default.nix
+++ b/pkgs/development/python-modules/openant/default.nix
@@ -5,8 +5,8 @@
 }:
 
 buildPythonPackage {
-  pname = "openant-unstable";
-  version = "2017-02-11";
+  pname = "openant";
+  version = "unstable-2017-02-11";
 
   src = fetchFromGitHub {
     owner = "Tigge";

--- a/pkgs/development/python-modules/qreactor/default.nix
+++ b/pkgs/development/python-modules/qreactor/default.nix
@@ -8,8 +8,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "qreactor-unstable";
-  version = "2018-09-29";
+  pname = "qreactor";
+  version = "unstable-2018-09-29";
 
   src = fetchFromGitHub {
     owner = "frmdstryr";

--- a/pkgs/development/tools/analysis/evmdis/default.nix
+++ b/pkgs/development/tools/analysis/evmdis/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  pname = "evmdis-unstable";
-  version = "2018-03-23";
+  pname = "evmdis";
+  version = "unstable-2018-03-23";
   goPackagePath = "github.com/Arachnid/evmdis";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/build-managers/kati/default.nix
+++ b/pkgs/development/tools/build-managers/kati/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "kati-unstable";
-  version = "2019-09-23";
+  pname = "kati";
+  version = "unstable-2019-09-23";
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/development/tools/check/default.nix
+++ b/pkgs/development/tools/check/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoPackage rec {
-  pname = "check-unstable";
-  version = "2018-09-12";
+  pname = "check";
+  version = "unstable-2018-09-12";
   rev = "88db195993f8e991ad402754accd0635490769f9";
 
   goPackagePath = "gitlab.com/opennota/check";

--- a/pkgs/development/tools/deadcode/default.nix
+++ b/pkgs/development/tools/deadcode/default.nix
@@ -6,8 +6,8 @@
 # TODO(yl): should we package https://github.com/remyoudompheng/go-misc instead of
 # the standalone extract of deadcode from it?
 buildGoPackage rec {
-  pname = "deadcode-unstable";
-  version = "2016-07-24";
+  pname = "deadcode";
+  version = "unstable-2016-07-24";
   rev = "210d2dc333e90c7e3eedf4f2242507a8e83ed4ab";
 
   goPackagePath = "github.com/tsenart/deadcode";

--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "gocode-unstable";
-  version = "2020-04-06";
+  pname = "gocode";
+  version = "unstable-2020-04-06";
   rev = "4acdcbdea79de6b3dee1c637eca5cbea0fdbe37c";
 
   goPackagePath = "github.com/mdempsky/gocode";

--- a/pkgs/development/tools/gogetdoc/default.nix
+++ b/pkgs/development/tools/gogetdoc/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoModule rec {
-  pname = "gogetdoc-unstable";
-  version = "2019-02-28";
+  pname = "gogetdoc";
+  version = "unstable-2019-02-28";
   rev = "b37376c5da6aeb900611837098f40f81972e63e4";
 
   vendorSha256 = null;

--- a/pkgs/development/tools/iferr/default.nix
+++ b/pkgs/development/tools/iferr/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoPackage rec {
-  pname = "iferr-unstable";
-  version = "2018-06-15";
+  pname = "iferr";
+  version = "unstable-2018-06-15";
   rev = "bb332a3b1d9129b6486c7ddcb7030c11b05cfc88";
 
   goPackagePath = "github.com/koron/iferr";

--- a/pkgs/development/tools/ineffassign/default.nix
+++ b/pkgs/development/tools/ineffassign/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoPackage rec {
-  pname = "ineffassign-unstable";
-  version = "2018-09-09";
+  pname = "ineffassign";
+  version = "unstable-2018-09-09";
   rev = "1003c8bd00dc2869cb5ca5282e6ce33834fed514";
 
   goPackagePath = "github.com/gordonklaus/ineffassign";

--- a/pkgs/development/tools/maligned/default.nix
+++ b/pkgs/development/tools/maligned/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoPackage rec {
-  pname = "maligned-unstable";
-  version = "2018-07-07";
+  pname = "maligned";
+  version = "unstable-2018-07-07";
   rev = "6e39bd26a8c8b58c5a22129593044655a9e25959";
 
   goPackagePath = "github.com/mdempsky/maligned";

--- a/pkgs/development/tools/mpfshell/default.nix
+++ b/pkgs/development/tools/mpfshell/default.nix
@@ -1,8 +1,8 @@
 { lib, python3Packages, fetchFromGitHub }:
 
 python3Packages.buildPythonPackage rec {
-  pname = "mpfshell-unstable";
-  version = "2020-04-11";
+  pname = "mpfshell";
+  version = "unstable-2020-04-11";
 
   src = fetchFromGitHub {
     owner = "wendlers";

--- a/pkgs/development/tools/reftools/default.nix
+++ b/pkgs/development/tools/reftools/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoModule rec {
-  pname = "reftools-unstable";
-  version = "2019-12-21";
+  pname = "reftools";
+  version = "unstable-2019-12-21";
   rev = "65925cf013156409e591f7a1be4df96f640d02f4";
 
   vendorSha256 = null;

--- a/pkgs/development/tools/unconvert/default.nix
+++ b/pkgs/development/tools/unconvert/default.nix
@@ -5,8 +5,8 @@
 }:
 
 buildGoPackage rec {
-  pname = "unconvert-unstable";
-  version = "2018-07-03";
+  pname = "unconvert";
+  version = "unstable-2018-07-03";
   rev = "1a9a0a0a3594e9363e49545fb6a4e24ac4c68b7b";
 
   goPackagePath = "github.com/mdempsky/unconvert";

--- a/pkgs/development/tools/vndr/default.nix
+++ b/pkgs/development/tools/vndr/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "vndr-unstable";
-  version = "2020-07-28";
+  pname = "vndr";
+  version = "unstable-2020-07-28";
   rev = "f12b881cb8f081a5058408a58f429b9014833fc6";
 
   goPackagePath = "github.com/LK4D4/vndr";

--- a/pkgs/games/among-sus/default.nix
+++ b/pkgs/games/among-sus/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromSourcehut, port ? "1234" }:
 
 stdenv.mkDerivation {
-  pname = "among-sus-unstable";
-  version = "2021-05-19";
+  pname = "among-sus";
+  version = "unstable-2021-05-19";
 
   src = fetchFromSourcehut {
     owner = "~martijnbraam";

--- a/pkgs/misc/stabber/default.nix
+++ b/pkgs/misc/stabber/default.nix
@@ -5,8 +5,8 @@
 with lib;
 
 stdenv.mkDerivation {
-  pname = "stabber-unstable";
-  version = "2020-06-08";
+  pname = "stabber";
+  version = "unstable-2020-06-08";
 
   src = fetchFromGitHub {
     owner = "boothj5";

--- a/pkgs/os-specific/linux/flashbench/default.nix
+++ b/pkgs/os-specific/linux/flashbench/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "flashbench-unstable";
-  version = "2020-01-23";
+  pname = "flashbench";
+  version = "unstable-2020-01-23";
 
   src = fetchFromGitHub {
     owner = "bradfa";

--- a/pkgs/os-specific/linux/gpu-switch/default.nix
+++ b/pkgs/os-specific/linux/gpu-switch/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "gpu-switch-unstable";
-  version = "2017-04-28";
+  pname = "gpu-switch";
+  version = "unstable-2017-04-28";
   src = fetchFromGitHub {
     owner = "0xbb";
     repo = "gpu-switch";

--- a/pkgs/os-specific/linux/wlgreet/default.nix
+++ b/pkgs/os-specific/linux/wlgreet/default.nix
@@ -4,8 +4,8 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "wlgreet-unstable";
-  version = "2022-01-25";
+  pname = "wlgreet";
+  version = "unstable-2022-01-25";
 
   src = fetchFromSourcehut {
     owner = "~kennylevinsen";

--- a/pkgs/servers/monitoring/prometheus/mikrotik-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mikrotik-exporter.nix
@@ -1,8 +1,8 @@
 { lib, buildGoModule, fetchFromGitHub, nixosTests }:
 
 buildGoModule rec {
-  pname = "mikrotik-exporter-unstable";
-  version = "2021-08-10";
+  pname = "mikrotik-exporter";
+  version = "unstable-2021-08-10";
 
   src = fetchFromGitHub {
     owner = "nshttpd";

--- a/pkgs/servers/shairplay/default.nix
+++ b/pkgs/servers/shairplay/default.nix
@@ -2,8 +2,8 @@
 , avahi, libao }:
 
 stdenv.mkDerivation rec {
-  pname = "shairplay-unstable";
-  version = "2018-08-24";
+  pname = "shairplay";
+  version = "unstable-2018-08-24";
 
   src = fetchFromGitHub {
     owner  = "juhovh";

--- a/pkgs/servers/sql/postgresql/ext/smlar.nix
+++ b/pkgs/servers/sql/postgresql/ext/smlar.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchgit, postgresql }:
 
 stdenv.mkDerivation rec {
-  pname = "smlar-unstable";
-  version = "2020-10-07";
+  pname = "smlar";
+  version = "unstable-2020-10-07";
 
   src = fetchgit {
     url = "git://sigaev.ru/smlar.git";

--- a/pkgs/shells/dgsh/default.nix
+++ b/pkgs/shells/dgsh/default.nix
@@ -4,8 +4,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "dgsh-unstable";
-  version = "2017-02-05";
+  pname = "dgsh";
+  version = "unstable-2017-02-05";
 
   src = fetchFromGitHub {
     owner = "dspinellis";

--- a/pkgs/shells/mrsh/default.nix
+++ b/pkgs/shells/mrsh/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, readline }:
 
 stdenv.mkDerivation rec {
-  pname = "mrsh-unstable";
-  version = "2021-01-10";
+  pname = "mrsh";
+  version = "unstable-2021-01-10";
 
   src = fetchFromGitHub {
     owner = "emersion";

--- a/pkgs/shells/zsh/fzf-zsh/default.nix
+++ b/pkgs/shells/zsh/fzf-zsh/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, fzf }:
 
 stdenv.mkDerivation rec {
-  pname = "fzf-zsh-unstable";
-  version = "2019-09-09";
+  pname = "fzf-zsh";
+  version = "unstable-2019-09-09";
 
   src = fetchFromGitHub {
     owner = "Wyntau";

--- a/pkgs/shells/zsh/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/zsh/lambda-mod-zsh-theme/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "lambda-mod-zsh-theme-unstable";
-  version = "2020-10-03";
+  pname = "lambda-mod-zsh-theme";
+  version = "unstable-2020-10-03";
 
   src = fetchFromGitHub {
     owner = "halfo";

--- a/pkgs/tools/compression/bzip2/1_1.nix
+++ b/pkgs/tools/compression/bzip2/1_1.nix
@@ -6,8 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "bzip2-unstable";
-  version = "2020-08-11";
+  pname = "bzip2";
+  version = "unstable-2020-08-11";
 
   src = fetchFromGitLab {
     owner = "federicomenaquintero";

--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, fuse3, bzip2, zlib, attr, cmake }:
 
 stdenv.mkDerivation {
-  pname = "apfs-fuse-unstable";
-  version = "2020-09-28";
+  pname = "apfs-fuse";
+  version = "unstable-2020-09-28";
 
   src = fetchFromGitHub {
     owner  = "sgan81";

--- a/pkgs/tools/graphics/lepton/default.nix
+++ b/pkgs/tools/graphics/lepton/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, cmake, git, glibc }:
 
 stdenv.mkDerivation rec {
-  version = "2019-08-20";
-  pname = "lepton-unstable";
+  version = "unstable-2019-08-20";
+  pname = "lepton";
 
   src = fetchFromGitHub {
     repo = "lepton";

--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -30,8 +30,8 @@ let
 in
 
 stdenv.mkDerivation {
-  pname = "skk-dicts-unstable";
-  version = "2020-03-24";
+  pname = "skk-dicts";
+  version = "unstable-2020-03-24";
   srcs = [ small medium large edict assoc ];
   nativeBuildInputs = [ skktools ] ++ lib.optional stdenv.isDarwin libiconv;
 

--- a/pkgs/tools/misc/capture/default.nix
+++ b/pkgs/tools/misc/capture/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, slop, ffmpeg, fetchFromGitHub, makeWrapper}:
 
 stdenv.mkDerivation {
-  pname = "capture-unstable";
-  version = "2019-03-10";
+  pname = "capture";
+  version = "unstable-2019-03-10";
 
   src = fetchFromGitHub {
     owner = "buhman";

--- a/pkgs/tools/misc/dvtm/unstable.nix
+++ b/pkgs/tools/misc/dvtm/unstable.nix
@@ -1,7 +1,7 @@
 {callPackage, fetchFromGitHub, fetchpatch}:
 callPackage ./dvtm.nix {
-  pname = "dvtm-unstable";
-  version = "2018-03-31";
+  pname = "dvtm";
+  version = "unstable-2018-03-31";
 
   src = fetchFromGitHub {
     owner = "martanne";

--- a/pkgs/tools/misc/pb_cli/default.nix
+++ b/pkgs/tools/misc/pb_cli/default.nix
@@ -6,8 +6,8 @@ assert video -> capture != null;
 assert clipboard -> xclip != null;
 
 stdenv.mkDerivation rec {
-  pname = "pb_cli-unstable";
-  version = "2019-03-10";
+  pname = "pb_cli";
+  version = "unstable-2019-03-10";
 
   src = fetchFromGitHub {
     owner = "ptpb";

--- a/pkgs/tools/misc/sd-mux-ctrl/default.nix
+++ b/pkgs/tools/misc/sd-mux-ctrl/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchgit, cmake, pkg-config, libftdi1, popt}:
 
 stdenv.mkDerivation rec {
-  pname = "sd-mux-ctrl-unstable";
-  version = "2020-02-17";
+  pname = "sd-mux-ctrl";
+  version = "unstable-2020-02-17";
 
   src = fetchgit {
     url = "https://git.tizen.org/cgit/tools/testlab/sd-mux";

--- a/pkgs/tools/misc/sonota/default.nix
+++ b/pkgs/tools/misc/sonota/default.nix
@@ -12,8 +12,8 @@ let
   };
 
 in buildPythonApplication rec {
-  pname = "sonota-unstable";
-  version = "2018-10-07";
+  pname = "sonota";
+  version = "unstable-2018-10-07";
 
   src = fetchFromGitHub {
     owner  = "mirko";

--- a/pkgs/tools/misc/tewisay/default.nix
+++ b/pkgs/tools/misc/tewisay/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchFromGitHub, makeWrapper }:
 
 buildGoPackage rec {
-  pname = "tewisay-unstable";
-  version = "2017-04-14";
+  pname = "tewisay";
+  version = "unstable-2017-04-14";
 
   goPackagePath = "github.com/lucy/tewisay";
 

--- a/pkgs/tools/misc/xprite-editor/default.nix
+++ b/pkgs/tools/misc/xprite-editor/default.nix
@@ -8,8 +8,8 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "xprite-editor-unstable";
-  version = "2019-09-22";
+  pname = "xprite-editor";
+  version = "unstable-2019-09-22";
 
   src = fetchFromGitHub {
     owner = "rickyhan";

--- a/pkgs/tools/misc/xsel/default.nix
+++ b/pkgs/tools/misc/xsel/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchFromGitHub, libX11, autoreconfHook }:
 
 stdenv.mkDerivation {
-  pname = "xsel-unstable";
-  version = "2020-05-27";
+  pname = "xsel";
+  version = "unstable-2020-05-27";
 
   src = fetchFromGitHub {
     owner = "kfish";

--- a/pkgs/tools/security/medusa/default.nix
+++ b/pkgs/tools/security/medusa/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, freerdp, openssl, libssh2 }:
 
 stdenv.mkDerivation rec {
-  pname = "medusa-unstable";
-  version = "2018-12-16";
+  pname = "medusa";
+  version = "unstable-2018-12-16";
 
   src = fetchFromGitHub {
     owner = "jmk-foofus";

--- a/pkgs/tools/system/systemd-journal2gelf/default.nix
+++ b/pkgs/tools/system/systemd-journal2gelf/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "SystemdJournal2Gelf-unstable";
-  version = "20200813";
+  pname = "SystemdJournal2Gelf";
+  version = "unstable-20200813";
 
   src = fetchFromGitHub {
     rev = "d389dc8583b752cbd37c389a55a6c82200e47394";

--- a/pkgs/tools/wayland/wshowkeys/default.nix
+++ b/pkgs/tools/wayland/wshowkeys/default.nix
@@ -4,8 +4,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "wshowkeys-unstable";
-  version = "2021-08-01";
+  pname = "wshowkeys";
+  version = "unstable-2021-08-01";
 
   src = fetchFromGitHub {
     owner = "ammgws";


### PR DESCRIPTION
There are currently two conventions for naming derivations that build not from
upstream release, but from arbitrary git commit -- either

{ pname = "foo-unstable"; version = "1970-01-01"; }

or

{ pname = "foo"; version = "unstable-1970-01-01"; }

Both of them result in same output path name, but second version is blessed by
nixpkgs manual. This commit mechanically converts packages that use first
convention to use second convention in cases when ${version} is not referenced
anywhere else in default.nix

=> https://nixos.org/manual/nixpkgs/unstable/#sec-package-naming

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
