### PR TITLE
rr-unstable: unstable-2021-07-06 -> unstable-2022-05-12

### DIFF
--- a/pkgs/development/tools/analysis/rr/unstable.nix
+++ b/pkgs/development/tools/analysis/rr/unstable.nix
@@ -11,12 +11,12 @@ let
 in
 
   rr.overrideAttrs (old: {
-    version = "unstable-2021-07-06";
+    version = "unstable-2022-05-12";
 
     src = fetchFromGitHub {
       owner = "mozilla";
       repo = "rr";
-      rev = "0fc21a8d654dabc7fb1991d76343824cb7951ea0";
-      sha256 = "0s851rflxmvxcfw97zmplcwzhv86xmd3my78pi4c7gkj18d621i5";
+      rev = "c96cb688106634ad09af6214aa91252c3a4f74b1";
+      sha256 = "sha256-K4cEQnvBXr/j9qXCgIHLqMrRzm96ushTO5STivRj+Mk=";
     };
   })


### PR DESCRIPTION
###### Description of changes

Bumped `rr-unstable` to the latest commit in order to fix the build.

ZHF: https://github.com/NixOS/nixpkgs/issues/172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>rr-unstable</li>
  </ul>
</details>

@NixOS/nixos-release-managers