### PR TITLE
python3Packages.protonvpn-nm-lib: add dependencies

### DIFF
--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -2,9 +2,10 @@
 , buildPythonApplication
 , fetchFromGitHub
 , wrapGAppsHook
+, gdk-pixbuf
 , gobject-introspection
 , imagemagick
-, networkmanager
+, librsvg
 , pango
 , webkitgtk
 # Python libs
@@ -26,6 +27,7 @@ buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
+    gdk-pixbuf
     gobject-introspection
     imagemagick
     wrapGAppsHook
@@ -39,7 +41,7 @@ buildPythonApplication rec {
   buildInputs = [
     # To avoid enabling strictDeps = false (#56943)
     gobject-introspection
-    networkmanager
+    librsvg
     pango
     webkitgtk
   ] ++ lib.optionals withIndicator [ libappindicator-gtk3 ];

--- a/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pythonOlder
 , substituteAll
+, dbus-python
 , distro
 , jinja2
 , keyring
@@ -10,7 +11,10 @@
 , pygobject3
 , pyxdg
 , systemd
+, ncurses
 , networkmanager
+, pkgs-systemd
+, xdg-utils
 }:
 
 buildPythonPackage rec {
@@ -26,6 +30,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    dbus-python
     distro
     jinja2
     keyring
@@ -33,6 +38,10 @@ buildPythonPackage rec {
     pygobject3
     pyxdg
     systemd
+    ncurses
+    networkmanager
+    pkgs-systemd
+    xdg-utils
   ];
 
   patches = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6797,7 +6797,9 @@ in {
 
   protonup = callPackage ../development/python-modules/protonup { };
 
-  protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib { };
+  protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib {
+    pkgs-systemd = pkgs.systemd;
+  };
 
   prov = callPackage ../development/python-modules/prov { };
 


### PR DESCRIPTION
###### Description of changes

#172831

In detail, `protonvpn-nm-lib` requires `systemd` (the package, because of `systemctl`, and Python library), `ncurses` (`clear`), `networkmanager` (`nmcli`) and `xdg-utils` (`xdg-open`). Also, after reviewing #174171, `dbus-python` is also needed:

```
Traceback (most recent call last):
  File "/nix/store/0jzzlwp426hv1gp0z66c9pdjlmg6sqx8-protonvpn-cli-3.11.1/bin/.protonvpn-cli-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/0jzzlwp426hv1gp0z66c9pdjlmg6sqx8-protonvpn-cli-3.11.1/lib/python3.9/site-packages/protonvpn_cli/main.py", line 20, in main
    from .cli import ProtonVPNCLI
  File "/nix/store/0jzzlwp426hv1gp0z66c9pdjlmg6sqx8-protonvpn-cli-3.11.1/lib/python3.9/site-packages/protonvpn_cli/cli.py", line 8, in <module>
    from .cli_wrapper import CLIWrapper
  File "/nix/store/0jzzlwp426hv1gp0z66c9pdjlmg6sqx8-protonvpn-cli-3.11.1/lib/python3.9/site-packages/protonvpn_cli/cli_wrapper.py", line 9, in <module>
    from protonvpn_nm_lib.api import protonvpn
  File "/nix/store/w0br2hw764s2r0rjcxja3k0i0rqny1kd-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/api.py", line 6, in <module>
    from .core.report import BugReport
  File "/nix/store/w0br2hw764s2r0rjcxja3k0i0rqny1kd-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/report/__init__.py", line 1, in <module>
    from .bug import BugReport
  File "/nix/store/w0br2hw764s2r0rjcxja3k0i0rqny1kd-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/report/bug.py", line 7, in <module>
    from ..subprocess_wrapper import subprocess
  File "/nix/store/w0br2hw764s2r0rjcxja3k0i0rqny1kd-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/subprocess_wrapper.py", line 123, in <module>
    subprocess = SubprocessWrapper() # noqa
  File "/nix/store/w0br2hw764s2r0rjcxja3k0i0rqny1kd-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/subprocess_wrapper.py", line 34, in __init__
    self.__ensure_executables_exist()
  File "/nix/store/w0br2hw764s2r0rjcxja3k0i0rqny1kd-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/subprocess_wrapper.py", line 81, in __ensure_executables_exist
    raise RuntimeError(
RuntimeError: Couldn't find acceptable executables for {'clear', 'nmcli', 'systemctl', 'xdg-open'}
```
```
-----------     Initialized protonvpn   -----------

-------------------------------------------------
2022-05-23 22:02:26,086 — main.py — INFO —do_startup:87 — ProtonVPN v1.8.0 (protonvpn-nm-lib v3.9.0; proton-client
 v0.7.1)
2022-05-23 22:02:26,154 — main.py — INFO —do_startup:109 — Startup successful
2022-05-23 22:02:26,784 — dashboard.py — INFO —setup_icons_images:382 — Setting up dashboard images and icons
2022-05-23 22:02:26,796 — dashboard.py — INFO —setup_css:421 — Setting up css
2022-05-23 22:02:26,805 — dashboard.py — INFO —setup_actions:448 — Setting up actions
2022-05-23 22:02:26,828 — main.py — INFO —do_activate:275 — Window to display <dashboard.DashboardView object at 0
x7fcf3f7dd880 (DashboardView at 0x12a4590)>
2022-05-23 22:03:08,465 — dashboard.py — ERROR —__on_startup_load_dashboard_resources:245 — No module named 'dbus'
Traceback (most recent call last):
  File "/nix/store/9gkxmqb1grjzx8rn6jayi3q26wc3akic-protonvpn-gui-1.8.0/lib/python3.9/site-packages/protonvpn_gui/
view_model/dashboard.py", line 240, in __on_startup_load_dashboard_resources
    if not protonvpn.get_active_protonvpn_connection():
  File "/nix/store/fj2ihsvcv6naa1w25dnsrxpha91dvi8p-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/p
rotonvpn_nm_lib/api.py", line 407, in get_active_protonvpn_connection
    return self._env.connection_backend\
  File "/nix/store/fj2ihsvcv6naa1w25dnsrxpha91dvi8p-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/p
rotonvpn_nm_lib/core/environment.py", line 43, in connection_backend
    from .connection_backend import ConnectionBackend
  File "/nix/store/fj2ihsvcv6naa1w25dnsrxpha91dvi8p-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/connection_backend/__init__.py", line 1, in <module>
    from .nm_client import nm_client # noqa
  File "/nix/store/fj2ihsvcv6naa1w25dnsrxpha91dvi8p-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/connection_backend/nm_client/nm_client.py", line 3, in <module>
    from dbus.mainloop.glib import DBusGMainLoop
ModuleNotFoundError: No module named 'dbus'
```

Also, as this PR also deals with `protonvpn-gui`, I will include the changes from #174171 (thank you @andresilva).

After adding those and running both `protonvpn-cli|gui` with an empty `PATH`, they both work. Also, after removing `networkmanager` from `protonvpn-gui` and testing with an empty `PATH`, it still works as intended.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
