### PR TITLE
python310Packages.datatable: mark broken

### DIFF
--- a/pkgs/development/python-modules/datatable/default.nix
+++ b/pkgs/development/python-modules/datatable/default.nix
@@ -6,6 +6,7 @@
 , llvm
 , pytestCheckHook
 , typesentry
+, isPy310
 }:
 
 buildPythonPackage rec {
@@ -63,6 +64,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ abbradar ];
     # uses custom build system and adds -Wunused-variable -Werror
     # warning: ‘dt::expr::doc_first’ defined but not used [-Wunused-variable]
-    broken = true;
+    broken = isPy310;
   };
 }


### PR DESCRIPTION
###### Description of changes

A failing dependency for e.g. `python310Packages.xgboost` so let's mark it as such

```
error: builder for '/nix/store/yazfmlnswn7k6scmwnszh3bgcyrb2b8y-python3.10-datatable-0.11.0.drv' failed with exit code 1;
       last 10 log lines:
       > | src/core/column/cast_string.cc:66:10: warning: ‘y’ may be used uninitialized [-Wmaybe-uninitialized]
       > |    66 |     *out = static_cast<V>(y);
       > |       |     ~~~~~^~~~~~~~~~~~~~~~~~~
       > | src/core/column/cast_string.cc:64:13: note: ‘y’ was declared here
       > |    64 |     int64_t y;
       > |       |             ^
       > |
       > +===============================
       > Error compiling _datatable
       >
       For full logs, run 'nix log /nix/store/yazfmlnswn7k6scmwnszh3bgcyrb2b8y-python3.10-datatable-0.11.0.drv'.
```


cc maintainer @abbradar 