### PR TITLE
[Backport release-21.11] minio: 2022-01-08T03-11-54Z -> 2022-05-08T23-50-31

### DIFF
--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-03-22T02-05-10Z";
+  version = "2022-05-08T23-50-31Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-N0ua+XHkLr33PElSdOzVQF3POPU+lx4/M6LJzxtkisI=";
+    sha256 = "sha256-Ssuqk/ax6MWdXtbJqWeTTtsIiTK4FmYSR5rOqxh+IaU=";
   };
 
-  vendorSha256 = "sha256-Ql3J2r489Hzhy6E9uZwQXJIw/njb5oafCYjOyWGzbXs=";
+  vendorSha256 = "sha256-JoI3B3rDzlY0lDHF3rjrzv8/Rq+XCFRs35bWVZqfAKA=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-02-24T22-12-01Z";
+  version = "2022-02-26T02-54-46Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-7bnT+rxQw2h1wCkXjsYm8ystU9F4EUL0KASkJmqLgXQ=";
+    sha256 = "sha256-+XiormhPdbQRzlqD4Y/+zcPnlIxNJnz9dU53eKYdG5Q=";
   };
 
-  vendorSha256 = "sha256-fYpnYMt6VrC2eem8XvK8oAR1B0rQ4DV6ZWo0cLNCjCs=";
+  vendorSha256 = "sha256-omX4nT85+ZT71cQXdiPJHyR+/afEbb43GqeJuxzV0mA=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-02-18T01-50-10Z";
+  version = "2022-02-24T22-12-01Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-4SUmnUrO89hRcr2w1v6qZiY3swlIZsPgmCHa+q+iFK0=";
+    sha256 = "sha256-7bnT+rxQw2h1wCkXjsYm8ystU9F4EUL0KASkJmqLgXQ=";
   };
 
-  vendorSha256 = "sha256-5OJntT5ed4pmugB1yw0fa906McREzv5aPuC8vBVx5o0=";
+  vendorSha256 = "sha256-fYpnYMt6VrC2eem8XvK8oAR1B0rQ4DV6ZWo0cLNCjCs=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-02-07T08-17-33Z";
+  version = "2022-02-12T00-51-25Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-NF6i63wLlUh/kjuCL8ScqqtZFsiJkS5P9AQM5c+j7lE=";
+    sha256 = "sha256-xAzfMyUa81gZgZhfe1XNAFJ6LFXdR2cFCba8aBDg6Rc=";
   };
 
-  vendorSha256 = "sha256-s6lhz37S3cTnXB3+ach91UqC5eeyA3eW0zUipu5i36E=";
+  vendorSha256 = "sha256-tw7SUCqQrDrET+GQbSkHaHC4usCapnH+NpILLwm6l9U=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-03-17T06-34-49Z";
+  version = "2022-03-22T02-05-10Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-iHwFkxfSLrtzSiOmfVFggBvfL0SL6ZLVJWMGK3RHZGU=";
+    sha256 = "sha256-N0ua+XHkLr33PElSdOzVQF3POPU+lx4/M6LJzxtkisI=";
   };
 
-  vendorSha256 = "sha256-ujkrbP7FuL7jdYTRaGMEYha1BJKJnpCssuO47XGMBGo=";
+  vendorSha256 = "sha256-Ql3J2r489Hzhy6E9uZwQXJIw/njb5oafCYjOyWGzbXs=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-02-26T02-54-46Z";
+  version = "2022-03-17T06-34-49Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-+XiormhPdbQRzlqD4Y/+zcPnlIxNJnz9dU53eKYdG5Q=";
+    sha256 = "sha256-iHwFkxfSLrtzSiOmfVFggBvfL0SL6ZLVJWMGK3RHZGU=";
   };
 
-  vendorSha256 = "sha256-omX4nT85+ZT71cQXdiPJHyR+/afEbb43GqeJuxzV0mA=";
+  vendorSha256 = "sha256-ujkrbP7FuL7jdYTRaGMEYha1BJKJnpCssuO47XGMBGo=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-01-08T03-11-54Z";
+  version = "2022-02-07T08-17-33Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-aOFG3/BnDJOjPiVZL1jKwYUzPX6mI9FkRDZIzTAnT+8=";
+    sha256 = "sha256-NF6i63wLlUh/kjuCL8ScqqtZFsiJkS5P9AQM5c+j7lE=";
   };
 
-  vendorSha256 = "sha256-sQoD+Kdw3epjzDmqCfw6rXC0dQCeaEpvfLqZpxKcViw=";
+  vendorSha256 = "sha256-s6lhz37S3cTnXB3+ach91UqC5eeyA3eW0zUipu5i36E=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-02-12T00-51-25Z";
+  version = "2022-02-16T00-35-27Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-xAzfMyUa81gZgZhfe1XNAFJ6LFXdR2cFCba8aBDg6Rc=";
+    sha256 = "sha256-Lh51R5CAidPmqScwzmQEGlSlv2sNJbqa+z9fsTnQb+s=";
   };
 
-  vendorSha256 = "sha256-tw7SUCqQrDrET+GQbSkHaHC4usCapnH+NpILLwm6l9U=";
+  vendorSha256 = "sha256-V8hCSpdIYQKFlHuV2GI9dt2rEhhr5q3cCSd8kEyMiDM=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2022-02-16T00-35-27Z";
+  version = "2022-02-18T01-50-10Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-Lh51R5CAidPmqScwzmQEGlSlv2sNJbqa+z9fsTnQb+s=";
+    sha256 = "sha256-4SUmnUrO89hRcr2w1v6qZiY3swlIZsPgmCHa+q+iFK0=";
   };
 
-  vendorSha256 = "sha256-V8hCSpdIYQKFlHuV2GI9dt2rEhhr5q3cCSd8kEyMiDM=";
+  vendorSha256 = "sha256-5OJntT5ed4pmugB1yw0fa906McREzv5aPuC8vBVx5o0=";
 
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport of https://github.com/NixOS/nixpkgs/pull/172605#issuecomment-1126383537
Closes #172504

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
