### PR TITLE
disk_indicator: unstable-2014-05-19 -> unstable-2018-12-18

### DIFF
--- a/pkgs/os-specific/linux/disk-indicator/default.nix
+++ b/pkgs/os-specific/linux/disk-indicator/default.nix
@@ -2,31 +2,40 @@
 
 stdenv.mkDerivation {
   pname = "disk-indicator";
-  version = "unstable-2014-05-19";
+  version = "unstable-2018-12-18";
 
   src = fetchFromGitHub {
     owner = "MeanEYE";
     repo = "Disk-Indicator";
-    rev = "51ef4afd8141b8d0659cbc7dc62189c56ae9c2da";
-    sha256 = "sha256-bRaVEe18VUmyftXzMNmGuL5gZ/dKCipuEDYrnHo1XYI=";
+    rev = "ec2d2f6833f038f07a72d15e2d52625c23e10b12";
+    sha256 = "sha256-cRqgIxF6H1WyJs5hhaAXVdWAlv6t22BZLp3p/qRlCSM=";
   };
 
   buildInputs = [ libX11 ];
 
-  patchPhase = ''
-    substituteInPlace ./makefile --replace "COMPILER=c99" "COMPILER=gcc -std=c99"
-    substituteInPlace ./makefile --replace "COMPILE_FLAGS=" "COMPILE_FLAGS=-O2 "
+  postPatch = ''
+    # avoid -Werror
+    substituteInPlace Makefile --replace "-Werror" ""
+    # avoid host-specific options
+    substituteInPlace Makefile --replace "-march=native" ""
   '';
 
-  buildPhase = "make -f makefile";
+  postConfigure = ''
+    patchShebangs ./configure.sh
+    ./configure.sh --all
+  '';
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
-
-  hardeningDisable = [ "fortify" ];
+  makeFlags = [
+    "COMPILER=${stdenv.cc.targetPrefix}cc"
+  ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/bin"
     cp ./disk_indicator "$out/bin/"
+
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
Among other things pull in fix fo r-fno-common toolchains.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
