### PR TITLE
{libbencodetools,uade123}: Bump

### DIFF
--- a/pkgs/development/libraries/libbencodetools/default.nix
+++ b/pkgs/development/libraries/libbencodetools/default.nix
@@ -1,23 +1,30 @@
-{ stdenv, lib, fetchFromGitLab
+{ stdenv
+, lib
+, fetchFromGitLab
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "libbencodetools";
-  version = "unstable-2021-04-15";
+  version = "unstable-2022-05-11";
 
   src = fetchFromGitLab {
     owner = "heikkiorsila";
     repo = "bencodetools";
-    rev = "1ab11f6509a348975e8aec829d7abbf2f8e9b7d1";
-    sha256 = "1i2dgvxxwj844yn45hnfx3785ljbvbkri0nv0jx51z4i08w7cz0h";
+    rev = "384d78d297a561dddbbd0f4632f0c74c0db41577";
+    sha256 = "1d699q9r33hkmmqkbh92ax54mcdf9smscmc0dza2gp4srkhr83qm";
   };
 
   postPatch = ''
-    patchShebangs .
+    patchShebangs configure
+    substituteInPlace configure \
+      --replace 'python_install_option=""' 'python_install_option="--prefix=$out"'
   '';
 
-  configureFlags = [
-    "--without-python"
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    python3
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

- libbencodetools: unstable-2021-04-15 -> unstable-2022-05-11
- uade123:
  - unstable-2021-05-21 -> 3.01
  - Package new Python tools

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
