### PR TITLE
nodePackages: add aws-cdk

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -32,6 +32,7 @@
 , "audiosprite"
 , "autoprefixer"
 , "aws-azure-login"
+, "aws-cdk"
 , "awesome-lint"
 , "balanceofsatoshis"
 , "bash-language-server"


### PR DESCRIPTION
###### Description of changes

Add [aws-cdk](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) to nodePackages, rerun generate.sh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

nixpkgs-review fails with 
```
$ nix-env --option system aarch64-darwin -f /Users/jon/.cache/nixpkgs-review/rev-14ab5c66d65b67d2f1b7f14dc47d3f65fe62f592/nixpkgs -qaP --xml --out-path --show-trace --meta
$ git worktree prune
Traceback (most recent call last):
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/bin/.nixpkgs-review-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/__init__.py", line 10, in main
    cli.main(command, args)
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/cli/__init__.py", line 262, in main
    return cast(str, args.func(args))
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/cli/rev.py", line 12, in rev_command
    return review_local_revision(f"rev-{commit}", args, commit)
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/review.py", line 472, in review_local_revision
    review.review_commit(builddir.path, args.branch, commit, staged)
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/review.py", line 260, in review_commit
    self.start_review(self.build_commit(branch_rev, reviewed_commit, staged), path)
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/review.py", line 167, in build_commit
    merged_packages = list_packages(
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/review.py", line 330, in list_packages
    return parse_packages_xml(f)
  File "/nix/store/8rn6p8s4nygvx0nl99akz9l7532zfm4v-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/review.py", line 297, in parse_packages_xml
    values = (e.attrib["value"] for e in elem.getchildren())
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
```

but that doesn't seem to be specific to this change