### PR TITLE
ocamlPackages.genspio: 0.0.2 → 0.0.3

### DIFF
--- a/pkgs/development/ocaml-modules/genspio/default.nix
+++ b/pkgs/development/ocaml-modules/genspio/default.nix
@@ -1,27 +1,19 @@
 { lib, fetchFromGitHub, buildDunePackage
-, nonstd, sosa
+, base, fmt
 }:
 
 buildDunePackage rec {
   pname = "genspio";
-  version = "0.0.2";
-
-  useDune2 = false;
+  version = "0.0.3";
 
   src = fetchFromGitHub {
     owner = "hammerlab";
     repo = pname;
     rev = "${pname}.${version}";
-    sha256 = "0cp6p1f713sfv4p2r03bzvjvakzn4ili7hf3a952b3w1k39hv37x";
+    sha256 = "sha256:1788cnn10idp5i1hggg4pys7k0w8m3h2p4xa42jipfg4cpj7shaf";
   };
 
-  minimalOCamlVersion = "4.03";
-
-  propagatedBuildInputs = [ nonstd sosa ];
-
-  configurePhase = ''
-    ocaml please.mlt configure
-  '';
+  propagatedBuildInputs = [ base fmt ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Description of changes

Compatibility with recent versions of dune (hence of OCaml).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
