### PR TITLE
dbus-broker: 29 -> 31, use external c-util dependencies

### DIFF
--- a/pkgs/development/libraries/c-util/c-dvar/default.nix
+++ b/pkgs/development/libraries/c-util/c-dvar/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja
+, c-stdaux, c-utf8 }:
+
+stdenv.mkDerivation rec {
+  pname = "c-dvar";
+  version = "unstable-2022-05-03";
+
+  nativeBuildInputs = [
+    meson ninja pkg-config
+    c-stdaux c-utf8
+  ];
+
+  src = fetchFromGitHub {
+    owner = "c-util";
+    repo = "c-dvar";
+    rev = "139ea946b0c4f711d0eb07bc7b282eec43c81085";
+    sha256 = "1v2ddqy24mr8j5flalyayxrvs571vix0vcxmfpk10ryl76q2j02s";
+  };
+
+  meta = with lib; {
+    description = "Common Utility Libraries for C11";
+    homepage    = "https://c-util.github.io/c-dvar/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ xaverdh ];
+  };
+}

--- a/pkgs/development/libraries/c-util/c-ini/default.nix
+++ b/pkgs/development/libraries/c-util/c-ini/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja, c-stdaux, c-list, c-utf8, c-rbtree }:
+
+stdenv.mkDerivation rec {
+  pname = "c-ini";
+  version = "unstable-2022-05-12";
+
+  nativeBuildInputs = [
+    meson ninja pkg-config
+    c-stdaux c-list c-utf8 c-rbtree
+  ];
+
+  src = fetchFromGitHub {
+    owner = "c-util";
+    repo = "c-ini";
+    rev = "a44543e41ea1a86a85152f6fe7c56e4f86bb3ce6";
+    sha256 = "18hy4zv89pkc5bwjl66ik0hwvpjzzh3akx8ji5h9r33j1ynlkva6";
+  };
+
+  meta = with lib; {
+    description = "Common Utility Libraries for C11";
+    homepage    = "https://c-util.github.io/c-ini/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ xaverdh ];
+  };
+}

--- a/pkgs/development/libraries/c-util/c-list/default.nix
+++ b/pkgs/development/libraries/c-util/c-list/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja, c-stdaux }:
+
+stdenv.mkDerivation rec {
+  pname = "c-list";
+  version = "unstable-2022-05-03";
+
+  nativeBuildInputs = [ meson ninja pkg-config c-stdaux ];
+
+  src = fetchFromGitHub {
+    owner = "c-util";
+    repo = "c-list";
+    rev = "b86ba656ac22b00fe785b2f058123e807f97c109";
+    sha256 = "1kb99ws6kkpbc08g32n4sb4pmga7ahlgmlhy254wc32yx7gsxla0";
+  };
+
+  meta = with lib; {
+    description = "Common Utility Libraries for C11";
+    homepage    = "https://c-util.github.io/c-list/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ xaverdh ];
+  };
+}

--- a/pkgs/development/libraries/c-util/c-rbtree/default.nix
+++ b/pkgs/development/libraries/c-util/c-rbtree/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja, c-stdaux }:
+
+stdenv.mkDerivation rec {
+  pname = "c-rbtree";
+  version = "unstable-2022-05-03";
+
+  nativeBuildInputs = [ meson ninja pkg-config c-stdaux ];
+
+  src = fetchFromGitHub {
+    owner = "c-util";
+    repo = "c-rbtree";
+    rev = "9b9713aeb9eca98566a85c8c90a02942ea430819";
+    sha256 = "0wd6jjwv0rvhg7ficyzj6xbcirkcz2a3msax6pinj1n65bf2574g";
+  };
+
+  meta = with lib; {
+    description = "Common Utility Libraries for C11";
+    homepage    = "https://c-util.github.io/c-rbtree/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ xaverdh ];
+  };
+}

--- a/pkgs/development/libraries/c-util/c-shquote/default.nix
+++ b/pkgs/development/libraries/c-util/c-shquote/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja, c-stdaux }:
+
+stdenv.mkDerivation rec {
+  pname = "c-shquote";
+  version = "unstable-2022-05-12";
+
+  nativeBuildInputs = [ meson ninja pkg-config c-stdaux ];
+
+  src = fetchFromGitHub {
+    owner = "c-util";
+    repo = "c-shquote";
+    rev = "8b82a8cf51b6b85ae343e2e7842edd06b8cb0798";
+    sha256 = "1v56zxdyxhchz5j34kizkcp2aifa31p5a5w4qshimgk2d5bkf6jq";
+  };
+
+  meta = with lib; {
+    description = "Common Utility Libraries for C11";
+    homepage    = "https://c-util.github.io/c-shquote/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ xaverdh ];
+  };
+}

