### PR TITLE
clamav: 0.103.5 -> 0.103.6

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "clamav";
-  version = "0.103.5";
+  version = "0.103.6";
 
   src = fetchurl {
     url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
-    sha256 = "sha256-HnSx4dKoqQVkScMT9Ippg7nVug1vte8LK+atPIQaVCY=";
+    sha256 = "sha256-qqEuPcGfHTI7HFDXoQ+or1V+Q5AUnoZNWb3jm2rZujM=";
   };
 
   # don't install sample config files into the absolute sysconfdir folder


### PR DESCRIPTION
Fixes a number of vulnerabilities.

https://github.com/Cisco-Talos/clamav/blob/rel/0.103/NEWS.md#01036
https://mmmds.pl/clamav/

Fixes: CVE-2022-20803, CVE-2022-20770, CVE-2022-20796, CVE-2022-20771,
       CVE-2022-20785, CVE-2022-20792

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
