### PR TITLE
prometheus: fix build when all service discovery plugins are disabled

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -55,6 +55,7 @@ buildGoModule rec {
 
     # Enable only select service discovery to shrink binaries.
     (
+      true  # prevent bash syntax error when all plugins are disabled
     ${lib.optionalString (enableAWS)
       "echo - github.com/prometheus/prometheus/discovery/aws"}
     ${lib.optionalString (enableAzure)


### PR DESCRIPTION
Since c6fae8bb0e343c067643f49feb5994102b615597, when all discovery
plugins are disabled, the postPatch phase contains shell code like

> ( ) > plugins.yml

which is invalid syntax. So make sure there's always at least
one statement for the subshell, giving the expected empty file.