### PR TITLE
trafficserver: 9.1.1 -> 9.1.2

### DIFF
--- a/pkgs/servers/http/trafficserver/default.nix
+++ b/pkgs/servers/http/trafficserver/default.nix
@@ -50,11 +50,11 @@
 
 stdenv.mkDerivation rec {
   pname = "trafficserver";
-  version = "9.1.1";
+  version = "9.1.2";
 
   src = fetchzip {
     url = "mirror://apache/trafficserver/trafficserver-${version}.tar.bz2";
-    sha256 = "sha256-oicRqKFE6hOpcNG9o3BmrMujtEzi4hrPhBWaljOW+VI=";
+    sha256 = "sha256-eRpyTdwwO5EzrVpt9fF6VEYGZjHb905nQJd065wY5RU=";
   };
 
   patches = [
@@ -65,12 +65,7 @@ stdenv.mkDerivation rec {
       sha256 = "0z1ikgpp00rzrrcqh97931586yn9wbksgai9xlkcjd5cg8gq0150";
     })
 
-    # Fix build against ncurses-6.3:
-    #  https://github.com/apache/trafficserver/pull/8437
-    (fetchpatch {
-      url = "https://github.com/apache/trafficserver/commit/66c86c6b082903a92b9db33c60e3ed947e77d540.patch";
-      sha256 = "1hgpp80xnnjr4k5i6gcllrb7dw4q4xcdrkwxpc1xk2np5cbyxd16";
-    })
+    ./fix-catch2-version-incompatibility.patch
   ];
 
   # NOTE: The upstream README indicates that flex is needed for some features,
@@ -115,6 +110,8 @@ stdenv.mkDerivation rec {
 
     substituteInPlace configure --replace '/usr/bin/file' '${file}/bin/file'
 
+    # TODO: remove after the following change has been released
+    # https://github.com/apache/trafficserver/pull/8683
     cp ${catch2}/include/catch2/catch.hpp tests/include/catch.hpp
   '' + lib.optionalString stdenv.isLinux ''
     substituteInPlace configure \

--- a/pkgs/servers/http/trafficserver/fix-catch2-version-incompatibility.patch
+++ b/pkgs/servers/http/trafficserver/fix-catch2-version-incompatibility.patch
@@ -1,0 +1,43 @@
+diff --git a/src/tscore/unit_tests/test_History.cc b/src/tscore/unit_tests/test_History.cc
+index 3e699139da0..7505f10aa4c 100644
+--- a/src/tscore/unit_tests/test_History.cc
++++ b/src/tscore/unit_tests/test_History.cc
+@@ -59,10 +59,10 @@ TEST_CASE("History", "[libts][History]")
+   REQUIRE(history[2].reentrancy == static_cast<short>(NO_REENTRANT));
+ 
+   history[0].location.str(buf, sizeof(buf));
+-  REQUIRE(string_view{buf} == "test_History.cc:48 (____C_A_T_C_H____T_E_S_T____0)");
++  REQUIRE(string_view{buf} == "test_History.cc:48 (C_A_T_C_H_T_E_S_T_0)");
+ 
+   history[1].location.str(buf, sizeof(buf));
+-  REQUIRE(string_view{buf} == "test_History.cc:49 (____C_A_T_C_H____T_E_S_T____0)");
++  REQUIRE(string_view{buf} == "test_History.cc:49 (C_A_T_C_H_T_E_S_T_0)");
+ 
+   ts::LocalBufferWriter<128> w;
+   SM<HISTORY_DEFAULT_SIZE> *sm = new SM<HISTORY_DEFAULT_SIZE>;
+@@ -71,10 +71,10 @@ TEST_CASE("History", "[libts][History]")
+   SM_REMEMBER(sm, 3, NO_REENTRANT);
+ 
+   w.print("{}", sm->history[0].location);
+-  REQUIRE(w.view() == "test_History.cc:69 (____C_A_T_C_H____T_E_S_T____0)");
++  REQUIRE(w.view() == "test_History.cc:69 (C_A_T_C_H_T_E_S_T_0)");
+ 
+   w.reset().print("{}", sm->history[1].location);
+-  REQUIRE(w.view() == "test_History.cc:70 (____C_A_T_C_H____T_E_S_T____0)");
++  REQUIRE(w.view() == "test_History.cc:70 (C_A_T_C_H_T_E_S_T_0)");
+ 
+   REQUIRE(sm->history[0].event == 1);
+   REQUIRE(sm->history[0].reentrancy == 1);
+@@ -106,10 +106,10 @@ TEST_CASE("History", "[libts][History]")
+   REQUIRE(sm2->history.overflowed() == true);
+ 
+   w.reset().print("{}", sm2->history[0].location);
+-  REQUIRE(w.view() == "test_History.cc:103 (____C_A_T_C_H____T_E_S_T____0)");
++  REQUIRE(w.view() == "test_History.cc:103 (C_A_T_C_H_T_E_S_T_0)");
+ 
+   w.reset().print("{}", sm2->history[1].location);
+-  REQUIRE(w.view() == "test_History.cc:98 (____C_A_T_C_H____T_E_S_T____0)");
++  REQUIRE(w.view() == "test_History.cc:98 (C_A_T_C_H_T_E_S_T_0)");
+ 
+   sm2->history.clear();
+   REQUIRE(sm2->history.size() == 0);


### PR DESCRIPTION
###### Description of changes

ZHF: #172160

ping @NixOS/nixos-release-managers

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
