### PR TITLE
emacs.pkgs.ement: unstable-2022-05-05 -> unstable-2022-05-14

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/ement/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/ement/default.nix
@@ -13,13 +13,13 @@
 
 trivialBuild {
   pname = "ement";
-  version = "unstable-2022-05-05";
+  version = "unstable-2022-05-14";
 
   src = fetchFromGitHub {
     owner = "alphapapa";
     repo = "ement.el";
-    rev = "84739451afa8355360966dfa788d469d9dc4a8e3";
-    sha256 = "sha256-XdegBKZfoKbFaMM/l8249VD9KKC5/4gQIK6ggPcoOaE=";
+    rev = "961d650377f9e7440e47c36c0386e899f5b2d86b";
+    sha256 = "sha256-4KTSPgso7UvzCRKNFI3YaPR1t4DUwggO4KtBYLm0W4Y=";
   };
 
   packageRequires = [

--- a/pkgs/applications/editors/emacs/elisp-packages/ement/handle-nil-images.patch
+++ b/pkgs/applications/editors/emacs/elisp-packages/ement/handle-nil-images.patch
@@ -1,8 +1,8 @@
-diff --git a/ement.el b/ement.el
-index c9596a7..1b33045 100644
---- a/ement.el
-+++ b/ement.el
-@@ -682,14 +682,15 @@ can cause undesirable underlining."
+diff --git a/ement-lib.el b/ement-lib.el
+index f0b2738..025a191 100644
+--- a/ement-lib.el
++++ b/ement-lib.el
+@@ -644,14 +644,15 @@ can cause undesirable underlining."
    "Return a copy of IMAGE set to MAX-WIDTH and MAX-HEIGHT.
  IMAGE should be one as created by, e.g. `create-image'."
    ;; It would be nice if the image library had some simple functions to do this sort of thing.
@@ -24,5 +24,5 @@ index c9596a7..1b33045 100644
 +            (image-property new-image :max-height) max-height)
 +      new-image)))
  
- ;;;;; Reading/writing sessions
- 
+ (defun ement--room-alias (room)
+   "Return latest m.room.canonical_alias event in ROOM."


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
