### PR TITLE
networkmanager-l2tp: 1.2.12 → 1.20.4

### DIFF
--- a/pkgs/tools/networking/networkmanager/l2tp/default.nix
+++ b/pkgs/tools/networking/networkmanager/l2tp/default.nix
@@ -3,11 +3,9 @@
 , substituteAll
 , fetchFromGitHub
 , autoreconfHook
-, libtool
-, intltool
 , pkg-config
-, file
 , gtk3
+, gtk4
 , networkmanager
 , ppp
 , xl2tpd
@@ -15,19 +13,22 @@
 , libsecret
 , withGnome ? true
 , libnma
+, libnma-gtk4
 , glib
+, openssl
+, nss
 }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname = "NetworkManager-l2tp";
-  version = "1.2.12";
+  version = "1.20.4";
 
   src = fetchFromGitHub {
     owner = "nm-l2tp";
     repo = "network-manager-l2tp";
     rev = version;
-    sha256 = "0cq07kvlm98s8a7l4a3zmqnif8x3307kv7n645zx3f1r7x72b8m4";
+    sha256 = "VoqPjMQILBYemRE5VD/XwhWi9zL9QxxHZJ2JKtGglFo=";
   };
 
   patches = [
@@ -39,35 +40,31 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
-    libtool
-    intltool
     pkg-config
-    file
   ];
 
   buildInputs = [
     networkmanager
     ppp
     glib
+    openssl
+    nss
   ] ++ lib.optionals withGnome [
     gtk3
+    gtk4
     libsecret
     libnma
+    libnma-gtk4
   ];
 
   configureFlags = [
-    "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
+    "--with-gtk4=${if withGnome then "yes" else "no"}"
     "--localstatedir=/var"
-    "--sysconfdir=$(out)/etc"
     "--enable-absolute-paths"
   ];
 
   enableParallelBuilding = true;
-
-  preConfigure = ''
-    intltoolize -f
-  '';
 
   passthru = {
     networkManagerPlugin = "VPN/nm-l2tp-service.name";

--- a/pkgs/tools/networking/networkmanager/l2tp/default.nix
+++ b/pkgs/tools/networking/networkmanager/l2tp/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     description = "L2TP plugin for NetworkManager";
     inherit (networkmanager.meta) platforms;
     homepage = "https://github.com/nm-l2tp/network-manager-l2tp";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ abbradar obadz ];
   };
 }

--- a/pkgs/tools/networking/networkmanager/l2tp/default.nix
+++ b/pkgs/tools/networking/networkmanager/l2tp/default.nix
@@ -1,7 +1,22 @@
-{ lib, stdenv, substituteAll, fetchFromGitHub, autoreconfHook, libtool, intltool, pkg-config
+{ stdenv
+, lib
+, substituteAll
+, fetchFromGitHub
+, autoreconfHook
+, libtool
+, intltool
+, pkg-config
 , file
-, gtk3, networkmanager, ppp, xl2tpd, strongswan, libsecret
-, withGnome ? true, libnma, glib }:
+, gtk3
+, networkmanager
+, ppp
+, xl2tpd
+, strongswan
+, libsecret
+, withGnome ? true
+, libnma
+, glib
+}:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
@@ -22,14 +37,23 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ networkmanager ppp glib ]
-    ++ lib.optionals withGnome [ gtk3 libsecret libnma ];
+  nativeBuildInputs = [
+    autoreconfHook
+    libtool
+    intltool
+    pkg-config
+    file
+  ];
 
-  nativeBuildInputs = [ autoreconfHook libtool intltool pkg-config file ];
-
-  preConfigure = ''
-    intltoolize -f
-  '';
+  buildInputs = [
+    networkmanager
+    ppp
+    glib
+  ] ++ lib.optionals withGnome [
+    gtk3
+    libsecret
+    libnma
+  ];
 
   configureFlags = [
     "--without-libnm-glib"
@@ -40,6 +64,10 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+
+  preConfigure = ''
+    intltoolize -f
+  '';
 
   passthru = {
     networkManagerPlugin = "VPN/nm-l2tp-service.name";

--- a/pkgs/tools/networking/networkmanager/l2tp/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/l2tp/fix-paths.patch
@@ -1,22 +1,22 @@
 diff --git a/shared/utils.c b/shared/utils.c
-index c978a1f..d2c36cd 100644
+index 453e277..28716a5 100644
 --- a/shared/utils.c
 +++ b/shared/utils.c
-@@ -52,7 +52,7 @@ nm_find_ipsec (void)
+@@ -39,7 +39,7 @@ check_ipsec_daemon(const char *path)
+ const char *
+ nm_find_ipsec(void)
  {
- 	static const char *ipsec_binary_paths[] =
- 		{
--			"/sbin/ipsec",
-+			"@strongswan@/bin/ipsec",
- 			"/usr/sbin/ipsec",
- 			"/usr/local/sbin/ipsec",
- 			"/sbin/strongswan",
-@@ -77,7 +77,7 @@ nm_find_l2tpd (void)
- {
- 	static const char *l2tp_binary_paths[] =
- 		{
--			"/sbin/xl2tpd",
-+			"@xl2tpd@/bin/xl2tpd",
- 			"/usr/sbin/xl2tpd",
- 			"/usr/local/sbin/xl2tpd",
- 			NULL
+-    static const char *ipsec_binary_paths[] = {"/usr/bin/ipsec",
++    static const char *ipsec_binary_paths[] = {"@strongswan@/bin/ipsec",
+                                                "/sbin/ipsec",
+                                                "/usr/sbin/ipsec",
+                                                "/usr/local/sbin/ipsec",
+@@ -70,7 +70,7 @@ nm_find_l2tpd(NML2tpL2tpDaemon *l2tp_daemon)
+                                                "/usr/local/sbin/kl2tpd",
+                                                NULL};
+ 
+-    static const char *xl2tp_binary_paths[] = {"/usr/bin/xl2tpd",
++    static const char *xl2tp_binary_paths[] = {"@xl2tpd@/bin/xl2tpd",
+                                                "/sbin/xl2tpd",
+                                                "/usr/sbin/xl2tpd",
+                                                "/usr/local/sbin/xl2tpd",


### PR DESCRIPTION
###### Description of changes

- Adds support for GNOME 42.
- Allows using go-l2tp instead of xl2tpd but we do not have the former packaged.
- Removes some old cruft, allowing us to simplify the expression.

https://github.com/nm-l2tp/NetworkManager-l2tp/blob/1.20.4/NEWS

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


Confirmed in GNOME VM that it the connection editor now shows, did not test connecting since I do not have server handy.

![l2tp config in GNOME Control Center](https://user-images.githubusercontent.com/705123/168464676-965bd09a-e320-488a-af22-36f7d7fd41d8.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
