### PR TITLE
sile: Note exta dependencies when built with older Luas

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -18,7 +18,6 @@ let
   luaEnv = lua.withPackages(ps: with ps; [
     cassowary
     cosmo
-    compat53
     linenoise
     lpeg
     lua-zlib
@@ -33,6 +32,10 @@ let
     penlight
     stdlib
     vstruct
+  ] ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
+    bit32
+  ] ++ lib.optionals (lib.versionOlder lua.luaversion "5.3") [
+    compat53
   ]);
 in
 


### PR DESCRIPTION
See discussion in #172749.

Specifically, [this comment](https://github.com/NixOS/nixpkgs/pull/172749#issuecomment-1125824908).

The `compat53` LuaRock is only need by SILE on Lua prior to 5.3. An earlier PR that changed the default from 5.2 to 5.4 overlooked this.

Additionally, the `bit32` LuaRock is needed for Lua 5.1. This was never spotted because 5.2 was the default and it didn't matter.

The `bit32` dependency could be skipped on LuaJIT which provides an alternative built in that SILE also supports (`luabitop`), but I wasn't sure about the syntax for that here. It won't hurt this way, it just isn't fully optimized.
