### PR TITLE
amaranth: patch out use of deprecated jinja2 function

### DIFF
--- a/pkgs/development/python-modules/amaranth/default.nix
+++ b/pkgs/development/python-modules/amaranth/default.nix
@@ -57,6 +57,10 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "Jinja2~=2.11" "Jinja2>=2.11" \
       --replace "pyvcd~=0.2.2" "pyvcd"
+
+    # jinja2.contextfunction was removed in jinja2 v3.1
+    substituteInPlace amaranth/build/plat.py \
+      --replace "@jinja2.contextfunction" "@jinja2.pass_context"
   '';
 
   pythonImportsCheck = [ "amaranth" ];


### PR DESCRIPTION
###### Description of changes

ZHF: #172160
@NixOS/nixos-release-managers 

Trying to fix the broken glasgow package I realized it was trigerring a call to the deprecated function `jinja2.contextfunction`.
The call originated from an amaranth file.
As mentioned here https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.contextfunction `jinja2.contextfunction` was removed in jinja2 v3.1.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
