### PR TITLE
python3Packages.cirq*: 0.13.1 -> 0.14.1, fix build

### DIFF
--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -30,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "cirq-core";
-  version = "0.13.1";
+  version = "0.14.1";
 
   disabled = pythonOlder "3.6";
 
@@ -38,32 +38,17 @@ buildPythonPackage rec {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    sha256 = "sha256-MVfJ8iEeW8gFvCNTqrWfYpNNYuDAufHgcjd7Nh3qp8U=";
+    sha256 = "sha256-cIDwV3IBXrTJ4jC1/HYmduY3tLe/f6wj8CWZ4cnThG8=";
   };
 
   sourceRoot = "source/${pname}";
-
-  patches = [
-    # present in upstream master - remove after 0.13.1
-    (fetchpatch {
-      name = "fix-test-tolerances.part-1.patch";
-      url = "https://github.com/quantumlib/Cirq/commit/eb1d9031e55d3c8801ea44abbb6a4132b2fc5126.patch";
-      sha256 = "0ka24v6dfxnap9p07ni32z9zccbmw0lbrp5mcknmpsl12hza98xm";
-      stripLen = 1;
-    })
-    (fetchpatch {
-      name = "fix-test-tolerances.part-2.patch";
-      url = "https://github.com/quantumlib/Cirq/commit/a28d601b2bcfc393336375c53e5915fd16455395.patch";
-      sha256 = "0k2dqsm4ydn6556d40kc8j04jgjn59z4wqqg1jn1r916a7yxw493";
-      stripLen = 1;
-    })
-  ];
 
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace "matplotlib~=3.0" "matplotlib" \
       --replace "networkx~=2.4" "networkx" \
-      --replace "numpy~=1.16" "numpy"
+      --replace "numpy~=1.16" "numpy" \
+      --replace "sympy<1.10" "sympy"
   '';
 
   propagatedBuildInputs = [
@@ -93,9 +78,9 @@ buildPythonPackage rec {
     freezegun
   ];
 
-  pytestFlagsArray = lib.optionals (!withContribRequires) [
+  disabledTestPaths = lib.optionals (!withContribRequires) [
     # requires external (unpackaged) libraries, so untested.
-    "--ignore=cirq/contrib/"
+    "cirq/contrib/"
   ];
   disabledTests = [
     "test_metadata_search_path" # tries to import flynt, which isn't in Nixpkgs

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -1,4 +1,5 @@
 { buildPythonPackage
+, fetchpatch
 , cirq-aqt
 , cirq-core
 , cirq-google
@@ -13,6 +14,14 @@
 buildPythonPackage rec {
   pname = "cirq";
   inherit (cirq-core) version src meta;
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/quantumlib/Cirq/commit/b832db606e5f1850b1eda168a6d4a8e77d8ec711.patch";
+      name = "pr-5330-prevent-implicit-packages.patch";
+      sha256 = "sha256-HTEH3fFxPiBedaz5GxZjXayvoiazwHysKZIOzqwZmbg=";
+    })
+  ];
 
   propagatedBuildInputs = [
     cirq-aqt


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
﻿- python3Packages.cirq-core: 0.13.1 -> 0.14.1
- python3Packages.cirq: fix build

Release notes:
* https://github.com/quantumlib/Cirq/releases/tag/v0.14.0
* https://github.com/quantumlib/Cirq/releases/tag/v0.14.1

ZHF: #172160 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
