### PR TITLE
tree-sitter: Bump grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ram02z/tree-sitter-fish",
-  "rev": "d482d70ea8e191c05b2c1b613ed6fdff30a14da0",
-  "date": "2022-03-14T15:15:13+00:00",
-  "path": "/nix/store/5ajcf2hl1hph7iky6lwp5vh7a49k587s-tree-sitter-fish",
-  "sha256": "0idnm9lrvj1jhrvrgcddppkc09hr7inciz6k02d0nnxv8pqaw3w6",
+  "rev": "8a3571fc4a702b216ff918a08c9c5895df7ea06c",
+  "date": "2022-05-12T18:32:55+01:00",
+  "path": "/nix/store/vyfppzpljszmwwrk1gdg132c4nswy048-tree-sitter-fish",
+  "sha256": "1svca1agsr29ypn6pz44lwxg4b6a1k5qsm983czk3h16z5igka05",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8",
-  "date": "2022-04-21T11:20:07-07:00",
-  "path": "/nix/store/5f0z08shhb8d03ab4zlaq9ss4dim6k9f-tree-sitter-json",
-  "sha256": "1amiaiizd4mvmnbwqbr8lmisi9831di8r8xck9wyi5sfj3nd8hai",
+  "rev": "67d33d619e4fb729432a6d9aff1f7b08bb563728",
+  "date": "2022-05-12T23:07:45-07:00",
+  "path": "/nix/store/k42yw134pyyxwf5zca5ycagsnin7k967-tree-sitter-json",
+  "sha256": "1rbrb87gsy2l27vn0zmncrqpjnsp6k6yd2b0gwhl0l4flqas7qb4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "6d6aaa50793b8265b6a8b6628577a0083d3b923d",
-  "date": "2021-11-29T00:27:21-06:00",
-  "path": "/nix/store/6cjadxvqbrh205lsqnk2rnzq3badxdxv-tree-sitter-nix",
-  "sha256": "0cbk6dqppasrvnm87pwfgm718z6b0xmy9m7zj8ysil0h8bklz1w9",
+  "rev": "470b15a60520ff7b86f51732b8d8f1118c86041e",
+  "date": "2022-03-18T01:42:08-05:00",
+  "path": "/nix/store/c5y76kz7wmfq05hfw4xpqz2ahcdy924f-tree-sitter-nix",
+  "sha256": "1hl0mpy0i6r160v6v3nflrdi5fnmd8i5zbx963h5nj9fg4srkb5r",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "aee42e302f36045cdc671223ce10a069203fd604",
-  "date": "2022-04-21T11:07:14+08:00",
-  "path": "/nix/store/jviqv18g5yszjcqmv48rpml6z4q4ccv8-tree-sitter-scheme",
-  "sha256": "1piw1g5w29jxhwrvivpmdkyr2vbi8fpj2idzk8bwvplzbb6hfr7x",
+  "rev": "27fb77db05f890c2823b4bd751c6420378df146b",
+  "date": "2022-05-12T23:43:19+08:00",
+  "path": "/nix/store/8h41l86z17msbbdsqrdr45lcys6r9a83-tree-sitter-scheme",
+  "sha256": "15ziav4gas038442yl8f4yz3a2r7grccwyfcyydxw0xpsjnsn5c2",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
