### PR TITLE
[21.11] firefox{,-bin}: 100.0 -> 100.0.1; firefox-devedition: 98.0b5 -> 101.0b6; thunderbird{,bin}: 91.8.1 -> 91.9.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "98.0b5";
+  version = "99.0b6";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ach/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ach/firefox-99.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "75ed4180a84010f7bb509f9f8107e303c6243008071f0ab925313aab0e4dea60";
+      sha256 = "0bb4605a97661502cb23fe2ebfdb1a31831f8ca015349b3105d1245fcaa5eb69";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/af/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/af/firefox-99.0b6.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "b4c380c4d73ecb913a1ffcf0dc0d3dd771240f1188204f728464df8a65671013";
+      sha256 = "564fd8895c6fa6aecebd5a7250bd73df45a6e51f90845d9597e59cd9175b6c2c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/an/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/an/firefox-99.0b6.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "247918ac04cdef6ad1452f1d7cb0754f48c70cdffc2e20a3187901c72a023f30";
+      sha256 = "76035e42b93995e6cda0de737981760a0025013bc3330142b95ba7329d54153b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ar/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ar/firefox-99.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "68514334b54f4a626d7eb37f563bb39f418d6be4b980c7d3d31f417153d51482";
+      sha256 = "31abbbdf4378559e6b612fd3b0167bbaad332edc47d6ff67e8d9aa7e01130808";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ast/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ast/firefox-99.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "cf6a2ade0caaed45038a1237d4881c2e07867d1ba283432e7464ffee5c84258d";
+      sha256 = "1c4a2c370c3f566823c722082a3a9f149050cb7a891f3a1f21b7ca8ec899ca92";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/az/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/az/firefox-99.0b6.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "5c481ca36bb79dbfa5f4e6b83c76a0746b6f4f3fb69200642315a9226ec04809";
+      sha256 = "b1d0effa84614c985001705630da49b70f09e91be3715795fc18d926303b6b95";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/be/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/be/firefox-99.0b6.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "676169af51ba1089aeeedc1c57fc19bf383fbeff03df5b13ef401b63ec9aa249";
+      sha256 = "d0ace001eff838f8dcb80090a193307e143a5c1f3b1dac143ded5af3fecbdfda";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/bg/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bg/firefox-99.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "5e030aeb833b356b145c8ee624ec18facd95c16dbed374d1f2e90c4c14427404";
+      sha256 = "784d6029972a843829783581796263899371c777cf669f0e4f6978f35a8d6199";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/bn/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bn/firefox-99.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "7211a76921bb81307bb14bb57c5e062fde21de58fa61ef4f676652cc2c5d365f";
+      sha256 = "7cdc3a6f35c2a56b87a58eaf3112148c51b2d2d0fe5d9afc5deccfb2d2269b2e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/br/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/br/firefox-99.0b6.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "a2a6dcaba8188b205207bbf815b899a8413a494af1e87060b1da73cda1a8ca0f";
+      sha256 = "abbe12c9d887ea98d85479105bf2640bdbe3d295def41b626d3d8feef3627b36";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/bs/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bs/firefox-99.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "fd0bfad035287c35a809c1fbeff9b00e78f6c5a067e8b301c30b76ef37922dc2";
+      sha256 = "fc1076c2eda5623869a3af5c850fb51cf8611501f51984c85f690b4c545cc93b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ca-valencia/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ca-valencia/firefox-99.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "ab4d58c4640a4b0e65d824e62a898aa19674d37929c1748a27e4aed8e5be0e97";
+      sha256 = "d328055c61c96c92dd05989c23a3f8f49b36cb755f72118c21331f986ba3b44d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ca/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ca/firefox-99.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "0429ac4f1050234a28ac1cb3fea8eeef0a763e4c316154e6f02452fde434d968";
+      sha256 = "6a020e56c5f4136deff38f07d94b516971af1a31a804384a50396dbf6241877e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/cak/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cak/firefox-99.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "c69d5c22998d097213fc0016a344c967064193e81fdf45b2bfd5f1687883690d";
+      sha256 = "c6298bdeba82a637bb3903aaf73b9de9f0a3ce4ec22637b1ee1340273b7e36af";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/cs/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cs/firefox-99.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "7d06915a6b86c9bc8bf408fabbb2db73f56c3f0dc3a81d7c11324b564bde3d51";
+      sha256 = "1facd79fe087052af58205d2a0a9acce68a1d9bc58d1a3bd3e49b740f6e51647";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/cy/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cy/firefox-99.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "3e7ea4aebf641697f182c1ed5cd8848a4aac239f1fd7082f5deaf7911ca99f5f";
+      sha256 = "e7305badc55114c4a39edc317202338b3e61feba9844fc2cd8edc1518486736a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/da/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/da/firefox-99.0b6.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "b151987307e07fdc86ee14a9c0487c3be73b954d28c5beffd9b00ee05740da15";
+      sha256 = "6b1d2403e1e74c97c763476a128c56079d546967c87f1b225ac790d9acb6940d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/de/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/de/firefox-99.0b6.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "433edd8dc45eee166d14d1340453637985f8e606d635ebffed09f20c93cf851e";
+      sha256 = "c8d01b9a1bbcdeb1fa0fa63ff553209d095280ebad4eb03efa47e029505b8204";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/dsb/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/dsb/firefox-99.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "46b731e6ebac3d2e729e69a2d671b5980f6a2d8ccf83c1e6828feab93bff73ce";
+      sha256 = "bea09c23f3099c85e415bb05916ab9e3374f78e897e2b8549fb9f67895b7c052";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/el/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/el/firefox-99.0b6.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "a6f5e1ce2b6333468a250c1a28bdcb7e44539315ecaf3da09091f7cf3c08f3db";
+      sha256 = "bd740ab9aaad78e4b16e42d610ea1b914db95e2f8396f0e9c4803e38c9810f20";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/en-CA/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-CA/firefox-99.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "bc56c9b18f7d8ecbbdb6f3d4b56607bcf9355156174d537e0e85d41f32876be4";
+      sha256 = "acf5c9da684d5f7bb5b25e5fbd62d5dfafb1a5f33bd6c7baa385a37967e516a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/en-GB/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-GB/firefox-99.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "35b574db65cd0f4511d745892690dd2e64fa4c0ca1eeb2be56ad2259b45f48c5";
+      sha256 = "76cfab3fb29274bcec47ce72e88f783668653d3f8ea4ad00637bdd7ad5d32364";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/en-US/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-US/firefox-99.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "2968f69125d5a203c2edb96bdb9a922d26064c7f903d5d1b9d7f5d0f7a4aef8e";
+      sha256 = "798f68125a37ac1e60d72dff3a773cd167075a58d523d7d9659cd5fb511e2dcb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/eo/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/eo/firefox-99.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "7f5abde625cf25801bede74f74cdc1413c3dee3a4288eaf75d5e967ce133a88a";
+      sha256 = "0b65dc59679b42a298484d3901f3f47d6073f08e260a792a6e80d9c5a0e6ad0b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/es-AR/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-AR/firefox-99.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "1626c5996088df57740cd8907d61210c8081bb0a2a1b19d8bc9129c14fbd6dfe";
+      sha256 = "3a894741998ee1a2adb6def1c8d548b2c5fcab8fbea655a013dbeef9a29ab228";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/es-CL/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-CL/firefox-99.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "5bed3b64b239ded8424a27b01a8456248e317b8e2b8ee92ef50c9462574189b5";
+      sha256 = "1964534e196d426a9d6dbe664dc16790f010214cfba85e98f5df728e110e0a74";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/es-ES/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-ES/firefox-99.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "cf79cade9876dede8e6a4886875181d153169ca4f8ae5bfa9958c48f2abdcdf2";
+      sha256 = "32b21ccb56fbe2e46aba0e21c417e2a7d3404a0a3487186c75d042fd84c5033a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/es-MX/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-MX/firefox-99.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "544ec72d7f304ba702c134d1325f6589e30354d3d4b03d641451bc2f560446cc";
+      sha256 = "d70ff15a4cced1028433e603151af021be98d1026322203f0412605685611e5d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/et/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/et/firefox-99.0b6.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5a5775bc02aa61edf7d218ffc9506e70ca2dfb781f0abf5e4aabc288328deb1d";
+      sha256 = "df844133edc74d396a2fe66b0a71efda2c4797ca7110a12c4c7e620cbacbfe8d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/eu/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/eu/firefox-99.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "27bdd41a21e159e19bc9ef1464f1f76ac48126decd2942b4a18d4ea0777db743";
+      sha256 = "1ca8ba1a7ba29a0c21d7bdf5cbb046fa0e145a9bdad5debd93d121b512a060a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/fa/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fa/firefox-99.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "7e3d58ae913c919aab4f716308a9fdc6cfb590538b0dd0b90aad3dc099caead9";
+      sha256 = "a4c223f683bf75c96650d939c56aa17bfeca975ba8863e44dd5ce0449b436b3e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ff/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ff/firefox-99.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "553b4b1025749f374f82acac4e529799d9e555754e63ae4a8bdf016ac8ed620e";
+      sha256 = "6b165789213fc3f9c3f46457a04974e3c718b2c0aebd44c57c7bf8f41c73687b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/fi/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fi/firefox-99.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7514590c9dc0d9181ae439a637640ee1dee40e00e9283008a54ac3a07ec8256a";
+      sha256 = "eea67a8d94f324a9ab74caae5a7755f9505781ff690760a06a62ad034ba76bd5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/fr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fr/firefox-99.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ffd7579cdb4e6c8f5e1e66b26e3b064362292d93776313b9ded9da4a3b764cb0";
+      sha256 = "d4cc1a70f8d020870ccac0b023574b9c0f39fd44bbbcfd8a35f6c688183f2a9a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/fy-NL/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fy-NL/firefox-99.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "1f8457a73eb013abd48669f4cf1e109d307f307881e1d9b46ba9aafb09ecaebb";
+      sha256 = "df49ee1a9db407819fcc7baa9c6bc9c6fc9ab2c2b57b08d85c9478f1b0aaf6c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ga-IE/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ga-IE/firefox-99.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "6e9798462e2c2c0c50927276595c42539880cee4f58d00808cdfc5113aba9399";
+      sha256 = "e7e846a95ba695a8a3edf233ad31117f4d35d4942784c5f6c5a1ebed7f2f8e4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/gd/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gd/firefox-99.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "95f41bc7fb4c6fa19851827e0712bc8d7c9344eddc3c341172478fea583265ad";
+      sha256 = "48ef5fa12ec7415ad23a5a40f2f882147e03ecc074b33b173f413e53cc0cdde6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/gl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gl/firefox-99.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "b785913074c6d311380b382b63d57c2eae45dffee759d1aa0cd2d0c12f736e1b";
+      sha256 = "b44500b87f3b2219ba10e06bd937ba06784fc00085be12a16f69fe26f7733317";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/gn/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gn/firefox-99.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "1b7b37e1569244fdb6a11fa1d8d371d01756150bf376662b2b0246a4f08bfb37";
+      sha256 = "0e521a61d44d1058ceb566ae58272e41f0aab7f2267555781bb3235ff5e3a59c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/gu-IN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gu-IN/firefox-99.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "8623a915fcc694e5c8295bc1b95b4c6a37aacd0aed505f91239a2ab48fba8d72";
+      sha256 = "2179c82d7763294f5adedb8c905ed5e009a4d3d176fae58c7503404015214c51";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/he/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/he/firefox-99.0b6.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "52cf134be5f9981534a93d454cd7a893fd605026ad814a7257ba0e59f4cbbe1c";
+      sha256 = "69383070d17f2ae68363e8a29efc53e2748b8f784137c854162ec0132295a9e1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/hi-IN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hi-IN/firefox-99.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "e06f6fc47a98f4564a65d236f8c322e5eaaedb98d049171dfa1fafaaec8bb690";
+      sha256 = "71e57a59cfc523d5c1c73c9b5547b3247170865a95022e5bd3098967c3e6002c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/hr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hr/firefox-99.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "a93e7425c0cbcd7579fb4de0a7ece495d77c01eb2ce2a11a9413bc6a8baae3a3";
+      sha256 = "9ea82b192336e83c7ac450dc7068f2730c031f43633a87b7fa554651cf64a912";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/hsb/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hsb/firefox-99.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "66b42537cbd4d2338fd6a07b86c52c44f1210124f4c3572518c5bf7f0be217a5";
+      sha256 = "e3814f823f3bde2812751e9dd6a2b51a8861952eb04cb845d543a9252501dbba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/hu/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hu/firefox-99.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "637e898fc7bec9727fa489498abf1e6989a32e5f8b92340d0f645aa1150885c5";
+      sha256 = "e647f86de2e7687e23320aa0f36d96743f5da2cf43b2d83444a41506d13face9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/hy-AM/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hy-AM/firefox-99.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "b1b6b24039321e322f0b7d1fd2c59de13029aa56017e48e5211c18838744e9e5";
+      sha256 = "21cc172fad6136a17df0a6ae4c6e90ec72a02db744cfcb5252cedcf48223e543";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ia/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ia/firefox-99.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "5ad069400e47bae81e7e8581e81763905b3334ca5146672317e2986fde7fbfbe";
+      sha256 = "5f0c85a36ec40ef57cfa2bbbc1a4663ce10c8659e0d6ecad67ea993186c9cbb6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/id/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/id/firefox-99.0b6.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "0c80a2786e149afb12de10a49584d6017980e3b52fa1c411d9db289ee537290f";
+      sha256 = "e6671d2ac6b63ea4f2a84d1d0e89038ef1030d85e84d6b47c5b878ddc8d96b60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/is/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/is/firefox-99.0b6.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "39ebabcb230336731e5be1d4024add0d639b3ef0c9d9d94a9b59b5bcf00c6263";
+      sha256 = "5bcafb210fa3aa06d56f17972d94c17faaaa2937948890b993bbc6c9bfbeecad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/it/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/it/firefox-99.0b6.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "8646c156daf2b9e76f1cc93bda605186c8041114bcafa8b67aa27c767297a830";
+      sha256 = "3c14104a82a312324c1d42644eca6f80b7375f946a42edcb0a23f8a824bd0eb7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ja/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ja/firefox-99.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ac9284b3b994f9e3505808cc94391e04e62fc70a75a7ec4919dec56b79a63f84";
+      sha256 = "00713bc8710add3312294aa755c881701ebbb2d00e1f5f242ca12d102ab6f19b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ka/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ka/firefox-99.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "3627584688564c9fbaab025f1fc97eb988dc8b5c4eed58bd55f3fa1cb08bcd12";
+      sha256 = "ba6985797ef85bdccb1f81053456baddbe2cfd9e1097e42b20617270f681c1ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/kab/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kab/firefox-99.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "b0a8e54764b3f0d947894d0daf2a5031d43a65e19fd3bfcda7f0499ff065441b";
+      sha256 = "8be17598d305e257005ba0f9ef2f7053ee7e79bf3c1b4caade77c8e5a7e8a57c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/kk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kk/firefox-99.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "b6cc1c4cbe1cae43a45f5fe1b2ea1ca6c3d0de7cf2d085b7e5536232c9213bf8";
+      sha256 = "7e142151f26355256d2923b183fa1d225e3ed26026cbedf9abcebef301dc1045";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/km/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/km/firefox-99.0b6.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "069f7428b290da1db567a21ae0a5dc54a0cea3ab0012248658d3a273c9b45abb";
+      sha256 = "0df166d5a55e52ad60f8873afff5c1c43816ef99b56e1d817b4d4c29f173def5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/kn/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kn/firefox-99.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a7ba3abc8eaa5348b47b287b98961506e87c40740c25b88e0da611153e95f992";
+      sha256 = "193c7b709c03212ba91ea99da00c6b1c53edebbc9390d7321bd9815e5ced8233";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ko/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ko/firefox-99.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "ec46b6e6f2c852272dc5247053a55797468ba911dad70d4b1d927465ddd6ba5b";
+      sha256 = "d265a984bcc6a381f715eff5e2501acde0c8793b111e15877f7d4e9086ddcf10";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/lij/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lij/firefox-99.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "c401224b42efadc03055787bc20df523cfbde82b65d1b885a0ef6ff23bed9a21";
+      sha256 = "4a8327447982439a2f9e5ecff39b77ddd2bfdcb081d9b6f89848f2c93db3b3ca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/lt/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lt/firefox-99.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "323f765f5db4ceb5dcd167ccb4c997bfe820498aa2249a1fa2557285a1f2ad5f";
+      sha256 = "cb2a9545762247192f909c1600097b1198fbddfed1c383adf5dfa9666ddc0e80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/lv/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lv/firefox-99.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "053e095300c9c1ccb3d8fff574aff799c40215482cb977087255d69dabf9362e";
+      sha256 = "6ed249ade30c7d2d5ff290c4b65d3eaf3df4e49e112412cb3153da15bcf23fcd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/mk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/mk/firefox-99.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "946d5de91994de14941bbd9a4a1ded228b97eb76d503c8aeb164d1a718758257";
+      sha256 = "56af16c66d20eaae2d6b487c3bec4f438d21effd3e3b1582579bb9c1836956d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/mr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/mr/firefox-99.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "ed084fcb7285e047548c0969914bc43fa3572cbbb5faae91dc85688e2de77a7b";
+      sha256 = "fa6f5e496fdac7eda06220a423683f608d6c49b0e3caada52b9fd903b5ebcbe9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ms/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ms/firefox-99.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "58fcdd5fc46f80aef8a736dab07ffce340175ef07845a3c09da0f7056b30df3a";
+      sha256 = "0820d7fcdeb7226d067f920e7cb8a0bb3bfd98ea931d468ae58ed54e074dd1f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/my/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/my/firefox-99.0b6.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "3049e29781a51f1e9c1f5da7ffccdcc52b71ffd5e7e068a17b364d7b71b91982";
+      sha256 = "20ab8faa3a4aa4b4f94f6c057d4fc9602201a55482d492bc6dd7acc5173364a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/nb-NO/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nb-NO/firefox-99.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "10c4764716f879429754d9665f439c2b23dab89c9a1d159ed229569b987ccb26";
+      sha256 = "77bf24610d6ad64859c83125909b70b3dd768e90e563971461f2c18fa2cd7693";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ne-NP/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ne-NP/firefox-99.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "a46fbe8f8058d9280d28412bac9e3172d9554f0da6c5f5bfc97258e15bb1a5b6";
+      sha256 = "fe5477509d83a14875e0409f99e2336abba237da75d1e56d753e27b7d1016c9c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/nl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nl/firefox-99.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "a99eadaf1d78c5afab26f951f3ee69d49326bac0db27132ac931651a2fa7eb39";
+      sha256 = "3b67159e8d34c836d5367a2e17b54bd2aa274e1f602ae42649afc2ba2fa1429f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/nn-NO/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nn-NO/firefox-99.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b7da10f47cc22661606c3e2d7ce1885a4b6a5aea42ef7e17ec80766d9c5d92fb";
+      sha256 = "4faf2904a8b9a0c315c222d7e810d2fb3e24947dda1e006ddd1f727d2f9f967a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/oc/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/oc/firefox-99.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "653bc3cbcc3145ed8b93f3835486f2756c51318c74c8ce3006fec19420b771e3";
+      sha256 = "1dfa10fd1d9f958d487023144b7fad8ca8d1e528954f11e28509b7e22e48a341";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/pa-IN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pa-IN/firefox-99.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "efc1573dd48edebe52a4ef241132715db0a41b75db7e857f3abd0631fc2e5d02";
+      sha256 = "e6e4cc03a47ab8ff0546457b2ee0b55b8702463ed5666c15c0d2d98716fa84d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/pl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pl/firefox-99.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "a856f24cfdc51898dcad5e2ccd9f9bb406622d33daaf03362fbabfa11893b413";
+      sha256 = "525023c756ff0a0eae303c02ef9b7155fdad5f0f41bc4e539be5ca21d1af0ceb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/pt-BR/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pt-BR/firefox-99.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "1cdfb66a7616eefe00025f70f1e5fd317890a141e5495066971fc53e3102106d";
+      sha256 = "1a8070c38035f97ed771b02e59b3c2b0ef0073560c8ba285be9779fd4e99b61f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/pt-PT/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pt-PT/firefox-99.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "c8a127fd0bc4edb0eaad1b06e32e050ffe1df11ef657e05d89de3ec97f8fe607";
+      sha256 = "ea356edfa8b398ea16719993cf05e65b5c63b4d2c4e589a9a26814ae275e4be2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/rm/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/rm/firefox-99.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "6c4f66d3b22cf226ff9fbfd05e0ce463d80044bccf8228721b5b8cc5476e8d1b";
+      sha256 = "f07ca7d4233860a6271eaa972358bd05b834c7f56c4b64d45eb9af72bcf2dd9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ro/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ro/firefox-99.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "08d7eab6ce8f18abde13feab2ceaabcc3e23652730a3ee7dc98d8c9234043b0b";
+      sha256 = "fccb8f523251dba30a73f6ec9259113142514b6d4657f63b88f5b9d9e8a01923";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ru/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ru/firefox-99.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "e6fa1e2b5b3d0ce7586fba3c0d2f9c34514c767bae4a5066052df2bfb511907d";
+      sha256 = "d87928af8f4a0b28abdcd0386755a3f4f70d7e17e455fe5913b1e177c3edff2c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/sco/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sco/firefox-99.0b6.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "2c6e9d6804839a525925ad29adfafdda06ecdac1ccf034a2afbcffd5d13dfa66";
+      sha256 = "de3bda2032217c56213f64b31332e8e6ea9598c7f31f3dce1a7b136c40c3153d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/si/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/si/firefox-99.0b6.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f3172fa7c4655496565322f717f176d908ad60d97c99692a92bfb948186d17a9";
+      sha256 = "22dbdccec8073bd1d83cc236fc563aa97a3607a92e9b3908d4c8c0307dca8b08";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/sk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sk/firefox-99.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "78f88185772cf164bf548d134b00d602cc9cbfe88a5b29e9c4a0c93f3de74efc";
+      sha256 = "d5f73c93ef57cd600a2c4269a99a498896b580ec99b549db8b0ee1537a644bb1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/sl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sl/firefox-99.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "15f31bf52e10de228b50be002deddc1cc89ee6a882def6420d1055f021f75b6a";
+      sha256 = "12459b203b0de94241b243b07b9f54e7ae612f7887581c5cd3ac7ca2a08a54d9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/son/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/son/firefox-99.0b6.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "b4412fe101e6de2ca6f66d818823e48e337f06490645bd58455c6e4f9aa6723d";
+      sha256 = "2d44c84feaa5c5e3595055289f84f320b447664d01c653b0a3b50f1da24b1a78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/sq/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sq/firefox-99.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "420aaf8816745afabe98906716a8b23d0e0f84de677538a102ebc290c0f57154";
+      sha256 = "fa3f9724380818a71d895252631b354ffb692f35679eb9b8ffa5b2beede8ab61";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/sr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sr/firefox-99.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "573aedef6185562efcb03d11e0fe2c19f28f16d593f598b529eab5c80648d91f";
+      sha256 = "c2e5ad218b8cbadfda7c455266e018a6eaf9b450a905e8a73b01d02b7efed608";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/sv-SE/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sv-SE/firefox-99.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "13a4fb70bf63f3f99321998e6e01a1eebe745eeefb33848b345c2020c0e8befd";
+      sha256 = "12060ac843f03a7544db8631c7f53bcd0cc6fb15d62cd997b02a83f0560722aa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/szl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/szl/firefox-99.0b6.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "8daa190aa592e6e11fefed3558c3f91cbcee630e20c3a452ff88d333b483885b";
+      sha256 = "71ace92d020f3fbd1d5e223dfaa01e3a53ac625ba5ecf074153aad8ccb640ede";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ta/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ta/firefox-99.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "21cff7fb1234defe7732e4e933e24cacfe27b782c37c447f079662ddb6a58d85";
+      sha256 = "6ace267aab85845babad8b11b68e154e1128b920ed16b8b8d011d53f6dced16c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/te/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/te/firefox-99.0b6.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "4f9fb449f2524d47994fa17e8a561b8706f48b36566cf36c39b590a26b04ec55";
+      sha256 = "e381faff48999b63b4981695e7c80bb946b44503ab5275344f12b7005ed49ef3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/th/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/th/firefox-99.0b6.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "f9fedd16f2ddf56c8be38579b29ae2c09b4e62228674decb88475be72eed93a1";
+      sha256 = "6c2ddea1c0ccf0521b9b647827569b78ac2143163895e67476051f8496011b66";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/tl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/tl/firefox-99.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "b62e425beec561b02a273e2a432eec4e857683ad83295376e902852245ee7b27";
+      sha256 = "9d949c9c61922756d0f2dbcff76906191d438d161c74fbe7d702c7372c11b5d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/tr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/tr/firefox-99.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "ce56109695065dbbc78251d436d490bccc895a1a668c3507d6231f71a1046ada";
+      sha256 = "88763e4847b865603a7d953d54b86e6a053d2476209b4046bcb09149275690f8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/trs/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/trs/firefox-99.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "38451517de283d29f3147b41b1438c99a74eecc3fe56c042637344585bb4d8e7";
+      sha256 = "b6e7aa724a06f85e4eaae7e1c55e3ed1ec9a6b5664150745a257bd3f63310d53";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/uk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/uk/firefox-99.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "ab9d0993bf83de703245b62fac86453c091ca46f2b0bb3e96c8cd1be30fba295";
+      sha256 = "69b200c0c4c92430f188ea12bf5e60aae18203a76e61cc163738d46c3627b137";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/ur/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ur/firefox-99.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8d5d39a0c363817c4d728c6d6d9cf215d136e60ea989a0578cf76930f5caac5e";
+      sha256 = "330bb00cc0c0882a1e8aa06fdf7d283eaeef04500a9bfccef50f7b2ab8becf81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/uz/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/uz/firefox-99.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "e1b4738410bec169f0947c2d6df5048c3c1ca51f632a2a94233be51963bb0947";
+      sha256 = "a9b7087c1deec3aedcc2c279b135b113e79739a28e31ba6cd090541505e5d9e5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/vi/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/vi/firefox-99.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b950e0e6fbb707f4c0dd70b491b100f890255077ab756af92d419e0d0518cf27";
+      sha256 = "76b034ed53b8c99cf7909a6a5651627fcd9cdebd7f8ccdbd3d2286cb19dc7eaa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/xh/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/xh/firefox-99.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "e01cb86ff2b60435d5717dca42e522c5a4824c09486067574cedf8de09d98064";
+      sha256 = "a1c9ec73200bea835c46879d8196b380a3157c98404e6a009fbdb24b1662ddde";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/zh-CN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/zh-CN/firefox-99.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e388cf188ed66903c46c0694aac5725ae1f2015ba3faba4645277d6456719721";
+      sha256 = "74fd44c26c503014d0fc3a32dbb726feefd572ce52697879a392996243b5811d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-x86_64/zh-TW/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/zh-TW/firefox-99.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b6cdace1499535a36e4573914b49a2c3e4ce9cffbad250438bbaab78f3dbe4fc";
+      sha256 = "a9d86ddb8f5388370a28ac643e3d21a411625b7098aca9c399551f8e2c125da9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ach/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ach/firefox-99.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "d269fe06dfb496fdb6b9ce50d7ea4c9064e8070bbc2a47e6e6641aa79a13e772";
+      sha256 = "67b0501117e5d93046031860df5dc6eef3fc3126f0b10240cc13b83f6f1cfdb9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/af/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/af/firefox-99.0b6.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "0c6a0ddb0937c59ff5b88d09ef291e685cb29f8435b4fb6227eb0c12b82d20b5";
+      sha256 = "43b9b1107fb13b97f6b955b3abaa4f1d590bbb1747859e54bb306c9578fbdfe6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/an/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/an/firefox-99.0b6.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "efd0afc4e2ce06b094a2c1fb005c246bf8dad02fa9b8e2a0037e6f88f0fccb19";
+      sha256 = "da752ce8f7a9a0769c93f6f1817649354f892c440cdd48f0dd75739baedcff40";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ar/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ar/firefox-99.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "29ef8698f0026dedf638fa32a2ed32d0014e131f41500969d271ca62c38f5cc2";
+      sha256 = "e67fc64daef74e78eee12a1e5d4c1ef5a89a8278d19187d9e0c67ac5ea350623";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ast/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ast/firefox-99.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "244697199ae0e2895f242c64bd6f23d641deb124950ded7a0c0e8d1e18017636";
+      sha256 = "115cb0605bfb7629b854d242634cd2797b5072f735c840a6611325faf7bc3f77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/az/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/az/firefox-99.0b6.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "77bf85d57fb887f5f1e0073daf09807286e2e5d835ecd9400f698dcf0108a949";
+      sha256 = "c839a19dc4f5d938fe7a5426a8abd7b228c89a262201c019b4b53953211aea78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/be/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/be/firefox-99.0b6.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "6e18fb3773dea1a99c9ea383868a9db07e2bf2a0ba30b9acd283107a3b557b17";
+      sha256 = "94c8e688578059f8c4f7fd2a65a8fd77280b4047e845efd6ea66e34f5320d119";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/bg/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bg/firefox-99.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "1be4cc0e4a2b9c4cd00813cade9b09db97f3cec3087d103c0204cfb64bceee12";
+      sha256 = "9f7acb26e7cd9193e9e435da3e2f4e9d9ee82195cc18e8de8295cba2446da1f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/bn/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bn/firefox-99.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "c18cf7a7dd09718fd59457e8eb7153229061e4962e29abde5e83add456e2f086";
+      sha256 = "93f31b395a9a42386b0de322db1f675810a3db106a0e8c583f18ad4dd0c56488";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/br/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/br/firefox-99.0b6.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "d6ac7e4e279ce4858f77cf3613c05b4d6dc0ac0be4cfd66aa880b5761f9dbd02";
+      sha256 = "a04a2b2f2b70f33bfe288d9907291aa61f2daa64d0d6802c784d7b4f44b38326";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/bs/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bs/firefox-99.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "b785f4a680031be8ab963a66df4d61dbc54510fcd400d7e061c54e4bff554dd9";
+      sha256 = "154456c3aeefe93d6891306fe295342aa02c294bf64693fe93943ae836fc796d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ca-valencia/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ca-valencia/firefox-99.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "69ccaf431b505db72245a8a6bce287dff88993055cfa3bdafbb31ef9783598bc";
+      sha256 = "c00ab86f77e5113f85feb8eb14b74c2c144e9c7e08c4442b06b749ffccde2cf1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ca/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ca/firefox-99.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "d779e8ca6fcf77cd4c5e0edb4883d0d28dcba2eba456de9cd4216d96e7aedb03";
+      sha256 = "07de1d9c72f9d5487b9ff57ec609a2b6ce37a8b09fc81200a6cc6610a7e66b9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/cak/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cak/firefox-99.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "dcedaaaaf1d9acac61fdedaf893d288052df18a925f8853722934ef54e92a71f";
+      sha256 = "ee05ba6ce42f873ab79032553302caae28069d84c5105192623f1261d2d3d609";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/cs/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cs/firefox-99.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "b761e7d712a9ad951a00ee73f36eb5a764faa1285ce22af168e4dbe1516edfbf";
+      sha256 = "9b2af581c1c70b72cbf82cf656f94e65058063f0fd6807d99760dfe9b68af808";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/cy/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cy/firefox-99.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f640b0ffc029f473c3638ec8e08884997533d087cc8590a35458571403b5396d";
+      sha256 = "f638faf94045b5e739736926e4b3e173f8830542287d46aed70337d9ac3a4495";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/da/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/da/firefox-99.0b6.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "0e56091cf2787215884df9c1dc0e2c208021fa99088d0dce18324b18b0b57aa5";
+      sha256 = "3dad188b310fef15b704ca788b320d502a0a6ee59538296176fb17d2b440163a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/de/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/de/firefox-99.0b6.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "39d1c2ee79f1434f263ff804122d9dc20744c8c050513c95c75d7c424a5325c1";
+      sha256 = "1bdb5b60bdf16126de86ba1413eb5ac4184f727b3e57a36d424dfe39647f53be";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/dsb/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/dsb/firefox-99.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "09544d8f51134e5f74c5d90b98844e49ee5b0be7ed5c63e2fa9753a08cfd2600";
+      sha256 = "b306d40607d73314c0e3e87bb1bce65369846be3e370943088a8e7e9731098fc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/el/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/el/firefox-99.0b6.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "c76d10c0f9036b33e5e0048fafa7b4d8571af5e27f25d7dc92c336ffac2726da";
+      sha256 = "45202f79f9cbf2a44bfefa9ce50bd0a6b88485207105db4df1f26f547c1f556b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/en-CA/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-CA/firefox-99.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "c85152d5ba80dc5a843312da61aed21834257bede5019b1042353a7955ef0e35";
+      sha256 = "78020bb6fa9395fc4e2cf40645e127d0f6d6dfca4044e5c00f63a90e24824add";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/en-GB/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-GB/firefox-99.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "52696aed9eaf8be1994c88ed50925cc32f8139aa92ed9f9e1ed91d8c01468e44";
+      sha256 = "647947c0b765d1142947d3cb35ceb308946090e928ecbd4cf8c3eba4b57afa47";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/en-US/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-US/firefox-99.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "e60a2d3079cb76ce879cda5d9c67ca33938d501c3ceb517fd69b58e6f932bf2c";
+      sha256 = "4249f742c2918d66af2e7defe1c6b34870f258fe047ae7b38f91b0394b453cbe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/eo/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/eo/firefox-99.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "0f27a6f422d03c65879233a22cf469cf287d24d7c250dcea2bf8d845af303bd7";
+      sha256 = "1726df9605c7deafd6963c18c4b8dbd4bbbed86814fa9932367fd04f6ef609fc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/es-AR/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-AR/firefox-99.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "639027a3d48570d8bc98965802f9b7661d545ece751ad1d734e7e303f8649962";
+      sha256 = "c3820a35047f21efc721889fa0003d8e74e13858aad4d3aea038c01b5cd6c657";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/es-CL/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-CL/firefox-99.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "44f2a552486e6f22b111e793d0e69a67e635929f02f6f3da814dd2daf22210c2";
+      sha256 = "b1f5bf697007d8b6ac9f1fa057f292bcfb860d71229a7d0ad6d611ab02991211";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/es-ES/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-ES/firefox-99.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "02e56e76df00d39b0a8fd68038a9e8c956ceb512867d453f47209cdb9ce65597";
+      sha256 = "de33571140d165d0422b2e4543893bab6435b6626333a05bfef39682ef759db0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/es-MX/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-MX/firefox-99.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "2386378b0917c770b419ea6561823ab0cfebe36c28a36e7747c47fe68201f95d";
+      sha256 = "f681be5b92c8959e0e8c90cf4c7f6cd9197e11be1828797e853310a49dc76698";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/et/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/et/firefox-99.0b6.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "382c77faf5501c3f03c626b1a8c99bbbd0d60cff39ab1b0ed33c7a3903866d03";
+      sha256 = "476a0ccde58372bffea3ebfb0d88795b31db2ec622f9c1b99df51287aa8ba69b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/eu/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/eu/firefox-99.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "9db254a521cb2185c82522121ba5f7d75a819298abb3c301b6a8b06007d242da";
+      sha256 = "d465a6a4a01853724894fd81e31b63b80e830cee268298d6e037e6877ae77661";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/fa/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fa/firefox-99.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "16576d6924c772e5d05285a8a9367e3cfbe407f26f96c499fd829529bfd3db4e";
+      sha256 = "cf8ac9c8d667ccb0066db1d20a9f43af807e40d1746931e001ec900b34fbbc02";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ff/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ff/firefox-99.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "e26dd072353546dab184c4fd527525bb23201a8ed05c3c2bb672cf5a3da2e776";
+      sha256 = "86dcb3f9e1d899973eaccd3caf401471b36ff70f4a4693fa9f857083e8641a2e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/fi/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fi/firefox-99.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "e785cc2e7c9abefcf9b4114f778def4789635e1bd0f354082ba1040435d9c4f1";
+      sha256 = "ca0b830aa6ec724aa31f957e7c84156726c26fa0a74ace80ecdea899a8091f82";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/fr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fr/firefox-99.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "7debe05c2c0128f6a125c627b26e441547d4da485ab263c5b5190cf5cc04b3a5";
+      sha256 = "e94a7a54ba806e2b4baa0159d2f8cb96e79abc9c01e2526821cac8253c6ad495";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/fy-NL/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fy-NL/firefox-99.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "6da5b56b5df3fda1f8ac8f35ed80a0150e66809ab4ae18af8e114a7e45bd10a6";
+      sha256 = "cae5c9c607c0dc99e4645f756befce2c9c4ae83b7edc39cf12af81781b33a7b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ga-IE/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ga-IE/firefox-99.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "e145c6ec469038e9cc2e195770fd5eb467bc3859c465d9c570df06e1af0d9532";
+      sha256 = "b9b1cb2a48cd17179d5e3a8a3fca9ac25c3367ff6281f632d826cd6a9bb4a633";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/gd/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gd/firefox-99.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "d95b7f7aad0d343bdfd8814f38ea59ebc277ea85426fb447173b0a1b4efd9a74";
+      sha256 = "b5454de81ba2fee053e98dcb37d3703b5385a51561e45fa32f6872494cfc047b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/gl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gl/firefox-99.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "def309ff0f7916df41f34ffe9ec2260a0738da4a2657020641d6d03ee2faed93";
+      sha256 = "be3b3decd8e75740a317f105bfa2e4c919ad7f31e391845fb60b299fae7bea7c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/gn/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gn/firefox-99.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "1dfb7e8a36039e5bb434f1273cf9356a3826444f0f6b058897d16d4b9b0d8676";
+      sha256 = "394562b739f81ec43a954f7393c5177f87d3d5b36d404d97e2e483f3000bb615";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/gu-IN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gu-IN/firefox-99.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "1c3e77637bba527e9a229665fc4a4921f0b26e05c14e5257a0b28507db34f08d";
+      sha256 = "d2e36f37146b48cbc710af7663ad8b4f7770dbb5f6a557e3f54d637e7061ad90";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/he/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/he/firefox-99.0b6.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d54c2e3377e75dea8400d9b5486259f9be1158e44f520439912052bc2097624a";
+      sha256 = "17bbbd7768ff852dc1f27b224b77dfdaaebabaf531028c71a371bf302a9dd92d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/hi-IN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hi-IN/firefox-99.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "a91f89a416dc77cda507aa9a1bea653f48249f55ba4655489a4376ea92cf066c";
+      sha256 = "2f431a3e50ac0b74a2bda65652a5aa45c0e1b44ef0837645ec49e30c6d0d7fbc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/hr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hr/firefox-99.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "ce38b5bc0b04a1bd86e2f5cf345c25718103d347803eb72d46f1cb90553695be";
+      sha256 = "e57e5fe2cb59c25002e9c06cd3298d9cb75c4437ddc9556590d6c56a1eac57bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/hsb/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hsb/firefox-99.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "201ec9e0bb4058d7183024545af8eefe0cd3505fe557b2d541d8a7330c2797fa";
+      sha256 = "7c1eefa455afacf5b3b1ee1d04b6e793e2db210912dae58910093c70a21a73f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/hu/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hu/firefox-99.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "997a9884e4669e6e883703934e4d747f784f38fb374ee43c7d30f82b9462bb2c";
+      sha256 = "d2b02034ce6686e0743af6444acc2a23ed657124bd7bb6ddfaf6d24cf11730b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/hy-AM/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hy-AM/firefox-99.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "fb97cbf935b6ae92c8c17be640820e4be73fed59d385bdeb2435ac2253c66651";
+      sha256 = "75589d2abd9488269693c0a0440d6359bafb354b1b5ee91b90306871903eda0b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ia/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ia/firefox-99.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "d999259f970084c684cf543460efc6faa3677eb839c67e9743af24232d81ecc9";
+      sha256 = "b26efd6320a41a558383e22db49cbcdd930161fb48ad0032d24e44b57b01f0c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/id/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/id/firefox-99.0b6.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d9bcf799f9d744ba94197900e2032cbc42e4eb3f5ee2d429ede4e2ca47c45d63";
+      sha256 = "d50fff8b0ff7ae5546ad3f25e485ef51280bd022708e3d0aae97d99f79788f0a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/is/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/is/firefox-99.0b6.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "69e55dfe9e542f9c4e0cdcd75e24c346ac565012b2214ad99534ff643d5b1a9e";
+      sha256 = "4cf7fbadac8084b8e134f6110ee07076ddd93cf00a10b6ef3d6276df9080bdc1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/it/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/it/firefox-99.0b6.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "b10c9af0a38a7cc456d7392dbb4a01a964e68fcaf963868011ba104a01c10f59";
+      sha256 = "6fabf495a730600869f6d1e2d9382120361f5061e3a893321f68a6378f7eeddc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ja/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ja/firefox-99.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "114df4baff98d81d046a069b6a3271f3cd385cafff9681bb1bdd988a4b806eb3";
+      sha256 = "95a537b3306ae1f6bfe9c4076042d6c29c6478c0f32e5aa4a01e800c1d2a75a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ka/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ka/firefox-99.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "79cbe62f30dc117fb656db52ba61895dc830f2f53b8f02edb69809a8fdfe4722";
+      sha256 = "e73b2b555f7318650ca1ea20f9d8c1fbc933d230eba3eaeb5e5a47dac24797b1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/kab/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kab/firefox-99.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "babe5ff8170ac703bc95db0c9b54e6c05c12e198dcdd42f0fce9eb2b2a366606";
+      sha256 = "cd55879a883ac4e4efef972d6200284d6839dc786e7dad4c3a81fd88b89b18ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/kk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kk/firefox-99.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "a4e3648681178444d8527539523fcd177741ca74a11cf608ae7cfe9608ff46d0";
+      sha256 = "cf2dd9ae9cd6347eaf976cdcf4a6cce81abb741b0cc273063cbe1274d271e05b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/km/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/km/firefox-99.0b6.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "42dd57a33216a86ccfaf915dbc2513b6ff9441ff5820cf51b0a97bdaecf1c00c";
+      sha256 = "f0f3982e7d838841a01b24c330ed3e74416073c40470293447551aacb5411506";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/kn/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kn/firefox-99.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "8b296ec5f02e7135209f83c53bb4d18c652336a4068b17db99b10dc9d3500744";
+      sha256 = "3e2953e55e3bc7fa76ff77aac08f79b20bbf2be52683c08b3d54a323a1754ed7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ko/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ko/firefox-99.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "85829c8e7d52e7e5879d52897ffee0763f3aa03b754647a4d4c0e2d59cfad230";
+      sha256 = "5c5bec8a40dbea26674eb2d4b7160c1c2f3ef37f68d67c24a7ca6a2cf77eac85";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/lij/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lij/firefox-99.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "89f0205a14d7b97c635382d3e2ea045103eda9df9f0b7184e7655626b34e39f6";
+      sha256 = "7cc492c5eff065cc3cbceb292d18d833e9f2bf76ace0d5ca960256290f049f94";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/lt/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lt/firefox-99.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "f9f88f5d24d5edcd157a030b482c50175bda9a9d4d95499b668227438045b6a0";
+      sha256 = "b4b56e01e65ffe4f7232daf661df178d4af1d813e1c8122c4ba56aada0b2ef52";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/lv/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lv/firefox-99.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "7da0fd946c235948ce659947e53f389955e12a10251d2ad564ba6808e13aee76";
+      sha256 = "b13ac2b90f13813b8252c5eb817d0f55f770a58e05f8a98b1a08fdf59fc9191a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/mk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/mk/firefox-99.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "9ffa05fc839c67e5c709b6203627b75b7bf7765e5e52e7151561ae0ff36d43f8";
+      sha256 = "6b1d2598350feb901e86f332598688853b607c7c14c13ac228610d16e89eeda3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/mr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/mr/firefox-99.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "ff45d74bd695b8677ba76ab1cf6a7726ac08d7ea0c6ed6f705dfedc536df8112";
+      sha256 = "9a6a47fc20500b4421b12381374f0a8ecfa9a0929a54a6f6dba73e1c2e5a6c81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ms/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ms/firefox-99.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "9494973f7facf05b5636bce50a39151596b827a3444ce80a601c66e55b488af0";
+      sha256 = "e79c4f88952ec9061b4d90f8ca5970be8b5c19cbc1df8d9970b9b23c801103a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/my/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/my/firefox-99.0b6.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "ef0b115274304dd0925d643903f15ac7d6c26281ad5ec57c6b73a0a0beb97486";
+      sha256 = "f8ce25b87b639843fa6fab4651326719f229f91a4d6b3a6ef17d0e9f4035b1f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/nb-NO/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nb-NO/firefox-99.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "79c7211ec24d7855f890cd83a65411302f0ad4296ed19fecb86969e62ab6c01a";
+      sha256 = "03f5550bf0c0f33c3cf252cbad1650204e008d852e6db46a6f7fb6f6b5ac10ed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ne-NP/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ne-NP/firefox-99.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "b4fd3ba21a5c906cdeab13d4db78c4d8c43dae758211d8edb6570d49561b9f26";
+      sha256 = "5d94d2dbdbdadf6abb7250772e6e046b9ce03cbf5e4c920ef7e8b5cae69359b7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/nl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nl/firefox-99.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "cfbfaffe54246e4ced8a35edd67b5e28567d9d61ed4fe867f11fc479864e8a6d";
+      sha256 = "3045ce321c102e2c114a48a46526572a2c52d228b44ab35d8241d92bd65dd9fa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/nn-NO/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nn-NO/firefox-99.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "74487e82d428166a870b0593ea7be3de9b912132542ff98bd3276e1b9091fc21";
+      sha256 = "a16aa9b6de0ac4213492ca117eb47fbd4994824c0f080001baa9136231fb69cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/oc/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/oc/firefox-99.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "004d5e020a627f95572f2c52bcdbd0ef52b66134c5ad64328c810ba2a910cfba";
+      sha256 = "70bf39cd4c3fc4ef772dd71d97f71fdc92324ce2caf9d359cc1d3f3d1557c3a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/pa-IN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pa-IN/firefox-99.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "4102b176aa98362b3ea6bca76bc5ad3fee3849b833f192d55c02ec72bbd7fcd5";
+      sha256 = "951263906c05aa6f60a65d77e917a95ce10e8ae31f156acac7f47ab4ec36deab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/pl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pl/firefox-99.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "acc2990be46dde74e93acc0e20d5c59acd2ec9b0ca2d3db1bc641eba9e17dd6d";
+      sha256 = "476ca14396dd7ee636ed1e74a20d9d0ff3b0c452e5b5f61eae6f0594ba060f3e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/pt-BR/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pt-BR/firefox-99.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "c1a286c4369f13a6df8dbbeb9ef60dea11d36d38e1403d8e9bb8387fac2226d8";
+      sha256 = "33ea09c993bddcc36621ae633713e758ac33349847604995e05fce0d26be398f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/pt-PT/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pt-PT/firefox-99.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "35805803b8487ed6f28bf8cf6ffba764c479cf0eb11bd418ae2613831ede598a";
+      sha256 = "fd4b924d8afa163ec40a2f5ca6ae0b89e1a22a8be8b8fbf9f43012159d0b7172";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/rm/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/rm/firefox-99.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "deb2e23159d458e4e2b030678075d793a0d68e87fad38473267e7e7d57939715";
+      sha256 = "97ce5f4af9e8ed2af039255e284ce1b55b6a3ac0eacf4c40be82b635b1df0f2b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ro/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ro/firefox-99.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "bb0c6227d2903080645a7c7ed0665db6922beda6438d7b82060d890b9ace2a64";
+      sha256 = "a959d39333b98c5a479e6975dfa82a4c2b3efe5d69d2d99fddc8d2aabdbe95ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ru/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ru/firefox-99.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b06680a771d8a347c25b65a56cf76bbfa1294fc8c7a2a303bf92175aec1e952e";
+      sha256 = "e4f65bbf839054b7009e01461cf4a0b943e1373df054e9b40797b5d233654aac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/sco/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sco/firefox-99.0b6.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "0519564a5e34f3c9c9ae9605f520da542bd69f20f9410c47739e30ed290ac5f5";
+      sha256 = "fac16861dbc011655c3b36b31d5e0816a09e1f88e34032d247d09f691c097ddd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/si/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/si/firefox-99.0b6.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8a5d4685384eaec411a278f92aa2c09f667df430cb65920dbf4f2a22ab749b22";
+      sha256 = "93423cb2cccf166f374fb4b8779f337fa1cfdff67f0f2c463a398a35ecd251bf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/sk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sk/firefox-99.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "6083bdf468dae23a0cd69506e04615f7312dfce6ee0fad744432f316001b23b0";
+      sha256 = "e63c2240f7b791b01c94084dbb28d74ddd6528a7bd1e62bb74ee9271d0fd81f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/sl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sl/firefox-99.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "42ae9e4a00b8a939a934505e5b4898dfc5edf2ef7c63451784770ae8e942dc3e";
+      sha256 = "87064873e57431bb9cfd3e231df07753c8f644e218ea0318b3731baa05b16c1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/son/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/son/firefox-99.0b6.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "2d808b21afc4b1af9ea72880acac4c017566e74d7a6635d0a3e9302159961f2d";
+      sha256 = "6ecdf2061f0787fc9adcd27465211446df45751d103e279aa50f278361061728";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/sq/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sq/firefox-99.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "799099d98be61d2ef50988e4a0dcc910a3d089c8b1b156c340bc6f306f0c05bf";
+      sha256 = "47783d01b35119b158c746c5ccede7e4832d15317958030306035d1b448b77dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/sr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sr/firefox-99.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "0627104342fa014aa267b4874d88592aad131b8b71ae9da4864233217dac9fcd";
+      sha256 = "4aa1908894de6eb3640b497361d5245ed3379d29ffe6e10401540cc1c10cb965";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/sv-SE/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sv-SE/firefox-99.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "cf22010a41298f31839c61c749b7f643f92b792050d62060305284d77fc21b35";
+      sha256 = "2334fb5859711a4471f06a9eb81907d0b41ba52a8fce05b7cec320a0d31a4167";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/szl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/szl/firefox-99.0b6.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "588fed1f0dc77c8d5a18ddb33d04c5570efe80adf3e96895b1b0243e82e92535";
+      sha256 = "39ad1c9f4da42278f2a1b3c125aa7e2a8005376a6f458a03851d42f85d116dee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ta/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ta/firefox-99.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "6d10537d9268c509fed6bfd86eb53351b772ea2ba96c0f386d589765b0f1153c";
+      sha256 = "24055aedcf23fcde0dc519bc2124a8d42c82ddd74dda46b694a20d25ff76d2ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/te/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/te/firefox-99.0b6.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "4ececc1167184b3a531f8176f4282b34b2f5e2c98f329af7dc67ac5be5efefe7";
+      sha256 = "18a90860a6428ab31229c975927b264d75b2e2f186f83ef270262f7598053d48";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/th/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/th/firefox-99.0b6.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "2860a9bf015972a38b1a15bfb532b87c65e2edb7b9ea8ed2db8ee6ab03d4e281";
+      sha256 = "b965a21a0585cc07714c39ba33afc5ce757294d595c7617ba5b330a0d1d8cf0b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/tl/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/tl/firefox-99.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "97134e6fc0b07c910f8a2ca263943724e3f5790d62b4f0d2fc697c3d5a15a6ec";
+      sha256 = "cd1fb6553daf6b123e6545cf0553038b2f16c12ae4a21425e253c68124a8ce42";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/tr/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/tr/firefox-99.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "5b38cc44c7d8aa425e70903f192f2ccf8cf4dbcd40952d0014a6f16c81ec66fa";
+      sha256 = "2a2c6abfa119022520e8a3ab4c430c282a7a3f7d5e72d2a67d070a64398b2bb9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/trs/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/trs/firefox-99.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "e5e7db1ca4c8bff1623bd2b78b1d66617510419a893f324af8092de1a9476a51";
+      sha256 = "aae079859fcf211c1e465a00a6a07514397a9f715bc02d704daf062e3d75220a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/uk/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/uk/firefox-99.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "357410778b50cd6da76d178dbc88efe9bdf01e71895699e1616ef4dff253aae1";
+      sha256 = "04ebb332d79d0a9aef5d2e93b2aa8dae0ded8d4e4c639d192ac969e8033ffa24";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/ur/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ur/firefox-99.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "f38359d87aa018b4bd8fee63829a04e7d552c928b945f74c3f2e0ec21524ea03";
+      sha256 = "8a8d6d6503657665882ccea44a56b324253adc8d98eba20696ecfd096311821f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/uz/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/uz/firefox-99.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "b23c4436a5fe3edb954c2ddc16ff16756d672a89afed91e0753b6f9c7018e9d9";
+      sha256 = "e2990d6a4c3bfb5547bdac49a2499c7dd958d0b8e665b636e0ffd6e9aebaab58";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/vi/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/vi/firefox-99.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "7156717a71e9fcc8d98eb0fd544b5a3bcd8ade7e805e7a2806b3b3ac363e2402";
+      sha256 = "b7c2a4d8c1c400f44fcad7e91572134328097d183c76b8e22d5eaa0a4959d35f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/xh/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/xh/firefox-99.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "5e5b2764b860bf45e5cc738c1d6ce989a6f85b226ebd4ab59d236295ef596a51";
+      sha256 = "e3dc9942f397812564b5d7728bb4857f0c217183300ac0ab28590921f56bda34";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/zh-CN/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/zh-CN/firefox-99.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "74fbfe561438450fc28539c6d88e16e89abcfabcb025dc57aef87bb2aa64bee0";
+      sha256 = "11ff62d8f465b9ce17591177f1fc98d6dcbbd819332f65bcffd685d43b5aa285";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/98.0b5/linux-i686/zh-TW/firefox-98.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/zh-TW/firefox-99.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "12467aa41392d7429a91d01e35894fe5bf3d18cfc4091e349490f063e4b69247";
+      sha256 = "406200aceeae06ce5ae2d736d8ff42713e2275b5f369682cd49946326c5cf21d";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "101.0b2";
+  version = "101.0b6";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ach/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ach/firefox-101.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "84d818f3e3533fa8d0f92c00d654023c036238db4a9a9048a0d71c0b60017eb6";
+      sha256 = "35ea1c2469983f97091d61dca34bfc24525ff8d33a91e840a0cd2b41445b9270";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/af/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/af/firefox-101.0b6.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "1d60a63bdf28d4e0ad1ffe1459cd949704bed08864d0a1118032acb6f9e9cd82";
+      sha256 = "0eae6ca2ba7acb54aa2d9f1da6fb5a6c0e37de1f81ae3d4249d471b05d3e4784";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/an/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/an/firefox-101.0b6.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "b779cd24703b623d06cf69b60c92e244ed6f8c0df5f30ccf8c3d5d9d08841af1";
+      sha256 = "8fd96e0261251b84eb4bf05c82d6a53a58ceb09fe6633b5c15694d6429241d50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ar/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ar/firefox-101.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "b8121d4f1a9b04814933df8e15c7e7c01ed24aba78ce1f43d29ec0130aeb7d50";
+      sha256 = "0821a5ebceff38fa9a56f57730fe5b88e9ef69f3b9ac254c3c2e6a7d663ca149";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ast/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ast/firefox-101.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "cffaf3288650509a3d25988ba32bcb0e7af0bd787b7b5ea297490f236ee91d5e";
+      sha256 = "27a18fbb0f56f4b870434c2dd1be3f1aaa7d737f5fbd360da7fc38c4646a8872";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/az/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/az/firefox-101.0b6.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "c9e62710701996c4d556320583209402dc955296117e8d70a6ead33472e07d0c";
+      sha256 = "36d73756079af0989974043310a81d260adb4cd4bc9804876988a2e713590da3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/be/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/be/firefox-101.0b6.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "4bb469f3523bdff58e83d9de56a80f1d9396df2fae2c048ea91cefa14d89def2";
+      sha256 = "10093c2bf9ab674fea1805653b6a1dc011435490b4cd421674a8098b44748d9b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/bg/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/bg/firefox-101.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "bbe96de47df523971ad2f7e72b4c5ef040b94dcf3d88dcded6a3808098aeb1c2";
+      sha256 = "b3d5674d5a761daa2ec957fce0a3fd96d596bb6797884ab6d8445b456e204fc9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/bn/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/bn/firefox-101.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "0973eae62bf490af5bdf71d5e33dffe291809a2c4389fb8c9cdf33670ab497cb";
+      sha256 = "b8f4890b18a89f9d974d617bafd4dd842b73491ccfad5ada8e92da203ba84dcd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/br/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/br/firefox-101.0b6.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "f693b340a2d7ac5bf40705b51333bf7bc22e9a62a9dd14952e6835a8d5374267";
+      sha256 = "70dd3b8b95955a4fa63b6a00216388378c72a52c89c8b95deea7911341c9c691";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/bs/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/bs/firefox-101.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "de631ff909d671164e52e7194c1f5f5ac6156ef66877f4642c5f067e806281b3";
+      sha256 = "ccaa40ec92084ea45b74d4578ae1d0e22e8769c66643fe6fea6933861f90e631";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ca-valencia/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ca-valencia/firefox-101.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "eb73e92b05b37a7aa042b8b865a630a95fdeed41e9881f659a3589c2dcf3fd99";
+      sha256 = "08a4ee92be6f0096b0e8f39ec382704bc98441d04a6d822d2f9b1ad15d0570a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ca/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ca/firefox-101.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "d227042106358cfc9025f3bdc84e12494550e29ba4a8a622fa6c1b88a6cfe7cc";
+      sha256 = "e7547a427aa19a33ad4d60af5a9de21862bf547f36e8846e49f8404a2d12d6f8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/cak/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/cak/firefox-101.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "6831c152ec2fcab6fe7e6792887c7b813c2e226836135acbfc4ca66a9b114014";
+      sha256 = "dd3634a402aaa7617d0733a91826b581cac2dcc76a6f93d0cc13f808d5edebd7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/cs/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/cs/firefox-101.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "c7c52ee04dbc90417e6c6d35cefe315daffddb6b13b7a239254bc15cb22f197c";
+      sha256 = "5826dda236e1feff127b5b34fa9dbba766ba52af202107aebcb6473b71ccc5e9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/cy/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/cy/firefox-101.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e6315de3fc02ab229e1e8422f614ceb0ac4ee1aa913492a24f200dd922dfb2ae";
+      sha256 = "55038dbea8f9d287c97eff976694bed3d80d89b85e77aa29a9d0ea086aa3a0ed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/da/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/da/firefox-101.0b6.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "1dbcc3ad30cae0c8e5cd29dc480373fe80989d8636d42e45698b8f7a76bb7781";
+      sha256 = "f0299f3f49ab789f436b388343787009876f1f5a970068d9433ec1f3c838f2ff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/de/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/de/firefox-101.0b6.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "43189166f2f1e7a3366922270b62e95027f2d750206bd1878b764a5a7572d360";
+      sha256 = "eae102610ba1574e20c1b2c567e88c583246ada29113a28de9af775faab7ecb7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/dsb/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/dsb/firefox-101.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "2016ca15c4ef78eb8c698646cf6a7ca605f2316cde2df5e1648510c117fa32dc";
+      sha256 = "fd3a8b2579d93ef8628b74b606c9c7374799484ea92e9ef340f3ad48bcdd6ebe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/el/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/el/firefox-101.0b6.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "7aa33608bd1e9ce1bf3a7b1943644873a7e3d91a5bbc72ac03be5fa1bc4ec8aa";
+      sha256 = "6dd99da93bce6beaad1e6576c9821f0b7a307a12cfc4d1df1e180fe43901e1cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/en-CA/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/en-CA/firefox-101.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "e31cc0e5dd155c22b1b3a6219b154544b729e700496e8d8f83a895174e6ecb7e";
+      sha256 = "51ffb0b22b973cd83233db9dc6504eee85e2cb8d855bbc981a65ad57400063e3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/en-GB/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/en-GB/firefox-101.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "7521c0e6c083d26d1f5a67f695354e64947ec3335d07991e97429e569aa17e23";
+      sha256 = "1008a4f5e4043f0e7ac004d5ab9b0848a32a9b9af61f9e29ab528da769059650";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/en-US/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/en-US/firefox-101.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "e1ad655ed971655a6b56446b5e09fb7f0415c8ff09370ad8fccf7f28dbbd17b0";
+      sha256 = "feaf2e2a3ec7395fc8c499535baab87b4fcb55947c1a5027bd0160180442dff7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/eo/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/eo/firefox-101.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "9afae49a33f2a0aa02a346fe6e456d09dbe88a0c655a015be5e50a307c472d95";
+      sha256 = "0f7cae5594e67097e0fce15a684de6bf47d5f778f294e5c8fbd380450a7737fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-AR/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-AR/firefox-101.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "f8919da0647b6e6a6587f4856ce20be5f6054f4e5b6d71562fbffbac594853cf";
+      sha256 = "f5d3e13d762e4ae984f368a1a0b4abff423f350431d5e5d4e3844d6a6994f155";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-CL/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-CL/firefox-101.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "b31b8a41ac391aefff8c1d85a29ab129983bd39474a15672cb3e74d916e0c9eb";
+      sha256 = "a45550be772a3e17a7f658305685017da70453df865bf0088705f9700ead21ef";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-ES/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-ES/firefox-101.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "f4f6e6100d85050d381beaa4f2dfeb6b5e7170cf2c079257ebbfbd80219904b4";
+      sha256 = "868957d9cf2ef87b5595cbcf3611c1b395f5024f98d1fc0b1bb6a9b0151059c9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-MX/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-MX/firefox-101.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c2e3bd2ccbfe64fc5eb1d4f920554ba3d170c0e2e478791d9cc19da955960200";
+      sha256 = "1da2c98d69b20547497e9ad235225171ffdc05581222e27963ac88b5a9b11e36";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/et/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/et/firefox-101.0b6.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "cc0b56f513294b0742023e37a06a462b107a480c1fcab118bfba6894c2e72375";
+      sha256 = "0e99f6f8cf19233f8c4810869b002b580d7d4ec4d273abcea3d2656ffeb656f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/eu/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/eu/firefox-101.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "8a18e5428a9dc60cd39ff3a1b0900282178efe54c11b43a8015b86d33368804b";
+      sha256 = "9b7d0583120b35f24f9db76dca1e4fb3409ee8fc9cf67282257d8378efd1780d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fa/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fa/firefox-101.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "75fce16479f2e95c9a00f369364c279b362c0248e787ade7f14f6aba934cc624";
+      sha256 = "9afb28fcaec8be5ccc2a4e4bff9ff332706a01f8413b92c02bb2fcb0df1f56f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ff/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ff/firefox-101.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "90081b6c7b487292a14e2a488a14e9d560183ff6313a67076f1a07033df54a80";
+      sha256 = "c34208d25830c2cd107acb7c41369bf64944e54c2099788c39522734d19d3ce1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fi/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fi/firefox-101.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "308fbcc9086fc3f899703a58cd95f55b7e10b7ab4fc0c4cac02c01f5dfd2ffc0";
+      sha256 = "9b6a577f06f1da58ddd4c9b618907a08477630f50ee05dcb7151116e70e0138c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fr/firefox-101.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "91cca9bb622e3546d683a8e3af9984ab63e6aff56a8f0b7a61c84795d452e198";
+      sha256 = "85b7b57c27bfe9dd40bfb51425f1c601253713b3287f339150129adc0ae874e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fy-NL/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fy-NL/firefox-101.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "37f87b1b0df5efce58dbc6366028b069bfd61007bba8a4835b8c72966ebfb584";
+      sha256 = "be51352afd27cb224428b3b659cc469aa735fdcbd27bdb0922c08defe5d3f8c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ga-IE/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ga-IE/firefox-101.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "d4a347e9ee59e1eae54783c9d4c99f88d6fe5eddd541d54f6efb1d2d0c494657";
+      sha256 = "0ce7dd080035623e151a3f89c17a705f3565c92a8d361808b64efdba4ca2ec9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gd/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gd/firefox-101.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "907d68789cfe8e2be69d85cff2b846d91bd9ccf7c3a183891472509db54a5e49";
+      sha256 = "72c61136484c5fc07bbd8571a2d1bf9adda5debc09b3b2a80073b6417e43eadd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gl/firefox-101.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "1d1e107df695c76652207006ed060fcdf2133508c7ea0fee4f402816a4eed53e";
+      sha256 = "167be0a528fe6185f5c656efbda8b6cb2cd107a83a21de8749490c285c168c90";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gn/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gn/firefox-101.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "b62af16daf08e4a2574bb6b96b4a61cfc64967328dc19fdc56ea56cc431019de";
+      sha256 = "0558cf95eb7b071307333123bdcdb0a4a76557f64c267cbfa1e8c24de2679a75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gu-IN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gu-IN/firefox-101.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "ef2f317ae3aaf608e74dc882b202a195ad4146295f00bff2673cda02338ae499";
+      sha256 = "a0fef36b0034e4dfec26b3e34ca532447e4b19da38fc66d015744a813a0ba4fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/he/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/he/firefox-101.0b6.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "4f5cd8a8f6dc9c0588d9a41cc9e68b0f643581cfc42b6f17bde51dc60c3ec2a4";
+      sha256 = "b77302bc16b7eb804d696cf1748e8fab2f9512b40f63a3d6a14d2fcbebeaf966";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hi-IN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hi-IN/firefox-101.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "16e96c75e96d656d8a5338c6692ee3c4d94af325b51e3e3326a5024549360f6f";
+      sha256 = "0f5820f233ca1ef094e84780c9c44456709682993f556bcb83885d0eb0513164";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hr/firefox-101.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "55a692fd61adb3c0cfe05317dac407f5804518d07ad1bdb6aa49a6e7d7635270";
+      sha256 = "dcf756c4a06764a858922a6edd32d6f3c587f94db8478cf71c057572df913b4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hsb/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hsb/firefox-101.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "d2786cb3a58bfaa5156c9efd5e36743bd30461e922f8d1f8421fc60ba743738f";
+      sha256 = "d502a44237b683d57f8c999373a22a2f5897b4a77fb9921926a51ab8071c41e4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hu/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hu/firefox-101.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "e4100b8208dfb367de6ea92252de3730728651d54027a7d8da989f52afae2f10";
+      sha256 = "4fadefa0133dcb1f762b7f7a3c9a0e5b13a3fd7f9eb7c9ee70910523f6ca27dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hy-AM/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hy-AM/firefox-101.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5f247f00eb048e01f8ac6f1e7cf8bd9a4e2d012e2534acc2dde7e9cd659ba48e";
+      sha256 = "62a3c25ebe7e6f39b51743c8c4818552aba4aa2f2e0c0be908f48910a56f8550";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ia/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ia/firefox-101.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "68a040005c7e2db14d380e36a28725d59635ad6166c3a918676e870207a790e6";
+      sha256 = "3f047d50f4a4143ebe31984a6f3881be30af675541b42021dd0732c0a0c01f8a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/id/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/id/firefox-101.0b6.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "f9dba308d0e9f6e1cdf70c26a914acd234cf8d35aecd5374d8661f2d025492f3";
+      sha256 = "de6cfbaeda8bd3c149ad14f06f9a6a2c26f81fd13bec07e24664da4c956509c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/is/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/is/firefox-101.0b6.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5d50987e3ffb7a7818479161ad4d019d59b259575cfcbc4ede9a4a6a5cf1b6ab";
+      sha256 = "b18fcb0783152f156db7491a80005e51ce0c70afac2810a4c2e48a21548b65f1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/it/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/it/firefox-101.0b6.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "b786c212f61213e69010d930f2eaf5bb3dd9c798446725f4822fc3bb37adc01c";
+      sha256 = "9a5134b2b676acd9eaf8fe2288d9128d1c8df1db74e0a5b11bdd5ec7c85214ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ja/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ja/firefox-101.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "825af27cf52551dfbc83d7b95e47e64ed0ac7f7db3095bf1debfea87b39a4378";
+      sha256 = "3ce0ce5d43ddbf6af0561d468a1c292e2b6bb20c3dea8501c4214b800ceacfab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ka/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ka/firefox-101.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "e009b3f2944e6a67d85f8937e5e7472c18049b2569bb2c9f234de468e636862c";
+      sha256 = "e360403486f3ad3a889b9cd3e0a69424887fe2bba7b700a29a904ac078ae9e27";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/kab/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/kab/firefox-101.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "168c16ddfe42858333d1f53ffae9baa16292687a3d65b29fc9f4605411a4a712";
+      sha256 = "dcefe66625c3359e93e6c844eabf5ba509b28e70f84a0ac65083fc2fded88d9c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/kk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/kk/firefox-101.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "e12266f2f186570c1aa382067f9cbf1cf78e0b14e14cce4b9c822f29366c2b05";
+      sha256 = "4fd5d16eeae79fef7365d6e42979b7b3ab409a85dbc6f08797f04c29a6ad8917";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/km/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/km/firefox-101.0b6.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "77f90b4c24f1dd8ef8ab06f299abfa734da6d74ae1b4298d3b425b08c28fce9f";
+      sha256 = "f204b64d5601cd3e469741070bfb18596968bfdbd881818f5dc27e961f940f41";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/kn/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/kn/firefox-101.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "c9015d588d9e1d07499b7f910d9b2236b81a6c3e5002bcc8d18ea970bf2ee8a5";
+      sha256 = "5657446336b013b1e31df2f06844e4e92be828e7d0aa5a058dd77b30fc282957";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ko/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ko/firefox-101.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "0c880beec3dad250b3e224c2e7b73b15253bda3bc043110aa874cf555d475094";
+      sha256 = "d7b7d644742ab4d02912a1eb0c4ba934482a8e5ccb12eec3921046646a82c742";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/lij/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/lij/firefox-101.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "ba25d461f97dc3f359a4d525143c5a19859a2c051db87017469ba848c421aef4";
+      sha256 = "b50a4257bd3a8ebfea78c0d1f715e7e67af090b36e7a704acfc761e361e01662";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/lt/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/lt/firefox-101.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "e73fe6e7477b4c37d33cb31fb872a845f8a67ab659d93752d936a2ce7a1e3d31";
+      sha256 = "4a6fcb8f3c275dc5f3b2bd8b16672494fc5577a562dfa88f2908b0376f687fab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/lv/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/lv/firefox-101.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "4b4d510eac153ceb3c2953d1141e893aeb913000cf6d557e4564f8983adf5b29";
+      sha256 = "e03bb3940710768efab9a307c2f6cd539cb1e6fe75d5ed703285d66a10cbe1c3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/mk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/mk/firefox-101.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "8a56b192d42351d40e2d35164f5809ffa5ceb52e16e5d6e85f4819f250deb67b";
+      sha256 = "b837ec9858521b4a9b5fe7b2199d8b624089dea99d0b6602ba4e697e4a9f1c7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/mr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/mr/firefox-101.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "efe2bcf5f97709240a09680c54c61ae25be5e8019003d67bae8cc166bb6de15c";
+      sha256 = "48b2c90ec63bc70d7e6db50cce59c128ca32187dcca46317bdef27639236d69d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ms/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ms/firefox-101.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "a5a1b3d542478648efdbed1f174f87f885593209dceb1b41d5090948a46f8c8b";
+      sha256 = "b34b90dd02a3f3870e15bbb187b1e6a2a08cf3e9552034f584babb393a141b26";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/my/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/my/firefox-101.0b6.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "baf5d8a4e2ccfc40fb9383ad84c15d9e47ddb81dca203ac2df5faa2aec6e2031";
+      sha256 = "1a663490165f5cf756e1b7d51370a069b645beb0e5514bd24d282bbd8c3b292d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/nb-NO/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/nb-NO/firefox-101.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "980c1a26381596b76f5519021327f5d3ab104f231e637e9bade9bf34e9f17df2";
+      sha256 = "134bfd08e127e9074f96f440e957d99369c74e0ffbbfcab05e76635cbaac91dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ne-NP/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ne-NP/firefox-101.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "15bc3ecc249798080feee3214a76fe843f16a68344673c5cbdfc6557d171b77d";
+      sha256 = "10b47f134e8c7ba0f62a925fa8c6f70c297793d117a5cf6f5f259db8c2d2efdf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/nl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/nl/firefox-101.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "cad9d94763528115c4ab4af90a722492eb3752066483bbdacea7d6933d2b4b2d";
+      sha256 = "c9f41b4133d56f13417b9fd9484efaa235c53828638be0e7dd4898b971c609c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/nn-NO/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/nn-NO/firefox-101.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "27ada324b58968fe5b9e2b6e367dea00097d83d10aa110d4d76db06bd22e9d5b";
+      sha256 = "1374307aff0e4621dacd5faaf4e2ccec7313de973c83578c92b945f7316ab340";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/oc/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/oc/firefox-101.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "9c4dfdfd16cfc0bb8502f31359acb01bda905089781edc89e15eeac4e52d0513";
+      sha256 = "2b49081e9bf9d7839ab687af1bdb5e2cfffaa91d0082f8f85110a072325fc32d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pa-IN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pa-IN/firefox-101.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "b10709e964787898a2c5e15c0856b8b580a3221dd33ea441073437f833770552";
+      sha256 = "bfe75dcda4bdb1bb1f2a1e546fbbfe84c272bec276167cadc042d8aa18e3da13";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pl/firefox-101.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "dd8b9baf6d1083f08695fbee6fdf3a3a14e3831d6cc797bc1e9e8ec0818ab0f0";
+      sha256 = "940b0b8231e15ee72b91b47cbde9b2ec5ae01e6543f185994e2d6dfc2d54266e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pt-BR/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pt-BR/firefox-101.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "14cd1b927d3dcdfdea02026c3b6a6fb0ecd331652d26f8c7fd344233514ee030";
+      sha256 = "a348c1bdf5913668baf8d0db6aabae722625ed1a054b8368db51602289698380";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pt-PT/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pt-PT/firefox-101.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "906bf971747d018c847dd949756618c923cfe72b461636fa4ab809e99c0b0428";
+      sha256 = "5852f75c3f29d245748d7a71c6ce30dbb1c1a93894a0793bf2eef56af510e0d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/rm/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/rm/firefox-101.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9a4d70191390d408104f77595fb8c3442b9133c529152a14edd8b81eb2a9b91b";
+      sha256 = "0a92e611ffc5e2a8eb0fc65b031b8158124cb637ee7fc72abd108599e2dc5a40";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ro/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ro/firefox-101.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "778a0242484198f61e747680eacf4391061255cc4969e1c1ea7d23261f92182a";
+      sha256 = "de99fa30311c87b71341457f3b27d9119451fd702da4c3a48b16c6739b9bca49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ru/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ru/firefox-101.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "f68bd731b44cb75c82f800a0944ff69f738692fb981dd27a097b60efd96bee1f";
+      sha256 = "4a52e23c1ad4d3b980aec067e5fdcb9dd5996698884f3141ea4d282ce2cc8709";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sco/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sco/firefox-101.0b6.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "f7f92d0fbc485d099a63b5bb71b349148bd4e475c212e8c4e49f1793f4bf16ad";
+      sha256 = "9628b1ba661ebeda1d828df7f2ab444496a2f15133e906893eea797cc61e1131";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/si/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/si/firefox-101.0b6.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "0b6e76241d452954a0438f9e3849743034c47089d6352cb22c1957b40a674c75";
+      sha256 = "675f86652bfc99d5107ef705309dce5eb16fd529a03479b0ed725a0582f1d636";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sk/firefox-101.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "aaecf4614bc84130ae7ea552704e375abccbbd80bdde0848718287d46b61a0db";
+      sha256 = "5d1c909fa7078a2b213b61f54a9380c63501b9ed7a56104cb3ae954575a31c2e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sl/firefox-101.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9fcf2320a0b7ce031ee2d607570177ec3eefe56b5a3e05f29022b6f6b1d4df49";
+      sha256 = "12f7d050d6480ca368d9eaf0c7f33ef95149791667f38d82ab44d0d9fbec6450";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/son/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/son/firefox-101.0b6.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "70d0fcc6a8ab38fead293a2bf41a4548e027ab34cb1981c0b5cef12301031e5f";
+      sha256 = "b1f3fce98e6b82f46f45070928e9049af5a5498692d46774654f8950f035e99c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sq/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sq/firefox-101.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "bfd2966ffc4f244c1af4b115a559865a86358125ca7485df838fa3c4d863237f";
+      sha256 = "95ddf7ea1b961828e4fe39469e0ec3d576ef4bf7444583b98b798c9fafa84547";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sr/firefox-101.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "6f2044c48819edcbb611d7455d30b212206a6427df74c186e7deff84d46607a2";
+      sha256 = "577ff957dfc31db345c7555eb11c64412b0efde4f659ff5de3bb7fb0c4da0a6c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sv-SE/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sv-SE/firefox-101.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "9fbd49d8dbb4c89447786380e468e74150ed8a94191fb9d942a3bc5fdd1eed23";
+      sha256 = "b52cecaf1ba436082fd73395e1fb0ac1cdf70663630ded1a4ea739021e820989";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/szl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/szl/firefox-101.0b6.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "9248fc2d9ae25129ea1dd440d6f3e8168c33809156c0ac28c89cf7a849ab71b8";
+      sha256 = "f77f5bfac61d567500c984e2b48906f168d34b22d514174c9c11d414434aa306";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ta/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ta/firefox-101.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "fa62feaac98df16853e98d40796679105efba2f2b133959d57a8c516d7bc679d";
+      sha256 = "299d97b80c0326ada876c453f9bb69dbb4365d124c12e1c7ce92cfc1216cb2f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/te/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/te/firefox-101.0b6.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "6ff13809cd57fc9415a78776cd809a07ca2731ffc3297c1315f70a80507a402c";
+      sha256 = "ff722708c7a5646877278ff37ba401a909e1685934625c6926c043f437c15f21";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/th/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/th/firefox-101.0b6.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "984722c2760f9162ea166c004295b529d50e87e983c30e223c19217bf2957349";
+      sha256 = "42b43c84169473d25a4a84f21f9a3af8aded03446901b8cedfa63b4e21b7c2fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/tl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/tl/firefox-101.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "c7c3570c25909af183593a9cc47dda28417163036af62522b1e762609c906408";
+      sha256 = "3f2f0d96c337d78889049a7b23eedca9deb9e376c1a23aef68378f297401b273";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/tr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/tr/firefox-101.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c09188f66bc7e84ecf36c316f6858786a76b6431b223141d7ddcfe5801017efa";
+      sha256 = "cea3871ce5b325d7dce5e1884ace2534e7a30dfe9c7754f80869b493daf4937b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/trs/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/trs/firefox-101.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "4e0a2711a19e334ea2b0b2b0c9e1f6b2e2dd8946ac5afc017f0b360ce92b1597";
+      sha256 = "558fc1282268a67bae66677df56f222907d8d06232f5f03ee275bd71fc1e0ed7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/uk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/uk/firefox-101.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "16c3317d11f94a098e3998e18d6af803e6cacd9cebf3d8aa7be64bb031ed4a1d";
+      sha256 = "4e049ee7770c94122e6b789ca80cda28a41dd848dec3faf189c71856506d804c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ur/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ur/firefox-101.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "59d7c4dd6cb4a62e01863cfdd176d23dea36c7ba9ffcd0e8f4a87803df25772e";
+      sha256 = "03139cbd273b22c50387c7a05a8529eb711d68dd6b272ee7f72dff68d341925e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/uz/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/uz/firefox-101.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "1874d3bc10804a1bb6ac7b934109649751f694d8eb36ac04c4bfb18df6d7ad49";
+      sha256 = "d5c6719320ba141b9d3ce087bea71d53e405eb589ce57fc1976de76116059ed0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/vi/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/vi/firefox-101.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "f4b6bac19de341c1dfec87263e41b4382f8716a9ed1ab61336a29270988bf17e";
+      sha256 = "37f9b3d4d3bf163c3364e4cbc0a27a4a95f1e4f9d8404cba72ad2eaa362a0c64";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/xh/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/xh/firefox-101.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "33e01f8d8e6c21afc055f73415c4c4be324cfbc73bfdc42d262ffde0e87301ce";
+      sha256 = "f46c96ae7a759144e31d3a18339d7b1b0ec071d242936972a330722485d027a6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/zh-CN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/zh-CN/firefox-101.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "a17b7f914930ebcbe92e5e8fa8ec0ca8fa121939d65c68287ab668db460097f0";
+      sha256 = "4e5eab279a056efc524730043b8746b6acfc4b070c46cf872295eb564f4ec15f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/zh-TW/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/zh-TW/firefox-101.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "ad987a76a4f4b5b521c7ac6eb1784c84086a7f11d9f9810f95b9219ed9d22c4c";
+      sha256 = "7b72a4c65d32e8121fe70ef5bb11a55011a252520d23d67f3d11f0742271d415";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ach/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ach/firefox-101.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "ee933397cb0be5acac1b67853871c5df8ccfca7bf2d8ffbdadd5575218ae317c";
+      sha256 = "c1792f25decfe86f8eca2cc9e158846fccd4e445833eb3721c44087d0b5dcf16";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/af/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/af/firefox-101.0b6.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c6d21ddbd2eda266e11dc5cb132b0549868706e8d6897a12c570044f0eeafa48";
+      sha256 = "35a75b213291b016184321da09522d62885b82ba63af3d9ccdfbedc339a512a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/an/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/an/firefox-101.0b6.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "ae66f452b5ff50aa82867184a0111692d8fcdbfe17a5f8fbc88d2345a058cd1d";
+      sha256 = "97e3f9e55a4fd5b7ac9e3f45047177d5972f6b8dc79bde79e621cbc61320a178";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ar/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ar/firefox-101.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "1feea62c9a13828854257a5edd93a139881179f52d735558920f21a67c58f895";
+      sha256 = "205fe9d4a4dca32c9470590a649d082f1e32e237a6297752e25932417d195003";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ast/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ast/firefox-101.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "05f800f114645ef5859d78d57d3c14ae8af37b27cb0fee766e948faac3548124";
+      sha256 = "d647e11555898cd89a9f85159ae3c477d69ad4c5341bc4c3d505735250865771";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/az/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/az/firefox-101.0b6.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "7170b694f972a73c88d32b1ce8f95d0c29cd549afc77dcc19b0ddb09bc138a1e";
+      sha256 = "dc9dab8cdfc33ad54d4cb50139ceb361a515da855c9540e08ec2754d77094c8b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/be/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/be/firefox-101.0b6.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "503e5f53a9fc97e25df4d7b67b5c97fbb809a2bd6a72a99776f1d30acd628f81";
+      sha256 = "4db146f0f4c73ca1f4e8a91a18da133ee7c65bb81db3f5e122b66daa2667cea7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/bg/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/bg/firefox-101.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "121339b4ced135ecaa3cfa01e8a120f82b8f49d7a12886e81777fddfc9a86d8a";
+      sha256 = "0428a713ea8fedc4af9907bf303e1bdd7716025abcbc52cf404a50e29743cf9d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/bn/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/bn/firefox-101.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e94b39bafbcb6d414608b607fda8ac366bc64e498ecc2d6f7ee29f3a807a0cce";
+      sha256 = "cc90412d57780f5438b2c27b3dfebc244809ef33cefab7322fe89baaa3700746";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/br/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/br/firefox-101.0b6.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "e35d8795752d5389d9cb6dba5657ff03326dc52f53b4523e568cb14a9d7ea812";
+      sha256 = "93dc7ba679adae2bd6d5468c31965ef9bbbd12ac8f80d351a558a9a0ed66b614";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/bs/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/bs/firefox-101.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "11ab8f6430b63a8ac4a84418a17bb5d7b347a7a887498b528fa3b07c5f69dc86";
+      sha256 = "898b62ca81a2c165c4410787ce81d1a58b9177e9f747d2c14b64c98bf44ad185";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ca-valencia/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ca-valencia/firefox-101.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "d9d5848da4d1818619e0b9641cffbee9c63358157be344dc6a30ad0e2230faac";
+      sha256 = "496fcfc25242a4fca065d842c036bcc815a90904286d2add60c4f9bd6d29470b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ca/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ca/firefox-101.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "3791d8354df11c7fd77f6e5dae3ee988fe93226ecf57db1d04d31830ee4cfd07";
+      sha256 = "e9cc4362a5c6dcf43ab719a808c4e5faf0b4b320179a372ba03864719c9c44dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/cak/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/cak/firefox-101.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "2d38dc2c29dca9c6618da8bd15a7be4fba88a866247fe975172556378d703a94";
+      sha256 = "eb63f5439364d1d8e6feed4acb6df4584dd44711cd0573ecb25bfe702726e248";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/cs/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/cs/firefox-101.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "987ab6a31f40aeb3ba4b4321ff755f8909f7bc78ed1568e01bc0936861d756dd";
+      sha256 = "bbb971333127ebd66c3489523d2a5e0d1272255cd699fe546aa0c54474e84b94";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/cy/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/cy/firefox-101.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "df843641be4d316cd6630a30158422c023d48bb0a4dd30622cef4e27b97c99ad";
+      sha256 = "97b48236085d110ce1dd6d4dcdcb9e212df16b785eafa2d61e271e9db89de74d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/da/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/da/firefox-101.0b6.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "ca5e5b23e9b4615f5a982b9217dd42b82c1f72b832b3aade4955f9f46f0e3e9a";
+      sha256 = "ee7f75da2cbc14db369e21eff246049e5d2ed4425b614bc8dce97e44e6cb6bf3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/de/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/de/firefox-101.0b6.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e07f89f21b1952310ce310a54428840053ae8f2dcaad5472b38b1761ef32b649";
+      sha256 = "3ff4fe9fcab61ac606111a5637326e9b49461f5959542d1a557479fa881cedaf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/dsb/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/dsb/firefox-101.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "c6e32545afdec0bfccc5f568892fc77cb226715fde84bdf2651627ab7d69cbe7";
+      sha256 = "84cd0d196fd04557fa1de6673aafb6d42bbe2d299f5e14c28a57d0a51ac657da";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/el/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/el/firefox-101.0b6.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "0a3d7ec83f0a64c6dec14f3649bd6335bb3118120d7b3da50fd0c8498fd899c0";
+      sha256 = "91ad9d28e1a25a0a27721ceeeb5da3b2550573f354b667c5ce90d78803c82c3c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/en-CA/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/en-CA/firefox-101.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "ce43791e216aa63a250c3d542c4f89eb7199b6d2805b0994f8479a6871f38bfc";
+      sha256 = "1f86f8464fc1d660a88d5c5edba540c1ee65b143c65d9a9a6ea472ae91bb5ab8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/en-GB/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/en-GB/firefox-101.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "61a60147594bea4ce7755d002edc914066f31ac4bab1f2933948b0c0f8987f01";
+      sha256 = "661344deb98582b390a8d9108721bf44d511cb61beccd1e1beffb0c1fba4d72d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/en-US/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/en-US/firefox-101.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "503b87ed02399c0804edcc99bced3ba07da78781c59616f7469bfbcf8a2ca07e";
+      sha256 = "d49c7b31c087f359e39442100f8727f95a6d4cb972fa5b1c9680f336a8654c1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/eo/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/eo/firefox-101.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "564b49b4ce197b4237c514a7cbd8cba982b3aa979e5b2ada991b951edee4d9e4";
+      sha256 = "3a80310c70d3acaa5ff6c3dc30b0070da346209a7b17cb347b6414883580d019";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-AR/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-AR/firefox-101.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "5f0b4e2c1078456a41f74b284ae424fa7fee61e99df08b1d1fce565bc65d1e25";
+      sha256 = "c30f0236aed9bd57c97bccd09fbbea401565ad110a5575d1f33642a9a0c9d0d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-CL/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-CL/firefox-101.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "333b857e916d2a98c38f61561ad9a1203e82cb8ba232f164b4c863c5d5921273";
+      sha256 = "91fd193a1f4036c51db8e9a48f82b06c312c04c0b7e453662ecea1683ba591b2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-ES/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-ES/firefox-101.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "ee9ccde18f190f18abed18fb068cbd10fb81ccd16c0644316d22f838ac68191f";
+      sha256 = "cfdf87531b32ef0e8d32dabae0be7af673d4bffa6e7f61c396e721eda57b70ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-MX/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-MX/firefox-101.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "ee18e46695e277001331493060354387cc2dce231e58ddc4c70b693b8a73ea30";
+      sha256 = "de7dae42b15d22244d581f2f7308b589d567947bc1a0d65333e7e817819dcc89";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/et/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/et/firefox-101.0b6.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "1d2a7947d04503f57098d3e1384c5cd5462674dc423cb5ee9f60d6055cf8d82b";
+      sha256 = "ef2b64f55f5aa53e2116eab02b46414b4ac856d7fcaece56954ce49d3df36be6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/eu/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/eu/firefox-101.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "bce92157723f47e97d252be307413b3d2423910e37f2d3064f28065391e4c6be";
+      sha256 = "7e23ffb76461673d9e42851a7313ed7347c103161af088f836ef6dac1547831a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fa/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fa/firefox-101.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "33fce9fcd652f9d79cbb4f06f8c6566df7227698ff191d5f2a8135e537018ce8";
+      sha256 = "6a6dc59e089687c0b4d281d77c8913a0511b49d7892920a51335b624203d9d46";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ff/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ff/firefox-101.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "8f7d299182ca59d040316254a5acad58c133af5f5199b2531388705e9ee74582";
+      sha256 = "f0e77eb65dd5ef0740b1fd4422e822ac1fc6ce3b57ab7ae6810b50e95a6f2138";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fi/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fi/firefox-101.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "f8f49abdcd30b1b9df88a38320235f470aa9932c554a274fb802e2b4b52fe8ed";
+      sha256 = "93af35692199f18e3bc7e3525c3b338885a30a649dba0a0c4bf2b2bfa36e7bbb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fr/firefox-101.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "3be37bda9be1c9a5fc4fe899010680499dec0e71ddb151f19e18e55a6450b771";
+      sha256 = "e9cabbe91cc99e5d86952dfe24e19f081ef6c5cc98a72bcd5cca084c8ee7b0ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fy-NL/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fy-NL/firefox-101.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "76598f5d5ab6be41b003e7648458d1f03dac48d82716d1072a47047dd4d0aa28";
+      sha256 = "5c4e2f31c02cab88f511095648aba78841e5ba2cd526cd1cabc00be255c6af74";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ga-IE/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ga-IE/firefox-101.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "d297c383365b1ff0fab543b42621671e96d831f0620751209f04b75b8022e1c1";
+      sha256 = "4002c60cc3e1493a8f65e898a7ece1dfb116b9fa4ff4220063670165be496047";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gd/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gd/firefox-101.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "86bd993b81b67f5d907a87f88666cac72413ecd9450d8c482c31738bd22135e2";
+      sha256 = "98e49248e91050b5ef3f08896605820a426e77e277e7e2f67fc6fd04d28982af";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gl/firefox-101.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "e33cffea73148da8b24e59dd7a2e203285af2d08e356e0892dab1a70a40cd4b4";
+      sha256 = "f483302c2d074c32d010edc3665de2dc098f5a02f7d71817f681eb88f450aa21";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gn/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gn/firefox-101.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "574df608df5b04549b2d89edd99a829afd2eea768a7dd33b12c21b8db4e00612";
+      sha256 = "709bab16d8b811d53e7a62918aa179e2a542dd668ed7b09c09f480d00d45cae2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gu-IN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gu-IN/firefox-101.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "910a1eae44a979c09edac6d470fd5cf19428028c8ebe5a04b27c8029700ce682";
+      sha256 = "3d4ca55cb965be9d9dbe573fdfb815e6ca1d3c7faba23948e6f9efbf7616554b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/he/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/he/firefox-101.0b6.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "17b634d9c38d21b8dcb6e8b8ae3d89c54099a2b17b68f7acfc56f10191163193";
+      sha256 = "d3c2d301ff6498ca252054f6e677f1cda5cd35fa60ee0627abc8c21104b59820";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hi-IN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hi-IN/firefox-101.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "e9fb302f798ede6c518ec72eb103dd087aae86826a61f6ff260bba146bd66cd0";
+      sha256 = "9f08ccb5b89de2f05f321f9205af529deb577ee4a01ce3ae55223a304a67f1ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hr/firefox-101.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "a976d4bb564eba983412a3301f3ccea463887d3e3c115fe702fc009059c92490";
+      sha256 = "590352d0c31e2710d3a315458b0ceac000644fb5cfd7ee95de3e3734c6ac95be";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hsb/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hsb/firefox-101.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "4ef0f578d5deb079d5cbec68e61e756b6c44b36a197740dbbcf473d17576d4d8";
+      sha256 = "744802853f3743f4dc5595a2bcae65bda00a2bd820f035c0ab96c74654251aaf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hu/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hu/firefox-101.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "0aca5d7dea85d3e0b823f8a209e39b54afe405c9a168d92f04cf8893272d8e45";
+      sha256 = "3783e09ee52fff1955f811c3393f043fd77ead18374e6f111011f22990f8837f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hy-AM/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hy-AM/firefox-101.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "a9595bab34e8034662f6ffc9827e22a97909793bc632ce20f5a12bde711fe77d";
+      sha256 = "2922d8ef833e4f378c1c457bee3fde892bd3637c74dc880ed9d6fa82a09d37a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ia/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ia/firefox-101.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "bf9e13c8c9ea858875d8940fa3ac3b8440f88279bd1e520bf2e8df3cfa1209a0";
+      sha256 = "1dfc6c2bf5eafbb6e8655a2ef2bd960c12bde5ea0d83971afb97c1f49e64d945";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/id/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/id/firefox-101.0b6.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "0a6e0a680e37d53960cfd41c7218dacf359a2dfd9046e4957a64d1cb70cbb9c2";
+      sha256 = "8bda0b0f5650b92cf242ae3bd7b0240a72a154b553f4c09f05df927d27929d94";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/is/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/is/firefox-101.0b6.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1a4029b76fa9239669fabb61daeda9dce78198e92c47b24225d01bf3ab38fd1e";
+      sha256 = "40be6971110ccab8c08eb3e0d580597762cabc585ec19bd866d08d9f8e4a8b44";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/it/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/it/firefox-101.0b6.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "45b29a5e11f55e3775b3fb8079549edb7d2d51ab70a1486f9b119dea3cc1c5a8";
+      sha256 = "e4bbff7cbf6a33a25022de324f2c7fb8cbc26aee5a88fdf4f0b8e82fd4ec7409";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ja/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ja/firefox-101.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "2ae2d1acb31d8d2cd8aa926b7650b81406444e4abed8fd6e2e1bd245c443405c";
+      sha256 = "cbf0a90515f98336d1a31b20cd6bceeca9a36f3d1c6bfe4a3933ae47c71fa119";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ka/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ka/firefox-101.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "730c2582c36982e81a3e86ad8d4c7f817bb32a1812eed3d0ca7692ee45b24180";
+      sha256 = "74633b44e282b2896e24505ec40cb162e8069333786d8a84aa6a2f633c3e257e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/kab/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/kab/firefox-101.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "b72a7e0310bc67576d4e3f882999077e7a8f0604dcbad55aa2c854b2cee858bf";
+      sha256 = "48324d9272031eb01bbf0c366ee62e7eae24dc199aeba434f53e4f70b9559ba1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/kk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/kk/firefox-101.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "9fa815efcb23f0cc91f1de66b33b9d6fa8e76aa5c03179e0f3808632be25bf60";
+      sha256 = "19e61accbbd82757f928465d8fc2f509e63605fb5b662d316d4bc1ccb5268e8c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/km/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/km/firefox-101.0b6.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "d4c451d65b82ef753b651b6404240b2bba5e6798285d3fa2737709e4eabee9a2";
+      sha256 = "4cce3981e2ba564a09a097c3b7b5fd56a1c2dd29556428e842e1fc296b14af92";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/kn/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/kn/firefox-101.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "a1d0ba8d2b61f5c554a7193e1f2e25f3901b667107b1a926f8ab2d8b28fafe1a";
+      sha256 = "2a5f3c17c3e168eee06838eaeab1f4226bc84264e124054c20c7602be5e024ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ko/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ko/firefox-101.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "c52a38a7c830aecea014596aa035dca5f6b2e8cc28e3455657fd58ccc8dc0a4f";
+      sha256 = "27652d87f6d6fa27cc8b78bce04ddb30678dc5739fae189262d515163b9efa9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/lij/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/lij/firefox-101.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "472d0a005d350dc9c358b62b6c428139e5ca784cd6364d73209683c5cdf73a72";
+      sha256 = "5d78b30ae0a63ba0d90bdedb38d2e2bb001473a21f653dc89a367a338b27dc25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/lt/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/lt/firefox-101.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "e07ebe646f72849afdb0d8e5c41a7654eab3034bf476216cf58a3b7f8e0c3648";
+      sha256 = "58540f2673fae77aaceb74687210ae4422fe3a2b02800e34e83fa94e849a45e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/lv/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/lv/firefox-101.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "441ee8be6452b90fe669843410a07b47db7f87ed47795dcbf81d91053ae263d5";
+      sha256 = "8d57ab0cc8429496539e4ae00f2b667620665f374e319cd3b6200dca593c65cb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/mk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/mk/firefox-101.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "a2dbd0436ebf1ee64300668771960d0021c744c2dae8ecc5bf976d7a821a1640";
+      sha256 = "3fa8c1d4f130e2d19783308e79308d8e8c7a22a6d7d377097908b2b2e913b502";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/mr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/mr/firefox-101.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "1311f1b8754f93669011358d574f970f258ca8b32cb5638a12266dc7e2a47595";
+      sha256 = "e507cfd3b29ee574a5a50c4a907e181a5caa30a8894697b191c5894e0005da4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ms/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ms/firefox-101.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8e78f3a12c599a29a01c9a84373ee799c3b8a8478e452b0a8ba27f4be9e7ed93";
+      sha256 = "f2a50d8d5bf8c023fb196050507d08585c9de656882ba923189423ea1fb125db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/my/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/my/firefox-101.0b6.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "d6be222fb3161f2737f2e54d0e26f208298162be21197b6b5a6e3c05d8948f1c";
+      sha256 = "a463f7ebfa97ffcd02c17375722463ad030a8364cd5a89d9b88f94877c7498f4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/nb-NO/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/nb-NO/firefox-101.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "c4a2f49f516a19542759296d61ffd5af32640d0e022aa960d6d7f2ec645bb353";
+      sha256 = "626e61c82232021d91109f454e348ee17e1e1190e5f00443e161f32b6177d80e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ne-NP/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ne-NP/firefox-101.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "4b9fba6e4cf8e9ef0878bdda30b12f89b857dba2475adccff386bb492f4efc4f";
+      sha256 = "1eb31a8504b1e7729223c6c80f209d13f37b98d8fdbbe7b0dfbfed6dbbb0805e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/nl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/nl/firefox-101.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "2561300f8fd8e53ac16506734f17aea5d9cb5b7d970e4070084f944de54c287c";
+      sha256 = "7b751e56de902cb60c2d74da40845e7db914a10760514f6d96350a181de0016d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/nn-NO/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/nn-NO/firefox-101.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "f2b880d35f85122c92efa10268f3bacb70063720fb93f85f565ff9d75f4d6a58";
+      sha256 = "083d2601e9b9363ce0557e75118d4da90abcac209e14442fe8adbb26c0cc0776";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/oc/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/oc/firefox-101.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "ea51d91008fef8163059b1b35403c049b236441c5e87df06f7cf5319dd480680";
+      sha256 = "c136ebffe703893ee7cd393e361dcab3948f8766729228977342eb4b275810d8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pa-IN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pa-IN/firefox-101.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "c0332f06388fe11e17599fbd0d2bf4074576d693355f05e0c0ac74b78e8a185a";
+      sha256 = "3e0a781064f9d1522c446259c6446287bad4740b633a792020455ba31df5f99c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pl/firefox-101.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "ce584b3d90775742be1c521c6e79bc57248eab426d6ea4bba00da22a7e9ced29";
+      sha256 = "03763b006ce67d79dd62923a9cbfd4e521f08622d8a78467e2e747e883497230";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pt-BR/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pt-BR/firefox-101.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "6ab1beb2ea5aa1390127fc13f8e0de6555f5ccdee64a96fb382dd0d411e5d280";
+      sha256 = "44a3dce9250c9d88452c52729d85ad8fc83ebc4ec7a14f96b45ec525d246ed63";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pt-PT/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pt-PT/firefox-101.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "641396a068e0de827b6feb03edf4f71f343baef24e5409d892c68e4ce48ec51c";
+      sha256 = "0c84ac122fd151eb519f9fad7a13121e3121a5c87ab599a27e881aa7869c18a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/rm/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/rm/firefox-101.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "a7cdb00dddcee0ce416c36c160ce9ab5fedc6de4ad3caaa4c8b14f9a6e1ea05c";
+      sha256 = "6150790b2abaf22e301e35e7ff9acabf6ae3004ba7880511b59ab89a4221d0fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ro/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ro/firefox-101.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "eb360965ed5379374b31030b0db3a66e6637687c2b1ee6dcc893c0308bf5ee41";
+      sha256 = "534e4c1396410351b80fc176005fdeaeccf0e0d3cce32901e6514d71a4976653";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ru/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ru/firefox-101.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "7da4c79b922a9e03c0ba677ae01271f10c0408ed0125d6c020182572bc6989d5";
+      sha256 = "dacc87ed313bbbae096040008d55c390e0e379a6ed63e94dcf8b1ece728e33f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sco/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sco/firefox-101.0b6.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "af1717f13e40806345ca2042fdcaa5105cbf23845ce63f1e89cbf43e57cf8edd";
+      sha256 = "c73de2e7aee09703156f9190394386f958f6b6b3b4e4fb0025adda3ee0424782";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/si/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/si/firefox-101.0b6.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "673f9978ea53996d6021990373484eede873a13e75bd32caab8d9c8a915e046d";
+      sha256 = "8cf170b5741ae909ccd8fdbde2c53ee73edccb10fc5a525fef27a2b9b752ad14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sk/firefox-101.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "db60bfe2a7cb89acc6250304c36c4e665de6c27f788dbb133a68989998e87c27";
+      sha256 = "d18ae5d2f8f7cc950de839f8a5715229f9d06fec3350a9cc1c62222ecb8780a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sl/firefox-101.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "22faba05601722a2e01e93bee941dc8065f35bf235037b5ec2259bcbd6c3c229";
+      sha256 = "6a129039d181988b9464ca40ece4089ac93b7bb7d15bc65306d9eb446b507e68";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/son/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/son/firefox-101.0b6.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "b6d6278671e2c7204b5ca7c357390c0abb8ac3fde1ec3f504c808455db990fb0";
+      sha256 = "2bd08442fca77a45766b7f9bdf024c10b21f6d7c8da64a4c40500e4b7e1e105e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sq/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sq/firefox-101.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "5571154a698ee65c6f10cebd318b425b265b36c20b6deac8a6a1fb8699aedee1";
+      sha256 = "56d99d1e355cfe2c3f7086d8dca78c194fc2d2a2409aa66c35a1d7571ed38a1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sr/firefox-101.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "130bb0c0fcad5bb8c7f54bf274a6d4dcb69bd4dc622fda9c32361a2859166231";
+      sha256 = "833c067513c4a2d235e030409ee356307c9d73de439d502c7470e1ecbb41fde7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sv-SE/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sv-SE/firefox-101.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "02199add3347abd89f5ec93f759cf12fd353b63fd4a2f91ee6b3f094f5512a49";
+      sha256 = "2c84063838384de54c808efc11927beb33359c2a20b268380cdc553216d38a3d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/szl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/szl/firefox-101.0b6.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "c1a99c03d63bea1b1130a02d30c051778648c73f18f38b294c53be83f7f978dd";
+      sha256 = "f298cf6e397978f1562f00918301c0e1702cbca6f867f2485ff69f1a2b0c2a4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ta/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ta/firefox-101.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "c01c7a1f56317f2d415bd777e5434366b0b3b2f4ff3a599a25011ef8b90420c4";
+      sha256 = "71f2dd3a5ea0df37b819acf3e5b4ec763247d2f763275dabb150b41b5f40c782";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/te/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/te/firefox-101.0b6.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "fcda6af3a7611243dac789fec6bf78a8517389ba3df5ccbb50157969281aa8fd";
+      sha256 = "bf8e272305ac553c0715f6098dd56a87f2fa7c500966910996fc00483cbc60de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/th/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/th/firefox-101.0b6.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "2d38c379f9d8aa9e7b7367eeccdf656cc9374858e5bd0cecc19eddd6b1a51cad";
+      sha256 = "804988c92b1b2cfe0281594438c4aaf4f323e371ee80cacd4b249e09adec0b50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/tl/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/tl/firefox-101.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "18e0bc9c89a0e89151b1edfe498760fecdb66b369e49ca4fa7ef3d5fdb0c4151";
+      sha256 = "f60150033304c70eec51e821b10facb3680455273853ea451a4d6a02f4c9337f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/tr/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/tr/firefox-101.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "bde092819c9f0771bb463df750fb35eb422862a7e28a308209953461be9c9d9e";
+      sha256 = "04bcf58bcba4b67e732bad7a7a448baa95c4885b793aa14eeb0d8b97e968a4bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/trs/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/trs/firefox-101.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "fca0c955097a04619e834f7bbce4d8bd7f65283dc0dc9bcb07cea7b4d31aa526";
+      sha256 = "def30527b0034fd72599502771387fcb595898ce3c92fee3a8d6a7944716512e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/uk/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/uk/firefox-101.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "31c97b928c9a5e7e80ffdcbec67485702de9fb82acc4f0a7cfc7195e8d214d75";
+      sha256 = "b91a4047cc9d6dd09601e1228b947359a07556c68b31715615cb10aa704d2d50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ur/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ur/firefox-101.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "ec9dc26f00786e8dd084d08e7e9c5612e42ada7e5381e889d940915c9360c837";
+      sha256 = "1e70b055dca6b9a2c53381127b5372ba4fe7271b36a270d4d40130320ec315a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/uz/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/uz/firefox-101.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "9d4de951bfd5d1cf65718f0118807596ce48b2a6a4ce8d29c8ff3c963e39907d";
+      sha256 = "af236bb72a7c4d9cb87d2120bb68fae63b86505eb080ebca41a7e204a7c89785";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/vi/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/vi/firefox-101.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "12726a8b22fdfe5d3e9637d665d7d4583e8762362032688367d3a8a5b96665a4";
+      sha256 = "9933b6c77accc651437fc5ad0ca538921708fbc27ed0ca181b05b28d9e0094da";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/xh/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/xh/firefox-101.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "64ee875cda3543a780a6da399ea7750027e85e4abe62d3eef4e4b21f3b0daa77";
+      sha256 = "820a745cb391875e8630173c7497a385982d62fa81e32af5a8247c5cce4035de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/zh-CN/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/zh-CN/firefox-101.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "694bc6bfb4a8ac1bd95f756278fb68514a69e58c17e1a6576aa2574cdafbacd6";
+      sha256 = "3b6da1d0fea706d59d85661d89c202fb26bfb3b84fe5d27ef01c7132cd9670d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/zh-TW/firefox-101.0b2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/zh-TW/firefox-101.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "1a7fb5edb2ce72fb7e2b62f2e6e48f56d44522ef7f11af208b8a2a52e945bd98";
+      sha256 = "2c72900dfbcd8d083c0ed6127bbaa1646d7f7a4e907b32ef1f60eecd90bed1df";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "100.0b5";
+  version = "100.0b6";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ach/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ach/firefox-100.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "fb1b570f098ca5d80f41f14ada1f7ad6dc43e5e1c6984e1fca29cfd275dabded";
+      sha256 = "6b5ac2e733e44616405f31b16bc995f945740477d00988ce5dd4f16c4ec74085";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/af/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/af/firefox-100.0b6.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "31322e6c45045322977b5d240350e0e4740f9c48174b719553410fea3212f475";
+      sha256 = "5b25ad2870b33002060f493368f79921046f5b19e4adf0c5e1836b7d00347790";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/an/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/an/firefox-100.0b6.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "137eb68b647af950362682646f7edf754bfb51a03b20f59b777f877b3ef003c2";
+      sha256 = "9fc4a88d9216ba0b5979e939092314f135da9e33a3d8df7cadcf142f19b0b71f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ar/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ar/firefox-100.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "22d24c6bad9ce2ded7634449fbc5d0bcdd4972aac15f60e04cf963ab0ee252bd";
+      sha256 = "23f33752d3df64ee98cdbdc569b8cb4cea2dbbae71810a3a14a82a6361f97b9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ast/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ast/firefox-100.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "e8a2e7ea146efe41105d84a667568662d029a9773855ae31768ba9c14abbdde7";
+      sha256 = "a5d357ed9b58fe0a2b7c95e24cb18659c7aee29cb1cda0071b7afdee9c3ac9eb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/az/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/az/firefox-100.0b6.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "34d76711bdc45cc45650cb4c94e553f67579be3f406c391c9878cb6de1c39bb5";
+      sha256 = "1191a7c0a3222d55a605bbb5f25d064414d08b9bfb6dc6ad74dd1de357177701";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/be/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/be/firefox-100.0b6.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "fdd4d1cea3b71f54b58230a30c744d2ff7b0237869fd14e617ba3322c2d59f6f";
+      sha256 = "69445ca3cf31d63162ddd0aab1538655a08e325aad57a3d343ac310193a942a3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bg/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/bg/firefox-100.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "e63e65a92f73a31d2adac6a0c1b6dc45f38425ed8596039332108565de43daa6";
+      sha256 = "f2ff0a6bf22b9ed16b0656d4e0848c509cee2de9a638d556500909e1352ae5b3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bn/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/bn/firefox-100.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "29fbffaeb7bd8750cf1fb543692855d427200d7df6e9ca92224bd96103b06b35";
+      sha256 = "1fbfdb8d6f22567eb1112c63ab6192cb439b9d2cd5e57c10401c76f9f9cd215b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/br/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/br/firefox-100.0b6.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "3c1bc8cace7f4d2c7522fc9dd994c42707ca4d54b74ead88726c8e83862c3757";
+      sha256 = "e05895d70c72aadcb77dc6d84a6a054a8410b29e05d5da6eeac0fdee1b66b130";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bs/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/bs/firefox-100.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "3e6c94efea22c4bd2620225e8a339689e3e4f642d474f4580092a85d7c4a4950";
+      sha256 = "ba125689cbd845e9bf8df940bbfd0796326939ba9b45d4bc0c0a8ddf64dd6f61";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ca-valencia/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ca-valencia/firefox-100.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "485b33fe034acd03412b3407338cd246077209fc1ccd566f2ac9d347c8da6308";
+      sha256 = "37a5ba26d10cbc2aa8222a2f19133a12710adeb389234ff53a91b43ddd5e901a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ca/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ca/firefox-100.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "a0b2780c0a634c85a9dbdc00b6952c81b503c3173d2c2cb9df5d9c5958ab640c";
+      sha256 = "5f11f3a11b93f06235981200b690cb9aaf95ed8d459ea8e1d6ac7c6a73d9d9e4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cak/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/cak/firefox-100.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "360abc1da779874423792e63b545343aaeb3984201193c687c3c8b67b67cecb1";
+      sha256 = "1d4a103b8c2c601b908a635d2b5edaec068c1a2e644e1924022a94e57e1b2f6a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cs/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/cs/firefox-100.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "1dc722b7931908a38f43254aa1c1c78fb77ee30868c15455c0448927e658613d";
+      sha256 = "358b2c3c3c5a9945b35f1c71eadaf7d5305d214ecfe37fda811fd37d326dfd35";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cy/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/cy/firefox-100.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "55eba066d11752cbf973312d55568e51b720f21e66bf590adadbe93be386e989";
+      sha256 = "bcbab842e30d22f7d646d2494451e0e676c40c16c1e3532b4c6cd6eb501fb7c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/da/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/da/firefox-100.0b6.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "cc3fa0c0ef8a1af9f8bb78e7196c5cc7a6c6df2d9f25c5fe8d79f47879354331";
+      sha256 = "3b462ea57616171ebe43e218d7fbcc8c45d508fa2b91490d5b107842bf936d25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/de/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/de/firefox-100.0b6.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "b745aa34eca890302b701be19bdd3affcba37e7b1af388e4844ce61c3a1244fb";
+      sha256 = "067a586989c84a280366c6021daf270652d443465b63d03e0fb9ff02eeb3f3ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/dsb/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/dsb/firefox-100.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "e7a4c1390919cfd01fe13f5a81ce35fbdf0868c725783d603c7d2e210e3ba368";
+      sha256 = "42621cd070dc172b08bdce256c91d6faeede97b116b353f1edf2354c0e37ec3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/el/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/el/firefox-100.0b6.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "6f0b80919e22ec67f80c7c034fdd9e290cf2ec442ae828a706e780df2ec54d90";
+      sha256 = "f079ccc06590277ccf09d4e34b73d3b363d79651d6e2a07d7e127a42ab552bac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-CA/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/en-CA/firefox-100.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "0184e33ff9582a77a5f9d61f1904f3cd097feda7576aaa276480eff92dfcb4de";
+      sha256 = "e3f239da659c77662a10ba061f806d615f9a57fe89d1207ac04cacc603a9a587";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-GB/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/en-GB/firefox-100.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "b5affd31a9004c9161d6a55cb713999932b18f1340ce67d0e7f77b0c805ca785";
+      sha256 = "e41640386bbceef99290458576da3272ea400e78641cbae73ece0e07045396ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-US/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/en-US/firefox-100.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "635c5b79c514b9b7717c903cdabc2f6bf3f19cb9689354dc33f21cc8eed3d540";
+      sha256 = "7f5888e7c0480f4f1626943f1878945166179ab94d995e23d0b8f5eb9d83ab4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/eo/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/eo/firefox-100.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "9e4a718c0932688ece8883fd2fa2d175c3483d73ac16075d8efa0e6758f4cf61";
+      sha256 = "6c07749b176c7c533a824357da81a42ef10fc78f09b58e7a090d3e36fd77a6d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-AR/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-AR/firefox-100.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3bc0ce89dc3ab79108bf527fccc9aa9663f61e6578b2561fc7e1950dcaaed1db";
+      sha256 = "2d23cfea40e6948fd330b2e72f40edab597e5261fb9abcbd539d0b9f513fd946";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-CL/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-CL/firefox-100.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "966db10e384f875272ffcdb743c472a78a75a95e0990a32fb16fe2b8d5a70761";
+      sha256 = "eef75de09e6fa7d21ca4aa799ea4b279dcdeefa79d9b4ef7f3b5266c90c2a8ff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-ES/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-ES/firefox-100.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "8b23f6957fb0825b973c4ab59c80ffdfeb8370a72a291ebec6ae7abff1ca3392";
+      sha256 = "31d985ab2af1ba15fc6b41580fed4a06fa33fb8cf3dfcf96b1a5ea4e361058f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-MX/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-MX/firefox-100.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "75102ce28fbb425fb0c13dccfdbc5095c1c92c4dd83e14140bd672fe60547603";
+      sha256 = "1fdc9e77eadf9abb55224bf0db1e555eb99f4a7c525f6021fe226ea7de9db026";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/et/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/et/firefox-100.0b6.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "ab7d6e1294e49e83307bac9541b15163263bc15693fd0845c335e523e5420623";
+      sha256 = "2df8328fcf9f10b84b2110f31ec32a5dce7054845c37f7e30b023daee4701322";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/eu/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/eu/firefox-100.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "6defedc5c4faacc9765a1d26352d9d8f30f895a6ec5bad1c3ed7c3d98ec42e16";
+      sha256 = "30037fbdb33703b894bb0e33b192d23aa1b67ab9b944b1381d27f95e0c44bdf9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fa/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fa/firefox-100.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "0fe1b25b3b970e04980ca729a6630648b0923b98fd00bc81a4553235d741a6c6";
+      sha256 = "37af6700e54f98541fe1f703c13ccad70a72bb7e28200762bf636bd3494b443d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ff/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ff/firefox-100.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "e8ad5c7403928bfa5e34c6bbb8958730dba8dcc6d799c9a7676d82440b8f1ab8";
+      sha256 = "3612950e42cf9532bb5be99f9f73e2f6b480c58570b1092f8eb337aba1257234";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fi/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fi/firefox-100.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "37e8619971dffc7c6caa43cf72f5870c5d5d1ed489bf8a3596215f285f17fa1a";
+      sha256 = "a8a2bace3af643c6b82bdfb043f90d4cd6ec10abfed6ada230786ef7eaaf9ee4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fr/firefox-100.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "90c21cec994d7fa1c4ffa6512c448a4948be5eb5d318a0f6c4ae6d6b6f801780";
+      sha256 = "296f91da1aec6481bdfecf311db4560268082d6f75f0354c6b09ab64494c211c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fy-NL/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fy-NL/firefox-100.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "c12a1b475b4d611d4083bb11d7384573817aef22796e91c7df968b7d6d726133";
+      sha256 = "3bdd5b38483c8a8fdab13767ad8f38d60e9c12359740d8017ec8a7a83338e99d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ga-IE/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ga-IE/firefox-100.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "fcdf90dbd66c1c87e7f8b25d820c5c866f0d905bbe424a8b6d8c27e7cbef5677";
+      sha256 = "5f734b553ce52eaa91bc3ee1ac2afea09aefb35e886ba68d56cf3b1e55dfbebc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gd/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gd/firefox-100.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "bfbeca59a046bffa5156621946c397884998fbd383085fab5159ae775db9cc9f";
+      sha256 = "c2b3ef9590646143e48ffebc75d7f9c4a688ae0d3c3a648683a5f7a02aaee74c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gl/firefox-100.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "c0f1de5a454ae0f8df7407d08394f73cf8e09f39342288d6670d4c0b8adf2e77";
+      sha256 = "513ca5b29b690986d0aef335cb98406d599a18ee44ed2b8fdf7687ff3dc87ba2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gn/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gn/firefox-100.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "5e177db13df6f5195603d8d2acb92dccdf2989fdb721e6ef6b758120f2efff75";
+      sha256 = "4a5974953f144ffff20a946073aa8891225d80e3dcc405d0230bc601973e8634";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gu-IN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gu-IN/firefox-100.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "748aedc09ffe44b4f8223456afbfb43901b492ff401c6ff39127ff4267ce6123";
+      sha256 = "a2e780ccad66a9a741551b5f7425be3e91f5a225a50e39ebf5770808fac484d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/he/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/he/firefox-100.0b6.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "91c1abfed2e942c076c6b0068edd2dca02e496321fbd79fdd39c7c2dbe7c5c2a";
+      sha256 = "093fef7512fc82efe8aaef9108bf84ab7a9730e2fa94b8092206c0804068bcd5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hi-IN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hi-IN/firefox-100.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "4e13080d458b980cac72cdda1f40a786db926b494fc905eab71cf3535f5383ea";
+      sha256 = "1b6955622ff8fda11d439dcb4f425a3d84c16c49ee30b1e6eb246555fa07bd09";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hr/firefox-100.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "583c5a5f6aa0e328c57c303ba97d1bdfc0a2a959485560d27aa2e906a0deeb8e";
+      sha256 = "571c7bc2b25002094425eaa8878aaa4b339027a5932d5a073b23fa7d3cf9c945";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hsb/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hsb/firefox-100.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "d8c10888b1e3735fce5d1213322f62732b030919ff4b5df70d12d934d348e91c";
+      sha256 = "7443ddc6143f466712de34ebffb4d41633aec8c0d7b253c3008f68b600a59b3c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hu/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hu/firefox-100.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4133206571188244ddf17b96d287d5683fbfeffe2cdd5b2c8ee63fb7db56e3c2";
+      sha256 = "7413002d74a0c2a0dbc19f783e84fb79a71c73fb28034ad4894a7d64d1745b03";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hy-AM/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hy-AM/firefox-100.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "7326ae0a0d0a0afc40f6aa8b0b1506dbe7ead006c641eed4812e63bbb58bdb82";
+      sha256 = "a8169b877a7f2e85bbf363c5f0b6a05b28f2aa948689535b2b608cdb8d4c5af5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ia/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ia/firefox-100.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "e61cc178ec2a648c0bb229e5145d8755343427388911bc6386fae77a5ecfae5e";
+      sha256 = "54245a95072f8b98a6d556ccb79547d56291b9f915f7e5723f49ff97a1bc1098";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/id/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/id/firefox-100.0b6.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "0ac90236941c9a0a5f17e2e5e96ee14c0ef6d5e5645566bc09cb9023359db882";
+      sha256 = "43fb95f81026dfae3b889d085b2584cbee7f6b1bec6edd0378d3965b056f8c8b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/is/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/is/firefox-100.0b6.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "b1efef91567c6b1d52b5fcccf9fbb3c3f81b05929242ebc68168c4712e47c3b5";
+      sha256 = "79e94ad99e19f325915231ce35fa741ed617c5595d5a2d1233ff0b2f2cf20733";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/it/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/it/firefox-100.0b6.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "33e8282f6b1b3a9e404374f93eb6207c3110177fdc11c831469fa721c6669d93";
+      sha256 = "0f2147837a3b3d90cddd387125a8579cc576e1613a520fab8265de36ba1039c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ja/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ja/firefox-100.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ad13269606214cc9fa7d05037db3c6ecb192a5bcc06872aa487b023c2823862d";
+      sha256 = "b755262db8331612cc447c6c5c944374338cd7d52fad732803c1b2d3b8744921";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ka/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ka/firefox-100.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "42b97eab01d92ad491e744890fe6984af4f435ce96595c5dd7bed02f6f5ff369";
+      sha256 = "3dffe30c39f3fee7ef4fdd0f02e619a79f1d67eb3b49efdf35838090e0c03bd9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kab/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/kab/firefox-100.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "64c9abf3921fcf698ed5cda9724884f2e3c1ad8651cbdf9a9fbebf2d8ca930fe";
+      sha256 = "c675eaf355c484362f3b9586a30eac9362452f548d90fa8f70ede88f33f7b30f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/kk/firefox-100.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "9f4546b31322c74e76b13e4557bc412d5d75adddbba16f4e0b0ca8badc81f83f";
+      sha256 = "cefa5aed2f200c3ebb263695c4192fd16b73861edb20085e956332f9f9c009ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/km/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/km/firefox-100.0b6.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "daac53a85b255ad6b491efa2c4d021c0aa91f927e3a5f0fb0d1462ae473a9daf";
+      sha256 = "02f6a77a412311af0ea581fafa12826bec93c333c14ff6d1f9da0dd783c8aa0d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kn/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/kn/firefox-100.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "20b8072ddf8fc07f5095ad97464fe0b84b10215fa02bdd9a31254a92c12541a9";
+      sha256 = "e6dedf44d9a0f1a8d379b8f07add326581b06223b335935f81f7c9a442bac2b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ko/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ko/firefox-100.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "29be35485bf287596145f26602aac5a520d7e980f3012b564a297e13b83bf489";
+      sha256 = "022550ce534cdf4ba489bbcd553052c535fb0ee908155b728718619f33f95630";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lij/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/lij/firefox-100.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "7023d002cc4a7081eccbd5f061bbfe295f1856ed39724be4228e727119bc0a57";
+      sha256 = "f2e075a6ef35fd8c802cd929f9c81043d9221f947269ca13be695b58edd603b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lt/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/lt/firefox-100.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "d121af78fa8bddf3825a89e751d37f12ea7c7513f331e015b0a951efedd80609";
+      sha256 = "4ac54a885a81db97df5940cac5429c59442de591fba560c9608cc0f9ba1df74d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lv/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/lv/firefox-100.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "3f4a005f6ba7b09766f9a9d0186c0d5c82049be965e40f58eaa9c0474fb9d5e0";
+      sha256 = "413dee96d7535b5a276a34871db10b37ae9b6ed233df8a81db0d9080b1cc2ae9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/mk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/mk/firefox-100.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "d1e7703d77584b93261676bb4e5e15a9df0953012392cc52636bafad697bfda8";
+      sha256 = "9fa2653fb6cbd77e874b1306c9c070097c4728deec0972edf9b7b03aa79a2b9d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/mr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/mr/firefox-100.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e7dcd45869323e949baed0e6e561a3051439e190ab3927d59af1008973e58f9b";
+      sha256 = "e26dc9319727f9f7c0fb98efae44d89228499b52edda8f02328586bfae4c79a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ms/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ms/firefox-100.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "bb605564c51282e7c5c48150fa61196374b77c2de48c394f4c887c2bd0456f11";
+      sha256 = "0001655c4a42a6c113f428315200b5cd1eee08cc417fd82464db87c322f5e949";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/my/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/my/firefox-100.0b6.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "9c0bec027eaad1ce4e2e6abeb35e62276805fd49ef818ddc67fd826c8a95f93e";
+      sha256 = "78fcac093123a0b4b6ebffb1e9f10ee5906d526b96d5be1b249a1e60acc4fcb9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nb-NO/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/nb-NO/firefox-100.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "141aec935cb203578e819481b9548e29212c29c94a6c60dd79bad0f676633cd9";
+      sha256 = "6c218dc369434feb3ff30840cd940c19e10d3e900325246445fdb7113c22c284";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ne-NP/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ne-NP/firefox-100.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "5d3e083b078496ca6fa34960a3e480baa69b582bb737fbcded6a119c9216c0b5";
+      sha256 = "9a1a9a2380ebc3da9035066bb212b14b1b8bb6fb80feb6ed220cad1a3969ca6b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/nl/firefox-100.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "f7a8257d2c2cd266e46db87b6ebd8a7530a486d503760baee3d7ab655dc5e7d2";
+      sha256 = "6ff75975cb1ba028e78aad213837b17fe0b06e5f522996b3b9cd450beab24b51";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nn-NO/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/nn-NO/firefox-100.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "30ec48d85ebccfc9314cb642a8171d5ce98dbd0ab102f6ec00cbff2d26163d0e";
+      sha256 = "911e765ba62cfc8d69d7e4d68f1a5d44a1b311400731a3593e98ad72516c47dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/oc/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/oc/firefox-100.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "4d580c477ef3dab1f217114b24486d29df4ce022fa444b013a296603c3ff5936";
+      sha256 = "23341acf2319454172a718a0123fa15bc9367028984449c7a2cdb50644a618b7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pa-IN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pa-IN/firefox-100.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "02953120d3becd386ce8551fd4f97e1da930b7778906096fda8d79340e53230f";
+      sha256 = "bae2060e37bd636ffdab3d3f84b73078c4dc78d7ec7eb7bb9504be4dbc3398bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pl/firefox-100.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "362c1d650bf4613e46384ba5837daa80a790b504fedc254c8af7cc146127fe1d";
+      sha256 = "cc397c80e75d00507fa6e170ec43df337450796c829e44d518523b871e33f585";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pt-BR/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pt-BR/firefox-100.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "38ec5f6aeb156437f2925df9f1e5135bfa9d85e55d570548c56770334fe09bb1";
+      sha256 = "2bcb44821f106ad7478fe7b61c7952c20be135a2efe1185d91123930729f78a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pt-PT/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pt-PT/firefox-100.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9cfcd7212cd3531ee0694cc58653a53acd211494705f1d3040bbf03b4bb537f3";
+      sha256 = "7f4c5713972e5bca35b891bd850fd90fcf60d254ebc15435e5b814a212428b44";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/rm/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/rm/firefox-100.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "ffce43f1c388618b53abaec130e288210cdb1361af512eedf0780d591e7ccffe";
+      sha256 = "67316b932226848b73a95687e6d218983d8056a966771c3bf16344f158578a53";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ro/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ro/firefox-100.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "62bbfeb4a6692c25a1a2a0eb5e790e262e0141dcb74056cb55dc5e7e4a958954";
+      sha256 = "7e61a6ce962f1ae0a74ff7a29b6edd7106fe95e4c2df399c22a17f1cf4d0dde9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ru/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ru/firefox-100.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "0acf8d6c81c1704a67c9b7b9542ac6f1bd0b929cd0f0814b84cf64a46cc38107";
+      sha256 = "bcad404db75ebac101f503fb793572ac010219f41c6716d33cec0552821bb281";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sco/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sco/firefox-100.0b6.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "fc172346729982645acf975a7fba8e045eb81755540faf3eea9699a7474e4ab5";
+      sha256 = "4b01c6ae78219c122ae455627b24594966be61d335dcca8e8547784e8050051f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/si/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/si/firefox-100.0b6.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "64ef404110234acc639faefe93499578b88506e287d0e75ec2fc36be625e7025";
+      sha256 = "5aed65aa84e19c8a270cbf6ad3284c23c83dbff841b4639a15af6cdd9148560f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sk/firefox-100.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "6fdeb9de76bc3d7d7b5907340368adcd69d28b0db7a46bf96ee54ab731821952";
+      sha256 = "a06083cf85f88232898d99dd0174e7999c3e65bc8f893c144775722975410235";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sl/firefox-100.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "259b7c2467220ed58a725006b70b1610d7b1589892e75b0eda1ed5a97ea8d65d";
+      sha256 = "fce1013364e0f49f9cf56b4d50be3f17ec92d4dfe77a0ba6672404abbfd954e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/son/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/son/firefox-100.0b6.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "56f4d79d2e4c3df1ea6903c230d790aa2e40adb704358c6d225fcb2103122cdd";
+      sha256 = "be37a85ae43d646b5b0249303c65d6f0e3c7e15b65986da7e221119d3b8537aa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sq/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sq/firefox-100.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "73490c2374b06cb4a8fdcf5c1ed32484581b62f380aef5d8d6da8c1319caa0b2";
+      sha256 = "dbbcd4da798dca36965a408f74deef86001cdefdbeedd93d3d5c8c34cfd5e4e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sr/firefox-100.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "06070996a689d5cac3f97348af762834d0a9e56446b8b58ceba11235f49f17cd";
+      sha256 = "cb8a4d3af1f8e5af4c6121afaab85eb51239d0a98e9caae0e87df435d9d746ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sv-SE/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sv-SE/firefox-100.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "bc2b8826c8635d5e96b596aa5add0a6f6146fd9b70195323b6fac588ad4e0a88";
+      sha256 = "941b3175289f26cc8102c5c436a477cb04af6a35e15861d2473d55b3dc36a04b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/szl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/szl/firefox-100.0b6.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "40eb80afc5f91513f4ee96dddd842b7b424b4caa2b41cbb0542b6a9c009b2099";
+      sha256 = "48fb048a32877082ff1511484cc1eb7847198da4af366c136bcc260879e30970";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ta/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ta/firefox-100.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "79132eab776f5e3eba46368a837297be38123ac7036ab550c82d60037e8bc594";
+      sha256 = "16ad13edf164a8867a56dcd59e4bb8c09d2cb3cabbab8c2d7e0a4ed0c02db587";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/te/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/te/firefox-100.0b6.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "b2062d708ca2964fe0d046da13c6e763dcc6702dbffc4bb32ace4301e2653941";
+      sha256 = "9c4e9fb72917b2e7b6abec7872366d687874af3c4e0d2acd862363120e3ceae0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/th/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/th/firefox-100.0b6.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4e1ce1968f16403268a69ab85abb33422eb52cb0f36c854a16dda87d5abd941d";
+      sha256 = "2a14cee27f951ec1e9e6e342cafee68a18513ed1b4d210e0490862296b12f0a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/tl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/tl/firefox-100.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "c1ee82d1b14be9bf7c634029884a7eb59c051f26663e00ea0bf6e5f74ef9e04c";
+      sha256 = "dd1bf5dbb47615dc2f3a473ab541686fe53cd7d3ac3e5bedab37ce436db5fe07";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/tr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/tr/firefox-100.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "0c58541768c627cb4d556b34ed8523f3bccfdaa757cdcde37d1fe7d19c934562";
+      sha256 = "eb9b3f14fa9c2c57784f1e37e198b9eb4bdb8cd3f11ebb52b2a51ba47cc10ccf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/trs/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/trs/firefox-100.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "139f2a1abb08dc5ef684d51226fbe64c41e08ad4f183a8b15ff155c5fe51e922";
+      sha256 = "d39ad94019221ecb2cc895ca16d71f4d461a52eef741b5728447ab054ffe12aa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/uk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/uk/firefox-100.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "633fa83f990bc1e8a791a0486bf9034f5b4709fd3e2d868f42895b66c5476ca7";
+      sha256 = "9fbc6fa34062cb64fc6c5eb09df6e3736865e09124efd465c6b30c1bc8329494";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ur/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ur/firefox-100.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "25d7518b88be9d1cbf504a8c214049f265f74a0def26bf5a1c60d562d999a5e8";
+      sha256 = "ca1ed7e7746e5a2085328158185715b7b850e8129adf77b1d6f4e90580563563";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/uz/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/uz/firefox-100.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "39f6c200dc56585bf527e8daa59f460d9193f7d5e7194efb7b1bfbf2d4f92e4e";
+      sha256 = "ad05af6f178de687697e7f98b18a64c2cbcc1bad2b167d5bb35e13ac57d03880";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/vi/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/vi/firefox-100.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e4d0a5838b837d7020da1595cf77093d53aa5d7f765fcc98da20c11c0e853874";
+      sha256 = "22b133203f3bb3c901c225e1275215c0c7e3ab5714e640d218532a9db8c636eb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/xh/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/xh/firefox-100.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "679180e00ca70e112d5053c72cabc0ca5eb92f2f16915c556aefc861188d0318";
+      sha256 = "570c959de8351eb8ffaae05292be916bd94f34f51a1ffcc84e3176b7f23d230b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/zh-CN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/zh-CN/firefox-100.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c280eef16ab855db69e975f8cac93a2987e125236d7df34a5a336cc837cfd901";
+      sha256 = "f0e4fa1b580f778be335285b1154abdfde0b95c6d2c67f7547ab07bcc7fd5172";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/zh-TW/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/zh-TW/firefox-100.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "2b6d0a74fd53d907a6e0f6e28be41e9cfa62e61c42dbc132d16c39f87980ad49";
+      sha256 = "cd49d2954a7014a926cc012c1e439926af1f58c5e11234e2f9d2489c417388f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ach/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ach/firefox-100.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "579452bc9bf650c9664775a5ec438be6cf4276b807840a38e30a0c08237a777d";
+      sha256 = "a3b67450658e8c34ce17f5f3b63afc4116cccdd2d786c72958afdb468c0c7eab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/af/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/af/firefox-100.0b6.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "a9828b2f4954f63b8b4b37722da0a50f1b9e6230aa981f51597718bf05e52b54";
+      sha256 = "c7a9ca1c35ed17fe138df0608d02b345c6e358612a03f3408bd46a792f3bed2b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/an/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/an/firefox-100.0b6.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "0d7083b1feef4c8cde1be64ff26c37afdba36454802266c28b1916f760881de4";
+      sha256 = "242731960f5b500d25f9b328731437a4229aa4d668fc849d2111506dc4741b97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ar/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ar/firefox-100.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "57e5e2863caf348c475daaa6949dabe013aab0b3e63db61b3a9b9ef4049e62e9";
+      sha256 = "4adf2045f911f74323a9e65b4fd2cf249a5369ad5143daa36eb0b1999b5adacc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ast/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ast/firefox-100.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "e954fde4dcca82fdfd8605bcd43930f0b85117c1b2dc9edeba75b435b77b121e";
+      sha256 = "d0827bf52bf91304a0a17c9f5edbc6081be1f1d9eaeba6dc24b63e8b251dbe11";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/az/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/az/firefox-100.0b6.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "a893f228de842c6bdd0c41df3db328c737b57a945a55e1e56f3672a7beffbe5b";
+      sha256 = "41de2d574563135721d0a975d8d90f4eccac60f3be51d4cca5e957473793629d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/be/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/be/firefox-100.0b6.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "8cb4ca15ee69f9bb74cd13de82697526d6e64c6968881489b7ddbe4ad9266c54";
+      sha256 = "736900d6a404a97e13cfeeef68681ec7980266ba983f62c0779fd6a8b502e22b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bg/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/bg/firefox-100.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "2d8a566a4619f549bf6b68a2d1b0fad51843de0257da54039050affbc21de948";
+      sha256 = "77351b45bc0bd3749c54ea1efb1ebb2ba1ced97f9885906a9b86523e85eb011d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bn/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/bn/firefox-100.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e75c5aecf6b0bd0d60423bb66980c085957b1acd1549426a44a4a7991d1f2db3";
+      sha256 = "5d9b274d20b5137e531660f92a7ac3b481abd756870af815159ac30e7df47e8d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/br/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/br/firefox-100.0b6.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "bb8794c3069989e0f06f0dbd0b7fee638bcf9e6e3d24d28ce41db3a182a83a60";
+      sha256 = "22239f50b370747d3029e7f4ab8ac47de15cd5aa8b6d421193299fed9f9b556e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bs/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/bs/firefox-100.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "db964f0e1eb920cac95cd0dc14175f5e20a1ec32f56a3b43554f22cc67dce752";
+      sha256 = "5e2d51cf768f00ab8a30f8d54e2bb88eed75baf20c381e87b7186f5927447137";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ca-valencia/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ca-valencia/firefox-100.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "ca124cd11585fc521b4e2d1c4bc0c2407056abffbb2b36e46ec568c6490b28d3";
+      sha256 = "cdbee7378c4584d51a7142c695401ebe21a05c87961171fae2fc71e76485e92e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ca/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ca/firefox-100.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "6ca6e8c905b44c09c4d061656fe2cace22d261ea4efd04917fc2aa2ce13a1cb6";
+      sha256 = "1f8f6e0a3917828f7e30deff842c6d5f0c5a2389c87969783d46950c6b072722";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cak/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/cak/firefox-100.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "44bfca1c2cac5eea67f68891da93604edbdf6e0eda92fd1686d83512feff2089";
+      sha256 = "42996e08427b937cb2e2aa4d7ea569b729c9002d293be5288e02ab1588e3cbfc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cs/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/cs/firefox-100.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "491a9c7a2471fc1a06751282340f1b6bd00118a8ea11d54420985822c0e9a19e";
+      sha256 = "692d99947185928b46142ae910c76d4c1ee2328aa2e67212919aef39741d67db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cy/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/cy/firefox-100.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "b9e55860c0f14afcd2d2cf87e5ca7d4b853fce667f93a6b493323423c16f8adc";
+      sha256 = "b2f7ee9c016bc107e63dee850688b048c43f5d1caca1aa81d22cde4ffbe6c964";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/da/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/da/firefox-100.0b6.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "899a53b667b4f64e953b7d1cf430eea8e67de747b28c93435cf33f008dc464eb";
+      sha256 = "095ae3d0657a68903c4d60a21240b9c3fc399284063e5c366ccedcf58361c80b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/de/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/de/firefox-100.0b6.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "efecb119d1becf00b34babaf42cae5f5c586dc8cc2a29c71d410b68b7aa00cc5";
+      sha256 = "359364e7ee5ed03556c7b7390cdb4b1e91e027598a74231cfc20fd5d5c601b1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/dsb/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/dsb/firefox-100.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "b47d0bed633a6c8608c600d6b1c8c49bfe40e4b1df6f72bb7dd49e722084cf81";
+      sha256 = "24f7caf5bbc8edefa104c6b4a646a1afa254da9bb8a1965193b7e4a97ef848ae";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/el/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/el/firefox-100.0b6.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "07b34038828ea049ea6c1bba71d27bada83ec514d8d58be92f9005ff01cd6853";
+      sha256 = "97bfe8f01d8f6024b85a6f25ee084642dc2e2c50dc189d1b6bccfa7835120bad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-CA/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/en-CA/firefox-100.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "fe1dfeca3de53837003d93aecf5fa971a51e8a585cbe9a1c44f338d8d1d7788c";
+      sha256 = "fa534341dcfeeb5778d19d5c38fdd8a56e92e756212d256c2fd40c499435e6cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-GB/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/en-GB/firefox-100.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "fe4baa77504d9ed1f789726db85599d5cc634765ae19cb4604234ccf7a43b97d";
+      sha256 = "a38f383c06a2cce4ddc49fd304b1b5742dcbc2cdd189dd5b6e91b1494231504a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-US/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/en-US/firefox-100.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "6ca97f006b90f98676efae14423c8707527182e118f4d3020e51eddcb14cf8d5";
+      sha256 = "c5ad47cc4f5829eb3d01c7031833e3f8aa24d07947415947d5e86e492be37c20";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/eo/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/eo/firefox-100.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "e9fb1b7b6752629891df490ff625897ae5d929c435c824cb6c5dce18340e3273";
+      sha256 = "d96ddc5a07581ac62078cac8d702425d6764cbffd93ea1a35ddcbfa5258e01ca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-AR/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-AR/firefox-100.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "b18a2fb101d28d1dae1b4a33d63906a7c6720ddf5e4418eecf8f6df0be58e017";
+      sha256 = "e5c069a162cd02c3449b6b6c800c491f80270cbd9e29bb418351b40ca318d08e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-CL/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-CL/firefox-100.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "37a54082b8bb69c925894718eefcb1229ad661cfe31aa95906da163a213ea4b6";
+      sha256 = "e45ea8d1bfc96f500e1061eed4694f2c7c81fb5b5ea76411cb7bdf7df8e74b1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-ES/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-ES/firefox-100.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "bb38bb93c74878646f31c09d524eaadf18a1e2f6ace957abfabd05e1e63898e2";
+      sha256 = "a86e913fce09abd34f69f72f338e5d276360b39584266fcb160aa4cb5ef15e10";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-MX/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-MX/firefox-100.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "6c75d42e34b6fde9e8b3ad31ad3574af87dfab2f5eef71b457fbdb9ca6dbe12e";
+      sha256 = "d39ac7c519aa5ab3c2b02da50f882480d657672573ac13b76ffa1620a7c31dea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/et/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/et/firefox-100.0b6.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "e25b97ff49fcfaef9906cee48f0f342272d2b9807a6221aa6b4fa5939bfba70e";
+      sha256 = "2d83aecece8c35f11bd3190da1d91100779c4516292fb683792c09a9df63297b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/eu/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/eu/firefox-100.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "f929034c74b057e32db4408ca25b9e9aff9b26d487db29cbb0c0fa0ade96748a";
+      sha256 = "acb38b6a8d2111511d31cb967da094d68eb4bc5e1fb4af613392cdb931a81b69";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fa/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fa/firefox-100.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "2fd4af491c79dbceee3de7e04fef413535757c0588072ece7e5ebcf252815782";
+      sha256 = "4c509afe344db0cf9eff8f3bafabdc80b25f78537dfcc931d05a326d97b3793b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ff/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ff/firefox-100.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "7b0f38144eef79ead877a352a03abb3d50631031b051750d3d9ab84dd8afe319";
+      sha256 = "23c02e6d2f18351c72917c02f6795b1183482e35c6fa5990ecab8e724959c4ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fi/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fi/firefox-100.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "fefaec6affe3be2d963967397aa6b0c7495570d0fb437820d87ef6289654fd80";
+      sha256 = "30f696e3e0b419017fed38ab434a99ffb303eaa4d9d96bd2525ad84cebb20d51";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fr/firefox-100.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "1dcb22611d288ea566f1d319b4fa8f6ec7057e05d39a1be794ae12f343e29809";
+      sha256 = "40d631f78caf08e8a04a4dc1286cd749d66130a9b3f887f8a74d1f15ed7247a3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fy-NL/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fy-NL/firefox-100.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "fe15fecf740bdc9f9476366f394a10f2f919d7c84f64844025faafbf28fef05f";
+      sha256 = "62563d3d7c5755f1163d956f1bf82cb81c48b5349db293e66185c95b8e65caa6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ga-IE/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ga-IE/firefox-100.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "06c5708ca8cf4ded0cbc7b52e0772bc4fb86ae55d822ff09088af5c35e60d917";
+      sha256 = "72914c49d6b5384987942a6c8127891c7eaa088d08bf9192ce448b11342f512e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gd/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gd/firefox-100.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "fdbf7f54a4120dee131687fc81e972e4df52347de4e8473a152ca0b98d7bef92";
+      sha256 = "1a127b1a4a8407476f1ed73ebd982fc5d0262e2fc413748b4228d9bc9d28a59e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gl/firefox-100.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "807d0deda34da90207a6ddac26649f38eded1a6b2337d9cb73ed28c55bd316b4";
+      sha256 = "1a84a2d00d065f69492a73e6917e07de8824b185139e3acb75b0f0dd5f82d604";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gn/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gn/firefox-100.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "a70ec6595f9ff5cfcc8ae0185d4ece632a17ff49817b98052bee8981dbd63d58";
+      sha256 = "6ddf864b2b2258d0ced011ac2d0ed13455e99d3c093642a477f95ca13a3349cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gu-IN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gu-IN/firefox-100.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "44e9a22d946e4405db84069d329b66293b0d789b59d98bed4570d98dd19b6c0f";
+      sha256 = "86688035900e5bf2dabfb7e8c7320dc4ccf33b46d8c9e963216a750ba2e2b300";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/he/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/he/firefox-100.0b6.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "1855cfb19d6bd857a14950399e238c30768e23c08d21a1db38b49dcedf2302bb";
+      sha256 = "d35c7ac5d61d9253ab69da2a77bbaef7037e7cfa2339d4730201fe41776adc90";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hi-IN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hi-IN/firefox-100.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "47fc9f90b3d52e353594bef6c84bf408ef3e37fa2d0eefe17997bab546b2f9b5";
+      sha256 = "48872f0b68ccf4df855e58a4520f5f8347b05de318a0991d83088521b4d178e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hr/firefox-100.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "bcbe511cd9bf09605f1e6bdb3b65e9f8eff6c6e8cbdb904987941d2edbd10b42";
+      sha256 = "9c1c1303aadb4071a82b558fd470c96671872cd480e444686ec74f41afd46e2f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hsb/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hsb/firefox-100.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "5a5b5063eaeeeec63d13f138ba43280ea6cde0aeb03bcf18c6f5ed0c7ab575d6";
+      sha256 = "828330501590e2ad3021397cb7b37a86c015b93536e4e2383fc5c5a1e8d6a6f1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hu/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hu/firefox-100.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "7828ea71f5ecf9afcc52fad0047789ece2c8be5c7ba8d390d98a24daffebc0c1";
+      sha256 = "592c69c6377657bccbf2b81ae54bc8f37fa6d081dc36d0465c20eaf6d673f32f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hy-AM/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hy-AM/firefox-100.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "c76b2e07e5085caf56c8c94848f7d7dc4b40c5000a792921bce762ed55b73f4a";
+      sha256 = "a95989dbd6b7b499840f5cc65a765129ca23392455afd21c0ff865112900b5b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ia/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ia/firefox-100.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "de9ace36727f9fb070138d30bb854bf28ad57b7a9895cff492d48231826044cd";
+      sha256 = "a9b225d969b0d8c621a2b545cbb42ce7188d78c09c248422d6379d83934201b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/id/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/id/firefox-100.0b6.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "01dcade8b0d7dd4f4ec9a408291c643bbfbcb922ba0b2cd84645799c22c46082";
+      sha256 = "304f4d04d3e73a477598a034d3fd016948c5e1662bc236d640219b4b96159690";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/is/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/is/firefox-100.0b6.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "a8aa5de061a5414e55f45c61bece3f4471662f36e3e30163daef028cbc62a675";
+      sha256 = "3cd144b87e3ef57703ce60c57a09ea8c6ab910408a7c891f9b9b653dca51c55c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/it/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/it/firefox-100.0b6.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "4610c04780fc075cb49a09e0815671dcd8f3b625a5b30913c8ff5be81cfd13cb";
+      sha256 = "b024d3b0fe4ac5691c6cf1e0c18ce2bff91083746bb988799f2eb3ab74e22e80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ja/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ja/firefox-100.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "7ca93bd2ab0a1e0e0aa1a41df7331c65f27747b3d511527c557e613272a736ba";
+      sha256 = "fe3d9b0c7d0e8f47e9f1bc12429200aeb951b303946365bb32f51c9d807259cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ka/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ka/firefox-100.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "55cf179d73cfafc5526e5701de3560e4bf9c1d02c28c77cc66801b828fa9e33f";
+      sha256 = "2e4d0f5f2eab6787db359c47a48b35a202b713de0807299a41a751b527a9ccf3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kab/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/kab/firefox-100.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "c7930dbea998892979a16d3e60b19db62cbbe8388e68a2ea59a11e234e8f94b9";
+      sha256 = "49166beef9b6952940d1ce420afd77777fbe84143b65693f9b75db6768b88e01";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/kk/firefox-100.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "771eb9217226b36cb04719555a82c3b11e783059183ebc9c295677ea06d69321";
+      sha256 = "24aec891a8189714c9299c695346a3d0a4ea52621f08b890d5db63ba36bc627d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/km/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/km/firefox-100.0b6.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "970daaec6f449ab1d6dc8688ee9f41b95d295523ed57ec14c5f34fc98ee18dee";
+      sha256 = "90f5b7811a2f0bdfefd14261d1e0e7fe85466dc96c666316134c97095606c6ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kn/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/kn/firefox-100.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "fae2d5a9a428ddba10cdafb6fce6e0d591b5ba8353d2cf88ed423602fd150576";
+      sha256 = "e423d1231edbef812e8cbd50f53dba4b48dc9083cbd5d91825392229015c38c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ko/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ko/firefox-100.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "4a66e9cec2224382645d962908218bb89fe4a499b9138c83966dd70d9d25b172";
+      sha256 = "cadd481242635d64b224e080adc1bdcfff9f7ced4715b0ea9655ab333ac7d039";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lij/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/lij/firefox-100.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "85ef4a63c9dc97f9b482382a83f5a7a6880c5df87acce7e142506c2d449e4f69";
+      sha256 = "4798691d44767027a39c1124053b2351523e615a06b32bd2bf4f9da7b858159a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lt/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/lt/firefox-100.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "da3ccc7021eb4b62c35c716089599f714cfef218856063e083c3547d64271b4c";
+      sha256 = "ac49b6d34eb8caac4a6900246adb3562eb2228a50fcdc543f79903ea267b339e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lv/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/lv/firefox-100.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "6aa1d5453d938f16330e0ed54d63bc59c5b57e7da5ddbc41a05c2f75dea68e73";
+      sha256 = "4f6e6a26a2b8a23855dbdeabd2363ee0155914542e4c48c655d6b52da6289b34";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/mk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/mk/firefox-100.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "e0cc100f8be06fd97cb029837a054e60d136272a9f6b78eaef692d3bc5d8a669";
+      sha256 = "522590d926022cbe833ce0050e5d23db47bab2c8de1e1e0ae3e96941b53dfb6c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/mr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/mr/firefox-100.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "d3a3d72bebefc51cd8eb1a1ebc1431a9845d15af6321b76e2982a0d210397409";
+      sha256 = "4df57dacc8b71070aa077281beffc04bfc632666b2b26caedc1fda4e484e59d9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ms/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ms/firefox-100.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "c59362f1817f98ec80ea275b39f50bed7a0ee1154d6a6ea3ad6dbe8f2eb1bf79";
+      sha256 = "005506663901ad539817197972864f67812a9f5e3f1055e7418ab4bb052ecdad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/my/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/my/firefox-100.0b6.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "ec1d06208223422633c2ca495bb17ca946e379d361a2e00f94ed08588b6b2263";
+      sha256 = "aeb8445d5425640ceb8d2b823a7dd3e79fbd355f07420d015af4559d2bf2cebe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nb-NO/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/nb-NO/firefox-100.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "2e31732057bda76dd2d74d8e2b3e6c38a2035bf163234fd82fc867b544d34dc1";
+      sha256 = "d41588beac0fc9a3eeab9f2843b8aef53e61a7c15dcdc34eb89e73838d9dab24";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ne-NP/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ne-NP/firefox-100.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "eba3a80cb0b761b68d5e318d5f8110a7d19da1261868cbc1f1a39eb47c08c018";
+      sha256 = "c3c981a5a701118e70b6b03338451d7d50325234be03838e403e57b822b6fb61";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/nl/firefox-100.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "1f7ae0dc78d5b30741e8d645471aa1875c2de144742383eb5c24cc2deda79f77";
+      sha256 = "ee902a63548299b6ceb9cfa263991233c32b0bf8534dc5256ce84714eab01f12";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nn-NO/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/nn-NO/firefox-100.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "acd635ad253a878043ec4121984da468901c49d4fb511ec9cfad478980ecf647";
+      sha256 = "e3fcf444660a2e8b3abe10d9d3a512985e9791fb7916ffafac564d9849816241";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/oc/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/oc/firefox-100.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "2721c54a1bee621d9c7cf2f5c657dc48a7d9406d80c5aeb9963bf7b128c17629";
+      sha256 = "0b80101b082209ead23287d0d7efa136eea099b9895b9a4a8906abafb8a7dbcd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pa-IN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pa-IN/firefox-100.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "97c435e09c0b56bd9bf66d50e90034a502e9af6cc1984d5acdd2d948f7556273";
+      sha256 = "14f8fe19c6cea1d38eba2f4aff8a8787875632e7ef867b44a48bcda59ad0c32f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pl/firefox-100.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "36e81c101b8cb68be0f69339c47ff4e5839397096775cf9ea46f0ff1efe5353a";
+      sha256 = "796b575f4ada12cd1aa0fdeae8b5c198eb2e6a327bd0cede066b1beff4961d96";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pt-BR/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pt-BR/firefox-100.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "fb90a3a2a303f945bc34e2a6ec397f0116ac77f02062e7a7c8dcd382606dfec0";
+      sha256 = "a1a83e3e317bc7465922b40327031fd48610627c0e1554569710a7b40fedd98c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pt-PT/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pt-PT/firefox-100.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "8797c65c277cc0f46a8d8b2cafc370be55c57eccc8e9fc88d3053e2969f9de58";
+      sha256 = "0ff375602235a96b6197366ae22f4c05cbb3c9068d48cdb08a035e3af084d3f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/rm/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/rm/firefox-100.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "b8cd7b28f31d4e1ee874f1073065897444eb9503e207b924a875a8c3a0b21509";
+      sha256 = "5599c540c50162d1a79ea16196bb15fda9fed825508b60b4961d91255709593d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ro/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ro/firefox-100.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "3907d9aa29f56fbf97008e65f83ae25719f4156961ff3e976661a2012f16fafd";
+      sha256 = "771be3da68642a15baa1e054bf23e9df272d0b0ab46f1e42c6fdf35e85035b9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ru/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ru/firefox-100.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "4913bf6de1f5b14d005f20bbc0d2ef97227903d296851034735e872e28b3f065";
+      sha256 = "bcca4b9aace48ed4da4c881ed47b0bbc3d20fddd07273ecf1c84758633f350b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sco/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sco/firefox-100.0b6.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "ac4fb9005a71ca5bd25120946b65ebc0f437d8c86b9dcdc11e9b874ade8b4dbb";
+      sha256 = "1ca439331c6437dee10d1f2cd72907499894bd98af036dbedc964248217ff510";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/si/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/si/firefox-100.0b6.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8fdac92f650f10a9dc9322f817f1bb6f60b5a9fe97942cc1ca5ae694aad71523";
+      sha256 = "b643cfd20a0bc56b1989dc1c4dc96535d6585a53bb5d13c85ca53bb1027e1732";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sk/firefox-100.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "57987896b0e1b8846911b878dc360d139002401ed57a9b95fe47f2801c983848";
+      sha256 = "5aa1dc132c3d2a42b6086cf824c8b6ae7a30d8b55341a05acfc3eaaa8dd4cad0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sl/firefox-100.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "3097cfb125f9b275270955c454577b7aa5ffe68b5ee0917cf6b3e0c31d9c5b25";
+      sha256 = "92b2a15a04c4cee559e0a6565509a546ac7a2c4e3fadbba0c6197356e99f71f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/son/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/son/firefox-100.0b6.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "8588038e834177672a47530e8e86c202123606ef6f1a5d9a4d5c40cac8cb9aec";
+      sha256 = "8a25e8af341178bbbcc0731788b1116ab64fbb55480836b94ad6e7830b6b5f16";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sq/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sq/firefox-100.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "cc229e95ce396fc37fd7103e70acae2414de501823beb04e71c702cc65c430f6";
+      sha256 = "66b7ea3b488b980c425576fdad6009d2c246bdb4686b24b519604a54dba6f756";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sr/firefox-100.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "9c134f28f92311c8c8764df4d37727134fecab10197cbbaae01d26773e2897a3";
+      sha256 = "1aecc3a24dab4a843a967b8c023bbe01488dc113e451cfd7d39e7c2caac1c153";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sv-SE/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sv-SE/firefox-100.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "40c8f4af652dae7a3eb1b1cab01f032ecb526600cbeea0dd5ccc4319b0d50310";
+      sha256 = "d5189ed627ac49286cec9733c8658c271ee99930f2d07754993e776a58eacfa0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/szl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/szl/firefox-100.0b6.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "d71882b04563f7f89a4c0bd2431e6b33e2af010b40b1dd50304f9daf0ca66525";
+      sha256 = "45c48d7381499d5aeca0fe340ecc8af33016821fa8f081f6c52c878a9af3640f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ta/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ta/firefox-100.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "a473f9123d53de141e0592e03e8c9dd6ce8f057c57f89f55957c1436d139582f";
+      sha256 = "1a8a9fe5eb0e9e8d213d667cc1aa478f9f381d5a444f8d2be518fb04926e4f64";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/te/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/te/firefox-100.0b6.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "042aae2c4d10d2b7407b3252a39600217ab8ac0c9e34045c31e70cd8e792968f";
+      sha256 = "1f3aa559af38662aea444f52974c2843ffede5505e71e83d73e331d2c4b92275";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/th/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/th/firefox-100.0b6.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "6455ef37c941c978b1380f6ff3de41c0b7f8348d498d154e78c9c7b6e8992187";
+      sha256 = "05bbf88a5b9e914d86244555d06d560b328e8e873e380e67d40edb6d3971d383";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/tl/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/tl/firefox-100.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "b41d0029729bb4fa1e8d8c596232272c1e238d8bbdb675d31e42250faed54396";
+      sha256 = "8cd7f71325ce2a54403032bc80fe366acfd7a8ce3e3871ae1a8f4e0b5315ddf9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/tr/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/tr/firefox-100.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "e0345c71199784d40fa159617371a72e3f3e05d2aadc041d14c6b3e450304afd";
+      sha256 = "41275c3dcfc9624390a2d3ce9d0aa0e746c4e3122f433924227299d46ff8ab42";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/trs/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/trs/firefox-100.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "4a6afcbbb3d05bf6f3abe3194a21aa6ea6d2f76cc5429ef4ca0a433ab1d97f76";
+      sha256 = "c04aafe011c8626d749990e0ba293a22c8a623c6eab9bc4bff2782708832a648";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/uk/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/uk/firefox-100.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "97709ab7965f859da2ce93cd4c22b875a0a94af8b8b7acabd1578d5ae82d6d85";
+      sha256 = "965f445606d8c81d1745a7028ffd15af7cb9bf2473bfba5e673e3621afeaa6e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ur/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ur/firefox-100.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "7c69d7f588540d0a72d9942671d40ab59f066b9798279dbe1b0b0980cfa13a06";
+      sha256 = "8955e64902aca993d110401fe36b56c84b53a414b2da569525653ee28801d9ca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/uz/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/uz/firefox-100.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "53c450eeb1223c2794b9270d257fdeec50bb4deece5bf5d7d05a5819f54989c5";
+      sha256 = "e05ef7856c3c4777da187ed7212ebab01900881702d1fa8e221a86c57c6ef4f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/vi/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/vi/firefox-100.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "395e8ffa9c6a0145f6fdd005df0b73fd4d59410ba780818232cde2f3fc257d50";
+      sha256 = "baca088760ee065eb8ad86d93c6b0325d23f88d18359693ba9c2a3971e9e5061";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/xh/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/xh/firefox-100.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "22359e92de488a24709445de54499c9ad49e841e4ef6ba45296b44fac089121c";
+      sha256 = "c679216fca120982454a15087890fda40d21bb269a940d96dbe37428672db65f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/zh-CN/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/zh-CN/firefox-100.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "7f5d0d771c546d41e835ce7842ee7659ec4a69cd78176b0c679b4b056e8d5499";
+      sha256 = "ba77a6dc02a406174a79a99b510c2cf7f8be6f877acc57822ee174cc5a99931d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/zh-TW/firefox-100.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/zh-TW/firefox-100.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "8bd0dbb9bf1a3682ea39e43da3819a4f12bc147484528d869a252d2ad000f95a";
+      sha256 = "108fbd9c48b974cfd533c514d8459990b5d278ac5381ba5cfb8fad8d885dcfac";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "100.0b6";
+  version = "100.0b7";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ach/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ach/firefox-100.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "6b5ac2e733e44616405f31b16bc995f945740477d00988ce5dd4f16c4ec74085";
+      sha256 = "45f6a861d33b0c658494e0b50006cdcce0e842cc3788666876d916f391c7b7ef";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/af/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/af/firefox-100.0b7.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "5b25ad2870b33002060f493368f79921046f5b19e4adf0c5e1836b7d00347790";
+      sha256 = "101ad51c55758373330a83914464d460843ff5ddbdeacdf20fc5dd0bfbcf493c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/an/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/an/firefox-100.0b7.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "9fc4a88d9216ba0b5979e939092314f135da9e33a3d8df7cadcf142f19b0b71f";
+      sha256 = "70daa1c1b8b79bba2b714c4f9eafae4eefe8e3539978a565ab59303acae14612";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ar/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ar/firefox-100.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "23f33752d3df64ee98cdbdc569b8cb4cea2dbbae71810a3a14a82a6361f97b9e";
+      sha256 = "4c12602aba16ad4b53af058037f5011ccd2b6ae84eca50d54ef4b87a6a600d1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ast/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ast/firefox-100.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "a5d357ed9b58fe0a2b7c95e24cb18659c7aee29cb1cda0071b7afdee9c3ac9eb";
+      sha256 = "b50598963cfd375bb67ffddf2b376f34698a82b46df6c80002ea6f0f6eb9cc4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/az/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/az/firefox-100.0b7.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "1191a7c0a3222d55a605bbb5f25d064414d08b9bfb6dc6ad74dd1de357177701";
+      sha256 = "6805c880b5e418e06b55c13bbadd351165dd204e41fb08b1b2eab5b94a0f3fc1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/be/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/be/firefox-100.0b7.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "69445ca3cf31d63162ddd0aab1538655a08e325aad57a3d343ac310193a942a3";
+      sha256 = "a4dba3ed59a9b2fc56d24e5e82ccfab1bb5824da8c3378bdae8b19697ab1ef18";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/bg/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/bg/firefox-100.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f2ff0a6bf22b9ed16b0656d4e0848c509cee2de9a638d556500909e1352ae5b3";
+      sha256 = "d70c6592a3da83ff561e7bc01380f9f800cb3400495d8b67658a1564e324fc3e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/bn/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/bn/firefox-100.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "1fbfdb8d6f22567eb1112c63ab6192cb439b9d2cd5e57c10401c76f9f9cd215b";
+      sha256 = "9d669c944eede493fa7ef2adeac05fbe6f85c88ca6323afa43eb7b3c5789de39";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/br/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/br/firefox-100.0b7.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e05895d70c72aadcb77dc6d84a6a054a8410b29e05d5da6eeac0fdee1b66b130";
+      sha256 = "7745681dff251572370a0872ef05def05fec417833f43f7a7ed51b83df936b60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/bs/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/bs/firefox-100.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "ba125689cbd845e9bf8df940bbfd0796326939ba9b45d4bc0c0a8ddf64dd6f61";
+      sha256 = "bb36eac7d390edea72366e9cb410fddb3bdd39345daf952ce38fe61b2d70f1b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ca-valencia/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ca-valencia/firefox-100.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "37a5ba26d10cbc2aa8222a2f19133a12710adeb389234ff53a91b43ddd5e901a";
+      sha256 = "6be81c01b1ae5942f3db31e2d091cad47bd5377713a248c87adbaa2af4a64791";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ca/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ca/firefox-100.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "5f11f3a11b93f06235981200b690cb9aaf95ed8d459ea8e1d6ac7c6a73d9d9e4";
+      sha256 = "675ca3f991d11f4a0b7e69031f05e55a43ff8ca40778efbabc3bf5d35790de99";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/cak/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/cak/firefox-100.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "1d4a103b8c2c601b908a635d2b5edaec068c1a2e644e1924022a94e57e1b2f6a";
+      sha256 = "b2d5f12391e2e6478b3e82ac7d60f319bff9b98cde20efcf9c89e3d8e1821c37";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/cs/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/cs/firefox-100.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "358b2c3c3c5a9945b35f1c71eadaf7d5305d214ecfe37fda811fd37d326dfd35";
+      sha256 = "356305df5b9f64f9b6b2d00189add782363658c62c5aadcb04f86ea097de8ae6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/cy/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/cy/firefox-100.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "bcbab842e30d22f7d646d2494451e0e676c40c16c1e3532b4c6cd6eb501fb7c2";
+      sha256 = "bd2b4b85b895101d12dd6edeae76d61a91a78bf248792a7a5376e9beaffbb2c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/da/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/da/firefox-100.0b7.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "3b462ea57616171ebe43e218d7fbcc8c45d508fa2b91490d5b107842bf936d25";
+      sha256 = "820836d6f61f94c19ee0216f1ce77cba5b647d169c62f35d025244bfa98fbbfd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/de/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/de/firefox-100.0b7.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "067a586989c84a280366c6021daf270652d443465b63d03e0fb9ff02eeb3f3ee";
+      sha256 = "5c81914bf7cbae74d4aa1e5309cdc351d3cfb77768c5a2ba67a14b5e0115c63b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/dsb/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/dsb/firefox-100.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "42621cd070dc172b08bdce256c91d6faeede97b116b353f1edf2354c0e37ec3a";
+      sha256 = "fe401e2a22957da728b61b05444abc8cefb4e033f83dcfdad2696bfb33ad7411";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/el/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/el/firefox-100.0b7.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "f079ccc06590277ccf09d4e34b73d3b363d79651d6e2a07d7e127a42ab552bac";
+      sha256 = "6fb923e5e24a9646854b5be2f596336ed755e122c47a928842d6b6af89f79812";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/en-CA/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/en-CA/firefox-100.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "e3f239da659c77662a10ba061f806d615f9a57fe89d1207ac04cacc603a9a587";
+      sha256 = "70064f73aaa2298f98bc0ed0261b1386c6a95742abe15cb4a2069ec3e944c000";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/en-GB/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/en-GB/firefox-100.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "e41640386bbceef99290458576da3272ea400e78641cbae73ece0e07045396ab";
+      sha256 = "f5e2105f6c6aaa27aa9c20cb622e648b23ec43eab17bc5a73cf087c356ce0a25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/en-US/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/en-US/firefox-100.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7f5888e7c0480f4f1626943f1878945166179ab94d995e23d0b8f5eb9d83ab4e";
+      sha256 = "faf84ba5b13fa1032f5b85848a216c05d329faf9b157d564e7dab0e821931eb1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/eo/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/eo/firefox-100.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "6c07749b176c7c533a824357da81a42ef10fc78f09b58e7a090d3e36fd77a6d5";
+      sha256 = "36def89a0f4bcbd4410402bfc3ca1a8622856068bee00fd6ed61be3ff5ce68d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-AR/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-AR/firefox-100.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "2d23cfea40e6948fd330b2e72f40edab597e5261fb9abcbd539d0b9f513fd946";
+      sha256 = "71a61a5620b41f50aa7ceed4582fc3166e40ce99016723593a6f00d028097d10";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-CL/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-CL/firefox-100.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "eef75de09e6fa7d21ca4aa799ea4b279dcdeefa79d9b4ef7f3b5266c90c2a8ff";
+      sha256 = "bfc017101cb198ec8a3c9110a63b4b03bfe2cf979f5a7ff87b3d58acf4040c21";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-ES/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-ES/firefox-100.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "31d985ab2af1ba15fc6b41580fed4a06fa33fb8cf3dfcf96b1a5ea4e361058f5";
+      sha256 = "61d9f463d7aa95343f0170b57eecaa6770c254f3b7edf69a2c10f3014add6bbd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/es-MX/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-MX/firefox-100.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "1fdc9e77eadf9abb55224bf0db1e555eb99f4a7c525f6021fe226ea7de9db026";
+      sha256 = "2aa594ad00793792ef4efd7b6d825867b63ac83dad2f95c7c4b4013615bd7821";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/et/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/et/firefox-100.0b7.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "2df8328fcf9f10b84b2110f31ec32a5dce7054845c37f7e30b023daee4701322";
+      sha256 = "71a59a893270312c304941412fde6354fe13848fe814d0f6f95f202c47efa9be";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/eu/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/eu/firefox-100.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "30037fbdb33703b894bb0e33b192d23aa1b67ab9b944b1381d27f95e0c44bdf9";
+      sha256 = "58c9ad0df354b819ba2090cd318423dd911abb01cce4bde924caea1adf38f5e3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fa/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fa/firefox-100.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "37af6700e54f98541fe1f703c13ccad70a72bb7e28200762bf636bd3494b443d";
+      sha256 = "fc6124b925fe2dc7f00a629754f373d4a3a43fa20b2e533ed350df0acc87f872";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ff/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ff/firefox-100.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "3612950e42cf9532bb5be99f9f73e2f6b480c58570b1092f8eb337aba1257234";
+      sha256 = "e267ce3bf5fe5f2143eaee3a647e32bc5a18bc395f06dc08698cf5eb5c5eea26";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fi/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fi/firefox-100.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "a8a2bace3af643c6b82bdfb043f90d4cd6ec10abfed6ada230786ef7eaaf9ee4";
+      sha256 = "9b63de9b660217226813a814cf3d2aea4de8c38e98386ca20a246e6552b0e755";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fr/firefox-100.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "296f91da1aec6481bdfecf311db4560268082d6f75f0354c6b09ab64494c211c";
+      sha256 = "a6a1eef4d559779248e0512d0611854f4fcc442c3e0c7e13b709a8d60fd132ca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/fy-NL/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fy-NL/firefox-100.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "3bdd5b38483c8a8fdab13767ad8f38d60e9c12359740d8017ec8a7a83338e99d";
+      sha256 = "78c0e2d701ed3fb9e5299f51c9cc7844035b8f7dfc314f2d79bbf76b79392a03";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ga-IE/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ga-IE/firefox-100.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "5f734b553ce52eaa91bc3ee1ac2afea09aefb35e886ba68d56cf3b1e55dfbebc";
+      sha256 = "97024d0b49f5475fb3c44cc9b95733349c854e69e7d73598b8e8e8bd319ddb99";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gd/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gd/firefox-100.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "c2b3ef9590646143e48ffebc75d7f9c4a688ae0d3c3a648683a5f7a02aaee74c";
+      sha256 = "d0aa045753b91db42d6c1ccf9548aa6dbb04fe22bfc68ace2f4fb797b45d2ca4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gl/firefox-100.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "513ca5b29b690986d0aef335cb98406d599a18ee44ed2b8fdf7687ff3dc87ba2";
+      sha256 = "45fa58685fb371f5633e74c26938b63bc21cd110df0b2197ab655f921abffd2c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gn/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gn/firefox-100.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "4a5974953f144ffff20a946073aa8891225d80e3dcc405d0230bc601973e8634";
+      sha256 = "f62a14f9bd49318cb88945cbc721837e263a8661ff9832460ddb37893eabc609";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/gu-IN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gu-IN/firefox-100.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "a2e780ccad66a9a741551b5f7425be3e91f5a225a50e39ebf5770808fac484d7";
+      sha256 = "396c16091b38f28f6b26807eed89a93935498f5dc137ffd869bac31e2e2931bf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/he/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/he/firefox-100.0b7.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "093fef7512fc82efe8aaef9108bf84ab7a9730e2fa94b8092206c0804068bcd5";
+      sha256 = "f453e1be32dba9f25271ee0cc826f26bf2fa77ff1b3ce3f430ce7d345c3ec5c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hi-IN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hi-IN/firefox-100.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "1b6955622ff8fda11d439dcb4f425a3d84c16c49ee30b1e6eb246555fa07bd09";
+      sha256 = "007e80ad1a41bfdb29572e9cb988c942118ff076aa616240304ebb7e7b16d37b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hr/firefox-100.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "571c7bc2b25002094425eaa8878aaa4b339027a5932d5a073b23fa7d3cf9c945";
+      sha256 = "c2df4257df1718d5b4e9fc287bc0ff021cc063d3bad6a1a10dac6f323a9a84d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hsb/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hsb/firefox-100.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "7443ddc6143f466712de34ebffb4d41633aec8c0d7b253c3008f68b600a59b3c";
+      sha256 = "eac23db86d26a97bb3a7c11febe50e0be009ab3d02bbc09ab1e85ebd651cd7a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hu/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hu/firefox-100.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "7413002d74a0c2a0dbc19f783e84fb79a71c73fb28034ad4894a7d64d1745b03";
+      sha256 = "4352ad9b31e1d49256126929fcfa8c95d113c0162481830674b6e38c22a14603";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/hy-AM/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hy-AM/firefox-100.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "a8169b877a7f2e85bbf363c5f0b6a05b28f2aa948689535b2b608cdb8d4c5af5";
+      sha256 = "f4acef80ee2d434ef18799e127e31f23a0dc22f959b116594d487d2baadedb08";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ia/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ia/firefox-100.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "54245a95072f8b98a6d556ccb79547d56291b9f915f7e5723f49ff97a1bc1098";
+      sha256 = "fcbc17a1e5672779fe07dc37c9a6911fa75ad08c0b4a01c875a2d18bcead0072";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/id/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/id/firefox-100.0b7.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "43fb95f81026dfae3b889d085b2584cbee7f6b1bec6edd0378d3965b056f8c8b";
+      sha256 = "965ead6176dd31c7da36cbe8e98c4391b76b6c169ed1277c5ea21fcd8d44ae73";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/is/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/is/firefox-100.0b7.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "79e94ad99e19f325915231ce35fa741ed617c5595d5a2d1233ff0b2f2cf20733";
+      sha256 = "961fb825436501d46dff5641847274d36a2aad75c463a1c222be50b3b640893f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/it/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/it/firefox-100.0b7.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "0f2147837a3b3d90cddd387125a8579cc576e1613a520fab8265de36ba1039c2";
+      sha256 = "1dfbbebc983d4a16abb3982794737e871aa63fd553ec07d19bc91e6a60781c01";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ja/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ja/firefox-100.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "b755262db8331612cc447c6c5c944374338cd7d52fad732803c1b2d3b8744921";
+      sha256 = "17a02ae89dbb4f75d9d36ce357b284f71d722e7ae205a732be676d013ab2eb6f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ka/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ka/firefox-100.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "3dffe30c39f3fee7ef4fdd0f02e619a79f1d67eb3b49efdf35838090e0c03bd9";
+      sha256 = "6352c8941b2b54002cd6d978e6063a4a96c9c50f8e69ea8686782bbcc393269a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/kab/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/kab/firefox-100.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "c675eaf355c484362f3b9586a30eac9362452f548d90fa8f70ede88f33f7b30f";
+      sha256 = "9913ba498028f09879854c7856837f75290dad95c2e6e5b4663f8689b879da8f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/kk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/kk/firefox-100.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cefa5aed2f200c3ebb263695c4192fd16b73861edb20085e956332f9f9c009ab";
+      sha256 = "dace65fe6273c77b1e2f8920aa44220f2c8c698a966086c0576f31e47b143010";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/km/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/km/firefox-100.0b7.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "02f6a77a412311af0ea581fafa12826bec93c333c14ff6d1f9da0dd783c8aa0d";
+      sha256 = "5e0f4911a567f1148145e57610f40c10da6b76be1bd99b5050f70201891e5ac7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/kn/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/kn/firefox-100.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "e6dedf44d9a0f1a8d379b8f07add326581b06223b335935f81f7c9a442bac2b0";
+      sha256 = "ed3d93ce4836566d22a68d38046717d3464e61feed8c7b11727ed458e32618bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ko/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ko/firefox-100.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "022550ce534cdf4ba489bbcd553052c535fb0ee908155b728718619f33f95630";
+      sha256 = "125aa76b23fafe9fe5517a6b22d324f15b2a1a841b27f3b8682ba36638a0c8bf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/lij/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/lij/firefox-100.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "f2e075a6ef35fd8c802cd929f9c81043d9221f947269ca13be695b58edd603b8";
+      sha256 = "6ec7112a6c3196941661d8a2788301b4bb52fdcaf36f4f76f801357e4a9b5bdd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/lt/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/lt/firefox-100.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "4ac54a885a81db97df5940cac5429c59442de591fba560c9608cc0f9ba1df74d";
+      sha256 = "483661514a9186e2775f241a61e3880689ff71e40a3e4ad67987635d12eb1351";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/lv/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/lv/firefox-100.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "413dee96d7535b5a276a34871db10b37ae9b6ed233df8a81db0d9080b1cc2ae9";
+      sha256 = "501ecf97aefc8280ace103cbe11fd3c629f7212244e31cb83168073d3e6226dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/mk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/mk/firefox-100.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "9fa2653fb6cbd77e874b1306c9c070097c4728deec0972edf9b7b03aa79a2b9d";
+      sha256 = "21059932cc2903fd4d7c2840db186d359c8f061f70da43760e8bc98301a89c5d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/mr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/mr/firefox-100.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e26dc9319727f9f7c0fb98efae44d89228499b52edda8f02328586bfae4c79a5";
+      sha256 = "0d6103bb16917f2705406460d5cb87dbadb0d401f5c18cd5e2f20871c7996ea5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ms/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ms/firefox-100.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0001655c4a42a6c113f428315200b5cd1eee08cc417fd82464db87c322f5e949";
+      sha256 = "8273516807ea2973cffe6249a9ef07125b9d47400bcba9b129a6916e033e99bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/my/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/my/firefox-100.0b7.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "78fcac093123a0b4b6ebffb1e9f10ee5906d526b96d5be1b249a1e60acc4fcb9";
+      sha256 = "1b0814a8ea7475d56538a63d45ae5007fdec6f0f6b5c8f97e7b9cad890b5b4b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/nb-NO/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/nb-NO/firefox-100.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "6c218dc369434feb3ff30840cd940c19e10d3e900325246445fdb7113c22c284";
+      sha256 = "8babecf3aaa07bfd61ffd8e365bde7adc3191f7fc6eacd7eca3eef87e6ae1398";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ne-NP/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ne-NP/firefox-100.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "9a1a9a2380ebc3da9035066bb212b14b1b8bb6fb80feb6ed220cad1a3969ca6b";
+      sha256 = "a2aa3b90a98991fa34d0c246bce9856d709a505997e9e192744d77620dc9c1b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/nl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/nl/firefox-100.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "6ff75975cb1ba028e78aad213837b17fe0b06e5f522996b3b9cd450beab24b51";
+      sha256 = "47358e610f00142263c05be47614bf2735dc4a1ed402d3b9d40969c7047b6a67";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/nn-NO/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/nn-NO/firefox-100.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "911e765ba62cfc8d69d7e4d68f1a5d44a1b311400731a3593e98ad72516c47dd";
+      sha256 = "7c256f4ac09086ac447aa121827e9b395335a2f076a7796dc036fe409a59448b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/oc/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/oc/firefox-100.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "23341acf2319454172a718a0123fa15bc9367028984449c7a2cdb50644a618b7";
+      sha256 = "25d201fd87e89682f97e7988aa3005f67875b765a2ccd8ecacda36ee7af2cb4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pa-IN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pa-IN/firefox-100.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "bae2060e37bd636ffdab3d3f84b73078c4dc78d7ec7eb7bb9504be4dbc3398bb";
+      sha256 = "3ea7dea71a9e932da701de62b612a950b5c9fa2d90e1dcb980c9f8f07e0f9dd1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pl/firefox-100.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "cc397c80e75d00507fa6e170ec43df337450796c829e44d518523b871e33f585";
+      sha256 = "b823ebb4c8a2cb1025485cd97967ecc32b08f6d40e41ab3480df937ee88ac7ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pt-BR/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pt-BR/firefox-100.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "2bcb44821f106ad7478fe7b61c7952c20be135a2efe1185d91123930729f78a4";
+      sha256 = "08dcf6b0c4f93c7e9fdf644366ae52b05fa895ebbedb5ffac184713482cf42a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/pt-PT/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pt-PT/firefox-100.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "7f4c5713972e5bca35b891bd850fd90fcf60d254ebc15435e5b814a212428b44";
+      sha256 = "8b978b3a0b58c991013c8635353be6e3adc265c5ae8cad3a4a57273e5c2c4fec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/rm/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/rm/firefox-100.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "67316b932226848b73a95687e6d218983d8056a966771c3bf16344f158578a53";
+      sha256 = "564773609e4aeb07e39dedfaff3df7fc600b826b53e32fbef70eb7443c4b84f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ro/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ro/firefox-100.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "7e61a6ce962f1ae0a74ff7a29b6edd7106fe95e4c2df399c22a17f1cf4d0dde9";
+      sha256 = "d3711b0f323291f2582007f4f65f2de729a6ad10b4ee0574e6e14c5f4c70e9fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ru/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ru/firefox-100.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "bcad404db75ebac101f503fb793572ac010219f41c6716d33cec0552821bb281";
+      sha256 = "4240da7fa582c3b191d767f1e8f6f650461b34488239b805c9a77dd5bdb46fad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sco/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sco/firefox-100.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "4b01c6ae78219c122ae455627b24594966be61d335dcca8e8547784e8050051f";
+      sha256 = "c5eb3b80c44ca17831945daf0d1726d801d21240a69567b514483613312289fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/si/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/si/firefox-100.0b7.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "5aed65aa84e19c8a270cbf6ad3284c23c83dbff841b4639a15af6cdd9148560f";
+      sha256 = "5d2ced80b6686bd46f73025579552e43a699f515fa4620b877e0820dd59540e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sk/firefox-100.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "a06083cf85f88232898d99dd0174e7999c3e65bc8f893c144775722975410235";
+      sha256 = "ad7e5648eddb96b26990a360d4540e8258cd4fe951acbe76ddc25b3a1f77a686";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sl/firefox-100.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "fce1013364e0f49f9cf56b4d50be3f17ec92d4dfe77a0ba6672404abbfd954e6";
+      sha256 = "26004863b81e81f5bce8e05ddf6d62e637e6731ff3a4f6c3a13bc4fbe83654ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/son/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/son/firefox-100.0b7.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "be37a85ae43d646b5b0249303c65d6f0e3c7e15b65986da7e221119d3b8537aa";
+      sha256 = "c8adc653c901d76033c13dd12aec4fd3067fc6ca4ae7bbeb94eb8dc9d5fe728a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sq/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sq/firefox-100.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "dbbcd4da798dca36965a408f74deef86001cdefdbeedd93d3d5c8c34cfd5e4e6";
+      sha256 = "a3fcaa3ff65deea47e57f719e718c5b938dc71a5cb9c1ca0732cbd4b0719b5f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sr/firefox-100.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "cb8a4d3af1f8e5af4c6121afaab85eb51239d0a98e9caae0e87df435d9d746ad";
+      sha256 = "646032e2e36631981542aa67c68dd719f0e0a520f2886b3b0c0763165d32f537";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/sv-SE/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sv-SE/firefox-100.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "941b3175289f26cc8102c5c436a477cb04af6a35e15861d2473d55b3dc36a04b";
+      sha256 = "27a70a36c93ea3e2d2f6a9fb3df73332c192933fdbbdf1e0f5948db3be8036d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/szl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/szl/firefox-100.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "48fb048a32877082ff1511484cc1eb7847198da4af366c136bcc260879e30970";
+      sha256 = "eb9bda106e777ce6a005d21f69f25d842a8ae0c13dfa36ba074f53dd481199a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ta/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ta/firefox-100.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "16ad13edf164a8867a56dcd59e4bb8c09d2cb3cabbab8c2d7e0a4ed0c02db587";
+      sha256 = "d33d4f79c43834061bdfe880e708370a8adcc3dbd56b3cc5f8811ba76bc464e1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/te/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/te/firefox-100.0b7.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "9c4e9fb72917b2e7b6abec7872366d687874af3c4e0d2acd862363120e3ceae0";
+      sha256 = "de525627d54158709d71d107ab7f4f037c6077b1a3783fdc46e247168e2af392";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/th/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/th/firefox-100.0b7.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "2a14cee27f951ec1e9e6e342cafee68a18513ed1b4d210e0490862296b12f0a9";
+      sha256 = "53a4f6d8cf6d643aec951211176671a72e35f3c19826d78c549a0763eb48e648";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/tl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/tl/firefox-100.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "dd1bf5dbb47615dc2f3a473ab541686fe53cd7d3ac3e5bedab37ce436db5fe07";
+      sha256 = "0e46be2ac97260c1faddd7947ea786f655ea84842bdf825a8937233927296ff3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/tr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/tr/firefox-100.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "eb9b3f14fa9c2c57784f1e37e198b9eb4bdb8cd3f11ebb52b2a51ba47cc10ccf";
+      sha256 = "99539faff861a1a02c7f73fe8aa06f75b7cefed2d7e484a4062a31414a1f455d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/trs/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/trs/firefox-100.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "d39ad94019221ecb2cc895ca16d71f4d461a52eef741b5728447ab054ffe12aa";
+      sha256 = "1fef6ce89db57b6a3b7f62b285a11382c5a4c40d26ab981ab32e9ea7bb0ecc9c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/uk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/uk/firefox-100.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "9fbc6fa34062cb64fc6c5eb09df6e3736865e09124efd465c6b30c1bc8329494";
+      sha256 = "d0ba5c1709f044b7c34ef96467353298b8fda8c776cd8ce4476f852053b55499";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/ur/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ur/firefox-100.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "ca1ed7e7746e5a2085328158185715b7b850e8129adf77b1d6f4e90580563563";
+      sha256 = "5dab30c9c8358b0ee59bf71dc8f52f6b3bce86e9f29fd4b36237a27eb940359b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/uz/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/uz/firefox-100.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "ad05af6f178de687697e7f98b18a64c2cbcc1bad2b167d5bb35e13ac57d03880";
+      sha256 = "dab6538f27b5ce01a883749716428033dc784c448c2ad0539b5dfbaeb4babe92";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/vi/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/vi/firefox-100.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "22b133203f3bb3c901c225e1275215c0c7e3ab5714e640d218532a9db8c636eb";
+      sha256 = "a6ed442be9bf1a66576ec063c917d2cbc40c21df63fb344d07ea9b7d58953abe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/xh/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/xh/firefox-100.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "570c959de8351eb8ffaae05292be916bd94f34f51a1ffcc84e3176b7f23d230b";
+      sha256 = "a28a22c149f4b11505a21402016554eb5f6fc1f420048ba734bd7442592ebd55";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/zh-CN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/zh-CN/firefox-100.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "f0e4fa1b580f778be335285b1154abdfde0b95c6d2c67f7547ab07bcc7fd5172";
+      sha256 = "5ae34e6fc1fc7f2d97a602bda9796b37fb7d4020d93e10941a510c9cfaaca8ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-x86_64/zh-TW/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/zh-TW/firefox-100.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "cd49d2954a7014a926cc012c1e439926af1f58c5e11234e2f9d2489c417388f7";
+      sha256 = "aab07c9634ca85518f0bab1db8a29fe13f909567345ae312813a513e33511a43";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ach/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ach/firefox-100.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "a3b67450658e8c34ce17f5f3b63afc4116cccdd2d786c72958afdb468c0c7eab";
+      sha256 = "e2f1132454d71e4d0dfa19c556deeda3aa6e2363ffd8dc15ec9b755717e6d582";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/af/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/af/firefox-100.0b7.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c7a9ca1c35ed17fe138df0608d02b345c6e358612a03f3408bd46a792f3bed2b";
+      sha256 = "0a871d4a04ffafbb7d67653e31980ab24f8b43919ccb7b6f0d1441f4147b54c7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/an/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/an/firefox-100.0b7.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "242731960f5b500d25f9b328731437a4229aa4d668fc849d2111506dc4741b97";
+      sha256 = "fc0277838485dcccae156d1301fced7c276281d90f405dd3ddc1470a63727690";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ar/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ar/firefox-100.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "4adf2045f911f74323a9e65b4fd2cf249a5369ad5143daa36eb0b1999b5adacc";
+      sha256 = "b748c3d5baf24f4d819cbf477cd616f3aaf924a1130966e84dbfb99fbfa6b9b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ast/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ast/firefox-100.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "d0827bf52bf91304a0a17c9f5edbc6081be1f1d9eaeba6dc24b63e8b251dbe11";
+      sha256 = "39496e3d198f70b7a20a6c79b23c6f8a1d63c762bffef7e93719d8d4cfca33c3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/az/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/az/firefox-100.0b7.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "41de2d574563135721d0a975d8d90f4eccac60f3be51d4cca5e957473793629d";
+      sha256 = "5d16783595c82248729309ad1cd21cd11e36b7556e8bbd134add392acb177466";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/be/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/be/firefox-100.0b7.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "736900d6a404a97e13cfeeef68681ec7980266ba983f62c0779fd6a8b502e22b";
+      sha256 = "269e9e24a50d62c21941883fb3a5db290b12aebadddbdb9b6e23ab130e64831b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/bg/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/bg/firefox-100.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "77351b45bc0bd3749c54ea1efb1ebb2ba1ced97f9885906a9b86523e85eb011d";
+      sha256 = "6e33402ee18479afb715abeea84087a03ef9d4f26a8e1bb74a96c30efaa48b00";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/bn/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/bn/firefox-100.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "5d9b274d20b5137e531660f92a7ac3b481abd756870af815159ac30e7df47e8d";
+      sha256 = "fb4fd96e59e3d37b0bb2933c95876d1b6ac8b43ed421e38ddc85a1279298afe5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/br/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/br/firefox-100.0b7.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "22239f50b370747d3029e7f4ab8ac47de15cd5aa8b6d421193299fed9f9b556e";
+      sha256 = "21c91db183e5f056a814289cb5cc62118b7a56f4fec13b4d873a5d42bff09d06";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/bs/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/bs/firefox-100.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "5e2d51cf768f00ab8a30f8d54e2bb88eed75baf20c381e87b7186f5927447137";
+      sha256 = "295b9e4a89db50d6895dd47c28bf3471a8302d854d46a8adfea394bfbac9200b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ca-valencia/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ca-valencia/firefox-100.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "cdbee7378c4584d51a7142c695401ebe21a05c87961171fae2fc71e76485e92e";
+      sha256 = "f3ee2dd40c44b98f5184bdbe61ad724b6800e5c0f7548120f1a54d23adbed0d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ca/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ca/firefox-100.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "1f8f6e0a3917828f7e30deff842c6d5f0c5a2389c87969783d46950c6b072722";
+      sha256 = "9d076f83f3108befe98c3139ba5a9db594ae71f8d0c48cc1071f065b4bf24743";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/cak/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/cak/firefox-100.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "42996e08427b937cb2e2aa4d7ea569b729c9002d293be5288e02ab1588e3cbfc";
+      sha256 = "580a9ff85dbb5fc7b7907376d3956088a954c4c8bc3ca7584cd4a79d0741ebf7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/cs/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/cs/firefox-100.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "692d99947185928b46142ae910c76d4c1ee2328aa2e67212919aef39741d67db";
+      sha256 = "91e149a74e5cf6ad29f041da22f26b13150aff31d88ec97cca857a880158cba0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/cy/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/cy/firefox-100.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "b2f7ee9c016bc107e63dee850688b048c43f5d1caca1aa81d22cde4ffbe6c964";
+      sha256 = "149b5ef740485be2dc136b4a90a5b7dd220fd4c4adf91804ff44dd4363890325";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/da/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/da/firefox-100.0b7.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "095ae3d0657a68903c4d60a21240b9c3fc399284063e5c366ccedcf58361c80b";
+      sha256 = "a698f6ef0f568d2aaeac9a6bd83c91715d86e0538495bc19cc72babf6ef96123";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/de/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/de/firefox-100.0b7.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "359364e7ee5ed03556c7b7390cdb4b1e91e027598a74231cfc20fd5d5c601b1d";
+      sha256 = "c2e061d645bd1014f4e7f6f78d7a966abcf81ef88d1c9cadac513c65fba5c1ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/dsb/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/dsb/firefox-100.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "24f7caf5bbc8edefa104c6b4a646a1afa254da9bb8a1965193b7e4a97ef848ae";
+      sha256 = "47dfee2a58997c6c9f1f858e1ceaefaab326a9163a7d2eebfd1c58cf9638ae03";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/el/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/el/firefox-100.0b7.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "97bfe8f01d8f6024b85a6f25ee084642dc2e2c50dc189d1b6bccfa7835120bad";
+      sha256 = "36ad5003b537c25002f36cc812b75649c45a65e3d1cc25a8fdd9fa7ad7285ccc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/en-CA/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/en-CA/firefox-100.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "fa534341dcfeeb5778d19d5c38fdd8a56e92e756212d256c2fd40c499435e6cc";
+      sha256 = "6e0e5126871c10b7a11172cd885de1fc73222b9f7bb40edc2998655f08bf6355";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/en-GB/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/en-GB/firefox-100.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "a38f383c06a2cce4ddc49fd304b1b5742dcbc2cdd189dd5b6e91b1494231504a";
+      sha256 = "248589234f8cfa9a240e9bb1fb0021c16aba61cdb15aedebac8e944eb0e1dba8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/en-US/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/en-US/firefox-100.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "c5ad47cc4f5829eb3d01c7031833e3f8aa24d07947415947d5e86e492be37c20";
+      sha256 = "0f885cb5e18ed86f35d75835db7deaaceec3afb0e1d5ec8013923d5d2a9c4b71";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/eo/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/eo/firefox-100.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "d96ddc5a07581ac62078cac8d702425d6764cbffd93ea1a35ddcbfa5258e01ca";
+      sha256 = "0a1f3429e068c8a46cec4a0d9a33c3d08f08120e14ba69a23c3f8498866c7040";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-AR/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-AR/firefox-100.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e5c069a162cd02c3449b6b6c800c491f80270cbd9e29bb418351b40ca318d08e";
+      sha256 = "97915c9b25807fb84b2f1221e7de4442065b85a51d1301a5716d562e5921cf63";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-CL/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-CL/firefox-100.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "e45ea8d1bfc96f500e1061eed4694f2c7c81fb5b5ea76411cb7bdf7df8e74b1b";
+      sha256 = "32648414c5a60d737eda07000e5a257c2a47b17e8b16130ccc2dbce332a7e18a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-ES/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-ES/firefox-100.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "a86e913fce09abd34f69f72f338e5d276360b39584266fcb160aa4cb5ef15e10";
+      sha256 = "1961fbcb8c930a1e59a0b03986421a95ac934f6c6989a6b11fdfb566ddb86274";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/es-MX/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-MX/firefox-100.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "d39ac7c519aa5ab3c2b02da50f882480d657672573ac13b76ffa1620a7c31dea";
+      sha256 = "5f35681b153efb60f95c41ed228c51a562d5e97191a1169cdf80a62d33402bfb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/et/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/et/firefox-100.0b7.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "2d83aecece8c35f11bd3190da1d91100779c4516292fb683792c09a9df63297b";
+      sha256 = "8eedeea42887dd22839a84452057274c78fd248d0af17c95d5d3764d805edac8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/eu/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/eu/firefox-100.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "acb38b6a8d2111511d31cb967da094d68eb4bc5e1fb4af613392cdb931a81b69";
+      sha256 = "be1fd6bdf9b56dded4fe896b1de6803a08b2224e53348a8697cdbede06dacd4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fa/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fa/firefox-100.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "4c509afe344db0cf9eff8f3bafabdc80b25f78537dfcc931d05a326d97b3793b";
+      sha256 = "db40fd0a7487730eaa163d1886e3c24a5f9a3e41df2b11abf0d6e76b557cee88";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ff/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ff/firefox-100.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "23c02e6d2f18351c72917c02f6795b1183482e35c6fa5990ecab8e724959c4ce";
+      sha256 = "8125cfc50d585e0ea94369c99fc15a6fa4a7acd2f186e085034b76f8d026d9ff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fi/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fi/firefox-100.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "30f696e3e0b419017fed38ab434a99ffb303eaa4d9d96bd2525ad84cebb20d51";
+      sha256 = "dc7a4da2faa9670e752f2655ec487fa8b54e88a98e00c850bced3b78c8d76ec4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fr/firefox-100.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "40d631f78caf08e8a04a4dc1286cd749d66130a9b3f887f8a74d1f15ed7247a3";
+      sha256 = "4c853431a4c212a6074de606d8f179024d1621e8da3a937bff5bc6508cbe4562";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/fy-NL/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fy-NL/firefox-100.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "62563d3d7c5755f1163d956f1bf82cb81c48b5349db293e66185c95b8e65caa6";
+      sha256 = "bd1612eb9dab3e3e1e68f033b9319a83701e3361039a44f35f2d53fea6d88784";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ga-IE/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ga-IE/firefox-100.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "72914c49d6b5384987942a6c8127891c7eaa088d08bf9192ce448b11342f512e";
+      sha256 = "4d8e15ca851e8447fd2dfe5874d6bac21f7735612f84afdc23138d73d5b366f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gd/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gd/firefox-100.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "1a127b1a4a8407476f1ed73ebd982fc5d0262e2fc413748b4228d9bc9d28a59e";
+      sha256 = "7a02b828a508bcc61fa90b4d33507f099b6e712c7e76e6663d4c1e2443439375";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gl/firefox-100.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "1a84a2d00d065f69492a73e6917e07de8824b185139e3acb75b0f0dd5f82d604";
+      sha256 = "af8f8249705a3fcdd4845daf6f4c803d90b1995989cfd8b6f353a2d8e0f9e9de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gn/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gn/firefox-100.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "6ddf864b2b2258d0ced011ac2d0ed13455e99d3c093642a477f95ca13a3349cc";
+      sha256 = "61ae6d25194519a2140ba8bb25bc2a7c3dca836e77e7f4301265a3896d1eab10";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/gu-IN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gu-IN/firefox-100.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "86688035900e5bf2dabfb7e8c7320dc4ccf33b46d8c9e963216a750ba2e2b300";
+      sha256 = "0536657ee7414ee88cfcf31cdc5df21ebb2a41261dd4d7ff6161b3930a7c00b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/he/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/he/firefox-100.0b7.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d35c7ac5d61d9253ab69da2a77bbaef7037e7cfa2339d4730201fe41776adc90";
+      sha256 = "b6effb5e62c1bc6309e761b66f09d904f2302788bb126b03a91ade2daeada373";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hi-IN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hi-IN/firefox-100.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "48872f0b68ccf4df855e58a4520f5f8347b05de318a0991d83088521b4d178e6";
+      sha256 = "006c2e83a9db48f6df4623aa5a6b3cc0821f593e2c5e9362e663604e599ef4c1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hr/firefox-100.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "9c1c1303aadb4071a82b558fd470c96671872cd480e444686ec74f41afd46e2f";
+      sha256 = "4570367de940689ee32b3bf5440306476c560b9f504681f576ba8d3211a2425c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hsb/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hsb/firefox-100.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "828330501590e2ad3021397cb7b37a86c015b93536e4e2383fc5c5a1e8d6a6f1";
+      sha256 = "370653444070c812ed6b42e95030347b75fdc5b35858490399fbe5b8987144fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hu/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hu/firefox-100.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "592c69c6377657bccbf2b81ae54bc8f37fa6d081dc36d0465c20eaf6d673f32f";
+      sha256 = "cfa67c91337924528a34931702077141961ce73e28ab5cb656698710f6346a9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/hy-AM/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hy-AM/firefox-100.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "a95989dbd6b7b499840f5cc65a765129ca23392455afd21c0ff865112900b5b6";
+      sha256 = "6f6d0c09ee43e1dc111a7113ed3e8d97c185282f39e4144d2a0d6cf84dc539af";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ia/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ia/firefox-100.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "a9b225d969b0d8c621a2b545cbb42ce7188d78c09c248422d6379d83934201b6";
+      sha256 = "3032771db5898b2a479a05d0b9a3b45c28d1e6a4347bb70599fad6d8ddd5a469";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/id/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/id/firefox-100.0b7.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "304f4d04d3e73a477598a034d3fd016948c5e1662bc236d640219b4b96159690";
+      sha256 = "0917f87dcbe0eada2e67a25acbaae854559526fb1e0f02f04ecdfbc0b7de250a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/is/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/is/firefox-100.0b7.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "3cd144b87e3ef57703ce60c57a09ea8c6ab910408a7c891f9b9b653dca51c55c";
+      sha256 = "24add589785677ac265cfa8634ea299c9f6940b04884be27a9a79e57c4f0fb40";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/it/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/it/firefox-100.0b7.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "b024d3b0fe4ac5691c6cf1e0c18ce2bff91083746bb988799f2eb3ab74e22e80";
+      sha256 = "ca498fc4b33b6cb61ebfb6bce70f514ca6955709b50d086be8bd9bd7a94d1abc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ja/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ja/firefox-100.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "fe3d9b0c7d0e8f47e9f1bc12429200aeb951b303946365bb32f51c9d807259cf";
+      sha256 = "724f02327973299231772e570e5faeb5de01a648e53157e41d74e8a416efe10e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ka/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ka/firefox-100.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2e4d0f5f2eab6787db359c47a48b35a202b713de0807299a41a751b527a9ccf3";
+      sha256 = "dc3e0fa8931a803e20a1ad277a55e598472649a88f10ac90e28571e226d69ad0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/kab/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/kab/firefox-100.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "49166beef9b6952940d1ce420afd77777fbe84143b65693f9b75db6768b88e01";
+      sha256 = "044bca177a01b9f16c1ca0702c50c5d84f765281c817d0536b82c43fc03d5255";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/kk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/kk/firefox-100.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "24aec891a8189714c9299c695346a3d0a4ea52621f08b890d5db63ba36bc627d";
+      sha256 = "596b5be0ceb592fd855a0b76ab8e4860c2062da66ae5ddef08c9cd4d29f7e7f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/km/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/km/firefox-100.0b7.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "90f5b7811a2f0bdfefd14261d1e0e7fe85466dc96c666316134c97095606c6ce";
+      sha256 = "c73bbeffdb3bad4404b3c27b8d9b3193bd07a0c95468961bf620a3e41e63ef89";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/kn/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/kn/firefox-100.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "e423d1231edbef812e8cbd50f53dba4b48dc9083cbd5d91825392229015c38c8";
+      sha256 = "603406f262ee396460687d5d99270b8c72c43bab8d9dd8b4e1904c4b11e9762e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ko/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ko/firefox-100.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "cadd481242635d64b224e080adc1bdcfff9f7ced4715b0ea9655ab333ac7d039";
+      sha256 = "3977dcbde872183c2c34dd74c8a7c6c70f05a581e07528b3cc2c6a86e97bc036";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/lij/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/lij/firefox-100.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "4798691d44767027a39c1124053b2351523e615a06b32bd2bf4f9da7b858159a";
+      sha256 = "4e699a00f53f91c494f67229583aa1d4d804589665de8f0509936e74c077af4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/lt/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/lt/firefox-100.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "ac49b6d34eb8caac4a6900246adb3562eb2228a50fcdc543f79903ea267b339e";
+      sha256 = "9359df2e784ba5141288d954093cc649d98174c0cdea531a6c46e284ef8aa45c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/lv/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/lv/firefox-100.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "4f6e6a26a2b8a23855dbdeabd2363ee0155914542e4c48c655d6b52da6289b34";
+      sha256 = "59453ef729d13434fa654381746892b33c61980a8645f1c575f1d2381c95a02f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/mk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/mk/firefox-100.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "522590d926022cbe833ce0050e5d23db47bab2c8de1e1e0ae3e96941b53dfb6c";
+      sha256 = "af21c80a6f60b987cf89d433895c1f304b0ae4f9385e6550b134482d06e7db65";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/mr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/mr/firefox-100.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "4df57dacc8b71070aa077281beffc04bfc632666b2b26caedc1fda4e484e59d9";
+      sha256 = "9b3609ac04e996b33a73ab8deb694cd15b20116b974b12d9b1069dbddd67283d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ms/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ms/firefox-100.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "005506663901ad539817197972864f67812a9f5e3f1055e7418ab4bb052ecdad";
+      sha256 = "71d49a2c4654d59c4e17c2b360f0efe454843e73c051a607eb9c129a17471906";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/my/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/my/firefox-100.0b7.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "aeb8445d5425640ceb8d2b823a7dd3e79fbd355f07420d015af4559d2bf2cebe";
+      sha256 = "b953c471f3605b5556dd2dd17e25159a7632fc5b791422b2cbdba80c0d06ed86";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/nb-NO/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/nb-NO/firefox-100.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "d41588beac0fc9a3eeab9f2843b8aef53e61a7c15dcdc34eb89e73838d9dab24";
+      sha256 = "8912c1a33108017b642b4114842a65acf5ceac38ffcc2865bf7408cb399a4678";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ne-NP/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ne-NP/firefox-100.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "c3c981a5a701118e70b6b03338451d7d50325234be03838e403e57b822b6fb61";
+      sha256 = "c61087912505bb32b180ec9689107fc111829688d2faacf13fb3814e8bf9b2c3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/nl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/nl/firefox-100.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "ee902a63548299b6ceb9cfa263991233c32b0bf8534dc5256ce84714eab01f12";
+      sha256 = "2d600c4193e811c62108a1190513bd0018a7455c98e149df341127a2bdbb7e65";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/nn-NO/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/nn-NO/firefox-100.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e3fcf444660a2e8b3abe10d9d3a512985e9791fb7916ffafac564d9849816241";
+      sha256 = "09a5f6d038ddee88bb1bb1e6967c73acbb2943fcf73cee9955d7df35b09d9e3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/oc/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/oc/firefox-100.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "0b80101b082209ead23287d0d7efa136eea099b9895b9a4a8906abafb8a7dbcd";
+      sha256 = "d7846a38fc71a95bb78ac3259b6ec6f31bb4eca94d1183211b0a8723db5ca4fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pa-IN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pa-IN/firefox-100.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "14f8fe19c6cea1d38eba2f4aff8a8787875632e7ef867b44a48bcda59ad0c32f";
+      sha256 = "265180f0ff89839e362934a764f611085a7e93b8ae1bae7e0f7eb99d31b3b282";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pl/firefox-100.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "796b575f4ada12cd1aa0fdeae8b5c198eb2e6a327bd0cede066b1beff4961d96";
+      sha256 = "153260d85868f3779ee1ac9ac4ebfacdeb5ec76964505e925c68abd117cd6f4f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pt-BR/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pt-BR/firefox-100.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "a1a83e3e317bc7465922b40327031fd48610627c0e1554569710a7b40fedd98c";
+      sha256 = "a4e34175bc0aa9c9d12d9829594713644d4145cf40657143651f32a309f4bbf5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/pt-PT/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pt-PT/firefox-100.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "0ff375602235a96b6197366ae22f4c05cbb3c9068d48cdb08a035e3af084d3f3";
+      sha256 = "da4252acd1c15770065d9598436881693f3ef739a502901d4bb36844607d885e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/rm/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/rm/firefox-100.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "5599c540c50162d1a79ea16196bb15fda9fed825508b60b4961d91255709593d";
+      sha256 = "6589408d18e6f023801f3784cacb1b62d46b2285078304d563726f87c79e5870";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ro/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ro/firefox-100.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "771be3da68642a15baa1e054bf23e9df272d0b0ab46f1e42c6fdf35e85035b9f";
+      sha256 = "bbabd43860e5f6bbff0fa9a3e3c0ffc80d6ac73a32af8ddf94b971d861c41b61";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ru/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ru/firefox-100.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "bcca4b9aace48ed4da4c881ed47b0bbc3d20fddd07273ecf1c84758633f350b4";
+      sha256 = "7c8455135e769fb8463819c2654a10319ec107a4b41c803a8f246c1c1ecd8903";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sco/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sco/firefox-100.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "1ca439331c6437dee10d1f2cd72907499894bd98af036dbedc964248217ff510";
+      sha256 = "cc783e50c8280bd41d677b9bd9d8f64038c34ecf7ae8e0cfef102da3b64ee06f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/si/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/si/firefox-100.0b7.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "b643cfd20a0bc56b1989dc1c4dc96535d6585a53bb5d13c85ca53bb1027e1732";
+      sha256 = "157aa7231eba1ec554858a496416de257def2c1269697ae369b8c7c02b402b10";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sk/firefox-100.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5aa1dc132c3d2a42b6086cf824c8b6ae7a30d8b55341a05acfc3eaaa8dd4cad0";
+      sha256 = "fcd1e50fb12d74ed82eb708bc6d885de8c1fa6092cf53438801bdcd33e181aef";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sl/firefox-100.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "92b2a15a04c4cee559e0a6565509a546ac7a2c4e3fadbba0c6197356e99f71f9";
+      sha256 = "9dc1e653e20cf71d8b193b56799f278bff95c92de3d088912668f2b7332665e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/son/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/son/firefox-100.0b7.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "8a25e8af341178bbbcc0731788b1116ab64fbb55480836b94ad6e7830b6b5f16";
+      sha256 = "10b26692f26c8fbe1b6557df01fe6153b0fefbc1ed30cba4e85857338f8ffce6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sq/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sq/firefox-100.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "66b7ea3b488b980c425576fdad6009d2c246bdb4686b24b519604a54dba6f756";
+      sha256 = "ea1e6e22af939509d475b3011582fd56f5db36dc17285f3ad82eb4788dc591ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sr/firefox-100.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "1aecc3a24dab4a843a967b8c023bbe01488dc113e451cfd7d39e7c2caac1c153";
+      sha256 = "6f8ad70d943d4c7e628f8cd54fddf28f686e9b679ca457cf80b2a16d71a72a49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/sv-SE/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sv-SE/firefox-100.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "d5189ed627ac49286cec9733c8658c271ee99930f2d07754993e776a58eacfa0";
+      sha256 = "0ca7017fab9c40b1eeacb41b16df2ddaf06505f4a0761e52d7e38612c002d5ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/szl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/szl/firefox-100.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "45c48d7381499d5aeca0fe340ecc8af33016821fa8f081f6c52c878a9af3640f";
+      sha256 = "0fb3240d285fab151c4f337ed5356a3658cd00c513100173945289a44026bd9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ta/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ta/firefox-100.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "1a8a9fe5eb0e9e8d213d667cc1aa478f9f381d5a444f8d2be518fb04926e4f64";
+      sha256 = "44c34317983ef10d101ed8915f163498189f3dcaa4ff135595c9b0358a544db6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/te/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/te/firefox-100.0b7.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "1f3aa559af38662aea444f52974c2843ffede5505e71e83d73e331d2c4b92275";
+      sha256 = "ec9f6ade838760457bb04943fc621d17000c6d181862aaaea9a75c3165d38943";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/th/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/th/firefox-100.0b7.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "05bbf88a5b9e914d86244555d06d560b328e8e873e380e67d40edb6d3971d383";
+      sha256 = "bc75568cea6301a007311fb17578bdc4c0aee3d261cfa02fe9daa957ce878056";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/tl/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/tl/firefox-100.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "8cd7f71325ce2a54403032bc80fe366acfd7a8ce3e3871ae1a8f4e0b5315ddf9";
+      sha256 = "912f73b037376c3b73d2928b54a58d925eeb173bfc984fb76da6bc3449335ebf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/tr/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/tr/firefox-100.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "41275c3dcfc9624390a2d3ce9d0aa0e746c4e3122f433924227299d46ff8ab42";
+      sha256 = "30644d7135590255bba66600ccaed0a7ec13f236f21e9ff9f95b8e0f4b87107e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/trs/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/trs/firefox-100.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "c04aafe011c8626d749990e0ba293a22c8a623c6eab9bc4bff2782708832a648";
+      sha256 = "f48442eb911018feb1ce1cab93137e5d09bde2b63be84b1eb44a5e4282bfec25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/uk/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/uk/firefox-100.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "965f445606d8c81d1745a7028ffd15af7cb9bf2473bfba5e673e3621afeaa6e2";
+      sha256 = "2a1cac9d9d36bae12ff645208e867694327474bed416b91f2e06b24ba7146ac3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/ur/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ur/firefox-100.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "8955e64902aca993d110401fe36b56c84b53a414b2da569525653ee28801d9ca";
+      sha256 = "6ea818062e9e0ae9da8d97db066194e20be9bebeae0a172596890730284d392f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/uz/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/uz/firefox-100.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "e05ef7856c3c4777da187ed7212ebab01900881702d1fa8e221a86c57c6ef4f9";
+      sha256 = "559cdbd37fc19f9fc933a13fc50f4d4be98cb3901a6ad9012c6fc274bdc1af4d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/vi/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/vi/firefox-100.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "baca088760ee065eb8ad86d93c6b0325d23f88d18359693ba9c2a3971e9e5061";
+      sha256 = "b0035df920eddd52ad0aae4633554f2bfda685a10b27ebdb75382fa5ae07f503";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/xh/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/xh/firefox-100.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "c679216fca120982454a15087890fda40d21bb269a940d96dbe37428672db65f";
+      sha256 = "ed27fc27c0d81c5952bd37384bdc4f12de51ee457c8c7bc48bfd2a76551f7991";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/zh-CN/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/zh-CN/firefox-100.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "ba77a6dc02a406174a79a99b510c2cf7f8be6f877acc57822ee174cc5a99931d";
+      sha256 = "753d46b0152d9ad4a85079510abfc03d57469951ca5818af912d2e097c348002";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b6/linux-i686/zh-TW/firefox-100.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/zh-TW/firefox-100.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "108fbd9c48b974cfd533c514d8459990b5d278ac5381ba5cfb8fad8d885dcfac";
+      sha256 = "7a75012a7c1c190524db37f7b8df6965e048256025879a1127f17722e325c270";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "99.0b6";
+  version = "100.0b5";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ach/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ach/firefox-100.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "0bb4605a97661502cb23fe2ebfdb1a31831f8ca015349b3105d1245fcaa5eb69";
+      sha256 = "fb1b570f098ca5d80f41f14ada1f7ad6dc43e5e1c6984e1fca29cfd275dabded";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/af/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/af/firefox-100.0b5.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "564fd8895c6fa6aecebd5a7250bd73df45a6e51f90845d9597e59cd9175b6c2c";
+      sha256 = "31322e6c45045322977b5d240350e0e4740f9c48174b719553410fea3212f475";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/an/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/an/firefox-100.0b5.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "76035e42b93995e6cda0de737981760a0025013bc3330142b95ba7329d54153b";
+      sha256 = "137eb68b647af950362682646f7edf754bfb51a03b20f59b777f877b3ef003c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ar/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ar/firefox-100.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "31abbbdf4378559e6b612fd3b0167bbaad332edc47d6ff67e8d9aa7e01130808";
+      sha256 = "22d24c6bad9ce2ded7634449fbc5d0bcdd4972aac15f60e04cf963ab0ee252bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ast/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ast/firefox-100.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "1c4a2c370c3f566823c722082a3a9f149050cb7a891f3a1f21b7ca8ec899ca92";
+      sha256 = "e8a2e7ea146efe41105d84a667568662d029a9773855ae31768ba9c14abbdde7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/az/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/az/firefox-100.0b5.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "b1d0effa84614c985001705630da49b70f09e91be3715795fc18d926303b6b95";
+      sha256 = "34d76711bdc45cc45650cb4c94e553f67579be3f406c391c9878cb6de1c39bb5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/be/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/be/firefox-100.0b5.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d0ace001eff838f8dcb80090a193307e143a5c1f3b1dac143ded5af3fecbdfda";
+      sha256 = "fdd4d1cea3b71f54b58230a30c744d2ff7b0237869fd14e617ba3322c2d59f6f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bg/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bg/firefox-100.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "784d6029972a843829783581796263899371c777cf669f0e4f6978f35a8d6199";
+      sha256 = "e63e65a92f73a31d2adac6a0c1b6dc45f38425ed8596039332108565de43daa6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bn/firefox-100.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "7cdc3a6f35c2a56b87a58eaf3112148c51b2d2d0fe5d9afc5deccfb2d2269b2e";
+      sha256 = "29fbffaeb7bd8750cf1fb543692855d427200d7df6e9ca92224bd96103b06b35";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/br/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/br/firefox-100.0b5.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "abbe12c9d887ea98d85479105bf2640bdbe3d295def41b626d3d8feef3627b36";
+      sha256 = "3c1bc8cace7f4d2c7522fc9dd994c42707ca4d54b74ead88726c8e83862c3757";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/bs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/bs/firefox-100.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "fc1076c2eda5623869a3af5c850fb51cf8611501f51984c85f690b4c545cc93b";
+      sha256 = "3e6c94efea22c4bd2620225e8a339689e3e4f642d474f4580092a85d7c4a4950";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ca-valencia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ca-valencia/firefox-100.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d328055c61c96c92dd05989c23a3f8f49b36cb755f72118c21331f986ba3b44d";
+      sha256 = "485b33fe034acd03412b3407338cd246077209fc1ccd566f2ac9d347c8da6308";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ca/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ca/firefox-100.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6a020e56c5f4136deff38f07d94b516971af1a31a804384a50396dbf6241877e";
+      sha256 = "a0b2780c0a634c85a9dbdc00b6952c81b503c3173d2c2cb9df5d9c5958ab640c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cak/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cak/firefox-100.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "c6298bdeba82a637bb3903aaf73b9de9f0a3ce4ec22637b1ee1340273b7e36af";
+      sha256 = "360abc1da779874423792e63b545343aaeb3984201193c687c3c8b67b67cecb1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cs/firefox-100.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "1facd79fe087052af58205d2a0a9acce68a1d9bc58d1a3bd3e49b740f6e51647";
+      sha256 = "1dc722b7931908a38f43254aa1c1c78fb77ee30868c15455c0448927e658613d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/cy/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/cy/firefox-100.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e7305badc55114c4a39edc317202338b3e61feba9844fc2cd8edc1518486736a";
+      sha256 = "55eba066d11752cbf973312d55568e51b720f21e66bf590adadbe93be386e989";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/da/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/da/firefox-100.0b5.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "6b1d2403e1e74c97c763476a128c56079d546967c87f1b225ac790d9acb6940d";
+      sha256 = "cc3fa0c0ef8a1af9f8bb78e7196c5cc7a6c6df2d9f25c5fe8d79f47879354331";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/de/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/de/firefox-100.0b5.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c8d01b9a1bbcdeb1fa0fa63ff553209d095280ebad4eb03efa47e029505b8204";
+      sha256 = "b745aa34eca890302b701be19bdd3affcba37e7b1af388e4844ce61c3a1244fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/dsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/dsb/firefox-100.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "bea09c23f3099c85e415bb05916ab9e3374f78e897e2b8549fb9f67895b7c052";
+      sha256 = "e7a4c1390919cfd01fe13f5a81ce35fbdf0868c725783d603c7d2e210e3ba368";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/el/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/el/firefox-100.0b5.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "bd740ab9aaad78e4b16e42d610ea1b914db95e2f8396f0e9c4803e38c9810f20";
+      sha256 = "6f0b80919e22ec67f80c7c034fdd9e290cf2ec442ae828a706e780df2ec54d90";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-CA/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-CA/firefox-100.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "acf5c9da684d5f7bb5b25e5fbd62d5dfafb1a5f33bd6c7baa385a37967e516a1";
+      sha256 = "0184e33ff9582a77a5f9d61f1904f3cd097feda7576aaa276480eff92dfcb4de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-GB/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-GB/firefox-100.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "76cfab3fb29274bcec47ce72e88f783668653d3f8ea4ad00637bdd7ad5d32364";
+      sha256 = "b5affd31a9004c9161d6a55cb713999932b18f1340ce67d0e7f77b0c805ca785";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/en-US/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/en-US/firefox-100.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "798f68125a37ac1e60d72dff3a773cd167075a58d523d7d9659cd5fb511e2dcb";
+      sha256 = "635c5b79c514b9b7717c903cdabc2f6bf3f19cb9689354dc33f21cc8eed3d540";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/eo/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/eo/firefox-100.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0b65dc59679b42a298484d3901f3f47d6073f08e260a792a6e80d9c5a0e6ad0b";
+      sha256 = "9e4a718c0932688ece8883fd2fa2d175c3483d73ac16075d8efa0e6758f4cf61";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-AR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-AR/firefox-100.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3a894741998ee1a2adb6def1c8d548b2c5fcab8fbea655a013dbeef9a29ab228";
+      sha256 = "3bc0ce89dc3ab79108bf527fccc9aa9663f61e6578b2561fc7e1950dcaaed1db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-CL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-CL/firefox-100.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "1964534e196d426a9d6dbe664dc16790f010214cfba85e98f5df728e110e0a74";
+      sha256 = "966db10e384f875272ffcdb743c472a78a75a95e0990a32fb16fe2b8d5a70761";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-ES/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-ES/firefox-100.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "32b21ccb56fbe2e46aba0e21c417e2a7d3404a0a3487186c75d042fd84c5033a";
+      sha256 = "8b23f6957fb0825b973c4ab59c80ffdfeb8370a72a291ebec6ae7abff1ca3392";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/es-MX/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/es-MX/firefox-100.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "d70ff15a4cced1028433e603151af021be98d1026322203f0412605685611e5d";
+      sha256 = "75102ce28fbb425fb0c13dccfdbc5095c1c92c4dd83e14140bd672fe60547603";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/et/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/et/firefox-100.0b5.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "df844133edc74d396a2fe66b0a71efda2c4797ca7110a12c4c7e620cbacbfe8d";
+      sha256 = "ab7d6e1294e49e83307bac9541b15163263bc15693fd0845c335e523e5420623";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/eu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/eu/firefox-100.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "1ca8ba1a7ba29a0c21d7bdf5cbb046fa0e145a9bdad5debd93d121b512a060a4";
+      sha256 = "6defedc5c4faacc9765a1d26352d9d8f30f895a6ec5bad1c3ed7c3d98ec42e16";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fa/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fa/firefox-100.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "a4c223f683bf75c96650d939c56aa17bfeca975ba8863e44dd5ce0449b436b3e";
+      sha256 = "0fe1b25b3b970e04980ca729a6630648b0923b98fd00bc81a4553235d741a6c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ff/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ff/firefox-100.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "6b165789213fc3f9c3f46457a04974e3c718b2c0aebd44c57c7bf8f41c73687b";
+      sha256 = "e8ad5c7403928bfa5e34c6bbb8958730dba8dcc6d799c9a7676d82440b8f1ab8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fi/firefox-100.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "eea67a8d94f324a9ab74caae5a7755f9505781ff690760a06a62ad034ba76bd5";
+      sha256 = "37e8619971dffc7c6caa43cf72f5870c5d5d1ed489bf8a3596215f285f17fa1a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fr/firefox-100.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "d4cc1a70f8d020870ccac0b023574b9c0f39fd44bbbcfd8a35f6c688183f2a9a";
+      sha256 = "90c21cec994d7fa1c4ffa6512c448a4948be5eb5d318a0f6c4ae6d6b6f801780";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/fy-NL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/fy-NL/firefox-100.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "df49ee1a9db407819fcc7baa9c6bc9c6fc9ab2c2b57b08d85c9478f1b0aaf6c0";
+      sha256 = "c12a1b475b4d611d4083bb11d7384573817aef22796e91c7df968b7d6d726133";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ga-IE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ga-IE/firefox-100.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e7e846a95ba695a8a3edf233ad31117f4d35d4942784c5f6c5a1ebed7f2f8e4a";
+      sha256 = "fcdf90dbd66c1c87e7f8b25d820c5c866f0d905bbe424a8b6d8c27e7cbef5677";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gd/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gd/firefox-100.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "48ef5fa12ec7415ad23a5a40f2f882147e03ecc074b33b173f413e53cc0cdde6";
+      sha256 = "bfbeca59a046bffa5156621946c397884998fbd383085fab5159ae775db9cc9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gl/firefox-100.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "b44500b87f3b2219ba10e06bd937ba06784fc00085be12a16f69fe26f7733317";
+      sha256 = "c0f1de5a454ae0f8df7407d08394f73cf8e09f39342288d6670d4c0b8adf2e77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gn/firefox-100.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "0e521a61d44d1058ceb566ae58272e41f0aab7f2267555781bb3235ff5e3a59c";
+      sha256 = "5e177db13df6f5195603d8d2acb92dccdf2989fdb721e6ef6b758120f2efff75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/gu-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/gu-IN/firefox-100.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "2179c82d7763294f5adedb8c905ed5e009a4d3d176fae58c7503404015214c51";
+      sha256 = "748aedc09ffe44b4f8223456afbfb43901b492ff401c6ff39127ff4267ce6123";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/he/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/he/firefox-100.0b5.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "69383070d17f2ae68363e8a29efc53e2748b8f784137c854162ec0132295a9e1";
+      sha256 = "91c1abfed2e942c076c6b0068edd2dca02e496321fbd79fdd39c7c2dbe7c5c2a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hi-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hi-IN/firefox-100.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "71e57a59cfc523d5c1c73c9b5547b3247170865a95022e5bd3098967c3e6002c";
+      sha256 = "4e13080d458b980cac72cdda1f40a786db926b494fc905eab71cf3535f5383ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hr/firefox-100.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "9ea82b192336e83c7ac450dc7068f2730c031f43633a87b7fa554651cf64a912";
+      sha256 = "583c5a5f6aa0e328c57c303ba97d1bdfc0a2a959485560d27aa2e906a0deeb8e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hsb/firefox-100.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e3814f823f3bde2812751e9dd6a2b51a8861952eb04cb845d543a9252501dbba";
+      sha256 = "d8c10888b1e3735fce5d1213322f62732b030919ff4b5df70d12d934d348e91c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hu/firefox-100.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "e647f86de2e7687e23320aa0f36d96743f5da2cf43b2d83444a41506d13face9";
+      sha256 = "4133206571188244ddf17b96d287d5683fbfeffe2cdd5b2c8ee63fb7db56e3c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/hy-AM/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/hy-AM/firefox-100.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "21cc172fad6136a17df0a6ae4c6e90ec72a02db744cfcb5252cedcf48223e543";
+      sha256 = "7326ae0a0d0a0afc40f6aa8b0b1506dbe7ead006c641eed4812e63bbb58bdb82";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ia/firefox-100.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "5f0c85a36ec40ef57cfa2bbbc1a4663ce10c8659e0d6ecad67ea993186c9cbb6";
+      sha256 = "e61cc178ec2a648c0bb229e5145d8755343427388911bc6386fae77a5ecfae5e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/id/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/id/firefox-100.0b5.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "e6671d2ac6b63ea4f2a84d1d0e89038ef1030d85e84d6b47c5b878ddc8d96b60";
+      sha256 = "0ac90236941c9a0a5f17e2e5e96ee14c0ef6d5e5645566bc09cb9023359db882";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/is/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/is/firefox-100.0b5.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5bcafb210fa3aa06d56f17972d94c17faaaa2937948890b993bbc6c9bfbeecad";
+      sha256 = "b1efef91567c6b1d52b5fcccf9fbb3c3f81b05929242ebc68168c4712e47c3b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/it/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/it/firefox-100.0b5.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3c14104a82a312324c1d42644eca6f80b7375f946a42edcb0a23f8a824bd0eb7";
+      sha256 = "33e8282f6b1b3a9e404374f93eb6207c3110177fdc11c831469fa721c6669d93";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ja/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ja/firefox-100.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "00713bc8710add3312294aa755c881701ebbb2d00e1f5f242ca12d102ab6f19b";
+      sha256 = "ad13269606214cc9fa7d05037db3c6ecb192a5bcc06872aa487b023c2823862d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ka/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ka/firefox-100.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "ba6985797ef85bdccb1f81053456baddbe2cfd9e1097e42b20617270f681c1ad";
+      sha256 = "42b97eab01d92ad491e744890fe6984af4f435ce96595c5dd7bed02f6f5ff369";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kab/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kab/firefox-100.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "8be17598d305e257005ba0f9ef2f7053ee7e79bf3c1b4caade77c8e5a7e8a57c";
+      sha256 = "64c9abf3921fcf698ed5cda9724884f2e3c1ad8651cbdf9a9fbebf2d8ca930fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kk/firefox-100.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "7e142151f26355256d2923b183fa1d225e3ed26026cbedf9abcebef301dc1045";
+      sha256 = "9f4546b31322c74e76b13e4557bc412d5d75adddbba16f4e0b0ca8badc81f83f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/km/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/km/firefox-100.0b5.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "0df166d5a55e52ad60f8873afff5c1c43816ef99b56e1d817b4d4c29f173def5";
+      sha256 = "daac53a85b255ad6b491efa2c4d021c0aa91f927e3a5f0fb0d1462ae473a9daf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/kn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/kn/firefox-100.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "193c7b709c03212ba91ea99da00c6b1c53edebbc9390d7321bd9815e5ced8233";
+      sha256 = "20b8072ddf8fc07f5095ad97464fe0b84b10215fa02bdd9a31254a92c12541a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ko/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ko/firefox-100.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "d265a984bcc6a381f715eff5e2501acde0c8793b111e15877f7d4e9086ddcf10";
+      sha256 = "29be35485bf287596145f26602aac5a520d7e980f3012b564a297e13b83bf489";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lij/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lij/firefox-100.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "4a8327447982439a2f9e5ecff39b77ddd2bfdcb081d9b6f89848f2c93db3b3ca";
+      sha256 = "7023d002cc4a7081eccbd5f061bbfe295f1856ed39724be4228e727119bc0a57";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lt/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lt/firefox-100.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "cb2a9545762247192f909c1600097b1198fbddfed1c383adf5dfa9666ddc0e80";
+      sha256 = "d121af78fa8bddf3825a89e751d37f12ea7c7513f331e015b0a951efedd80609";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/lv/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/lv/firefox-100.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "6ed249ade30c7d2d5ff290c4b65d3eaf3df4e49e112412cb3153da15bcf23fcd";
+      sha256 = "3f4a005f6ba7b09766f9a9d0186c0d5c82049be965e40f58eaa9c0474fb9d5e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/mk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/mk/firefox-100.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "56af16c66d20eaae2d6b487c3bec4f438d21effd3e3b1582579bb9c1836956d0";
+      sha256 = "d1e7703d77584b93261676bb4e5e15a9df0953012392cc52636bafad697bfda8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/mr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/mr/firefox-100.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "fa6f5e496fdac7eda06220a423683f608d6c49b0e3caada52b9fd903b5ebcbe9";
+      sha256 = "e7dcd45869323e949baed0e6e561a3051439e190ab3927d59af1008973e58f9b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ms/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ms/firefox-100.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0820d7fcdeb7226d067f920e7cb8a0bb3bfd98ea931d468ae58ed54e074dd1f7";
+      sha256 = "bb605564c51282e7c5c48150fa61196374b77c2de48c394f4c887c2bd0456f11";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/my/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/my/firefox-100.0b5.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "20ab8faa3a4aa4b4f94f6c057d4fc9602201a55482d492bc6dd7acc5173364a7";
+      sha256 = "9c0bec027eaad1ce4e2e6abeb35e62276805fd49ef818ddc67fd826c8a95f93e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nb-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nb-NO/firefox-100.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "77bf24610d6ad64859c83125909b70b3dd768e90e563971461f2c18fa2cd7693";
+      sha256 = "141aec935cb203578e819481b9548e29212c29c94a6c60dd79bad0f676633cd9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ne-NP/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ne-NP/firefox-100.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "fe5477509d83a14875e0409f99e2336abba237da75d1e56d753e27b7d1016c9c";
+      sha256 = "5d3e083b078496ca6fa34960a3e480baa69b582bb737fbcded6a119c9216c0b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nl/firefox-100.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "3b67159e8d34c836d5367a2e17b54bd2aa274e1f602ae42649afc2ba2fa1429f";
+      sha256 = "f7a8257d2c2cd266e46db87b6ebd8a7530a486d503760baee3d7ab655dc5e7d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/nn-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/nn-NO/firefox-100.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "4faf2904a8b9a0c315c222d7e810d2fb3e24947dda1e006ddd1f727d2f9f967a";
+      sha256 = "30ec48d85ebccfc9314cb642a8171d5ce98dbd0ab102f6ec00cbff2d26163d0e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/oc/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/oc/firefox-100.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "1dfa10fd1d9f958d487023144b7fad8ca8d1e528954f11e28509b7e22e48a341";
+      sha256 = "4d580c477ef3dab1f217114b24486d29df4ce022fa444b013a296603c3ff5936";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pa-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pa-IN/firefox-100.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "e6e4cc03a47ab8ff0546457b2ee0b55b8702463ed5666c15c0d2d98716fa84d2";
+      sha256 = "02953120d3becd386ce8551fd4f97e1da930b7778906096fda8d79340e53230f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pl/firefox-100.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "525023c756ff0a0eae303c02ef9b7155fdad5f0f41bc4e539be5ca21d1af0ceb";
+      sha256 = "362c1d650bf4613e46384ba5837daa80a790b504fedc254c8af7cc146127fe1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pt-BR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pt-BR/firefox-100.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "1a8070c38035f97ed771b02e59b3c2b0ef0073560c8ba285be9779fd4e99b61f";
+      sha256 = "38ec5f6aeb156437f2925df9f1e5135bfa9d85e55d570548c56770334fe09bb1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/pt-PT/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/pt-PT/firefox-100.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ea356edfa8b398ea16719993cf05e65b5c63b4d2c4e589a9a26814ae275e4be2";
+      sha256 = "9cfcd7212cd3531ee0694cc58653a53acd211494705f1d3040bbf03b4bb537f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/rm/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/rm/firefox-100.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "f07ca7d4233860a6271eaa972358bd05b834c7f56c4b64d45eb9af72bcf2dd9f";
+      sha256 = "ffce43f1c388618b53abaec130e288210cdb1361af512eedf0780d591e7ccffe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ro/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ro/firefox-100.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "fccb8f523251dba30a73f6ec9259113142514b6d4657f63b88f5b9d9e8a01923";
+      sha256 = "62bbfeb4a6692c25a1a2a0eb5e790e262e0141dcb74056cb55dc5e7e4a958954";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ru/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ru/firefox-100.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "d87928af8f4a0b28abdcd0386755a3f4f70d7e17e455fe5913b1e177c3edff2c";
+      sha256 = "0acf8d6c81c1704a67c9b7b9542ac6f1bd0b929cd0f0814b84cf64a46cc38107";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sco/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sco/firefox-100.0b5.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "de3bda2032217c56213f64b31332e8e6ea9598c7f31f3dce1a7b136c40c3153d";
+      sha256 = "fc172346729982645acf975a7fba8e045eb81755540faf3eea9699a7474e4ab5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/si/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/si/firefox-100.0b5.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "22dbdccec8073bd1d83cc236fc563aa97a3607a92e9b3908d4c8c0307dca8b08";
+      sha256 = "64ef404110234acc639faefe93499578b88506e287d0e75ec2fc36be625e7025";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sk/firefox-100.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d5f73c93ef57cd600a2c4269a99a498896b580ec99b549db8b0ee1537a644bb1";
+      sha256 = "6fdeb9de76bc3d7d7b5907340368adcd69d28b0db7a46bf96ee54ab731821952";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sl/firefox-100.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "12459b203b0de94241b243b07b9f54e7ae612f7887581c5cd3ac7ca2a08a54d9";
+      sha256 = "259b7c2467220ed58a725006b70b1610d7b1589892e75b0eda1ed5a97ea8d65d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/son/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/son/firefox-100.0b5.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "2d44c84feaa5c5e3595055289f84f320b447664d01c653b0a3b50f1da24b1a78";
+      sha256 = "56f4d79d2e4c3df1ea6903c230d790aa2e40adb704358c6d225fcb2103122cdd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sq/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sq/firefox-100.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "fa3f9724380818a71d895252631b354ffb692f35679eb9b8ffa5b2beede8ab61";
+      sha256 = "73490c2374b06cb4a8fdcf5c1ed32484581b62f380aef5d8d6da8c1319caa0b2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sr/firefox-100.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c2e5ad218b8cbadfda7c455266e018a6eaf9b450a905e8a73b01d02b7efed608";
+      sha256 = "06070996a689d5cac3f97348af762834d0a9e56446b8b58ceba11235f49f17cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/sv-SE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/sv-SE/firefox-100.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "12060ac843f03a7544db8631c7f53bcd0cc6fb15d62cd997b02a83f0560722aa";
+      sha256 = "bc2b8826c8635d5e96b596aa5add0a6f6146fd9b70195323b6fac588ad4e0a88";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/szl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/szl/firefox-100.0b5.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "71ace92d020f3fbd1d5e223dfaa01e3a53ac625ba5ecf074153aad8ccb640ede";
+      sha256 = "40eb80afc5f91513f4ee96dddd842b7b424b4caa2b41cbb0542b6a9c009b2099";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ta/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ta/firefox-100.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "6ace267aab85845babad8b11b68e154e1128b920ed16b8b8d011d53f6dced16c";
+      sha256 = "79132eab776f5e3eba46368a837297be38123ac7036ab550c82d60037e8bc594";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/te/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/te/firefox-100.0b5.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "e381faff48999b63b4981695e7c80bb946b44503ab5275344f12b7005ed49ef3";
+      sha256 = "b2062d708ca2964fe0d046da13c6e763dcc6702dbffc4bb32ace4301e2653941";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/th/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/th/firefox-100.0b5.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "6c2ddea1c0ccf0521b9b647827569b78ac2143163895e67476051f8496011b66";
+      sha256 = "4e1ce1968f16403268a69ab85abb33422eb52cb0f36c854a16dda87d5abd941d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/tl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/tl/firefox-100.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "9d949c9c61922756d0f2dbcff76906191d438d161c74fbe7d702c7372c11b5d0";
+      sha256 = "c1ee82d1b14be9bf7c634029884a7eb59c051f26663e00ea0bf6e5f74ef9e04c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/tr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/tr/firefox-100.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "88763e4847b865603a7d953d54b86e6a053d2476209b4046bcb09149275690f8";
+      sha256 = "0c58541768c627cb4d556b34ed8523f3bccfdaa757cdcde37d1fe7d19c934562";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/trs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/trs/firefox-100.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b6e7aa724a06f85e4eaae7e1c55e3ed1ec9a6b5664150745a257bd3f63310d53";
+      sha256 = "139f2a1abb08dc5ef684d51226fbe64c41e08ad4f183a8b15ff155c5fe51e922";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/uk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/uk/firefox-100.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "69b200c0c4c92430f188ea12bf5e60aae18203a76e61cc163738d46c3627b137";
+      sha256 = "633fa83f990bc1e8a791a0486bf9034f5b4709fd3e2d868f42895b66c5476ca7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/ur/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/ur/firefox-100.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "330bb00cc0c0882a1e8aa06fdf7d283eaeef04500a9bfccef50f7b2ab8becf81";
+      sha256 = "25d7518b88be9d1cbf504a8c214049f265f74a0def26bf5a1c60d562d999a5e8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/uz/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/uz/firefox-100.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "a9b7087c1deec3aedcc2c279b135b113e79739a28e31ba6cd090541505e5d9e5";
+      sha256 = "39f6c200dc56585bf527e8daa59f460d9193f7d5e7194efb7b1bfbf2d4f92e4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/vi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/vi/firefox-100.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "76b034ed53b8c99cf7909a6a5651627fcd9cdebd7f8ccdbd3d2286cb19dc7eaa";
+      sha256 = "e4d0a5838b837d7020da1595cf77093d53aa5d7f765fcc98da20c11c0e853874";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/xh/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/xh/firefox-100.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a1c9ec73200bea835c46879d8196b380a3157c98404e6a009fbdb24b1662ddde";
+      sha256 = "679180e00ca70e112d5053c72cabc0ca5eb92f2f16915c556aefc861188d0318";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/zh-CN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/zh-CN/firefox-100.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "74fd44c26c503014d0fc3a32dbb726feefd572ce52697879a392996243b5811d";
+      sha256 = "c280eef16ab855db69e975f8cac93a2987e125236d7df34a5a336cc837cfd901";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-x86_64/zh-TW/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-x86_64/zh-TW/firefox-100.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a9d86ddb8f5388370a28ac643e3d21a411625b7098aca9c399551f8e2c125da9";
+      sha256 = "2b6d0a74fd53d907a6e0f6e28be41e9cfa62e61c42dbc132d16c39f87980ad49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ach/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ach/firefox-100.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "67b0501117e5d93046031860df5dc6eef3fc3126f0b10240cc13b83f6f1cfdb9";
+      sha256 = "579452bc9bf650c9664775a5ec438be6cf4276b807840a38e30a0c08237a777d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/af/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/af/firefox-100.0b5.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "43b9b1107fb13b97f6b955b3abaa4f1d590bbb1747859e54bb306c9578fbdfe6";
+      sha256 = "a9828b2f4954f63b8b4b37722da0a50f1b9e6230aa981f51597718bf05e52b54";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/an/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/an/firefox-100.0b5.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "da752ce8f7a9a0769c93f6f1817649354f892c440cdd48f0dd75739baedcff40";
+      sha256 = "0d7083b1feef4c8cde1be64ff26c37afdba36454802266c28b1916f760881de4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ar/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ar/firefox-100.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e67fc64daef74e78eee12a1e5d4c1ef5a89a8278d19187d9e0c67ac5ea350623";
+      sha256 = "57e5e2863caf348c475daaa6949dabe013aab0b3e63db61b3a9b9ef4049e62e9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ast/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ast/firefox-100.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "115cb0605bfb7629b854d242634cd2797b5072f735c840a6611325faf7bc3f77";
+      sha256 = "e954fde4dcca82fdfd8605bcd43930f0b85117c1b2dc9edeba75b435b77b121e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/az/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/az/firefox-100.0b5.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "c839a19dc4f5d938fe7a5426a8abd7b228c89a262201c019b4b53953211aea78";
+      sha256 = "a893f228de842c6bdd0c41df3db328c737b57a945a55e1e56f3672a7beffbe5b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/be/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/be/firefox-100.0b5.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "94c8e688578059f8c4f7fd2a65a8fd77280b4047e845efd6ea66e34f5320d119";
+      sha256 = "8cb4ca15ee69f9bb74cd13de82697526d6e64c6968881489b7ddbe4ad9266c54";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bg/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bg/firefox-100.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "9f7acb26e7cd9193e9e435da3e2f4e9d9ee82195cc18e8de8295cba2446da1f0";
+      sha256 = "2d8a566a4619f549bf6b68a2d1b0fad51843de0257da54039050affbc21de948";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bn/firefox-100.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "93f31b395a9a42386b0de322db1f675810a3db106a0e8c583f18ad4dd0c56488";
+      sha256 = "e75c5aecf6b0bd0d60423bb66980c085957b1acd1549426a44a4a7991d1f2db3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/br/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/br/firefox-100.0b5.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "a04a2b2f2b70f33bfe288d9907291aa61f2daa64d0d6802c784d7b4f44b38326";
+      sha256 = "bb8794c3069989e0f06f0dbd0b7fee638bcf9e6e3d24d28ce41db3a182a83a60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/bs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/bs/firefox-100.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "154456c3aeefe93d6891306fe295342aa02c294bf64693fe93943ae836fc796d";
+      sha256 = "db964f0e1eb920cac95cd0dc14175f5e20a1ec32f56a3b43554f22cc67dce752";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ca-valencia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ca-valencia/firefox-100.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "c00ab86f77e5113f85feb8eb14b74c2c144e9c7e08c4442b06b749ffccde2cf1";
+      sha256 = "ca124cd11585fc521b4e2d1c4bc0c2407056abffbb2b36e46ec568c6490b28d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ca/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ca/firefox-100.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "07de1d9c72f9d5487b9ff57ec609a2b6ce37a8b09fc81200a6cc6610a7e66b9f";
+      sha256 = "6ca6e8c905b44c09c4d061656fe2cace22d261ea4efd04917fc2aa2ce13a1cb6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cak/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cak/firefox-100.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "ee05ba6ce42f873ab79032553302caae28069d84c5105192623f1261d2d3d609";
+      sha256 = "44bfca1c2cac5eea67f68891da93604edbdf6e0eda92fd1686d83512feff2089";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cs/firefox-100.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "9b2af581c1c70b72cbf82cf656f94e65058063f0fd6807d99760dfe9b68af808";
+      sha256 = "491a9c7a2471fc1a06751282340f1b6bd00118a8ea11d54420985822c0e9a19e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/cy/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/cy/firefox-100.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f638faf94045b5e739736926e4b3e173f8830542287d46aed70337d9ac3a4495";
+      sha256 = "b9e55860c0f14afcd2d2cf87e5ca7d4b853fce667f93a6b493323423c16f8adc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/da/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/da/firefox-100.0b5.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "3dad188b310fef15b704ca788b320d502a0a6ee59538296176fb17d2b440163a";
+      sha256 = "899a53b667b4f64e953b7d1cf430eea8e67de747b28c93435cf33f008dc464eb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/de/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/de/firefox-100.0b5.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "1bdb5b60bdf16126de86ba1413eb5ac4184f727b3e57a36d424dfe39647f53be";
+      sha256 = "efecb119d1becf00b34babaf42cae5f5c586dc8cc2a29c71d410b68b7aa00cc5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/dsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/dsb/firefox-100.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "b306d40607d73314c0e3e87bb1bce65369846be3e370943088a8e7e9731098fc";
+      sha256 = "b47d0bed633a6c8608c600d6b1c8c49bfe40e4b1df6f72bb7dd49e722084cf81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/el/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/el/firefox-100.0b5.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "45202f79f9cbf2a44bfefa9ce50bd0a6b88485207105db4df1f26f547c1f556b";
+      sha256 = "07b34038828ea049ea6c1bba71d27bada83ec514d8d58be92f9005ff01cd6853";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-CA/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-CA/firefox-100.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "78020bb6fa9395fc4e2cf40645e127d0f6d6dfca4044e5c00f63a90e24824add";
+      sha256 = "fe1dfeca3de53837003d93aecf5fa971a51e8a585cbe9a1c44f338d8d1d7788c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-GB/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-GB/firefox-100.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "647947c0b765d1142947d3cb35ceb308946090e928ecbd4cf8c3eba4b57afa47";
+      sha256 = "fe4baa77504d9ed1f789726db85599d5cc634765ae19cb4604234ccf7a43b97d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/en-US/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/en-US/firefox-100.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "4249f742c2918d66af2e7defe1c6b34870f258fe047ae7b38f91b0394b453cbe";
+      sha256 = "6ca97f006b90f98676efae14423c8707527182e118f4d3020e51eddcb14cf8d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/eo/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/eo/firefox-100.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "1726df9605c7deafd6963c18c4b8dbd4bbbed86814fa9932367fd04f6ef609fc";
+      sha256 = "e9fb1b7b6752629891df490ff625897ae5d929c435c824cb6c5dce18340e3273";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-AR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-AR/firefox-100.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "c3820a35047f21efc721889fa0003d8e74e13858aad4d3aea038c01b5cd6c657";
+      sha256 = "b18a2fb101d28d1dae1b4a33d63906a7c6720ddf5e4418eecf8f6df0be58e017";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-CL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-CL/firefox-100.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "b1f5bf697007d8b6ac9f1fa057f292bcfb860d71229a7d0ad6d611ab02991211";
+      sha256 = "37a54082b8bb69c925894718eefcb1229ad661cfe31aa95906da163a213ea4b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-ES/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-ES/firefox-100.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "de33571140d165d0422b2e4543893bab6435b6626333a05bfef39682ef759db0";
+      sha256 = "bb38bb93c74878646f31c09d524eaadf18a1e2f6ace957abfabd05e1e63898e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/es-MX/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/es-MX/firefox-100.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f681be5b92c8959e0e8c90cf4c7f6cd9197e11be1828797e853310a49dc76698";
+      sha256 = "6c75d42e34b6fde9e8b3ad31ad3574af87dfab2f5eef71b457fbdb9ca6dbe12e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/et/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/et/firefox-100.0b5.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "476a0ccde58372bffea3ebfb0d88795b31db2ec622f9c1b99df51287aa8ba69b";
+      sha256 = "e25b97ff49fcfaef9906cee48f0f342272d2b9807a6221aa6b4fa5939bfba70e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/eu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/eu/firefox-100.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "d465a6a4a01853724894fd81e31b63b80e830cee268298d6e037e6877ae77661";
+      sha256 = "f929034c74b057e32db4408ca25b9e9aff9b26d487db29cbb0c0fa0ade96748a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fa/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fa/firefox-100.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "cf8ac9c8d667ccb0066db1d20a9f43af807e40d1746931e001ec900b34fbbc02";
+      sha256 = "2fd4af491c79dbceee3de7e04fef413535757c0588072ece7e5ebcf252815782";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ff/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ff/firefox-100.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "86dcb3f9e1d899973eaccd3caf401471b36ff70f4a4693fa9f857083e8641a2e";
+      sha256 = "7b0f38144eef79ead877a352a03abb3d50631031b051750d3d9ab84dd8afe319";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fi/firefox-100.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "ca0b830aa6ec724aa31f957e7c84156726c26fa0a74ace80ecdea899a8091f82";
+      sha256 = "fefaec6affe3be2d963967397aa6b0c7495570d0fb437820d87ef6289654fd80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fr/firefox-100.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "e94a7a54ba806e2b4baa0159d2f8cb96e79abc9c01e2526821cac8253c6ad495";
+      sha256 = "1dcb22611d288ea566f1d319b4fa8f6ec7057e05d39a1be794ae12f343e29809";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/fy-NL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/fy-NL/firefox-100.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "cae5c9c607c0dc99e4645f756befce2c9c4ae83b7edc39cf12af81781b33a7b9";
+      sha256 = "fe15fecf740bdc9f9476366f394a10f2f919d7c84f64844025faafbf28fef05f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ga-IE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ga-IE/firefox-100.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "b9b1cb2a48cd17179d5e3a8a3fca9ac25c3367ff6281f632d826cd6a9bb4a633";
+      sha256 = "06c5708ca8cf4ded0cbc7b52e0772bc4fb86ae55d822ff09088af5c35e60d917";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gd/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gd/firefox-100.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "b5454de81ba2fee053e98dcb37d3703b5385a51561e45fa32f6872494cfc047b";
+      sha256 = "fdbf7f54a4120dee131687fc81e972e4df52347de4e8473a152ca0b98d7bef92";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gl/firefox-100.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "be3b3decd8e75740a317f105bfa2e4c919ad7f31e391845fb60b299fae7bea7c";
+      sha256 = "807d0deda34da90207a6ddac26649f38eded1a6b2337d9cb73ed28c55bd316b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gn/firefox-100.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "394562b739f81ec43a954f7393c5177f87d3d5b36d404d97e2e483f3000bb615";
+      sha256 = "a70ec6595f9ff5cfcc8ae0185d4ece632a17ff49817b98052bee8981dbd63d58";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/gu-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/gu-IN/firefox-100.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "d2e36f37146b48cbc710af7663ad8b4f7770dbb5f6a557e3f54d637e7061ad90";
+      sha256 = "44e9a22d946e4405db84069d329b66293b0d789b59d98bed4570d98dd19b6c0f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/he/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/he/firefox-100.0b5.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "17bbbd7768ff852dc1f27b224b77dfdaaebabaf531028c71a371bf302a9dd92d";
+      sha256 = "1855cfb19d6bd857a14950399e238c30768e23c08d21a1db38b49dcedf2302bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hi-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hi-IN/firefox-100.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "2f431a3e50ac0b74a2bda65652a5aa45c0e1b44ef0837645ec49e30c6d0d7fbc";
+      sha256 = "47fc9f90b3d52e353594bef6c84bf408ef3e37fa2d0eefe17997bab546b2f9b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hr/firefox-100.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e57e5fe2cb59c25002e9c06cd3298d9cb75c4437ddc9556590d6c56a1eac57bb";
+      sha256 = "bcbe511cd9bf09605f1e6bdb3b65e9f8eff6c6e8cbdb904987941d2edbd10b42";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hsb/firefox-100.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "7c1eefa455afacf5b3b1ee1d04b6e793e2db210912dae58910093c70a21a73f5";
+      sha256 = "5a5b5063eaeeeec63d13f138ba43280ea6cde0aeb03bcf18c6f5ed0c7ab575d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hu/firefox-100.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "d2b02034ce6686e0743af6444acc2a23ed657124bd7bb6ddfaf6d24cf11730b6";
+      sha256 = "7828ea71f5ecf9afcc52fad0047789ece2c8be5c7ba8d390d98a24daffebc0c1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/hy-AM/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/hy-AM/firefox-100.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "75589d2abd9488269693c0a0440d6359bafb354b1b5ee91b90306871903eda0b";
+      sha256 = "c76b2e07e5085caf56c8c94848f7d7dc4b40c5000a792921bce762ed55b73f4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ia/firefox-100.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "b26efd6320a41a558383e22db49cbcdd930161fb48ad0032d24e44b57b01f0c6";
+      sha256 = "de9ace36727f9fb070138d30bb854bf28ad57b7a9895cff492d48231826044cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/id/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/id/firefox-100.0b5.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d50fff8b0ff7ae5546ad3f25e485ef51280bd022708e3d0aae97d99f79788f0a";
+      sha256 = "01dcade8b0d7dd4f4ec9a408291c643bbfbcb922ba0b2cd84645799c22c46082";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/is/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/is/firefox-100.0b5.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "4cf7fbadac8084b8e134f6110ee07076ddd93cf00a10b6ef3d6276df9080bdc1";
+      sha256 = "a8aa5de061a5414e55f45c61bece3f4471662f36e3e30163daef028cbc62a675";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/it/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/it/firefox-100.0b5.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "6fabf495a730600869f6d1e2d9382120361f5061e3a893321f68a6378f7eeddc";
+      sha256 = "4610c04780fc075cb49a09e0815671dcd8f3b625a5b30913c8ff5be81cfd13cb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ja/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ja/firefox-100.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "95a537b3306ae1f6bfe9c4076042d6c29c6478c0f32e5aa4a01e800c1d2a75a5";
+      sha256 = "7ca93bd2ab0a1e0e0aa1a41df7331c65f27747b3d511527c557e613272a736ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ka/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ka/firefox-100.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "e73b2b555f7318650ca1ea20f9d8c1fbc933d230eba3eaeb5e5a47dac24797b1";
+      sha256 = "55cf179d73cfafc5526e5701de3560e4bf9c1d02c28c77cc66801b828fa9e33f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kab/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kab/firefox-100.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "cd55879a883ac4e4efef972d6200284d6839dc786e7dad4c3a81fd88b89b18ab";
+      sha256 = "c7930dbea998892979a16d3e60b19db62cbbe8388e68a2ea59a11e234e8f94b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kk/firefox-100.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "cf2dd9ae9cd6347eaf976cdcf4a6cce81abb741b0cc273063cbe1274d271e05b";
+      sha256 = "771eb9217226b36cb04719555a82c3b11e783059183ebc9c295677ea06d69321";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/km/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/km/firefox-100.0b5.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "f0f3982e7d838841a01b24c330ed3e74416073c40470293447551aacb5411506";
+      sha256 = "970daaec6f449ab1d6dc8688ee9f41b95d295523ed57ec14c5f34fc98ee18dee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/kn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/kn/firefox-100.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "3e2953e55e3bc7fa76ff77aac08f79b20bbf2be52683c08b3d54a323a1754ed7";
+      sha256 = "fae2d5a9a428ddba10cdafb6fce6e0d591b5ba8353d2cf88ed423602fd150576";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ko/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ko/firefox-100.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "5c5bec8a40dbea26674eb2d4b7160c1c2f3ef37f68d67c24a7ca6a2cf77eac85";
+      sha256 = "4a66e9cec2224382645d962908218bb89fe4a499b9138c83966dd70d9d25b172";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lij/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lij/firefox-100.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "7cc492c5eff065cc3cbceb292d18d833e9f2bf76ace0d5ca960256290f049f94";
+      sha256 = "85ef4a63c9dc97f9b482382a83f5a7a6880c5df87acce7e142506c2d449e4f69";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lt/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lt/firefox-100.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "b4b56e01e65ffe4f7232daf661df178d4af1d813e1c8122c4ba56aada0b2ef52";
+      sha256 = "da3ccc7021eb4b62c35c716089599f714cfef218856063e083c3547d64271b4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/lv/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/lv/firefox-100.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "b13ac2b90f13813b8252c5eb817d0f55f770a58e05f8a98b1a08fdf59fc9191a";
+      sha256 = "6aa1d5453d938f16330e0ed54d63bc59c5b57e7da5ddbc41a05c2f75dea68e73";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/mk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/mk/firefox-100.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "6b1d2598350feb901e86f332598688853b607c7c14c13ac228610d16e89eeda3";
+      sha256 = "e0cc100f8be06fd97cb029837a054e60d136272a9f6b78eaef692d3bc5d8a669";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/mr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/mr/firefox-100.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "9a6a47fc20500b4421b12381374f0a8ecfa9a0929a54a6f6dba73e1c2e5a6c81";
+      sha256 = "d3a3d72bebefc51cd8eb1a1ebc1431a9845d15af6321b76e2982a0d210397409";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ms/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ms/firefox-100.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "e79c4f88952ec9061b4d90f8ca5970be8b5c19cbc1df8d9970b9b23c801103a1";
+      sha256 = "c59362f1817f98ec80ea275b39f50bed7a0ee1154d6a6ea3ad6dbe8f2eb1bf79";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/my/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/my/firefox-100.0b5.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "f8ce25b87b639843fa6fab4651326719f229f91a4d6b3a6ef17d0e9f4035b1f3";
+      sha256 = "ec1d06208223422633c2ca495bb17ca946e379d361a2e00f94ed08588b6b2263";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nb-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nb-NO/firefox-100.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "03f5550bf0c0f33c3cf252cbad1650204e008d852e6db46a6f7fb6f6b5ac10ed";
+      sha256 = "2e31732057bda76dd2d74d8e2b3e6c38a2035bf163234fd82fc867b544d34dc1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ne-NP/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ne-NP/firefox-100.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "5d94d2dbdbdadf6abb7250772e6e046b9ce03cbf5e4c920ef7e8b5cae69359b7";
+      sha256 = "eba3a80cb0b761b68d5e318d5f8110a7d19da1261868cbc1f1a39eb47c08c018";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nl/firefox-100.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "3045ce321c102e2c114a48a46526572a2c52d228b44ab35d8241d92bd65dd9fa";
+      sha256 = "1f7ae0dc78d5b30741e8d645471aa1875c2de144742383eb5c24cc2deda79f77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/nn-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/nn-NO/firefox-100.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "a16aa9b6de0ac4213492ca117eb47fbd4994824c0f080001baa9136231fb69cf";
+      sha256 = "acd635ad253a878043ec4121984da468901c49d4fb511ec9cfad478980ecf647";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/oc/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/oc/firefox-100.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "70bf39cd4c3fc4ef772dd71d97f71fdc92324ce2caf9d359cc1d3f3d1557c3a5";
+      sha256 = "2721c54a1bee621d9c7cf2f5c657dc48a7d9406d80c5aeb9963bf7b128c17629";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pa-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pa-IN/firefox-100.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "951263906c05aa6f60a65d77e917a95ce10e8ae31f156acac7f47ab4ec36deab";
+      sha256 = "97c435e09c0b56bd9bf66d50e90034a502e9af6cc1984d5acdd2d948f7556273";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pl/firefox-100.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "476ca14396dd7ee636ed1e74a20d9d0ff3b0c452e5b5f61eae6f0594ba060f3e";
+      sha256 = "36e81c101b8cb68be0f69339c47ff4e5839397096775cf9ea46f0ff1efe5353a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pt-BR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pt-BR/firefox-100.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "33ea09c993bddcc36621ae633713e758ac33349847604995e05fce0d26be398f";
+      sha256 = "fb90a3a2a303f945bc34e2a6ec397f0116ac77f02062e7a7c8dcd382606dfec0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/pt-PT/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/pt-PT/firefox-100.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "fd4b924d8afa163ec40a2f5ca6ae0b89e1a22a8be8b8fbf9f43012159d0b7172";
+      sha256 = "8797c65c277cc0f46a8d8b2cafc370be55c57eccc8e9fc88d3053e2969f9de58";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/rm/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/rm/firefox-100.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "97ce5f4af9e8ed2af039255e284ce1b55b6a3ac0eacf4c40be82b635b1df0f2b";
+      sha256 = "b8cd7b28f31d4e1ee874f1073065897444eb9503e207b924a875a8c3a0b21509";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ro/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ro/firefox-100.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a959d39333b98c5a479e6975dfa82a4c2b3efe5d69d2d99fddc8d2aabdbe95ce";
+      sha256 = "3907d9aa29f56fbf97008e65f83ae25719f4156961ff3e976661a2012f16fafd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ru/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ru/firefox-100.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e4f65bbf839054b7009e01461cf4a0b943e1373df054e9b40797b5d233654aac";
+      sha256 = "4913bf6de1f5b14d005f20bbc0d2ef97227903d296851034735e872e28b3f065";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sco/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sco/firefox-100.0b5.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "fac16861dbc011655c3b36b31d5e0816a09e1f88e34032d247d09f691c097ddd";
+      sha256 = "ac4fb9005a71ca5bd25120946b65ebc0f437d8c86b9dcdc11e9b874ade8b4dbb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/si/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/si/firefox-100.0b5.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "93423cb2cccf166f374fb4b8779f337fa1cfdff67f0f2c463a398a35ecd251bf";
+      sha256 = "8fdac92f650f10a9dc9322f817f1bb6f60b5a9fe97942cc1ca5ae694aad71523";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sk/firefox-100.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "e63c2240f7b791b01c94084dbb28d74ddd6528a7bd1e62bb74ee9271d0fd81f6";
+      sha256 = "57987896b0e1b8846911b878dc360d139002401ed57a9b95fe47f2801c983848";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sl/firefox-100.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "87064873e57431bb9cfd3e231df07753c8f644e218ea0318b3731baa05b16c1e";
+      sha256 = "3097cfb125f9b275270955c454577b7aa5ffe68b5ee0917cf6b3e0c31d9c5b25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/son/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/son/firefox-100.0b5.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "6ecdf2061f0787fc9adcd27465211446df45751d103e279aa50f278361061728";
+      sha256 = "8588038e834177672a47530e8e86c202123606ef6f1a5d9a4d5c40cac8cb9aec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sq/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sq/firefox-100.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "47783d01b35119b158c746c5ccede7e4832d15317958030306035d1b448b77dc";
+      sha256 = "cc229e95ce396fc37fd7103e70acae2414de501823beb04e71c702cc65c430f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sr/firefox-100.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "4aa1908894de6eb3640b497361d5245ed3379d29ffe6e10401540cc1c10cb965";
+      sha256 = "9c134f28f92311c8c8764df4d37727134fecab10197cbbaae01d26773e2897a3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/sv-SE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/sv-SE/firefox-100.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "2334fb5859711a4471f06a9eb81907d0b41ba52a8fce05b7cec320a0d31a4167";
+      sha256 = "40c8f4af652dae7a3eb1b1cab01f032ecb526600cbeea0dd5ccc4319b0d50310";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/szl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/szl/firefox-100.0b5.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "39ad1c9f4da42278f2a1b3c125aa7e2a8005376a6f458a03851d42f85d116dee";
+      sha256 = "d71882b04563f7f89a4c0bd2431e6b33e2af010b40b1dd50304f9daf0ca66525";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ta/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ta/firefox-100.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "24055aedcf23fcde0dc519bc2124a8d42c82ddd74dda46b694a20d25ff76d2ce";
+      sha256 = "a473f9123d53de141e0592e03e8c9dd6ce8f057c57f89f55957c1436d139582f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/te/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/te/firefox-100.0b5.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "18a90860a6428ab31229c975927b264d75b2e2f186f83ef270262f7598053d48";
+      sha256 = "042aae2c4d10d2b7407b3252a39600217ab8ac0c9e34045c31e70cd8e792968f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/th/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/th/firefox-100.0b5.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b965a21a0585cc07714c39ba33afc5ce757294d595c7617ba5b330a0d1d8cf0b";
+      sha256 = "6455ef37c941c978b1380f6ff3de41c0b7f8348d498d154e78c9c7b6e8992187";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/tl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/tl/firefox-100.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "cd1fb6553daf6b123e6545cf0553038b2f16c12ae4a21425e253c68124a8ce42";
+      sha256 = "b41d0029729bb4fa1e8d8c596232272c1e238d8bbdb675d31e42250faed54396";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/tr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/tr/firefox-100.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "2a2c6abfa119022520e8a3ab4c430c282a7a3f7d5e72d2a67d070a64398b2bb9";
+      sha256 = "e0345c71199784d40fa159617371a72e3f3e05d2aadc041d14c6b3e450304afd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/trs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/trs/firefox-100.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "aae079859fcf211c1e465a00a6a07514397a9f715bc02d704daf062e3d75220a";
+      sha256 = "4a6afcbbb3d05bf6f3abe3194a21aa6ea6d2f76cc5429ef4ca0a433ab1d97f76";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/uk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/uk/firefox-100.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "04ebb332d79d0a9aef5d2e93b2aa8dae0ded8d4e4c639d192ac969e8033ffa24";
+      sha256 = "97709ab7965f859da2ce93cd4c22b875a0a94af8b8b7acabd1578d5ae82d6d85";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/ur/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/ur/firefox-100.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "8a8d6d6503657665882ccea44a56b324253adc8d98eba20696ecfd096311821f";
+      sha256 = "7c69d7f588540d0a72d9942671d40ab59f066b9798279dbe1b0b0980cfa13a06";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/uz/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/uz/firefox-100.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "e2990d6a4c3bfb5547bdac49a2499c7dd958d0b8e665b636e0ffd6e9aebaab58";
+      sha256 = "53c450eeb1223c2794b9270d257fdeec50bb4deece5bf5d7d05a5819f54989c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/vi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/vi/firefox-100.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b7c2a4d8c1c400f44fcad7e91572134328097d183c76b8e22d5eaa0a4959d35f";
+      sha256 = "395e8ffa9c6a0145f6fdd005df0b73fd4d59410ba780818232cde2f3fc257d50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/xh/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/xh/firefox-100.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "e3dc9942f397812564b5d7728bb4857f0c217183300ac0ab28590921f56bda34";
+      sha256 = "22359e92de488a24709445de54499c9ad49e841e4ef6ba45296b44fac089121c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/zh-CN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/zh-CN/firefox-100.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "11ff62d8f465b9ce17591177f1fc98d6dcbbd819332f65bcffd685d43b5aa285";
+      sha256 = "7f5d0d771c546d41e835ce7842ee7659ec4a69cd78176b0c679b4b056e8d5499";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/99.0b6/linux-i686/zh-TW/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b5/linux-i686/zh-TW/firefox-100.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "406200aceeae06ce5ae2d736d8ff42713e2275b5f369682cd49946326c5cf21d";
+      sha256 = "8bd0dbb9bf1a3682ea39e43da3819a4f12bc147484528d869a252d2ad000f95a";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "100.0b7";
+  version = "101.0b2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ach/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ach/firefox-101.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "45f6a861d33b0c658494e0b50006cdcce0e842cc3788666876d916f391c7b7ef";
+      sha256 = "84d818f3e3533fa8d0f92c00d654023c036238db4a9a9048a0d71c0b60017eb6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/af/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/af/firefox-101.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "101ad51c55758373330a83914464d460843ff5ddbdeacdf20fc5dd0bfbcf493c";
+      sha256 = "1d60a63bdf28d4e0ad1ffe1459cd949704bed08864d0a1118032acb6f9e9cd82";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/an/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/an/firefox-101.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "70daa1c1b8b79bba2b714c4f9eafae4eefe8e3539978a565ab59303acae14612";
+      sha256 = "b779cd24703b623d06cf69b60c92e244ed6f8c0df5f30ccf8c3d5d9d08841af1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ar/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ar/firefox-101.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "4c12602aba16ad4b53af058037f5011ccd2b6ae84eca50d54ef4b87a6a600d1b";
+      sha256 = "b8121d4f1a9b04814933df8e15c7e7c01ed24aba78ce1f43d29ec0130aeb7d50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ast/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ast/firefox-101.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "b50598963cfd375bb67ffddf2b376f34698a82b46df6c80002ea6f0f6eb9cc4a";
+      sha256 = "cffaf3288650509a3d25988ba32bcb0e7af0bd787b7b5ea297490f236ee91d5e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/az/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/az/firefox-101.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "6805c880b5e418e06b55c13bbadd351165dd204e41fb08b1b2eab5b94a0f3fc1";
+      sha256 = "c9e62710701996c4d556320583209402dc955296117e8d70a6ead33472e07d0c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/be/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/be/firefox-101.0b2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "a4dba3ed59a9b2fc56d24e5e82ccfab1bb5824da8c3378bdae8b19697ab1ef18";
+      sha256 = "4bb469f3523bdff58e83d9de56a80f1d9396df2fae2c048ea91cefa14d89def2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/bg/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/bg/firefox-101.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d70c6592a3da83ff561e7bc01380f9f800cb3400495d8b67658a1564e324fc3e";
+      sha256 = "bbe96de47df523971ad2f7e72b4c5ef040b94dcf3d88dcded6a3808098aeb1c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/bn/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/bn/firefox-101.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "9d669c944eede493fa7ef2adeac05fbe6f85c88ca6323afa43eb7b3c5789de39";
+      sha256 = "0973eae62bf490af5bdf71d5e33dffe291809a2c4389fb8c9cdf33670ab497cb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/br/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/br/firefox-101.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "7745681dff251572370a0872ef05def05fec417833f43f7a7ed51b83df936b60";
+      sha256 = "f693b340a2d7ac5bf40705b51333bf7bc22e9a62a9dd14952e6835a8d5374267";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/bs/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/bs/firefox-101.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "bb36eac7d390edea72366e9cb410fddb3bdd39345daf952ce38fe61b2d70f1b8";
+      sha256 = "de631ff909d671164e52e7194c1f5f5ac6156ef66877f4642c5f067e806281b3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ca-valencia/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ca-valencia/firefox-101.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "6be81c01b1ae5942f3db31e2d091cad47bd5377713a248c87adbaa2af4a64791";
+      sha256 = "eb73e92b05b37a7aa042b8b865a630a95fdeed41e9881f659a3589c2dcf3fd99";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ca/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ca/firefox-101.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "675ca3f991d11f4a0b7e69031f05e55a43ff8ca40778efbabc3bf5d35790de99";
+      sha256 = "d227042106358cfc9025f3bdc84e12494550e29ba4a8a622fa6c1b88a6cfe7cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/cak/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/cak/firefox-101.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "b2d5f12391e2e6478b3e82ac7d60f319bff9b98cde20efcf9c89e3d8e1821c37";
+      sha256 = "6831c152ec2fcab6fe7e6792887c7b813c2e226836135acbfc4ca66a9b114014";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/cs/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/cs/firefox-101.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "356305df5b9f64f9b6b2d00189add782363658c62c5aadcb04f86ea097de8ae6";
+      sha256 = "c7c52ee04dbc90417e6c6d35cefe315daffddb6b13b7a239254bc15cb22f197c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/cy/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/cy/firefox-101.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "bd2b4b85b895101d12dd6edeae76d61a91a78bf248792a7a5376e9beaffbb2c5";
+      sha256 = "e6315de3fc02ab229e1e8422f614ceb0ac4ee1aa913492a24f200dd922dfb2ae";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/da/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/da/firefox-101.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "820836d6f61f94c19ee0216f1ce77cba5b647d169c62f35d025244bfa98fbbfd";
+      sha256 = "1dbcc3ad30cae0c8e5cd29dc480373fe80989d8636d42e45698b8f7a76bb7781";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/de/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/de/firefox-101.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "5c81914bf7cbae74d4aa1e5309cdc351d3cfb77768c5a2ba67a14b5e0115c63b";
+      sha256 = "43189166f2f1e7a3366922270b62e95027f2d750206bd1878b764a5a7572d360";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/dsb/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/dsb/firefox-101.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "fe401e2a22957da728b61b05444abc8cefb4e033f83dcfdad2696bfb33ad7411";
+      sha256 = "2016ca15c4ef78eb8c698646cf6a7ca605f2316cde2df5e1648510c117fa32dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/el/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/el/firefox-101.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "6fb923e5e24a9646854b5be2f596336ed755e122c47a928842d6b6af89f79812";
+      sha256 = "7aa33608bd1e9ce1bf3a7b1943644873a7e3d91a5bbc72ac03be5fa1bc4ec8aa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/en-CA/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/en-CA/firefox-101.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "70064f73aaa2298f98bc0ed0261b1386c6a95742abe15cb4a2069ec3e944c000";
+      sha256 = "e31cc0e5dd155c22b1b3a6219b154544b729e700496e8d8f83a895174e6ecb7e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/en-GB/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/en-GB/firefox-101.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "f5e2105f6c6aaa27aa9c20cb622e648b23ec43eab17bc5a73cf087c356ce0a25";
+      sha256 = "7521c0e6c083d26d1f5a67f695354e64947ec3335d07991e97429e569aa17e23";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/en-US/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/en-US/firefox-101.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "faf84ba5b13fa1032f5b85848a216c05d329faf9b157d564e7dab0e821931eb1";
+      sha256 = "e1ad655ed971655a6b56446b5e09fb7f0415c8ff09370ad8fccf7f28dbbd17b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/eo/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/eo/firefox-101.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "36def89a0f4bcbd4410402bfc3ca1a8622856068bee00fd6ed61be3ff5ce68d3";
+      sha256 = "9afae49a33f2a0aa02a346fe6e456d09dbe88a0c655a015be5e50a307c472d95";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-AR/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-AR/firefox-101.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "71a61a5620b41f50aa7ceed4582fc3166e40ce99016723593a6f00d028097d10";
+      sha256 = "f8919da0647b6e6a6587f4856ce20be5f6054f4e5b6d71562fbffbac594853cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-CL/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-CL/firefox-101.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "bfc017101cb198ec8a3c9110a63b4b03bfe2cf979f5a7ff87b3d58acf4040c21";
+      sha256 = "b31b8a41ac391aefff8c1d85a29ab129983bd39474a15672cb3e74d916e0c9eb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-ES/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-ES/firefox-101.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "61d9f463d7aa95343f0170b57eecaa6770c254f3b7edf69a2c10f3014add6bbd";
+      sha256 = "f4f6e6100d85050d381beaa4f2dfeb6b5e7170cf2c079257ebbfbd80219904b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/es-MX/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/es-MX/firefox-101.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "2aa594ad00793792ef4efd7b6d825867b63ac83dad2f95c7c4b4013615bd7821";
+      sha256 = "c2e3bd2ccbfe64fc5eb1d4f920554ba3d170c0e2e478791d9cc19da955960200";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/et/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/et/firefox-101.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "71a59a893270312c304941412fde6354fe13848fe814d0f6f95f202c47efa9be";
+      sha256 = "cc0b56f513294b0742023e37a06a462b107a480c1fcab118bfba6894c2e72375";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/eu/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/eu/firefox-101.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "58c9ad0df354b819ba2090cd318423dd911abb01cce4bde924caea1adf38f5e3";
+      sha256 = "8a18e5428a9dc60cd39ff3a1b0900282178efe54c11b43a8015b86d33368804b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fa/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fa/firefox-101.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "fc6124b925fe2dc7f00a629754f373d4a3a43fa20b2e533ed350df0acc87f872";
+      sha256 = "75fce16479f2e95c9a00f369364c279b362c0248e787ade7f14f6aba934cc624";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ff/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ff/firefox-101.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "e267ce3bf5fe5f2143eaee3a647e32bc5a18bc395f06dc08698cf5eb5c5eea26";
+      sha256 = "90081b6c7b487292a14e2a488a14e9d560183ff6313a67076f1a07033df54a80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fi/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fi/firefox-101.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "9b63de9b660217226813a814cf3d2aea4de8c38e98386ca20a246e6552b0e755";
+      sha256 = "308fbcc9086fc3f899703a58cd95f55b7e10b7ab4fc0c4cac02c01f5dfd2ffc0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fr/firefox-101.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "a6a1eef4d559779248e0512d0611854f4fcc442c3e0c7e13b709a8d60fd132ca";
+      sha256 = "91cca9bb622e3546d683a8e3af9984ab63e6aff56a8f0b7a61c84795d452e198";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/fy-NL/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/fy-NL/firefox-101.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "78c0e2d701ed3fb9e5299f51c9cc7844035b8f7dfc314f2d79bbf76b79392a03";
+      sha256 = "37f87b1b0df5efce58dbc6366028b069bfd61007bba8a4835b8c72966ebfb584";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ga-IE/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ga-IE/firefox-101.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "97024d0b49f5475fb3c44cc9b95733349c854e69e7d73598b8e8e8bd319ddb99";
+      sha256 = "d4a347e9ee59e1eae54783c9d4c99f88d6fe5eddd541d54f6efb1d2d0c494657";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gd/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gd/firefox-101.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "d0aa045753b91db42d6c1ccf9548aa6dbb04fe22bfc68ace2f4fb797b45d2ca4";
+      sha256 = "907d68789cfe8e2be69d85cff2b846d91bd9ccf7c3a183891472509db54a5e49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gl/firefox-101.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "45fa58685fb371f5633e74c26938b63bc21cd110df0b2197ab655f921abffd2c";
+      sha256 = "1d1e107df695c76652207006ed060fcdf2133508c7ea0fee4f402816a4eed53e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gn/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gn/firefox-101.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "f62a14f9bd49318cb88945cbc721837e263a8661ff9832460ddb37893eabc609";
+      sha256 = "b62af16daf08e4a2574bb6b96b4a61cfc64967328dc19fdc56ea56cc431019de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/gu-IN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/gu-IN/firefox-101.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "396c16091b38f28f6b26807eed89a93935498f5dc137ffd869bac31e2e2931bf";
+      sha256 = "ef2f317ae3aaf608e74dc882b202a195ad4146295f00bff2673cda02338ae499";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/he/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/he/firefox-101.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "f453e1be32dba9f25271ee0cc826f26bf2fa77ff1b3ce3f430ce7d345c3ec5c6";
+      sha256 = "4f5cd8a8f6dc9c0588d9a41cc9e68b0f643581cfc42b6f17bde51dc60c3ec2a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hi-IN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hi-IN/firefox-101.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "007e80ad1a41bfdb29572e9cb988c942118ff076aa616240304ebb7e7b16d37b";
+      sha256 = "16e96c75e96d656d8a5338c6692ee3c4d94af325b51e3e3326a5024549360f6f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hr/firefox-101.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "c2df4257df1718d5b4e9fc287bc0ff021cc063d3bad6a1a10dac6f323a9a84d0";
+      sha256 = "55a692fd61adb3c0cfe05317dac407f5804518d07ad1bdb6aa49a6e7d7635270";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hsb/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hsb/firefox-101.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "eac23db86d26a97bb3a7c11febe50e0be009ab3d02bbc09ab1e85ebd651cd7a8";
+      sha256 = "d2786cb3a58bfaa5156c9efd5e36743bd30461e922f8d1f8421fc60ba743738f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hu/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hu/firefox-101.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4352ad9b31e1d49256126929fcfa8c95d113c0162481830674b6e38c22a14603";
+      sha256 = "e4100b8208dfb367de6ea92252de3730728651d54027a7d8da989f52afae2f10";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/hy-AM/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/hy-AM/firefox-101.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "f4acef80ee2d434ef18799e127e31f23a0dc22f959b116594d487d2baadedb08";
+      sha256 = "5f247f00eb048e01f8ac6f1e7cf8bd9a4e2d012e2534acc2dde7e9cd659ba48e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ia/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ia/firefox-101.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "fcbc17a1e5672779fe07dc37c9a6911fa75ad08c0b4a01c875a2d18bcead0072";
+      sha256 = "68a040005c7e2db14d380e36a28725d59635ad6166c3a918676e870207a790e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/id/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/id/firefox-101.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "965ead6176dd31c7da36cbe8e98c4391b76b6c169ed1277c5ea21fcd8d44ae73";
+      sha256 = "f9dba308d0e9f6e1cdf70c26a914acd234cf8d35aecd5374d8661f2d025492f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/is/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/is/firefox-101.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "961fb825436501d46dff5641847274d36a2aad75c463a1c222be50b3b640893f";
+      sha256 = "5d50987e3ffb7a7818479161ad4d019d59b259575cfcbc4ede9a4a6a5cf1b6ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/it/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/it/firefox-101.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "1dfbbebc983d4a16abb3982794737e871aa63fd553ec07d19bc91e6a60781c01";
+      sha256 = "b786c212f61213e69010d930f2eaf5bb3dd9c798446725f4822fc3bb37adc01c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ja/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ja/firefox-101.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "17a02ae89dbb4f75d9d36ce357b284f71d722e7ae205a732be676d013ab2eb6f";
+      sha256 = "825af27cf52551dfbc83d7b95e47e64ed0ac7f7db3095bf1debfea87b39a4378";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ka/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ka/firefox-101.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "6352c8941b2b54002cd6d978e6063a4a96c9c50f8e69ea8686782bbcc393269a";
+      sha256 = "e009b3f2944e6a67d85f8937e5e7472c18049b2569bb2c9f234de468e636862c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/kab/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/kab/firefox-101.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "9913ba498028f09879854c7856837f75290dad95c2e6e5b4663f8689b879da8f";
+      sha256 = "168c16ddfe42858333d1f53ffae9baa16292687a3d65b29fc9f4605411a4a712";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/kk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/kk/firefox-101.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "dace65fe6273c77b1e2f8920aa44220f2c8c698a966086c0576f31e47b143010";
+      sha256 = "e12266f2f186570c1aa382067f9cbf1cf78e0b14e14cce4b9c822f29366c2b05";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/km/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/km/firefox-101.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "5e0f4911a567f1148145e57610f40c10da6b76be1bd99b5050f70201891e5ac7";
+      sha256 = "77f90b4c24f1dd8ef8ab06f299abfa734da6d74ae1b4298d3b425b08c28fce9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/kn/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/kn/firefox-101.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "ed3d93ce4836566d22a68d38046717d3464e61feed8c7b11727ed458e32618bb";
+      sha256 = "c9015d588d9e1d07499b7f910d9b2236b81a6c3e5002bcc8d18ea970bf2ee8a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ko/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ko/firefox-101.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "125aa76b23fafe9fe5517a6b22d324f15b2a1a841b27f3b8682ba36638a0c8bf";
+      sha256 = "0c880beec3dad250b3e224c2e7b73b15253bda3bc043110aa874cf555d475094";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/lij/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/lij/firefox-101.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "6ec7112a6c3196941661d8a2788301b4bb52fdcaf36f4f76f801357e4a9b5bdd";
+      sha256 = "ba25d461f97dc3f359a4d525143c5a19859a2c051db87017469ba848c421aef4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/lt/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/lt/firefox-101.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "483661514a9186e2775f241a61e3880689ff71e40a3e4ad67987635d12eb1351";
+      sha256 = "e73fe6e7477b4c37d33cb31fb872a845f8a67ab659d93752d936a2ce7a1e3d31";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/lv/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/lv/firefox-101.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "501ecf97aefc8280ace103cbe11fd3c629f7212244e31cb83168073d3e6226dc";
+      sha256 = "4b4d510eac153ceb3c2953d1141e893aeb913000cf6d557e4564f8983adf5b29";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/mk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/mk/firefox-101.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "21059932cc2903fd4d7c2840db186d359c8f061f70da43760e8bc98301a89c5d";
+      sha256 = "8a56b192d42351d40e2d35164f5809ffa5ceb52e16e5d6e85f4819f250deb67b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/mr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/mr/firefox-101.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "0d6103bb16917f2705406460d5cb87dbadb0d401f5c18cd5e2f20871c7996ea5";
+      sha256 = "efe2bcf5f97709240a09680c54c61ae25be5e8019003d67bae8cc166bb6de15c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ms/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ms/firefox-101.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "8273516807ea2973cffe6249a9ef07125b9d47400bcba9b129a6916e033e99bd";
+      sha256 = "a5a1b3d542478648efdbed1f174f87f885593209dceb1b41d5090948a46f8c8b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/my/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/my/firefox-101.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "1b0814a8ea7475d56538a63d45ae5007fdec6f0f6b5c8f97e7b9cad890b5b4b0";
+      sha256 = "baf5d8a4e2ccfc40fb9383ad84c15d9e47ddb81dca203ac2df5faa2aec6e2031";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/nb-NO/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/nb-NO/firefox-101.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "8babecf3aaa07bfd61ffd8e365bde7adc3191f7fc6eacd7eca3eef87e6ae1398";
+      sha256 = "980c1a26381596b76f5519021327f5d3ab104f231e637e9bade9bf34e9f17df2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ne-NP/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ne-NP/firefox-101.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "a2aa3b90a98991fa34d0c246bce9856d709a505997e9e192744d77620dc9c1b9";
+      sha256 = "15bc3ecc249798080feee3214a76fe843f16a68344673c5cbdfc6557d171b77d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/nl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/nl/firefox-101.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "47358e610f00142263c05be47614bf2735dc4a1ed402d3b9d40969c7047b6a67";
+      sha256 = "cad9d94763528115c4ab4af90a722492eb3752066483bbdacea7d6933d2b4b2d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/nn-NO/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/nn-NO/firefox-101.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "7c256f4ac09086ac447aa121827e9b395335a2f076a7796dc036fe409a59448b";
+      sha256 = "27ada324b58968fe5b9e2b6e367dea00097d83d10aa110d4d76db06bd22e9d5b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/oc/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/oc/firefox-101.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "25d201fd87e89682f97e7988aa3005f67875b765a2ccd8ecacda36ee7af2cb4c";
+      sha256 = "9c4dfdfd16cfc0bb8502f31359acb01bda905089781edc89e15eeac4e52d0513";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pa-IN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pa-IN/firefox-101.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "3ea7dea71a9e932da701de62b612a950b5c9fa2d90e1dcb980c9f8f07e0f9dd1";
+      sha256 = "b10709e964787898a2c5e15c0856b8b580a3221dd33ea441073437f833770552";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pl/firefox-101.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "b823ebb4c8a2cb1025485cd97967ecc32b08f6d40e41ab3480df937ee88ac7ad";
+      sha256 = "dd8b9baf6d1083f08695fbee6fdf3a3a14e3831d6cc797bc1e9e8ec0818ab0f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pt-BR/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pt-BR/firefox-101.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "08dcf6b0c4f93c7e9fdf644366ae52b05fa895ebbedb5ffac184713482cf42a1";
+      sha256 = "14cd1b927d3dcdfdea02026c3b6a6fb0ecd331652d26f8c7fd344233514ee030";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/pt-PT/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/pt-PT/firefox-101.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "8b978b3a0b58c991013c8635353be6e3adc265c5ae8cad3a4a57273e5c2c4fec";
+      sha256 = "906bf971747d018c847dd949756618c923cfe72b461636fa4ab809e99c0b0428";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/rm/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/rm/firefox-101.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "564773609e4aeb07e39dedfaff3df7fc600b826b53e32fbef70eb7443c4b84f3";
+      sha256 = "9a4d70191390d408104f77595fb8c3442b9133c529152a14edd8b81eb2a9b91b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ro/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ro/firefox-101.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "d3711b0f323291f2582007f4f65f2de729a6ad10b4ee0574e6e14c5f4c70e9fe";
+      sha256 = "778a0242484198f61e747680eacf4391061255cc4969e1c1ea7d23261f92182a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ru/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ru/firefox-101.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "4240da7fa582c3b191d767f1e8f6f650461b34488239b805c9a77dd5bdb46fad";
+      sha256 = "f68bd731b44cb75c82f800a0944ff69f738692fb981dd27a097b60efd96bee1f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sco/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sco/firefox-101.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "c5eb3b80c44ca17831945daf0d1726d801d21240a69567b514483613312289fe";
+      sha256 = "f7f92d0fbc485d099a63b5bb71b349148bd4e475c212e8c4e49f1793f4bf16ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/si/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/si/firefox-101.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "5d2ced80b6686bd46f73025579552e43a699f515fa4620b877e0820dd59540e0";
+      sha256 = "0b6e76241d452954a0438f9e3849743034c47089d6352cb22c1957b40a674c75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sk/firefox-101.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "ad7e5648eddb96b26990a360d4540e8258cd4fe951acbe76ddc25b3a1f77a686";
+      sha256 = "aaecf4614bc84130ae7ea552704e375abccbbd80bdde0848718287d46b61a0db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sl/firefox-101.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "26004863b81e81f5bce8e05ddf6d62e637e6731ff3a4f6c3a13bc4fbe83654ea";
+      sha256 = "9fcf2320a0b7ce031ee2d607570177ec3eefe56b5a3e05f29022b6f6b1d4df49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/son/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/son/firefox-101.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "c8adc653c901d76033c13dd12aec4fd3067fc6ca4ae7bbeb94eb8dc9d5fe728a";
+      sha256 = "70d0fcc6a8ab38fead293a2bf41a4548e027ab34cb1981c0b5cef12301031e5f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sq/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sq/firefox-101.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a3fcaa3ff65deea47e57f719e718c5b938dc71a5cb9c1ca0732cbd4b0719b5f6";
+      sha256 = "bfd2966ffc4f244c1af4b115a559865a86358125ca7485df838fa3c4d863237f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sr/firefox-101.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "646032e2e36631981542aa67c68dd719f0e0a520f2886b3b0c0763165d32f537";
+      sha256 = "6f2044c48819edcbb611d7455d30b212206a6427df74c186e7deff84d46607a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/sv-SE/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/sv-SE/firefox-101.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "27a70a36c93ea3e2d2f6a9fb3df73332c192933fdbbdf1e0f5948db3be8036d6";
+      sha256 = "9fbd49d8dbb4c89447786380e468e74150ed8a94191fb9d942a3bc5fdd1eed23";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/szl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/szl/firefox-101.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "eb9bda106e777ce6a005d21f69f25d842a8ae0c13dfa36ba074f53dd481199a8";
+      sha256 = "9248fc2d9ae25129ea1dd440d6f3e8168c33809156c0ac28c89cf7a849ab71b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ta/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ta/firefox-101.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "d33d4f79c43834061bdfe880e708370a8adcc3dbd56b3cc5f8811ba76bc464e1";
+      sha256 = "fa62feaac98df16853e98d40796679105efba2f2b133959d57a8c516d7bc679d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/te/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/te/firefox-101.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "de525627d54158709d71d107ab7f4f037c6077b1a3783fdc46e247168e2af392";
+      sha256 = "6ff13809cd57fc9415a78776cd809a07ca2731ffc3297c1315f70a80507a402c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/th/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/th/firefox-101.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "53a4f6d8cf6d643aec951211176671a72e35f3c19826d78c549a0763eb48e648";
+      sha256 = "984722c2760f9162ea166c004295b529d50e87e983c30e223c19217bf2957349";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/tl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/tl/firefox-101.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "0e46be2ac97260c1faddd7947ea786f655ea84842bdf825a8937233927296ff3";
+      sha256 = "c7c3570c25909af183593a9cc47dda28417163036af62522b1e762609c906408";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/tr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/tr/firefox-101.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "99539faff861a1a02c7f73fe8aa06f75b7cefed2d7e484a4062a31414a1f455d";
+      sha256 = "c09188f66bc7e84ecf36c316f6858786a76b6431b223141d7ddcfe5801017efa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/trs/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/trs/firefox-101.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "1fef6ce89db57b6a3b7f62b285a11382c5a4c40d26ab981ab32e9ea7bb0ecc9c";
+      sha256 = "4e0a2711a19e334ea2b0b2b0c9e1f6b2e2dd8946ac5afc017f0b360ce92b1597";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/uk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/uk/firefox-101.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "d0ba5c1709f044b7c34ef96467353298b8fda8c776cd8ce4476f852053b55499";
+      sha256 = "16c3317d11f94a098e3998e18d6af803e6cacd9cebf3d8aa7be64bb031ed4a1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/ur/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/ur/firefox-101.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "5dab30c9c8358b0ee59bf71dc8f52f6b3bce86e9f29fd4b36237a27eb940359b";
+      sha256 = "59d7c4dd6cb4a62e01863cfdd176d23dea36c7ba9ffcd0e8f4a87803df25772e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/uz/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/uz/firefox-101.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "dab6538f27b5ce01a883749716428033dc784c448c2ad0539b5dfbaeb4babe92";
+      sha256 = "1874d3bc10804a1bb6ac7b934109649751f694d8eb36ac04c4bfb18df6d7ad49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/vi/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/vi/firefox-101.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a6ed442be9bf1a66576ec063c917d2cbc40c21df63fb344d07ea9b7d58953abe";
+      sha256 = "f4b6bac19de341c1dfec87263e41b4382f8716a9ed1ab61336a29270988bf17e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/xh/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/xh/firefox-101.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a28a22c149f4b11505a21402016554eb5f6fc1f420048ba734bd7442592ebd55";
+      sha256 = "33e01f8d8e6c21afc055f73415c4c4be324cfbc73bfdc42d262ffde0e87301ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/zh-CN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/zh-CN/firefox-101.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "5ae34e6fc1fc7f2d97a602bda9796b37fb7d4020d93e10941a510c9cfaaca8ad";
+      sha256 = "a17b7f914930ebcbe92e5e8fa8ec0ca8fa121939d65c68287ab668db460097f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-x86_64/zh-TW/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-x86_64/zh-TW/firefox-101.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "aab07c9634ca85518f0bab1db8a29fe13f909567345ae312813a513e33511a43";
+      sha256 = "ad987a76a4f4b5b521c7ac6eb1784c84086a7f11d9f9810f95b9219ed9d22c4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ach/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ach/firefox-101.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "e2f1132454d71e4d0dfa19c556deeda3aa6e2363ffd8dc15ec9b755717e6d582";
+      sha256 = "ee933397cb0be5acac1b67853871c5df8ccfca7bf2d8ffbdadd5575218ae317c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/af/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/af/firefox-101.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "0a871d4a04ffafbb7d67653e31980ab24f8b43919ccb7b6f0d1441f4147b54c7";
+      sha256 = "c6d21ddbd2eda266e11dc5cb132b0549868706e8d6897a12c570044f0eeafa48";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/an/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/an/firefox-101.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "fc0277838485dcccae156d1301fced7c276281d90f405dd3ddc1470a63727690";
+      sha256 = "ae66f452b5ff50aa82867184a0111692d8fcdbfe17a5f8fbc88d2345a058cd1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ar/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ar/firefox-101.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "b748c3d5baf24f4d819cbf477cd616f3aaf924a1130966e84dbfb99fbfa6b9b8";
+      sha256 = "1feea62c9a13828854257a5edd93a139881179f52d735558920f21a67c58f895";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ast/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ast/firefox-101.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "39496e3d198f70b7a20a6c79b23c6f8a1d63c762bffef7e93719d8d4cfca33c3";
+      sha256 = "05f800f114645ef5859d78d57d3c14ae8af37b27cb0fee766e948faac3548124";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/az/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/az/firefox-101.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "5d16783595c82248729309ad1cd21cd11e36b7556e8bbd134add392acb177466";
+      sha256 = "7170b694f972a73c88d32b1ce8f95d0c29cd549afc77dcc19b0ddb09bc138a1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/be/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/be/firefox-101.0b2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "269e9e24a50d62c21941883fb3a5db290b12aebadddbdb9b6e23ab130e64831b";
+      sha256 = "503e5f53a9fc97e25df4d7b67b5c97fbb809a2bd6a72a99776f1d30acd628f81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/bg/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/bg/firefox-101.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "6e33402ee18479afb715abeea84087a03ef9d4f26a8e1bb74a96c30efaa48b00";
+      sha256 = "121339b4ced135ecaa3cfa01e8a120f82b8f49d7a12886e81777fddfc9a86d8a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/bn/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/bn/firefox-101.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "fb4fd96e59e3d37b0bb2933c95876d1b6ac8b43ed421e38ddc85a1279298afe5";
+      sha256 = "e94b39bafbcb6d414608b607fda8ac366bc64e498ecc2d6f7ee29f3a807a0cce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/br/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/br/firefox-101.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "21c91db183e5f056a814289cb5cc62118b7a56f4fec13b4d873a5d42bff09d06";
+      sha256 = "e35d8795752d5389d9cb6dba5657ff03326dc52f53b4523e568cb14a9d7ea812";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/bs/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/bs/firefox-101.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "295b9e4a89db50d6895dd47c28bf3471a8302d854d46a8adfea394bfbac9200b";
+      sha256 = "11ab8f6430b63a8ac4a84418a17bb5d7b347a7a887498b528fa3b07c5f69dc86";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ca-valencia/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ca-valencia/firefox-101.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "f3ee2dd40c44b98f5184bdbe61ad724b6800e5c0f7548120f1a54d23adbed0d7";
+      sha256 = "d9d5848da4d1818619e0b9641cffbee9c63358157be344dc6a30ad0e2230faac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ca/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ca/firefox-101.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "9d076f83f3108befe98c3139ba5a9db594ae71f8d0c48cc1071f065b4bf24743";
+      sha256 = "3791d8354df11c7fd77f6e5dae3ee988fe93226ecf57db1d04d31830ee4cfd07";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/cak/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/cak/firefox-101.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "580a9ff85dbb5fc7b7907376d3956088a954c4c8bc3ca7584cd4a79d0741ebf7";
+      sha256 = "2d38dc2c29dca9c6618da8bd15a7be4fba88a866247fe975172556378d703a94";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/cs/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/cs/firefox-101.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "91e149a74e5cf6ad29f041da22f26b13150aff31d88ec97cca857a880158cba0";
+      sha256 = "987ab6a31f40aeb3ba4b4321ff755f8909f7bc78ed1568e01bc0936861d756dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/cy/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/cy/firefox-101.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "149b5ef740485be2dc136b4a90a5b7dd220fd4c4adf91804ff44dd4363890325";
+      sha256 = "df843641be4d316cd6630a30158422c023d48bb0a4dd30622cef4e27b97c99ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/da/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/da/firefox-101.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "a698f6ef0f568d2aaeac9a6bd83c91715d86e0538495bc19cc72babf6ef96123";
+      sha256 = "ca5e5b23e9b4615f5a982b9217dd42b82c1f72b832b3aade4955f9f46f0e3e9a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/de/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/de/firefox-101.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c2e061d645bd1014f4e7f6f78d7a966abcf81ef88d1c9cadac513c65fba5c1ad";
+      sha256 = "e07f89f21b1952310ce310a54428840053ae8f2dcaad5472b38b1761ef32b649";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/dsb/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/dsb/firefox-101.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "47dfee2a58997c6c9f1f858e1ceaefaab326a9163a7d2eebfd1c58cf9638ae03";
+      sha256 = "c6e32545afdec0bfccc5f568892fc77cb226715fde84bdf2651627ab7d69cbe7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/el/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/el/firefox-101.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "36ad5003b537c25002f36cc812b75649c45a65e3d1cc25a8fdd9fa7ad7285ccc";
+      sha256 = "0a3d7ec83f0a64c6dec14f3649bd6335bb3118120d7b3da50fd0c8498fd899c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/en-CA/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/en-CA/firefox-101.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "6e0e5126871c10b7a11172cd885de1fc73222b9f7bb40edc2998655f08bf6355";
+      sha256 = "ce43791e216aa63a250c3d542c4f89eb7199b6d2805b0994f8479a6871f38bfc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/en-GB/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/en-GB/firefox-101.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "248589234f8cfa9a240e9bb1fb0021c16aba61cdb15aedebac8e944eb0e1dba8";
+      sha256 = "61a60147594bea4ce7755d002edc914066f31ac4bab1f2933948b0c0f8987f01";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/en-US/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/en-US/firefox-101.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "0f885cb5e18ed86f35d75835db7deaaceec3afb0e1d5ec8013923d5d2a9c4b71";
+      sha256 = "503b87ed02399c0804edcc99bced3ba07da78781c59616f7469bfbcf8a2ca07e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/eo/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/eo/firefox-101.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "0a1f3429e068c8a46cec4a0d9a33c3d08f08120e14ba69a23c3f8498866c7040";
+      sha256 = "564b49b4ce197b4237c514a7cbd8cba982b3aa979e5b2ada991b951edee4d9e4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-AR/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-AR/firefox-101.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "97915c9b25807fb84b2f1221e7de4442065b85a51d1301a5716d562e5921cf63";
+      sha256 = "5f0b4e2c1078456a41f74b284ae424fa7fee61e99df08b1d1fce565bc65d1e25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-CL/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-CL/firefox-101.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "32648414c5a60d737eda07000e5a257c2a47b17e8b16130ccc2dbce332a7e18a";
+      sha256 = "333b857e916d2a98c38f61561ad9a1203e82cb8ba232f164b4c863c5d5921273";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-ES/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-ES/firefox-101.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1961fbcb8c930a1e59a0b03986421a95ac934f6c6989a6b11fdfb566ddb86274";
+      sha256 = "ee9ccde18f190f18abed18fb068cbd10fb81ccd16c0644316d22f838ac68191f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/es-MX/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/es-MX/firefox-101.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "5f35681b153efb60f95c41ed228c51a562d5e97191a1169cdf80a62d33402bfb";
+      sha256 = "ee18e46695e277001331493060354387cc2dce231e58ddc4c70b693b8a73ea30";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/et/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/et/firefox-101.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "8eedeea42887dd22839a84452057274c78fd248d0af17c95d5d3764d805edac8";
+      sha256 = "1d2a7947d04503f57098d3e1384c5cd5462674dc423cb5ee9f60d6055cf8d82b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/eu/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/eu/firefox-101.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "be1fd6bdf9b56dded4fe896b1de6803a08b2224e53348a8697cdbede06dacd4a";
+      sha256 = "bce92157723f47e97d252be307413b3d2423910e37f2d3064f28065391e4c6be";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fa/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fa/firefox-101.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "db40fd0a7487730eaa163d1886e3c24a5f9a3e41df2b11abf0d6e76b557cee88";
+      sha256 = "33fce9fcd652f9d79cbb4f06f8c6566df7227698ff191d5f2a8135e537018ce8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ff/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ff/firefox-101.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "8125cfc50d585e0ea94369c99fc15a6fa4a7acd2f186e085034b76f8d026d9ff";
+      sha256 = "8f7d299182ca59d040316254a5acad58c133af5f5199b2531388705e9ee74582";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fi/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fi/firefox-101.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "dc7a4da2faa9670e752f2655ec487fa8b54e88a98e00c850bced3b78c8d76ec4";
+      sha256 = "f8f49abdcd30b1b9df88a38320235f470aa9932c554a274fb802e2b4b52fe8ed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fr/firefox-101.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "4c853431a4c212a6074de606d8f179024d1621e8da3a937bff5bc6508cbe4562";
+      sha256 = "3be37bda9be1c9a5fc4fe899010680499dec0e71ddb151f19e18e55a6450b771";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/fy-NL/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/fy-NL/firefox-101.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "bd1612eb9dab3e3e1e68f033b9319a83701e3361039a44f35f2d53fea6d88784";
+      sha256 = "76598f5d5ab6be41b003e7648458d1f03dac48d82716d1072a47047dd4d0aa28";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ga-IE/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ga-IE/firefox-101.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4d8e15ca851e8447fd2dfe5874d6bac21f7735612f84afdc23138d73d5b366f5";
+      sha256 = "d297c383365b1ff0fab543b42621671e96d831f0620751209f04b75b8022e1c1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gd/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gd/firefox-101.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "7a02b828a508bcc61fa90b4d33507f099b6e712c7e76e6663d4c1e2443439375";
+      sha256 = "86bd993b81b67f5d907a87f88666cac72413ecd9450d8c482c31738bd22135e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gl/firefox-101.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "af8f8249705a3fcdd4845daf6f4c803d90b1995989cfd8b6f353a2d8e0f9e9de";
+      sha256 = "e33cffea73148da8b24e59dd7a2e203285af2d08e356e0892dab1a70a40cd4b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gn/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gn/firefox-101.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "61ae6d25194519a2140ba8bb25bc2a7c3dca836e77e7f4301265a3896d1eab10";
+      sha256 = "574df608df5b04549b2d89edd99a829afd2eea768a7dd33b12c21b8db4e00612";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/gu-IN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/gu-IN/firefox-101.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "0536657ee7414ee88cfcf31cdc5df21ebb2a41261dd4d7ff6161b3930a7c00b0";
+      sha256 = "910a1eae44a979c09edac6d470fd5cf19428028c8ebe5a04b27c8029700ce682";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/he/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/he/firefox-101.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "b6effb5e62c1bc6309e761b66f09d904f2302788bb126b03a91ade2daeada373";
+      sha256 = "17b634d9c38d21b8dcb6e8b8ae3d89c54099a2b17b68f7acfc56f10191163193";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hi-IN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hi-IN/firefox-101.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "006c2e83a9db48f6df4623aa5a6b3cc0821f593e2c5e9362e663604e599ef4c1";
+      sha256 = "e9fb302f798ede6c518ec72eb103dd087aae86826a61f6ff260bba146bd66cd0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hr/firefox-101.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4570367de940689ee32b3bf5440306476c560b9f504681f576ba8d3211a2425c";
+      sha256 = "a976d4bb564eba983412a3301f3ccea463887d3e3c115fe702fc009059c92490";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hsb/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hsb/firefox-101.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "370653444070c812ed6b42e95030347b75fdc5b35858490399fbe5b8987144fd";
+      sha256 = "4ef0f578d5deb079d5cbec68e61e756b6c44b36a197740dbbcf473d17576d4d8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hu/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hu/firefox-101.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "cfa67c91337924528a34931702077141961ce73e28ab5cb656698710f6346a9e";
+      sha256 = "0aca5d7dea85d3e0b823f8a209e39b54afe405c9a168d92f04cf8893272d8e45";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/hy-AM/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/hy-AM/firefox-101.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "6f6d0c09ee43e1dc111a7113ed3e8d97c185282f39e4144d2a0d6cf84dc539af";
+      sha256 = "a9595bab34e8034662f6ffc9827e22a97909793bc632ce20f5a12bde711fe77d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ia/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ia/firefox-101.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "3032771db5898b2a479a05d0b9a3b45c28d1e6a4347bb70599fad6d8ddd5a469";
+      sha256 = "bf9e13c8c9ea858875d8940fa3ac3b8440f88279bd1e520bf2e8df3cfa1209a0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/id/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/id/firefox-101.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "0917f87dcbe0eada2e67a25acbaae854559526fb1e0f02f04ecdfbc0b7de250a";
+      sha256 = "0a6e0a680e37d53960cfd41c7218dacf359a2dfd9046e4957a64d1cb70cbb9c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/is/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/is/firefox-101.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "24add589785677ac265cfa8634ea299c9f6940b04884be27a9a79e57c4f0fb40";
+      sha256 = "1a4029b76fa9239669fabb61daeda9dce78198e92c47b24225d01bf3ab38fd1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/it/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/it/firefox-101.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "ca498fc4b33b6cb61ebfb6bce70f514ca6955709b50d086be8bd9bd7a94d1abc";
+      sha256 = "45b29a5e11f55e3775b3fb8079549edb7d2d51ab70a1486f9b119dea3cc1c5a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ja/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ja/firefox-101.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "724f02327973299231772e570e5faeb5de01a648e53157e41d74e8a416efe10e";
+      sha256 = "2ae2d1acb31d8d2cd8aa926b7650b81406444e4abed8fd6e2e1bd245c443405c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ka/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ka/firefox-101.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "dc3e0fa8931a803e20a1ad277a55e598472649a88f10ac90e28571e226d69ad0";
+      sha256 = "730c2582c36982e81a3e86ad8d4c7f817bb32a1812eed3d0ca7692ee45b24180";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/kab/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/kab/firefox-101.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "044bca177a01b9f16c1ca0702c50c5d84f765281c817d0536b82c43fc03d5255";
+      sha256 = "b72a7e0310bc67576d4e3f882999077e7a8f0604dcbad55aa2c854b2cee858bf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/kk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/kk/firefox-101.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "596b5be0ceb592fd855a0b76ab8e4860c2062da66ae5ddef08c9cd4d29f7e7f5";
+      sha256 = "9fa815efcb23f0cc91f1de66b33b9d6fa8e76aa5c03179e0f3808632be25bf60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/km/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/km/firefox-101.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "c73bbeffdb3bad4404b3c27b8d9b3193bd07a0c95468961bf620a3e41e63ef89";
+      sha256 = "d4c451d65b82ef753b651b6404240b2bba5e6798285d3fa2737709e4eabee9a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/kn/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/kn/firefox-101.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "603406f262ee396460687d5d99270b8c72c43bab8d9dd8b4e1904c4b11e9762e";
+      sha256 = "a1d0ba8d2b61f5c554a7193e1f2e25f3901b667107b1a926f8ab2d8b28fafe1a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ko/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ko/firefox-101.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "3977dcbde872183c2c34dd74c8a7c6c70f05a581e07528b3cc2c6a86e97bc036";
+      sha256 = "c52a38a7c830aecea014596aa035dca5f6b2e8cc28e3455657fd58ccc8dc0a4f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/lij/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/lij/firefox-101.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "4e699a00f53f91c494f67229583aa1d4d804589665de8f0509936e74c077af4e";
+      sha256 = "472d0a005d350dc9c358b62b6c428139e5ca784cd6364d73209683c5cdf73a72";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/lt/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/lt/firefox-101.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "9359df2e784ba5141288d954093cc649d98174c0cdea531a6c46e284ef8aa45c";
+      sha256 = "e07ebe646f72849afdb0d8e5c41a7654eab3034bf476216cf58a3b7f8e0c3648";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/lv/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/lv/firefox-101.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "59453ef729d13434fa654381746892b33c61980a8645f1c575f1d2381c95a02f";
+      sha256 = "441ee8be6452b90fe669843410a07b47db7f87ed47795dcbf81d91053ae263d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/mk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/mk/firefox-101.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "af21c80a6f60b987cf89d433895c1f304b0ae4f9385e6550b134482d06e7db65";
+      sha256 = "a2dbd0436ebf1ee64300668771960d0021c744c2dae8ecc5bf976d7a821a1640";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/mr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/mr/firefox-101.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "9b3609ac04e996b33a73ab8deb694cd15b20116b974b12d9b1069dbddd67283d";
+      sha256 = "1311f1b8754f93669011358d574f970f258ca8b32cb5638a12266dc7e2a47595";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ms/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ms/firefox-101.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "71d49a2c4654d59c4e17c2b360f0efe454843e73c051a607eb9c129a17471906";
+      sha256 = "8e78f3a12c599a29a01c9a84373ee799c3b8a8478e452b0a8ba27f4be9e7ed93";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/my/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/my/firefox-101.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "b953c471f3605b5556dd2dd17e25159a7632fc5b791422b2cbdba80c0d06ed86";
+      sha256 = "d6be222fb3161f2737f2e54d0e26f208298162be21197b6b5a6e3c05d8948f1c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/nb-NO/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/nb-NO/firefox-101.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "8912c1a33108017b642b4114842a65acf5ceac38ffcc2865bf7408cb399a4678";
+      sha256 = "c4a2f49f516a19542759296d61ffd5af32640d0e022aa960d6d7f2ec645bb353";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ne-NP/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ne-NP/firefox-101.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "c61087912505bb32b180ec9689107fc111829688d2faacf13fb3814e8bf9b2c3";
+      sha256 = "4b9fba6e4cf8e9ef0878bdda30b12f89b857dba2475adccff386bb492f4efc4f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/nl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/nl/firefox-101.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "2d600c4193e811c62108a1190513bd0018a7455c98e149df341127a2bdbb7e65";
+      sha256 = "2561300f8fd8e53ac16506734f17aea5d9cb5b7d970e4070084f944de54c287c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/nn-NO/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/nn-NO/firefox-101.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "09a5f6d038ddee88bb1bb1e6967c73acbb2943fcf73cee9955d7df35b09d9e3f";
+      sha256 = "f2b880d35f85122c92efa10268f3bacb70063720fb93f85f565ff9d75f4d6a58";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/oc/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/oc/firefox-101.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "d7846a38fc71a95bb78ac3259b6ec6f31bb4eca94d1183211b0a8723db5ca4fb";
+      sha256 = "ea51d91008fef8163059b1b35403c049b236441c5e87df06f7cf5319dd480680";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pa-IN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pa-IN/firefox-101.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "265180f0ff89839e362934a764f611085a7e93b8ae1bae7e0f7eb99d31b3b282";
+      sha256 = "c0332f06388fe11e17599fbd0d2bf4074576d693355f05e0c0ac74b78e8a185a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pl/firefox-101.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "153260d85868f3779ee1ac9ac4ebfacdeb5ec76964505e925c68abd117cd6f4f";
+      sha256 = "ce584b3d90775742be1c521c6e79bc57248eab426d6ea4bba00da22a7e9ced29";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pt-BR/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pt-BR/firefox-101.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "a4e34175bc0aa9c9d12d9829594713644d4145cf40657143651f32a309f4bbf5";
+      sha256 = "6ab1beb2ea5aa1390127fc13f8e0de6555f5ccdee64a96fb382dd0d411e5d280";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/pt-PT/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/pt-PT/firefox-101.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "da4252acd1c15770065d9598436881693f3ef739a502901d4bb36844607d885e";
+      sha256 = "641396a068e0de827b6feb03edf4f71f343baef24e5409d892c68e4ce48ec51c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/rm/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/rm/firefox-101.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "6589408d18e6f023801f3784cacb1b62d46b2285078304d563726f87c79e5870";
+      sha256 = "a7cdb00dddcee0ce416c36c160ce9ab5fedc6de4ad3caaa4c8b14f9a6e1ea05c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ro/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ro/firefox-101.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "bbabd43860e5f6bbff0fa9a3e3c0ffc80d6ac73a32af8ddf94b971d861c41b61";
+      sha256 = "eb360965ed5379374b31030b0db3a66e6637687c2b1ee6dcc893c0308bf5ee41";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ru/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ru/firefox-101.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "7c8455135e769fb8463819c2654a10319ec107a4b41c803a8f246c1c1ecd8903";
+      sha256 = "7da4c79b922a9e03c0ba677ae01271f10c0408ed0125d6c020182572bc6989d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sco/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sco/firefox-101.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "cc783e50c8280bd41d677b9bd9d8f64038c34ecf7ae8e0cfef102da3b64ee06f";
+      sha256 = "af1717f13e40806345ca2042fdcaa5105cbf23845ce63f1e89cbf43e57cf8edd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/si/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/si/firefox-101.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "157aa7231eba1ec554858a496416de257def2c1269697ae369b8c7c02b402b10";
+      sha256 = "673f9978ea53996d6021990373484eede873a13e75bd32caab8d9c8a915e046d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sk/firefox-101.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "fcd1e50fb12d74ed82eb708bc6d885de8c1fa6092cf53438801bdcd33e181aef";
+      sha256 = "db60bfe2a7cb89acc6250304c36c4e665de6c27f788dbb133a68989998e87c27";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sl/firefox-101.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "9dc1e653e20cf71d8b193b56799f278bff95c92de3d088912668f2b7332665e0";
+      sha256 = "22faba05601722a2e01e93bee941dc8065f35bf235037b5ec2259bcbd6c3c229";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/son/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/son/firefox-101.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "10b26692f26c8fbe1b6557df01fe6153b0fefbc1ed30cba4e85857338f8ffce6";
+      sha256 = "b6d6278671e2c7204b5ca7c357390c0abb8ac3fde1ec3f504c808455db990fb0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sq/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sq/firefox-101.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "ea1e6e22af939509d475b3011582fd56f5db36dc17285f3ad82eb4788dc591ce";
+      sha256 = "5571154a698ee65c6f10cebd318b425b265b36c20b6deac8a6a1fb8699aedee1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sr/firefox-101.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6f8ad70d943d4c7e628f8cd54fddf28f686e9b679ca457cf80b2a16d71a72a49";
+      sha256 = "130bb0c0fcad5bb8c7f54bf274a6d4dcb69bd4dc622fda9c32361a2859166231";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/sv-SE/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/sv-SE/firefox-101.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "0ca7017fab9c40b1eeacb41b16df2ddaf06505f4a0761e52d7e38612c002d5ee";
+      sha256 = "02199add3347abd89f5ec93f759cf12fd353b63fd4a2f91ee6b3f094f5512a49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/szl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/szl/firefox-101.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "0fb3240d285fab151c4f337ed5356a3658cd00c513100173945289a44026bd9e";
+      sha256 = "c1a99c03d63bea1b1130a02d30c051778648c73f18f38b294c53be83f7f978dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ta/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ta/firefox-101.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "44c34317983ef10d101ed8915f163498189f3dcaa4ff135595c9b0358a544db6";
+      sha256 = "c01c7a1f56317f2d415bd777e5434366b0b3b2f4ff3a599a25011ef8b90420c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/te/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/te/firefox-101.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "ec9f6ade838760457bb04943fc621d17000c6d181862aaaea9a75c3165d38943";
+      sha256 = "fcda6af3a7611243dac789fec6bf78a8517389ba3df5ccbb50157969281aa8fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/th/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/th/firefox-101.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "bc75568cea6301a007311fb17578bdc4c0aee3d261cfa02fe9daa957ce878056";
+      sha256 = "2d38c379f9d8aa9e7b7367eeccdf656cc9374858e5bd0cecc19eddd6b1a51cad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/tl/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/tl/firefox-101.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "912f73b037376c3b73d2928b54a58d925eeb173bfc984fb76da6bc3449335ebf";
+      sha256 = "18e0bc9c89a0e89151b1edfe498760fecdb66b369e49ca4fa7ef3d5fdb0c4151";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/tr/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/tr/firefox-101.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "30644d7135590255bba66600ccaed0a7ec13f236f21e9ff9f95b8e0f4b87107e";
+      sha256 = "bde092819c9f0771bb463df750fb35eb422862a7e28a308209953461be9c9d9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/trs/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/trs/firefox-101.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "f48442eb911018feb1ce1cab93137e5d09bde2b63be84b1eb44a5e4282bfec25";
+      sha256 = "fca0c955097a04619e834f7bbce4d8bd7f65283dc0dc9bcb07cea7b4d31aa526";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/uk/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/uk/firefox-101.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "2a1cac9d9d36bae12ff645208e867694327474bed416b91f2e06b24ba7146ac3";
+      sha256 = "31c97b928c9a5e7e80ffdcbec67485702de9fb82acc4f0a7cfc7195e8d214d75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/ur/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/ur/firefox-101.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "6ea818062e9e0ae9da8d97db066194e20be9bebeae0a172596890730284d392f";
+      sha256 = "ec9dc26f00786e8dd084d08e7e9c5612e42ada7e5381e889d940915c9360c837";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/uz/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/uz/firefox-101.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "559cdbd37fc19f9fc933a13fc50f4d4be98cb3901a6ad9012c6fc274bdc1af4d";
+      sha256 = "9d4de951bfd5d1cf65718f0118807596ce48b2a6a4ce8d29c8ff3c963e39907d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/vi/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/vi/firefox-101.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b0035df920eddd52ad0aae4633554f2bfda685a10b27ebdb75382fa5ae07f503";
+      sha256 = "12726a8b22fdfe5d3e9637d665d7d4583e8762362032688367d3a8a5b96665a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/xh/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/xh/firefox-101.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "ed27fc27c0d81c5952bd37384bdc4f12de51ee457c8c7bc48bfd2a76551f7991";
+      sha256 = "64ee875cda3543a780a6da399ea7750027e85e4abe62d3eef4e4b21f3b0daa77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/zh-CN/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/zh-CN/firefox-101.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "753d46b0152d9ad4a85079510abfc03d57469951ca5818af912d2e097c348002";
+      sha256 = "694bc6bfb4a8ac1bd95f756278fb68514a69e58c17e1a6576aa2574cdafbacd6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/100.0b7/linux-i686/zh-TW/firefox-100.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b2/linux-i686/zh-TW/firefox-101.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7a75012a7c1c190524db37f7b8df6965e048256025879a1127f17722e325c270";
+      sha256 = "1a7fb5edb2ce72fb7e2b62f2e6e48f56d44522ef7f11af208b8a2a52e945bd98";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "100.0";
+  version = "100.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ach/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ach/firefox-100.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "3e85609f0b3e4eb15262cd8567d8973bed2195f6a19199d76a99ed361cc0d0cf";
+      sha256 = "6ada3d7eeffb7b9e1be26a0d21236e0d1dc6b77743854dac1a7677e1fac1af52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/af/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/af/firefox-100.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "0950ef9c6c9c386df1e2d9f85312d9f3fe0dbc1668aff6710da54f8a3cdbc5de";
+      sha256 = "8e3da7449094c66e48bdcec44289711786f920e9ebd70e9968c92fcd18135d4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/an/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/an/firefox-100.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "af97c6a4dcc34e7edd52111c6ba9480f5ecd2765ca972cb43745ecb54ba01d7b";
+      sha256 = "5976e5e1cec347202cd2d11d56e9edf6bb1932859fad534c8344c97dfb2d0c2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ar/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ar/firefox-100.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "0f9947456cee9db27baffd0476e62ce529b349213ad1a0c2196bcf6d7f0e582c";
+      sha256 = "bddc80f4e86e714a808b068e6970ca9fce2bfe86b1e729e5a7f8cd6b091491b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ast/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ast/firefox-100.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "c0da6abaaecee287732a5e00520d2bacfd61a3a7ca64a5bffe37830f53cf5d20";
+      sha256 = "7c0561731c31b69c17185e7ea9f032d45f9f5f7217541dd867a71e6864632964";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/az/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/az/firefox-100.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "1d57a9d3038dff5a354f24e7ebc7d93d11dccc57be72644988dbbb20c734d243";
+      sha256 = "62505ac8a5543eb163535414e69c5d122097479e9a00d3b9c9f1907f1dc456bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/be/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/be/firefox-100.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d20e556064f10c5730f094b55b4014816df7b49840d0e9934fe3167e135bd789";
+      sha256 = "32ae1685ddeea2acb044db016bddfeceff189b98cd1904a5412debfb194f47a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/bg/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/bg/firefox-100.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "2d26cdef7ee0d7c263599c38d5352268380125ccc3f901f48ed60134badae1c7";
+      sha256 = "98f8d8a0d804183cd74204145173f855534bf8af87d7be91f08c6fdd9be3df9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/bn/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/bn/firefox-100.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "61395cb64c519a14ef879b6b1f9444f727a6ac73074d0e67e3e68a89428c7651";
+      sha256 = "af53e108f0134f85bde8d6c29d513fb7d5e0f3903d12cb4058dc680f3cf8738a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/br/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/br/firefox-100.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "486b59f31c0a63155d04cf0818d5c8629e846b313cd6eabcc762bb0c51adf35a";
+      sha256 = "0bc0db14942ba3a448745ef3f1850fd5a7974dba246c4b7ba0398d7abd142bee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/bs/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/bs/firefox-100.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "656911e5fdd030ee191f1bcab6dc9f2a66f888a6fa726007e528716df5d6667e";
+      sha256 = "b896e6fed373f5104dfe7b3bc0c3e066c4a57a10c7b9ac19802b5d4c1f0938aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ca-valencia/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ca-valencia/firefox-100.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "f31c75df5bf3639bfa4db86cc0237f7602a725b242e6330259ca4cbb61dd715d";
+      sha256 = "b5bbd6eac96ce13d1c979041fd1cb4b5e8ba9cc36d3d966ee2363a6487b1181a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ca/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ca/firefox-100.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "7f53e06ccec188fb5e85a33c7968ba90c88bf1d3a782aee179e3fef5010a33b4";
+      sha256 = "3b5552c60fe25d1d972a5872ecf93614f0fb7c5ca9ed46e0746eeb9f271ab1a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/cak/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/cak/firefox-100.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a1b8349ffe436cce151c5358b2e1d5a928a0ef3e623ef2c98e9f55b0ce2f405b";
+      sha256 = "6362c8cfd78b3287f940bc3664bbd93465b603fb96832cde9abfd41ae14c09c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/cs/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/cs/firefox-100.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "b11f724a20c13ccec73c9058e90387a031e6a9b22e02ae4ab59357d8f191ce65";
+      sha256 = "9b90cc81784eddaf88a6a668f8c5e80adacf74bd6257a58e5e65e5b9284c1a51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/cy/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/cy/firefox-100.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "71e1faa584d6c9243ab806f694e548fec92672f44d6239828fb7f3c5363850b8";
+      sha256 = "fa152ba20395e703a66c8909d41c897566e66e8d40df449d5aa411abd2df3dea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/da/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/da/firefox-100.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "e811e13df31bf0e55904a696b69ca0fd0785c7e60f9bc79fae920cc7bb55ee39";
+      sha256 = "69da786e7acf0f829d432de555d057c75265cd8d8e5abafcae62d80e64a7e9aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/de/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/de/firefox-100.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "22c6c8d312db6b64dabc7d401751ce7aecd3b5889eb8e5538433bbf5aeb55d5f";
+      sha256 = "aa51cec598a71e4f23822cefa2a331160ea813284a32ea919269b94bfcf81330";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/dsb/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/dsb/firefox-100.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "76d7d9ba4483c6b727568dfbf497940dc38871cc18f5cf6823cdbd539d9f559d";
+      sha256 = "40bf083cb656f524ad8db69751c481321bfc9f3d1f2e4b3b58434cc8f49f31d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/el/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/el/firefox-100.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "59f4fab29a3888a7b86b8f50281eff8d3c7ed512a92fbceb5ab3ebfaaa4faad6";
+      sha256 = "c716d294f368139dabc3bd950e5b5fabf0b89be97ed3da70966d80b00c578667";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/en-CA/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/en-CA/firefox-100.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "1c493929d5ab703f59b2e6e6ca86004725dcda7ca23c3a2b34de425e6a969cad";
+      sha256 = "71fb8ec0723f4e65e3cd81db107173f3f591de376a32c7bdb655d7a9a65e87f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/en-GB/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/en-GB/firefox-100.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "2e48068db4bed6722568a35d7a2aaa84b68a8e18304744940c36437cf88b10d4";
+      sha256 = "ca4e13f6d65e2f38e5b2bf01192aeca3d01db9f55442c4e8f614584cfe60e974";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/en-US/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/en-US/firefox-100.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "528845df1a15acf081fdc9e1e7276f0b4601acc9df3553324e02c9c6fb9b7d9d";
+      sha256 = "e36ced1a9f836bdba45b4a657b541e53432ea8540982e137fbd19f2e62734c22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/eo/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/eo/firefox-100.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0fa2f3f4a7cbe7e9e41d0d08ba8649efa84b727d9adb621b408cf7732312fc6f";
+      sha256 = "81a2d2f08cd5f9739eaf14e22290f485a86f1eb6b8122b65687f00931a2effa3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/es-AR/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-AR/firefox-100.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "6afb61b7e361735321934a4189063cc5f424c79022b7482b0923a0204160c2b0";
+      sha256 = "bfdde9f6407c5d9e9cc551a83f7036bcc9e84d1aa8f12513a2234698d186f164";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/es-CL/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-CL/firefox-100.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "382ba75ab94f81ecdaeeb98b41467969b103e9feb73cbbad18b69d5f39013dc0";
+      sha256 = "af26356904b0d303c54a67fb3d0cc3c08e752f9ad3c2c163133addcbc9c11bc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/es-ES/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-ES/firefox-100.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "1a09045c93cceb449e6f0dd9d644abcab2ec30bd39f5c9aab091fc49f32a2592";
+      sha256 = "6ea51a5a857fb48ac780faf8b69358fadfb646be5c429fe83921b7dd6cf806aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/es-MX/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-MX/firefox-100.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "68f0ef188418452de2efc73d3f94a5c1e515bd07b6907168b20b909f7739be84";
+      sha256 = "4eeb15ded4bed74b5f364bbadf616c64615d60d8a1c42270f156d34f7ec29607";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/et/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/et/firefox-100.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "7142bcf0d715b73f11cba9f181f3a02cfeef9e07e825dae7120df51b10697765";
+      sha256 = "d54a20731435be1e06efdba1583b82dc6fa92430dc96359c4f0f545d4785b09c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/eu/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/eu/firefox-100.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "563fed2bb7c6168aa9d973d1578e59c2ed1e785ca82d796de4aecebb8d6dc404";
+      sha256 = "15dfb9380881f0d37147b27597c624c3a93e714dd9cd67a0195b253a67741780";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/fa/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fa/firefox-100.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "f7ec308585ab8aa0e112057cd0af1df524e6712611b7ae93e893e681c8b117c6";
+      sha256 = "c03b048fd67a01591a3dd10f7b2c7cd4baddf843b55f566623a4c358f73380aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ff/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ff/firefox-100.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "d678cc64bba6370a300a64dbdc52343b7eaae73953ddec584038d70dee8f09ed";
+      sha256 = "3777542f6f56e03f58ca5ba34e372648e72261a28290c1af4769891069d5471e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/fi/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fi/firefox-100.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "998746f48e543897806e8024e8e6c6cac3dd63471b3896d83ebd80279d8f026e";
+      sha256 = "ec237a6b72cfcdf6d485e6adddbdfca2dadbd3c380a930b2d17d1d769c503e1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/fr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fr/firefox-100.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "11bd3ad17ad680049dcb262ffa18a477d9d8285040e403b26a2f45a449a63139";
+      sha256 = "08c668bf7f89851861acf067b3c3a48d00ba02d4ccb001fe4e0973c677d62632";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/fy-NL/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fy-NL/firefox-100.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "508f784775df7b89e6144d9290f98e05b17b831f43f81fde5f45cadb0355bfcf";
+      sha256 = "b4485bceb5b98e08afeffdf2e93fd9f0b15c3174fd98716045ac360d76d18a96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ga-IE/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ga-IE/firefox-100.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "3185a57d4a065ed4cc85fac6c3ee14597b25b5f3acdf9f0c9232d7b1935ad25b";
+      sha256 = "d5b1eaee16406e4f6acf77c2e7813b84d3796d68eadd796f8ec3c625aa67724b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/gd/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gd/firefox-100.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "580397f6ec486a571768f9eb4b4d1b5b7e10a9e791c90907c7b0be0eccfb355a";
+      sha256 = "04da8612852941a4a53d38707a275fe6b72d5e49973148de9afce55a3611f570";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/gl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gl/firefox-100.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "485a806aeaafda44d687fc41eab57a276cca691c01a67eae6baf10288e7aec67";
+      sha256 = "7b2360ea8beb7388fff23c76aa9e6712d15e425afa2505e4cff7723d2eb121d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/gn/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gn/firefox-100.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "44a2699e0c3d79bfb2dbf3d4da4bcb92e7a4453daebfd57a53d9a0a6ac3e3248";
+      sha256 = "d7caa55e48cb1bf622a18d92324ef4fa2f043fa87c2c8b8b5aa9490b7c3c72aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/gu-IN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gu-IN/firefox-100.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "5d817fdcff89b4c440580facabb01d30915962d8b076e7e79781f7209bf83023";
+      sha256 = "ca54efbc7e381f14dd33809594b09a6192ca50a662e9d042e73979a4b06f90f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/he/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/he/firefox-100.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "1756cb46aa5cae3d4cdedd720441a2ef97dfc5cfb22eed734f0b649eb65a282f";
+      sha256 = "89cd1649a9333840eb27ed47047c3c0f363b4a4490862ca53ba5ba3d41cefd75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/hi-IN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hi-IN/firefox-100.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "27dcf3edd4b9fa67132c761dc3186d8ddbc0f63b32d5606abd43140a4f2a58b6";
+      sha256 = "86f879f17d580dafc2f7d3a1ffdeb42223398b5e7d551aeb2472c4d2d8cfe3c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/hr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hr/firefox-100.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "1aa433ebcb2b0fc185efd98b8312dc1c5b5315ffb6710e3ab69ceac0d22e1871";
+      sha256 = "08f976fe7afb5752dcea56464399ec64fe645a042f6a00ab5b0ae553ef9c0952";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/hsb/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hsb/firefox-100.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "a0d343a341c593f6b746acb81eab4386a68cd023a5409e0182d908786243e5e1";
+      sha256 = "98b55e66b9a2e5570046341a9ef142bde6347ba66650a499db96fd2d73c8e36f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/hu/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hu/firefox-100.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "de0a800eef3f292b7157dda727878d9ed953c1ffff1c7ecdd2cf49c1024dfcf0";
+      sha256 = "5a629c221ff19cebf9a9e4572688d7f3fda4bd6aca487457cc4b143bec266065";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/hy-AM/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hy-AM/firefox-100.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "44c824309b419151fcc634d4d20774fee6f514df428c6203990ffbe7cb56e6bd";
+      sha256 = "039b211ec8ee00bede3685782d0be71c8914937dc5eecf0df4cc9d34922a969b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ia/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ia/firefox-100.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "edf777a9904981d1b345390a7ab06c23e543f600a57d3e0ce0e41ab7dcca2ee0";
+      sha256 = "fa82e2574af2c672836bf71e526f81064fcb9c6f5f31d9574d73b6585da24a7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/id/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/id/firefox-100.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "458ad2e7a89dfb4c50376114f270d36220c9986bad5103ccfdb11eb5452d6f5f";
+      sha256 = "14064c53c93c6768da1c655b24638dc52e4d6e2399f4dcd9cafec222ca18d843";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/is/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/is/firefox-100.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5bf8868b2dbea3f4d08a4201864dab6682c351912a7cd3622dcda5eb0fc67e20";
+      sha256 = "19b5b8869af023c7dd8df6ed57a9756658569a2488586ba023ce33633339f669";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/it/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/it/firefox-100.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "057b3ee3698696b59b49a66a8622d281c50c35c2b900fcfc95aedf4cb06701b4";
+      sha256 = "1fa2597bc637f274b3c4a7dcafe38f13e3a8cb024deea2221a6c7560887306ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ja/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ja/firefox-100.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "168207c2ed591603529d9f281f0fba5be8c775d130082fa6016ab77a06e392b4";
+      sha256 = "3df4f4a4dfc9827e2b036b57f993b2de579babee21b7f53747f340cf5f4dc80e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ka/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ka/firefox-100.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "92564e5dda8d74245d00d83ef06c29fbff798db36d665cdd69b88d4e00474299";
+      sha256 = "c8b0fe0d2bdc97cbb8f3674f8ab86272ede370e79029e3ea3095d9e75e5cde7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/kab/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/kab/firefox-100.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "c6641d1b22d9fd07885e18ac4ae6d0770ff6c1f88c04d41c6e43020c774a47cd";
+      sha256 = "046dd7439c464d2c8b7a2623db9faa3a532f1793494c5ab4480ce188589684fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/kk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/kk/firefox-100.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "24dce49c8e0c343f3178b0280e01c34716654fa705cfc16f22b5815f2d4c524b";
+      sha256 = "521fea48d9e42afc75644141010f134abe58dd9ff256dfe5ea58dd504517ff82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/km/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/km/firefox-100.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "662aabaa2dfb2d6d217f359979770cc698063816d4f2db28d959cde88931aa4f";
+      sha256 = "dc0ca54c9f7e31f3bf068c936469b4a17cd45758048cdb97fc72da7a0be876e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/kn/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/kn/firefox-100.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "343213168dd6522af4e206a33c9c6f8872853207ecfa34e85189439a46be6aa3";
+      sha256 = "e18f235c3bdb701541d369a226a67d198b9838676d6dfa89506c610ffa18bd49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ko/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ko/firefox-100.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "31cfa145a16c339911b9374f70b9124fcdc94c7fd630263fd19676279f257ab6";
+      sha256 = "9cd09c7055aa8fdf3ea4561093385810bb751c7e46a991079ad2dabe6b692e4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/lij/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/lij/firefox-100.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "7b3cf0ac4286c6ba3dd8167349cefee9f55979651566e82e2d4e979d5f8b47ea";
+      sha256 = "46b17f8cb3a8840346325148101a636fd82fa99b34b3fa6812c2f0ba2b8c1291";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/lt/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/lt/firefox-100.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "47715eb38d43b6cf2c873d7d7c9f643c3e895dc31e64b0481fe46d20ea670572";
+      sha256 = "cdc25ffdad5e09db643ecb51b8b615e7c6ea0690d954d35e5b87085e90ba0c48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/lv/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/lv/firefox-100.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "77afd745728346eeba893bb8eb7bc2517c69f68ade939fd2273c595607f7a4f1";
+      sha256 = "36fb350e44e31e647af95722a859605edf4450658cdcce89fc5654ccaefce3c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/mk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/mk/firefox-100.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "2c287aa2b2854e45b3a49df38d3aa8ded24d63a931c7f37ff320bc8d4358e0a5";
+      sha256 = "72370de9282bd6068f85adc5d85e146e79a8ad5f6a50bdce9484c47f7f34c608";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/mr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/mr/firefox-100.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "4212b8ddb9cd59bc692921d2ab70613ea738ca3a4a23bda0cb038707dda1262e";
+      sha256 = "f2f5008338e1458cb0067c0cb7d153cdfd982810c92f6f82f5719e5bfd87cfd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ms/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ms/firefox-100.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "a0b878c3171af29ab631b734c20dac581ec7c1cd0487835bdb23db6ca72ca378";
+      sha256 = "865fea23b01442d6f1aebbe3653a6c98b9831ca3aa3473e4cab594950550e84a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/my/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/my/firefox-100.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "afeeea7ec03567ec058c5d77e813997f8cda6a654771da1a433a69bc27bf254a";
+      sha256 = "c4c75ba9afc055c66917e4bbb80f2d0def181ac32405420c49a4bef3fc5593b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/nb-NO/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/nb-NO/firefox-100.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "a359e3b9a83aec399890324ab484c811a9a5f615ee8237bf1a1f58d9140432f5";
+      sha256 = "3deb7db3fec4607c31b32988982871eb4be6b493221a6fe52491f58ad703b242";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ne-NP/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ne-NP/firefox-100.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "2aa43032307675ce450c2e35a2e833edddd9ab94626be008785c8226f0d62ecc";
+      sha256 = "c69598bb2526122404e3d79058f305fdfb9664f8be66eaef7b772a0614f1acf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/nl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/nl/firefox-100.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "ca8eaebfbbc6843f1273ff8ae8bca03209a436a3de86784049aafe52d7a3e950";
+      sha256 = "4cfddb0dbd9f2583c9684344f0ff1baec4ef9d6bf2529e1adf89fd68bffac29e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/nn-NO/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/nn-NO/firefox-100.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "5472b83b2e26c8ce88a959cc3e97c140f6e3efdff5f0c9208fb2d599f43081e0";
+      sha256 = "e2d45e33bb117493c923ce76ead2e74e823fbb611c952d1fe1959d9ec5e30a57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/oc/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/oc/firefox-100.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "19552e9822f186ec64e38ce170f0d93f433ba1d15fa25fd7388567af48925bc4";
+      sha256 = "217abdc711b1494d604f34c2b44961721120429f5e3e6d6c49a1ef99d6cf2c5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/pa-IN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pa-IN/firefox-100.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "75f3516e0f14233bb158cde3a57be644fcd6b01256ade0a9cef21ad81d434454";
+      sha256 = "3556bae814e84afd49c205e72a7cad36adafb9881f2f5a334ceb8c8d95f24d72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/pl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pl/firefox-100.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "2cbb208a9f23b39c66c9e50be0a873d989083f0abf9ab56e48e9b7ada91718e6";
+      sha256 = "ca2e5a7c6bb2ff194166a8e396b8fce59a4e7925ff02f483e11ba71d9295ee14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/pt-BR/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pt-BR/firefox-100.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "2b9a5b1d37a000d86fb7cc41977c3ff8444047330ab0b2e10da288e418569905";
+      sha256 = "9a100fe3b01a07e0c17c39b3601fc3a863793bba5edfe1eef3e4eeceb7b025d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/pt-PT/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pt-PT/firefox-100.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "73de91287952c4bc9dc53099ce911aab140bcda6356788e8bab5c667f1d363c4";
+      sha256 = "9fa6de674e0a7d7eae29702a9f2269ae0de2b90b5afd6158090536d23922537b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/rm/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/rm/firefox-100.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "39c934e5c3b08e41889ed47f63e2e9f24a08602e40d20497cc7d9edb42132aff";
+      sha256 = "c8d7dce153de2b56c8ee4b67215afec78030170202b8cdaf78aed488a780e2c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ro/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ro/firefox-100.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "d23606050f9956d22efd779f09db6cb439cf8624cdc3e509f0ec6a7f0e3c9e46";
+      sha256 = "37ef8251d538e6a7666b261e032e74fe15131f4264ded564621b092744469069";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ru/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ru/firefox-100.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "b940390f3199cba2de06ef37a48ce6d0a892c8edd6e0125be088d50fa6c2e06b";
+      sha256 = "57a1da9aa5437571789cbc86b7176088768bd2729a344495430b898de0e6fa78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/sco/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sco/firefox-100.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "3a1bb5b617b7a1633c79b6d7c80e559de15e6e6c9265d574de89628cc246e2f8";
+      sha256 = "0b7537211ff107faf6b94b18479f0a03d695a5fd58fe17496aca910ffd33487e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/si/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/si/firefox-100.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "e90f56c11a25fd023b3fe282858d93504e49cace7c26fd542fef10565f844742";
+      sha256 = "2598b094ba5d970c09d910a5122e8d569d8a429d7ce841cfbfb87df96add5e44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/sk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sk/firefox-100.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "a33f598ef8e2d9865cc01ef4a03a1a0e6ea96231dec4301ada4d128bb672d35f";
+      sha256 = "146bd774e0586a22a6010e03ac36d147bda493b9e815a88a428c719b23532e09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/sl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sl/firefox-100.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "939ffbab94871eb84bf36719debfaad1f160e0b10e0481082e5a1cf534537a54";
+      sha256 = "b0f578235541419a1651a6b2b984c6ad8cef196f8747c2edbdbe4e6bdc401b45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/son/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/son/firefox-100.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ecb166da7e16c925f14cbc3fb4748a039b942f20088ff6f9ba02489f1602c0c4";
+      sha256 = "2ebece0a0d69405a766783cadba2e39f1e2fd773f0cd1df91d6273e77b38dc9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/sq/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sq/firefox-100.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "53b31c2c83fd1aab0b54cbbcf77459c38a8d466b4df866a49b1a0474038651d9";
+      sha256 = "cad14d9094286613eda3adb3a60d7db5423b2466ebdaa05f54d9b5984108de22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/sr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sr/firefox-100.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "15b9b971d1ca2a7ab1422b040b813de9e984c451ea41eab8bad2939c5b9ae604";
+      sha256 = "97bcd1f7fe26bb4347fc685eb8706e1ffe75224363c782d666f6efa85ea51d78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/sv-SE/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sv-SE/firefox-100.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "7f44e7cec1f32a69b173ef832501dcb38002c0b690284af21a53b4862053c596";
+      sha256 = "e96f49fd65a18738c6f835bdfadb46085dafeeab800378a8258060d8ecb43266";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/szl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/szl/firefox-100.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "df3d1186c2472d0e42e36efedd231b6beef43c1dbf18bcb1a27f86aee47257d2";
+      sha256 = "bbc7ae8588435a896003a590ec23f03a73df473108c42c371af94790cc790ae2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ta/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ta/firefox-100.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "d14d94ab5bed1b3c2118d5ac1dd31caf950f287b3b40de80e136b3500bdc773c";
+      sha256 = "62fc3626284d1cbb196c9f4e3bc90ccfabf94c477d8e733f555ffd0ea444777e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/te/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/te/firefox-100.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "e11c66e7eae928a06f3d705ce3024cda3961c52727bed2217ac6dce444367107";
+      sha256 = "6a982566ca6b127b16ad73cd59ed21a884eba58dfa33f8f2b3dd24427ed7f9fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/th/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/th/firefox-100.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4b29e95c96b9c8c5ff9fce146c3d85a1313c849a74694b56de177d921173956d";
+      sha256 = "dc6f630bb651869a04531022a3b17b1fec42a6fbc450e6639e9f4d93f2e60027";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/tl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/tl/firefox-100.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "0d9c3749adc06152e7bf8a72f81e1652901a020abee1a46c9e68b1a37009f96c";
+      sha256 = "0210844f4f6000b4aaedc259acd3c00cd1c92bc79a6b5bbc4688ab96f5e244a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/tr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/tr/firefox-100.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "fea26051836eaec249373404e594329c7a0f357cf94edd93f494989a80e8b6c6";
+      sha256 = "a3da6b5cb4557d51a90d6d70614d5895e4910b07d33347dfc23607bd0e1c9820";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/trs/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/trs/firefox-100.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "cef307d45f53e95ee954731106a66bc313a007dbaf96ec3b670acc392345cea8";
+      sha256 = "931d0b84a4ca86a25b5500c20584c446f2f52fe5aeb1506fc33ac18afbae36f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/uk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/uk/firefox-100.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "20b1054ed238bf426ecdc511a86e1a01c946522caed30a21f8d0b470949db921";
+      sha256 = "7fcde2b430e1bcae291c7ab8bed21d1b72d3c9565a2129f73d3fc63d5574a946";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/ur/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ur/firefox-100.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "3009c02b5983a89dcb331daedc49bfc6bd629161a755a5e29f28405b4706ca32";
+      sha256 = "3ae4339545e6f04b34430f56ed44363a0afb688988e72b8574bb0a6d402beae5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/uz/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/uz/firefox-100.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2ecf4078582f805b624f6ac612ceb10c22d1c2c3fd1a855cb86704addb9f9180";
+      sha256 = "98b1af516b139a005d7ff925c94ec2f8f91dcfd8a8144a5026509f63525a6b67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/vi/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/vi/firefox-100.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a73072f4a152256972a41a38ebd7dd72f1cae40bbb568bd6384bef2ffa8c7d64";
+      sha256 = "2bf7b52cc505201a493824fcc36807c9aa6f712557e6a053aee691a6012978c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/xh/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/xh/firefox-100.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "eec036004690e9fbd1e1d6934b594787e8e269e2a2a10a818096ea5854da481f";
+      sha256 = "5381ea1b5a97e643243cfaac928e36c286ca8252ee8338bdd3ca1d4ceaa3cbb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/zh-CN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/zh-CN/firefox-100.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "b65ee16996593d88be41f19fae95f7f5826db828b3f0d7e40f1dbd9c45f43fbc";
+      sha256 = "738eacf9518b80e6f653d2b7717ac1948b22de62ad6b3ea7b931f28670dd2487";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-x86_64/zh-TW/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/zh-TW/firefox-100.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "c3e5b7119b95c3da1145cdecded90b8194b99f722d41855e5282d615ae2a86f9";
+      sha256 = "79fe50565241c2fae2ad7b0f88100392663549b266a7c532bf4276e7681cf6b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ach/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ach/firefox-100.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "6ada766fccaa1e54ecbf0ee75bd807a42ecbfcedd9f218ff65443aa43f4e18e1";
+      sha256 = "24ce38b5868c80e3994c0e5ba4aabc17ba7b4c5d1166b9d3c3cd77e043392db6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/af/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/af/firefox-100.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "6925ff4e7b2746249c526c11b65a87b95ccfaaa2e3f57dfe38fa5ed8bfde7637";
+      sha256 = "f1625660a3bde1cbf437c0fc74ce29393a9d08b344b12ac4b31356284ee84370";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/an/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/an/firefox-100.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "bf146035e88c2b2c80bd3e352a251f4bf527089fd0252ef320b13752e045b0d4";
+      sha256 = "e48e52c6e04c17cdb8e21adc92f031fe5b29abec58f296a3fecb076703bbe450";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ar/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ar/firefox-100.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "f891728a186e9746b46b12cdaf7a28e81152bf71a361f49b3fb9e048050b216d";
+      sha256 = "1dd7c29e3955730b4abe1997a0d2ef4745b4b7d91407a8332357e9cd0eb2c5eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ast/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ast/firefox-100.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "3fe9530affb6eee7fd3c35d8f3274c0659f54ff45a51e04b02d4685b22283d97";
+      sha256 = "5f4d6f9963d51a1671f9018e86b904f0cf95a2fe4a5d25c728c45e75b2c1a5d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/az/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/az/firefox-100.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "7d62e6cb2de5130e24aef684a014ae72db408cfd3227e0b67f080a8395004d71";
+      sha256 = "3a75c419702efcb7aa6ab2e834ad4fe4cb15a1a65b08903b507336da7429063a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/be/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/be/firefox-100.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "2c7c9285e61e0b74f7fec985462098459475e9932b6e2a44243bf54c649add52";
+      sha256 = "346375d800e68f445a857f65cf44acbef85d950434f0c5e641d6a3d96ff0661e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/bg/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/bg/firefox-100.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "31ba288d27f7b045cc7c685e83f49ec8b9b6579745f7c1ab373a18c8e8264aa8";
+      sha256 = "77e25564ac2a0c88b18c2fba10b43a89f52876226611ab29a9fac276f736bf99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/bn/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/bn/firefox-100.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "927749fadf833f84120c36996e1364e714bf353de6cff38cc68f78af6143390e";
+      sha256 = "f8975d4f080e0e304913fa9f3ca385dc2fd3053c5360cc9bc28b09556bd62d17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/br/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/br/firefox-100.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "82f398c8b1ae36706b8d5e0e1bd12a568de584d342141eab4d35a40abcf14fcb";
+      sha256 = "86bf713dc9f9c1ec03a5b5c34689f8ec6b2f417c8880f89734b3b4dc3d7e608d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/bs/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/bs/firefox-100.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "01609251ed3198064326e99c9e97b2c9128f1216581971896ccbd692ea9aaefa";
+      sha256 = "e265b3d0f30da9011601eb3397ff92235a65f1d0aa01bd50aaf9d1b53eff8859";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ca-valencia/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ca-valencia/firefox-100.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "c35d207480e63f3b2538290e74fe6859e1de3061eeebddc10de4e44d040080b8";
+      sha256 = "dc8d8093d8eb47fc86697ac3c5952446b6e5c399a5dbbe0903bb62f6544f12c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ca/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ca/firefox-100.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "3419b0ce1e30db92646c4675701eb6a7201c0c65b722b3f86bbd90c4cc236ace";
+      sha256 = "64e59c43843cd0f17ba5505ad19a4a3fcb207bdcc0543d10ac0232bb05b2b698";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/cak/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/cak/firefox-100.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "3f19b7d4a9ab541b12f2a2156039d38af9c13b10ff2f80a22dc365e41d307d96";
+      sha256 = "1600ee686b486f9d76c6fccd072f9764ec36a95cf8d1773c7dbebffb06d0f7f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/cs/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/cs/firefox-100.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "2df78b68ddf8771f5e0bb2b24d024a04972a75b2b4aacfb85ac5d1b122cfc47d";
+      sha256 = "bb99d2cad57a56b63de7d07f767a3c18c99322c128b1ae291065e1de7e58ade1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/cy/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/cy/firefox-100.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "263fc246ede739f74cdb5d266a871cfc063fc162c42ace9cd111c2522bd7044a";
+      sha256 = "3f5b740653c9a24e0baf641d73f4f9ebff2d81d5ebd65ae4693d026c7a72d66e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/da/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/da/firefox-100.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "225a09327f2d8bdcd2084eeb5cba8995b899150fe5a42f97efd34e39ca9b9693";
+      sha256 = "132513dc8e51bd169152ba55b8f78243ef2bebd51e60f67f86e22c2215dafad8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/de/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/de/firefox-100.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e636784c7a794d8a18741aa4915c8028dfb8259381c1a0dcccd8a17796a9e340";
+      sha256 = "f89ca6f7b71fc47a09204f698b4b002f2398b883c39ecb7213afbc9563d14a8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/dsb/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/dsb/firefox-100.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "f9bad69c8fda65665c556f736401a4ce522fcc90592aedc7576076fa530a3599";
+      sha256 = "2b59020559917bb713d55fb260852a3608b2ebf50e17be09426f9a5e9d6f6795";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/el/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/el/firefox-100.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b825735e8461779f3dab037360e67fe4fa8d849881f811a179f8db33d49f44f6";
+      sha256 = "53b0f26d985cd4fd9ce03c56ab1ff6649eab5dd10227803f52a6994758342d2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/en-CA/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/en-CA/firefox-100.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "e944d750a11e9ab1ee653402e058cb3f65b46eadf551a29d31919ee1640b1272";
+      sha256 = "feaf69d30202bb414c8e9e940e012b701d9221f129f71ab97b048d0afd3e698f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/en-GB/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/en-GB/firefox-100.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "0039ab82d3eb22e9c8d1036f2d3ada46d37faeb192209b447d3e20dbe0450163";
+      sha256 = "04b848deee052a727f428b2293d5e0bc3236048068a67318ee056d81773869dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/en-US/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/en-US/firefox-100.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "5013a7a3d601c4f532becf4efad8090e73fab442a1bc8599f4195c65d5813dc0";
+      sha256 = "8257e96d135b32e7b8f0a500f2d5ecbc833a58112cd77491209224311f48518b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/eo/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/eo/firefox-100.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "b05d2600e407bf47c1eeeda8a5154495dfee6f0aa7044f089d5fad558134ff3f";
+      sha256 = "6c21f77bda58250aa7931d566b2259b1a78d5d333e97a21a9c9e3a1667ce6753";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/es-AR/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-AR/firefox-100.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "27e30ab50cf1be112c8dcc625d98de5a14495bdc639de9b0e5d8795eab90f4c3";
+      sha256 = "9765a1cbb05caeb3b581c934ca58adb74e9a219648578059975e12b5f6fbdcd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/es-CL/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-CL/firefox-100.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "c82b39f32baf5a63bed4ddd4bd97e7c45ba213957d114559506039986cc78c0d";
+      sha256 = "5a9f1f670a7c324ad84ffdc04d79a822b53c1ebf5ff31c74dc00ada6ec871cf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/es-ES/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-ES/firefox-100.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1ca07d869f0f36cfb79b00cc24f374f546f8e8ed9061caeba9ccd82ea1890b62";
+      sha256 = "7861def3da7db4f1f1bb8e9f6e3c5913fe00b8d109e320cc27e86c3b890adb3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/es-MX/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-MX/firefox-100.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "8775da0ec29b758d82e2c33defe858c45a50eaeb824c34c1e31f97a07c9a9f48";
+      sha256 = "82453536bdbbb709ca314de9d4ab5e0b5eae79a00cbf9a034ee85b95c53b0953";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/et/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/et/firefox-100.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "29655eefbcbb0975f4d73124881c13ce465d0422088d33ea2c62bcc23a94a372";
+      sha256 = "5599fddbf92f9308da984a4f8a2b11c2e1a4c5f890e286f3f5b31cbed1436356";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/eu/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/eu/firefox-100.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "47394c402cbb327335d7ed47670cc3f0c16a875581637d171d3c714d03e859c1";
+      sha256 = "6a25ab3cda70e355d4c013e4be42a96c6151749d4906a399d7f57082612bc752";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/fa/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fa/firefox-100.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "133433694832d6b4d0a03ff93f1a51a52543e67da3b58d171ee9ddf8caf10d24";
+      sha256 = "a6f245cb675b13b9ce93eb33c48008626705eaf7854d685c066aacf61339e812";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ff/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ff/firefox-100.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "16078dcca2ef7dff68d20f29cdf941f08df9ca2b3c247be26e0386e88fc1b16e";
+      sha256 = "6fb187a3c5bb3dc7ac783f0f541e052fdd7e11668a4cdb1109f61b4aeb6c8000";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/fi/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fi/firefox-100.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "2c2a44c45a3f4e449f270b8eabfbf279c922eaa0596794c0fa80b06d2f17db19";
+      sha256 = "e8a59d35683d47b8f2e378d771e7f3484f0471f50d90ea98bb5a6abb4131e02f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/fr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fr/firefox-100.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "59b0f88988d896144cbf6c9f4ed607fc318e8357b2d96c6df6ad3488f73fc9e4";
+      sha256 = "906b61eed97a446ba70b04810aa7ba57adf1434935f2b9e5d8c38b5c3b535913";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/fy-NL/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fy-NL/firefox-100.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "97a98a714e543c101e159d7f3ca052a970421a1f74e2bcbbfdb9b9755388caa2";
+      sha256 = "195a6d20b629fce7cac7f7bc63d91a192ad879b49d5399eb64101fa809c17de8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ga-IE/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ga-IE/firefox-100.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "3221dda3f7d232f986e1e111a6cfb945bc1c1768464cc18d0a345ba140eef706";
+      sha256 = "423ca6ca999511e83b82e137812294381434650a574990e52448f081fd81ab9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/gd/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gd/firefox-100.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "c61156527cfe9966916573cfd7005a16313b134e353258b05e2362414ef0d9f8";
+      sha256 = "c06f81e488a8845aac61495aba82a61ab7852804def21e6873b3b4dd1b495ce4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/gl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gl/firefox-100.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "16f762ba8291f190b165b05f9980c22d93a1612ed2251d6ec1ec18fa465044b6";
+      sha256 = "760eb80e6ee37b5aa0dc48a64e192c64cd896fca6849438542aedb85b6aab69e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/gn/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gn/firefox-100.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "c1d51a4e5629a0f04187d76edd1dd94bb5d55ff2e0757932aa218eec3a50027c";
+      sha256 = "f8ff0112426366d2ae811b9a0882b64229e27d5f3c3aa530d0c02458f784cb38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/gu-IN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gu-IN/firefox-100.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "a3f92bc8d213b0cdd4df2a853951a5f446786ae5d08bebef2799e866fcde06bd";
+      sha256 = "852f4765df495e61ff01ac29e71cc9d5f891212fcb1be33f40fd32b39cdd80ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/he/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/he/firefox-100.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "ea432d8c4cb390f92d42c27101b7b1b3c331d7b1f18a88f6acfbd3ef1b2c1544";
+      sha256 = "f9f951a34d1248c887911f1c668495efd0c7e1d398ac2c807ef06f2cbe038f77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/hi-IN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hi-IN/firefox-100.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "a6aa3110e9b792398860bbb2ceed29d6fa619a8ac73af96b858813d2d388855e";
+      sha256 = "322c3a6c88afb2e89e6e00a524044cb6716b27ff177ab29c962eec6db01a6b1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/hr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hr/firefox-100.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "ea1e36606ac218db3dd39891fb17ce2ac398381ab41102a3dd3170ccc37fd329";
+      sha256 = "159692c9c8243641696bce5b1e29548aabdaaf980eb7f4ee2189804fc74a0cc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/hsb/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hsb/firefox-100.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "ec80f48bcc37a517bacc258411da614c472a5179743717cb47561f8968c395e1";
+      sha256 = "898f4c2196e487b0c39184c5215cb5d45cb5bf2318da1c8c4c2611d9d7235902";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/hu/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hu/firefox-100.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "d8622685ea6132887d8f9657d2e09d5dbcf6b9571cc7c64a85646219e5c972b0";
+      sha256 = "2efb0f45bfbd19f8e4e419f33f7a4902cace0dc6d6e0d2bc83ed9d050eba08fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/hy-AM/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hy-AM/firefox-100.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "dd3eb9c5db97fe3e6c6dd0705406eed897e955423a96e773eb842d2e4d65f845";
+      sha256 = "b9597fa6f653cf7103b1ea316280ae57e2a7f53b6b72a88a3ddf9639afdc52ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ia/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ia/firefox-100.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "7e94b98322ad8cbcbe5ee4bebd84f2ac82a4b78673ed357bbb02a4f0b2c63c6c";
+      sha256 = "80196e2fb1838c5f69a8fcc9b5b70e2b6511a815a34101d9b4fb12c8f20169be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/id/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/id/firefox-100.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "b4bc9b6384b44b392a70144cb71fbd9e6d5afc3cccec4e7c86ad023bcc52dd72";
+      sha256 = "72ef1d83d52ba585ffd45544e7f378f007b9b7cafbf4f4720c9ec03f2638e120";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/is/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/is/firefox-100.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "951d6273c916a84e9139f74f916a9db4b4a976f83900d3e5506356b8817943ee";
+      sha256 = "5b0e468c75003fe6abb3695d19dd19e843cce4c47fdc836811624716e3787f44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/it/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/it/firefox-100.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "ac5c51fb5e42544696d975d769edf81c07e2a42bd5279eddb016e434c1945f1e";
+      sha256 = "596a68e101e6531d56bb8d0c2a0854820b2e5841276040b851cf7ed2ad2a1e89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ja/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ja/firefox-100.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "99c6b533a3e3ddab8dfd9b4a66f6e403bc79ab214027d604671d9f27ae897041";
+      sha256 = "482dcf07335ec9b0b7b63d71c5d6a3300b1f54271a663338c51b33b5e977e3fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ka/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ka/firefox-100.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "73eb8f1c4f22fda48ba752982265363730e23d4695fe2296b30cd74191da3c08";
+      sha256 = "27879b1f25158a13ade851481739177cd5ac4f77a952f35ca55514070c16c0cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/kab/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/kab/firefox-100.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "a3ee102058a90cc02c745434178fe519aead9ed4552d3923eaddfaed8fbea207";
+      sha256 = "7d3b4ba9f636c3fa61febca9c2661fa196de6daabafc63a9a793a38d918f3637";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/kk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/kk/firefox-100.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "0858af4f79d5b8592ce18701968331a19ac0d35d50117dc95096bb9f7d3cbca1";
+      sha256 = "9e74469c19d01a2f385ed9c3e565699c2585e24355964d4aab44f85c12c87d5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/km/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/km/firefox-100.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "b4509b98696f18d19850320f6b9e3d97dbcc0f5f55019cf3e0e62581ebd5d747";
+      sha256 = "60feaf0bc9ec8525d9bb3b1fe06019e92f45fa746835c8e7e5aab3defe1acd03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/kn/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/kn/firefox-100.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "8b9e139b3e0e98f266a77cba5d5a7deb3ee714176cffd5cb2b8f9e8ae85189e4";
+      sha256 = "f2f30c130331586378b7ff34f61f2ff9184be15b2d2ddc028f69d1f0b6a1ced4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ko/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ko/firefox-100.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a43471bf0cb5e36f8e8db03e6d9e8be46bf4cb3209f66c6d721cd8ddcaf1b560";
+      sha256 = "b6912e5f2541003e8eb806b61fde091e3ad6764940d6ccd94ab9df6afa4167db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/lij/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/lij/firefox-100.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "8dadda12fef18c64ed1331eac980c87772a45b821f524f48d73384758a003357";
+      sha256 = "98df2438c65cef3f7093587c9e5d376695af56ba0097ef9f6d50328ceedde314";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/lt/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/lt/firefox-100.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "93dbe1924d766b5dce326597c7a5557b26bf1137bae68bed6a319ce5caf63ab1";
+      sha256 = "049cf802b99fb218db3a1ea5d5709120d139a40e10619f7e859df469ba506b68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/lv/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/lv/firefox-100.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "a161963a911846e93e64beff2eda2db9bf449f266697214a4483dafa97d1a2fb";
+      sha256 = "b774821e5e5abc1d9cb0b023b011dcb82b551351684ddc29bb8a1abf59d9e09f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/mk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/mk/firefox-100.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "77db19a56be146f189436ca7d6c71defa6006ba3e34f2e10a8d1d362526dad71";
+      sha256 = "bec25ffa39198d9a4f2fc5f69e3a0bab7b2eada13912787aa6b135b0aef2336c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/mr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/mr/firefox-100.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "fbdf4862658eb780d499f089c1fa89b4374945e1990ed8892b2fdbaeffb28ed5";
+      sha256 = "0bb35cc0198feceb8a794b905437d823ff692740095919d9a5d95b8d130f51fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ms/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ms/firefox-100.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "16e5dcdba19020f498c767732f3426915cb5f9b8f5b2be3adb2825d0db52a1d4";
+      sha256 = "592dce9e358601c01fbd93b7dd4d2b6b8cf9b07be7fdd193478e4c220a134aa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/my/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/my/firefox-100.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "c19ed3d409233f055ac633b4baa40de0e2be99d731f3091f0cccf772eaa39f2b";
+      sha256 = "bc5a831a7d2f107e2706b5f961dea62588dd65c02d549b04e399676d74e7e01b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/nb-NO/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/nb-NO/firefox-100.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "c36dd328395d5fe3e7907d990e1f8185144e93961da9d8aaf81a1bbede55eed8";
+      sha256 = "337930769e9c2a59fb06e58fe75cda8327df7c172fb63cde6939427f1b476024";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ne-NP/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ne-NP/firefox-100.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "6672d29f0fb08645f7cd4b7b7de2edff850da86e29f078fe7e49c10dbf4c35ca";
+      sha256 = "cf893e5a61a9d70bc5d9daa9f385a1e03a5023c2eb2baded93726b1b3aef07a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/nl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/nl/firefox-100.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "71f9339624aa2014238c35c78142a1fda6762c61f5b199becc0682532c9c8de8";
+      sha256 = "a98042f35aeb7b040e63259bb86a86608af79e9edf50f5b23a11896a97f7045e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/nn-NO/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/nn-NO/firefox-100.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "5f9f59d3ef36aaa01d3b058adb9a08f09e184ed408d1b5b25ec415c3e83b404a";
+      sha256 = "94413cf0f5e40598f203ab6425d080718704fdd5fc4a85be463ce653060b3faf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/oc/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/oc/firefox-100.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "76d7b330ba2f5c7df4df6bdddda7a887a5222f0ba3caa13f77d6ea956ec7e685";
+      sha256 = "5800a59ea116c594aa4c362e927379a497b3c3f1baf1f107d3a703ac0b265e54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/pa-IN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pa-IN/firefox-100.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "569b151ad53b47338ad8f78d4266247e7e7fa4ef207ee58b3606dc299b0f16af";
+      sha256 = "7ff731e1b3d41fbc6a79fe53451e7cc4072ae9c887a62e92251d81a3cf9224ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/pl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pl/firefox-100.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "af4ca741d8eb82e40775b0a2cc9338c2e81854df5107815bab8f4b6188c7189a";
+      sha256 = "406af31b7fc942eb16c64c2806cd5b73baa8579a5485908b0e840d09e0f7042d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/pt-BR/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pt-BR/firefox-100.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "16ed593e6c116418ca5969a07fbcbd9f93af3972edc2227271256d269066b61d";
+      sha256 = "aee93d65a4b17c020572e1152d4cc19d4674cf116f047c76a87dd8ad26bd6847";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/pt-PT/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pt-PT/firefox-100.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "2a5b5a26185ff4560691d5f32fbb29ecd9123df63020492aa2829e0088aa6b1b";
+      sha256 = "eb2039bb0858f3d311676d1452c8bdf590450f8a189b3701829a979dd41736f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/rm/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/rm/firefox-100.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "e80cf9ebb3010c97acd5d2f6cc672aa6ce4fdca930974238a148c2683f8a8dd8";
+      sha256 = "afe95de3ebb394257b09e790afedd324250e099e53ddc301ed68f93f5dd2b33e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ro/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ro/firefox-100.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "4db1842a3ead551700c83be677aacdd00e1957ecb6534f2b8933a19a6eedb38b";
+      sha256 = "6475e10dc4c37c780b4b3544500f9583f4a8d45f11f64089ffc25a261b20296e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ru/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ru/firefox-100.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6f821c7186343dc0bc5860bce1ae24f45c3de253223a0e99d05e582f037e7447";
+      sha256 = "72cdb657fa263fa475297620d87e38c26dc64c979e07be81cbe0ab7129a11e70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/sco/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sco/firefox-100.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "e213b13f3ffc309feb993239308053d029f200fa58cb35f27a52e540e544e83c";
+      sha256 = "4193be83fcc2b792bcc3025500172aac0c2123569967f2e645bdb37d907ed440";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/si/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/si/firefox-100.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "a59e9a00f0e1b054e08706abb823ec7c6a87ca0975b97444f6cfd265e0c25b22";
+      sha256 = "67d3f460bf9156b4715390247f7f4481cdee8b25583055cef0e4ba18daef1159";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/sk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sk/firefox-100.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "b6602ad437d41c679d43cbe7e705bb5ed31909591a8ef51ef4b5604b3a4c884e";
+      sha256 = "67a16caf8b1e1d23a99a038c58f33cbdc942e04e497afd117dd96fae417e6e4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/sl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sl/firefox-100.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "b82f1f2745235271d7a99ad0c36f664b67826276a447285165100678f4de3030";
+      sha256 = "61c12adb77007ea54c3dae44d174d86f31486a7cb6b45e69370dd6897a2ff792";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/son/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/son/firefox-100.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "508c90bede375fe243f39a6ee26b972e0ec86bfa2978f3d01d0e83784731cafb";
+      sha256 = "0529e0adc9ed86507ebdc8ab129529ab4457d7987b205c746e0899a8727336a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/sq/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sq/firefox-100.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "db2799e56ade9c1b691d41803255a5fd1ddc08c69e199f5c1b253df11249cf67";
+      sha256 = "c773d92b78498d544337cfc05e61342ccf51faddcba5f28394d3d1decc31f468";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/sr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sr/firefox-100.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "d3502cba898ee0009292f942c2e3fc2ca0225cdd2470667bd943103fa7770201";
+      sha256 = "40192e74663678ebb06c19af919d765ed11692df8cbc4dc75ef4d5e5d865c096";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/sv-SE/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sv-SE/firefox-100.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "eca5f29ebd1e756206dde952980c03b8d4fb19c544bdf814bdab5ed05ce5fef3";
+      sha256 = "611190e442f223b5502c1631725c7058f8c5dae094bf0510b6e59e603787e152";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/szl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/szl/firefox-100.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "fbc098de33187fde99bbf3d205882d281e404140619d624961d0b8d1af7e3fed";
+      sha256 = "f465417b16937405f084dd8b61233fb13e9abc2bdef5f2914d91b45c89afaa58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ta/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ta/firefox-100.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "a3f3f3472932be60c4f8296a13538bd12b898057a977dd7c33edc12016438dbd";
+      sha256 = "d20fa90ba3eb82e8c4322eb96baffa5b74a22ae9d5b9225b4fff0031d3756d24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/te/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/te/firefox-100.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "d0b562f554afa76bcc034eca7a167151a7ee38c6e82005d9a47273df08e6c0f5";
+      sha256 = "cc0ab7a9a27a8899fd693f9f040b0e5c954d21c63cc54bf89ca4205e0fe03fad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/th/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/th/firefox-100.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "c362a365677131af77786b0f6390b62bd224ba26b7f79e69ad1826a6a15800db";
+      sha256 = "f8530e492521e3426573c3bb642d714ba3368d1a5f0ebd0e29655e868a19a2d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/tl/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/tl/firefox-100.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "8249e0d3bb2aaf5c0be9def1842874af417bae275ba224c912371049de62a43d";
+      sha256 = "0e9fda135f96c8c6b0a515e5027613076c7969f70eb480aef9bbfa516fa109ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/tr/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/tr/firefox-100.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "82a3a504ba862849c4574ed96bdc5a737479a06a21f011f6cd74b2001bb192ff";
+      sha256 = "12a9d9f4fc5f330b6b98c7ba40e61d764cd9d3dffccc3797113ddaf57efe55be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/trs/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/trs/firefox-100.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "da6f0d69580df77ae2b1d091aecfbeda640440d3a15348ac38221209c6674079";
+      sha256 = "e91ab97279eb6e814775984c88c20a3c00654d7ec9d6972c0d460f3f39098c74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/uk/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/uk/firefox-100.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "c04848cd11abb05635e33977c98f76b4acda3a6807c8f5bc8b5d2a9b49208f1d";
+      sha256 = "f3b39c7919e83c0dd1293e76e48d7f97aacf83ce0ee5971880ca752c2b31bdc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/ur/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ur/firefox-100.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "ba779105d6a9dfe3138f4b73ba60078ec66ad9fe8468f2d72f57dd19161fa09c";
+      sha256 = "a2653a31b730d3b76b0d785f861c85ea817b55632fffc172bb3d207e62b801f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/uz/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/uz/firefox-100.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "190691fd5777153daa29d56542f6792356aa916073d5e842845fe1c9444e632b";
+      sha256 = "2842862fb1579833e629aec52ff883dc630966c260fe18f88978cfc500abd8ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/vi/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/vi/firefox-100.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b5ea01ae5980892d6379eac4ba7d0f3d2643c54ade18452d39be84e44c676c01";
+      sha256 = "595a53c656a2e4ba03490e1da994f6db8d3d08d8033204fee1678b98e9d0a5ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/xh/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/xh/firefox-100.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "6c2f218caa8effa6fd6d9553088f7eb9a8ccf6297e3a9cd8c57d0ec5902c4c19";
+      sha256 = "e76d00d6e119afd9e567f9d22dccf3a01886b0b61d65ecc114704d03022fba3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/zh-CN/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/zh-CN/firefox-100.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "61838f9c25bec8dbb0d386ae8412f34be8701e0d6f593503eab51c2009c5e069";
+      sha256 = "9e4d863b6b1d614e0c53247b7bc38af5b2ec606d851e00f33f3524fde9f50e53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0/linux-i686/zh-TW/firefox-100.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/zh-TW/firefox-100.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "48ea7e4ae524dbb9ef83aada60b597524091be85a1dfc3665d1fdc9dba16498b";
+      sha256 = "9c26d129e3454867c1284ee410ed12eef163c6df71306322bac3ec38b77e79fb";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    version = "100.0";
+    version = "100.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "29c56391c980209ff94c02a9aba18fe27bea188bdcbcf7fe0c0f27f61e823f4507a3ec343b27cb5285cf3901843e9cc4aca8e568beb623c4b69b7282e662b2aa";
+      sha512 = "6ba09542d1573e903978f8e63f39381dcf2180219e80e7401c62c8347100d6d4a973208b8094cff07d76106636cdfef93829fff3398011fd9536dac477ef118e";
     };
 
     meta = {

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,655 +1,655 @@
 {
-  version = "91.8.1";
+  version = "91.9.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/af/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/af/thunderbird-91.9.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "b7a5a88216d094bce6d1f18f506dc4c500c13340e0c6a9da2aeadc32d9ae0062";
+      sha256 = "9a7e2e7501710134294798d2d7d5ba9d11b18440e6f0a09f398baa3b9c5e8aa1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ar/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ar/thunderbird-91.9.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "33f807c2a2182149f2da7a394e455775027753a082b998db766c036d0aa7c976";
+      sha256 = "2b77f10e1152158cfee96c840d86a64e3fe831c675482ef63b2220cc65565599";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ast/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ast/thunderbird-91.9.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "08a38759b492ac47e567774b5a4fe5ee75f5a4c513ee046b7ace9636cd61a00a";
+      sha256 = "e3aa8dd11bfc018c0025628020aeb77e17ad975baaa84441464c704afb7d0555";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/be/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/be/thunderbird-91.9.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "09644be773dea25b602b30c0e783a2be3de406d63a1aa528e80830357cec8756";
+      sha256 = "f78c3ade5637eba2dacb34437cd2b158f7e5f1a95988bd400ca284a04a283fea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/bg/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/bg/thunderbird-91.9.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "546bc2422a40ed4c04b1d8fa2c203a60fbb8c2a060b7c63ae4464109d08c440e";
+      sha256 = "85c411d57556a0365d46174ea1fe7c0fd19a697a9ddd9dad0a83644749782b7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/br/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/br/thunderbird-91.9.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "1977584751a826bb52e8bd154880f34b009df777481915f0cb84e018f7a3a1fe";
+      sha256 = "2767877f299b4c871ecfe861d84975cb7e1d17715a249410b6d1252c3df42611";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ca/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ca/thunderbird-91.9.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "e2c6e403fbcdb58eaf747f36796d4a0af1d8f112715c068ca98f85198189e884";
+      sha256 = "020ee30e402972f341620c7e37981a6a197378c1cafaeead0af71bde56a66af3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/cak/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/cak/thunderbird-91.9.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "f5992ea2ab6acf94993f6bc590e95e36c5ab87b650e0f38ee5e808a2bf9189da";
+      sha256 = "11b911c4dd1cbafe84406f0209379e911d047833a126c47523889f62e9a2b512";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/cs/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/cs/thunderbird-91.9.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "4770e0c95ba84953aab5585f4059c1e20e69b9ee98578ebda34ded2a1b170a25";
+      sha256 = "834e66f9f2f8cede63df9d84b66024f6b848a847fcce7229d74880d47751b7b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/cy/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/cy/thunderbird-91.9.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "a9729784e7a05d763e6dd715da80ca7f65e42f27b25e58ed2139f26f12061855";
+      sha256 = "df5fbca74bc8f1f42c4f20402822b9b0811c4df7e740336c51853d83dabf54c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/da/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/da/thunderbird-91.9.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "a917c157c7507d2ee457a5c8dcff3b1b23225b5ea946be547e801e93c10d4a5d";
+      sha256 = "d836561fdfdf1ce984aba8913d5d7d8709a1b4a929774bb23d12ede7208be9ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/de/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/de/thunderbird-91.9.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "73141650aba88315828e5419d9a9a05861dcd504b9256c8a184396e3824211f2";
+      sha256 = "a24ef049b9b14f89421144f883ddd19af3854339b74d7c9ffeeb85a15fb7bc0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/dsb/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/dsb/thunderbird-91.9.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7b7adb5c1e01efa9a0129a22308eb878f45d1ed0190b7430aae92b55f061fb35";
+      sha256 = "741cb5362255fac4f5fd087f057cfbe2a6f11e21dab45acded8f217a2be4de5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/el/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/el/thunderbird-91.9.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "ffa921418d6d334e48aa51f4fff1b4855f3cf7ce3ac77ed38c6b0b699606d971";
+      sha256 = "26bcbad1471e262c34125eb8f7671b0dbcb44dea78c5a03e235e1708d052efcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/en-CA/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/en-CA/thunderbird-91.9.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "caa62088b677cbf18cd95a80ebc57b97597df35f8172d27a7cc55ded145e29c9";
+      sha256 = "22b90cbb168b0992523205e4f7af1b4acf3008c4ee84f5afd8249dbe31122178";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/en-GB/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/en-GB/thunderbird-91.9.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6dff28a894f3b48798939105a9742b3f9dcc3c4389160f71126cdd08ff573c74";
+      sha256 = "ba13594d0a4f612000c278a6c0ce45fc83cc16be8f6f792e783b9e4097fb657e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/en-US/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/en-US/thunderbird-91.9.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "3a6c1302f51a86297960d40f40fe6273349ae407b07e634b1c01758bc8cc3a0b";
+      sha256 = "8815aa634aa4ecd7663f65b4d101d9eefd719debc0f18a76aa631637a515788a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/es-AR/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/es-AR/thunderbird-91.9.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "383d13f5094543f99dd64e29df261c956e6f13782c3158d4ac831a8c734b7d18";
+      sha256 = "5e6ea5a2849dc6885d671a16dd120e711e0462defc79292c46cc473cf87683bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/es-ES/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/es-ES/thunderbird-91.9.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "d2753f076d929933cb51e79c0c0b66f2fc3457e3f25bb68b9b10c84566cfb70d";
+      sha256 = "d1bf062fd21eb99e88b5a506cc73874d77571bdf37d4836174844537653186d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/et/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/et/thunderbird-91.9.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "a71e3bdee857892bd62d582fd6cd9e7df41be92854c65d34b26b57fbad16ce2f";
+      sha256 = "c841f7987818ba478ea74beca578cfd689016b55d3a1eaf53e250a5b30d60e31";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/eu/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/eu/thunderbird-91.9.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "40f3aa9558eab5511c0176dd817880142e49bfc157546676ce15d559ace8e359";
+      sha256 = "d415edd9c0bf60d15f504ef12ee24ee7a63cf09a0e4c069ff6ab9695e3359ce2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/fi/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/fi/thunderbird-91.9.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "c758f45ff3b714e6e7fd1c66421a0f815ac54fa3590df682c11bd05f604bd848";
+      sha256 = "b6685d1ea83fc5b3dabe8db910e0f76eb85cfdf45d6f508a558fe38b0adc3daa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/fr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/fr/thunderbird-91.9.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "1e2588b80017f6f10ada4675c4af5165de9216d65881f20feb844fa59fa60fbe";
+      sha256 = "848e77ec6c0e8a0d8b66c5984d56c4fcd270351b942aba72984105a661f77e36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/fy-NL/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/fy-NL/thunderbird-91.9.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "c3ab99f1539a40f60cb2b3ca68178307b39b013a763a671ffd05124ed8d82988";
+      sha256 = "f977281f87c12fabb61a1bc73b3adf9b5a6a9ae6abe7c3bff590162388313809";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ga-IE/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ga-IE/thunderbird-91.9.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "7af72cd55c26e368378a3b86844b6ee72f08b7f2c207170817ccbeaad1a114a0";
+      sha256 = "98b0e23dcd4a4759427cbbdffa6cf306d0e6bbda246041614f0824f7fc35c487";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/gd/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/gd/thunderbird-91.9.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "9a91e7b6d3572ee78a4df915a2b30e5dbd10351e6f16316e6dbbbffdbe1217d4";
+      sha256 = "316f05c861afd02e8d8f84c65d4d4e9cf3c110cdb92d5bc1f5e675e9cb5247b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/gl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/gl/thunderbird-91.9.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "2c8f4043668dfa15ab191ed05218c1772472dbee932ea98e3cc08c05764812cb";
+      sha256 = "a75a9fddfd57dce2d31c8d13adaa3268aff11ae4b40c3ac4434df55d0fb467da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/he/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/he/thunderbird-91.9.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "e3b038e94553d388eb4cf53c250d8297531ddb2fb0fc7c678291fa48c46fbc12";
+      sha256 = "b553ff588c310175aa06d8783c740522ee0dcc4cfb26fb173731bc993f67b818";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/hr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hr/thunderbird-91.9.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "a66c1c904f58879e11ceeba5c214302fc982468718af1567634ec53d16850cc4";
+      sha256 = "18e46ba1050ff7cbda89e3eb6e4fbc1bd5f80dd06506fa0d122a659edde0f29a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/hsb/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hsb/thunderbird-91.9.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e2f3b04485ba430799e1049ed9cdc4cf191014f6a2aa44c3f8e51d87d47332dc";
+      sha256 = "bb8422e3ea7c8b9ef2a3fac6dd2e76b8944b426cdd6bb711dc90d34900bf69b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/hu/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hu/thunderbird-91.9.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "611bd8281d26324503fac16bd6e25175c988f6fb12b6bcf6f3016dcfa6ec44d8";
+      sha256 = "fc3ef5d1f1a1b0f3d1cb960520a1c64d649b974d7ac00a9425ca9b15df721b20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/hy-AM/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hy-AM/thunderbird-91.9.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "88cd6e24ae4a54f0b4684bf3ab7116fcdce2dbe2d6a074af5cb50c3967ebda1f";
+      sha256 = "beb591f7fc7b724924bc3470b9b09c76d027b3a0f0839e0dbec50b30619861bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/id/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/id/thunderbird-91.9.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1be3f82fc0a8254548c35a08d2fd4ef77b86df774acbe5bb17784d25af802eb7";
+      sha256 = "763b014909a2859a8c3e95b12b38ad481e2418b635fa76bc95863e0a05fb2f7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/is/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/is/thunderbird-91.9.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "332e85aba591c744a9d53b70e06218fafbdc94600643963c63f6a693edbfd035";
+      sha256 = "13ea8123543ff8a14da10e619e71f71d091d953d05a16ae6eef628b223eb1e8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/it/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/it/thunderbird-91.9.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "95ca9342dd991d8306922df03c5f09adeb63dc93f678384989315ddf1df622d3";
+      sha256 = "797c7e71a2189ee4b306aeed63c7c3781cf2a056dc0c654cb163b120531f2052";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ja/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ja/thunderbird-91.9.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "977a0e4ca8d9e8d8d6c289608a9318971553b011bbcda66ee888624ef6b9d56b";
+      sha256 = "1c96839f767eaff3edb4478aad1871b5353380c3279063e06cfca9ec8b584974";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ka/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ka/thunderbird-91.9.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "1a8360cd576a4e2a0b6d316441eff481c2a1d9b80e7f9eeeb0fc6fc38df08d1f";
+      sha256 = "fe537966801a2943d098c12112c21f23665c43d36f74ceea4f133dd584c29902";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/kab/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/kab/thunderbird-91.9.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "d318ccb72f4476d8222eb4423c755378f10cf187cc6ea73152833953375cac35";
+      sha256 = "8f73600ff6cf691c70dab81014b1dd561fc6dd24760b7b299d2c4cfb3d302c0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/kk/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/kk/thunderbird-91.9.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "854f310728f2c1c2e3e3dec57787bb293f344a31cb1f0b8a131f0768c409fb08";
+      sha256 = "66da7b225492be2f8eed83d3babc8a0a13eca244b2b0d5b7437a8e74b75c1959";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ko/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ko/thunderbird-91.9.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "c740a972a708627d9700c9dd3b2bb56a5b1a3e0ac6f438021aa56033e6e6b40e";
+      sha256 = "8157a73e18b899f99f2a71430300b329ae8faca13ba668270f216f0a43a1e5bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/lt/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/lt/thunderbird-91.9.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "7a1c14eb2fd539dc9e2681a8868fb6e82ed2e9ce0b9523a613e20a48ec52d2ac";
+      sha256 = "188c85d228bec3abaae34d1d6f90f986ca956834feee84804c4495626deda52b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/lv/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/lv/thunderbird-91.9.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "bde11f8e943b462f4c8a084ee7d1328f59e93a6bf2d39fed8a3dd1408b0ee716";
+      sha256 = "2abf6f28470ccfcdaa742012edb1f5c5041c6590b5c49204527a59983291d7f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ms/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ms/thunderbird-91.9.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "f76f9bde41a1be40c32bb3fa1990adba3460bdca0b98e466e6dcbbc6d8d944a0";
+      sha256 = "99d02d8a0a17f01749aff5dc0785fa4a22c556ddb4ae80b6d629d19beca5f9c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/nb-NO/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/nb-NO/thunderbird-91.9.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "e8a052e7c841feda1c54b5f349181695c03f2549f95ca1d9108b60e8dd13c85e";
+      sha256 = "82c0ec62f1c6c6b4862656556371b9dad8804eb3199e0c357ba2f5e491897d32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/nl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/nl/thunderbird-91.9.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5eea4e47045706a621ca398a55a76a2165d461c061ea3e410418839a9a069ca7";
+      sha256 = "48a4cb7792ccfe6fcd364734efadef7dbdf37e93695537b3bad25e54f4863e97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/nn-NO/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/nn-NO/thunderbird-91.9.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "a819e0ede22abce7d3e10ab1dbe3d4571889c63284e6f1c917834f766ad3c73a";
+      sha256 = "dd3b69bcc83296beb03a1fec9675062be98c4eefcf67074691d1474d5d9a8265";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/pa-IN/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pa-IN/thunderbird-91.9.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "523f7c451f618b1f7705d0892b50700f61c0c3a12ca85957630e5e146ed7eccd";
+      sha256 = "212c9ee1beac598d885425d4960b5f479f87df8a8ca0e362b288cd2a5dfbc0b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/pl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pl/thunderbird-91.9.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "45d17f737b24ab1ca34e7dc5d16493203e1673c4592a099b3dffa8559908b64b";
+      sha256 = "75c2a144e3217a73827868ef130efb5f16d1924739a9cc3ca44ba80f0eb28ce6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/pt-BR/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pt-BR/thunderbird-91.9.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "d4d3cc55f0924a9eefb2b76d3cf524238e87ee0f016b5fcb4df59c28a6f8539c";
+      sha256 = "61ef799e1364b35c2a795626fed3bbfa525ce4a78c88a505afd86d87efd00a11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/pt-PT/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pt-PT/thunderbird-91.9.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "1a6b22cc0fca62a1fac036b87f04a7ef2d101e8a4323e370856338ceffd3193f";
+      sha256 = "3f8f817fa8358990bc95fe2ece3541eefd3d782bf82116af3a6a555b1b01fc59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/rm/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/rm/thunderbird-91.9.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "cd9b4f7274a3fe1c5c29ac68377b82ac134a9d23828700399009021ae6920c1e";
+      sha256 = "31dfb6c6a9d77d22d49a077003be98c6228c52aee541e2f31c407c9d7cd45c24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ro/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ro/thunderbird-91.9.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "0c0dd2e9612c64eb2f70d52f32fad70af989537018d2d1457941d773e5d8200c";
+      sha256 = "19dcff1362dc909d70311402c798b6359ea8da9b3fdbddb18114c71f47226ef9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/ru/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ru/thunderbird-91.9.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "4f89db6c6bff251b9e642b6525e2d6dab30fd5faddff814a8566e3db0109f895";
+      sha256 = "231b1f5e0ce7a502581c7cae0ab327b867e96cbe1ec49a7c24522c38d69ec370";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/sk/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sk/thunderbird-91.9.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "9b7c6e1536dd288634f1e635cf65b59bfd8953853143ad4611b66189119fe8ea";
+      sha256 = "ce2b6fb7f4d3204f2b11b73847d06705ac5df064e65291f2f505cb59108ebb7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/sl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sl/thunderbird-91.9.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9b55f025b7b64d57c0ae1ffb54fcfd24dfffedaf8dcfb0cff870e5023e018e22";
+      sha256 = "d8b7585b7161004c700f3aed7d70f24bca77fe680cc43150c03802f2ddb8a4ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/sq/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sq/thunderbird-91.9.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a7c42d3f546482eec81a021f299bc57fc05d349cfbfdd65ad3dbe46019e29851";
+      sha256 = "3b70ea054b82c6477e9b1d32cd369a040bc7fe7a82964ab3b4508d14a86cc6dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/sr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sr/thunderbird-91.9.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c990d6f1d94f50ba0edc2683acb89fd17dc94ceb0406549309c85be3e294c43a";
+      sha256 = "49c3b1c67411e2750cde324db4bc0e5c8e3f71fb3cab584a6d568584e32df5c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/sv-SE/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sv-SE/thunderbird-91.9.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "cff7a55dd6a5ef6a3bff8757decda52e685fd500ba00ddc9f96724a6e803759e";
+      sha256 = "bfbf94b605d477c8c65daefec9578d248fd46b28c9a28e698a7595486082cd3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/th/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/th/thunderbird-91.9.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "e04a3b749f86f8f13b26d58c1562f7249e9d298431f348709678d6b5eb2d56c4";
+      sha256 = "7374e4dcc99e02d1fe08010b9139ce0d4147ea6ff1716046e163a8d50974b9ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/tr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/tr/thunderbird-91.9.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "f3bc44135cc943509e5f821b011b30df42ba9e44884be588130326dd123ffc13";
+      sha256 = "442f818b275905964e228f90eb68048adaec4e4031f082cf679828d9b08c1cf9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/uk/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/uk/thunderbird-91.9.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c93fbc4795bc051ff6e55ced73765673c347a6fcea5c0b0f12d5a2b7e4ea13f6";
+      sha256 = "60963d1c0cc62cb487a19442406c6628eb33b79ca5e3a02113acc0fb1d1582be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/uz/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/uz/thunderbird-91.9.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "4737baf26dd8ae9a9fe4a52c56e75a2e76e76a976dac66cb02cc9175a432d114";
+      sha256 = "97c54746a2aa415f14d1ea7b70f9f7f6e2ee19f789372a406dd01b1e84727620";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/vi/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/vi/thunderbird-91.9.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "8962b27c70530ad685753df464c4f4c982258abb82fc9788c623eebd2bd319fd";
+      sha256 = "ad05455a8aae0eb0e5ee7735d61e1ed9e37acfb96aba51eaf4c8067e54ee9681";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/zh-CN/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/zh-CN/thunderbird-91.9.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e9343251571b2922f5ab2f84590759e41fb0734c38541336215f9984c4fe6882";
+      sha256 = "558fdfa5539597ee19d7912b18309ff87b85596642d1387a12711d107cb7f697";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-x86_64/zh-TW/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/zh-TW/thunderbird-91.9.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "efbcb13dcb468a82b0ec71d67af4addefce97addfca6befaba0b96c92617091b";
+      sha256 = "0df3944210faab8ce41dae7464c4932b66aac74f631afbd36feec22d0cb930a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/af/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/af/thunderbird-91.9.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "d96e9de630ad5502fd86de653337ff7df4444ea5bdc22e07cb77f67f1dc4d04f";
+      sha256 = "e66231f6a08cad94c5f1106c798590a422d8c8ba50b72e1159b6364d8542ed4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ar/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ar/thunderbird-91.9.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d5273d01309d15e77a897fa25a142851470f9569b25b253e66d09dee6984d061";
+      sha256 = "f31dddbdb4bdcd2b7ac2393093af3f05a20b0d9021574517fe791aa4106cf20a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ast/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ast/thunderbird-91.9.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "8466aa8df2090de75cd7140b58c03856b351536f14875569c18abeaebdcb3249";
+      sha256 = "489cd880a24798032ea2d2f6718c5ec26d443d93fe49003f776b12c04d66f3c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/be/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/be/thunderbird-91.9.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "f2940433250516531cd782e5f7a2c85dbb81d5fae83b29ff2fba93450dcb14ef";
+      sha256 = "57f0a27259797967d3d32fb8583dd5788dc8f48c817d3c67e1b6fc724d365510";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/bg/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/bg/thunderbird-91.9.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "70198e5c4857d84b0c84c158fabf269d759fcd7b966d82e2f529c540d833a244";
+      sha256 = "7faaff4eb705d05ed28147b447bd5d3e633034d2eeabca03b9825f83757e8548";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/br/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/br/thunderbird-91.9.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "02391abf4167231531b8e8490fd2d7feab36cf89ddc5cb6d072cb33a67d4520a";
+      sha256 = "2631a5c137f0520c35628241006e48b57c2115c57f0c6f67c96cc0c4be8182cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ca/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ca/thunderbird-91.9.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "7178baf7bdc7914bb803995b8d1fc66087f9c65264b100e8876fa1be463623d2";
+      sha256 = "bac12f398fac2be718b26276c082fc201ee05005802a09dea5b374db86496edf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/cak/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/cak/thunderbird-91.9.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "579bdce1b8b4a2ebf2688c95e5ee4f2e20347a983874633bcdb92c3d6c19ee8e";
+      sha256 = "fc20f1147e9b924d06666c30f0b33d8c9369af3e8bb751bf0ed885d07b92deb3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/cs/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/cs/thunderbird-91.9.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "2eccefb9c82eae0f339ec9d5291c82a873ddcdc80822a7588e686ffaa50e7763";
+      sha256 = "0341bd367ba45396762cb9d614f5b9e87cc8c5f7de6197a50e37e17abef517c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/cy/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/cy/thunderbird-91.9.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "0616bd3fb1baa79b4dbfddf260d013c03829edcdf761e25980b8600e63922f52";
+      sha256 = "6a489b731883f4a2579a576ffa571e735dfe2a165a7553e61859ed5eee2c9f9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/da/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/da/thunderbird-91.9.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "56c3cf0930c0966212d607589a32cec910d6b0a7bc7db314b317e0f717321fc6";
+      sha256 = "cfa573a68f3e7ba870f5cc5cf36088efb2220389b20190671a02babb4213c51f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/de/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/de/thunderbird-91.9.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "5ef59f3d0575ec3f570f4b1d0a401ac3eaf42a901ccece9bbb46cd4bab4a61b1";
+      sha256 = "b39140f5baf32c12473e0a10333025e255ea995516e4582ea98905808e148b50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/dsb/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/dsb/thunderbird-91.9.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "e4ba253ee1f3629d5e3bde8475a49b8a95fb1a0bb76c14cb62a53a6e6f545804";
+      sha256 = "fd0b1a4012f46a5bf5c20ab38d7ab8adf3cdda405bae986f727b1cfc96cc77a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/el/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/el/thunderbird-91.9.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7c342ff901eb195ee06b0b67d4a52b118053ee8153d9dffae48c83e937a04be4";
+      sha256 = "85f2196748e34f860327412b2f82ae500738da2e8304be589a3c554c47789950";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/en-CA/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/en-CA/thunderbird-91.9.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "35cc280dfa58eeb62c12d133d4bccfcd85e694121129e154770c840f6e87169d";
+      sha256 = "4b64e7bc90ffb0e0d245616c6118d890fc4d0e48936b2e59f69200580dc675af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/en-GB/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/en-GB/thunderbird-91.9.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "ac393ceb36bcf7afefdaa1f6fdbdc49ef739781979878f055d623cae78cc0468";
+      sha256 = "a361abc8f7deba8bb86afaed722043e601e1eded41d913ff21ec44e081aceb12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/en-US/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/en-US/thunderbird-91.9.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "bac3f4695e762b67b21b399edd406340a6500a8a5bcf4973a74904b9065078c8";
+      sha256 = "c00b81beaccfba7472392c6c09b6867ded00fdddf7bd9e1b3d79fa7a34c92ae2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/es-AR/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/es-AR/thunderbird-91.9.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "5ec79874c0a76555e68a84aa8f41ceff5ff72877d4636301cae99ef56ea16e74";
+      sha256 = "a8c42e78867bf7cde2aee765a1d25545bd25daa185029d6eb472d1aae2e34b87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/es-ES/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/es-ES/thunderbird-91.9.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "3465df8574f3d9dcb86a458147c388ae662cd17b998176591eb3841a448c543a";
+      sha256 = "adcdf96e70c2153ec918007384104f13221d96ec7439c9e553ea673de80cdc9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/et/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/et/thunderbird-91.9.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "58a1a76c81c6687a5673150ad5effa421b5a32a8825c52a7106a5a77cf4d66bf";
+      sha256 = "b2051a281105ac081c0dd52dcfbda86eaa3b1f589fae308e3c6a7bbe641623f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/eu/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/eu/thunderbird-91.9.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c90e4acc10b1157d3f1009f55d5ebe70828288ebf057f01d0cfc78f306536d19";
+      sha256 = "feee691079859e3b82b70c87d9838dcf4d1cccf609bd96547902c7b08b980c40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/fi/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/fi/thunderbird-91.9.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "249943c795ac7b7d94331399c7badfd2d7ea86ccbf96e7eb653985ead8d50975";
+      sha256 = "5a88a2e3e265c705eb569ed4004c60be3c9bca7ea90010ad560c5261db415779";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/fr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/fr/thunderbird-91.9.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "6464ce3e03ec947fe8752096d3049390b307ed44eaea036194c6d58750064a1d";
+      sha256 = "61f9507bcc5a8538fac0118ae5fad9a8a515f90fe3c417fbf43974f9eab55e91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/fy-NL/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/fy-NL/thunderbird-91.9.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "a45de5dd3f37b9a7c39b260ba84a03cef94b103787235cd34ad45cf4592e7ed2";
+      sha256 = "03bf28a074999f0e2ed06ece50484cf8b2ed92dfba82aedd2e2382ed4399765c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ga-IE/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ga-IE/thunderbird-91.9.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "ed509287d305e2457137d051b1842d26401b5b337a5272562a7b19922e874c2c";
+      sha256 = "89d0092430a7a71ac7f985d050a8d1ff62aeddcdca4fc267b1bef693e31814f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/gd/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/gd/thunderbird-91.9.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2c8a2c587bb522aa2dceb3fb3d68e338f9e22b1be57745e26441c4c72257b22b";
+      sha256 = "1aa98c5ccc1788d839fea37dc48cedff39425075a434abadcf79b6aef24fe0bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/gl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/gl/thunderbird-91.9.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "4dd7eb1c72eca568c03c233f5078bbcf24da14e123106ce877096ab2b1637b61";
+      sha256 = "c0cd9773a7bee196c3231677c1a0644d04ceea01ce5be591ea26a0f700750ba1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/he/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/he/thunderbird-91.9.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "82f8168ab4eceaf92f03fd777160ec28d25f4801944469a5ac3f6df8de1773e1";
+      sha256 = "4719f0d0ebd8fde4103bfce65a598839325818f4ed9b97e3c59bc4e35794413b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/hr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hr/thunderbird-91.9.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "80221f2fc08812f864dd09edc4e6b7693d5966b292d8ea66c2931a51f35bfaa8";
+      sha256 = "884f4cdfb559d4d611d18d18cd9c35469b8656816af4d3347fc01bbe70419143";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/hsb/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hsb/thunderbird-91.9.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9e6b7c4cd402675cbac43088328e321a6f738cd7d83406d7cd7f8ac6060b6f11";
+      sha256 = "d8a773542b5033c0ec305652ce94fadeed905494226ed63816e5ef6f288e2218";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/hu/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hu/thunderbird-91.9.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "4cea9f48504060e31006f69eecafe3c352440f54d599f637d4a1a536d48e27a3";
+      sha256 = "665cabba7b182c7a85e932997e504dfe1485b32709a0c9fde25c1ec565ad0fd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/hy-AM/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hy-AM/thunderbird-91.9.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "55d887cf63952b1eec43bf2449fa3eb8c543d91ee4cdeaa1e54a00cd4a009357";
+      sha256 = "c4a0f8e4c0def83c8b8bae39dca8e493a60af7348942f6d1999cf2c3d2e0c5d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/id/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/id/thunderbird-91.9.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "32dcdae28370e35f61a3f5c12085830f6263b0b4b9b272d780f2c748d1474961";
+      sha256 = "1b44a02defba8f27835d5429dc77ffe55db5d22a4ee98b06ab593e26f0a6a6d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/is/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/is/thunderbird-91.9.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "df47af9356ee1b9bed415421f14f797499402dccc96f3aef18538d64b4b5b8b9";
+      sha256 = "672249813fe8efd3be4dc89a2366d935fa4ef6da648e7f9411b7286a6e0afbad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/it/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/it/thunderbird-91.9.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "1cf50c518e5d8137c52bf37eaeac618007e2efbc8f94deb9461a01b2787df434";
+      sha256 = "89e554e40f3038d4754c22a67839480a16aac5bc4c550de8707f4401fd94793b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ja/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ja/thunderbird-91.9.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "031d2db07bc2dfc8dbb4c86119a993725a661ad4f6596241bd5590ebbdc01e3c";
+      sha256 = "06e1723de2de13c79af0094dad06838067919adead28f659af0155d91b39d677";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ka/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ka/thunderbird-91.9.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "18f1b2a900381ce85cded1046e0bc10c015eb3ab5602497e93190229aea26bcd";
+      sha256 = "f1c215e0c6725539c039f6d1c4ad97c5ae1b322a5cdedbb7c45af59e33a85b2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/kab/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/kab/thunderbird-91.9.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "10b42a83af77d82343297439f8c56cdb3ab85fa4ea88aa77e49aeb6a01a90c99";
+      sha256 = "76b51a10a530ce127f079c2c37b859313a57bda456a2e44c7d742e4f11a4c3bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/kk/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/kk/thunderbird-91.9.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "1e0b1740eaf8c48ecb2a41c3687f51afc07b9243c098637d60c5452259ae9192";
+      sha256 = "4d6b9db8cf3b52474f183adb5638030a3072f970b888f910fd3dd2bd19e5c05e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ko/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ko/thunderbird-91.9.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "da9a00752a4e6a3aca2f298eecae39e661435f95c723f7327ed60eeb0e75d50d";
+      sha256 = "32dc2eef4cbb3a6ea483ef5cac66a75ca4ccfe5091f5dbb7921f171ea0edcb3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/lt/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/lt/thunderbird-91.9.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "7ece24971b0a7b901ab165ff30c3b5239161a488be02c7f5cf5d6a2dfc6dce3e";
+      sha256 = "f2382f9a49d52e7e5574a72e8daee5a5e209a25f188e76a438c15cbc6b27d2de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/lv/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/lv/thunderbird-91.9.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "baf96d476ec159bbc4567e4beae29d3c61fef9683190cdc7c207163ed67797fb";
+      sha256 = "57fe94803333b8efe57b752334f3fa56e66663f03abfb1c683663a155abe4300";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ms/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ms/thunderbird-91.9.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "3b356c61079130bd3d5b5023116f74961ed84595222284fadc45f3224281bbfc";
+      sha256 = "288358a22ef7cef6a2d521416dec846835195904ea6f347b2eec0632eddd8ec8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/nb-NO/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/nb-NO/thunderbird-91.9.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "225a885cc788b64c864efab9cb0adbb0399a7e68e747551bb98cfba903898bec";
+      sha256 = "17085e1c350d86573ee6f2033deb2ca2ccbe5508315fab1d5a9eea0697a20c7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/nl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/nl/thunderbird-91.9.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "1c75e3df164a37c46f83421e0df28dd1cd4fd9e725a4e6c8d03378c800c53f04";
+      sha256 = "3df971e99e9f797676b1d5b1b827e1134f25dd96d3d2f9cc131e67388d02401b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/nn-NO/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/nn-NO/thunderbird-91.9.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "fc154d52fa4e19ef4e727663a1bc4599da9e7c3aba0e563d823a3d4995d2632e";
+      sha256 = "ead88f4e76979f38866527dd67f9c1c3187f28126f48dbf9b176290bf5ab0f20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/pa-IN/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pa-IN/thunderbird-91.9.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "27a95c486a5a075fa8011add5c06c616ffafa7cb266afc26f7511cd510f8f403";
+      sha256 = "561c5b20f4bb0a175495d8da9140a130d876df07d097cc6674a0d665ef875a1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/pl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pl/thunderbird-91.9.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "34563d04912e27e93f122c47eca56a368f2b723406498f98f312f92459265f87";
+      sha256 = "bd52618c81ef5a98dbdbd47d5dad062144c4ea55ddbfc5694e9d5d71a9d00ccd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/pt-BR/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pt-BR/thunderbird-91.9.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "6ab98477ca80c945c4b780aa704b231e7831fd2334a70c57937b2815357f3150";
+      sha256 = "c51999a9581e89b3e901dea88e102e86ff8f906b0c6b4f75af01e5ec96c71038";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/pt-PT/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pt-PT/thunderbird-91.9.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "0919ca9a0125a8545de083f629a4f338e8db0f0e7a87bb7c55172f163605f8d1";
+      sha256 = "148ead072bbcaf700c2a5b5c6160d5dcf45632c205b01f4da7912fa47bbb32fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/rm/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/rm/thunderbird-91.9.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "31d4de40f1ad6c284e388ffd760d3758174ce99c01ca23b0ccbf9d1a4f343bab";
+      sha256 = "b0af2b91e243016f03d376361b497783568ae91f8790b4fc1e630e430d9b935f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ro/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ro/thunderbird-91.9.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "3e0a763faa79aa775e29907e018f81d506fbaa025d9900516447c6081e6c31b1";
+      sha256 = "c43a7f827b71f680c2edeec47e047b075e00c136c68cc3939ed53d9a34d99b00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/ru/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ru/thunderbird-91.9.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "ee485a4f7287d770107d9d41d678ace5873079e1fdc726a30800b6d055f68267";
+      sha256 = "09fce7f1f8b0c97a843254ffbd9ff4337aa690791379e58d66dcdeb016cc04f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/sk/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sk/thunderbird-91.9.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "e8cc9b1a9e767ab548de614da8feb1b42213444e91e4a1382b2cdc7323872215";
+      sha256 = "724bebdcaee664a6e816f2a84c402eb781ddc9030e1bb94b130b9e0b86718a86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/sl/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sl/thunderbird-91.9.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "271b3fa48e9f1cedfe3fbfbd72fd23b0b477e9993108996dbc897835de0750c9";
+      sha256 = "939bf67c268617a16283f173169462e6d929b7cbf73e1cb9d079af5bbc5145ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/sq/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sq/thunderbird-91.9.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "7fac9e56f3e5070f0b9e038483f0b0fb97a42d947410c3f8677b7e6d8ebf3828";
+      sha256 = "4c84dd39f46c082679bcba75fd268a976cd7ba71e1616a837f0fba54bd8d9b68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/sr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sr/thunderbird-91.9.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "903c9408c4bce12a78cf5941b9413f65d946b49c5c6819c1cc1c7006373d6802";
+      sha256 = "038d5349d895484e1df3dc0d4f89a9d833c94465590e6c4cd210cf78d379dc59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/sv-SE/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sv-SE/thunderbird-91.9.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "c6ff664cd1d80bd36f1bbcffa239f3f8d7b31e5b68918001b1a26bd91ea49376";
+      sha256 = "1ebd35eeaa07af867dc21594cc40c41d50485139e27836ebb3a5c3d09743169f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/th/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/th/thunderbird-91.9.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "ad27252f979daad7e7e842ff1144ab731fa4e588adc015f3e388ba26f2cf21de";
+      sha256 = "7fecc47a7d0244fe1c0498e964b950ecdad4b740d6591291d36ceed0fb40979a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/tr/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/tr/thunderbird-91.9.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "55581a2277ea6fa27389fa4ffdda72a02a8c3f8b2c92b0b04e7deb2d24840ee4";
+      sha256 = "2439b401b71e826ea849514a9f9fc2218dd515b67880155ac3d8e7cb858af910";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/uk/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/uk/thunderbird-91.9.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "5b687b3839f6c4ce67c71c56965eccd85eab94063fb9bfc5d4e2f30336f3fe0d";
+      sha256 = "bec6c00c743557c5cb68ec38143e9b5289e724725127c61058b02349534ebfac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/uz/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/uz/thunderbird-91.9.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "41344413282a295db0c33e7ba01074b46c69d6267f94b36d10200f2adb42b39e";
+      sha256 = "15de16cc6cb131f3a2c517a754f2128bfb92cced786cdea789821c04405c2e07";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/vi/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/vi/thunderbird-91.9.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "57bfaac37e13e218d631af0830cef177d342f45a64fc19f86bfc5aa9c940e632";
+      sha256 = "2328b631bec6bbea52d9c11b20371b06ce70c31fa8077adf786d901a57a4c6a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/zh-CN/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/zh-CN/thunderbird-91.9.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "417a2b7ca7f3981d171e453ca7ea709fbb05bc2283d874d82a4b002d8e64f816";
+      sha256 = "206da1db9b057d22f5bc3e26c718b82434ff59eedd94d1881b6e83dc7a9dcf09";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.8.1/linux-i686/zh-TW/thunderbird-91.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/zh-TW/thunderbird-91.9.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "2c92131700a89dc2c590901cf356705d308aa3520ad3f713ba866fce04edb8c7";
+      sha256 = "805867514c008cfceb5312663005672cbbc81fcd337af2828328ba4da85249e6";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -10,12 +10,12 @@ in
 rec {
   thunderbird = common rec {
     pname = "thunderbird";
-    version = "91.8.1";
+    version = "91.9.0";
     application = "comm/mail";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "1591f3e9c76c1f2ea7fa5e194a7d030c8657a7855a95c8a177e8067c5aa838f0d8ca2652cd049b4bc88d0c9e604285a47b0c8316c190e2ceadfc1130d1e4de6c";
+      sha512 = "474b5aca9c5e54fdc72eebff938f0d217bc039c3ac8d1caf965fb61bd1cf349f389a1df751a525de567a1eeabd7bb1bf2246014e84c7aab89edce059fe2e72d1";
     };
     patches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
Backport #173071 and multiple versions of firefox-devedition

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
