### PR TITLE
python3Packages.deal: init at 4.23.3

### DIFF
--- a/pkgs/development/python-modules/deal-solver/default.nix
+++ b/pkgs/development/python-modules/deal-solver/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, flit-core
+, z3
+, astroid
+, pytestCheckHook
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "deal-solver";
+  version = "0.1.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "life4";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-eSSyLBwPc0rrfew91nLBagYDD6aJRyx0cE9YTTSODI8=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  postPatch = ''
+    # Use upstream z3 implementation
+    substituteInPlace pyproject.toml \
+      --replace "\"z3-solver\"," "" \
+      --replace "\"--cov=deal_solver\"," "" \
+      --replace "\"--cov-report=html\"," "" \
+      --replace "\"--cov-report=xml\"," "" \
+      --replace "\"--cov-report=term-missing:skip-covered\"," "" \
+      --replace "\"--cov-fail-under=100\"," ""
+  '';
+
+  propagatedBuildInputs = [
+    z3
+    astroid
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    hypothesis
+  ];
+
+  disabledTests = [
+    # z3 assertion error
+    "test_expr_asserts_ok"
+  ];
+
+  disabledTestPaths = [
+    # regex matching seems flaky on tests
+    "tests/test_stdlib/test_re.py"
+  ];
+
+  pythonImportsCheck = [ "deal_solver" ];
+
+  meta = with lib; {
+    description = "Z3-powered solver (theorem prover) for deal";
+    homepage = "https://github.com/life4/deal-solver";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/deal/default.nix
+++ b/pkgs/development/python-modules/deal/default.nix
@@ -1,0 +1,100 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, flit-core
+, astroid
+, pytestCheckHook
+, docstring-parser
+, isort
+, marshmallow
+, pytest-cov
+, sphinx
+, hypothesis
+, vaa
+, deal-solver
+, pygments
+, typeguard
+, coverage
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "deal";
+  version = "4.23.3";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "life4";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-duFxe2KSQQb7HB5KrrE32xzTb6QkQcrQssiuXLKao50=";
+  };
+
+  postPatch = ''
+    # don't do coverage
+    substituteInPlace pyproject.toml \
+      --replace "\"--cov-fail-under=100\"," "" \
+      --replace "\"--cov=deal\"," "" \
+      --replace "\"--cov-report=html\"," "" \
+      --replace "\"--cov-report=term-missing:skip-covered\"," ""
+  '';
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    astroid
+    deal-solver
+    pygments
+    typeguard
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+
+    docstring-parser
+    marshmallow
+    sphinx
+    hypothesis
+    vaa
+    urllib3
+  ];
+
+  disabledTests = [
+    # needs internet access
+    "test_smoke_has"
+    "test_pure_offline"
+    "test_raises_doesnt_override_another_contract"
+    "test_raises_doesnt_override_another_contract_async"
+    "test_raises_generator"
+    # AttributeError: module 'vaa' has no attribute 'Error'
+    "test_source_vaa_scheme"
+    "test_vaa_scheme_and_custom_exception"
+    "test_scheme_string_validation_args_correct"
+    "test_method_chain_decorator_with_scheme_is_fulfilled"
+    "test_scheme_contract_is_satisfied_when_setting_arg"
+    "test_scheme_contract_is_satisfied_within_chain"
+    "test_scheme_errors_rewrite_message"
+  ];
+
+  disabledTestPaths = [
+    # needs internet access
+    "tests/test_runtime/test_offline.py"
+  ];
+
+  pythonImportsCheck = [ "deal" ];
+
+  meta = with lib; {
+    description = "Library for design by contract (DbC) and checking values, exceptions, and side-effects";
+    longDescription = ''
+      In a nutshell, deal empowers you to write bug-free code.
+      By adding a few decorators to your code, you get for free tests, static analysis, formal verification, and much more
+    '';
+    homepage = "https://github.com/life4/deal";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/pyschemes/default.nix
+++ b/pkgs/development/python-modules/pyschemes/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonAtLeast
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyschemes";
+  version = "unstable-2017-11-08";
+  format = "setuptools";
+
+  disabled = pythonAtLeast "3.10";
+
+  src = fetchFromGitHub {
+    owner = "spy16";
+    repo = pname;
+    rev = "ca6483d13159ba65ba6fc2f77b90421c40f2bbf2";
+    hash = "sha256-PssucudvlE8mztwVme70+h+2hRW/ri9oV9IZayiZhdU=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyschemes" ];
+
+  meta = with lib; {
+    description = "A library for validating data structures in Python";
+    homepage = "https://github.com/spy16/pyschemes";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/vaa/default.nix
+++ b/pkgs/development/python-modules/vaa/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pytestCheckHook
+, cerberus
+, django
+, djangorestframework
+, marshmallow
+, pyschemes
+, wtforms
+, email_validator
+}:
+
+buildPythonPackage rec {
+  pname = "vaa";
+  version = "0.2.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "life4";
+    repo = pname;
+    rev = "refs/tags/v.${version}";
+    hash = "sha256-24GTTJSZ55ejyHoWP1/S3DLTKvOolAJr9UhWoOm84CU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "requires = [\"flit\"]" "requires = [\"flit_core\"]" \
+      --replace "build-backend = \"flit.buildapi\"" "build-backend = \"flit_core.buildapi\""
+  '';
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    cerberus
+    django
+    djangorestframework
+    marshmallow
+    pyschemes
+    wtforms
+    email_validator
+  ];
+
+  pythonImportsCheck = [ "vaa" ];
+
+  meta = with lib; {
+    description = "VAlidators Adapter makes validation by any existing validator with the same interface";
+    homepage = "https://github.com/life4/vaa";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2129,6 +2129,8 @@ in {
 
   ddt = callPackage ../development/python-modules/ddt { };
 
+  deal-solver = callPackage ../development/python-modules/deal-solver { };
+
   deap = callPackage ../development/python-modules/deap { };
 
   debian = callPackage ../development/python-modules/debian { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2129,6 +2129,8 @@ in {
 
   ddt = callPackage ../development/python-modules/ddt { };
 
+  deal = callPackage ../development/python-modules/deal { };
+
   deal-solver = callPackage ../development/python-modules/deal-solver { };
 
   deap = callPackage ../development/python-modules/deap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10762,6 +10762,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices CoreServices;
   };
 
+  vaa = callPackage ../development/python-modules/vaa { };
+
   validate-email = callPackage ../development/python-modules/validate-email { };
 
   validators = callPackage ../development/python-modules/validators { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6470,6 +6470,8 @@ in {
 
   pysbd = callPackage ../development/python-modules/pysbd { };
 
+  pyschemes = callPackage ../development/python-modules/pyschemes { };
+
   pyshark = callPackage ../development/python-modules/pyshark { };
 
   pysiaalarm = callPackage ../development/python-modules/pysiaalarm { };


### PR DESCRIPTION
###### Description of changes

Add [deal](https://github.com/life4/deal)

Short description: 
A Python library for [design by contract](https://en.wikipedia.org/wiki/Design_by_contract) (DbC) and checking values, exceptions, and side-effects. In a nutshell, deal empowers you to write bug-free code. By adding a few decorators to your code, you get for free tests, static analysis, formal verification, and much more. Read [intro](https://deal.readthedocs.io/basic/intro.html) to get started.

Also adds the necessary dependencies:
- pyschemes
- vaa
- deal-solver

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


This is a semi-automatic executed nixpkgs-review with nixpkgs-review-checks extension. It is checked by a human on a best effort basis and does not build all packages (e.g. lumo, tensorflow or pytorch).

Result of nixpkgs-review run on x86_64-linux 1

<details>
<summary>3 packages failed to build and are new build failures:</summary>
  <ul>
<li>python310Packages.deal: log was empty</li>
<li>python310Packages.pyschemes: log was empty</li>
<li>python310Packages.vaa: log was empty</li>
  </ul>
</details>
<details>
<summary>
5 packages built:
</summary>
<ul>
<li>python310Packages.deal-solver</li>
<li>python39Packages.deal</li>
<li>python39Packages.deal-solver</li>
<li>python39Packages.pyschemes</li>
<li>python39Packages.vaa</li>
</ul>
</details>