### PR TITLE
restic-rest-server: Fix tests on Darwin

### DIFF
--- a/pkgs/tools/backup/restic/rest-server.nix
+++ b/pkgs/tools/backup/restic/rest-server.nix
@@ -1,22 +1,27 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch }:
 
 buildGoModule rec {
   pname = "restic-rest-server";
   version = "0.11.0";
+  owner = "restic";
+  repo = "rest-server";
 
   src = fetchFromGitHub {
-    owner = "restic";
-    repo = "rest-server";
+    inherit owner repo;
     rev = "v${version}";
     hash = "sha256-ninPODztNzvB2js9cuNAuExQLK/OGOu80ZNW0BPrdds=";
   };
 
   vendorSha256 = "sha256-8x5qYvIX/C5BaewrTNVbIIadL+7XegbRUZiEDWmJM+c=";
 
-  preCheck = ''
-    substituteInPlace cmd/rest-server/main_test.go \
-      --replace "/tmp/restic" "/build/restic"
-  '';
+  patches = [
+    (fetchpatch {
+      name = "backport_rest-server_tests_os.TempDir.patch";
+      url = "https://github.com/${owner}/${repo}/commit/a87a50ad114bdaddc895413396438df6ea0affbb.patch";
+      sha256 = "sha256-O6ENxTK2fCVTZZKTFHrvZ+3dT8TbgbIE0o3sYE/RUqc=";
+    })
+
+  ];
 
   meta = with lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
Backport unit test changes from project's master branch to replace
hardcoded `/tmp` with `os.TempDir()` calls in Go.

It can now handle `/private/tmp/nix-build-{pname}-{version}.drv-0` paths
on Darwin.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

ZHF: #172160 @NixOS/nixos-release-managers 