### PR TITLE
epgstation: fix build

### DIFF
--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -41,7 +41,7 @@ let
     # dependencies are pruned afterwards.
     production = false;
 
-    buildInputs = [ bash ];
+    buildInputs = (drv.buildInputs or [ ]) ++ [ bash ];
     nativeBuildInputs = (drv.nativeBuildInputs or [ ]) ++ [
       makeWrapper
     ];

--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -42,7 +42,7 @@ let
     production = false;
 
     buildInputs = [ bash ];
-    nativeBuildInputs = drv.nativeBuildInputs ++ [
+    nativeBuildInputs = (drv.nativeBuildInputs or [ ]) ++ [
       makeWrapper
     ];
 

--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -23,18 +23,6 @@ let
     sha256 = "K1cAvmqWEfS6EY4MKAtjXb388XLYHtouxNM70PWgFig=";
   };
 
-  workaround-opencollective-buildfailures = stdenv.mkDerivation {
-    # FIXME: This should be removed when a complete fix is available
-    # https://github.com/svanderburg/node2nix/issues/145
-    name = "workaround-opencollective-buildfailures";
-    dontUnpack = true;
-    installPhase = ''
-      mkdir -p $out/bin
-      touch $out/bin/opencollective-postinstall
-      chmod +x $out/bin/opencollective-postinstall
-    '';
-  };
-
   client = nodePackages.epgstation-client.override (drv: {
     # FIXME: remove this option if possible
     #
@@ -49,21 +37,14 @@ let
   server = nodePackages.epgstation.override (drv: {
     inherit src;
 
-    bypassCache = false;
-
     # This is set to false to keep devDependencies at build time. Build time
     # dependencies are pruned afterwards.
     production = false;
 
     buildInputs = [ bash ];
-    nativeBuildInputs = [
-      nodejs
-      workaround-opencollective-buildfailures
+    nativeBuildInputs = drv.nativeBuildInputs ++ [
       makeWrapper
-    ] ++ (with nodePackages; [
-      node-pre-gyp
-      node-gyp-build
-    ]);
+    ];
 
     preRebuild = ''
       # Fix for not being able to connect to mysql using domain sockets.

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -119,6 +119,7 @@ let
     # NOTE: this is a stub package to fetch npm dependencies for
     # ../../applications/video/epgstation
     epgstation = super."epgstation-../../applications/video/epgstation".override (drv: {
+      nativeBuildInputs = [ self.node-pre-gyp self.node-gyp-build ];
       meta = drv.meta // {
         platforms = pkgs.lib.platforms.none;
       };

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -119,7 +119,7 @@ let
     # NOTE: this is a stub package to fetch npm dependencies for
     # ../../applications/video/epgstation
     epgstation = super."epgstation-../../applications/video/epgstation".override (drv: {
-      nativeBuildInputs = [ self.node-pre-gyp self.node-gyp-build ];
+      buildInputs = [ self.node-pre-gyp self.node-gyp-build ];
       meta = drv.meta // {
         platforms = pkgs.lib.platforms.none;
       };


### PR DESCRIPTION
###### Description of changes

ZHF: #172160

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
