### PR TITLE
cdpr: pull patch pending upstream inclusion for -fno-common

### DIFF
--- a/pkgs/tools/networking/cdpr/default.nix
+++ b/pkgs/tools/networking/cdpr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libpcap }:
+{ lib, stdenv, fetchurl, fetchpatch, libpcap }:
 
 stdenv.mkDerivation rec {
   pname = "cdpr";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/${pname}/${pname}/${version}/${pname}-${version}.tgz";
     sha256 = "1idyvyafkk0ifcbi7mc65b60qia6hpsdb6s66j4ggqp7if6vblrj";
   };
+  patches = [
+    # Pull fix pending upstream inclusion for gcc-10 compatibility:
+    #  https://sourceforge.net/p/cdpr/bugs/3/
+    (fetchurl {
+      name = "fno-common";
+      url = "https://sourceforge.net/p/cdpr/bugs/3/attachment/0001-cdpr-fix-build-on-gcc-10-fno-common.patch";
+      sha256 = "023cvkpc4ry1pbjd91kkwj4af3hia0layk3fp8q40vh6mbr14pnp";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace Makefile --replace 'gcc' '"$$CC"'


### PR DESCRIPTION
Without the change build fails agains -fno-common toolchains as:

    ld: /build/cct3qrT9.o:(.bss+0x0): multiple definition of `handle'; /build/cc4dJNO8.o:(.bss+0x0): first defined here
    ld: /build/cct3qrT9.o:(.bss+0x8): multiple definition of `cdprs'; /build/cc4dJNO8.o:(.bss+0x8): first defined here
    ld: /build/cct3qrT9.o:(.bss+0xc): multiple definition of `timeout'; /build/cc4dJNO8.o:(.bss+0xc): first defined here
    ld: /build/ccbaP0xb.o:(.bss+0x0): multiple definition of `handle'; /build/cc4dJNO8.o:(.bss+0x0): first defined here
    ld: /build/ccbaP0xb.o:(.bss+0x8): multiple definition of `cdprs'; /build/cc4dJNO8.o:(.bss+0x8): first defined here
    ld: /build/ccbaP0xb.o:(.bss+0xc): multiple definition of `timeout'; /build/cc4dJNO8.o:(.bss+0xc): first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
