### PR TITLE
clamav: 0.103.5 -> 0.105.0

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "clamav";
-  version = "0.103.5";
+  version = "0.103.6";
 
   src = fetchurl {
     url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
-    sha256 = "sha256-HnSx4dKoqQVkScMT9Ippg7nVug1vte8LK+atPIQaVCY=";
+    sha256 = "sha256-qqEuPcGfHTI7HFDXoQ+or1V+Q5AUnoZNWb3jm2rZujM=";
   };
 
   # don't install sample config files into the absolute sysconfdir folder

--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,52 +1,32 @@
-{ lib, stdenv, fetchurl, pkg-config
+{ lib, stdenv, fetchurl, pkg-config, cmake
 , zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl, libmilter, pcre2
 , libmspack, systemd, Foundation, json_c, check
+, rustc, rust-bindgen, rustfmt, cargo, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "clamav";
-  version = "0.103.6";
+  version = "0.105.0";
 
   src = fetchurl {
     url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
-    sha256 = "sha256-qqEuPcGfHTI7HFDXoQ+or1V+Q5AUnoZNWb3jm2rZujM=";
+    sha256 = "sha256-JwIDpUxFgEnbVPzZNoP/Wy2xkVHzY8SOgs7O/d4rNdQ=";
   };
 
-  # don't install sample config files into the absolute sysconfdir folder
-  postPatch = ''
-    substituteInPlace Makefile.in --replace ' etc ' ' '
-  '';
+  # Flaky test, remove this when https://github.com/Cisco-Talos/clamav/issues/343 is fixed
+  patches = [ ./remove-freshclam-test.patch ];
 
   enableParallelBuilding = true;
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config rustc rust-bindgen rustfmt cargo python3 ];
   buildInputs = [
     zlib bzip2 libxml2 openssl ncurses curl libiconv libmilter pcre2 libmspack json_c check
   ] ++ lib.optional stdenv.isLinux systemd
     ++ lib.optional stdenv.isDarwin Foundation;
 
-  configureFlags = [
-    "--libdir=$(out)/lib"
-    "--sysconfdir=/etc/clamav"
-    "--disable-llvm" # enabling breaks the build at the moment
-    "--with-zlib=${zlib.dev}"
-    "--with-xml=${libxml2.dev}"
-    "--with-openssl=${openssl.dev}"
-    "--with-libcurl=${curl.dev}"
-    "--with-libjson=${json_c.dev}"
-    "--with-system-libmspack"
-    "--enable-milter"
-    "--disable-unrar" # disable unrar because it's non-free and requires some extra patching to work properly
-    "--enable-check"
-  ] ++ lib.optional stdenv.isLinux
-    "--with-systemdsystemunitdir=$(out)/lib/systemd";
+  cmakeFlags = [
+    "-DSYSTEMD_UNIT_DIR=${placeholder "out"}/lib/systemd"
+  ];
 
-  postInstall = ''
-    mkdir $out/etc
-    cp etc/*.sample $out/etc
-  '';
-
-  # Only required for the unit tests
-  hardeningDisable = [ "format" ];
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/tools/security/clamav/remove-freshclam-test.patch
+++ b/pkgs/tools/security/clamav/remove-freshclam-test.patch
@@ -1,0 +1,20 @@
+diff --git a/unit_tests/CMakeLists.txt b/unit_tests/CMakeLists.txt
+index 1460357ba..1194abc9d 100644
+--- a/unit_tests/CMakeLists.txt
++++ b/unit_tests/CMakeLists.txt
+@@ -371,15 +371,6 @@ if(ENABLE_APP)
+         set_property(TEST clamd_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
+     endif()
+ 
+-    add_test(NAME freshclam COMMAND ${PythonTest_COMMAND};freshclam_test.py
+-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+-    set_property(TEST freshclam PROPERTY ENVIRONMENT ${ENVIRONMENT})
+-    if(Valgrind_FOUND)
+-        add_test(NAME freshclam_valgrind COMMAND ${PythonTest_COMMAND};freshclam_test.py
+-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+-        set_property(TEST freshclam_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
+-    endif()
+-
+     add_test(NAME sigtool COMMAND ${PythonTest_COMMAND};sigtool_test.py
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+     set_property(TEST sigtool PROPERTY ENVIRONMENT ${ENVIRONMENT})


### PR DESCRIPTION
###### Description of changes

This goes beyond #172835 to update clamav past the [build system change](https://github.com/Cisco-Talos/clamav/blob/rel/0.105/NEWS.md#new-requirements). Benefits include a smaller expression and the full manual being installed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).