### PR TITLE
lxqt.libqtxdg: 3.9.0 -> 3.9.1

### DIFF
--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -17,6 +17,7 @@ let
     lxqt-build-tools = callPackage ./lxqt-build-tools {};
     libsysstat = callPackage ./libsysstat {};
     liblxqt = callPackage ./liblxqt {};
+    qtxdg-tools = callPackage ./qtxdg-tools {};
 
     ### CORE 1
     libfm-qt = callPackage ./libfm-qt {};

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -10,13 +10,13 @@
 
 mkDerivation rec {
   pname = "libqtxdg";
-  version = "3.9.0";
+  version = "3.9.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "llE4OxI4I/n0P8Pv5tKT3tXM7IfD3VMQSxdaLkBJ4Gk=";
+    sha256 = "zrlaOiIsfbwjHFjqhYZ9lCo+oTsddICxl2UAum9Xoi4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-session/default.nix
@@ -11,6 +11,7 @@
 , kwindowsystem
 , liblxqt
 , libqtxdg
+, qtxdg-tools
 , procps
 , xorg
 , xdg-user-dirs
@@ -19,13 +20,13 @@
 
 mkDerivation rec {
   pname = "lxqt-session";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "urm4Ehd26fmssJwu/V9Uu/lZ0J8yDOtAA0DIihTPxng=";
+    sha256 = "NOwuHz5SiygE/9cLrYPz24L5v8BE6Hwqp6uKD5SnOBU=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +43,7 @@ mkDerivation rec {
     kwindowsystem
     liblxqt
     libqtxdg
+    qtxdg-tools
     procps
     xorg.libpthreadstubs
     xorg.libXdmcp

--- a/pkgs/desktops/lxqt/qtxdg-tools/default.nix
+++ b/pkgs/desktops/lxqt/qtxdg-tools/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, qtbase
+, libqtxdg
+, lxqt-build-tools
+, lxqtUpdateScript
+}:
+
+mkDerivation rec {
+  pname = "qtxdg-tools";
+  version = "3.9.1";
+
+  src = fetchFromGitHub {
+    owner = "lxqt";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-NUSeXEJ6zjTz6p/8R6YTVfPQEnk1ukZ2ikdDdkaPeSw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    lxqt-build-tools
+  ];
+
+  buildInputs = [
+    qtbase
+    libqtxdg
+  ];
+
+  passthru.updateScript = lxqtUpdateScript { inherit pname version src; };
+
+  meta = with lib; {
+    homepage = "https://github.com/lxqt/qtxdg-tools";
+    description = "libqtxdg user tools";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = teams.lxqt.members;
+  };
+}


### PR DESCRIPTION
###### Description of changes

- Add qtxdg-tools at version [3.9.1](https://github.com/lxqt/qtxdg-tools/releases/tag/3.9.1)
- Update libqtxdg to version [3.9.1](https://github.com/lxqt/libqtxdg/releases/tag/3.9.1)
- Update lxqt-session to version [1.1.1](https://github.com/lxqt/lxqt-session/releases/tag/1.1.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
