### PR TITLE
schildichat-{web,desktop}: 1.10.4-sc.1 -> 1.10.12-sc.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/schildichat/pin.json
+++ b/pkgs/applications/networking/instant-messengers/schildichat/pin.json
@@ -1,9 +1,9 @@
 {
-  "version": "1.10.4-sc.1",
-  "rev": "v1.10.4-sc.1",
-  "srcHash": "0sxibzskbw9pa6wmbk1y3n7p74cfj9zvm2hsw76sp6wfac1wnbwl",
-  "webYarnHash": "1z8xr35gh74y2iv9kfk6d6b6f3iclcrpkdds5q7rh2irpf14fwpw",
-  "jsSdkYarnHash": "1cwvb0hwq19dh2937fmcbfvnkkfmalk9wrxf1yv81nsbyjnx86di",
-  "reactSdkYarnHash": "0j4rxg11q35idfzvjrpmyrwkz9yqgzpwps3xqx1k4qcs844jjs9f",
-  "desktopYarnHash": "0akmgib212gkygvs2snn9c43k3ika3ipg85d480j3hqyb6yxwqmn"
+  "version": "1.10.12-sc.1",
+  "rev": "v1.10.12-sc.1",
+  "srcHash": "1rpfax6xx731w59a2i7v6jr17l3rnrn79d666f0cjchg36nkqqg9",
+  "webYarnHash": "0m5dnz3m68iz94siwmavzj50wxd6w6wanjsm1zhq76lgymgcbqc2",
+  "jsSdkYarnHash": "1k1jvavbqr7vcbdaxc6yqiq5254kxhywn1s2zndrfny7ap8z5c1c",
+  "reactSdkYarnHash": "0cz7pgrbysljmhpf4m0wqwqjqijxahl3wz5qhczlkj46dvq6qyxb",
+  "desktopYarnHash": "09ri87ynfgxrv22sykggiy6nlcf20qwj7zj9qq0rz3c2acr6g9mn"
 }

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
@@ -78,13 +78,8 @@ in stdenv.mkDerivation rec {
   buildPhase = ''
     runHook preBuild
 
-    pushd matrix-react-sdk
-    ../element-web/node_modules/.bin/reskindex -h ../element-web/src/header
-    popd
-
     pushd element-web
     node scripts/copy-res.js
-    node_modules/.bin/reskindex -h ../element-web/src/header
     node_modules/.bin/webpack --progress --mode production
     popd
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5431,7 +5431,7 @@ with pkgs;
 
   schildichat-desktop = callPackage ../applications/networking/instant-messengers/schildichat/schildichat-desktop.nix {
     inherit (darwin.apple_sdk.frameworks) Security AppKit CoreServices;
-    electron = electron_15;
+    electron = electron_17;
   };
   schildichat-desktop-wayland = writeScriptBin "schildichat-desktop" ''
     #!/bin/sh


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
