### PR TITLE
ocamlPackages.telegraml: init unstable-2021-06-17

### DIFF
--- a/pkgs/development/ocaml-modules/telegraml/default.nix
+++ b/pkgs/development/ocaml-modules/telegraml/default.nix
@@ -1,0 +1,34 @@
+{ batteries
+, buildDunePackage
+, cohttp-lwt-unix
+, fetchFromGitHub
+, lib
+, logs
+, yojson
+}:
+
+buildDunePackage rec {
+  pname = "telegraml";
+  version = "unstable-2021-06-17";
+
+  src = fetchFromGitHub {
+    owner = "nv-vn";
+    repo = "TelegraML";
+    rev = "3e28933a287e5eacd34c46b434c487f155397abc";
+    sha256 = "sha256-2bMHARatwl8Zl/fWppvwbH6Ut+igJVKzwyQb8Q4gem4=";
+  };
+
+  propagatedBuildInputs = [
+    batteries
+    cohttp-lwt-unix
+    logs
+    yojson
+  ];
+
+  meta = with lib; {
+    description = "An OCaml library implementing the Telegram bot API";
+    homepage = "https://github.com/nv-vn/TelegraML/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1344,6 +1344,8 @@ let
 
     tcslib = callPackage ../development/ocaml-modules/tcslib { };
 
+    telegraml = callPackage ../development/ocaml-modules/telegraml { };
+
     terminal = callPackage ../development/ocaml-modules/terminal { };
 
     terminal_size = callPackage ../development/ocaml-modules/terminal_size { };


### PR DESCRIPTION
ocamlPackages.telegraml: init unstable-2021-06-17

* I was in doubt if I should propagate libraries or not. In my demo/example here, I had to add all the same buildInputs. I had checked META file and it shows as `required` there. Does `required` means it should be included in the `propagatedBuildInputs`?
