### PR TITLE
header-file-mode: unstable-2022-04-19 -> unstable-2022-05-13

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/header-file-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/header-file-mode/default.nix
@@ -5,13 +5,13 @@
 
 trivialBuild {
   pname = "header-file-mode";
-  version = "unstable-2022-04-19";
+  version = "unstable-2022-05-13";
 
   src = fetchFromGitHub {
-    owner = "0x4b";
+    owner = "aidalgol";
     repo = "header-file-mode";
-    rev = "fdf1930730e1b0c3f82490099a1325805491eff5";
-    sha256 = "sha256-FJgRI6RLQk9osh7d+YRfrV5CoGCDx2cZvsjAWlm969c=";
+    rev = "bcfd19a2c70030ebf5fa68e87aca4b3db8fad13e";
+    sha256 = "sha256-XMXOU+vWJ/0e0ny4Dz3DxWpdEfSNXGzm03sBke32Dwc=";
   };
 
   postUnpack = ''


### PR DESCRIPTION
###### Description of changes

Update to version with a fix to make the package work with Emacs 28.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
