### PR TITLE
python3Packages.uamqp: re-introduce darwin-fixing patch

### DIFF
--- a/pkgs/development/python-modules/uamqp/darwin-azure-c-shared-utility-corefoundation.patch
+++ b/pkgs/development/python-modules/uamqp/darwin-azure-c-shared-utility-corefoundation.patch
@@ -1,0 +1,37 @@
+From 52ab2095649b5951e6af77f68954209473296983 Mon Sep 17 00:00:00 2001
+From: Sandro <sandro.jaeckel@gmail.com>
+Date: Sat, 16 Jan 2021 15:54:05 +0100
+Subject: [PATCH] Fix finding apple libraries
+
+---
+ CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+ 
+
+(rejected by upstream in https://github.com/Azure/azure-c-shared-utility/pull/499,
+seems problem it's solving is nixpkgs-specific)
+
+diff --git a/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/CMakeLists.txt b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/CMakeLists.txt
+index 7bbfa6f3f..3567b18bc 100644
+--- a/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/CMakeLists.txt
++++ b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/CMakeLists.txt
+@@ -120,8 +120,9 @@ endif()
+ 
+ if(${use_applessl})
+     # MACOSX only has native tls and open ssl, so use the native apple tls
+-    find_library(cf_foundation Foundation)
++    find_library(cf_foundation CoreFoundation)
+     find_library(cf_network CFNetwork)
++    find_library(cf_security Security)
+ endif()
+ 
+ if(${no_logging})
+@@ -581,7 +582,7 @@ endif()
+ 
+ 
+ if(${use_applessl})
+-    set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} ${cf_foundation} ${cf_network})
++    set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} ${cf_foundation} ${cf_network} ${cf_security})
+ endif()
+ 
+ if(WIN32)

--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -23,6 +23,10 @@ buildPythonPackage rec {
     sha256 = "sha256-guhfOMvddC4E+oOmvpeG8GsXEfqLcSHVdtj3w8fF2Vs=";
   };
 
+  patches = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    ./darwin-azure-c-shared-utility-corefoundation.patch
+  ];
+
   nativeBuildInputs = [
     cmake
   ];


### PR DESCRIPTION
###### Description of changes
ZHF: #172160

Patch previously removed in bf0f23274136ddb2b6b0fa91952e1453b990a88d, this fixes x86_64 darwin builds. Including in-repo as upstream rejected it and we shouldn't rely on github keeping the reference around.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
