### PR TITLE
python39Packages.pydy: fix build

### DIFF
--- a/pkgs/development/python-modules/pydy/default.nix
+++ b/pkgs/development/python-modules/pydy/default.nix
@@ -6,21 +6,18 @@
 , numpy
 , scipy
 , sympy
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pydy";
   version = "0.6.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-e/Ssfd5llioA7ccLULlRdHR113IbR4AJ4/HmzQuU7vI=";
   };
-
-  checkInputs = [
-    nose
-    cython
-  ];
 
   propagatedBuildInputs = [
     numpy
@@ -28,9 +25,19 @@ buildPythonPackage rec {
     sympy
   ];
 
-  checkPhase = ''
-    nosetests
-  '';
+  checkInputs = [
+    nose
+    cython
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Tests not fixed yet. Check https://github.com/pydy/pydy/issues/465
+    "test_generate_cse"
+    "test_generate_code_blocks"
+    "test_doprint"
+    "test_OctaveMatrixGenerator"
+  ];
 
   meta = with lib; {
     description = "Python tool kit for multi-body dynamics";


### PR DESCRIPTION
###### Description of changes

ZHF: #172160 

Although PyPI indicates `pydy` [is not intended to build on Python 3.10](https://pypi.org/project/pydy/), the tests (disabling the ones that fail) work fine and the build finishes successfully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
