### PR TITLE
treewide: add enableParallelBuilding's to bootstrap packages so hashes stay the same

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -128,6 +128,8 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontConfigure = true;
 
+  enableParallelBuilding = true;
+
   unpackPhase = ''
     src=$PWD
   '';

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -162,6 +162,7 @@ stdenv.mkDerivation {
 
   dontBuild = true;
   dontConfigure = true;
+  enableParallelBuilding = true;
 
   unpackPhase = ''
     src=$PWD

--- a/pkgs/build-support/expand-response-params/default.nix
+++ b/pkgs/build-support/expand-response-params/default.nix
@@ -4,6 +4,7 @@ stdenv.mkDerivation {
   name = "expand-response-params";
   src = ./expand-response-params.c;
   strictDeps = true;
+  enableParallelBuilding = true;
   # Work around "stdenv-darwin-boot-2 is not allowed to refer to path
   # /nix/store/...-expand-response-params.c"
   unpackPhase = ''

--- a/pkgs/build-support/nuke-references/default.nix
+++ b/pkgs/build-support/nuke-references/default.nix
@@ -15,6 +15,7 @@ stdenvNoCC.mkDerivation {
   name = "nuke-references";
 
   strictDeps = true;
+  enableParallelBuilding = true;
   dontUnpack = true;
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation {
   pname = targetPrefix + pkg-config.pname + "-wrapper";
   inherit (pkg-config) version;
 
+  enableParallelBuilding = true;
+
   preferLocalBuild = true;
 
   shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -71,6 +71,7 @@ rec {
     # TODO(@Artturin): enable strictDeps always
     }: buildCommand:
     stdenv.mkDerivation ({
+      enableParallelBuilding = true;
       inherit buildCommand name;
       passAsFile = [ "buildCommand" ]
         ++ (derivationArgs.passAsFile or []);

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ]; # TODO: fix referrers
   outputBin = "dev";
 
+  enableParallelBuilding = true;
+
   configureFlags = lib.optional stdenv.isFreeBSD "--with-pic";
 
   outputMan = "dev"; # tiny page for a dev tool

--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     ./preprocessor-warnings.patch
   ];
 
+  enableParallelBuilding = true;
+
   doCheck = true;
 
   configureFlags = []

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   outputs = [ "out" "dev" "man" "info" ];
 
+  enableParallelBuilding = true;
+
   configureFlags = [
     "--with-gcc-arch=generic" # no detection of -march= or -mtune=
     "--enable-pax_emutramp"

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "016c57srqr0bza5fxjxfrx6aqxkqy0s3gkhcg7p7fhk5i6sv38g6";
   };
 
+  enableParallelBuilding = true;
+
   setupHooks = [
     ../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
 
   patches = optional stdenv.isDarwin ./fix-error-darwin.patch;
 
+  enableParallelBuilding = true;
+
   # The above patch causes the documentation to be regenerated, so the
   # documentation tools are required.
   nativeBuildInputs = optionals stdenv.isDarwin [ help2man texinfo ];

--- a/pkgs/development/libraries/libmpc/default.nix
+++ b/pkgs/development/libraries/libmpc/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
+  enableParallelBuilding = true;
+
   buildInputs = [ gmp mpfr ];
 
   doCheck = true; # not cross;

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -5,6 +5,10 @@
 , outputs ? [ "out" "devdoc" ]
 , src ? null
 
+# enabling or disabling does nothing for perl packages so set it explicitly
+# to false to not change hashes when enableParallelBuildingByDefault is enabled
+, enableParallelBuilding ? false
+
 , doCheck ? true
 , checkTarget ? "test"
 
@@ -51,7 +55,7 @@ lib.warnIf (attrs ? name) "builtPerlPackage: `name' (\"${attrs.name}\") is depre
 
     fullperl = buildPerl;
 
-    inherit outputs src doCheck checkTarget;
+    inherit outputs src doCheck checkTarget enableParallelBuilding;
     inherit PERL_AUTOINSTALL AUTOMATED_TESTING PERL_USE_UNSAFE_INC;
 
     meta = defaultMeta // (attrs.meta or { });

--- a/pkgs/development/tools/misc/autoconf-archive/default.nix
+++ b/pkgs/development/tools/misc/autoconf-archive/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
+  enableParallelBuilding = true;
+
   buildInputs = [ xz ];
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
+  enableParallelBuilding = true;
+
   doCheck = false;
 
   configureFlags = [ "--with-syscmd-shell=${stdenv.shell}" ]

--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ gettext perlPackages.perl perlPackages.LocaleGettext ];
   buildInputs = [ perlPackages.LocaleGettext libintl ];
 

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   setupHook = [ ./setup-hook.sh ];
 
+  enableParallelBuilding = true;
+
   # fails 8 out of 24 tests, problems when loading libc.so.6
   doCheck = stdenv.name == "stdenv-linux";
 

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation {
   NATIVE_TOOLS_LDFLAGS = if crossBuildTools then "-L${getLib buildPackages.ncurses}/lib" else null;
 
   strictDeps = true;
+  enableParallelBuilding = true;
+
   # We need a native compiler to build perl XS extensions
   # when cross-compiling.
   depsBuildBuild = [ buildPackages.stdenv.cc perl ];

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -15,6 +15,8 @@ let
     ARCH = stdenvNoCC.hostPlatform.linuxArch;
 
     strictDeps = true;
+    enableParallelBuilding = true;
+
     # It may look odd that we use `stdenvNoCC`, and yet explicit depend on a cc.
     # We do this so we have a build->build, not build->host, C compiler.
     depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -164,6 +164,7 @@ in
         pname = "bootstrap-stage0-${localSystem.libc}";
         strictDeps = true;
         version = "bootstrap";
+        enableParallelBuilding = true;
         buildCommand = ''
           mkdir -p $out
           ln -s ${bootstrapTools}/lib $out/lib
@@ -268,6 +269,7 @@ in
         # apparently the interpreter needs to match libc, too.
         bintools = self.stdenvNoCC.mkDerivation {
           inherit (prevStage.bintools.bintools) name;
+          enableParallelBuilding = true;
           dontUnpack = true;
           dontBuild = true;
           strictDeps = true;

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional enableStatic "--disable-shared";
 
+  enableParallelBuilding = true;
   doCheck = true;
 
   preCheck = ''

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
+  enableParallelBuilding = true;
+
   nativeBuildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
   buildInputs = [ zlib ]
     ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;

--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
+  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://www.gnu.org/software/which/";


### PR DESCRIPTION
when enableParallelBuildingByDefault is enabled

verified with
 `nix-diff $(nix eval ".#gcc-unwrapped.drvPath") $(nix eval --expr 'with import ./. { config = { enableParallelBuildingByDefault = true; }; }; gcc-unwrapped.drvPath' --impure)`
    
    
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
