### PR TITLE
chromiumBeta: Fix the build

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -160,6 +160,10 @@ let
       ./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
       ./patches/widevine-79.patch
+    ] ++ optionals (versionRange "102" "103") [
+      # https://dawn-review.googlesource.com/c/dawn/+/88582
+      # Wrap get_gitHash in try-catch to prevent failures in tarball builds.
+      ./patches/m102-fix-dawn_version_generator-failure.patch
     ];
 
     postPatch = optionalString (chromiumVersionAtLeast "102") ''

--- a/pkgs/applications/networking/browsers/chromium/patches/m102-fix-dawn_version_generator-failure.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/m102-fix-dawn_version_generator-failure.patch
@@ -1,0 +1,43 @@
+From e9ffd084ec1ff9f7bfc86879732953dc58256958 Mon Sep 17 00:00:00 2001
+From: Loko Kung <lokokung@google.com>
+Date: Tue, 3 May 2022 00:28:53 +0000
+Subject: [PATCH] Wrap get_gitHash in try-catch to prevent failures in tarball
+ builds.
+
+Bug: chromium:1321370
+Change-Id: If39d2236d1b4d965f7bd189f6bd1cdc70436c41d
+Reviewed-on: https://dawn-review.googlesource.com/c/dawn/+/88582
+Commit-Queue: Loko Kung <lokokung@google.com>
+Reviewed-by: Austin Eng <enga@chromium.org>
+Kokoro: Kokoro <noreply+kokoro@google.com>
+(cherry picked from commit 03ddfbb81fb4127ca37ea53e70fcb34fe851e24e)
+---
+ third_party/dawn/generator/dawn_version_generator.py | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/third_party/dawn/generator/dawn_version_generator.py b/third_party/dawn/generator/dawn_version_generator.py
+index 1907e88da..3c1927bee 100644
+--- a/third_party/dawn/generator/dawn_version_generator.py
++++ b/third_party/dawn/generator/dawn_version_generator.py
+@@ -23,11 +23,14 @@ def get_git():
+
+
+ def get_gitHash(dawnDir):
+-    result = subprocess.run([get_git(), 'rev-parse', 'HEAD'],
+-                            stdout=subprocess.PIPE,
+-                            cwd=dawnDir)
+-    if result.returncode == 0:
+-        return result.stdout.decode('utf-8').strip()
++    try:
++        result = subprocess.run([get_git(), "rev-parse", "HEAD"],
++                                stdout=subprocess.PIPE,
++                                cwd=dawnDir)
++        if result.returncode == 0:
++            return result.stdout.decode("utf-8").strip()
++    except Exception:
++        return ""
+     # No hash was available (possibly) because the directory was not a git checkout. Dawn should
+     # explicitly handle its absenece and disable features relying on the hash, i.e. caching.
+     return ''
+--
+2.36.0


### PR DESCRIPTION
The build was failing with:
[4758/49762] ACTION //third_party/dawn/src/dawn/common:dawn_version_gen__json_tarball(//build/toolchain/linux/unbundle:default)Ke:default)ux/unbundle:default)[Kuide/optimization_guide_internals/resources/optimization_guide_internals.mojom-webui.js
FAILED: gen/third_party/dawn/dawn_version_gen.json_tarball
python3 ../../third_party/dawn/generator/dawn_version_generator.py --dawn-dir ../../third_party/dawn/ --template-dir /build/chromium-102.0.5005.49/third_party/dawn/generator/templates --jinja2-path /build/chromium-102.0.5005.49/third_party/jinja2 --output-json-tarball gen/third_party/dawn/dawn_version_gen.json_tarball --depfile gen/third_party/dawn/dawn_version_gen.json_tarball.d --expected-outputs-file gen/third_party/dawn/dawn_version_gen.expected_outputs --allowed-output-dirs-file gen/third_party/dawn/dawn_version_gen.allowed_output_dirs
Traceback (most recent call last):
[...]
FileNotFoundError: [Errno 2] No such file or directory: 'git'
[4761/49762] ACTION //third_party/blink/renderer/bindings:generate_bindings_all(//build/toolchain/linux/unbundle:default)fault)
ninja: build stopped: subcommand failed.

More details here: https://bugs.chromium.org/p/chromium/issues/detail?id=1321370

The patch doesn't apply to M102 so I had to cherry-pick it manually.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
