### PR TITLE
fx: 22.0.10 → 24.0.0

### DIFF
--- a/pkgs/development/tools/fx/default.nix
+++ b/pkgs/development/tools/fx/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "fx";
-  version = "22.0.10";
+  version = "24.0.0";
 
   src = fetchFromGitHub {
     owner = "antonmedv";
     repo = pname;
     rev = version;
-    sha256 = "sha256-BoWb27sRqcYHSLhUvjRIRIkcj90FitpbrH2R3VHsRyI=";
+    sha256 = "sha256-Sg+mluDOGpkEUl+3BoItuPnMqs8F6o+D5xIqF0w0EIU=";
   };
 
-  vendorSha256 = "sha256-ZDPRKrum2tnhscZxLzslezYs/hOOtHwAORrAWoQhXbs=";
+  vendorSha256 = "sha256-4hx1AZQQ4xHBTzBK0OmrTUGMK4Rfu36cmopVV4SOjCQ=";
 
   meta = with lib; {
     description = "Terminal JSON viewer";


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/antonmedv/fx/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).