### PR TITLE
ocamlPackages.reperf: add printbox-text to propagatedBuildInputs

### DIFF
--- a/pkgs/development/ocaml-modules/reperf/default.nix
+++ b/pkgs/development/ocaml-modules/reperf/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ reason ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     printbox-text
   ];
 


### PR DESCRIPTION
ocamlPackages.reperf: add printbox-text to propagatedBuildInputs

Fixing propagatedBuildInputs (as advised at https://github.com/NixOS/nixpkgs/pull/172716#issuecomment-1125723550)
```
$ cat result/lib/ocaml/4.13.1/site-lib/reperf/META 
package "lib" (
  directory = "lib"
  version = "dev"
  description = ""
  requires = "printbox-text unix"
  archive(byte) = "reperf.cma"
  archive(native) = "reperf.cmxa"
  plugin(byte) = "reperf.cma"
  plugin(native) = "reperf.cmxs"
```