### PR TITLE
semgrep: init at 0.92.0

### DIFF
--- a/pkgs/development/python-modules/semgrep/default.nix
+++ b/pkgs/development/python-modules/semgrep/default.nix
@@ -1,0 +1,76 @@
+{ lib, buildPythonPackage, fetchPypi, fetchurl, fetchzip, jsonschema
+, wcmatch, click, ruamel-yaml, click-option-group, boltons, tqdm, glom, requests
+, colorama, defusedxml, packaging, peewee, setuptools }:
+
+let
+  version = "0.92.0";
+
+  # semgrep engine is written in OCaml and sources are present in
+  # https://github.com/returntocorp/semgrep, but I failed to build it.
+  #
+  # It looks like dypgen required ocaml <= 4.06 and atdgen ocaml >= 4.08.
+  #
+  # Clearly, I don't understand something, and this can and should be done
+  # properly. In mean time, I cheat and download upstream-provided static
+  # binary. That constraints derivation to x86_64 architecture.
+  #
+  # 2022-05-12 ~kaction
+  semgrep-core = fetchzip {
+    url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}-ubuntu-16.04.tgz";
+    sha256 = "01zn4xihzgwvyadfqzk8r1ngihsx6m4m1wrfyzady8h1x11v877a";
+    stripRoot = false;
+    extraPostFetch = ''
+      mv $out/semgrep-files $out/bin
+    '';
+  };
+
+in buildPythonPackage rec {
+  pname = "semgrep";
+  inherit version;
+
+  # FIXME: This is also cheating, should fetch from github.
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nsfk7dkfl6ddqvrsrc1afhjlpj7mfcii5svljh286v6i0nf25sx";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py                \
+      --replace 'jsonschema~=' 'jsonschema>=' \
+      --replace 'boltons~=' 'boltons<='
+  '';
+
+  # Upstream insists that `semgrep-core` is present in build environment, hence
+  # it must be in nativeBuildInputs. But really it is propagated runtime
+  # dependency.
+  nativeBuildInputs = [ semgrep-core ];
+
+  propagatedBuildInputs = [
+    semgrep-core
+
+    boltons
+    click
+    click-option-group
+    colorama
+    defusedxml
+    glom
+    jsonschema
+    packaging
+    peewee
+    requests
+    ruamel-yaml
+    setuptools
+    tqdm
+    wcmatch
+  ];
+
+  pythonImportsCheck = [ "semgrep" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/returntocorp/semgrep";
+    description = "Lightweight static analysis for many languages.";
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ kaction ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16106,6 +16106,8 @@ with pkgs;
 
   selendroid = callPackage ../development/tools/selenium/selendroid { };
 
+  semgrep = with python3Packages; toPythonApplication semgrep;
+
   semver-tool = callPackage ../development/tools/misc/semver-tool { };
 
   semantik = libsForQt5.callPackage ../applications/office/semantik { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9368,6 +9368,8 @@ in {
 
   semantic-version = callPackage ../development/python-modules/semantic-version { };
 
+  semgrep = callPackage ../development/python-modules/semgrep { };
+
   semver = callPackage ../development/python-modules/semver { };
 
   send2trash = callPackage ../development/python-modules/send2trash { };


### PR DESCRIPTION
- Built on platform(s)
  - [x] x86_64-linux
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

RFC. This is nice tool (although not supporting Nix language), and I would like to have it in Nixpkgs.

Packaging quality is, hm, not Debian level, but the only two distributions that package it at all -- Arch (AUR) and Gentoo, also use upstream binaries.