### PR TITLE
gnomeExtensions.vitals: remove workaround

### DIFF
--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -47,10 +47,6 @@ def fetch_extension_data(uuid: str, version: str) -> Tuple[str, str]:
     uuid = uuid.replace("@", "")
     url: str = f"https://extensions.gnome.org/extension-data/{uuid}.v{version}.shell-extension.zip"
 
-    # TODO remove when Vitals@CoreCoding.com version != 53, this extension has a missing manifest.json
-    if url == 'https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension.zip':
-        url = 'https://extensions.gnome.org/extension-data/VitalsCoreCoding.com.v53.shell-extension_v1BI2FB.zip'
-
     # Download extension and add the zip content to nix-store
     process = subprocess.run(
         ["nix-prefetch-url", "--unpack", "--print-path", url], capture_output=True, text=True


### PR DESCRIPTION
###### Things done

As you can see all GNOME versions have a version higher than 53.

```json
{
    "uuid": "Vitals@CoreCoding.com",
    "name": "Vitals",
    "pname": "vitals",
    "description": "A glimpse into your computer's temperature, voltage, fan speed, memory usage, processor load, system resources, network speed and storage stats. This is a one stop shop to monitor all of your vital sensors. Uses asynchronous polling to provide a smooth user experience. Feature requests or bugs? Please use GitHub.",
    "link": "https://extensions.gnome.org/extension/1460/vitals/",
    "shell_version_map": {
        "38": {
            "version": "54",
            "sha256": "1wfaxzsbzkmnzvszwpapxwj1370idgpxwmyg8a0drvb1jxxq3v1y",
            "metadata": "ewogICJfZ2VuZXJhdGVkIjogIkdlbmVyYXRlZCBieSBTd2VldFRvb3RoLCBkbyBub3QgZWRpdCIsCiAgImRlc2NyaXB0aW9uIjogIkEgZ2xpbXBzZSBpbnRvIHlvdXIgY29tcHV0ZXIncyB0ZW1wZXJhdHVyZSwgdm9sdGFnZSwgZmFuIHNwZWVkLCBtZW1vcnkgdXNhZ2UsIHByb2Nlc3NvciBsb2FkLCBzeXN0ZW0gcmVzb3VyY2VzLCBuZXR3b3JrIHNwZWVkIGFuZCBzdG9yYWdlIHN0YXRzLiBUaGlzIGlzIGEgb25lIHN0b3Agc2hvcCB0byBtb25pdG9yIGFsbCBvZiB5b3VyIHZpdGFsIHNlbnNvcnMuIFVzZXMgYXN5bmNocm9ub3VzIHBvbGxpbmcgdG8gcHJvdmlkZSBhIHNtb290aCB1c2VyIGV4cGVyaWVuY2UuIEZlYXR1cmUgcmVxdWVzdHMgb3IgYnVncz8gUGxlYXNlIHVzZSBHaXRIdWIuIiwKICAiZ2V0dGV4dC1kb21haW4iOiAidml0YWxzIiwKICAibmFtZSI6ICJWaXRhbHMiLAogICJzZXR0aW5ncy1zY2hlbWEiOiAib3JnLmdub21lLnNoZWxsLmV4dGVuc2lvbnMudml0YWxzIiwKICAic2hlbGwtdmVyc2lvbiI6IFsKICAgICIzLjM4IiwKICAgICI0MCIsCiAgICAiNDEiLAogICAgIjQyIgogIF0sCiAgInVybCI6ICJodHRwczovL2dpdGh1Yi5jb20vY29yZWNvZGluZy9WaXRhbHMiLAogICJ1dWlkIjogIlZpdGFsc0BDb3JlQ29kaW5nLmNvbSIsCiAgInZlcnNpb24iOiA1NAp9"
        },
        "40": {
            "version": "54",
            "sha256": "1wfaxzsbzkmnzvszwpapxwj1370idgpxwmyg8a0drvb1jxxq3v1y",
            "metadata": "ewogICJfZ2VuZXJhdGVkIjogIkdlbmVyYXRlZCBieSBTd2VldFRvb3RoLCBkbyBub3QgZWRpdCIsCiAgImRlc2NyaXB0aW9uIjogIkEgZ2xpbXBzZSBpbnRvIHlvdXIgY29tcHV0ZXIncyB0ZW1wZXJhdHVyZSwgdm9sdGFnZSwgZmFuIHNwZWVkLCBtZW1vcnkgdXNhZ2UsIHByb2Nlc3NvciBsb2FkLCBzeXN0ZW0gcmVzb3VyY2VzLCBuZXR3b3JrIHNwZWVkIGFuZCBzdG9yYWdlIHN0YXRzLiBUaGlzIGlzIGEgb25lIHN0b3Agc2hvcCB0byBtb25pdG9yIGFsbCBvZiB5b3VyIHZpdGFsIHNlbnNvcnMuIFVzZXMgYXN5bmNocm9ub3VzIHBvbGxpbmcgdG8gcHJvdmlkZSBhIHNtb290aCB1c2VyIGV4cGVyaWVuY2UuIEZlYXR1cmUgcmVxdWVzdHMgb3IgYnVncz8gUGxlYXNlIHVzZSBHaXRIdWIuIiwKICAiZ2V0dGV4dC1kb21haW4iOiAidml0YWxzIiwKICAibmFtZSI6ICJWaXRhbHMiLAogICJzZXR0aW5ncy1zY2hlbWEiOiAib3JnLmdub21lLnNoZWxsLmV4dGVuc2lvbnMudml0YWxzIiwKICAic2hlbGwtdmVyc2lvbiI6IFsKICAgICIzLjM4IiwKICAgICI0MCIsCiAgICAiNDEiLAogICAgIjQyIgogIF0sCiAgInVybCI6ICJodHRwczovL2dpdGh1Yi5jb20vY29yZWNvZGluZy9WaXRhbHMiLAogICJ1dWlkIjogIlZpdGFsc0BDb3JlQ29kaW5nLmNvbSIsCiAgInZlcnNpb24iOiA1NAp9"
        },
        "41": {
            "version": "54",
            "sha256": "1wfaxzsbzkmnzvszwpapxwj1370idgpxwmyg8a0drvb1jxxq3v1y",
            "metadata": "ewogICJfZ2VuZXJhdGVkIjogIkdlbmVyYXRlZCBieSBTd2VldFRvb3RoLCBkbyBub3QgZWRpdCIsCiAgImRlc2NyaXB0aW9uIjogIkEgZ2xpbXBzZSBpbnRvIHlvdXIgY29tcHV0ZXIncyB0ZW1wZXJhdHVyZSwgdm9sdGFnZSwgZmFuIHNwZWVkLCBtZW1vcnkgdXNhZ2UsIHByb2Nlc3NvciBsb2FkLCBzeXN0ZW0gcmVzb3VyY2VzLCBuZXR3b3JrIHNwZWVkIGFuZCBzdG9yYWdlIHN0YXRzLiBUaGlzIGlzIGEgb25lIHN0b3Agc2hvcCB0byBtb25pdG9yIGFsbCBvZiB5b3VyIHZpdGFsIHNlbnNvcnMuIFVzZXMgYXN5bmNocm9ub3VzIHBvbGxpbmcgdG8gcHJvdmlkZSBhIHNtb290aCB1c2VyIGV4cGVyaWVuY2UuIEZlYXR1cmUgcmVxdWVzdHMgb3IgYnVncz8gUGxlYXNlIHVzZSBHaXRIdWIuIiwKICAiZ2V0dGV4dC1kb21haW4iOiAidml0YWxzIiwKICAibmFtZSI6ICJWaXRhbHMiLAogICJzZXR0aW5ncy1zY2hlbWEiOiAib3JnLmdub21lLnNoZWxsLmV4dGVuc2lvbnMudml0YWxzIiwKICAic2hlbGwtdmVyc2lvbiI6IFsKICAgICIzLjM4IiwKICAgICI0MCIsCiAgICAiNDEiLAogICAgIjQyIgogIF0sCiAgInVybCI6ICJodHRwczovL2dpdGh1Yi5jb20vY29yZWNvZGluZy9WaXRhbHMiLAogICJ1dWlkIjogIlZpdGFsc0BDb3JlQ29kaW5nLmNvbSIsCiAgInZlcnNpb24iOiA1NAp9"
        },
        "42": {
            "version": "54",
            "sha256": "1wfaxzsbzkmnzvszwpapxwj1370idgpxwmyg8a0drvb1jxxq3v1y",
            "metadata": "ewogICJfZ2VuZXJhdGVkIjogIkdlbmVyYXRlZCBieSBTd2VldFRvb3RoLCBkbyBub3QgZWRpdCIsCiAgImRlc2NyaXB0aW9uIjogIkEgZ2xpbXBzZSBpbnRvIHlvdXIgY29tcHV0ZXIncyB0ZW1wZXJhdHVyZSwgdm9sdGFnZSwgZmFuIHNwZWVkLCBtZW1vcnkgdXNhZ2UsIHByb2Nlc3NvciBsb2FkLCBzeXN0ZW0gcmVzb3VyY2VzLCBuZXR3b3JrIHNwZWVkIGFuZCBzdG9yYWdlIHN0YXRzLiBUaGlzIGlzIGEgb25lIHN0b3Agc2hvcCB0byBtb25pdG9yIGFsbCBvZiB5b3VyIHZpdGFsIHNlbnNvcnMuIFVzZXMgYXN5bmNocm9ub3VzIHBvbGxpbmcgdG8gcHJvdmlkZSBhIHNtb290aCB1c2VyIGV4cGVyaWVuY2UuIEZlYXR1cmUgcmVxdWVzdHMgb3IgYnVncz8gUGxlYXNlIHVzZSBHaXRIdWIuIiwKICAiZ2V0dGV4dC1kb21haW4iOiAidml0YWxzIiwKICAibmFtZSI6ICJWaXRhbHMiLAogICJzZXR0aW5ncy1zY2hlbWEiOiAib3JnLmdub21lLnNoZWxsLmV4dGVuc2lvbnMudml0YWxzIiwKICAic2hlbGwtdmVyc2lvbiI6IFsKICAgICIzLjM4IiwKICAgICI0MCIsCiAgICAiNDEiLAogICAgIjQyIgogIF0sCiAgInVybCI6ICJodHRwczovL2dpdGh1Yi5jb20vY29yZWNvZGluZy9WaXRhbHMiLAogICJ1dWlkIjogIlZpdGFsc0BDb3JlQ29kaW5nLmNvbSIsCiAgInZlcnNpb24iOiA1NAp9"
        }
    }
}
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
