### PR TITLE
dendrite: 0.8.4 -> 0.8.5

### DIFF
--- a/pkgs/servers/dendrite/default.nix
+++ b/pkgs/servers/dendrite/default.nix
@@ -1,17 +1,18 @@
-{ lib, buildGoModule, fetchFromGitHub, fetchurl, nixosTests, postgresql, postgresqlTestHook }:
+{ lib, buildGoModule, fetchFromGitHub
+, nixosTests, postgresql, postgresqlTestHook }:
 
 buildGoModule rec {
   pname = "matrix-dendrite";
-  version = "0.8.4";
+  version = "0.8.5";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "dendrite";
     rev = "v${version}";
-    sha256 = "sha256-w4un+TdFTzfVZltvo6ZAPQ3B9HJvnGlJW+LmZHuYk1M=";
+    sha256 = "sha256-MPWvBUI6Mqt3f5UY6lpTBwPpihW+QSNq1M3FnIff+mM=";
   };
 
-  vendorSha256 = "sha256-AJ7Hn23aji/cXioDaOSyF8XD3Mr135DZf7KbUW1SoJ4=";
+  vendorSha256 = "sha256-OXy2xuwTLPNvBnVB6wj/YRW/XMiekjTubRRPVX9bxdQ=";
 
   checkInputs = [
     postgresqlTestHook
@@ -31,8 +32,8 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    homepage = "https://matrix.org";
-    description = "Dendrite is a second-generation Matrix homeserver written in Go!";
+    homepage = "https://matrix-org.github.io/dendrite";
+    description = "A second-generation Matrix homeserver written in Go";
     license = licenses.asl20;
     maintainers = teams.matrix.members;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Description of changes

Change log: https://github.com/matrix-org/dendrite/releases/tag/v0.8.5

In the new documentation, `global.database.connection_string` is [suggested for monolith deployment](https://matrix-org.github.io/dendrite/installation/configuration#database-connections).  Is it possible to have this option define along side the API-specific ones, since each has a default?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).