### PR TITLE
electron: (mostly) remove dependency on libXss.so

### DIFF
--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -63,6 +63,7 @@ let
   electronLibPath = with lib; makeLibraryPath (
     [ libuuid at-spi2-atk at-spi2-core libappindicator-gtk3 ]
     ++ optionals (versionAtLeast version "9.0.0") [ libdrm mesa ]
+    ++ optionals (versionOlder version "10.0.0") [ libXScrnSaver ]
     ++ optionals (versionAtLeast version "11.0.0") [ libxkbcommon ]
     ++ optionals (versionAtLeast version "12.0.0") [ libxshmfence ]
     ++ optionals (versionAtLeast version "17.0.0") [ libglvnd ]
@@ -95,9 +96,7 @@ let
         $out/lib/electron/electron \
         ${lib.optionalString (lib.versionAtLeast version "15.0.0") "$out/lib/electron/chrome_crashpad_handler" }
 
-      wrapProgram $out/lib/electron/electron \
-        --prefix LD_PRELOAD : ${lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1 \
-        "''${gappsWrapperArgs[@]}"
+      wrapProgram $out/lib/electron/electron "''${gappsWrapperArgs[@]}"
     '';
   };
 


### PR DESCRIPTION
###### Description of changes

Electron 10, which is built from Chromium 85.0.4183.84, no longer depends on libXScrnSaver. This was removed from Chromium upstream in [revision 782094](https://chromium-review.googlesource.com/c/chromium/src/+/2261490), which landed in [Chromium 85.0.4182.0](https://storage.googleapis.com/chromium-find-releases-static/aa5.html#aa5c637805cd33366f2181ed6ec54e0ed174a6f9).

This change removes the `LD_PRELOAD` of libXss.so.1 (which probably should have been done differently in the first place) and simply includes libXScrnSaver in the rpath for Electron versions prior to 10.0.0.

I tested the only package that still depends on Electron 9, `authy`, which seems to start up fine, as well as a package that depends on Electron 10, `teleprompter`, which also starts seemingly correctly. I also verified that the newer binaries don't have `libXss.so.1` in their `DT_NEEDED`.

Fixes #150541
Fixes #165148

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
