### PR TITLE
octave: add patch for octave incorrectly failing on package builds

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -119,6 +119,11 @@ let
       sha256 = "sha256-1KnYHz9ntKbgfLeoDcsQrV6RdvzDB2LHCoFYCmS4sLY=";
     };
 
+    patches = [
+      # https://savannah.gnu.org/bugs/?func=detailitem&item_id=62436
+      ./patches/bug62436.patch
+    ];
+
     buildInputs = [
       readline
       ncurses

--- a/pkgs/development/interpreters/octave/patches/bug62436.patch
+++ b/pkgs/development/interpreters/octave/patches/bug62436.patch
@@ -1,0 +1,27 @@
+# HG changeset patch
+# User John Donoghue <john.donoghue@ieee.org>
+# Date 1652358904 14400
+#      Thu May 12 08:35:04 2022 -0400
+# Branch stable
+# Node ID 8c940cfcce257369677c09154da2aab2c56eaa79
+# Parent  63710f3bd9811c2d206ac9e7b4f47cf06c47e153
+* scripts/pkg/private/build.m: check configure and Makefile exist before trying to unlink them (Bug #62436)
+
+diff -r 63710f3bd981 -r 8c940cfcce25 scripts/pkg/private/build.m
+--- a/scripts/pkg/private/build.m	Wed May 11 09:44:55 2022 -0700
++++ b/scripts/pkg/private/build.m	Thu May 12 08:35:04 2022 -0400
+@@ -77,8 +77,12 @@
+     else
+       arch_abi = getarch ();
+       configure_make (desc, build_root, verbose);
+-      unlink (fullfile (build_root, "src", "configure"));
+-      unlink (fullfile (build_root, "src", "Makefile"));
++      if exist (fullfile (build_root, "src", "configure"), "file")
++        unlink (fullfile (build_root, "src", "configure"));
++      endif
++      if exist (fullfile (build_root, "src", "Makefile"), "file")
++        unlink (fullfile (build_root, "src", "Makefile"));
++      endif
+     endif
+     tar_name = [desc.name "-" desc.version "-" arch_abi ".tar"];
+     tar_path = fullfile (builddir, tar_name);


### PR DESCRIPTION
Patch comes from https://savannah.gnu.org/bugs/?func=detailitem&item_id=62436

###### Description of changes
Add a patch file which changes the package build script included with Octave.
There was an undocumented regression in the way the `unlink` function built into Octave worked, causing issues.
https://savannah.gnu.org/bugs/?func=detailitem&item_id=62436

Resolves #168943.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
