### PR TITLE
python310Packages.scancode-toolkit: 30.1.0 -> 31.0.0b4, python310Packages.typecode: 21.6.1 -> 30.0.0, python310Packages.plugincode: 21.1.21 -> 30.0.0

### DIFF
--- a/pkgs/development/python-modules/container-inspector/default.nix
+++ b/pkgs/development/python-modules/container-inspector/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
     hash = "sha256-YwtyNZsTMb8iFXo/rojvjkKUbMNRCXVamzFykpwYCOk=";
   };
 
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
   dontConfigure = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/debian-inspector/default.nix
+++ b/pkgs/development/python-modules/debian-inspector/default.nix
@@ -6,23 +6,29 @@
 , commoncode
 , pytestCheckHook
 , setuptools-scm
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "debian-inspector";
   version = "30.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     pname = "debian_inspector";
     inherit version;
-    sha256 = "sha256-0PT5sT6adaqgYQtWjks12ys0z1C3n116aeJaEKR/Wxg=";
+    hash = "sha256-0PT5sT6adaqgYQtWjks12ys0z1C3n116aeJaEKR/Wxg=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  dontConfigure = true;
 
   nativeBuildInputs = [
     setuptools-scm
   ];
-
-  dontConfigure = true;
 
   propagatedBuildInputs = [
     chardet

--- a/pkgs/development/python-modules/license-expression/default.nix
+++ b/pkgs/development/python-modules/license-expression/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage rec {
     hash = "sha256-tGXNZm9xH8sXa7dtBFsTzGgT+hfbmkwps7breR7KUWU=";
   };
 
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
   dontConfigure = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/parameter-expansion-patched/default.nix
+++ b/pkgs/development/python-modules/parameter-expansion-patched/default.nix
@@ -3,18 +3,26 @@
 , fetchPypi
 , pytestCheckHook
 , pythonOlder
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "parameter-expansion-patched";
-  version = "0.2.1b4";
+  version = "0.3.1";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1vhshscjifi78qapzwn29gln6p8jhyc7cccszl8ai2jamhcph5zs";
+    hash = "sha256-/128ifveWC8zNlYtGWtxB3HpK6p7bVk1ahSwhaC2dAs=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
   checkInputs = [
     pytestCheckHook
@@ -26,7 +34,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "POSIX parameter expansion in Python";
-    homepage = "https://github.com/nexB/commoncode";
+    homepage = "https://github.com/nexB/parameter_expansion_patched";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/pip-requirements-parser/default.nix
+++ b/pkgs/development/python-modules/pip-requirements-parser/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage rec {
     hash = "sha256-i4hw3tS4i2ek2JzcDiGo5aFFJ9J2JJ9MB5vxDhOilb0=";
   };
 
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
   dontConfigure = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/plugincode/default.nix
+++ b/pkgs/development/python-modules/plugincode/default.nix
@@ -7,14 +7,19 @@
 , pluggy
 , pytestCheckHook
 , pytest-xdist
+, pythonOlder
 }:
+
 buildPythonPackage rec {
   pname = "plugincode";
-  version = "21.1.21";
+  version = "30.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "97b5a2c96f0365c80240be103ecd86411c68b11a16f137913cbea9129c54907a";
+    hash = "sha256-QjcQCvhlaBzcbBB8MIhbsx4cRy7XkdvUcmG7rM48Sos=";
   };
 
   dontConfigure = true;
@@ -38,8 +43,13 @@ buildPythonPackage rec {
     "plugincode"
   ];
 
+  disabledTests = [
+    # We don't want black as an input
+    "test_skeleton_codestyle"
+  ];
+
   meta = with lib; {
-    description = "A library that provides plugin functionality for ScanCode toolkit";
+    description = "Library that provides plugin functionality for ScanCode toolkit";
     homepage = "https://github.com/nexB/plugincode";
     license = licenses.asl20;
     maintainers = teams.determinatesystems.members;

--- a/pkgs/development/python-modules/pyahocorasick/default.nix
+++ b/pkgs/development/python-modules/pyahocorasick/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "pyahocorasick";
-  version = "1.4.4";
+  version = "2.0.0b1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -17,15 +17,11 @@ buildPythonPackage rec {
     owner = "WojciechMula";
     repo = pname;
     rev = version;
-    hash = "sha256-X6ifwOwf7GAaNUxInKhR3NX6hKhvFMkvfbK6XpH8CBo=";
+    hash = "sha256-APpL99kOwzIQjePvRDeJ0FDm1kjBi6083JMKuBqtaRk=";
   };
 
   checkInputs = [
     pytestCheckHook
-  ];
-
-  pytestFlagsArray = [
-    "unittests.py"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/scancode-toolkit/default.nix
+++ b/pkgs/development/python-modules/scancode-toolkit/default.nix
@@ -8,8 +8,9 @@
 , click
 , colorama
 , commoncode
+, container-inspector
 , debian-inspector
-, dparse
+, dparse2
 , extractcode
 , extractcode-7z
 , extractcode-libarchive
@@ -32,7 +33,8 @@
 , packaging
 , parameter-expansion-patched
 , pefile
-, pkginfo
+, pip-requirements-parser
+, pkginfo2
 , pluggy
 , plugincode
 , publicsuffix2
@@ -58,13 +60,13 @@
 
 buildPythonPackage rec {
   pname = "scancode-toolkit";
-  version = "30.1.0";
+  version = "31.0.0b4";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-UYQf+cBi2FmyZxIbQJo7vLjPuoePIMC8FugvoG1Ebj0=";
+    hash = "sha256-sPFHaIbbWw/wk3Q1PBDj5O4il9ntigoyanecg938a9A=";
   };
 
   dontConfigure = true;
@@ -78,8 +80,9 @@ buildPythonPackage rec {
     click
     colorama
     commoncode
+    container-inspector
     debian-inspector
-    dparse
+    dparse2
     extractcode
     extractcode-7z
     extractcode-libarchive
@@ -88,6 +91,7 @@ buildPythonPackage rec {
     ftfy
     gemfileparser
     html5lib
+    importlib-metadata
     intbitset
     jaraco_functools
     javaproperties
@@ -100,7 +104,8 @@ buildPythonPackage rec {
     packaging
     parameter-expansion-patched
     pefile
-    pkginfo
+    pip-requirements-parser
+    pkginfo2
     pluggy
     plugincode
     publicsuffix2
@@ -118,9 +123,8 @@ buildPythonPackage rec {
     typecode-libmagic
     urlpy
     xmltodict
-    zipp
   ] ++ lib.optionals (pythonOlder "3.9") [
-    importlib-metadata
+    zipp
   ] ++ lib.optionals (pythonOlder "3.7") [
     typing
   ];

--- a/pkgs/development/python-modules/typecode/default.nix
+++ b/pkgs/development/python-modules/typecode/default.nix
@@ -10,16 +10,19 @@
 , typecode-libmagic
 , pytestCheckHook
 , pytest-xdist
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "typecode";
-  version = "21.6.1";
+  version = "30.0.0";
   format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d3a82859df5607c900972e08e1bca31e3fe2daed37afd1b8231cad2ef613d8d6";
+    hash = "sha256-pRGLU/xzQQqDZMIsrq1Fy7VgGIpFjnHtpmO+yL7t4g8=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes
Follow-up of #172460
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
