### PR TITLE
 proxychains{,-ng}: install default config 

### DIFF
--- a/pkgs/tools/networking/proxychains-ng/default.nix
+++ b/pkgs/tools/networking/proxychains-ng/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -13,6 +14,18 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-uu/zN6W0ue526/3a9QeYg6J4HLaovZJVOYXksjouYok=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/rofl0r/proxychains-ng/commit/04023d3811d8ee34b498b429bac7a871045de59c.patch";
+      sha256 = "sha256-Xcg2kmAhj/OJn/RKJAxb9MOJNJQY7FXmxEIzQ5dvabo=";
+    })
+  ];
+
+  installFlags = [
+    "install-config"
+    "install-zsh-completion"
+  ];
 
   meta = with lib; {
     description = "A preloader which hooks calls to sockets in dynamically linked programs and redirects it through one or more socks/http proxies";

--- a/pkgs/tools/networking/proxychains-ng/default.nix
+++ b/pkgs/tools/networking/proxychains-ng/default.nix
@@ -16,16 +16,26 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # zsh completion
     (fetchpatch {
       url = "https://github.com/rofl0r/proxychains-ng/commit/04023d3811d8ee34b498b429bac7a871045de59c.patch";
       sha256 = "sha256-Xcg2kmAhj/OJn/RKJAxb9MOJNJQY7FXmxEIzQ5dvabo=";
+    })
+    (fetchpatch {
+      url = "https://github.com/rofl0r/proxychains-ng/commit/9b42da71f4df7b783cf07a58ffa095e293c43380.patch";
+      sha256 = "sha256-tYv9XP51WtsjaoklwQk3D/MQceoOvtdMwBraECt6AXQ=";
     })
   ];
 
   installFlags = [
     "install-config"
-    "install-zsh-completion"
+    # TODO: check on next update if that works and remove postInstall
+    # "install-zsh-completion"
   ];
+
+  postInstall = ''
+    ./tools/install.sh -D -m 644 completions/_proxychains $out/share/zsh/site_functions/_proxychains4
+  '';
 
   meta = with lib; {
     description = "A preloader which hooks calls to sockets in dynamically linked programs and redirects it through one or more socks/http proxies";

--- a/pkgs/tools/networking/proxychains/default.nix
+++ b/pkgs/tools/networking/proxychains/default.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace "-Werror" "-Werror -Wno-stringop-truncation"
   '';
 
+  installFlags = [
+    "install-config"
+  ];
+
   meta = with lib; {
     description = "Proxifier for SOCKS proxies";
     homepage = "http://proxychains.sourceforge.net";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
