### PR TITLE
dotnetPackages.SharpZipLib: 0.86.0 -> 1.3.3

### DIFF
--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -53,8 +53,8 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
   SharpZipLib = fetchNuGet {
     pname = "SharpZipLib";
-    version = "0.86.0";
-    sha256 = "01w2038gckfnq31pncrlgm7d0c939pwr1x4jj5450vcqpd4c41jr";
+    version = "1.3.3";
+    sha256 = "sha256-HWEQTKh9Ktwg/zIl079dAiH+ob2ShWFAqLgG6XgIMr4=";
     outputFiles = [ "lib/*" ];
   };
 


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2021-32840 see #160635

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>17 packages built:</summary>
  <ul>
    <li>dotnetPackages.SharpZipLib</li>
    <li>openra</li>
    <li>openraPackages.engines.bleed</li>
    <li>openraPackages.engines.playtest</li>
    <li>openraPackages.mods.ca</li>
    <li>openraPackages.mods.d2</li>
    <li>openraPackages.mods.dr</li>
    <li>openraPackages.mods.gen</li>
    <li>openraPackages.mods.kknd</li>
    <li>openraPackages.mods.mw</li>
    <li>openraPackages.mods.ra2</li>
    <li>openraPackages.mods.raclassic</li>
    <li>openraPackages.mods.rv</li>
    <li>openraPackages.mods.sp</li>
    <li>openraPackages.mods.ss</li>
    <li>openraPackages.mods.ura</li>
    <li>openraPackages.mods.yr</li>
  </ul>
</details>
