### PR TITLE
ocamlPackages: add meta.mainProgram to many packages

### DIFF
--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -17,9 +17,10 @@ buildDunePackage rec {
   };
 
   meta = with lib; {
-    homepage = "https://github.com/mjambon/atd";
     description = "Syntax for cross-language type definitions";
+    homepage = "https://github.com/mjambon/atd";
     license = licenses.mit;
     maintainers = with maintainers; [ aij jwilberding ];
+    mainProgram = "atdcat";
   };
 }

--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -32,9 +32,10 @@ buildDunePackage rec {
 
   meta = with lib; {
     description = "SSH implementation in OCaml";
-    license = licenses.isc;
     homepage = "https://github.com/mirage/awa-ssh";
     changelog = "https://github.com/mirage/awa-ssh/raw/v${version}/CHANGES.md";
+    license = licenses.isc;
     maintainers = [ maintainers.sternenseemann ];
+    mainProgram = "awa_lwt_server";
   };
 }

--- a/pkgs/development/ocaml-modules/bisect_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/bisect_ppx/default.nix
@@ -21,8 +21,9 @@ buildDunePackage rec {
 
   meta = with lib; {
     description = "Bisect_ppx is a code coverage tool for OCaml and Reason. It helps you test thoroughly by showing what's not tested.";
-    license = licenses.mit;
     homepage = "https://github.com/aantron/bisect_ppx";
+    license = licenses.mit;
     maintainers = with maintainers; [ ];
+    mainProgram = "bisect-ppx-report";
   };
 }

--- a/pkgs/development/ocaml-modules/ca-certs-nss/default.nix
+++ b/pkgs/development/ocaml-modules/ca-certs-nss/default.nix
@@ -43,9 +43,10 @@ buildDunePackage rec {
   checkInputs = [ alcotest ];
 
   meta = with lib; {
-    license = licenses.isc;
     description = "X.509 trust anchors extracted from Mozilla's NSS";
-    maintainers = [ maintainers.sternenseemann ];
     homepage = "https://github.com/mirage/ca-certs-nss";
+    license = licenses.isc;
+    maintainers = [ maintainers.sternenseemann ];
+    mainProgram = "extract-from-certdata";
   };
 }

--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -39,9 +39,10 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = {
-    homepage = "https://github.com/mirage/checkseum";
     description = "ADLER-32 and CRC32C Cyclic Redundancy Check";
+    homepage = "https://github.com/mirage/checkseum";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
+    mainProgram = "checkseum.checkseum";
   };
 }

--- a/pkgs/development/ocaml-modules/coin/default.nix
+++ b/pkgs/development/ocaml-modules/coin/default.nix
@@ -30,8 +30,9 @@ buildDunePackage rec {
 
   meta = {
     description = "A library to normalize an KOI8-{U,R} input to Unicode";
-    license = lib.licenses.mit;
     homepage = "https://github.com/mirage/coin";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ];
+    mainProgram = "coin.generate";
   };
 }

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -31,10 +31,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://www.coherentpdf.com/";
-    inherit (ocaml.meta) platforms;
     description = "PDF Command Line Tools";
+    homepage = "https://www.coherentpdf.com/";
     license = licenses.unfree;
     maintainers = [ maintainers.vbgl ];
+    mainProgram = "cpdf";
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/decompress/default.nix
+++ b/pkgs/development/ocaml-modules/decompress/default.nix
@@ -23,8 +23,9 @@ buildDunePackage rec {
 
   meta = {
     description = "Pure OCaml implementation of Zlib";
+    homepage = "https://github.com/mirage/decompress";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
-    homepage = "https://github.com/mirage/decompress";
+    mainProgram = "decompress.pipe";
   };
 }

--- a/pkgs/development/ocaml-modules/dns/client.nix
+++ b/pkgs/development/ocaml-modules/dns/client.nix
@@ -16,5 +16,6 @@ buildDunePackage {
 
   meta = dns.meta // {
     description = "Pure DNS resolver API";
+    mainProgram = "dns-client.unix";
   };
 }

--- a/pkgs/development/ocaml-modules/hidapi/default.nix
+++ b/pkgs/development/ocaml-modules/hidapi/default.nix
@@ -24,9 +24,10 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = "https://github.com/vbmithr/ocaml-hidapi";
     description = "Bindings to Signal11's hidapi library";
+    homepage = "https://github.com/vbmithr/ocaml-hidapi";
     license = licenses.isc;
     maintainers = [ maintainers.alexfmpe ];
+    mainProgram = "ocaml-hid-enumerate";
   };
 }

