### PR TITLE
system76-keyboard-configurator: init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/system76-keyboard-configurator/default.nix
+++ b/pkgs/applications/misc/system76-keyboard-configurator/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, gtk3, glib, wrapGAppsHook, libusb1, hidapi, udev, pkgconfig }:
+
+# system76-keyboard-configurator tries to spawn a daemon as root via pkexec, so
+# your system needs a PolicyKit authentication agent running for the
+# configurator to work.
+
+rustPlatform.buildRustPackage rec {
+  pname = "system76-keyboard-configurator";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "keyboard-configurator";
+    rev = "v${version}";
+    sha256 = "sha256-CVCXNPmc/0T8vkxfU+i1nSbfusZGFVkLEveSoCePK0M=";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    glib # for glib-compile-resources
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    hidapi
+    libusb1
+    udev
+  ];
+
+  cargoSha256 = "sha256-/p2cVxOvWKkcVOYIR0N8tQSCniw+QhXhC+pus4NsQ8k=";
+
+  meta = with lib; {
+    description = "Keyboard configuration application for System76 keyboards and laptops";
+    homepage = "https://github.com/pop-os/keyboard-configurator";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ mirrexagon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23443,6 +23443,8 @@ with pkgs;
 
   system76-firmware = callPackage ../os-specific/linux/firmware/system76-firmware { };
 
+  system76-keyboard-configurator = callPackage ../applications/misc/system76-keyboard-configurator { };
+
   ocf-resource-agents = callPackage ../os-specific/linux/ocf-resource-agents { };
 
   open-vm-tools = callPackage ../applications/virtualization/open-vm-tools { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant 
packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Testing: used the configurator to update the keymap of my System76 Launch keyboard.

The configurator spawns a subprocess/daemon as root via `pkexec` which is used to actually communicate with hardware. It connects via stdin/stdout pipes, so there doesn't seem to be an easy way to run the daemon separately.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
