### PR TITLE
pe-parse: drop `no-sign-conversion` compile flag

### DIFF
--- a/pkgs/development/libraries/pe-parse/default.nix
+++ b/pkgs/development/libraries/pe-parse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake }:
+{ stdenv, lib, fetchFromGitHub, cmake, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "pe-parse";
@@ -11,10 +11,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-HwWlMRhpB/sa/JRyAZF7LZzkXCCyuxB+gtDAfHt7e6k=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/trailofbits/pe-parse/commit/eecdb3d36eb44e306398a2e66e85490f9bdcc74c.patch";
+      hash = "sha256-pd6D/JMctiQqJxnJU9Nm/GDVf4/CaIGeXx1UfdcCupo=";
+    })
+  ];
 
-  # See https://github.com/trailofbits/pe-parse/issues/169
-  NIX_CFLAGS_COMPILE = "-Wno-sign-conversion";
+  nativeBuildInputs = [ cmake ];
 
   doInstallCheck = true;
   installCheckPhase = ''


### PR DESCRIPTION
###### Description of changes

Upstream has merged a patch to fix the issue so we can use that instead of being lax when compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>pe-parse</li>
    <li>uthenticode</li>
  </ul>
</details>