### PR TITLE
crosvm: 100.14526.0.0-rc1 -> 103.3 

### DIFF
--- a/pkgs/applications/virtualization/crosvm/Cargo.lock
+++ b/pkgs/applications/virtualization/crosvm/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "kvm",
  "kvm_sys",
  "libc",
+ "memoffset 0.6.5",
  "minijail",
  "remain",
  "resources",
@@ -33,22 +34,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_log-sys"
-version = "0.2.0"
+name = "aho-corasick"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "arch"
 version = "0.1.0"
 dependencies = [
  "acpi_tables",
+ "anyhow",
  "base",
  "devices",
  "gdbstub_arch",
@@ -67,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "argh"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb41d85d92dfab96cb95ab023c265c5e4261bb956c0fb49ca06d90c570f1958"
+checksum = "a7e7e4aa7e40747e023c0761dafcb42333a9517575bbf1241747f68dd3177a62"
 dependencies = [
  "argh_derive",
  "argh_shared",
@@ -77,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "argh_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be69f70ef5497dd6ab331a50bd95c6ac6b8f7f17a7967838332743fbd58dc3b5"
+checksum = "69f2bd7ff6ed6414f4e5521bd509bae46454bbd513801767ced3f21a751ab4bc"
 dependencies = [
  "argh_shared",
  "heck",
@@ -90,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "argh_shared"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f8c380fa28aa1b36107cd97f0196474bb7241bb95a453c5c01a15ac74b2eac"
+checksum = "47253b98986dafc7a3e1cf3259194f1f47ac61abb57a57f46ec09e48d004ecda"
 
 [[package]]
 name = "assertions"
@@ -100,15 +114,15 @@ version = "0.1.0"
 
 [[package]]
 name = "async-task"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -116,13 +130,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "audio_streams"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "cros_async",
+ "futures",
  "remain",
- "sync",
  "thiserror",
 ]
 
@@ -153,16 +177,33 @@ name = "base"
 version = "0.1.0"
 dependencies = [
  "audio_streams",
- "cros_async",
+ "base_poll_token_derive",
+ "cfg-if",
+ "chrono",
  "data_model",
+ "lazy_static",
  "libc",
+ "log",
+ "rand 0.8.5",
+ "regex",
  "remain",
  "serde",
  "serde_json",
  "smallvec",
  "sync",
- "sys_util",
+ "tempfile",
  "thiserror",
+ "win_util",
+ "winapi",
+]
+
+[[package]]
+name = "base_poll_token_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -188,6 +229,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cbindgen"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,15 +255,37 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "cloudabi"
@@ -215,22 +297,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-sha1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "cros_async"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "anyhow",
  "async-task",
  "async-trait",
+ "audio_streams",
+ "base",
+ "cfg-if",
  "data_model",
  "futures",
+ "futures-executor",
+ "futures-util",
  "intrusive-collections",
  "io_uring",
  "libc",
@@ -238,10 +332,14 @@ dependencies = [
  "paste",
  "pin-utils",
  "remain",
+ "serde",
  "slab",
+ "smallvec",
  "sync",
- "sys_util",
+ "tempfile",
  "thiserror",
+ "win_util",
+ "winapi",
 ]
 
 [[package]]
@@ -249,6 +347,16 @@ name = "cros_fuzz"
 version = "0.1.0"
 dependencies = [
  "rand_core 0.4.2",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -263,6 +371,7 @@ dependencies = [
  "audio_streams",
  "base",
  "bit_field",
+ "cfg-if",
  "crosvm_plugin",
  "data_model",
  "devices",
@@ -275,8 +384,10 @@ dependencies = [
  "kernel_loader",
  "kvm",
  "kvm_sys",
+ "lazy_static",
  "libc",
  "libcras",
+ "log",
  "minijail",
  "net_util",
  "p9",
@@ -287,9 +398,13 @@ dependencies = [
  "rutabaga_gfx",
  "scudo",
  "serde_json",
+ "serde_keyvalue",
  "sync",
  "tempfile",
+ "terminal_size",
  "thiserror",
+ "tube_transporter",
+ "uuid",
  "vhost",
  "vm_control",
  "vm_memory",
@@ -309,7 +424,7 @@ dependencies = [
  "hypervisor",
  "kernel_loader",
  "libc",
- "rand",
+ "rand 0.6.5",
  "tempfile",
  "usb_util",
  "vm_memory",
@@ -319,7 +434,9 @@ dependencies = [
 name = "crosvm_control"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base",
+ "cbindgen",
  "libc",
  "vm_control",
 ]
@@ -341,17 +458,19 @@ name = "data_model"
 version = "0.1.0"
 dependencies = [
  "assertions",
+ "cfg-if",
  "libc",
  "remain",
  "serde",
  "thiserror",
+ "winapi",
 ]
 
 [[package]]
 name = "dbus"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0a745c25b32caa56b82a3950f5fec7893a960f4c10ca3b02060b0c38d8c2ce"
+checksum = "6f8bcdd56d2e5c4ed26a529c5a9029f5db8290d433497506f958eae3be148eb6"
 dependencies = [
  "libc",
  "libdbus-sys",
@@ -370,6 +489,7 @@ dependencies = [
  "balloon_control",
  "base",
  "bit_field",
+ "cfg-if",
  "cros_async",
  "data_model",
  "dbus",
@@ -384,6 +504,7 @@ dependencies = [
  "libcras",
  "libvda",
  "linux_input_sys",
+ "memoffset 0.6.5",
  "minijail",
  "net_sys",
  "net_util",
@@ -397,14 +518,15 @@ dependencies = [
  "rutabaga_gfx",
  "serde",
  "serde_json",
+ "serde_keyvalue",
  "smallvec",
  "sync",
- "sys_util",
  "system_api",
  "tempfile",
  "thiserror",
  "tpm2",
  "usb_util",
+ "uuid",
  "vfio_sys",
  "vhost",
  "virtio_sys",
@@ -441,15 +563,15 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "enumn"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e58b112d5099aa0857c5d05f0eacab86406dd8c0f85fe5d320a13256d29ecf4"
+checksum = "052bc8773a98bd051ff37db74a8a25f00e6bfa2cbd03373390c72e9f7afbf344"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -477,6 +599,7 @@ version = "0.1.0"
 dependencies = [
  "base",
  "bitflags",
+ "crossbeam-utils",
  "data_model",
  "enumn",
  "libc",
@@ -492,6 +615,7 @@ checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -513,6 +637,18 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+ "num_cpus",
+]
 
 [[package]]
 name = "futures-io"
@@ -563,11 +699,12 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e135587d3f6eee6fa02c4ba174270c2337424e6d852c156942c0840b3c0f5cc"
+checksum = "1c1f9371c87c11642ee94dcf92cb48b1484ba250b8e8bff3df71c28651f3f4e7"
 dependencies = [
- "cfg-if 0.1.10",
+ "bitflags",
+ "cfg-if",
  "log",
  "managed",
  "num-traits",
@@ -576,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub_arch"
-version = "0.1.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e358b9c0e1468eae66099062e47bb502849308b987b74b5e72f1936397c33c16"
+checksum = "c24f469ba9556c5a063d6df35a8a338025fccf96ecae44f330a156b686f7a268"
 dependencies = [
  "gdbstub",
  "num-traits",
@@ -586,13 +723,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -610,12 +747,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -630,9 +782,20 @@ dependencies = [
  "kvm",
  "kvm_sys",
  "libc",
+ "memoffset 0.6.5",
  "serde",
  "sync",
  "vm_memory",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg 1.1.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -641,7 +804,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -658,30 +821,31 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb484b70a4ebad7f571bf84e9cd06b5bfb6a7e4db0c36e13dd1570c6b449c10d"
+checksum = "bfe531a7789d7120f3e17d4f3f2cd95f54418ba7354f60b7b622b6644a07888a"
 dependencies = [
- "memoffset",
+ "memoffset 0.5.6",
 ]
 
 [[package]]
 name = "io_uring"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "base",
  "data_model",
  "libc",
  "remain",
  "sync",
- "sys_util",
+ "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "kernel_cmdline"
@@ -734,9 +898,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libcras"
@@ -771,11 +935,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -786,15 +950,24 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -821,6 +994,7 @@ name = "net_sys"
 version = "0.1.0"
 dependencies = [
  "base",
+ "libc",
 ]
 
 [[package]]
@@ -828,35 +1002,56 @@ name = "net_util"
 version = "0.1.0"
 dependencies = [
  "base",
+ "cfg-if",
  "cros_async",
  "data_model",
  "libc",
  "net_sys",
  "remain",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.14"
+name = "num-integer"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.1.0",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.10.0"
+name = "num_cpus"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "p9"
 version = "0.1.0"
 dependencies = [
  "libc",
- "sys_util",
  "wire_format_derive",
 ]
 
@@ -868,9 +1063,9 @@ checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -885,15 +1080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
-name = "poll_token_derive"
-version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "power_monitor"
 version = "0.1.0"
 dependencies = [
@@ -906,12 +1092,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.36"
+name = "ppv-lite86"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -964,7 +1156,6 @@ dependencies = [
 name = "qcow_utils"
 version = "0.1.0"
 dependencies = [
- "argh",
  "base",
  "disk",
  "libc",
@@ -972,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -987,7 +1178,7 @@ checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.8",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc",
  "rand_isaac",
@@ -999,6 +1190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1208,16 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.8",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1022,6 +1234,15 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rand_hc"
@@ -1104,10 +1325,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "remain"
-version = "0.2.2"
+name = "regex"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ba1e78fa68412cb93ef642fd4d20b9a941be49ee9333875ebaf13112673ea7"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c35270ea384ac1762895831cc8acb96f171468e52cec82ed9186f9416209fa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1149,20 +1387,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rutabaga_gfx_ffi"
-version = "0.1.0"
-dependencies = [
- "base",
- "data_model",
- "libc",
- "rutabaga_gfx",
-]
-
-[[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "scudo"
@@ -1186,18 +1414,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1206,13 +1434,34 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_keyvalue"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "remain",
+ "serde",
+ "serde_keyvalue_derive",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_keyvalue_derive"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1223,40 +1472,30 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "sync"
 version = "0.1.0"
-
-[[package]]
-name = "sys_util"
-version = "0.1.0"
-dependencies = [
- "android_log-sys",
- "data_model",
- "libc",
- "poll_token_derive",
- "remain",
- "serde",
- "serde_json",
- "sync",
- "tempfile",
- "thiserror",
-]
 
 [[package]]
 name = "system_api"
@@ -1268,7 +1507,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -1277,23 +1516,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.30"
+name = "terminal_size"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1312,16 +1590,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tube_transporter"
+version = "0.1.0"
+dependencies = [
+ "base",
+ "data_model",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "win_util",
+ "winapi",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-width"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "usb_sys"
@@ -1353,10 +1651,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "vfio_sys"
 version = "0.1.0"
 dependencies = [
  "base",
+ "data_model",
 ]
 
 [[package]]
@@ -1378,6 +1683,7 @@ name = "virtio_sys"
 version = "0.1.0"
 dependencies = [
  "base",
+ "data_model",
 ]
 
 [[package]]
@@ -1410,6 +1716,7 @@ dependencies = [
  "data_model",
  "libc",
  "remain",
+ "serde",
  "thiserror",
 ]
 
@@ -1418,20 +1725,29 @@ name = "vmm_vhost"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base",
  "bitflags",
+ "cfg-if",
  "data_model",
  "libc",
  "remain",
- "sys_util",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
@@ -1442,6 +1758,17 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "win_util"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "libc",
+ "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -1467,6 +1794,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a43e544233e20425d5a58e9671cf76d6aed9e6f211508c050facb29b188dc10f"
+dependencies = [
+ "const-sha1",
+ "windows_gen",
+ "windows_macros",
+]
+
+[[package]]
+name = "windows_gen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6283570a39b3594e31c64a498f48058758cc063eb087d972bb6476ad134a16"
+
+[[package]]
+name = "windows_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f757e7665f81f33ace9f89b0f0fc3a7c770e24ff4fa1475c6503bb35b4524893"
+dependencies = [
+ "syn",
+ "windows_gen",
+]
+
+[[package]]
 name = "wire_format_derive"
 version = "0.1.0"
 dependencies = [
@@ -1480,6 +1834,7 @@ name = "x86_64"
 version = "0.1.0"
 dependencies = [
  "acpi_tables",
+ "anyhow",
  "arch",
  "assertions",
  "base",

--- a/pkgs/applications/virtualization/crosvm/default-seccomp-policy-dir.diff
+++ b/pkgs/applications/virtualization/crosvm/default-seccomp-policy-dir.diff
@@ -1,15 +1,15 @@
-diff --git a/src/crosvm.rs b/src/crosvm.rs
-index b7055df..5989c87 100644
---- a/src/crosvm.rs
-+++ b/src/crosvm.rs
-@@ -141,7 +141,9 @@ impl Default for Config {
-             x_display: None,
-             shared_dirs: Vec::new(),
-             sandbox: !cfg!(feature = "default-no-sandbox"),
+diff --git i/src/crosvm.rs w/src/crosvm.rs
+index ab7c466b..636dc140 100644
+--- i/src/crosvm.rs
++++ w/src/crosvm.rs
+@@ -345,7 +345,9 @@ impl Default for JailConfig {
+     fn default() -> Self {
+         JailConfig {
+             pivot_root: PathBuf::from(option_env!("DEFAULT_PIVOT_ROOT").unwrap_or("/var/empty")),
 -            seccomp_policy_dir: PathBuf::from(SECCOMP_POLICY_DIR),
 +            seccomp_policy_dir: PathBuf::from(
 +                option_env!("DEFAULT_SECCOMP_POLICY_DIR").unwrap_or(SECCOMP_POLICY_DIR),
 +            ),
              seccomp_log_failures: false,
-             cras_audio: false,
-             cras_capture: false,
+         }
+     }

--- a/pkgs/applications/virtualization/crosvm/default.nix
+++ b/pkgs/applications/virtualization/crosvm/default.nix
@@ -53,7 +53,7 @@ in
 
     meta = with lib; {
       description = "A secure virtual machine monitor for KVM";
-      homepage = "https://chromium.googlesource.com/chromiumos/platform/crosvm/";
+      homepage = "https://chromium.googlesource.com/crosvm/crosvm/";
       maintainers = with maintainers; [ qyliss ];
       license = licenses.bsd3;
       platforms = [ "aarch64-linux" "x86_64-linux" ];

--- a/pkgs/applications/virtualization/crosvm/update.py
+++ b/pkgs/applications/virtualization/crosvm/update.py
@@ -10,9 +10,6 @@ import subprocess
 from os.path import abspath, dirname, splitext
 from urllib.request import urlopen
 
-git_path = 'chromiumos/platform/crosvm'
-git_root = 'https://chromium.googlesource.com/'
-
 # CrOS version numbers look like this:
 # [<chrome-major-version>.]<tip-build>.<branch-build>.<branch-branch-build>
 #
@@ -50,7 +47,7 @@ with urlopen(f'https://chromium.googlesource.com/chromiumos/platform/crosvm/+log
 # can be passed straight to fetchGit when imported by Nix.
 argv = ['nix-prefetch-git',
         '--fetch-submodules',
-        '--url', git_root + git_path,
+        '--url', 'https://chromium.googlesource.com/crosvm/crosvm',
         '--rev', f'refs/heads/{release_branch}']
 output = subprocess.check_output(argv)
 data['src'] = json.loads(output.decode('utf-8'))

--- a/pkgs/applications/virtualization/crosvm/update.py
+++ b/pkgs/applications/virtualization/crosvm/update.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -p nix-prefetch-git "python3.withPackages (ps: with ps; [ lxml ])"
+#! nix-shell -p nix-prefetch-git python3
 #! nix-shell -i python
 
-import base64
 import csv
 import json
 import re
@@ -13,8 +12,6 @@ from urllib.request import urlopen
 
 git_path = 'chromiumos/platform/crosvm'
 git_root = 'https://chromium.googlesource.com/'
-manifest_versions = f'{git_root}chromiumos/manifest-versions'
-buildspecs_url = f'{manifest_versions}/+/refs/heads/master/full/buildspecs/'
 
 # CrOS version numbers look like this:
 # [<chrome-major-version>.]<tip-build>.<branch-build>.<branch-branch-build>
@@ -39,38 +36,22 @@ with urlopen('https://chromiumdash.appspot.com/cros/download_serving_builds_csv?
         platform_version = max(platform_version, this_platform_version)
 
 chrome_major_version = chrome_version[0]
-chromeos_tip_build = str(platform_version[0])
+chromeos_tip_build = platform_version[0]
+release_branch = f'release-R{chrome_major_version}-{chromeos_tip_build}.B-chromeos'
 
-# Find the most recent buildspec for the stable Chrome version and
-# Chromium OS build number.  Its branch build and branch branch build
-# numbers will (almost?) certainly be 0.  It will then end with an rc
-# number -- presumably these are release candidates, one of which
-# becomes the final release.  Presumably the one with the highest rc
-# number.
-with urlopen(f'{buildspecs_url}{chrome_major_version}/?format=TEXT') as resp:
-    listing = base64.decodebytes(resp.read()).decode('utf-8')
-    buildspecs = [(line.split('\t', 1)[1]) for line in listing.splitlines()]
-    buildspecs = [s for s in buildspecs if s.startswith(f"{chromeos_tip_build}.")]
-    buildspecs.sort(reverse=True)
-    buildspec = splitext(buildspecs[0])[0]
-
-# Read the buildspec, and extract the git revision.
-with urlopen(f'{buildspecs_url}{chrome_major_version}/{buildspec}.xml?format=TEXT') as resp:
-    xml = base64.decodebytes(resp.read())
-    root = etree.fromstring(xml)
-    revision = root.find(f'./project[@name="{git_path}"]').get('revision')
-
-# Initialize the data that will be output from this script.  Leave the
-# rc number in buildspec so nobody else is subject to the same level
-# of confusion I have been.
-data = {'version': f'{chrome_major_version}.{buildspec}'}
+# Determine the patch version by counting the commits that have been
+# added to the release branch since it forked off the chromeos branch.
+with urlopen(f'https://chromium.googlesource.com/chromiumos/platform/crosvm/+log/refs/heads/chromeos..refs/heads/{release_branch}?format=JSON') as resp:
+    resp.readline() # Remove )]}' header
+    branch_commits = json.load(resp)['log']
+    data = {'version': f'{chrome_major_version}.{len(branch_commits)}'}
 
 # Fill in the 'src' key with the output from nix-prefetch-git, which
 # can be passed straight to fetchGit when imported by Nix.
 argv = ['nix-prefetch-git',
         '--fetch-submodules',
         '--url', git_root + git_path,
-        '--rev', revision]
+        '--rev', f'refs/heads/{release_branch}']
 output = subprocess.check_output(argv)
 data['src'] = json.loads(output.decode('utf-8'))
 

--- a/pkgs/applications/virtualization/crosvm/update.py
+++ b/pkgs/applications/virtualization/crosvm/update.py
@@ -7,7 +7,6 @@ import json
 import re
 import shlex
 import subprocess
-from codecs import iterdecode
 from os.path import abspath, dirname, splitext
 from lxml import etree
 from lxml.etree import HTMLParser

--- a/pkgs/applications/virtualization/crosvm/update.py
+++ b/pkgs/applications/virtualization/crosvm/update.py
@@ -48,7 +48,7 @@ chromeos_tip_build = re.match(r'\d+', platform_version)[0]
 with urlopen(f'{buildspecs_url}{chrome_major_version}/?format=TEXT') as resp:
     listing = base64.decodebytes(resp.read()).decode('utf-8')
     buildspecs = [(line.split('\t', 1)[1]) for line in listing.splitlines()]
-    buildspecs = [s for s in buildspecs if s.startswith(chromeos_tip_build)]
+    buildspecs = [s for s in buildspecs if s.startswith(f"{chromeos_tip_build}.")]
     buildspecs.sort(reverse=True)
     buildspec = splitext(buildspecs[0])[0]
 

--- a/pkgs/applications/virtualization/crosvm/upstream-info.json
+++ b/pkgs/applications/virtualization/crosvm/upstream-info.json
@@ -1,11 +1,11 @@
 {
-  "version": "100.14526.0.0-rc1",
+  "version": "103.3",
   "src": {
     "url": "https://chromium.googlesource.com/chromiumos/platform/crosvm",
-    "rev": "bdf5e4d4379030cfa2d0510328b8acce73162217",
-    "date": "2022-02-14T19:13:41+00:00",
-    "path": "/nix/store/xw31chiwnpzgcp07nf448g2npcwiwkkm-crosvm-bdf5e4d",
-    "sha256": "0mrnjyyqmz24z1yvdq2mysmhmz0577k8kf9y4v51g7860crqp9ji",
+    "rev": "e7db3a5cc78ca90ab06aadd5f08bb151090269b6",
+    "date": "2022-06-01T00:13:12+00:00",
+    "path": "/nix/store/r08jyffmjdq38f8yy57v8wgfjiil6586-crosvm",
+    "sha256": "0hyz0mg5fn6hi97awfpxfykgv68m935r037sdf85v3vcwjy5n5ki",
     "fetchLFS": false,
     "fetchSubmodules": true,
     "deepClone": false,

--- a/pkgs/applications/virtualization/crosvm/upstream-info.json
+++ b/pkgs/applications/virtualization/crosvm/upstream-info.json
@@ -1,7 +1,7 @@
 {
   "version": "103.3",
   "src": {
-    "url": "https://chromium.googlesource.com/chromiumos/platform/crosvm",
+    "url": "https://chromium.googlesource.com/crosvm/crosvm",
     "rev": "e7db3a5cc78ca90ab06aadd5f08bb151090269b6",
     "date": "2022-06-01T00:13:12+00:00",
     "path": "/nix/store/r08jyffmjdq38f8yy57v8wgfjiil6586-crosvm",


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The dashboard we were previously using no longer exists.
I've also included some other small fixes.
More details in commit messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
