### PR TITLE
sony-headphones-client: patch gcc-20 support

### DIFF
--- a/pkgs/applications/audio/sony-headphones-client/default.nix
+++ b/pkgs/applications/audio/sony-headphones-client/default.nix
@@ -19,26 +19,35 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-Wno-dev" ];
 
+  patches = [ ./gcc.patch ];
+
+  postPatch = ''
+    substituteInPlace Constants.h \
+      --replace "UNKNOWN = -1" "// UNKNOWN removed since it doesn't fit in char"
+  '';
+
   installPhase = ''
     runHook preInstall
     install -Dm755 -t $out/bin SonyHeadphonesClient
     runHook postInstall
   '';
 
-  desktopItems = [ (makeDesktopItem {
-    name = "SonyHeadphonesClient";
-    exec = "SonyHeadphonesClient";
-    icon = "SonyHeadphonesClient";
-    desktopName = "Sony Headphones Client";
-    comment     = "A client recreating the functionality of the Sony Headphones app";
-    categories  = [ "Audio" "Mixer" ];
-  }) ];
+  desktopItems = [
+    (makeDesktopItem {
+      name = "SonyHeadphonesClient";
+      exec = "SonyHeadphonesClient";
+      icon = "SonyHeadphonesClient";
+      desktopName = "Sony Headphones Client";
+      comment = "A client recreating the functionality of the Sony Headphones app";
+      categories = [ "Audio" "Mixer" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A client recreating the functionality of the Sony Headphones app";
-    homepage    = "https://github.com/Plutoberth/SonyHeadphonesClient";
-    license     = licenses.mit;
+    homepage = "https://github.com/Plutoberth/SonyHeadphonesClient";
+    license = licenses.mit;
     maintainers = with maintainers; [ stunkymonkey ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/sony-headphones-client/gcc.patch
+++ b/pkgs/applications/audio/sony-headphones-client/gcc.patch
@@ -1,0 +1,19 @@
+diff --git a/SingleInstanceFuture.h b/SingleInstanceFuture.h
+index 8af733f..d2e6c49 100644
+--- a/SingleInstanceFuture.h
++++ b/SingleInstanceFuture.h
+@@ -12,13 +12,13 @@ template <class T>
+ class SingleInstanceFuture : public std::future<T>
+ {
+ public:
+-	SingleInstanceFuture<T>() = default;
++	SingleInstanceFuture(void) = default;
+ 	template<class Func, class... Args>
+ 	void setFromAsync(Func func, Args&&... args) noexcept(false);
+ 	bool ready();
+ 
+ private:
+-	SingleInstanceFuture<T>(std::future<T> other);
++	SingleInstanceFuture(std::future<T> other);
+ 	SingleInstanceFuture<T> operator=(std::future<T>& other);
+ };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
it does not compile currently

surpasses #172286

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
ZHF: #172160