### PR TITLE
gyb: init at 1.62

### DIFF
--- a/pkgs/tools/backup/gyb/default.nix
+++ b/pkgs/tools/backup/gyb/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, python3
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gyb";
+  version = "1.62";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "GAM-team";
+    repo = "got-your-back";
+    rev = "v${version}";
+    sha256 = "sha256-HaexQ0y5i9Q0xgjzAX6E2xeyeDvARo7/Gx3ytohRT7U=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    google-api-python-client
+    google-auth
+    google-auth-oauthlib
+    google-auth-httplib2
+    httplib2
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,${python3.sitePackages}}
+    mv gyb.py "$out/bin/gyb"
+    mv *.py "$out/${python3.sitePackages}/"
+
+    runHook postInstall
+  '';
+
+  checkPhase = ''
+    $out/bin/gyb --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = ''
+      Got Your Back (GYB) is a command line tool for backing up your Gmail
+      messages to your computer using Gmail's API over HTTPS.
+    '';
+    homepage = "https://github.com/GAM-team/got-your-back";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6628,6 +6628,8 @@ with pkgs;
 
   grin = callPackage ../tools/text/grin { };
 
+  gyb = callPackage ../tools/backup/gyb { };
+
   igrep = callPackage ../tools/text/igrep {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

Add GYB. It's a nice backup and restore CLI for Gmail.

https://github.com/GAM-team/got-your-back/wiki

Setup is a little funky, it's basically just a few Python files and a `requirements.txt`. No `setup.py`, no `pyproject.toml`, no tests. I ran through a backup of ~3,000 emails and it worked fine.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).