### PR TITLE
clightning: 0.11.0.1 -> 0.11.1

### DIFF
--- a/pkgs/applications/blockchains/clightning/default.nix
+++ b/pkgs/applications/blockchains/clightning/default.nix
@@ -21,11 +21,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "clightning";
-  version = "0.11.0.1";
+  version = "0.11.1";
 
   src = fetchurl {
     url = "https://github.com/ElementsProject/lightning/releases/download/v${version}/clightning-v${version}.zip";
-    sha256 = "e2ad6eead19a0cd8869e291c27d318cf553bb015339c1f0e8d8b30e7bc0910d8";
+    sha256 = "0vsh6gpv3458pfc5cggay9pw7bxjzyxpcniks9b2s3y1rxwk15xi";
   };
 
   # when building on darwin we need dawin.cctools to provide the correct libtool


### PR DESCRIPTION
That fixes a critical bug where channels can be spontaneously closed.

https://github.com/ElementsProject/lightning/releases/tag/v0.11.1

cc @prusnak

###### Things done

- [x] Built and run on `x86_64-linux`