### PR TITLE
libopensmtpd: init at 0.7; opensmtpd-filter-dkimsign: init at 0.6

### DIFF
--- a/pkgs/servers/mail/opensmtpd/filter-dkimsign/default.nix
+++ b/pkgs/servers/mail/opensmtpd/filter-dkimsign/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchurl
+, libopensmtpd
+, openssl
+, mandoc
+}:
+stdenv.mkDerivation rec {
+  pname = "opensmtpd-filter-dkimsign";
+  version = "0.6";
+
+  src = fetchurl {
+    url = "https://imperialat.at/releases/filter-dkimsign-${version}.tar.gz";
+    hash = "sha256-O18NtAuSNg82uKnUx+R4h3e1IBSElTrFWBBkr2AYNsM=";
+  };
+
+  patches = [ ./no-chown-while-installing.patch ];
+
+  buildInputs = [ libopensmtpd openssl ];
+
+  nativeBuildInputs = [ mandoc ];
+
+  makeFlags = [
+    "-f Makefile.gnu"
+    "HAVE_ED25519=1"
+    "DESTDIR=$(out)"
+    "LOCALBASE="
+  ];
+
+  meta = with lib; {
+    description = "OpenSMTPD filter for DKIM signing";
+    homepage = "http://imperialat.at/dev/filter-dkimsign/";
+    license = licenses.isc;
+    maintainers = with maintainers; [ malvo ];
+  };
+}

--- a/pkgs/servers/mail/opensmtpd/filter-dkimsign/no-chown-while-installing.patch
+++ b/pkgs/servers/mail/opensmtpd/filter-dkimsign/no-chown-while-installing.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile.gnu b/Makefile.gnu
+index 1f97bd2..807b692 100644
+--- a/Makefile.gnu
++++ b/Makefile.gnu
+@@ -46,11 +46,7 @@ NEED_PLEDGE?=		1
+ 
+ MANFORMAT?=		mangz
+ 
+-BINOWN?=	root
+-BINGRP?=	root
+ BINPERM?=	755
+-MANOWN?=	root
+-MANGRP?=	root
+ MANPERM?=	644
+ 
+ ifeq (${MANFORMAT}, mangz)
+@@ -115,5 +111,5 @@ clean:
+ 
+ .PHONY: install
+ install: ${PROG}
+-	${INSTALL} -D -o ${BINOWN} -g ${BINGRP} -m ${BINPERM} ${PROG} ${DESTDIR}${BINDIR}/${PROG}
+-	${INSTALL} -D -o ${MANOWN} -g ${MANGRP} -m ${MANPERM} ${TARGET_MAN} ${DESTDIR}${MANDIR}/${TARGET_MAN}
++	${INSTALL} -D -m ${BINPERM} ${PROG} ${DESTDIR}${BINDIR}/${PROG}
++	${INSTALL} -D -m ${MANPERM} ${TARGET_MAN} ${DESTDIR}${MANDIR}/${TARGET_MAN}

--- a/pkgs/servers/mail/opensmtpd/libopensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/libopensmtpd/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchurl
+, libevent
+, mandoc
+}:
+stdenv.mkDerivation rec {
+  pname = "libopensmtpd";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://imperialat.at/releases/libopensmtpd-${version}.tar.gz";
+    hash = "sha256-zdbV4RpwY/kmXaQ6QjCcZGVUuLaLA5gsqEctvisIphM=";
+  };
+
+  patches = [ ./no-chown-while-installing.patch ];
+
+  buildInputs = [ libevent ];
+
+  nativeBuildInputs = [ mandoc ];
+
+  makeFlags = [
+    "-f Makefile.gnu"
+    "DESTDIR=$(out)"
+    "LOCALBASE="
+  ];
+
+  meta = with lib; {
+    description = "Library for creating OpenSMTPD filters";
+    homepage = "http://imperialat.at/dev/libopensmtpd/";
+    license = licenses.isc;
+    maintainers = with maintainers; [ malvo ];
+  };
+}

