### PR TITLE
Add exec, eachSystem, mkApp functions

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -62,7 +62,7 @@ let
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
 
-    inherit (self.flakes) callLocklessFlake;
+    inherit (self.flakes) callLocklessFlake eachSystem mkApp mkApp';
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isString length
@@ -74,7 +74,7 @@ let
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare
       functionArgs setFunctionArgs isFunction toFunction
-      toHexString toBaseDigits;
+      toHexString toBaseDigits exec;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/flakes.nix
+++ b/lib/flakes.nix
@@ -1,6 +1,9 @@
 { lib }:
 
-rec {
+let
+  inherit (lib) isDerivation exec;
+  inherit (builtins) isAttrs mapAttrs attrNames foldl';
+in rec {
 
   /* imports a flake.nix without acknowledging its lock file, useful for
     referencing subflakes from a parent flake. The second argument allows
@@ -18,5 +21,82 @@ rec {
         ((import (path + "/flake.nix")).outputs (inputs // { self = self; }));
     in
     self;
+
+  /*
+    Builds a map from <attr>=value to <attr>.<system>=value for each system,
+    except for the `hydraJobs` attribute, where it maps the inner attributes,
+    from hydraJobs.<attr>=value to hydraJobs.<attr>.<system>=value.
+  */
+  eachSystem = systems: f:
+    let
+
+      /*
+        Used to match Hydra's convention of how to define jobs. Basically transforms
+
+            hydraJobs = {
+              hello = <derivation>;
+              haskellPackages.aeson = <derivation>;
+            }
+
+        to
+
+            hydraJobs = {
+              hello.x86_64-linux = <derivation>;
+              haskellPackages.aeson.x86_64-linux = <derivation>;
+            }
+
+        if the given flake does `eachSystem [ "x86_64-linux" ] { ... }`.
+      */
+      pushDownSystem = system: merged:
+        mapAttrs
+          (name: value:
+            if ! (isAttrs value) then value
+            else if isDerivation value then (merged.${name} or {}) // { ${system} = value; }
+            else pushDownSystem system (merged.${name} or {}) value);
+
+      # Merge together the outputs for all systems.
+      op = attrs: system:
+        let
+          ret = f system;
+          op = attrs: key:
+            let
+              appendSystem = key: system: ret:
+                if key == "hydraJobs"
+                  then (pushDownSystem system (attrs.hydraJobs or {}) ret.hydraJobs)
+                  else { ${system} = ret.${key}; };
+            in attrs //
+              {
+                ${key} = (attrs.${key} or { }) // (appendSystem key system ret);
+              }
+          ;
+        in
+        foldl' op attrs (attrNames ret);
+    in
+    foldl' op { } systems
+  ;
+
+  /*
+    Returns the structure used by `nix app`
+
+    Example:
+      mkApp neovim
+      => { type = "app"; program = "/nix/store/.../bin/nvim"; }
+  */
+  mkApp = drv: {
+    type = "app";
+    program = exec drv;
+  };
+
+  /*
+    Returns the structure used by `nix app`
+
+    Example:
+      mkApp libnotify "notify-send"
+      => { type = "app"; program = "/nix/store/.../bin/notify-send"; }
+  */
+  mkApp' = drv: binName: {
+    type = "app";
+    program = "${drv}/bin/${binName}";
+  };
 
 }

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -151,6 +151,23 @@ rec {
     # Argument to check for null before passing it to `f`
     a: if a == null then a else f a;
 
+
+  /*
+    Convert derivation to path of main executable
+
+    Type: exec :: Derivation -> Path
+
+    Example:
+      exec pkgs.bash
+      => /nix/store/...-bash-x-x-x/bin/bash
+      exec pkgs.libnotify
+      => /nix/store/...-libnotify-x-x-x/bin/notify-send
+      exec (pkgs.writeShellScriptBin "abc.sh" "")
+      => /nix/store/...-abc.sh/bin/abc.sh
+  */
+  exec = pkg: "${pkg}/bin/${pkg.meta.mainProgram or pkg.pname or pkg.name}";
+
+
   # Pull in some builtins not included elsewhere.
   inherit (builtins)
     pathExists readFile isBool


### PR DESCRIPTION
###### Description of changes

Added several helper functions.
`eachSystem` function is copied from flake-utils, this allows hundreds if not thousands of flakes to remove `flake-utils` as a dependency

This should help to test out this PR https://github.com/gytis-ivaskevicius/nix2vim/commit/33cd8547ff077e34381f3049fce255cfbb1c74a5

`exec` function is used as part of `mkApp`, but mainly inteadead for cases as such:
```nix
  ocrScript = pkgs.writeShellScript "ocr.sh" ''
    ${exec pkgs.grim} -g "$(${exec slurp})" -t ppm - | ${exec tesseract} - - | ${wl-clipboard}/bin/wl-copy
    ${exec libnotify} "$(${wl-clipboard}/bin/wl-paste)"
  '';
  ```

Worth considering renaming `exec` to something like `I` or `_` so it would look more like an operator. I personally would love such change but did not commit it in such a way to avoid people protesting outside my window


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
