### PR TITLE
ocamlPackages.otoml: 0.9.0 → 1.0.1; soupault: 3.2.0 → 4.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/otoml/default.nix
+++ b/pkgs/development/ocaml-modules/otoml/default.nix
@@ -1,4 +1,6 @@
-{ lib, fetchFromGitHub, buildDunePackage
+{ lib
+, fetchFromGitHub
+, buildDunePackage
 , menhir
 , menhirLib
 , uutf
@@ -6,7 +8,7 @@
 
 buildDunePackage rec {
   pname = "otoml";
-  version = "0.9.0";
+  version = "1.0.1";
 
   useDune2 = true;
 
@@ -16,7 +18,7 @@ buildDunePackage rec {
     owner = "dmbaturin";
     repo = pname;
     rev = version;
-    sha256 = "0l0c60rzgk11y8xq05kr8q9hkzb3c8vi995mq84x98ys73wb42j3";
+    sha256 = "sha256-2WGuq4ZLbLvfG6WZ3iimiSMqMYHCuruZc1EttZ/5rBE=";
   };
 
   strictDeps = true;

--- a/pkgs/tools/typesetting/soupault/default.nix
+++ b/pkgs/tools/typesetting/soupault/default.nix
@@ -1,20 +1,27 @@
-{ fetchFromGitHub, ocamlPackages, lib }:
+{ lib
+, fetchFromGitea
+, ocamlPackages
+}:
 
 ocamlPackages.buildDunePackage rec {
   pname = "soupault";
-  version = "3.2.0";
+  version = "4.0.0";
 
   useDune2 = true;
 
-  src = fetchFromGitHub {
-    owner = "dmbaturin";
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "PataphysicalSociety";
     repo = pname;
     rev = version;
-    sha256 = "sha256-T1K/ntCK19LfPmMtaAa9c1JjSL+5dax2SNhM4yUFln4=";
+    sha256 = "sha256-txNKAZMd3LReFoAtf6iaoDF+Ku3IUNDzBWUqGC2ePKw=";
   };
 
   buildInputs = with ocamlPackages; [
     base64
+    camomile
     containers
     ezjsonm
     fileutils
@@ -32,11 +39,10 @@ ocamlPackages.buildDunePackage rec {
     yaml
   ];
 
-  meta = with lib; {
+  meta = {
     description = "A tool that helps you create and manage static websites";
     homepage = "https://soupault.app/";
-    license = licenses.mit;
-    maintainers = [ maintainers.toastal ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ toastal ];
   };
 }
-


### PR DESCRIPTION
###### Description of changes

@vberger I used this to build Soupault version 4.0.0; ~~a merge request for that will be coming shortly~~ #173033 is dependent on this issue. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