--- a/pkgs/servers/mail/opensmtpd/libopensmtpd/no-chown-while-installing.patch
+++ b/pkgs/servers/mail/opensmtpd/libopensmtpd/no-chown-while-installing.patch
@@ -1,0 +1,38 @@
+diff --git a/Makefile.gnu b/Makefile.gnu
+index b4bcaef..981721c 100644
+--- a/Makefile.gnu
++++ b/Makefile.gnu
+@@ -27,7 +27,7 @@ SYMBOL_LIST=	${CURDIR}/Symbols.list
+ includes:
+ 	@cd ${CURDIR}; for i in ${HDRS}; do \
+ 	    j="cmp -s $$i ${DESTDIR}${LOCALBASE}/include/$$i || \
+-	    ${INSTALL} -D -o ${BINOWN} -g ${BINGRP} -m 444 $$i\
++	    ${INSTALL} -D -m 444 $$i\
+ 		${DESTDIR}${LOCALBASE}/include/$$i"; \
+ 	    echo $$j; \
+ 	    eval "$$j"; \
+@@ -52,11 +52,7 @@ MANFORMAT?=		mangz
+ INSTALL?=	install
+ LINK?=		ln
+ 
+-BINOWN?=	root
+-BINGRP?=	root
+ LIBPERM?=	755
+-MANOWN?=	root
+-MANGRP?=	root
+ MANPERM?=	644
+ 
+ include ${CURDIR}/shlib_version
+@@ -138,10 +134,10 @@ all: ${TARGET_LIB} ${TARGET_MAN}
+ 
+ .PHONY: install
+ install: includes ${TARGET_LIB} ${TARGET_MAN}
+-	${INSTALL} -D -o ${BINOWN} -g ${BINGRP} -m ${LIBPERM} ${TARGET_LIB} ${DESTDIR}${LIBDIR}/${TARGET_LIB}
++	${INSTALL} -D -m ${LIBPERM} ${TARGET_LIB} ${DESTDIR}${LIBDIR}/${TARGET_LIB}
+ 	${LINK} -s ${TARGET_LIB} ${DESTDIR}${LIBDIR}/${SONAME_LIB}
+ 	${LINK} -s ${TARGET_LIB} ${DESTDIR}${LIBDIR}/${BASE_LIB}
+-	${INSTALL} -D -o ${MANOWN} -g ${MANGRP} -m ${MANPERM} ${TARGET_MAN} ${DESTDIR}${MANDIR}/${TARGET_MAN}
++	${INSTALL} -D -m ${MANPERM} ${TARGET_MAN} ${DESTDIR}${MANDIR}/${TARGET_MAN}
+ 
+ CLEANFILES+=	*.o ${TARGET_LIB}
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22085,6 +22085,7 @@ with pkgs;
   opensmtpd = callPackage ../servers/mail/opensmtpd { };
   opensmtpd-extras = callPackage ../servers/mail/opensmtpd/extras.nix { };
   opensmtpd-filter-rspamd = callPackage ../servers/mail/opensmtpd/filter-rspamd.nix { };
+  opensmtpd-filter-dkimsign = callPackage ../servers/mail/opensmtpd/filter-dkimsign { };
   libopensmtpd = callPackage ../servers/mail/opensmtpd/libopensmtpd { };
 
   openxr-loader = callPackage ../development/libraries/openxr-loader { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22085,6 +22085,7 @@ with pkgs;
   opensmtpd = callPackage ../servers/mail/opensmtpd { };
   opensmtpd-extras = callPackage ../servers/mail/opensmtpd/extras.nix { };
   opensmtpd-filter-rspamd = callPackage ../servers/mail/opensmtpd/filter-rspamd.nix { };
+  libopensmtpd = callPackage ../servers/mail/opensmtpd/libopensmtpd { };
 
   openxr-loader = callPackage ../development/libraries/openxr-loader { };
 


### PR DESCRIPTION
###### Description of changes

Adds a filter for OpenSMTPD that attaches DKIM signatures to outgoing mail. `libopensmtpd` is a dependency of that filter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
