### PR TITLE
coqPackages_8_13: init tactician

### DIFF
--- a/pkgs/development/coq-modules/tactician/default.nix
+++ b/pkgs/development/coq-modules/tactician/default.nix
@@ -1,0 +1,105 @@
+{ lib, mkCoqDerivation, coq, fetchFromGitHub, version ? null }:
+
+let
+  tactician-dummy =
+    (with lib; mkCoqDerivation {
+      inherit version;
+      pname = "tactician-dummy";
+      owner = "coq-tactician";
+      defaultVersion = with versions; switch coq.coq-version [
+        { case = "8.13"; out = "8.13"; }
+      ] null;
+      
+      release."8.13".rev = "fd5f81959d069d074b0475699a08e34275ac2f67";
+      release."8.13".sha256 = "sha256-nBTpREC2lwhbsW8u0aHvpXZejFQqr3L3WmIE6CgWbzo=";
+
+      # postPatch = ''
+      #   substituteInPlace Makefile.coq.local --replace \
+      #     '$(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)' \
+      #     '$(out)/bin/'
+      #   substituteInPlace Makefile.coq.local --replace 'g++' 'c++' --replace 'gcc' 'cc'
+      # '';
+
+      # configureFlags = [ "--use-opam" ];
+      
+      extraNativeBuildInputs = with coq.ocamlPackages; [ ocaml findlib zarith ];
+      # propagatedBuildInputs = with coq.ocamlPackages; [ ocaml ocamlbuild ];
+
+      preInstall = ''
+        mkdir -p $out/bin
+      '';
+
+      extraInstallFlags = [ "BINDIR=$(out)/bin" ];
+
+      mlPlugin = true;
+      useDune2 = true;
+      
+
+      meta = {
+        description = "A Seamless, Interactive Tactic Learner and Prover for Coq";
+        homepage = "https://coq-tactician.github.io/";
+        license = licenses.lgpl21;
+        maintainers = [ maintainers.siraben ];
+      };
+    }).overrideAttrs (oA: {
+      src = fetchFromGitHub {
+        repo = "coq-tactician-dummy";
+        owner = "coq-tactician";
+        rev = "fd5f81959d069d074b0475699a08e34275ac2f67";
+        sha256 = "sha256-nBTpREC2lwhbsW8u0aHvpXZejFQqr3L3WmIE6CgWbzo=";
+      };
+    });
+in
+(with lib; mkCoqDerivation {
+  inherit version;
+  pname = "tactician";
+  owner = "coq-tactician";
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = "8.13"; out = "8.13"; }
+    { case = "8.12"; out = "8.12"; }
+    { case = "8.11"; out = "8.11"; }
+  ] null;
+  release."8.13".sha256 = "sha256-xzWHcx2u+vn2w+pTfU0fzxrosgqgbUW9jR/X18WQJV0=";
+  release."8.12".sha256 = "sha256:0krsm8qj9lgfbggxv2jhkb03vy2cz63qypnarnl31fdmpykchi4b";
+  release."8.11".sha256 = "sha256:0krsm8qj9lgfbggxv2jhkb03vy2cz63qypnarnl31fdmpykchi4b";
+
+  releaseRev = v: "1.0-beta1-${v}";
+
+  # postPatch = ''
+  #   substituteInPlace Makefile.coq.local --replace \
+  #     '$(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)' \
+  #     '$(out)/bin/'
+  #   substituteInPlace Makefile.coq.local --replace 'g++' 'c++' --replace 'gcc' 'cc'
+  # '';
+
+  configureFlags = [
+    "--use-opam"
+  ];
+
+  propagatedBuildInputs = [ tactician-dummy ];
+  
+  extraNativeBuildInputs = with coq.ocamlPackages; [ ocaml findlib zarith ];
+  # propagatedBuildInputs = with coq.ocamlPackages; [ ocaml ocamlbuild ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  # mlPlugin = true;
+  useDune2 = true;
+  
+
+  meta = {
+    description = "A Seamless, Interactive Tactic Learner and Prover for Coq";
+    homepage = "https://coq-tactician.github.io/";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.siraben ];
+  };
+}).overrideAttrs (oA: {
+  src = fetchFromGitHub {
+    repo = "coq-tactician";
+    owner = "coq-tactician";
+    rev = "1.0-beta1-8.13";
+    sha256 = "sha256-xzWHcx2u+vn2w+pTfU0fzxrosgqgbUW9jR/X18WQJV0=";
+  };
+})

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -95,6 +95,7 @@ let
       smtcoq = callPackage ../development/coq-modules/smtcoq { };
       stdpp = callPackage ../development/coq-modules/stdpp { };
       StructTact = callPackage ../development/coq-modules/StructTact {};
+      tactician = callPackage ../development/coq-modules/tactician { };
       tlc = callPackage ../development/coq-modules/tlc {};
       topology = callPackage ../development/coq-modules/topology {};
       trakt = callPackage ../development/coq-modules/trakt {};


### PR DESCRIPTION
###### Description of changes
This is quite confusing to package. The expression here partially builds but I can't get the `tactician` binary to appear from the dummy phase. I'm not an expert in OPAM so some assistance would be appreciated.

cc: @vbgl @CohenCyril @veprbl


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
