### PR TITLE
npins: Init at 0.1.0

### DIFF
--- a/pkgs/tools/nix/npins/default.nix
+++ b/pkgs/tools/nix/npins/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, nix-gitignore
+, makeWrapper
+, stdenv
+, darwin
+, callPackage
+
+  # runtime dependencies
+, nix # for nix-prefetch-url
+, nix-prefetch-git
+, git # for git ls-remote
+}:
+
+let
+  runtimePath = lib.makeBinPath [ nix nix-prefetch-git git ];
+  sources = (builtins.fromJSON (builtins.readFile ./sources.json)).pins;
+in rustPlatform.buildRustPackage rec {
+  pname = "npins";
+  version = src.version;
+  src = passthru.mkSource sources.npins;
+
+  cargoSha256 = "0rwnzkmx91cwcz9yw0rbbqv73ba6ggim9f4qgz5pgy6h696ld2k8";
+
+  buildInputs = lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ]);
+  nativeBuildInputs = [ makeWrapper ];
+
+  # (Almost) all tests require internet
+  doCheck = false;
+
+  postFixup = ''
+    wrapProgram $out/bin/npins --prefix PATH : "${runtimePath}"
+  '';
+
+  meta = with lib; {
+    description = "Simple and convenient dependency pinning for Nix";
+    homepage = "https://github.com/andir/npins";
+    license = licenses.eupl12;
+    maintainers = with maintainers; [ piegames ];
+  };
+
+  passthru.mkSource = callPackage ./source.nix {};
+}

--- a/pkgs/tools/nix/npins/source.nix
+++ b/pkgs/tools/nix/npins/source.nix
@@ -1,0 +1,57 @@
+# Not part of the public API – for use within nixpkgs only
+#
+# Usage:
+# ```nix
+# let
+#   sources = builtins.fromJSON (builtins.readFile ./sources.json);
+# in mkMyDerivation rec {
+#   version = src.version; # This obviously only works for releases
+#   src = pkgs.npins.mkSource sources.mySource;
+# }
+# ```
+
+{ fetchgit
+, fetchzip
+, fetchurl
+}:
+let
+  mkSource = spec:
+    assert spec ? type; let
+      path =
+        if spec.type == "Git" then mkGitSource spec
+        else if spec.type == "GitRelease" then mkGitSource spec
+        else if spec.type == "PyPi" then mkPyPiSource spec
+        else if spec.type == "Channel" then mkChannelSource spec
+        else throw "Unknown source type ${spec.type}";
+    in
+    spec // { outPath = path; };
+
+  mkGitSource = { repository, revision, url ? null, hash, ... }:
+    assert repository ? type;
+    # At the moment, either it is a plain git repository (which has an url), or it is a GitHub/GitLab repository
+    # In the latter case, there we will always be an url to the tarball
+    if url != null then
+      (fetchzip {
+        inherit url;
+        sha256 = hash;
+        extension = "tar";
+      })
+    else assert repository.type == "Git"; fetchgit {
+      url = repository.url;
+      rev = revision;
+    };
+
+  mkPyPiSource = { url, hash, ... }:
+    fetchurl {
+      inherit url;
+      sha256 = hash;
+    };
+
+  mkChannelSource = { url, hash, ... }:
+    fetchzip {
+      inherit url;
+      sha256 = hash;
+      extension = "tar";
+    };
+in
+  mkSource

--- a/pkgs/tools/nix/npins/sources.json
+++ b/pkgs/tools/nix/npins/sources.json
@@ -1,0 +1,19 @@
+{
+  "pins": {
+    "npins": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "andir",
+        "repo": "npins"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "version": "0.1.0",
+      "revision": "5c9253ff6010f435ab73fbe1e50ae0fdca0ec07b",
+      "url": "https://api.github.com/repos/andir/npins/tarball/0.1.0",
+      "hash": "019fr9xsirld8kap75k18in3krkikqhjn4mglpy3lyhbhc5n1kh6"
+    }
+  },
+  "version": 2
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4019,6 +4019,8 @@ with pkgs;
 
   notify = callPackage ../tools/misc/notify { };
 
+  npins = callPackage ../tools/nix/npins { };
+
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
   nsync = callPackage ../development/libraries/nsync { };


### PR DESCRIPTION
###### Description of changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
