### PR TITLE
nixos/dendrite: change database defaults

### DIFF
--- a/nixos/modules/services/misc/dendrite.nix
+++ b/nixos/modules/services/misc/dendrite.nix
@@ -115,7 +115,7 @@ in
             description = ''
               Global database connection pool, for postgresql monolith deployments only.
               If this is set, you can omit all the other database connection strings.
-              For postgresql polylith or SQLite deployments, you must configure those instead of this one. 
+              For postgresql polylith or SQLite deployments, you must configure those instead of this one.
             '';
           };
         };

--- a/nixos/modules/services/misc/dendrite.nix
+++ b/nixos/modules/services/misc/dendrite.nix
@@ -109,11 +109,20 @@ in
               numbers and email addresses
             '';
           };
+          database.connection_string = lib.mkOption {
+            type = lib.types.str;
+            example = "postgres://user:password@hostname/database?sslmode=disable";
+            description = ''
+              Global database connection pool, for postgresql monolith deployments only.
+              If this is set, you can omit all the other database connection strings.
+              For postgresql polylith or SQLite deployments, you must configure those instead of this one. 
+            '';
+          };
         };
         options.app_service_api.database = {
           connection_string = lib.mkOption {
             type = lib.types.str;
-            default = "file:federationapi.db";
+            example = "file:federationapi.db";
             description = ''
               Database for the Appservice API.
             '';
@@ -132,7 +141,7 @@ in
         options.federation_api.database = {
           connection_string = lib.mkOption {
             type = lib.types.str;
-            default = "file:federationapi.db";
+            example = "file:federationapi.db";
             description = ''
               Database for the Federation API.
             '';
@@ -141,7 +150,7 @@ in
         options.key_server.database = {
           connection_string = lib.mkOption {
             type = lib.types.str;
-            default = "file:keyserver.db";
+            example = "file:keyserver.db";
             description = ''
               Database for the Key Server (for end-to-end encryption).
             '';
@@ -151,7 +160,7 @@ in
           database = {
             connection_string = lib.mkOption {
               type = lib.types.str;
-              default = "file:mediaapi.db";
+              example = "file:mediaapi.db";
               description = ''
                 Database for the Media API.
               '';
@@ -168,7 +177,7 @@ in
         options.room_server.database = {
           connection_string = lib.mkOption {
             type = lib.types.str;
-            default = "file:roomserver.db";
+            example = "file:roomserver.db";
             description = ''
               Database for the Room Server.
             '';
@@ -177,7 +186,7 @@ in
         options.sync_api.database = {
           connection_string = lib.mkOption {
             type = lib.types.str;
-            default = "file:syncserver.db";
+            example = "file:syncserver.db";
             description = ''
               Database for the Sync API.
             '';
@@ -187,7 +196,7 @@ in
           account_database = {
             connection_string = lib.mkOption {
               type = lib.types.str;
-              default = "file:userapi_accounts.db";
+              example = "file:userapi_accounts.db";
               description = ''
                 Database for the User API, accounts.
               '';
@@ -196,7 +205,7 @@ in
           device_database = {
             connection_string = lib.mkOption {
               type = lib.types.str;
-              default = "file:userapi_devices.db";
+              example = "file:userapi_devices.db";
               description = ''
                 Database for the User API, devices.
               '';
@@ -207,7 +216,7 @@ in
           database = {
             connection_string = lib.mkOption {
               type = lib.types.str;
-              default = "file:mscs.db";
+              example = "file:mscs.db";
               description = ''
                 Database for exerimental MSC's.
               '';

--- a/nixos/modules/services/misc/dendrite.nix
+++ b/nixos/modules/services/misc/dendrite.nix
@@ -122,7 +122,7 @@ in
         options.app_service_api.database = {
           connection_string = lib.mkOption {
             type = lib.types.str;
-            example = "file:federationapi.db";
+            example = "file:appserviceapi.db";
             description = ''
               Database for the Appservice API.
             '';


### PR DESCRIPTION
The currently defined default database connstrings are of type SQLite and thus are in conflict with the recommended (see https://github.com/matrix-org/dendrite#requirements) practice of using postgresql. See https://matrix-org.github.io/dendrite/installation/database. 

Therefore, for a postgresql setup, one currently has to manually override all of those individually. This is especially relevant in case of a single database setup (the recommended and typical use case), where only a single global connstring is required to be set overall, and none of these need to even be part of the config, see https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.monolith.yaml#L39.


###### Description of changes

Changed these currently defined default database connstrings into examples instead, so setting them becomes optional. This resolves the conflict.

Also, added an example global connstring for said single database postgresql setup, as given in the above sample config.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
