### PR TITLE
python*Packages.azure-core: 1.23.1 -> 1.24.0, fix tests

### DIFF
--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPy27
+{ lib, stdenv, buildPythonPackage, fetchpatch, fetchPypi, isPy27
 , aiodns
 , aiohttp
 , flask
@@ -15,15 +15,25 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.23.1";
+  version = "1.24.0";
   pname = "azure-core";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "sha256-KKAd+68KaBLE4qgtFkLqMJVqlznyW8d8myO5H06mjw8=";
+    sha256 = "sha256-NFsbBB+q19AgWyDVaX8dDfNEMC56qoUBkFWA/4e9C+U=";
   };
+
+  patches = [
+    # FIXME: fixes tests with new versions of flask/werkzeug
+    # upstream PR: https://github.com/Azure/azure-sdk-for-python/pull/24450
+    (fetchpatch {
+      url = "https://github.com/Azure/azure-sdk-for-python/commit/fb20b0b985f614bb7bcd84f3f5f6f3105de25fd9.patch";
+      stripLen = 3;
+      sha256 = "sha256-Gt5T/UkQT1yml8bqYbeUpimfOPlmzpN1KKKUnbU9xJw=";
+    })
+  ];
 
   propagatedBuildInputs = [
     requests


### PR DESCRIPTION
###### Description of changes

https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/CHANGELOG.md#1240-2022-05-06

The version bump didn't actually fix the tests.

Upstream PR for tests fix: https://github.com/Azure/azure-sdk-for-python/pull/24450

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
