### PR TITLE
Add a single-node cockroachdb option, and test for same

### DIFF
--- a/nixos/modules/services/databases/cockroachdb.nix
+++ b/nixos/modules/services/databases/cockroachdb.nix
@@ -10,7 +10,7 @@ let
     ([
       # Basic startup
       "${crdb}/bin/cockroach"
-      "start"
+      (if cfg.singleNode then "start-single-node" else "start")
       "--logtostderr"
       "--store=/var/lib/cockroachdb"
 
@@ -81,6 +81,12 @@ in
         type = types.nullOr types.str;
         default = null;
         description = "The addresses for connecting the node to a cluster.";
+      };
+
+      singleNode = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Run in single-node mode rather than as a cluster member";
       };
 
       insecure = mkOption {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -85,6 +85,7 @@ in
   cloud-init = handleTest ./cloud-init.nix {};
   cntr = handleTest ./cntr.nix {};
   cockroachdb = handleTestOn ["x86_64-linux"] ./cockroachdb.nix {};
+  cockroachdb-single-node = handleTest ./cockroachdb-single-node.nix {};
   collectd = handleTest ./collectd.nix {};
   consul = handleTest ./consul.nix {};
   containers-bridge = handleTest ./containers-bridge.nix {};

--- a/nixos/tests/cockroachdb-single-node.nix
+++ b/nixos/tests/cockroachdb-single-node.nix
@@ -1,0 +1,35 @@
+# Unlike the cockroachdb test, which spins up a proper cluster (and strictly
+# requires kvm), this test runs cockroachdb in single-user mode.
+#
+# Testing that cockroachdb can run in single-user mode ensures that folks can
+# test applications that depend on it, even though it's not a substitute for a
+# full clustered test.
+
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "cockroachdb";
+  nodes = {
+    machine = {
+      # cockroach is under a license that restricts ability to host the database as a service.
+      nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [ "cockroach" ];
+
+      # Bank/TPC-C benchmarks take some memory to complete
+      virtualisation.memorySize = 2048;
+
+      services.cockroachdb.enable = true;
+      services.cockroachdb.insecure = true;
+      services.cockroachdb.openPorts = true;
+      services.cockroachdb.singleNode = true;
+      services.cockroachdb.locality = "system=sol,planet=earth";
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("cockroachdb")
+    machine.succeed(
+        "cockroach sql --host=127.0.0.1 --insecure -e 'SHOW ALL CLUSTER SETTINGS' 2>&1",
+        "cockroach workload init bank 'postgresql://root@127.0.0.1:26257?sslmode=disable'",
+        "cockroach workload run bank --duration=1m 'postgresql://root@127.0.0.1:26257?sslmode=disable'",
+    )
+  '';
+})

--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, buildGoPackage, fetchurl
 , cmake, xz, which, autoconf
 , ncurses6, libedit, libunwind
-, installShellFiles
+, installShellFiles, nixosTests
 , removeReferencesTo, go
 }:
 
@@ -59,6 +59,10 @@ buildGoPackage rec {
   preFixup = ''
     find $out -type f -exec ${removeReferencesTo}/bin/remove-references-to -t ${go} '{}' +
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) cockroachdb-single-node;
+  };
 
   meta = with lib; {
     homepage    = "https://www.cockroachlabs.com";


### PR DESCRIPTION
###### Description of changes

CockroachDB has a separate entrypoint for use when being run in single-node mode.

This is useful for testing -- not just testing cockroachdb itself (although it _does_ add value there, as testing clustered mode requires a paravirtualized clock), but also testing client software that uses cockroachdb.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
