### PR TITLE
temporal-cli: init at 1.16.1

### DIFF
--- a/pkgs/applications/networking/cluster/temporal-cli/default.nix
+++ b/pkgs/applications/networking/cluster/temporal-cli/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, fetchpatch, buildGoModule, testers, temporal-cli }:
+
+buildGoModule rec {
+  pname = "temporal-cli";
+  version = "1.16.1";
+
+  src = fetchFromGitHub {
+    owner = "temporalio";
+    repo = "tctl";
+    rev = "v${version}";
+    sha256 = "sha256-WNdu/62/VmxTmzAvzx3zIlcAAlEmpN0yKzQOSUtrL8s=";
+  };
+
+  patches = [
+    # Fix tests
+    (fetchpatch {
+      name = "fix-tests.patch";
+      url = "https://github.com/temporalio/tctl/pull/203/commits/2b113da137a3a925e8fbd7c18bdaaefc31397db4.patch";
+      sha256 = "sha256-HFPwbmLZ2uPHzaHvYoB4MTZvMVyzvUKggA76/bh50DQ=";
+    })
+  ];
+
+  vendorSha256 = "sha256-WF3T+HNisfR0JoKkHCC77kmHmsGZ9NfQ7UCwOmpCG/o=";
+
+  ldflags = [ "-s" "-w" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = temporal-cli;
+  };
+
+  meta = with lib; {
+    description = "Temporal CLI";
+    homepage = "https://temporal.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aaronjheng ];
+    mainProgram = "tctl";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29916,6 +29916,10 @@ with pkgs;
 
   temporal = callPackage ../applications/networking/cluster/temporal { };
 
+  temporal-cli = callPackage ../applications/networking/cluster/temporal-cli {
+    buildGoModule = buildGo118Module;
+  };
+
   tenacity = callPackage ../applications/audio/tenacity { wxGTK = wxGTK31-gtk3; };
 
   tendermint = callPackage ../tools/networking/tendermint { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
