### PR TITLE
util-linux: make dependencies on pam and libcap optional

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,6 +1,10 @@
-{ lib, stdenv, fetchurl, pkg-config, zlib, shadow, libcap_ng
+{ lib, stdenv, fetchurl, pkg-config, zlib, shadow
+, capabilitiesSupport ? true
+, libcap_ng
 , ncursesSupport ? true
-, ncurses, pam
+, ncurses
+, pamSupport ? true
+, pam
 , systemdSupport ? stdenv.isLinux && !stdenv.hostPlatform.isStatic
 , systemd
 , nlsSupport ? true
@@ -59,7 +63,9 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ zlib pam libcap_ng ]
+  buildInputs = [ zlib ]
+    ++ lib.optionals pamSupport [ pam ]
+    ++ lib.optionals capabilitiesSupport [ libcap_ng ]
     ++ lib.optionals ncursesSupport [ ncurses ]
     ++ lib.optionals systemdSupport [ systemd ];
 


### PR DESCRIPTION
Introduce new boolean arguments "pamSupport" and "capabilitiesSupport" that
control whether "pam" and "libcap" are compiled in. These flags are true by
default, so this commit does not cause any rebuilds.

Following builds and works:

```
(import ./. { }).util-linux.override {
  pamSupport = false;
  systemdSupport = false;
  capabilitiesSupport = false;
}
```

- Built on platform(s)
  - [x] x86_64-linux
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
