### PR TITLE
xow: install firmware manually

### DIFF
--- a/pkgs/misc/drivers/xow/default.nix
+++ b/pkgs/misc/drivers/xow/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cabextract, fetchurl, fetchFromGitHub, libusb1 }:
+{ lib, stdenv, fetchFromGitHub, libusb1, xow_dongle-firmware }:
 
 stdenv.mkDerivation rec {
   pname = "xow";
@@ -11,11 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "0q5nr21p4dlx2a99hiivwz6qj9anrqqsdhiz6xi375yqkxis4251";
   };
 
-  firmware = fetchurl {
-    url = "http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
-    sha256 = "013g1zngxffavqrk5jy934q3bdhsv6z05ilfixdn8dj0zy26lwv5";
-  };
-
   makeFlags = [
     "BUILD=RELEASE"
     "VERSION=${version}-${src.rev}"
@@ -24,15 +19,10 @@ stdenv.mkDerivation rec {
     "MODLDIR=${placeholder "out"}/lib/modules-load.d"
     "MODPDIR=${placeholder "out"}/lib/modprobe.d"
     "SYSDDIR=${placeholder "out"}/lib/systemd/system"
+    "FIRMWARE=${xow_dongle-firmware}/lib/firmware/xow_dongle.bin"
   ];
 
-  postUnpack = ''
-    cabextract -F FW_ACC_00U.bin ${firmware}
-    mv FW_ACC_00U.bin source/firmware.bin
-  '';
-
   enableParallelBuilding = true;
-  nativeBuildInputs = [ cabextract ];
   buildInputs = [ libusb1 ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

As of https://github.com/medusalix/xow/commit/8b44d8f86d85cff1a8e20d8656e490ca0cc3fc7e the firmware isn't installed by the Makefile anymore.

I saw that https://github.com/NixOS/nixpkgs/pull/161008 added a package for the firmware, but I don't know if that's compatible. I tried setting `hardware.firmware = [pkgs.xow_dongle-firmware]` but that doesn't appear to install to `/lib/firmware`, so I assume this is for kernel drivers only? Please enlighten me if I did that wrong.

###### Things done

Added a `postInstall` that copies the firmware file.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).