### PR TITLE
colloid: init at 2022-05-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14542,4 +14542,11 @@
     github = "bryanhonof";
     githubId = 5932804;
   };
+  cirkku = {
+    name = "cirkku";
+    email = "cirkkuk@users.noreply.github.com";
+    github = "cirkku";
+    githubId = 81242398;
+  };
+
 }

--- a/pkgs/data/themes/colloid/default.nix
+++ b/pkgs/data/themes/colloid/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, gnome-themes-extra
+, gtk-engine-murrine
+, sassc
+, tweaks ? [ ] 
+, jdupes
+}:
+let
+  validTweaks = [ "compact" "nord" "rimless" "normal" "dracula" ];
+  unknownTweaks = lib.subtractLists validTweaks tweaks;
+in
+  assert lib.assertMsg (unknownTweaks == [ ]) ''
+    You entered wrong tweaks: ${toString unknownTweaks}
+    Valid tweaks are: ${toString validTweaks}
+  '';
+
+  stdenvNoCC.mkDerivation rec {
+    pname = "Colloid-gtk-theme";
+    version = "2022-05-15";
+
+    src = fetchFromGitHub {
+      owner = "vinceliuice";
+      repo = pname;
+      rev = "release_${version}";
+      sha256 = "1fbj9c3n749na214b707xyh3ya9fw57q80g0xllgj36fgzy06h13";
+      name = "pname";
+      };
+
+  nativeBuildInputs = [ jdupes sassc ];
+  buildInputs = [ gnome-themes-extra ];
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  preInstall = ''
+    mkdir -p $out/share/themes
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    
+    HOME=./tmp
+    bash install.sh -d $out/share/themes -t all ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks}
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    jdupes -L -r $out/share
+    rm -rf ./tmp
+  '';
+
+
+  meta = with lib; {
+    description = "Gtk MacOS and Nord inspired gtk theme";
+    homepage = "https://github.com/vinceliuice/Colloid-gtk-theme";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ cirkku ];
+  };
+}

--- a/pkgs/data/themes/colloid/default.nix
+++ b/pkgs/data/themes/colloid/default.nix
@@ -7,6 +7,7 @@
 , sassc
 , tweaks ? [ ] 
 , jdupes
+, bash
 }:
 let
   validTweaks = [ "compact" "nord" "rimless" "normal" "dracula" ];
@@ -24,17 +25,18 @@ in
     src = fetchFromGitHub {
       owner = "vinceliuice";
       repo = pname;
-      rev = "release_${version}";
-      sha256 = "1fbj9c3n749na214b707xyh3ya9fw57q80g0xllgj36fgzy06h13";
+      rev = "2c674203ab19776dd8b8dd74d88e239d89fbcf61";
+      sha256 = "pdc5lRFT3xiLCGLxhBXTUGkbqEqr5/e3nrQrlx2qIOg=";
       name = "pname";
       };
 
   nativeBuildInputs = [ jdupes sassc ];
-  buildInputs = [ gnome-themes-extra ];
+  buildInputs = [ bash gnome-themes-extra ];
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   preInstall = ''
     mkdir -p $out/share/themes
+    patchShebangs ./install.sh ./gtkrc.sh ./build.sh ./clean-old-theme.sh
   '';
 
   installPhase = ''

--- a/pkgs/data/themes/colloid/default.nix
+++ b/pkgs/data/themes/colloid/default.nix
@@ -39,10 +39,8 @@ in
 
   installPhase = ''
     runHook preInstall
-    
     HOME=./tmp
     bash install.sh -d $out/share/themes -t all ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks}
-
     runHook postInstall
   '';
 
@@ -50,7 +48,6 @@ in
     jdupes -L -r $out/share
     rm -rf ./tmp
   '';
-
 
   meta = with lib; {
     description = "Gtk MacOS and Nord inspired gtk theme";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24596,6 +24596,8 @@ with pkgs;
 
   nordic = callPackage ../data/themes/nordic { };
 
+  colloid = callPackage ../data/themes/colloid { };
+
   nordzy-cursor-theme = callPackage ../data/icons/nordzy-cursor-theme { };
 
   nordzy-icon-theme = callPackage ../data/icons/nordzy-icon-theme { };


### PR DESCRIPTION
###### Description of changes

Add Colloid GTK  theme.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

