### PR TITLE
teensy-udev-rules: init at version 2022-05-15

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -305,6 +305,11 @@
       </listitem>
       <listitem>
         <para>
+          Add udev rules for the Teensy family of microcontrollers.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           There is a new module for the <literal>thunar</literal>
           program (the Xfce file manager), which depends on the
           <literal>xfconf</literal> dbus service, and also has a dbus

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -114,6 +114,8 @@ Use `configure.packages` instead.
 
 - memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2. It is now the upstream version from https://www.memtest.org/, as coreboot's fork is no longer available.
 
+- Add udev rules for the Teensy family of microcontrollers.
+
 - There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/os-specific/linux/teensy-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/teensy-udev-rules/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, coreutils }:
+
+stdenv.mkDerivation {
+  pname = "teensy-udev-rules";
+  version = "2022-05-15";
+
+  # Source: https://www.pjrc.com/teensy/00-teensy.rules
+  src = ./teensy.rules;
+
+  dontUnpack = true;
+
+  runtimeDeps = [ coreutils ];
+
+  installPhase = ''
+    install -D $src $out/etc/udev/rules.d/70-teensy.rules
+    substituteInPlace $out/etc/udev/rules.d/70-teensy.rules \
+      --replace "/bin/stty" "${coreutils}/bin/stty"
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.pjrc.com/teensy/00-teensy.rules";
+    description = ''
+      udev rules that give non-root users permission to communicate with the
+      Teensy family of microcontrolers.
+
+      ModemManager (part of NetworkManager) can interfere with USB Serial
+      devices, which includes the Teensy.  See comments in the .rules file (or
+      this package's homepage) for possible workarounds.
+    '';
+    platforms = platforms.linux;
+    license = "unknown";
+    maintainers = with maintainers; [ aidalgol ];
+  };
+}

--- a/pkgs/os-specific/linux/teensy-udev-rules/teensy.rules
+++ b/pkgs/os-specific/linux/teensy-udev-rules/teensy.rules
@@ -1,0 +1,39 @@
+# UDEV Rules for Teensy boards, http://www.pjrc.com/teensy/
+#
+# The latest version of this file may be found at:
+#   http://www.pjrc.com/teensy/00-teensy.rules
+#
+# This file must be placed at:
+#
+# /etc/udev/rules.d/00-teensy.rules    (preferred location)
+#   or
+# /lib/udev/rules.d/00-teensy.rules    (req'd on some broken systems)
+#
+# To install, type this command in a terminal:
+#   sudo cp 00-teensy.rules /etc/udev/rules.d/00-teensy.rules
+#
+# After this file is installed, physically unplug and reconnect Teensy.
+#
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789a]*", ENV{MTP_NO_PROBE}="1"
+KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666", RUN:="/bin/stty -F /dev/%k raw -echo"
+KERNEL=="hidraw*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="0666"
+
+#
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.
+#
+# ModemManager tends to interfere with USB Serial devices like Teensy.
+# Problems manifest as the Arduino Serial Monitor missing some incoming
+# data, and "Unable to open /dev/ttyACM0 for reboot request" when
+# uploading.  If you experience these problems, disable or remove
+# ModemManager from your system.  If you must use a modem, perhaps
+# try disabling the "MM_FILTER_RULE_TTY_ACM_INTERFACE" ModemManager
+# rule.  Changing ModemManager's filter policy from "strict" to "default"
+# may also help.  But if you don't use a modem, completely removing
+# the troublesome ModemManager is the most effective solution.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24333,6 +24333,8 @@ with pkgs;
 
   wooting-udev-rules = callPackage ../os-specific/linux/wooting-udev-rules { };
 
+  teensy-udev-rules = callPackage ../os-specific/linux/teensy-udev-rules { };
+
   wpa_supplicant = callPackage ../os-specific/linux/wpa_supplicant { };
 
   wpa_supplicant_ro_ssids = wpa_supplicant.override {


### PR DESCRIPTION
###### Description of changes
Add udev rules for the Teensy family of microcontrollers so that they can be flashed as non-root users.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
