### PR TITLE
singular: fix darwin docbuilding

### DIFF
--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
+  patches = [ ./parallel-docbuild.patch ];
+
   # For reference (last checked on commit 75f460d):
   # https://github.com/Singular/Singular/blob/spielwiese/doc/Building-Singular-from-source.md
   # https://github.com/Singular/Singular/blob/spielwiese/doc/external-packages-dynamic-modules.md

--- a/pkgs/applications/science/math/singular/parallel-docbuild.patch
+++ b/pkgs/applications/science/math/singular/parallel-docbuild.patch
@@ -1,0 +1,23 @@
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 626017bf9..91e525c12 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -177,15 +177,15 @@ clean-local:
+ 	/bin/rm -f plural.tex letterplace.tex plulibs.tex sca.tex pyobject.tex
+ 
+ all-local:
+-	$(MAKE) -j1 -f Makefile-docbuild all
++	$(MAKE) -f Makefile-docbuild all
+ 
+ singular.info:
+-	$(MAKE) -j1 -f Makefile-docbuild $@
++	$(MAKE) -f Makefile-docbuild $@
+ 
+ if ENABLE_DOC_BUILD
+ EXTRA_DIST += doc.tbz2
+ doc.tbz2:
+-	$(MAKE) -j1 -f Makefile-docbuild singular.info html
++	$(MAKE) -f Makefile-docbuild singular.info html
+ 	chmod -R a+rX singular.info html
+ 	$(AMTAR) jcf $@ singular.info html
+ dist-hook:


### PR DESCRIPTION
###### Description of changes

Another attempt at fixing Darwin builds (see #172580). Let's see if ofBorg likes this one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
