### PR TITLE
openxray: 822-december-preview -> 1144-december-2021-rc1

### DIFF
--- a/pkgs/games/openxray/default.nix
+++ b/pkgs/games/openxray/default.nix
@@ -1,20 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, cmake, glew, freeimage,  liblockfile
-, openal, libtheora, SDL2, lzo, libjpeg, libogg, tbb
-, pcre, makeWrapper, fetchpatch }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, glew
+, freeimage
+, liblockfile
+, openal
+, libtheora
+, SDL2
+, lzo
+, libjpeg
+, libogg
+, pcre
+, makeWrapper
+, enableMultiplayer ? false # Requires old, insecure Crypto++ version
+}:
 
 let
-  version = "822-december-preview";
+  version = "1144-december-2021-rc1";
 
   src = fetchFromGitHub {
     owner = "OpenXRay";
     repo = "xray-16";
     rev = version;
     fetchSubmodules = true;
-    sha256 = "06f3zjnib7hipyl3hnc6mwcj9f50kbwn522wzdjydz8qgdg60h3m";
+    sha256 = "07qj1lpp21g4p583gvz5h66y2q71ymbsz4g5nr6dcys0vm7ph88v";
   };
 
   # https://github.com/OpenXRay/xray-16/issues/518
-  cryptopp = stdenv.mkDerivation {
+  ancientCryptopp = stdenv.mkDerivation {
     pname = "cryptopp";
     version = "5.6.5";
 
@@ -22,47 +36,59 @@ let
 
     sourceRoot = "source/Externals/cryptopp";
 
-    makeFlags = [ "PREFIX=${placeholder "out"}" ];
+    installFlags = [ "PREFIX=${placeholder "out"}" ];
+
     enableParallelBuilding = true;
 
     doCheck = true;
+
+    dontStrip = true;
 
     meta = with lib; {
       description = "Crypto++, a free C++ class library of cryptographic schemes";
       homepage = "https://cryptopp.com/";
       license = with licenses; [ boost publicDomain ];
       platforms = platforms.all;
+      knownVulnerabilities = [
+        "CVE-2019-14318"
+      ];
     };
   };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "openxray";
+
   inherit version src;
 
-  # TODO https://github.com/OpenXRay/GameSpy/pull/6, check if merged in version > 822
-  # Fixes format hardening
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/OpenXRay/GameSpy/pull/6/commits/155af876281f5d94f0142886693314d97deb2d4c.patch";
-      sha256 = "1l0vcgvzzx8n56shpblpfdhvpr6c12fcqf35r0mflaiql8q7wn88";
-      stripLen = 1;
-      extraPrefix = "Externals/GameSpy/";
-    })
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
   ];
-
-  cmakeFlags = [ "-DCMAKE_INCLUDE_PATH=${cryptopp}/include/cryptopp" ];
 
   buildInputs = [
-    glew freeimage liblockfile openal cryptopp libtheora SDL2 lzo
-    libjpeg libogg tbb pcre
+    glew
+    freeimage
+    liblockfile
+    openal
+    libtheora
+    SDL2
+    lzo
+    libjpeg
+    libogg
+    pcre
+  ] ++ lib.optionals enableMultiplayer [
+    ancientCryptopp
   ];
 
-  nativeBuildInputs = [ cmake makeWrapper ];
+  # Crashes can happen, we'd like them to be reasonably debuggable
+  cmakeBuildType = "RelWithDebInfo";
+  dontStrip = true;
 
-  # https://github.com/OpenXRay/xray-16/issues/786
-  preConfigure = ''
-    substituteInPlace src/xrCore/xrCore.cpp \
-      --replace /usr/share $out/share
-  '';
+  cmakeFlags = [
+    "-DUSE_CRYPTOPP=${if enableMultiplayer then "ON" else "OFF"}"
+  ] ++ lib.optionals enableMultiplayer [
+    "-DCMAKE_INCLUDE_PATH=${ancientCryptopp}/include/cryptopp"
+  ];
 
   postInstall = ''
     # needed because of SDL_LoadObject library loading code
@@ -71,8 +97,9 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    mainProgram = "xray-16";
     description = "Improved version of the X-Ray Engine, the game engine used in the world-famous S.T.A.L.K.E.R. game series by GSC Game World";
-    homepage = src.meta.homepage;
+    homepage = "https://github.com/OpenXRay/xray-16/";
     license = licenses.unfree // {
       url = "https://github.com/OpenXRay/xray-16/blob/xd_dev/License.txt";
     };


### PR DESCRIPTION
###### Description of changes

https://github.com/OpenXRay/xray-16/releases/tag/1144-december-2021-rc1

Just a release candidate and not a proper preview release, but it has been a full year between the last preview & this RC, and half a year since this RC, so I'll take a possible lack of polish over being years behind fixed bugs & improvements. :stuck_out_tongue:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (both with & without multiplayer support)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
