### PR TITLE
inkscape: 1.1.2 -> 1.2

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -5,7 +5,6 @@
 , cairo
 , cmake
 , fetchurl
-, fetchpatch
 , gettext
 , ghostscript
 , glib
@@ -44,20 +43,25 @@
 let
   python3Env = python3.withPackages
     (ps: with ps; [
+      appdirs
+      beautifulsoup4
+      cachecontrol
       numpy
       lxml
       pillow
       scour
       pyserial
-    ]);
+      requests
+      pygobject3
+    ] ++ inkex.propagatedBuildInputs);
 in
 stdenv.mkDerivation rec {
   pname = "inkscape";
-  version = "1.1.2";
+  version = "1.2";
 
   src = fetchurl {
-    url = "https://media.inkscape.org/dl/resources/file/${pname}-${version}.tar.xz";
-    sha256 = "sha256-P/5UoG0LJaTNi260JFNu8e0gW+E0Q6Oc1DfIx7ibltE=";
+    url = "https://media.inkscape.org/dl/resources/file/inkscape-${version}.tar.xz";
+    sha256 = "jZsxFCVUlFZk7f7+LWtVkQpQmXZfcXanEQfDTx3N5q0=";
   };
 
   # Inkscape hits the ARGMAX when linking on macOS. It appears to be
@@ -72,20 +76,6 @@ stdenv.mkDerivation rec {
       # Python is used at run-time to execute scripts,
       # e.g., those from the "Effects" menu.
       python3 = "${python3Env}/bin/python";
-    })
-
-    # Fix build with poppler 22.03
-    # https://gitlab.com/inkscape/inkscape/-/merge_requests/4187
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/a18c57ffff313fd08bc8a44f6b6bf0b01d7e9b75.patch";
-      sha256 = "UZb8ZTtfA5667uo5ZlVQ5vPowiSgd4ItAJ9U1BOsRQg=";
-    })
-
-    # Fix build with poppler 22.04
-    # https://gitlab.com/inkscape/inkscape/-/merge_requests/4266
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/d989cdf1059c78bc3bb6414330242073768d640b.patch";
-      sha256 = "2cJZdunbRgPIwhJgz1dQoQRw3ZYZ2Fp6c3hpVBV2PbE=";
     })
   ];
 

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -1,6 +1,9 @@
 { buildPythonPackage
 , inkscape
+, cssselect
 , lxml
+, numpy
+, pygobject3
 , python
 }:
 
