### PR TITLE
python3Packages.pyvips: 2.1.16 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -1,15 +1,22 @@
-{ buildPythonPackage, fetchFromGitHub, pytestCheckHook, glib, vips, cffi
-, pkgconfig, lib }:
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, glib
+, vips
+, cffi
+, pkgconfig
+, lib }:
 
 buildPythonPackage rec {
   pname = "pyvips";
-  version = "2.1.16";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "libvips";
     repo = "pyvips";
     rev = "v${version}";
-    sha256 = "sha256-8CeQbx3f2i0lEU0wxPeUwHlUGtzOztzTOdFNjIDy8s0=";
+    sha256 = "sha256-qMVoVzqXALhPWVKLzu+VqihHPN7J+pMhKnXdb+ow0zw=";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -19,6 +26,14 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ cffi ];
 
   checkInputs = [ pytestCheckHook ];
+
+  postPatch = ''
+    substituteInPlace pyvips/__init__.py \
+      --replace 'libvips.so.42' '${lib.getLib vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}' \
+      --replace 'libvips.42.dylib' '${lib.getLib vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}' \
+      --replace 'libgobject-2.0.so.0' '${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}' \
+      --replace 'libgobject-2.0.dylib' '${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}' \
+  '';
 
   pythonImportsCheck = [ "pyvips" ];
 


### PR DESCRIPTION
###### Description of changes

ZHF: #172160 

Although `pyvips` [is not intended to work from Python 3.7 onwards according to PyPI](https://pypi.org/project/pyvips/), I made some replacements on the code to make it buildable on versions 3.9 and 3.10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
