### PR TITLE
adlplug,opnplug: patch JUCE to fix build on Darwin

### DIFF
--- a/pkgs/applications/audio/adlplug/default.nix
+++ b/pkgs/applications/audio/adlplug/default.nix
@@ -45,12 +45,93 @@ stdenv.mkDerivation rec {
     sha256 = "0mqx4bzri8s880v7jwd24nb93m5i3aklqld0b3h0hjnz0lh2qz0f";
   };
 
+  # All of these patches can be cleaned up if we can update ADLplug to the
+  # latest, unreleased version. (It updates its bundled version of JUCE so
+  # that it contains all of these changes.)
+  #
   patches = [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/jpcima/ADLplug/83636c55bec1b86cabf634b9a6d56d07f00ecc61/resources/patch/juce-gcc9.patch";
       sha256 = "15hkdb76n9lgjsrpczj27ld9b4804bzrgw89g95cj4sc8wwkplyy";
       extraPrefix = "thirdparty/JUCE/";
       stripLen = 1;
+    })
+
+    (fetchpatch {
+      #
+      # Commit message:
+      #
+      #   macOS: Added missing OS versions to SystemStats::OperatingSystemType
+      #
+      # This is present by default in JUCE version 5.4.4.
+      #
+      # Needed so that subsequent patches apply cleanly.
+      #
+      url = "https://github.com/juce-framework/JUCE/commit/730fd6955fb1397c6da6774aeda1c7fa39792ce5.patch";
+      sha256 = "UT01GnnxGVIHupxPXD4HNifcPZR+zauqQQ3mzWOr3yQ=";
+      extraPrefix = "thirdparty/JUCE/";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      #
+      # Commit message:
+      #
+      #   Prevented the Apple system headers from including some unnecessary C library headers
+      #
+      # This is present by default in JUCE version 5.4.4.
+      #
+      # Needed so that subsequent patches apply cleanly.
+      #
+      url = "https://github.com/juce-framework/JUCE/commit/2830ecec0a24035ddfe383475243b397841af289.patch";
+      sha256 = "I3mS9HE10L0v5IWchvyL6cNozrvw60np0EYK+SEblxM=";
+      extraPrefix = "thirdparty/JUCE/";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      # Commit message:
+      #
+      #   Build: Fix Xcode 11.4 compatibility issues
+      #
+      # This is present by default in JUCE version 6.0.0.
+      #
+      url = "https://github.com/juce-framework/JUCE/commit/dddeb1ad68f8539f5ea2fbac36c07532f12bf9cf.patch";
+      sha256 = "B51UqvyHuc3beqkMp1mXE0aQ/yHbVioH0MPwAW4KHt8=";
+      extraPrefix = "thirdparty/JUCE/";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      # Commit message:
+      #
+      #   Cleanup: Remove redundant inlines
+      #
+      # This is present by default in JUCE version 6.0.0.
+      #
+      # Needed so that subsequent patches apply cleanly.
+      #
+      url = "https://github.com/juce-framework/JUCE/commit/4cf66d65221bee100c3de490ca3fe6fafc72f508.patch";
+      sha256 = "Jw4OeNcRNgNT9hYdl/juo2w81G4QWNoplyoZZ1m4VMo=";
+      extraPrefix = "thirdparty/JUCE/";
+      stripLen = 1;
+      includes = [
+        "thirdparty/JUCE/modules/juce_core/native/juce_osx_ObjCHelpers.h"
+      ];
+    })
+    (fetchpatch {
+      # Commit message:
+      #
+      #   macOS: Initial support for macOS 11 and arm64
+      #
+      # This fixes objc_msgSend_fpret is an unknown symbol errors.
+      #
+      # This is present by default in JUCE version 6.0.2.
+      #
+      url = "https://github.com/juce-framework/JUCE/commit/b27017a5e3db1d6acf11d89f35adfe7de8bdb600.patch";
+      sha256 = "NxOawDc3c6JFf9g0rg5KK9j2aS1VkTwel8WfYTfOYcs=";
+      extraPrefix = "thirdparty/JUCE/";
+      stripLen = 1;
+      excludes = [
+        "thirdparty/JUCE/docs/CMake API.md"
+      ];
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

I had to cherry-pick several patches from JUCE upstream, since ADLplug depends on an older version. This will no longer be necessary after updating ADLplug to the latest commit on its master branch.

When I tried to do the update, I ran into linking issues related to undefined symbols, and I realized I don't know enough to resolve those yet. So that is future work.

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
