### PR TITLE
{libmt32emu,mt32emu-qt,mt32emu-smf2wav}: Bump

### DIFF
--- a/pkgs/applications/audio/munt/libmt32emu.nix
+++ b/pkgs/applications/audio/munt/libmt32emu.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libmt32emu";
-  version = "2.5.3";
+  version = "2.6.3";
 
   src = fetchFromGitHub {
     owner = "munt";
     repo = "munt";
     rev = "${pname}_${lib.replaceChars [ "." ] [ "_" ] version}";
-    hash = "sha256-n5VV5Swh1tOVQGT3urEKl64A/w7cY95/0y5wC5ZuLm4=";
+    sha256 = "0ncy55fj9l2s750clxjpv102hrgcndz4qba9w2sf8lwzgy6d1xmp";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/applications/audio/munt/mt32emu-qt.nix
+++ b/pkgs/applications/audio/munt/mt32emu-qt.nix
@@ -13,15 +13,18 @@
 , withJack ? stdenv.hostPlatform.isUnix, libjack2
 }:
 
+let
+  char2underscore = char: str: lib.replaceChars [ char ] [ "_" ] str;
+in
 mkDerivation rec {
   pname = "mt32emu-qt";
-  version = "1.9.0";
+  version = "1.10.2";
 
   src = fetchFromGitHub {
     owner = "munt";
     repo = "munt";
-    rev = "mt32emu_qt_${lib.replaceChars [ "." ] [ "_" ] version}";
-    hash = "sha256-9vapBKpl1NC3mIDetuCb452IHV6c7c7NCzSyiBry5oo=";
+    rev = "${char2underscore "-" pname}_${char2underscore "." version}";
+    sha256 = "1dh5xpnsgx367ch45mm5c2p26vnxf3shax2afg2cd2lrbrlii7l9";
   };
 
   postPatch = ''
@@ -55,8 +58,8 @@ mkDerivation rec {
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/Applications
-    mv $out/bin/${meta.mainProgram}.app $out/Applications/
-    ln -s $out/{Applications/${meta.mainProgram}.app/Contents/MacOS,bin}/${meta.mainProgram}
+    mv $out/bin/${pname}.app $out/Applications/
+    ln -s $out/{Applications/${pname}.app/Contents/MacOS,bin}/${pname}
   '';
 
   meta = with lib; {
@@ -70,6 +73,5 @@ mkDerivation rec {
     license = with licenses; [ gpl3Plus ];
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.all;
-    mainProgram = "mt32emu-qt";
   };
 }

--- a/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
+++ b/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
@@ -7,15 +7,18 @@
 , pkg-config
 }:
 
+let
+  char2underscore = char: str: lib.replaceChars [ char ] [ "_" ] str;
+in
 stdenv.mkDerivation rec {
   pname = "mt32emu-smf2wav";
-  version = "1.7.0";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "munt";
     repo = "munt";
-    rev = "mt32emu_smf2wav_${lib.replaceChars [ "." ] [ "_" ] version}";
-    hash = "sha256-FnKlKJxe7P4Yqpv0oVGgV4253dMgSmgtb7EAa2FI+aI=";
+    rev = "${char2underscore "-" pname}_${char2underscore "." version}";
+    sha256 = "1dh5xpnsgx367ch45mm5c2p26vnxf3shax2afg2cd2lrbrlii7l9";
   };
 
   postPatch = ''
@@ -45,6 +48,5 @@ stdenv.mkDerivation rec {
     license = with licenses; [ gpl3Plus ];
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.all;
-    mainProgram = "mt32emu-smf2wav";
   };
 }


### PR DESCRIPTION
###### Description of changes

- libmt32emu: 2.5.3 -> 2.6.3
- mt32emu-qt: 1.9.0 -> 1.10.2, remove pointless `meta.mainProgram` (binary name matches `pname`)
- mt32emu-smf2wav: 1.7.0 -> 1.8.2, remove pointless `meta.mainProgram` (binary name matches `pname`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
