### PR TITLE
lua: fix on darwin by using makeBinaryWrapper

### DIFF
--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -1,10 +1,11 @@
 # similar to interpreters/python/default.nix
-{ stdenv, lib, callPackage, fetchurl, fetchpatch }:
+{ stdenv, lib, callPackage, fetchurl, fetchpatch, makeBinaryWrapper }:
 
 rec {
   lua5_4 = callPackage ./interpreter.nix {
     sourceVersion = { major = "5"; minor = "4"; patch = "3"; };
     hash = "1yxvjvnbg4nyrdv10bq42gz6dr66pyan28lgzfygqfwy2rv24qgq";
+    makeWrapper = makeBinaryWrapper;
 
     patches = lib.optional stdenv.isDarwin ./5.4.darwin.patch;
   };
@@ -16,6 +17,7 @@ rec {
   lua5_3 = callPackage ./interpreter.nix {
     sourceVersion = { major = "5"; minor = "3"; patch = "6"; };
     hash = "0q3d8qhd7p0b7a4mh9g7fxqksqfs6mr1nav74vq26qvkp2dxcpzw";
+    makeWrapper = makeBinaryWrapper;
 
     patches =
       lib.optionals stdenv.isDarwin [ ./5.2.darwin.patch ];
@@ -29,6 +31,7 @@ rec {
   lua5_2 = callPackage ./interpreter.nix {
     sourceVersion = { major = "5"; minor = "2"; patch = "4"; };
     hash = "0jwznq0l8qg9wh5grwg07b5cy3lzngvl5m2nl1ikp6vqssmf9qmr";
+    makeWrapper = makeBinaryWrapper;
     patches = lib.optional stdenv.isDarwin ./5.2.darwin.patch;
   };
 
@@ -40,6 +43,7 @@ rec {
   lua5_1 = callPackage ./interpreter.nix {
     sourceVersion = { major = "5"; minor = "1"; patch = "5"; };
     hash = "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333";
+    makeWrapper = makeBinaryWrapper;
     patches = (lib.optional stdenv.isDarwin ./5.1.darwin.patch)
       ++ [ ./CVE-2014-5461.patch ];
   };

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -126,6 +126,7 @@ self = stdenv.mkDerivation rec {
   passthru = rec {
     buildEnv = callPackage ./wrapper.nix {
       lua = self;
+      inherit makeWrapper;
       inherit (luaPackages) requiredLuaModules;
     };
     withPackages = import ./with-packages.nix { inherit buildEnv luaPackages;};

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -111,7 +111,6 @@ stdenv.mkDerivation rec {
     homepage = "https://sile-typesetter.org";
     changelog = "https://github.com/sile-typesetter/sile/raw/v${version}/CHANGELOG.md";
     platforms = platforms.unix;
-    broken = stdenv.isDarwin;   # https://github.com/NixOS/nixpkgs/issues/23018
     maintainers = with maintainers; [ doronbehar alerque ];
     license = licenses.mit;
   };


### PR DESCRIPTION
Darwin execve has issues with shebang lines that point to other scripts
with shebang lines. A new makeBinaryWrapper hook was added to workaround
the issue on darwin. See #171473 and #23018 for more information. This
uses that binary wrapper to fix packages like sile.

I'm not sure this can be considered complete but it appears to work for
sile at least.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @alerque 