--- a/pkgs/development/libraries/c-util/c-stdaux/default.nix
+++ b/pkgs/development/libraries/c-util/c-stdaux/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja }:
+
+stdenv.mkDerivation rec {
+  pname = "c-stdaux";
+  version = "unstable-2022-05-16";
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  src = fetchFromGitHub {
+    owner = "c-util";
+    repo = "c-stdaux";
+    rev = "adda5ff3e9d98648a4e01ad800fafd584e4640ce";
+    sha256 = "10rqvchbsbqq82vb9hqhhfrggm7b75szhacbal2xp1cn47f8gcax";
+  };
+
+  meta = with lib; {
+    description = "Common Utility Libraries for C11";
+    homepage    = "https://c-util.github.io/c-stdaux/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ xaverdh ];
+  };
+}

--- a/pkgs/development/libraries/c-util/c-utf8/default.nix
+++ b/pkgs/development/libraries/c-util/c-utf8/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja, c-stdaux }:
+
+stdenv.mkDerivation rec {
+  pname = "c-utf8";
+  version = "unstable-2022-05-03";
+
+  nativeBuildInputs = [ meson ninja pkg-config c-stdaux ];
+
+  src = fetchFromGitHub {
+    owner = "c-util";
+    repo = "c-utf8";
+    rev = "314559cb9c63a2d9ac420669bc1b5aca7ad0dcf5";
+    sha256 = "18yvjxz3f7n15aicwwcsi099mgzp8f9vacpiywxlmflmzxaz13vi";
+  };
+
+  meta = with lib; {
+    description = "Common Utility Libraries for C11";
+    homepage    = "https://c-util.github.io/c-utf8/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ xaverdh ];
+  };
+}

--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -1,19 +1,22 @@
 { lib, stdenv, fetchFromGitHub, docutils, meson, ninja, pkg-config
-, dbus, linuxHeaders, systemd }:
+, dbus, linuxHeaders, systemd
+, c-stdaux, c-list, c-utf8, c-rbtree, c-shquote, c-ini, c-dvar }:
 
 stdenv.mkDerivation rec {
   pname = "dbus-broker";
-  version = "29";
+  version = "31";
 
   src = fetchFromGitHub {
-    owner  = "bus1";
-    repo   = "dbus-broker";
-    rev    = "v${version}";
-    sha256 = "1abbi8c0mgdqjidlp2wnmy0a88xv173hq88sh5m966c5r1h6alkq";
-    fetchSubmodules = true;
+    owner = "bus1";
+    repo = "dbus-broker";
+    rev = "v${version}";
+    sha256 = "1v904wcf4wsysagbg02177slwaqh1ps1qqa2ayab8ljxdv0bbnvx";
   };
 
-  nativeBuildInputs = [ docutils meson ninja pkg-config ];
+  nativeBuildInputs = [
+    docutils meson ninja pkg-config
+    c-stdaux c-list c-utf8 c-rbtree c-shquote c-ini c-dvar
+  ];
 
   buildInputs = [ dbus linuxHeaders systemd ];
 

--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/bus1/dbus-broker/wiki";
     license     = licenses.asl20;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg xaverdh ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -376,6 +376,8 @@ with pkgs;
 
   c-stdaux = callPackage ../development/libraries/c-util/c-stdaux { };
 
+  c-list = callPackage ../development/libraries/c-util/c-list { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -380,6 +380,8 @@ with pkgs;
 
   c-utf8 = callPackage ../development/libraries/c-util/c-utf8 { };
 
+  c-rbtree = callPackage ../development/libraries/c-util/c-rbtree { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -378,6 +378,8 @@ with pkgs;
 
   c-list = callPackage ../development/libraries/c-util/c-list { };
 
+  c-utf8 = callPackage ../development/libraries/c-util/c-utf8 { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -384,6 +384,8 @@ with pkgs;
 
   c-shquote = callPackage ../development/libraries/c-util/c-shquote { };
 
+  c-ini = callPackage ../development/libraries/c-util/c-ini { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -382,6 +382,8 @@ with pkgs;
 
   c-rbtree = callPackage ../development/libraries/c-util/c-rbtree { };
 
+  c-shquote = callPackage ../development/libraries/c-util/c-shquote { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -374,6 +374,8 @@ with pkgs;
 
   datalad = callPackage ../applications/version-management/datalad { };
 
+  c-stdaux = callPackage ../development/libraries/c-util/c-stdaux { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -386,6 +386,8 @@ with pkgs;
 
   c-ini = callPackage ../development/libraries/c-util/c-ini { };
 
+  c-dvar = callPackage ../development/libraries/c-util/c-dvar { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };


### PR DESCRIPTION
###### Description of changes

Update to v31 (https://github.com/bus1/dbus-broker/blob/main/NEWS.md).

Different approach to https://github.com/NixOS/nixpkgs/pull/172845, we now unvendor all `c-util` dependencies.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

