### PR TITLE
pika-backup: 0.3.5 -> 0.4.0

### DIFF
--- a/pkgs/applications/backup/pika-backup/borg-path.patch
+++ b/pkgs/applications/backup/pika-backup/borg-path.patch
@@ -1,13 +1,22 @@
-diff --git a/src/borg/utils.rs b/src/borg/utils.rs
-index 4e30913..30d7d6f 100644
---- a/src/borg/utils.rs
-+++ b/src/borg/utils.rs
-@@ -223,7 +223,7 @@ impl BorgCall {
+diff --git a/src/borg/process.rs b/src/borg/process.rs
+index 63ea0ee..e3535e0 100644
+--- a/src/borg/process.rs
++++ b/src/borg/process.rs
+@@ -203,7 +203,7 @@ impl BorgCall {
      }
  
-     pub fn cmd(&self) -> Command {
--        let mut cmd = Command::new("borg");
-+        let mut cmd = Command::new("@borg@");
+     pub fn cmd(&self) -> Result<process::Command> {
+-        let mut cmd = process::Command::new("borg");
++        let mut cmd = process::Command::new("@borg@");
  
-         cmd.args(self.args())
-             .stderr(Stdio::piped())
+         cmd.envs([self.set_password()?]);
+ 
+@@ -221,7 +221,7 @@ impl BorgCall {
+     }
+ 
+     pub fn cmd_async(&self) -> Result<async_process::Command> {
+-        let mut cmd = async_process::Command::new("borg");
++        let mut cmd = async_process::Command::new("@borg@");
+ 
+         cmd.envs([self.set_password()?]);
+ 

--- a/pkgs/applications/backup/pika-backup/default.nix
+++ b/pkgs/applications/backup/pika-backup/default.nix
@@ -5,35 +5,34 @@
 , rustPlatform
 , substituteAll
 , desktop-file-utils
+, itstool
 , meson
 , ninja
 , pkg-config
 , python3
-, wrapGAppsHook
+, wrapGAppsHook4
 , borgbackup
-, dbus
-, gdk-pixbuf
-, glib
-, gtk3
-, libhandy
+, gtk4
+, libadwaita
+, libsecret
 }:
 
 stdenv.mkDerivation rec {
   pname = "pika-backup";
-  version = "0.3.5";
+  version = "0.4.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "pika-backup";
     rev = "v${version}";
-    sha256 = "sha256-8jT3n+bTNjhm64AMS24Ju+San75ytfqFXloH/TOgO1g=";
+    hash = "sha256-vQ0hlwsrY0WOUc/ppleE+kKRGHPt/ScEChXrkukln3U=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    sha256 = "198bs4z7l22sh8ck7v46s45mj8zpfbg03n1xzc6pnafdd8hf3q15";
+    hash = "sha256-IKUh5gkXTpmMToDaec+CpCIQqJjwJM2ZrmGQhZeTDsg=";
   };
 
   patches = [
@@ -41,12 +40,10 @@ stdenv.mkDerivation rec {
       src = ./borg-path.patch;
       borg = "${borgbackup}/bin/borg";
     })
-    # Fix build with meson 0.61, can be removed on next release.
-    # https://gitlab.gnome.org/World/pika-backup/-/issues/156
-    # https://github.com/mesonbuild/meson/issues/9441
     (fetchpatch {
-      url = "https://gitlab.gnome.org/World/pika-backup/-/commit/54be149c88fd69fb9e74b7362fe7182863237869.patch";
-      sha256 = "sha256-Tffxo5hlf/gSkp1GfyL4eHthX49tuTq6B+S53N8oA2M=";
+      name = "use-gtk4-update-icon-cache.patch";
+      url = "https://gitlab.gnome.org/World/pika-backup/-/merge_requests/64.patch";
+      hash = "sha256-AttGQGWealvTIvPwBl5M6FiC4Al/UD4/XckUAxM38SE=";
     })
   ];
 
@@ -56,11 +53,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     desktop-file-utils
+    itstool
     meson
     ninja
     pkg-config
     python3
-    wrapGAppsHook
+    wrapGAppsHook4
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo
@@ -68,16 +66,14 @@ stdenv.mkDerivation rec {
   ]);
 
   buildInputs = [
-    dbus
-    gdk-pixbuf
-    glib
-    gtk3
-    libhandy
+    gtk4
+    libadwaita
+    libsecret
   ];
 
   meta = with lib; {
     description = "Simple backups based on borg";
-    homepage = "https://wiki.gnome.org/Apps/PikaBackup";
+    homepage = "https://apps.gnome.org/app/org.gnome.World.PikaBackup";
     changelog = "https://gitlab.gnome.org/World/pika-backup/-/blob/v${version}/CHANGELOG.md";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dotlambda ];


### PR DESCRIPTION

###### Description of changes
https://gitlab.gnome.org/World/pika-backup/-/blob/v0.4.0/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
