### PR TITLE
python3.pkgs.sphinxcontrib-log-cabinet: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-log-cabinet/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-log-cabinet/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, sphinx }:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-log-cabinet";
+  version = "1.0.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "davidism";
+    repo = "sphinxcontrib-log-cabinet";
+    rev = "refs/tags/${version}";
+    sha256 = "03cxspgqsap9q74sqkdx6r6b4gs4hq6dpvx4j58hm50yfhs06wn1";
+  };
+
+  propagatedBuildInputs = [ sphinx ];
+
+  pythonImportsCheck = [ "sphinxcontrib.log_cabinet" ];
+  
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    homepage = "https://github.com/davidism/sphinxcontrib-log-cabinet";
+    description = "Sphinx extension to organize changelogs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/tools/misc/deheader/default.nix
+++ b/pkgs/development/tools/misc/deheader/default.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv, python3, xmlto, docbook-xsl-nons, fetchFromGitLab }:
+
+stdenv.mkDerivation rec {
+  pname = "deheader";
+  version = "1.8";
+  outputs = [ "out" "man" ];
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "deheader";
+    rev = "${version}";
+    sha256 = "sha256-sjxgUtdsi/sfxOViDj7l8591TSYwtCzDQcHsk9ClXuM=";
+  };
+
+  buildInputs = [ python3 ];
+
+  nativeBuildInputs = [ xmlto docbook-xsl-nons ];
+
+  # With upstream Makefile, xmlto is called without "--skip-validation". It
+  # makes it require a lot of dependencies, yet ultimately it fails
+  # nevertheless in attempt to fetch something from SourceForge.
+  buildPhase = ''
+    runHook preBuild
+
+    xmlto man --skip-validation deheader.xml
+    patchShebangs ./deheader
+
+    runHook postBuild
+  '';
+
+  # Normally "foundMakefile" variable is set by default buildPhase.
+  foundMakefile = 1;
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/man/man1}
+    install -m 755 ./deheader $out/bin
+    install -m 644 ./deheader.1 $out/share/man/man1
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tool to find and optionally remove unneeded includes in C or C++ source files";
+    longDescription = ''
+      This tool takes a list of C or C++ sourcefiles and generates a report
+      on which #includes can be omitted from them -- the test, for each foo.c
+      or foo.cc or foo.cpp, is simply whether 'rm foo.o; make foo.o' returns a
+      zero status. Optionally, with the -r option, the unneeded headers are removed.
+      The tool also reports on headers required for strict portability.
+    '';
+    homepage = "http://catb.org/~esr/deheader";
+    changelog = "https://gitlab.com/esr/deheader/-/blob/master/NEWS.adoc";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ kaction ];
+
+    # Single-file python3 script is probably unix-portable, but I am not
+    # interested in dealing with anything but linux; feel free to add yourself
+    # as another maintainer if you are. ~kaction, 2022-08-25
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3580,6 +3580,8 @@ with pkgs;
 
   dedup = callPackage ../tools/backup/dedup { };
 
+  deheader = callPackage ../development/tools/misc/deheader { };
+
   dehydrated = callPackage ../tools/admin/dehydrated { };
 
   deja-dup = callPackage ../applications/backup/deja-dup { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10354,6 +10354,8 @@ in {
 
   sphinxcontrib-katex = callPackage ../development/python-modules/sphinxcontrib-katex { };
 
+  sphinxcontrib-log-cabinet = callPackage ../development/python-modules/sphinxcontrib-log-cabinet { };
+
   sphinxcontrib-nwdiag = callPackage ../development/python-modules/sphinxcontrib-nwdiag { };
 
   sphinxcontrib_newsfeed = callPackage ../development/python-modules/sphinxcontrib_newsfeed { };


### PR DESCRIPTION
- python3.pkgs.sphinx-pallets-theme: init at 2.0.2
- python3.pkgs.sphinxcontrib-log-cabinent: init at 1.0.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
