### PR TITLE
php: Remove fixes for abandoned PHP versions

### DIFF
--- a/pkgs/development/php-packages/memcached/default.nix
+++ b/pkgs/development/php-packages/memcached/default.nix
@@ -13,8 +13,6 @@ buildPecl rec {
 
   internalDeps = [
     php.extensions.session
-  ] ++ lib.optionals (lib.versionOlder php.version "7.4") [
-    php.extensions.hash
   ];
 
   configureFlags = [

--- a/pkgs/development/php-packages/openswoole/default.nix
+++ b/pkgs/development/php-packages/openswoole/default.nix
@@ -9,7 +9,6 @@ buildPecl {
   sha256 = "sha256-Rhoa4ny86dwB3e86/1W30AlDGRUDYjK8RusquKF5Izg=";
 
   buildInputs = [ pcre2 ] ++ lib.optionals (!stdenv.isDarwin) [ valgrind ];
-  internalDeps = lib.optionals (lib.versionOlder php.version "7.4") [ php.extensions.hash ];
 
   meta = with lib; {
     changelog = "https://pecl.php.net/package/openswoole/${version}";

--- a/pkgs/development/php-packages/redis/default.nix
+++ b/pkgs/development/php-packages/redis/default.nix
@@ -10,8 +10,6 @@ buildPecl {
     session
   ] ++ lib.optionals (lib.versionOlder php.version "8.0") [
     json
-  ] ++ lib.optionals (lib.versionOlder php.version "7.4") [
-    hash
   ];
 
   meta = with lib; {

--- a/pkgs/development/php-packages/snuffleupagus/default.nix
+++ b/pkgs/development/php-packages/snuffleupagus/default.nix
@@ -22,8 +22,6 @@ buildPecl rec {
 
   internalDeps = with php.extensions; [
     session
-  ] ++ lib.optionals (lib.versionOlder php.version "7.4") [
-    hash
   ];
 
   patches = [

--- a/pkgs/development/php-packages/swoole/default.nix
+++ b/pkgs/development/php-packages/swoole/default.nix
@@ -7,7 +7,6 @@ buildPecl {
   sha256 = "sha256-SnhDRC7/a7BTHn87c6YCz/R8jI6aES1ibSD6YAl6R+I=";
 
   buildInputs = [ pcre2 ] ++ lib.optionals (!stdenv.isDarwin) [ valgrind ];
-  internalDeps = lib.optionals (lib.versionOlder php.version "7.4") [ php.extensions.hash ];
 
   doCheck = true;
   checkTarget = "tests";


### PR DESCRIPTION
Follow up of #172256, do the cleanup in `php-packages` as well.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