--- a/pkgs/development/ocaml-modules/irmin/pack.nix
+++ b/pkgs/development/ocaml-modules/irmin/pack.nix
@@ -20,6 +20,7 @@ buildDunePackage rec {
 
   meta = irmin.meta // {
     description = "Irmin backend which stores values in a pack file";
+    mainProgram = "irmin_fsck";
   };
 
 }

--- a/pkgs/development/ocaml-modules/irmin/unix.nix
+++ b/pkgs/development/ocaml-modules/irmin/unix.nix
@@ -26,6 +26,7 @@ buildDunePackage rec {
 
   meta = irmin.meta // {
     description = "Unix backends for Irmin";
+    mainProgram = "irmin";
   };
 
 }

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -405,7 +405,10 @@ with self;
     pname = "ppx_base";
     hash = "1wv3q0qyghm0c5izq03y97lv3czqk116059mg62wx6valn22a000";
     minimumOCamlVersion = "4.04.2";
-    meta.description = "Base set of ppx rewriters";
+    meta = {
+      description = "Base set of ppx rewriters";
+      mainProgram = "ppx-base";
+    };
     propagatedBuildInputs = [ ppx_cold ppx_enumerate ppx_hash ppx_js_style ];
   };
 
@@ -519,7 +522,10 @@ with self;
     pname = "ppx_jane";
     hash = "1kk238fvrcylymwm7xwc7llbyspmx1y662ypq00vy70g112rir7j";
     minimumOCamlVersion = "4.04.2";
-    meta.description = "Standard Jane Street ppx rewriters";
+    meta = {
+      description = "Standard Jane Street ppx rewriters";
+      mainProgram = "ppx-jane";
+    };
     propagatedBuildInputs = [ base_quickcheck ppx_bin_prot ppx_expect ppx_fixed_literal ppx_module_timer ppx_optcomp ppx_optional ppx_pipebang ppx_stable ppx_string ppx_typerep_conv ppx_variants_conv ];
   };
 

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -39,10 +39,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/lablgl.html";
     description = "OpenGL bindings for ocaml";
+    homepage = "http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/lablgl.html";
     license = licenses.gpl2;
     maintainers = with maintainers; [ pSub vbgl ];
+    mainProgram = "lablglut";
     broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -25,7 +25,8 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ zed lwt_log lwt_react mew_vi ];
 
-  meta = { description = "Terminal manipulation library for OCaml";
+  meta = {
+    description = "Terminal manipulation library for OCaml";
     longDescription = ''
     Lambda-term is a cross-platform library for
     manipulating the terminal. It provides an abstraction for keys,
@@ -43,8 +44,7 @@ buildDunePackage rec {
 
     inherit (src.meta) homepage;
     license = lib.licenses.bsd3;
-    maintainers = [
-      lib.maintainers.gal_bolle
-    ];
+    maintainers = [ lib.maintainers.gal_bolle ];
+    mainProgram = "lambda-term-actions";
   };
 }

--- a/pkgs/development/ocaml-modules/letsencrypt/app.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/app.nix
@@ -43,5 +43,6 @@ buildDunePackage {
 
   meta = letsencrypt.meta // {
     description = "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml";
+    mainProgram = "oacmel";
   };
 }

--- a/pkgs/development/ocaml-modules/lustre-v6/default.nix
+++ b/pkgs/development/ocaml-modules/lustre-v6/default.nix
@@ -20,9 +20,10 @@ buildDunePackage rec {
   ];
 
   meta = with lib; {
-    homepage = "https://www-verimag.imag.fr/lustre-v6.html";
     description = "Lustre V6 compiler";
+    homepage = "https://www-verimag.imag.fr/lustre-v6.html";
     license = lib.licenses.cecill21;
     maintainers = [ lib.maintainers.delta ];
+    mainProgram = "lv6";
   };
 }

--- a/pkgs/development/ocaml-modules/lutils/default.nix
+++ b/pkgs/development/ocaml-modules/lutils/default.nix
@@ -21,5 +21,6 @@ buildDunePackage rec {
     homepage = "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/";
     description = "Tools and libs shared by Verimag/synchronous tools (lustre, lutin, rdbg)";
     license = lib.licenses.cecill21;
+    mainProgram = "gnuplot-rif";
   };
 }

