### PR TITLE
vlang: weekly.2021.51 -> weekly.2022.19

### DIFF
--- a/pkgs/development/compilers/vlang/disable_vcreate_test.patch
+++ b/pkgs/development/compilers/vlang/disable_vcreate_test.patch
@@ -1,0 +1,133 @@
+diff --git a/cmd/tools/vcreate_test.v b/cmd/tools/vcreate_test.v
+index 3d07f4773..de8a202df 100644
+--- a/cmd/tools/vcreate_test.v
++++ b/cmd/tools/vcreate_test.v
+@@ -2,127 +2,6 @@ import os
+ 
+ const test_path = 'vcreate_test'
+ 
+-fn init_and_check() ? {
+-	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
+-
+-	assert os.read_file('vcreate_test.v') ? == [
+-		'module main\n',
+-		'fn main() {',
+-		"	println('Hello World!')",
+-		'}',
+-		'',
+-	].join_lines()
+-
+-	assert os.read_file('v.mod') ? == [
+-		'Module {',
+-		"	name: 'vcreate_test'",
+-		"	description: ''",
+-		"	version: ''",
+-		"	license: ''",
+-		'	dependencies: []',
+-		'}',
+-		'',
+-	].join_lines()
+-
+-	assert os.read_file('.gitignore') ? == [
+-		'# Binaries for programs and plugins',
+-		'main',
+-		'vcreate_test',
+-		'*.exe',
+-		'*.exe~',
+-		'*.so',
+-		'*.dylib',
+-		'*.dll',
+-		'vls.log',
+-		'',
+-	].join_lines()
+-
+-	assert os.read_file('.gitattributes') ? == [
+-		'*.v linguist-language=V text=auto eol=lf',
+-		'*.vv linguist-language=V text=auto eol=lf',
+-		'*.vsh linguist-language=V text=auto eol=lf',
+-		'**/v.mod linguist-language=V text=auto eol=lf',
+-		'',
+-	].join_lines()
+-
+-	assert os.read_file('.editorconfig') ? == [
+-		'[*]',
+-		'charset = utf-8',
+-		'end_of_line = lf',
+-		'insert_final_newline = true',
+-		'trim_trailing_whitespace = true',
+-		'',
+-		'[*.v]',
+-		'indent_style = tab',
+-		'indent_size = 4',
+-		'',
+-	].join_lines()
+-}
+-
+ fn test_v_init() ? {
+-	dir := os.join_path(os.temp_dir(), test_path)
+-	os.rmdir_all(dir) or {}
+-	os.mkdir(dir) or {}
+-	defer {
+-		os.rmdir_all(dir) or {}
+-	}
+-	os.chdir(dir) ?
+-
+-	init_and_check() ?
+-}
+-
+-fn test_v_init_in_git_dir() ? {
+-	dir := os.join_path(os.temp_dir(), test_path)
+-	os.rmdir_all(dir) or {}
+-	os.mkdir(dir) or {}
+-	defer {
+-		os.rmdir_all(dir) or {}
+-	}
+-	os.chdir(dir) ?
+-	os.execute_or_exit('git init .')
+-	init_and_check() ?
+-}
+-
+-fn test_v_init_no_overwrite_gitignore() ? {
+-	dir := os.join_path(os.temp_dir(), test_path)
+-	os.rmdir_all(dir) or {}
+-	os.mkdir(dir) or {}
+-	os.write_file('$dir/.gitignore', 'blah') ?
+-	defer {
+-		os.rmdir_all(dir) or {}
+-	}
+-	os.chdir(dir) ?
+-
+-	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
+-
+-	assert os.read_file('.gitignore') ? == 'blah'
+-}
+-
+-fn test_v_init_no_overwrite_gitattributes_and_editorconfig() ? {
+-	git_attributes_content := '*.v linguist-language=V text=auto eol=lf'
+-	editor_config_content := '[*]
+-charset = utf-8
+-end_of_line = lf
+-insert_final_newline = true
+-trim_trailing_whitespace = true
+-
+-[*.v]
+-indent_style = tab
+-indent_size = 4
+-'
+-
+-	dir := os.join_path(os.temp_dir(), test_path)
+-	os.rmdir_all(dir) or {}
+-	os.mkdir(dir) or {}
+-	os.write_file('$dir/.gitattributes', git_attributes_content) ?
+-	os.write_file('$dir/.editorconfig', editor_config_content) ?
+-	defer {
+-		os.rmdir_all(dir) or {}
+-	}
+-	os.chdir(dir) ?
+-
+-	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
+-
+-	assert os.read_file('.gitattributes') ? == git_attributes_content
+-	assert os.read_file('.editorconfig') ? == editor_config_content
++	println('vcreate_test disabled')
+ }


### PR DESCRIPTION
###### Description of changes
Version bump.
Close #161333
Fixes #173062
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
