### PR TITLE
blightmud: 3.5.0 -> 3.6.2

### DIFF
--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -3,16 +3,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "blightmud";
-  version = "3.5.0";
+  version = "3.6.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-DaICzwBew90YstV42wiY0IbvR1W4Hm8dzo3xY2qlMGQ=";
+    sha256 = "sha256-0TFJjOuaixBqpo6gHJynIbVHvI+PxRhwdubIXDcR098=";
   };
 
-  cargoSha256 = "sha256-BamMTPh+GN9GG4puxyTauPhjCC8heCu1wsgFaw98s9U=";
+  cargoSha256 = "sha256-jTyXoEC/QBeVbAnv2BspflGP1jA9qH+NPrRAx3x2kEg=";
 
   buildFeatures = lib.optional withTTS "tts";
 
@@ -51,6 +51,7 @@ rustPlatform.buildRustPackage rec {
       "test_gmcp_negotiation"
       "test_ttype_negotiation"
       "test_reconnect"
+      "test_is_connected"
       "test_mud"
       "test_server"
       "test_lua_script"
@@ -75,7 +76,5 @@ rustPlatform.buildRustPackage rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ cpu ];
     platforms = platforms.linux;
-    # See https://github.com/NixOS/nixpkgs/pull/160120
-    broken = withTTS;
   };
 }


### PR DESCRIPTION
###### Description of changes

Updates Blightmud to 3.6.2, this in turn brings in updated dependencies that fix building `blightmud-tts` with modern speechd. This allows removing the broken flag on this package (added in https://github.com/NixOS/nixpkgs/pull/172899 based on discussion in https://github.com/NixOS/nixpkgs/pull/160120).

###### Changelogs since 3.5.0:
* 3.6.2 https://github.com/Blightmud/Blightmud/releases/tag/v3.6.1
* 3.6.1 https://github.com/Blightmud/Blightmud/releases/tag/v3.6.1
* 3.6.0 https://github.com/Blightmud/Blightmud/releases/tag/v3.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).