### PR TITLE
calamares: fix keyboard switching on GNOME wayland

### DIFF
--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -33,6 +33,9 @@ mkDerivation rec {
     ./uimod.patch
     # Remove options for unsupported partition types
     ./partitions.patch
+    # Fix setting the kayboard layout on GNOME wayland
+    # By default the module uses the setxkbmap, which will not change the keyboard
+    ./waylandkbd.patch
   ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
@@ -57,7 +60,7 @@ mkDerivation rec {
     sed -e "s,pkexec calamares,calamares," \
         -i calamares.desktop
 
-    sed -e "s,X-AppStream-Ignore=true,&\nStartupWMClass=io.calamares.calamares," \
+    sed -e "s,X-AppStream-Ignore=true,&\nStartupWMClass=calamares," \
         -i calamares.desktop
 
     # Fix desktop reference with wayland

--- a/pkgs/tools/misc/calamares/waylandkbd.patch
+++ b/pkgs/tools/misc/calamares/waylandkbd.patch
@@ -1,0 +1,25 @@
+diff --git a/src/modules/keyboard/Config.cpp b/src/modules/keyboard/Config.cpp
+index 720588810..af0dd1c8d 100644
+--- a/src/modules/keyboard/Config.cpp
++++ b/src/modules/keyboard/Config.cpp
+@@ -219,7 +219,10 @@ Config::xkbApply()
+                                                { m_additionalLayoutInfo.additionalVariant, m_selectedVariant },
+                                                m_additionalLayoutInfo.groupSwitcher ) );
+ 
+-
++        QString xkbmap = QString( "[('xkb','%1\%2'),('xkb','%3\%4')]").arg(
++                m_selectedLayout, ((!m_selectedVariant.isEmpty()) ? "+" + m_selectedVariant : ""),
++                m_additionalLayoutInfo.additionalLayout, ((!m_additionalLayoutInfo.additionalVariant.isEmpty()) ? "+" + m_additionalLayoutInfo.additionalVariant : ""));
++        QProcess::execute( "sh", { "-c", "if command -v gsettings; then gsettings set org.gnome.desktop.input-sources sources \"$0\"; fi", xkbmap });
+         cDebug() << "xkbmap selection changed to: " << m_selectedLayout << '-' << m_selectedVariant << "(added "
+                  << m_additionalLayoutInfo.additionalLayout << "-" << m_additionalLayoutInfo.additionalVariant
+                  << " since current layout is not ASCII-capable)";
+@@ -227,6 +230,8 @@ Config::xkbApply()
+     else
+     {
+         QProcess::execute( "setxkbmap", xkbmap_layout_args( m_selectedLayout, m_selectedVariant ) );
++        QString xkbmap = QString( "[('xkb','%1\%2')]").arg( m_selectedLayout, ((!m_selectedVariant.isEmpty()) ? "+" + m_selectedVariant : "") );
++        QProcess::execute( "sh", { "-c", "if command -v gsettings; then gsettings set org.gnome.desktop.input-sources sources \"$0\"; fi", xkbmap });
+         cDebug() << "xkbmap selection changed to: " << m_selectedLayout << '-' << m_selectedVariant;
+     }
+     m_setxkbmapTimer.disconnect( this );


### PR DESCRIPTION
###### Description of changes

Currently, when using the GNOME graphical ISO with the default wayland session, when a keyboard is selected the system keyboard does not change to fit the newly selected layout (See https://github.com/NixOS/nixpkgs/issues/172134). The added patch checks whether `gsettings` is available and if so, changes the GNOME keyboard layout directly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Added a patch that modifies the calamares keyboard module to check if a gnome session is running, and if so, change the system keyboard layout with `gsettings` in addition to the default `setxkbmap`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
