### PR TITLE
python3Packages.icontract: init at 2.6.1

### DIFF
--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "dpcontracts";
+  version = "unstable-2018-11-20";
+  format = "setuptools";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "deadpixi";
+    repo = "contracts";
+    rev = "45cb8542272c2ebe095c6efb97aa9407ddc8bf3c";
+    hash = "sha256-FygJPXo7lZ9tlfqY6KmPJ3PLIilMGLBr3013uj9hCEs=";
+  };
+
+  # package does not have any tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "dpcontracts" ];
+
+  meta = with lib; {
+    description = "Provides a collection of decorators that makes it easy to write software using contracts";
+    homepage = "https://github.com/deadpixi/contracts";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/icontract/default.nix
+++ b/pkgs/development/python-modules/icontract/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, asttokens
+, typing-extensions
+, pytestCheckHook
+, yapf
+, docutils
+, pygments
+, dpcontracts
+, tabulate
+, py-cpuinfo
+, typeguard
+, astor
+, numpy
+, asyncstdlib
+}:
+
+buildPythonPackage rec {
+  pname = "icontract";
+  version = "2.6.1";
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Parquery";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-QyuegyjVyRLQS0DjBJXpTDNeBM7LigGJ5cztVOO7e3Y=";
+  };
+
+  preCheck = ''
+    # we don't want to use the precommit.py script to build the package.
+    # For the tests to succeed, "ICONTRACT_SLOW" needs to be set.
+    # see https://github.com/Parquery/icontract/blob/aaeb1b06780a34b05743377e4cb2458780e808d3/precommit.py#L57
+    export ICONTRACT_SLOW=1
+  '';
+
+
+  propagatedBuildInputs = [
+    asttokens
+    typing-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    yapf
+    docutils
+    pygments
+    dpcontracts
+    tabulate
+    py-cpuinfo
+    typeguard
+    astor
+    numpy
+    asyncstdlib
+  ];
+
+  disabledTestPaths = [
+    # needs an old version of deal to comply with the tests
+    # see https://github.com/Parquery/icontract/issues/244
+    "tests_with_others/test_deal.py"
+    # mypy decorator checks don't pass. For some reaseon mypy
+    # doesn't check the python file provided in the test.
+    "tests/test_mypy_decorators.py"
+  ];
+
+  pythonImportsCheck = [ "icontract" ];
+
+  meta = with lib; {
+    description = "Provide design-by-contract with informative violation messages";
+    homepage = "https://github.com/Parquery/icontract";
+    changelog = "https://github.com/Parquery/icontract/blob/master/CHANGELOG.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2520,6 +2520,8 @@ in {
 
   dpath = callPackage ../development/python-modules/dpath { };
 
+  dpcontracts = callPackage ../development/python-modules/dpcontracts { };
+
   dpkt = callPackage ../development/python-modules/dpkt { };
 
   dragonfly = callPackage ../development/python-modules/dragonfly { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4067,6 +4067,8 @@ in {
 
   idasen = callPackage ../development/python-modules/idasen { };
 
+  icontract = callPackage ../development/python-modules/icontract { };
+
   identify = callPackage ../development/python-modules/identify { };
 
   idna = callPackage ../development/python-modules/idna { };


### PR DESCRIPTION
###### Description of changes

Add [icontract](https://github.com/Parquery/icontract) a design-by-contract library to python.

Also includes dpcontracts, which is needed for icontract.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

