### PR TITLE
dirt: pull fix pending upstream inclusion for -fno-common toolchains

### DIFF
--- a/pkgs/applications/audio/dirt/default.nix
+++ b/pkgs/applications/audio/dirt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libsndfile, libsamplerate, liblo, libjack2 }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, libsndfile, libsamplerate, liblo, libjack2 }:
 
 stdenv.mkDerivation {
   pname = "dirt";
@@ -10,6 +10,15 @@ stdenv.mkDerivation {
     sha256 = "13adglk2d31d7mswfvi02b0rjdhzmsv11cc8smhidmrns3f9s96n";
     fetchSubmodules = true;
   };
+  patches = [
+    # Pull patch pending upstream inclusion for upstream gcc-10 support:
+    #  https://github.com/tidalcycles/Dirt/pull/65
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/tidalcycles/Dirt/commit/43fd267745d486228c4185b4fcbd7d9fbc362cc2.patch";
+      sha256 = "08r34ylzs31wwf0la995pb149ccq0vr7qg4792pkhca57zi0bff8";
+    })
+  ];
   buildInputs = [ libsndfile libsamplerate liblo libjack2 ];
   postPatch = ''
     sed -i "s|./samples|$out/share/dirt/samples|" dirt.c


### PR DESCRIPTION
Without the change build fails on -fno-common toolchains like upstream
gcc-10:

    ld: audio.o:/home/slyfox/dev/git/Dirt/audio.h:55: multiple definition of
      `delays'; dirt.o:/home/slyfox/dev/git/Dirt/audio.h:55: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
