### PR TITLE
ispc: unstable-2021-04-02 -> 1.18.0, (co-)maintain

### DIFF
--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -1,41 +1,29 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch
-, cmake, which, m4, python3, bison, flex, llvmPackages
+, cmake, which, m4, python3, bison, flex, llvmPackages, ncurses
 
   # the default test target is sse4, but that is not supported by all Hydra agents
-, testedTargets ? [ "sse2" ]
+, testedTargets ? [ "sse2-i32x4" ]
 }:
 
 stdenv.mkDerivation rec {
   pname   = "ispc";
-  version = "unstable-2021-04-02";
+  version = "1.18.0";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
-    # ISPC release 1.15.0 doesn't build against LLVM 11.1, only against 11.0. So we
-    # use latest ISPC main branch for now, until they support an LLVM version we have.
-    # https://github.com/ispc/ispc/issues/2027#issuecomment-784470530
-    rev    = "3e8313568265d2adfbf95bd6b6e1a4c70ef59bed";
-    sha256 = "sha256-gvr+VpoacmwQlP5gT4MnfmKdACZWJduVMIpR0YRzseg=";
+    rev    = "v${version}";
+    sha256 = "sha256-eI/zUhZDTd2SiFltjrs8kxvQQOPHpqhArGyOW+och3E=";
   };
 
-  patches = [
-    # Fix cmake error: `Failed to find clang++`
-    # https://github.com/ispc/ispc/pull/2055
-    (fetchpatch {
-      url = "https://github.com/erictapen/ispc/commit/338119b2f4e11fcf0b0852de296c320928e572a2.patch";
-      sha256 = "sha256-+RqDq1LMWomu/K4SgK0Nip47b1RwyM6W0cTSNGD4+m4=";
-    })
-  ];
-
-  nativeBuildInputs = [ cmake which m4 bison flex python3 llvmPackages.llvm.dev ];
+  nativeBuildInputs = [ cmake which m4 bison flex python3 llvmPackages.libllvm.dev ];
   buildInputs = with llvmPackages; [
-    llvm llvmPackages.libclang
+    libllvm libclang openmp ncurses
   ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace curses ncurses
+      --replace CURSES_CURSES_LIBRARY CURSES_NCURSES_LIBRARY
     substituteInPlace cmake/GenerateBuiltins.cmake \
       --replace 'bit 32 64' 'bit 64'
   '';
@@ -78,6 +66,6 @@ stdenv.mkDerivation rec {
     description = "Intel 'Single Program, Multiple Data' Compiler, a vectorised language";
     license     = licenses.bsd3;
     platforms   = [ "x86_64-linux" "x86_64-darwin" ]; # TODO: buildable on more platforms?
-    maintainers = with maintainers; [ aristid thoughtpolice ];
+    maintainers = with maintainers; [ aristid thoughtpolice athas ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