--- a/pkgs/development/ocaml-modules/mrmime/default.nix
+++ b/pkgs/development/ocaml-modules/mrmime/default.nix
@@ -67,8 +67,9 @@ buildDunePackage rec {
 
   meta = {
     description = "Parser and generator of mail in OCaml";
-    license = lib.licenses.mit;
     homepage = "https://github.com/mirage/mrmime";
-    maintainers = with lib.maintainers; [ ];
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "mrmime.generate";
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -17,5 +17,6 @@ buildDunePackage rec {
 
   meta = lsp.meta // {
     description = "OCaml Language Server Protocol implementation";
+    mainProgram = "ocamllsp";
   };
 }

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -34,8 +34,9 @@ stdenv.mkDerivation {
       of them.
     '';
     homepage = webpage;
-    inherit (ocaml.meta) platforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.jirkamarsik ];
+    mainProgram = "otftrip";
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -46,9 +46,10 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = "https://github.com/biocaml/phylogenetics";
     description = "Algorithms and datastructures for phylogenetics";
-    maintainers = [ maintainers.bcdarwin ];
+    homepage = "https://github.com/biocaml/phylogenetics";
     license = licenses.cecill-b;
+    maintainers = [ maintainers.bcdarwin ];
+    mainProgram = "phylosim";
   };
 }

--- a/pkgs/development/ocaml-modules/tuntap/default.nix
+++ b/pkgs/development/ocaml-modules/tuntap/default.nix
@@ -23,7 +23,8 @@ buildDunePackage rec {
 
   meta = {
     description = "Bindings to the UNIX tuntap facility";
-    license = lib.licenses.isc;
     homepage = "https://github.com/mirage/ocaml-tuntap";
+    license = lib.licenses.isc;
+    mainProgram = "otunctl";
   };
 }

--- a/pkgs/development/ocaml-modules/uuuu/default.nix
+++ b/pkgs/development/ocaml-modules/uuuu/default.nix
@@ -32,8 +32,9 @@ buildDunePackage rec {
 
   meta = {
     description = "A library to normalize an ISO-8859 input to Unicode code-point";
-    license = lib.licenses.mit;
     homepage = "https://github.com/mirage/uuuu";
-    maintainers = with lib.maintainers; [ ];
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "uuuu.generate";
   };
 }

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -57,8 +57,9 @@ stdenv.mkDerivation {
     module. An API allows to implement new renderers.
     '';
     homepage = webpage;
-    inherit (ocaml.meta) platforms;
     license = licenses.isc;
     maintainers = [ maintainers.jirkamarsik ];
+    mainProgram = "vecho";
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/wayland/default.nix
+++ b/pkgs/development/ocaml-modules/wayland/default.nix
@@ -42,8 +42,9 @@ buildDunePackage rec {
 
   meta = {
     description = "Pure OCaml Wayland protocol library";
+    homepage = "https://github.com/talex5/ocaml-wayland";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.sternenseemann ];
-    homepage = "https://github.com/talex5/ocaml-wayland";
+    mainProgram = "wayland-scanner-ocaml";
   };
 }

--- a/pkgs/development/ocaml-modules/webbrowser/default.nix
+++ b/pkgs/development/ocaml-modules/webbrowser/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://erratique.ch/software/webbrowser";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
+    mainProgram = "browse";
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/wodan/unix.nix
+++ b/pkgs/development/ocaml-modules/wodan/unix.nix
@@ -22,6 +22,9 @@ buildDunePackage rec {
     moveToOutput bin "''${!outputBin}"
   '';
 
-  meta = wodan.meta // { description = "Wodan clients with Unix integration"; };
+  meta = wodan.meta // {
+    description = "Wodan clients with Unix integration";
+    mainProgram = "wodanc";
+  };
 
 }

--- a/pkgs/development/tools/ocaml/ocaml-recovery-parser/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-recovery-parser/default.nix
@@ -27,9 +27,10 @@ buildDunePackage rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/serokell/ocaml-recovery-parser";
     description = "A simple fork of OCaml parser with support for error recovery";
+    homepage = "https://github.com/serokell/ocaml-recovery-parser";
     license = with licenses; [ lgpl2Only mit mpl20 ];
     maintainers = with maintainers; [ romildo ];
+    mainProgram = "menhir-recover";
   };
 }

--- a/pkgs/development/tools/ocaml/ocamlscript/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlscript/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     inherit (ocaml.meta) platforms;
     description = "Natively-compiled OCaml scripts";
     maintainers = [ maintainers.vbgl ];
+    mainProgram = "ocamlscript";
   };
 }


### PR DESCRIPTION
###### Description of changes

Following up on #172228, this PR adds `meta.mainProgram` to packages in `ocamlPackages` that provide a single executable whose name differs from the package's `name` or `pname`.

With this PR I believe all packages in `ocamlPackages` that build on `{aarch64,x86_64}-darwin` and `x86_64-linux`, now have `meta.mainProgram` set if appropriate (if the provide a single executable).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
