### PR TITLE
gerbv: pull fix pending upstream inclusion for -fno-common toolchains

### DIFF
--- a/pkgs/applications/science/electronics/gerbv/default.nix
+++ b/pkgs/applications/science/electronics/gerbv/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, pkg-config, gettext, libtool, automake, autoconf, cairo, gtk2, autoreconfHook }:
+{ lib, stdenv, fetchgit, fetchpatch, pkg-config, gettext, libtool, automake, autoconf, cairo, gtk2, autoreconfHook }:
 
 stdenv.mkDerivation {
   pname = "gerbv";
@@ -9,6 +9,16 @@ stdenv.mkDerivation {
     rev = "76b8b67bfa10823ce98f1c4c3b49a2afcadf7659";
     sha256 = "00jn1xhf6kblxc5gac1wvk8zm12fy6sk81nj3jwdag0z6wk3z446";
   };
+
+  patches = [
+    # Pull patch pending upstream inclusion for -fno-common toolchains:
+    #  https://sourceforge.net/p/gerbv/patches/84/
+    (fetchpatch {
+      name = "fnoc-mmon.patch";
+      url = "https://sourceforge.net/p/gerbv/patches/84/attachment/0001-gerbv-fix-build-on-gcc-10-fno-common.patch";
+      sha256 = "1avfbkqhxl7wxn1z19y30ilkwvdgpdkzhzawrs5y3damxmqq8ggk";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config automake autoconf ];
   buildInputs = [ gettext libtool cairo gtk2 ];


### PR DESCRIPTION
Without the change build fails on upstream gcc-10 as:

    ld: interface.o:/build/gerbv/src/callbacks.h:50: multiple definition of
      `toggle_layer'; callbacks.o:/build/gerbv/src/callbacks.h:50: first defined here
    ld: interface.o:/build/gerbv/src/callbacks.h:44: multiple definition of
      `CALLBACKS_SAVE_FILE_TYPE'; callbacks.o:/build/gerbv/src/callbacks.h:44: first defined here
    ld: render.o:/build/gerbv/src/callbacks.h:44: multiple definition of
      `CALLBACKS_SAVE_FILE_TYPE'; callbacks.o:/build/gerbv/src/callbacks.h:44: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
