### PR TITLE
vscode-extensions.matklad.rust-analyzer: 0.2.975 - > 0.2.1048

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
@@ -1,19 +1,19 @@
 {
   "name": "rust-analyzer",
-  "version": "0.2.975",
+  "version": "0.2.1048",
   "dependencies": {
-    "vscode-languageclient": "8.0.0-next.8",
+    "vscode-languageclient": "8.0.0-next.14",
     "d3": "^7.3.0",
-    "d3-graphviz": "^4.0.0",
+    "d3-graphviz": "^4.1.0",
     "@types/node": "~14.17.5",
-    "@types/vscode": "~1.63.0",
-    "@typescript-eslint/eslint-plugin": "^5.10.0",
-    "@typescript-eslint/parser": "^5.10.0",
-    "@vscode/test-electron": "^2.1.1",
-    "eslint": "^8.7.0",
+    "@types/vscode": "~1.66.0",
+    "@typescript-eslint/eslint-plugin": "^5.16.0",
+    "@typescript-eslint/parser": "^5.16.0",
+    "@vscode/test-electron": "^2.1.3",
+    "eslint": "^8.11.0",
     "tslib": "^2.3.0",
-    "typescript": "^4.5.5",
+    "typescript": "^4.6.3",
     "typescript-formatter": "^7.2.2",
-    "vsce": "^2.6.7"
+    "vsce": "^2.7.0"
   }
 }

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 nixpkgs=../../../../../../
 node_packages="$nixpkgs/pkgs/development/node-packages"
-owner=rust-analyzer
+owner=rust-lang
 repo=rust-analyzer
 ver=$(
     curl -s "https://api.github.com/repos/$owner/$repo/releases" |
@@ -22,7 +22,7 @@ if [[ "$(nix-instantiate --eval --strict -E "(builtins.compareVersions \"$req_vs
     exit 1
 fi
 
-extension_ver=$(curl "https://github.com/rust-analyzer/rust-analyzer/releases/download/$ver/rust-analyzer-linux-x64.vsix" -L |
+extension_ver=$(curl "https://github.com/$owner/$repo/releases/download/$ver/rust-analyzer-linux-x64.vsix" -L |
     bsdtar -xf - --to-stdout extension/package.json | # Use bsdtar to extract vsix(zip).
     jq --raw-output '.version')
 echo "Extension version: $extension_ver"


### PR DESCRIPTION
###### Description of changes

1. Update `vscode-extensions.matklad.rust-analyzer` to version 0.2.1048
2. Fix script responsible for updating rust-analyzer vscode-extension to the latest version (the project github repository has changes ownership and curl requested was failing)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
