### PR TITLE
kmscube: pull upstream fix for -fno-common toolchains

### DIFF
--- a/pkgs/os-specific/linux/kmscube/default.nix
+++ b/pkgs/os-specific/linux/kmscube/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, autoreconfHook, libdrm, libX11, libGL, mesa, pkg-config }:
+{ lib, stdenv, fetchgit, fetchpatch, autoreconfHook, libdrm, libX11, libGL, mesa, pkg-config }:
 
 stdenv.mkDerivation {
   pname = "kmscube";
@@ -9,6 +9,15 @@ stdenv.mkDerivation {
     rev = "9dcce71e603616ee7a54707e932f962cdf8fb20a";
     sha256 = "1q5b5yvyfj3127385mp1bfmcbnpnbdswdk8gspp7g4541xk4k933";
   };
+
+  patches = [
+    # Pull upstream patch for -fno-common toolchains.
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://gitlab.freedesktop.org/mesa/kmscube/-/commit/908ef39864442c0807954af5d3f88a3da1a6f8a5.patch";
+      sha256 = "1gxn3b50mvjlc25234839v5z29r8fd9di4176a3yx4gbsz8cc5vi";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libdrm libX11 libGL mesa ];


### PR DESCRIPTION
Without the change build against upstream gcc-10 fails as:

    ld: kmscube-cube-tex.o:/build/kmscube-9dcce71/cube-tex.c:48: multiple definition of `gl';
      kmscube-cube-smooth.o:/build/kmscube-9dcce71/cube-smooth.c:40: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
