### PR TITLE
openmolcas: 21.10 -> 22.02

### DIFF
--- a/pkgs/applications/science/chemistry/openmolcas/MKL-MPICH.patch
+++ b/pkgs/applications/science/chemistry/openmolcas/MKL-MPICH.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 276ae4e..5e56176 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1304,9 +1304,9 @@ if (LINALG STREQUAL "MKL")
+       endif ()
+     else ()
+       if (ADDRMODE EQUAL 64)
+-        set (libpath "${MKLROOT}/lib/intel64")
++        set (libpath "${MKLROOT}/lib")
+       elseif (ADDRMODE EQUAL 32)
+-        set (libpath "${MKLROOT}/lib/ia32")
++        set (libpath "${MKLROOT}/lib")
+       endif ()
+     endif ()
+     set (MKL_LIBRARY_PATH ${libpath} CACHE PATH "location of MKL libraries." FORCE)
+@@ -1380,7 +1380,7 @@ if (LINALG STREQUAL "MKL")
+     find_library (LIBMKL_BLACS NAMES "mkl_blacs_intelmpi_ilp64"
+                   PATHS ${MKL_LIBRARY_PATH} NO_DEFAULT_PATH)
+   elseif (MPI_IMPLEMENTATION STREQUAL "mpich")
+-    find_library (LIBMKL_BLACS NAMES "mkl_blacs_ilp64"
++    find_library (LIBMKL_BLACS NAMES "mkl_blacs_intelmpi_ilp64"
+                   PATHS ${MKL_LIBRARY_PATH} NO_DEFAULT_PATH)
+   endif ()


### PR DESCRIPTION
###### Description of changes
Update and unbreak build (ZHF: https://github.com/NixOS/nixpkgs/issues/172160)
* make MPI optional instead of default
* allow optional MKL build/switch wrapped BLAS interface

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