@@ -11,7 +14,10 @@ buildPythonPackage {
   format = "other";
 
   propagatedBuildInputs = [
+    cssselect
     lxml
+    numpy
+    pygobject3
   ];
 
   # We just copy the files.


### PR DESCRIPTION
https://inkscape.org/news/2022/05/16/inkscape-12/
https://media.inkscape.org/media/doc/release_notes/1.2/Inkscape_1.2.html

```
$ nix-review rev HEAD                               
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 65, done.
remote: Counting objects: 100% (63/63), done.
remote: Compressing objects: 100% (25/25), done.
remote: Total 65 (delta 34), reused 53 (delta 30), pack-reused 2
Unpacking objects: 100% (65/65), 176.16 KiB | 2.17 MiB/s, done.
From https://github.com/NixOS/nixpkgs
   34e4df55664c..ea69f7982997  master     -> refs/nixpkgs-review/0
$ git worktree add /home/matt/.cache/nixpkgs-review/rev-2af19ca97cfa9eb904cf4db893163d55b95cf357/nixpkgs ea69f79829972187ecf6c1eaede4ce7a15d81736
Preparing worktree (detached HEAD ea69f7982997)
Updating files: 100% (30489/30489), done.
HEAD is now at ea69f7982997 Merge pull request #172988 from McSinyx/dendrite-0.8.5
$ nix-env --option system x86_64-linux -f /home/matt/.cache/nixpkgs-review/rev-2af19ca97cfa9eb904cf4db893163d55b95cf357/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff 2af19ca97cfa9eb904cf4db893163d55b95cf357
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/matt/.cache/nixpkgs-review/rev-2af19ca97cfa9eb904cf4db893163d55b95cf357/nixpkgs -qaP --xml --out-path --show-trace --meta
38 packages updated:
adapta-gtk-theme arc-theme arx-libertatis asciidoc-full asciidoc-full-with-plugins ayu-theme-gtk-unstable capitaine-cursors cinnamon-screensaver clevis dblatex-full disorderfs emojione fim gnome-documents inkscape (1.1.2 → 1.2) inkscape-applytransforms inkscape-with-extensions (1.1.2 → 1.2) iso-flags-unstable iso-flags-unstable iso-flags-unstable k40-whisperer kabeljau luksmeta mate-utils mojave-gtk-theme-unstable numix-cursor-theme numix-solarized-gtk-theme plata-theme pop-gtk-theme python3.10-diagrams python310Packages.inkex (1.1.2 → 1.2) python3.9-diagrams python39Packages.inkex (1.1.2 → 1.2) rep spring springlobby tang wpa_gui

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/matt/.cache/nixpkgs-review/rev-2af19ca97cfa9eb904cf4db893163d55b95cf357/build.nix
error: builder for '/nix/store/pf7nk0iwaf61zmv57x1qxldrgbvarsgk-inkscape-applytransforms-0.pre+unstable=2021-05-11.drv' failed with exit code 2;
       last 10 log lines:
       > =============================== warnings summary ===============================
       > ../../nix/store/ry1qvmclhsi47c5h8g5agr32jwybjl06-python3.9-inkex-1.2/lib/python3.9/site-packages/inkex/elements/_svg.py:172
       >   /nix/store/ry1qvmclhsi47c5h8g5agr32jwybjl06-python3.9-inkex-1.2/lib/python3.9/site-packages/inkex/elements/_svg.py:172: DeprecationWarning: invalid escape sequence \s
       >     float(unit) for unit in re.split(",\s*|\s+", self.get("viewBox", "0"))
       >
       > -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
       > =========================== short test summary info ============================
       > ERROR tests/test_applytransform.py
       > !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
       > ========================= 1 warning, 1 error in 0.15s ==========================
       For full logs, run 'nix log /nix/store/pf7nk0iwaf61zmv57x1qxldrgbvarsgk-inkscape-applytransforms-0.pre+unstable=2021-05-11.drv'.
error: builder for '/nix/store/rvw9lmy156yjzrxvm0wbhvf92q5l71gx-spring-105.0.1-1486-g8581792.drv' failed with exit code 2;
       last 10 log lines:
       >       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       >    40 |                                   __va_arg_pack ());
       >       |                                   ~~~~~~~~~~~~~~~~~
       > [ 50%] Linking CXX static library libassimp.a
       > [ 50%] Built target assimp
       > [ 50%] Linking CXX shared library ../../libunitsync.so
       > [ 50%] Built target unitsync
       > [ 50%] Linking CXX executable ../../../spring-dedicated
       > [ 50%] Built target engine-dedicated
       > make: *** [Makefile:146: all] Error 2
       For full logs, run 'nix log /nix/store/rvw9lmy156yjzrxvm0wbhvf92q5l71gx-spring-105.0.1-1486-g8581792.drv'.
error: 1 dependencies of derivation '/nix/store/wd6vdxq6ksi9nkpw4hr3a2m5xivqndba-springlobby-0.270.drv' failed to build
error: 3 dependencies of derivation '/nix/store/nbg5cp7nama5n27mgab1wkpwvmi2d97l-review-shell.drv' failed to build
1 package marked as broken and skipped:
gnome.gnome-documents

3 packages failed to build:
inkscape-extensions.applytransforms spring springLobby

34 packages built:
adapta-gtk-theme arc-theme arx-libertatis asciidoc-full asciidoc-full-with-plugins ayu-theme-gtk capitaine-cursors cinnamon.cinnamon-screensaver cinnamon.iso-flags-png-320x420 cinnamon.iso-flags-svg clevis dblatexFull disorderfs emojione fim inkscape inkscape-with-extensions iso-flags k40-whisperer kabeljau kakounePlugins.rep luksmeta mate.mate-utils mojave-gtk-theme numix-cursor-theme numix-solarized-gtk-theme plata-theme pop-gtk-theme python310Packages.diagrams python310Packages.inkex python39Packages.diagrams python39Packages.inkex tang wpa_supplicant_gui
```

These errors don't seem to have anything to do with inkscape; appear to be errors in the packages themselves. Unfortunately, inkex displays a different error after fixing the dependency.

I also test `result/bin/inkscape` and seemed to work correctly.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
