### PR TITLE
nix-ld: 1.0.0 -> 1.0.2

### DIFF
--- a/nixos/modules/programs/nix-ld.nix
+++ b/nixos/modules/programs/nix-ld.nix
@@ -5,8 +5,6 @@
     programs.nix-ld.enable = lib.mkEnableOption ''nix-ld, Documentation: <link xlink:href="https://github.com/Mic92/nix-ld"/>'';
   };
   config = lib.mkIf config.programs.nix-ld.enable {
-    systemd.tmpfiles.rules = [
-      "L+ ${pkgs.nix-ld.ldPath} - - - - ${pkgs.nix-ld}/libexec/nix-ld"
-    ];
+    systemd.tmpfiles.packages = [ pkgs.nix-ld ];
   };
 }

--- a/nixos/tests/nix-ld.nix
+++ b/nixos/tests/nix-ld.nix
@@ -6,7 +6,7 @@ import ./make-test-python.nix ({ lib, pkgs, ...} :
     environment.systemPackages = [
       (pkgs.runCommand "patched-hello" {} ''
         install -D -m755 ${pkgs.hello}/bin/hello $out/bin/hello
-        patchelf $out/bin/hello --set-interpreter ${pkgs.nix-ld.ldPath}
+        patchelf $out/bin/hello --set-interpreter $(cat ${pkgs.nix-ld}/nix-support/ldpath)
       '')
     ];
   };

--- a/pkgs/os-specific/linux/nix-ld/default.nix
+++ b/pkgs/os-specific/linux/nix-ld/default.nix
@@ -1,49 +1,56 @@
-{ stdenv, meson, ninja, lib, nixosTests, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, nixosTests
+}:
 let
-  self = stdenv.mkDerivation {
-    name = "nix-ld";
-    src = fetchFromGitHub {
-      owner = "Mic92";
-      repo = "nix-ld";
-      rev = "1.0.0";
-      sha256 = "sha256-QYPg8wPpq7q5Xd1jW17Lh36iKFSsVkN/gWYoQRv2XoU=";
-    };
+  libDir = if builtins.elem stdenv.system [ "x86_64-linux" "mips64-linux" "powerpc64le-linux" ]
+           then "/lib64"
+           else "/lib";
+in
+stdenv.mkDerivation rec {
+  pname = "nix-ld";
+  version = "1.0.2";
 
-    doCheck = true;
-
-    nativeBuildInputs = [ meson ninja ];
-
-    mesonFlags = [
-      "-Dnix-system=${stdenv.system}"
-    ];
-
-    hardeningDisable = [
-      "stackprotector"
-    ];
-
-    postInstall = ''
-      mkdir -p $out/nix-support
-      basename $(< ${stdenv.cc}/nix-support/dynamic-linker) > $out/nix-support/ld-name
-    '';
-
-    passthru.tests.nix-ld = nixosTests.nix-ld;
-    passthru.ldPath = let
-      libDir = if stdenv.system == "x86_64-linux" ||
-                  stdenv.system == "mips64-linux" ||
-                  stdenv.system == "powerpc64le-linux"
-               then
-                 "/lib64"
-               else
-                 "/lib";
-      ldName = lib.fileContents "${self}/nix-support/ld-name";
-    in "${libDir}/${ldName}";
-
-    meta = with lib; {
-      description = "Run unpatched dynamic binaries on NixOS";
-      homepage = "https://github.com/Mic92/nix-ld";
-      license = licenses.mit;
-      maintainers = with maintainers; [ mic92 ];
-      platforms = platforms.linux;
-    };
+  src = fetchFromGitHub {
+    owner = "mic92";
+    repo = "nix-ld";
+    rev = version;
+    sha256 = "sha256-DlWU5i/MykqWgB9vstYbECy3e+XagXWCxi+XDJNey0s=";
   };
-in self
+
+  doCheck = true;
+
+  nativeBuildInputs = [ meson ninja ];
+
+  mesonFlags = [
+    "-Dnix-system=${stdenv.system}"
+  ];
+
+  hardeningDisable = [
+    "stackprotector"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/nix-support
+
+    ldpath=${libDir}/$(basename $(< ${stdenv.cc}/nix-support/dynamic-linker))
+    echo "$ldpath" > $out/nix-support/ldpath
+    mkdir -p $out/lib/tmpfiles.d/
+    cat > $out/lib/tmpfiles.d/nix-ld.conf <<EOF
+      L+ $ldpath - - - - $out/libexec/nix-ld
+    EOF
+  '';
+
+  passthru.tests.nix-ld = nixosTests.nix-ld;
+
+  meta = with lib; {
+    description = "Run unpatched dynamic binaries on NixOS";
+    homepage = "https://github.com/Mic92/nix-ld";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
