### PR TITLE
Update tageditor

### DIFF
--- a/pkgs/applications/audio/tageditor/default.nix
+++ b/pkgs/applications/audio/tageditor/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tageditor";
-  version = "3.3.10";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "martchus";
     repo = "tageditor";
     rev = "v${version}";
-    sha256 = "16cmq7dyalcwc8gx1y9acngw5imjh8ydp4prxy7qpzk4fj3kpsak";
+    sha256 = "08and6gfmj4i96ls2g1b9llsb100mw3i37qzgpr76ywkkqnq0r2n";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/tagparser/default.nix
+++ b/pkgs/development/libraries/tagparser/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tagparser";
-  version = "9.4.0";
+  version = "11.2.0";
 
   src = fetchFromGitHub {
     owner = "Martchus";
     repo = "tagparser";
     rev = "v${version}";
-    sha256 = "097dq9di19d3mvnlrav3fm78gzjni5babswyv10xnrxfhnf14f6x";
+    sha256 = "08and6gfmj4i96ls2g1b9llsb100mw3i37qzgpr76ywkkqnq0r2n";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Description of changes

After the update, `tageditor` does not build anymore because it does not find `qtutilities` anymore. I don't see why this is, maybe someone else can have a look?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

