### PR TITLE
blackmagic: unstable-2020-08-05 -> unstable-2022-04-16

### DIFF
--- a/pkgs/development/embedded/blackmagic/default.nix
+++ b/pkgs/development/embedded/blackmagic/default.nix
@@ -1,40 +1,37 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch
-, gcc-arm-embedded, libftdi1, libusb-compat-0_1, pkg-config
+{ stdenv, lib
+, fetchFromGitHub
+, gcc-arm-embedded
+, pkg-config
 , python3
+, hidapi
+, libftdi1
+, libusb1
 }:
-
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "blackmagic";
-  version = "unstable-2020-08-05";
+  version = "unstable-2022-04-16";
   # `git describe --always`
-  firmwareVersion = "v1.6.1-539-gdd74ec8";
+  firmwareVersion = "v1.7.1-415-gc4869a5";
 
   src = fetchFromGitHub {
     owner = "blacksphere";
     repo = "blackmagic";
-    rev = "dd74ec8e6f734302daa1ee361af88dfb5043f166";
-    sha256 = "18w8y64fs7wfdypa4vm3migk5w095z8nbd8qp795f322mf2bz281";
+    rev = "c4869a54733ae92099a7316954e34d1ab7b6097c";
+    hash = "sha256-0MC1v/5u/txSshxkOI5TErMRRrYCcHly3qbVTAk9Vc0=";
     fetchSubmodules = true;
   };
 
-  patches = [
-    # Fix deprecation warning with libftdi 1.5
-    (fetchpatch {
-      url = "https://github.com/blacksphere/blackmagic/commit/dea4be2539c5ea63836ec78dca08b52fa8b26ab5.patch";
-      sha256 = "0f81simij1wdhifsxaavalc6yxzagfbgwry969dbjmxqzvrsrds5";
-    })
-  ];
-
   nativeBuildInputs = [
-    gcc-arm-embedded pkg-config
+    gcc-arm-embedded
+    pkg-config
     python3
   ];
 
   buildInputs = [
+    hidapi
     libftdi1
-    libusb-compat-0_1
+    libusb1
   ];
 
   strictDeps = true;
@@ -50,12 +47,17 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  buildPhase = "${stdenv.shell} ${./helper.sh}";
+  buildPhase = ''
+    runHook preBuild
+    ${stdenv.shell} ${./helper.sh}
+    runHook postBuild
+  '';
+
   dontInstall = true;
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "In-application debugger for ARM Cortex microcontrollers";
     longDescription = ''
       The Black Magic Probe is a modern, in-application debugging tool


### PR DESCRIPTION
###### Description of changes
ZHF: #172160 
cc @NixOS/nixos-release-managers 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
