### PR TITLE
[21.11] electron: (mostly) remove dependency on libXss.so

### DIFF
--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -62,6 +62,7 @@ let
   electronLibPath = with lib; makeLibraryPath (
     [ libuuid at-spi2-atk at-spi2-core libappindicator-gtk3 ]
     ++ optionals (! versionOlder version "9.0.0") [ libdrm mesa ]
+    ++ optionals (versionOlder version "10.0.0") [ libXScrnSaver ]
     ++ optionals (! versionOlder version "11.0.0") [ libxkbcommon ]
     ++ optionals (! versionOlder version "12.0.0") [ libxshmfence ]
   );
@@ -93,9 +94,7 @@ let
         $out/lib/electron/electron \
         ${lib.optionalString (! lib.versionOlder version "15.0.0") "$out/lib/electron/chrome_crashpad_handler" }
 
-      wrapProgram $out/lib/electron/electron \
-        --prefix LD_PRELOAD : ${lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1 \
-        "''${gappsWrapperArgs[@]}"
+      wrapProgram $out/lib/electron/electron "''${gappsWrapperArgs[@]}"
     '';
   };
 


### PR DESCRIPTION
Electron 10, which is built from Chromium 85.0.4183.84, no longer
depends on libXScrnSaver. This was removed from Chromium upstream in
revision 782094
(https://chromium-review.googlesource.com/c/chromium/src/+/2261490),
which landed in Chromium 85.0.4182.0
(https://storage.googleapis.com/chromium-find-releases-static/aa5.html#aa5c637805cd33366f2181ed6ec54e0ed174a6f9).

This change removes the LD_PRELOAD of libXss.so.1 and simply includes
libXScrnSaver in the rpath for Electron versions prior to 10.0.0.

(cherry picked from commit f26abaa2ef8d4f17d79ef60a4f4a1389d840b7f8)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
