### PR TITLE
python3Packages.timetagger: use correct interpreter

### DIFF
--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -1,13 +1,18 @@
 { lib
-, python3Packages
+, buildPythonPackage
 , fetchFromGitHub
+, asgineer
+, itemdb
+, jinja2
+, markdown
+, pscript
+, pyjwt
+, uvicorn
 , pytestCheckHook
 , requests
-, pytest
-, pythonOlder
 }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "timetagger";
   version = "22.4.2";
 
@@ -18,7 +23,7 @@ python3Packages.buildPythonPackage rec {
     sha256 = "sha256-CWY+5O4Y1dvKQNy1Cclqj4+U6q5vVVj9hZq41MYqXKs=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     asgineer
     itemdb
     jinja2
@@ -35,11 +40,7 @@ python3Packages.buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
     requests
-    pytest
   ];
-
-  # fails with `No module named pytest` on python version 3.10
-  doCheck = pythonOlder "3.10";
 
   meta = with lib; {
     homepage = "https://timetagger.app";

--- a/pkgs/servers/timetagger/default.nix
+++ b/pkgs/servers/timetagger/default.nix
@@ -1,6 +1,5 @@
 { lib
-, pkgs
-, python3Packages
+, python3
 , fetchFromGitHub
 
 , addr ? "127.0.0.1"
@@ -13,24 +12,18 @@
 # timetagger.
 #
 
-let
-  tt = python3Packages.timetagger;
-in
-python3Packages.buildPythonPackage rec {
-  pname = tt.name;
-  version = tt.version;
-  src = tt.src;
-  meta = tt.meta;
+python3.pkgs.buildPythonApplication {
+  inherit (python3.pkgs.timetagger) pname version src meta;
 
-  propagatedBuildInputs = [ tt ]
-    ++ (with python3Packages; [
-      setuptools
-    ]);
+  propagatedBuildInputs = with python3.pkgs; [
+    setuptools
+    timetagger
+  ];
 
   format = "custom";
   installPhase = ''
     mkdir -p $out/bin
-    echo "#!${pkgs.python3}/bin/python3" >> $out/bin/timetagger
+    echo "#!${python3.interpreter}" >> $out/bin/timetagger
     cat run.py >> $out/bin/timetagger
     sed -Ei 's,0\.0\.0\.0:80,${addr}:${toString port},' $out/bin/timetagger
     chmod +x $out/bin/timetagger


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @matthiasbeyer 