### PR TITLE
byzanz: 0.2.3.alpha -> unstable-2016-03-12

### DIFF
--- a/pkgs/applications/video/byzanz/default.nix
+++ b/pkgs/applications/video/byzanz/default.nix
@@ -1,13 +1,26 @@
-{ lib, stdenv, fetchgit, wrapGAppsHook, which, gnome, glib, intltool, pkg-config, libtool, cairo, gtk3, gst_all_1, xorg }:
+{ lib, stdenv
+, fetchgit
+, wrapGAppsHook
+, cairo
+, glib
+, gnome
+, gst_all_1
+, gtk3
+, intltool
+, libtool
+, pkg-config
+, which
+, xorg
+}:
 
 stdenv.mkDerivation {
-  version = "0.2.3.alpha";
   pname = "byzanz";
+  version = "unstable-2016-03-12";
 
   src = fetchgit {
     url = "https://gitlab.gnome.org/Archive/byzanz";
-    rev = "1875a7f6a3903b83f6b1d666965800f47db9286a";
-    sha256 = "0a72fw2mxl8vdcdnzy0bwis4jk28pd7nc8qgr4vhyw5pd48dynvh";
+    rev = "81235d235d12c9687897f7fc6ec0de1feaed6623";
+    hash = "sha256-3DUwXCPBAmeCRlDkiPUgwNyBa6bCvC/TLguMCK3bo4E=";
   };
 
   patches = [ ./add-amflags.patch ];
@@ -16,11 +29,31 @@ stdenv.mkDerivation {
     ./autogen.sh --prefix=$out
   '';
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  NIX_CFLAGS_COMPILE = builtins.concatStringsSep " " [
+    "-Wno-error=deprecated-declarations"
+    "-Wno-error=incompatible-pointer-types"
+  ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ which gnome.gnome-common glib intltool libtool cairo gtk3 xorg.xwininfo xorg.libXdamage ]
-  ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-bad gst-plugins-good gst-plugins-ugly gst-libav wrapGAppsHook ]);
+  buildInputs = [
+    which
+    gnome.gnome-common
+    glib
+    intltool
+    libtool
+    cairo
+    gtk3
+    xorg.xwininfo
+    xorg.libXdamage
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-bad
+    gst-plugins-good
+    gst-plugins-ugly
+    gst-libav
+    wrapGAppsHook
+  ]);
 
   meta = with lib; {
     description = "Tool to record a running X desktop to an animation suitable for presentation in a web browser";


### PR DESCRIPTION
###### Description of changes
ZHF: #172160 
cc @NixOS/nixos-release-managers 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
