### PR TITLE
gitsign: init at 0.1.0

### DIFF
--- a/pkgs/tools/security/gitsign/default.nix
+++ b/pkgs/tools/security/gitsign/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub, stdenv }:
+
+buildGoModule rec {
+  pname = "gitsign";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "sigstore";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-tcWq+WZJLyO8lJKxV0QSDH1JKgW+9FaC9FxrSotLQag=";
+  };
+  vendorSha256 = "sha256-34pyHAUU1+K9qNAi7rPZIvaGAen+LrwEqLyrrzUaLbk=";
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = {
+    homepage = "https://github.com/sigstore/gitsign";
+    changelog = "https://github.com/sigstore/gitsign/releases/tag/v${version}";
+    description = "Keyless Git signing using Sigstore";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lesuisse ];
+    # Need updated macOS SDK
+    # https://github.com/NixOS/nixpkgs/issues/101229
+    broken = (stdenv.isDarwin && stdenv.isx86_64);
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6399,6 +6399,10 @@ with pkgs;
 
   gitleaks = callPackage ../tools/security/gitleaks { };
 
+  gitsign = callPackage ../tools/security/gitsign {
+    buildGoModule = buildGo118Module;
+  };
+
   gitaly = callPackage ../applications/version-management/gitlab/gitaly { };
 
   gitqlient = libsForQt5.callPackage ../applications/version-management/gitqlient { };


### PR DESCRIPTION
###### Description of changes

Add https://github.com/sigstore/gitsign

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

As a test, the commit of the PR is signed using the `gitsign` package introduced by this contribution.

```
$ git --no-pager log --show-signature -1
commit 38922ba35ea048e4215c4ff578bd756b0be5371b (HEAD -> gitsign-0.0.2-alpha, fork/gitsign-0.0.2-alpha)
tlog index: 2344065
smimesign: Signature made using certificate ID 0xb5093850f5b5929d17dde7d52219ff3a71886136 | CN=sigstore,O=sigstore.dev
smimesign: Good signature from [xxx@example.com]
Parsed Git signature: true
Validated Git signature: true
Located Rekor entry: true
Validated Rekor entry: true
Author: Thomas Gerbet <xxx@example.com>
Date:   Sat May 14 17:52:45 2022 +0200

    gitsign: init at 0.0.2-alpha
```