### PR TITLE
Add systemverilog plugin to yosys

### DIFF
--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -34,6 +34,14 @@ stdenv.mkDerivation rec {
     ]))
   ];
 
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    make -j $NIX_BUILD_CORES UnitTests
+    ctest --output-on-failure
+    runHook postCheck
+  '';
+
   postInstall = ''
     mv $out/lib/surelog/* $out/lib/
     rm -rf $out/lib/surelog

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -24,15 +24,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-  ];
-
-  buildInputs = [
-    libuuid
     openjdk11
     (python3.withPackages (p: with p; [
       psutil
       orderedmultidict
     ]))
+  ];
+
+  buildInputs = [
+    libuuid
     gperftools
   ];
 

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mv $out/lib/surelog/* $out/lib/
     rm -rf $out/lib/surelog
+    rm -rf $out/lib/pkg
   '';
 
   meta = {

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -6,6 +6,7 @@
 , pkg-config
 , libuuid
 , openjdk11
+, gperftools
 }:
 
 stdenv.mkDerivation rec {
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
       psutil
       orderedmultidict
     ]))
+    gperftools
   ];
 
   doCheck = true;

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+, pkg-config
+, libuuid
+, openjdk11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "Surelog";
+  version = "2022.05.15";
+
+  src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = pname;
+    rev = "15d3698ca5c7d45dd95b58c15e76131420cb001c";
+    hash = "sha256-dfje9yZ8ZR7x1EUxDUpKNcOWKYTPwPG6T4HzudV59R4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libuuid
+    openjdk11
+    (python3.withPackages (p: with p; [
+      psutil
+      orderedmultidict
+    ]))
+  ];
+
+  postInstall = ''
+    mv $out/lib/surelog/* $out/lib/
+    rm -rf $out/lib/surelog
+  '';
+
+  meta = {
+    description = "SystemVerilog 2017 Pre-processor, Parser, Elaborator, UHDM Compiler";
+    homepage = "https://github.com/chipsalliance/Surelog";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ matthuszagh ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "surelog";
-  version = "1.37";
+  version = "1.40";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-QYak0kWiL7C05zQmDd7Jl3a00rp4rMx0DJtd0K6lCII=";
+    hash = "sha256-5nhJilFIJJDCnJUEUgyPNtWSQUgWcvM6LDFgFatAl/k=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "surelog";
-  version = "v1.36";
+  version = "1.37";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = pname;
-    rev = version;
-    hash = "sha256-gMxpnSsJTXmg2VU7mQcw1J40OuqW6oo9/sGplLgV0ho=";
+    rev = "v${version}";
+    hash = "sha256-QYak0kWiL7C05zQmDd7Jl3a00rp4rMx0DJtd0K6lCII=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -46,8 +46,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mv $out/lib/surelog/* $out/lib/
-    rm -rf $out/lib/surelog
-    rm -rf $out/lib/pkg
+    mv $out/lib/pkg $out/lib/surelog/
   '';
 
   meta = {

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -55,6 +55,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/chipsalliance/Surelog";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ matthuszagh ];
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -10,14 +10,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "Surelog";
-  version = "2022.05.15";
+  pname = "surelog";
+  version = "v1.36";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = pname;
-    rev = "15d3698ca5c7d45dd95b58c15e76131420cb001c";
-    hash = "sha256-dfje9yZ8ZR7x1EUxDUpKNcOWKYTPwPG6T4HzudV59R4=";
+    rev = version;
+    hash = "sha256-gMxpnSsJTXmg2VU7mQcw1J40OuqW6oo9/sGplLgV0ho=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "UHDM";
+  version = "2022.05.15";
+
+  src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = pname;
+    rev = "18ec4cce8c9414c135dc0e69155f777195dfe328";
+    hash = "sha256-ZWeMHHqgpdYlYzhRdTLXCe07dh0Pe8/ylU5TO3cAOmA=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    (python3.withPackages (p: with p; [ orderedmultidict ]))
+  ];
+
+  doCheck = true;
+  checkPhase = "make test";
+
+  postInstall = ''
+    mv $out/lib/uhdm/* $out/lib/
+    rm -rf $out/lib/uhdm
+  '';
+
+  meta = {
+    description = "Universal Hardware Data Model";
+    homepage = "https://github.com/chipsalliance/UHDM";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ matthuszagh ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation rec {
     rm -rf $out/lib/uhdm
   '';
 
+  prePatch = ''
+    substituteInPlace CMakeLists.txt --replace \
+    'capnp compile' \
+    'capnp compile --src-prefix=''${GENDIR}/..'
+  '';
+
   meta = {
     description = "Universal Hardware Data Model";
     homepage = "https://github.com/chipsalliance/UHDM";

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "UHDM";
-  version = "0.9.1.37";
+  version = "0.9.1.40";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-mhbgjdbnjZShfwgdZEZshiNkRMPLT5oGcAnrvfrO7DM=";
+    hash = "sha256-CliKU2WM8B9012aDcS/mTyIf+JcsVsc4uRRi9+FRWbM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "UHDM";
-  version = "2022.05.15";
+  version = "0.9.1.37";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = pname;
-    rev = "18ec4cce8c9414c135dc0e69155f777195dfe328";
-    hash = "sha256-ZWeMHHqgpdYlYzhRdTLXCe07dh0Pe8/ylU5TO3cAOmA=";
+    rev = "v${version}";
+    hash = "sha256-mhbgjdbnjZShfwgdZEZshiNkRMPLT5oGcAnrvfrO7DM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -8,25 +8,24 @@
 , yosys
 , zlib
 , yosys-symbiflow
+, uhdm
+, surelog
 }: let
 
   src = fetchFromGitHub {
-    owner  = "SymbiFlow";
-    repo   = "yosys-symbiflow-plugins";
-    rev    = "35c6c33811a8de7c80dff6a7bcf7aa6ec9b21233";
-    hash   = "sha256-g5dX9+R+gWt8e7Bhbbg60O9qa+Vi6Ar0M1sHhYlAre8=";
+    owner  = "chipsalliance";
+    repo   = "yosys-f4pga-plugins";
+    rev    = "aadd1735b2b7af0472e56dc23f1035d6e1904712";
+    hash   = "sha256-gmpEx+8XDN7f+6e/YG25VKgdadwqApPqU3S6OB4AryA=";
   };
 
-  version = "2022.01.06";
+  version = "2022.05.13";
 
   # Supported symbiflow plugins.
   #
   # The following are disabled:
   #
   # "ql-qlf" builds but fails to load the plugin, so is not currently supported.
-  #
-  # "UHDM" doesn't currently build, as the work to package UHDM and surelog has
-  # not (yet) been undertaken.
   plugins = [
     "design_introspection"
     "fasm"
@@ -36,7 +35,7 @@
     # "ql-qlf"
     "sdc"
     "xdc"
-    # "UHDM"
+    "systemverilog"
   ];
 
   static_gtest = gtest.dev.overrideAttrs (old: {
@@ -51,7 +50,7 @@ in lib.genAttrs plugins (plugin: stdenv.mkDerivation (rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ which python3 ];
-  buildInputs = [ yosys readline zlib ] ;
+  buildInputs = [ yosys readline zlib uhdm surelog ];
 
   # xdc has an incorrect path to a test which has yet to be patched
   doCheck = plugin != "xdc";
@@ -102,5 +101,3 @@ in lib.genAttrs plugins (plugin: stdenv.mkDerivation (rec {
     maintainers = with maintainers; [ ollieB thoughtpolice ];
   };
 }))
-
-

--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -4,7 +4,6 @@
 , python3
 , readline
 , stdenv
-, which
 , yosys
 , zlib
 , yosys-symbiflow
@@ -15,11 +14,11 @@
   src = fetchFromGitHub {
     owner  = "chipsalliance";
     repo   = "yosys-f4pga-plugins";
-    rev    = "aadd1735b2b7af0472e56dc23f1035d6e1904712";
-    hash   = "sha256-gmpEx+8XDN7f+6e/YG25VKgdadwqApPqU3S6OB4AryA=";
+    rev    = "27208ce08200a5e89e3bd4f466bc68824df38c32";
+    hash   = "sha256-S7txjzlIp+idWIfp/DDOznluA3aMFfosMUt5dvi+g44=";
   };
 
-  version = "2022.05.13";
+  version = "2022.09.27";
 
   # Supported symbiflow plugins.
   #
@@ -49,7 +48,7 @@ in lib.genAttrs plugins (plugin: stdenv.mkDerivation (rec {
   inherit src version plugin;
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ which python3 ];
+  nativeBuildInputs = [ python3 ];
   buildInputs = [ yosys readline zlib uhdm surelog ];
 
   # xdc has an incorrect path to a test which has yet to be patched

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33419,6 +33419,8 @@ with pkgs;
 
   uhdm = callPackage ../applications/science/logic/uhdm {};
 
+  surelog = callPackage ../applications/science/logic/surelog {};
+
   mcy = callPackage ../applications/science/logic/mcy {};
 
   lingeling = callPackage ../applications/science/logic/lingeling {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33417,6 +33417,8 @@ with pkgs;
 
   symfpu = callPackage ../applications/science/logic/symfpu {};
 
+  uhdm = callPackage ../applications/science/logic/uhdm {};
+
   mcy = callPackage ../applications/science/logic/mcy {};
 
   lingeling = callPackage ../applications/science/logic/lingeling {};


### PR DESCRIPTION
###### Description of changes

Add UHDM and Surelog packages, and then add systemverilog plugin to yosys.

To test the systemverilog plugin, I ran

```
yosys> plugin -i systemverilog
yosys> read_systemverilog top.sv
```

top.sv:
```verilog
module top #(
  parameter integer N = 2
) (
  input logic clk,

  input logic [3:0] a [0:N-1],
  input logic [3:0] b [0:N-1],
  output logic [3:0] c [0:N-1]
);
    genvar i;
    generate
        for (i = 0; i < N; i = i + 1) begin
            always_ff @(posedge clk) c[i] <= a[i] + b[i];
        end
    endgenerate
endmodule
```

The `design_introspection` plugin doesn't compile along with `sdc` and `xdc`, which depend on it. The rest do.

I also wasn't able to get the tests working for Surelog.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
