### PR TITLE
catppuccin-gtk: init at unstable-2022-02-24

### DIFF
--- a/pkgs/data/themes/catppuccin-gtk/default.nix
+++ b/pkgs/data/themes/catppuccin-gtk/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, gnome-themes-extra
+, gtk-engine-murrine
+, sassc
+, which
+, tweaks ? [ ]         # can be "nord" "black" "rimless". cannot mix "nord" and "black"
+, size ? "standard"    # can be "standard" "compact"
+}:
+let
+  validSizes = [ "standard" "compact" ];
+  validTweaks = [ "nord" "black" "rimless" ];
+
+  unknownTweaks = lib.subtractLists validTweaks tweaks;
+  illegalMix = !(lib.elem "nord" tweaks) && !(lib.elem "black" tweaks);
+
+  assertIllegal = lib.assertMsg illegalMix ''
+    Tweaks "nord" and "black" cannot be mixed. Tweaks: ${toString tweaks}
+  '';
+
+  assertSize = lib.assertMsg (lib.elem size validSizes) ''
+    You entered wrong size: ${size}
+    Valid sizes are: ${toString validSizes}
+  '';
+
+  assertUnknown = lib.assertMsg (unknownTweaks == [ ]) ''
+    You entered wrong tweaks: ${toString unknownTweaks}
+    Valid tweaks are: ${toString validTweaks}
+  '';
+in
+
+assert assertIllegal;
+assert assertSize;
+assert assertUnknown;
+
+stdenvNoCC.mkDerivation rec {
+  pname = "catppuccin-gtk";
+  version = "unstable-2022-02-24";
+
+  src = fetchFromGitHub {
+    repo = "gtk";
+    owner = "catppuccin";
+    rev = "359c584f607c021fcc657ce77b81c181ebaff6de";
+    sha256 = "sha256-AVhFw1XTnkU0hoM+UyjT7ZevLkePybBATJUMLqRytpk=";
+  };
+
+  nativeBuildInputs = [ gtk3 sassc which ];
+
+  buildInputs = [ gnome-themes-extra ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  patches = [
+    # Allows installing with `-t all`. Works around missing grey assets.
+    # https://github.com/catppuccin/gtk/issues/17
+    ./grey-fix.patch
+  ];
+
+  postPatch = ''
+    patchShebangs --build scripts/*
+    substituteInPlace Makefile \
+      --replace '$(shell git rev-parse --show-toplevel)' "$PWD"
+    substituteInPlace 'scripts/install.sh' \
+      --replace '$(git rev-parse --show-toplevel)' "$PWD"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/themes
+    bash scripts/install.sh -d $out/share/themes -t all \
+      ${lib.optionalString (size != "") "-s ${size}"} \
+      ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Soothing pastel theme for GTK3";
+    homepage = "https://github.com/catppuccin/gtk";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.fufexan ];
+  };
+}

--- a/pkgs/data/themes/catppuccin-gtk/grey-fix.patch
+++ b/pkgs/data/themes/catppuccin-gtk/grey-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/scripts/install.sh b/scripts/install.sh
+index d2a2b86..bd05c93 100755
+--- a/scripts/install.sh
++++ b/scripts/install.sh
+@@ -20,7 +20,7 @@ fi
+ SASSC_OPT="-M -t expanded"
+ 
+ THEME_NAME=Catppuccin
+-THEME_VARIANTS=('' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-teal' '-grey')
++THEME_VARIANTS=('' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-teal')
+ COLOR_VARIANTS=('' '-light' '-dark')
+ SIZE_VARIANTS=('' '-compact')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -294,6 +294,8 @@ with pkgs;
 
   catatonit = callPackage ../applications/virtualization/catatonit { };
 
+  catppuccin-gtk = callPackage ../data/themes/catppuccin-gtk { };
+
   btdu = callPackage ../tools/misc/btdu { };
 
   cereal = callPackage ../development/libraries/cereal { };


### PR DESCRIPTION
###### Description of changes
Add `catppuccin-gtk` theme.
Currently `all` and `grey` colors are unsupported due to https://github.com/catppuccin/gtk/issues/17. Will add them once that's resolved.

The positioning in `all-packages.nix` may not be correct. Tell me if that's the case.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
