### PR TITLE
kde/frameworks: 5.93 -> 5.94

### DIFF
--- a/pkgs/applications/misc/ksmoothdock/default.nix
+++ b/pkgs/applications/misc/ksmoothdock/default.nix
@@ -1,7 +1,6 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , extra-cmake-modules
 , kactivities
@@ -10,27 +9,14 @@
 
 mkDerivation rec {
   pname = "KSmoothDock";
-  version = "6.2";
+  version = "6.3";
 
   src = fetchFromGitHub {
     owner = "dangvd";
     repo = "ksmoothdock";
     rev = "v${version}";
-    sha256 = "182x47cymgnp5xisa0xx93hmd5wrfigy8zccrr23p4r9hp8xbnam";
+    sha256 = "sha256-hO7xgjFMFrEhQs3oc2peFTjSVEDsl7Ma/TeVybEZMEk=";
   };
-
-  patches = [
-    # Fixed hard coded installation path to use CMAKE_INSTALL_BINDIR and CMAKE_INSTALL_PREFIX instead
-    (fetchpatch {
-      url = "https://github.com/dangvd/ksmoothdock/commit/00799bef8a1c1fe61ef9274866267d9fe9194041.patch";
-      sha256 = "1nmb7gf1ggzicxz8k4fd67xhwjy404myqzjpgjym66wqxm0arni4";
-    })
-    # Pull request to fix build on Qt 5.15 https://github.com/dangvd/ksmoothdock/pull/123
-    (fetchpatch {
-      url = "https://github.com/dangvd/ksmoothdock/commit/259527aacadb0fd9110d4425b9bf41a15bedce72.patch";
-      sha256 = "12nj58v9qqrynarn3gpywih3w27mr4n51z1b8mh0rfbnd2kib8dc";
-    })
-  ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
 

--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -1,6 +1,7 @@
 { lib
 , mkDerivation
 , fetchFromGitLab
+, fetchpatch
 , wafHook
 , pkg-config
 , cmake
@@ -33,7 +34,14 @@ mkDerivation rec {
     sha256 = "sha256-aXOokji6fYTpaeI/IIV+5RnTE2Cm8X3WfADf4Uftkss=";
   };
 
-  patches = [ ./qt5.patch ];
+  patches = [
+    (fetchpatch {
+      name = "fix-kdelibs4support.patch";
+      url = "https://gitlab.com/ita1024/semantik/-/commit/a991265bd6e3ed6541f8ec099420bc08cc62e30c.patch";
+      sha256 = "sha256-E4XjdWfUnqhmFJs9ORznHoXMDS9zHWNXvQIKKkN4AAo=";
+    })
+    ./qt5.patch
+  ];
 
   postPatch = ''
     echo "${lib.getDev qtwebengine}"

--- a/pkgs/applications/office/semantik/qt5.patch
+++ b/pkgs/applications/office/semantik/qt5.patch
@@ -40,14 +40,14 @@ diff --color -ur a/wscript b/wscript
  	if not os.path.exists(specpath):
  		raise ValueError('No spec path, cannot build')
  
-@@ -196,17 +220,28 @@
+@@ -196,17 +220,29 @@
  
  	conf.env.append_value('INCLUDES_KDECORE', specpath)
  
 -	libs = ['KF5KIOCore', 'KF5Auth', 'KF5KIOWidgets',
 -		'KF5IconThemes', 'KF5ConfigWidgets', 'KF5XmlGui',
 -		'KF5CoreAddons', 'KF5ConfigGui', 'KF5ConfigCore',
--		'KF5WidgetsAddons', 'KF5I18n', 'KF5SonnetUi']
+-		'KF5WidgetsAddons', 'KF5I18n', 'KF5SonnetUi', 'KF5AuthCore']
 +	libs = {
 +            'KF5KIOCore': '@KF5KIOCore_dev@',
 +            'KF5Auth': '@KF5Auth_dev@',
@@ -61,6 +61,7 @@ diff --color -ur a/wscript b/wscript
 +            'KF5WidgetsAddons': '@KF5WidgetsAddons_dev@',
 +            'KF5I18n': '@KF5I18n_dev@',
 +            'KF5SonnetUi': '@KF5SonnetUi_dev@',
++            'KF5AuthCore': '@KF5Auth_dev@',
 +        }
  
 -	for lib in libs:
@@ -73,6 +74,6 @@ diff --color -ur a/wscript b/wscript
 -		p = '%s/qt_%s.pri' % (path, name)
 +		p = '%s/qt_%s.pri' % (mkspec_path+"/mkspecs/modules", name)
 +		print("[log] path :",path,", name : ",name)
- 		for line in Utils.readf(p).splitlines():
- 			lst = line.strip().split(' = ')
- 			if lst[0].endswith('.name'):
+ 		try:
+ 			code = Utils.readf(p)
+ 		except EnvironmentError:

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.93/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.94/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/kapidox.nix
+++ b/pkgs/development/libraries/kde-frameworks/kapidox.nix
@@ -1,9 +1,25 @@
-{ mkDerivation, lib, extra-cmake-modules, python3 }:
+{ mkDerivation, python3, qtbase }:
 
 mkDerivation {
   pname = "kapidox";
-  nativeBuildInputs = [ extra-cmake-modules python3 python3.pkgs.setuptools ];
-  postFixup = ''
-    moveToOutput bin $bin
+  buildInputs = with python3.pkgs; [ jinja2 pyyaml requests ];
+  nativeBuildInputs = with python3.pkgs; [ qtbase setuptools ];
+
+  patchPhase = ''
+    sed -i -e 's|"doxy\w\+", ||g' setup.py
   '';
+
+  buildPhase = ''
+    runHook preBuild
+    ${python3.interpreter} setup.py build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    ${python3.interpreter} setup.py install --prefix="$out"
+    runHook postInstall
+  '';
+
+  outputs = [ "out" ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kapidox.nix
+++ b/pkgs/development/libraries/kde-frameworks/kapidox.nix
@@ -2,10 +2,11 @@
 
 mkDerivation {
   pname = "kapidox";
-  buildInputs = with python3.pkgs; [ jinja2 pyyaml requests ];
-  nativeBuildInputs = with python3.pkgs; [ qtbase setuptools ];
+  nativeBuildInputs = [ python3.pkgs.setuptools qtbase ];
 
-  patchPhase = ''
+  buildInputs = with python3.pkgs; [ jinja2 pyyaml requests ];
+
+  postPatch = ''
     sed -i -e 's|"doxy\w\+", ||g' setup.py
   '';
 

--- a/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
@@ -1,13 +1,13 @@
 { mkDerivation
 , extra-cmake-modules
-, qtbase, qtx11extras, wayland
+, qtbase, qtx11extras, wayland, plasma-wayland-protocols
 }:
 
 mkDerivation {
   pname = "kguiaddons";
 
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ qtx11extras wayland ];
+  buildInputs = [ qtx11extras wayland plasma-wayland-protocols ];
   propagatedBuildInputs = [ qtbase ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -4,667 +4,667 @@
 
 {
   attica = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/attica-5.93.0.tar.xz";
-      sha256 = "1qcj0n00ma6lyhbdk5dx2a1iwjqwzkbqvrwdhv8hgsqvj44q1hc1";
-      name = "attica-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/attica-5.94.0.tar.xz";
+      sha256 = "0rgg5n7m0bw5ir6k5bvq4r9k1s05xas42bdsh0h8352pvackcagn";
+      name = "attica-5.94.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/baloo-5.93.0.tar.xz";
-      sha256 = "1kfmmsinpnsh169dw8ycl9cavw4n7pfwx4davgfx12nvzmlibl95";
-      name = "baloo-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/baloo-5.94.0.tar.xz";
+      sha256 = "0fi7p586322h8x0f83x98kxkfs5klvv8h9d8sr3jmhq3b0p1ii4x";
+      name = "baloo-5.94.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/bluez-qt-5.93.0.tar.xz";
-      sha256 = "091n2bcvzczn28zkry5yxfrg0zpx78y2la3rhdybb4bplgm88pdb";
-      name = "bluez-qt-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/bluez-qt-5.94.0.tar.xz";
+      sha256 = "0ch6rkifx7vrgljz73vvaah09mw17jpb7i7yl2z7lwjy17mnyxvy";
+      name = "bluez-qt-5.94.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/breeze-icons-5.93.0.tar.xz";
-      sha256 = "1rh39pgyhz73lly7n9sp1z16z6isw2bbx284d2ilb9lanjkdyrs3";
-      name = "breeze-icons-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/breeze-icons-5.94.0.tar.xz";
+      sha256 = "1fx3nfzn4ky8cy91d9ywhpmv09az6hw6j1jc63585fjd6z93y2ry";
+      name = "breeze-icons-5.94.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/extra-cmake-modules-5.93.0.tar.xz";
-      sha256 = "088b93ahiw00msn20iibp8642p2vy5zd8wb99vvwayv425xylg89";
-      name = "extra-cmake-modules-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/extra-cmake-modules-5.94.0.tar.xz";
+      sha256 = "0yfjg3bci0yj6bwgs2sg34jyw51rz4mi207wfnkcz65rwa68lm13";
+      name = "extra-cmake-modules-5.94.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/frameworkintegration-5.93.0.tar.xz";
-      sha256 = "19m2i09r7hzqj8dkmxdkj7lh5jilm332i7177aadm6v7xv4m8vhm";
-      name = "frameworkintegration-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/frameworkintegration-5.94.0.tar.xz";
+      sha256 = "19psnjxs19xbf7fvhmpd8wq400wsh74iyqarwxd7chnjz3msnr4s";
+      name = "frameworkintegration-5.94.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kactivities-5.93.0.tar.xz";
-      sha256 = "0hv8y6i03ib89ivmpfg4ifypnnia73la6ljp5frs3fykh91j0szb";
-      name = "kactivities-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kactivities-5.94.0.tar.xz";
+      sha256 = "1pss8h7w3yhdaz1p0a3w6nk3qyr734r5p1m1nfxskcmf7nx5xpaj";
+      name = "kactivities-5.94.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kactivities-stats-5.93.0.tar.xz";
-      sha256 = "1a03xznriszw12jd0a2c7snilzd23nbgglx096isw1cf49r9h1pi";
-      name = "kactivities-stats-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kactivities-stats-5.94.0.tar.xz";
+      sha256 = "0h13xwlgpfz7kbwg7fjcjdm8mvh04y84jaa3327k83w3kl87vzl3";
+      name = "kactivities-stats-5.94.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kapidox-5.93.0.tar.xz";
-      sha256 = "0nqxz2jg51kyis07k2jqk4ni1wly6zx8mv81lgqfhb9l6mm34a22";
-      name = "kapidox-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kapidox-5.94.0.tar.xz";
+      sha256 = "0xsmwm35jfz7nzxzjs0aa86hhy0l71y9l2xmx2d1gqxz742m59qw";
+      name = "kapidox-5.94.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/karchive-5.93.0.tar.xz";
-      sha256 = "1yy7jibbjpi67d6aihz5kcq4ynq8c9j9ds5rz2vp00l682l2dqv1";
-      name = "karchive-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/karchive-5.94.0.tar.xz";
+      sha256 = "1r71apql80gzgknqqflsvmksm4mr6bqlmkpviqb9qr3s8fjqgkam";
+      name = "karchive-5.94.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kauth-5.93.0.tar.xz";
-      sha256 = "0v6s79n9bd75dzncz9rmp449j82945gralmcycsihqyzpxw00n1l";
-      name = "kauth-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kauth-5.94.0.tar.xz";
+      sha256 = "0na1svylmkzk2vd3pmg9scfgyvbv1lsfz9bkhbw5vym8d6nx1zlw";
+      name = "kauth-5.94.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kbookmarks-5.93.0.tar.xz";
-      sha256 = "0gw6zl87xhm3k2qdmd6993xyj8i0y2z5yvlwsnq91glrzyazgvry";
-      name = "kbookmarks-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kbookmarks-5.94.0.tar.xz";
+      sha256 = "0z2ibxrpap40wbabgls8jbyrr11v32ml7l5b0gasp6vfdymrkjwc";
+      name = "kbookmarks-5.94.0.tar.xz";
     };
   };
   kcalendarcore = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kcalendarcore-5.93.0.tar.xz";
-      sha256 = "0gqxbj3i0w3kfyyd6n9n3dxgmx2nwfh578srxnmy1z1r2wabq28n";
-      name = "kcalendarcore-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kcalendarcore-5.94.0.tar.xz";
+      sha256 = "0aq4gkbj2vf6j7636jac1bs0pzdcqvra9m22ny4vhkr1x3i1marv";
+      name = "kcalendarcore-5.94.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kcmutils-5.93.0.tar.xz";
-      sha256 = "0v8dsfrbba1pv8vrisr3pbyw8yanfl95i5jxqbbrzmpznxwgji8l";
-      name = "kcmutils-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kcmutils-5.94.0.tar.xz";
+      sha256 = "029ksln66n1g993zp4vfh2bmg8ws1cy2r89fhbj25jydj1lyz33r";
+      name = "kcmutils-5.94.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kcodecs-5.93.0.tar.xz";
-      sha256 = "12r8n8sq5yav62viddhgm1bjlxv1a0jrndmr1a52y55kma5mrz0f";
-      name = "kcodecs-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kcodecs-5.94.0.tar.xz";
+      sha256 = "1yg7p18z4fac4k4gprncw2v4nv547431dpi6lc2ry98x3kxykh5w";
+      name = "kcodecs-5.94.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kcompletion-5.93.0.tar.xz";
-      sha256 = "177vx3ck4yyc38b3kd4m5sm55hj15ybiwx2jm2f62nw7x1ar733z";
-      name = "kcompletion-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kcompletion-5.94.0.tar.xz";
+      sha256 = "193fz8xpmlcyrhmlllzprd0r8pq1b70dikrf1hmkbghbcm0kvl8s";
+      name = "kcompletion-5.94.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kconfig-5.93.0.tar.xz";
-      sha256 = "0vn009nvg3s540avq88fjr267j22lvjnmm6n5p11g442shh7r1bi";
-      name = "kconfig-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kconfig-5.94.0.tar.xz";
+      sha256 = "1mxk3jlixxamki6gl46i1ndlkqyad88yl0707c44znbhy0292vcf";
+      name = "kconfig-5.94.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kconfigwidgets-5.93.0.tar.xz";
-      sha256 = "1fr4kwkvx5jz9xb3qvk84sh6ma2x5n852xc7ypb6vbby47rf066v";
-      name = "kconfigwidgets-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kconfigwidgets-5.94.0.tar.xz";
+      sha256 = "025m5zw060jclar73gw9j8jmqzyk0y9wgdgrcw70yjzlgximy19m";
+      name = "kconfigwidgets-5.94.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kcontacts-5.93.0.tar.xz";
-      sha256 = "0xacc3yi169hdgf1x82rxb72nnzccmhspmz4v6493afgdin8qz2x";
-      name = "kcontacts-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kcontacts-5.94.0.tar.xz";
+      sha256 = "1y2jc9b2k7mmhv8z2bpc45dhnj9njarrk9k8y6f28w5jv7gigwzp";
+      name = "kcontacts-5.94.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kcoreaddons-5.93.0.tar.xz";
-      sha256 = "0hzhvf2mf53pyhfbfg4pczb20k3l0hv6y2kp0vfkmskxz652f2lj";
-      name = "kcoreaddons-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kcoreaddons-5.94.0.tar.xz";
+      sha256 = "02qirq0hwz5233yfxsp0fp0ww0l8gyv86x5ybaqsjshd0z7bc42w";
+      name = "kcoreaddons-5.94.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kcrash-5.93.0.tar.xz";
-      sha256 = "1midk5b5bmlv4qkjjn2wllmcwmdv0q33jad9yhp7aasbjb3ddy1g";
-      name = "kcrash-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kcrash-5.94.0.tar.xz";
+      sha256 = "1x9wy1qzcyyyk6hsii39hy6yvrffvw62d6lfdjdnxbf2m0n7kis8";
+      name = "kcrash-5.94.0.tar.xz";
     };
   };
   kdav = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kdav-5.93.0.tar.xz";
-      sha256 = "0s5d6h4p496y6fhrcm1gb10y15bsa0sidsljhh7v58gh400x9lx7";
-      name = "kdav-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kdav-5.94.0.tar.xz";
+      sha256 = "0gjv6dbsl25805ks3a4y8z5dcwx48wcy4s87bnp137q0w731w8cb";
+      name = "kdav-5.94.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kdbusaddons-5.93.0.tar.xz";
-      sha256 = "1n9ah83a0hg7vr5qamf1amvs1wwk2gjm9x4zhkqpmfb53r878b6c";
-      name = "kdbusaddons-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kdbusaddons-5.94.0.tar.xz";
+      sha256 = "1s6syhzqy0l5v31r94rzbzqygpwsz6ym7dlxggmg3mnagh8k058a";
+      name = "kdbusaddons-5.94.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kdeclarative-5.93.0.tar.xz";
-      sha256 = "0rsh68nqjy5lk8v2irvaj53qrhp726f9rlj2gkc8k3dajg3lba88";
-      name = "kdeclarative-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kdeclarative-5.94.0.tar.xz";
+      sha256 = "023bvl93ia8nwl3swr98n71gz4xwsq87v29kj8ng950rcyknr6gj";
+      name = "kdeclarative-5.94.0.tar.xz";
     };
   };
   kded = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kded-5.93.0.tar.xz";
-      sha256 = "1psrh4vqa25k4lpmd7rx1bkc4nzci8rciax15kxgijnc444k34hr";
-      name = "kded-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kded-5.94.0.tar.xz";
+      sha256 = "1igk8in16i29jckqyf5dqn83h2hx727d8n35j7jq2ky6x2in2k9g";
+      name = "kded-5.94.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kdelibs4support-5.93.0.tar.xz";
-      sha256 = "0z1p0wmj2y318r5d8wgab2p4c2yi3vyrlkzj60lw3avbrj01sgka";
-      name = "kdelibs4support-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kdelibs4support-5.94.0.tar.xz";
+      sha256 = "0cv0lzcgyny2xravgdsbpjz5j5jlp7202dk077nxblv60yqfn9np";
+      name = "kdelibs4support-5.94.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kdesignerplugin-5.93.0.tar.xz";
-      sha256 = "1bwaca721dzydwrky64p7h4z0bigvajpb7wg5mj8k2ym3vyb96pi";
-      name = "kdesignerplugin-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kdesignerplugin-5.94.0.tar.xz";
+      sha256 = "00walz1w0mx1jqx7yx76qyig5k1n39mh6xmq4qg317rsgzj53l3b";
+      name = "kdesignerplugin-5.94.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kdesu-5.93.0.tar.xz";
-      sha256 = "1gwd2gc98s0v8mlj7iqr1l7wljdx9rmzpcvaa75f5w2ri6d9s0kz";
-      name = "kdesu-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kdesu-5.94.0.tar.xz";
+      sha256 = "1qfwm4l30iy4gy4df8gf7i8mg11szv2c4s60jgfqqk5bxcil6jch";
+      name = "kdesu-5.94.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kdewebkit-5.93.0.tar.xz";
-      sha256 = "0m9gzm8a4gl1ycz2l7x8g61461x4n7vhph248bblsgbnc1b9pzm2";
-      name = "kdewebkit-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kdewebkit-5.94.0.tar.xz";
+      sha256 = "0n8df6y84hd4b3iwfjxk7h06avigq3vgcksi8jh8kjvwwvl77jlv";
+      name = "kdewebkit-5.94.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kdnssd-5.93.0.tar.xz";
-      sha256 = "0fwh5wzx1bp9ndhd8l1gjp61maw47jnzd1i9pfjpx1mm2i7kd5yw";
-      name = "kdnssd-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kdnssd-5.94.0.tar.xz";
+      sha256 = "0qs8jr506aq9i39p8smjsiswjh5zspap3dsvmh7bhayrhgzs5sr8";
+      name = "kdnssd-5.94.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kdoctools-5.93.0.tar.xz";
-      sha256 = "0p2xnq83c7v5llh3i4a379l68qbrjccw99959swnfdn5a7qkzs15";
-      name = "kdoctools-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kdoctools-5.94.0.tar.xz";
+      sha256 = "1x6j7h1lg4bbr1jjb8nl4jsl0v9lcc5h4hg3svkk9rn5x3zn2kpm";
+      name = "kdoctools-5.94.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kemoticons-5.93.0.tar.xz";
-      sha256 = "0474bb6h9s3ks3z8pankr7zxpjha1n88bapxm01z2p4kfkrkvjl3";
-      name = "kemoticons-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kemoticons-5.94.0.tar.xz";
+      sha256 = "00hkwg63pqz7m10sybcyknn246nr7np62hxg2iayf5x0fmfv2zgs";
+      name = "kemoticons-5.94.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kfilemetadata-5.93.0.tar.xz";
-      sha256 = "05m8fvk6j0zdg6x64hy8bslqhdrx4jh8l8rnbpjgcs7hlmqw059h";
-      name = "kfilemetadata-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kfilemetadata-5.94.0.tar.xz";
+      sha256 = "1rkp95bx4yvg6qia2lq4vmmlnc3s9lvy7yfw149k77il60d3nmvz";
+      name = "kfilemetadata-5.94.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kglobalaccel-5.93.0.tar.xz";
-      sha256 = "04mpjzpfyrviyva3mrgxamsnkhglz48vfp65k4nn7ir9n3rbh1n8";
-      name = "kglobalaccel-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kglobalaccel-5.94.0.tar.xz";
+      sha256 = "1s9md2iz03xhxpx4sacygqqcqqys6z9aa0xjvqy9gl3jd88h0jx3";
+      name = "kglobalaccel-5.94.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kguiaddons-5.93.0.tar.xz";
-      sha256 = "02pl99a7dbxc3hmpp0l76x4v4l3yv1pzsm61hv5spl8b2j967wi7";
-      name = "kguiaddons-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kguiaddons-5.94.0.tar.xz";
+      sha256 = "0wrqjxqnrngn85wga4prxyl2jr6wvp4vsxxa5v1wndwd4skq4cgj";
+      name = "kguiaddons-5.94.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kholidays-5.93.0.tar.xz";
-      sha256 = "0hdq0ikwr4dd1il3lszkh0ygkvddfy3ld02d5hxyf7jh4fw1yjhd";
-      name = "kholidays-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kholidays-5.94.0.tar.xz";
+      sha256 = "0p85i8l157616an8p1iaydzy575wh47qn3cfq7imhxlxki9kadz5";
+      name = "kholidays-5.94.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/khtml-5.93.0.tar.xz";
-      sha256 = "0jv1hqpidlfsvvcfvxvvkzyba48cw7l27ixxwac8n96p5rsvdgri";
-      name = "khtml-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/khtml-5.94.0.tar.xz";
+      sha256 = "0ycvzqj1xdjbwwgqp97siljxbk5fig8ijrydjcnirg1g98l2mgcq";
+      name = "khtml-5.94.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/ki18n-5.93.0.tar.xz";
-      sha256 = "0fbk4gjwvzd7vw4m9mngywagdk2aq66v5bz1vw98dwbms4058w62";
-      name = "ki18n-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/ki18n-5.94.0.tar.xz";
+      sha256 = "0jll112q4wrcjrd8wmspf95a0a1aqxkhv1390i9yhw1m6hr86nhc";
+      name = "ki18n-5.94.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kiconthemes-5.93.0.tar.xz";
-      sha256 = "1d72k0ssnqwkkzk3jfnx1n0w1h7xvf2a50dx9j5j46jg9yrwbxvm";
-      name = "kiconthemes-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kiconthemes-5.94.0.tar.xz";
+      sha256 = "14s9h6mk3f4qg97bj0d3b6j7x80jhnlb4kdx9bpp9jvwrlfxhwnr";
+      name = "kiconthemes-5.94.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kidletime-5.93.0.tar.xz";
-      sha256 = "1ndpnyyfx3ym5gdbin96g0qmdpl36il0z9jvmqpbdbpsw7gib4sd";
-      name = "kidletime-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kidletime-5.94.0.tar.xz";
+      sha256 = "1s73nk23js4ly679pq5c4lbry8sgvh0dzf5fyrn8dj6fbda3s756";
+      name = "kidletime-5.94.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kimageformats-5.93.0.tar.xz";
-      sha256 = "1l67vlfqwiqj9pvda054wa0wshzjh2wrc174w1wmkybswnfyvc0m";
-      name = "kimageformats-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kimageformats-5.94.0.tar.xz";
+      sha256 = "0m2ffzlgjl4sz1plf1lpsxvkni1nr93rq8kab2frbj8x15n652di";
+      name = "kimageformats-5.94.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kinit-5.93.0.tar.xz";
-      sha256 = "16743hyyycld1mdpa1hkhjmsr1f5pq3skiyq9rx3n5ihbfys6dnv";
-      name = "kinit-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kinit-5.94.0.tar.xz";
+      sha256 = "0qdw3qz9zbp3i19zgal8wffwiylib3d3ydmfih7dqdx8rq4zk67f";
+      name = "kinit-5.94.0.tar.xz";
     };
   };
   kio = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kio-5.93.0.tar.xz";
-      sha256 = "0i2cbngyy3malcl9sv5bj8di6cgq1m17qjn88y8fpjayzfya946j";
-      name = "kio-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kio-5.94.0.tar.xz";
+      sha256 = "16yhj3wh57gc0azqq01ssqzg0nqa6f904p68jl6p6ifq967bzh45";
+      name = "kio-5.94.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kirigami2-5.93.0.tar.xz";
-      sha256 = "13xb8zfnxcps64v74scn76n8hsccirc9hin9knp12q3pxcjaihm7";
-      name = "kirigami2-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kirigami2-5.94.0.tar.xz";
+      sha256 = "0fcf8ah4vh7arb3iavpk0psy81agyj6vfg8s9sgk7ssz6aipvwnp";
+      name = "kirigami2-5.94.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kitemmodels-5.93.0.tar.xz";
-      sha256 = "0ns8y2lw74lydnnys081z8qlz9dyim7f1ay5aayg2dxcja5r3fav";
-      name = "kitemmodels-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kitemmodels-5.94.0.tar.xz";
+      sha256 = "12ag11m7sf23h9nd41jvpws7cakzwicvawckdx1vmch2fnwz4pvh";
+      name = "kitemmodels-5.94.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kitemviews-5.93.0.tar.xz";
-      sha256 = "1gsswmqpv61byzwkzldgx829a6llpcz8fnb8dz62hnvr7gn1vw4k";
-      name = "kitemviews-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kitemviews-5.94.0.tar.xz";
+      sha256 = "0bmm71lm59spxwc0hrw1yd7m0a8qs55yydijld57zq4wf55k6xav";
+      name = "kitemviews-5.94.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kjobwidgets-5.93.0.tar.xz";
-      sha256 = "1yrrghkdqym0sq19pww57fz44bhp2jvb45xk3hmb79bggms9ni32";
-      name = "kjobwidgets-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kjobwidgets-5.94.0.tar.xz";
+      sha256 = "01xh880avavzbbrk65y6gsn011w6pbsk7ian753az1i8m3y4akq1";
+      name = "kjobwidgets-5.94.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kjs-5.93.0.tar.xz";
-      sha256 = "0hh9z6xjqx0nxxpif4gmhjddls6cp37zngjxi565cx97kkg03al5";
-      name = "kjs-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kjs-5.94.0.tar.xz";
+      sha256 = "06rw7gch4hw2kib4v9p5zzlkz8n3wjifdrxhwywcqy5rvsi18gpr";
+      name = "kjs-5.94.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kjsembed-5.93.0.tar.xz";
-      sha256 = "096lh47xr4xjkdg4dnpkj1qflfz5zfqhkj9wazmjd41z1fzx6mgs";
-      name = "kjsembed-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kjsembed-5.94.0.tar.xz";
+      sha256 = "0bpnvvz0gc8j5ywljhc8i5ws6f6inds710xwxvp9ymqgkm3kgkpk";
+      name = "kjsembed-5.94.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kmediaplayer-5.93.0.tar.xz";
-      sha256 = "02l3fhg73hqzgr5pin74zl6q7lv2y3pr49w128hsz8zyn2ssza5d";
-      name = "kmediaplayer-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kmediaplayer-5.94.0.tar.xz";
+      sha256 = "1310v2krzgxz7ghcws83p47hrlap7qxpnc38l5y3j7g21kgzdw8b";
+      name = "kmediaplayer-5.94.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/knewstuff-5.93.0.tar.xz";
-      sha256 = "0nappdgg7lw8grhkb5bndnvkcc54gvvhf47zyrhmzh04dki4ip1a";
-      name = "knewstuff-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/knewstuff-5.94.0.tar.xz";
+      sha256 = "0vrkj2p9pqp49ph0rpy45dawli3j4mbcncw3x45d8rmbk57h3kda";
+      name = "knewstuff-5.94.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/knotifications-5.93.0.tar.xz";
-      sha256 = "0jysjrkpjayqlkazaf1xg4r7rr2kiph0zdx32bidg0aqwlgin6gy";
-      name = "knotifications-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/knotifications-5.94.0.tar.xz";
+      sha256 = "1gs39fvk0rylrlxsvym8pb58c8106fqbvrx3bp3rdw355giirmf8";
+      name = "knotifications-5.94.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/knotifyconfig-5.93.0.tar.xz";
-      sha256 = "1k8rcrcfxzjrdvi5khlvj1mrslmby217n06dclclam8mcdkf37fc";
-      name = "knotifyconfig-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/knotifyconfig-5.94.0.tar.xz";
+      sha256 = "0449pb1j2m3jxafvv53qyrma309g3xm3q7fxxlpqxaw2fjd9i1db";
+      name = "knotifyconfig-5.94.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kpackage-5.93.0.tar.xz";
-      sha256 = "1kf55v26fbqh4whd5chvnl8j54jhlqx2i4wxj6wldxqwxpbfrrld";
-      name = "kpackage-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kpackage-5.94.0.tar.xz";
+      sha256 = "057lpas5d9m43rshp36p2dmrwpk14saa5n7jg5l0zcf940lrqk2d";
+      name = "kpackage-5.94.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kparts-5.93.0.tar.xz";
-      sha256 = "0x8nrnxrh34bipp0pvr0qx86r9ysrrmjv92gj192y6n79ikfk268";
-      name = "kparts-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kparts-5.94.0.tar.xz";
+      sha256 = "1fkbs0gfcg6ps5az0anf03w961xm9vmq0pd8br7yip4p387i5985";
+      name = "kparts-5.94.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kpeople-5.93.0.tar.xz";
-      sha256 = "0wgk96xyhig8psh3byic5qqp2g58krb1il0nnbbvsapsh9ljdqfk";
-      name = "kpeople-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kpeople-5.94.0.tar.xz";
+      sha256 = "0x2jdb9x1fss95bzra51dz902q8h78qgq4j5j4c3agi2ihvvlzi1";
+      name = "kpeople-5.94.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kplotting-5.93.0.tar.xz";
-      sha256 = "0vd2nsb60kbk8iy8via5rvizdbwbch86madnzxcm5x8k89linvaq";
-      name = "kplotting-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kplotting-5.94.0.tar.xz";
+      sha256 = "1ah6fsskdnkh6m2nyjm64rxqfyxgg6jj0ydcqivq1m81hrhnsgbq";
+      name = "kplotting-5.94.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kpty-5.93.0.tar.xz";
-      sha256 = "04pc94v4r8066dzic8a5q5clmcn36vf99d1k5zrq5c4ypx6ia19a";
-      name = "kpty-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kpty-5.94.0.tar.xz";
+      sha256 = "1jj6aw0zlbw5mljv2q990m62y381aqjih7pvqnjsdk2licqn16jn";
+      name = "kpty-5.94.0.tar.xz";
     };
   };
   kquickcharts = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kquickcharts-5.93.0.tar.xz";
-      sha256 = "0j580h8gysdqmsyzhx40arrkszbzkb9fa3byyazqbmyihk26ld14";
-      name = "kquickcharts-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kquickcharts-5.94.0.tar.xz";
+      sha256 = "0a4mxb7wkqjq3iclhxnb7pkikb7yj2y4lyb080cni2wknjyzlr9h";
+      name = "kquickcharts-5.94.0.tar.xz";
     };
   };
   kross = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kross-5.93.0.tar.xz";
-      sha256 = "1hqsanjk8n786qbr47pxpwvfpwfd1l6152bqac21f6vk70jgv9ib";
-      name = "kross-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kross-5.94.0.tar.xz";
+      sha256 = "0j9dchgldl0z2xi25r82fcflvqp05njgscpqjzmddpih4nyjas8x";
+      name = "kross-5.94.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/krunner-5.93.0.tar.xz";
-      sha256 = "14f993x6s2y6s3bcjqp9q6f5hhiz31ij4bnqwbsqfpa1klbbkiid";
-      name = "krunner-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/krunner-5.94.0.tar.xz";
+      sha256 = "1lfbnwhk74b42cs5vnlx36mrrlnj9s2qqnca5zggk10837dbrc1j";
+      name = "krunner-5.94.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kservice-5.93.0.tar.xz";
-      sha256 = "0cblwvrjwis8w45a6wnjgns6c78xn2lamzss3hqhx2gv6zw95ks6";
-      name = "kservice-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kservice-5.94.0.tar.xz";
+      sha256 = "0civwkm4wknrh30674lw2mag46m0jdpzjabfpqf0n1m4q1gi1b8s";
+      name = "kservice-5.94.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/ktexteditor-5.93.0.tar.xz";
-      sha256 = "1hyn5gkbc246rbv5rxaz190c5fa2j87ndjw0jz7sjbfdhaw3gx3s";
-      name = "ktexteditor-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/ktexteditor-5.94.0.tar.xz";
+      sha256 = "1dmkw5am89pjzazs2s9f1yv5lni0aa3hxr6w46w8lwbx2sbrjbfq";
+      name = "ktexteditor-5.94.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/ktextwidgets-5.93.0.tar.xz";
-      sha256 = "05f2nzgqpprri8zh2da9hj36zif0bv2dwvdxxf2z8dfv564mhzz2";
-      name = "ktextwidgets-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/ktextwidgets-5.94.0.tar.xz";
+      sha256 = "0rnqkqwq9zffxh6swpd5riyir21rpdbm5mf1cqy4qvsjrgdfxz24";
+      name = "ktextwidgets-5.94.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kunitconversion-5.93.0.tar.xz";
-      sha256 = "1j1gl1ahpqafdwlq4bcwc1xv3q59489jyjgr4wkv7lljxmmgpblv";
-      name = "kunitconversion-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kunitconversion-5.94.0.tar.xz";
+      sha256 = "0jc0lffaz1wq26a251vgk6c16lqfqdkb81p789016ifv4kqz1bg4";
+      name = "kunitconversion-5.94.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kwallet-5.93.0.tar.xz";
-      sha256 = "1syx1zi7q14lf1xn8wqkgi475aaydahn2y3v9x2hn9gvgr3zcmpd";
-      name = "kwallet-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kwallet-5.94.0.tar.xz";
+      sha256 = "0ciabsayzy2r1aknwgns7s9759y2kfrxwmzycwxm9rsffm16ndh1";
+      name = "kwallet-5.94.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kwayland-5.93.0.tar.xz";
-      sha256 = "1gks1an0c9yp047jwdik6lg1w5gbjwz9mzzdl2aih30wmmrs4j0n";
-      name = "kwayland-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kwayland-5.94.0.tar.xz";
+      sha256 = "0di6rax4mdismqa4fzx30rj5y2ds211b7kwir6cff76qnkhxi95j";
+      name = "kwayland-5.94.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kwidgetsaddons-5.93.0.tar.xz";
-      sha256 = "045489l353jz52rl346lwazyc4xqd3whn628zn5ybakgiiyy2dcw";
-      name = "kwidgetsaddons-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kwidgetsaddons-5.94.0.tar.xz";
+      sha256 = "0cix00d2dbbb3l523xri4is4xvbf3bn6vg10yyjrhqjxqqayv3k7";
+      name = "kwidgetsaddons-5.94.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kwindowsystem-5.93.0.tar.xz";
-      sha256 = "18g4xccvq56i9sz4rcwf8nkhwclcbvzi0vj9xniqfx0s9lx25jwp";
-      name = "kwindowsystem-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kwindowsystem-5.94.0.tar.xz";
+      sha256 = "0y1wlhm3ng2pb970hvgsyv6gn3irrkw5y9nmvzx28gxcx7abgssj";
+      name = "kwindowsystem-5.94.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/kxmlgui-5.93.0.tar.xz";
-      sha256 = "16dhykbn9z0wyh95ihmfr6lf2ff7xycx253fnsfd035cbzcnbfkl";
-      name = "kxmlgui-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/kxmlgui-5.94.0.tar.xz";
+      sha256 = "1mlxc4wdqnh77g7j0hxrg9jfrdjk9sh3bahp10r17l8fzwq1g8s3";
+      name = "kxmlgui-5.94.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/portingAids/kxmlrpcclient-5.93.0.tar.xz";
-      sha256 = "0v1p94ngq6cvw42rf6qfkl45rdcj0v3zjsfnwrgdjq2nkzzimd0c";
-      name = "kxmlrpcclient-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/portingAids/kxmlrpcclient-5.94.0.tar.xz";
+      sha256 = "10hz8nijhih0n3z83n3khy2hdflsjq8i4q0y9jjpqp1d0b5rbb35";
+      name = "kxmlrpcclient-5.94.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/modemmanager-qt-5.93.0.tar.xz";
-      sha256 = "1a3718kkx288c8ysf3fc5kd51zzw8i7x7sh7x86rsjsj6rlxxv9s";
-      name = "modemmanager-qt-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/modemmanager-qt-5.94.0.tar.xz";
+      sha256 = "1wmz27713kh2i2m227008f412dcf65nvnnax60hrg2nkp8vdqa3r";
+      name = "modemmanager-qt-5.94.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/networkmanager-qt-5.93.0.tar.xz";
-      sha256 = "0q59xg00pxhva75rncwizjca7fjq7h7ib9hyyn14c28iv3i8qn5q";
-      name = "networkmanager-qt-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/networkmanager-qt-5.94.0.tar.xz";
+      sha256 = "00k5k1xv53hf24k9w3sd5am64zz5zph3fx63q6xpf3pz371qq80j";
+      name = "networkmanager-qt-5.94.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/oxygen-icons5-5.93.0.tar.xz";
-      sha256 = "019h6my69cq32rlmnxkpnzix6m5r78rpzpn518snbrivvi23ykkk";
-      name = "oxygen-icons5-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/oxygen-icons5-5.94.0.tar.xz";
+      sha256 = "1l6izhrqqvf5vh2ib8zf1fjh5d9i9ri5jg9x3k1wi0xp7yy9sg90";
+      name = "oxygen-icons5-5.94.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/plasma-framework-5.93.0.tar.xz";
-      sha256 = "08n3nnbds4smd0jdqidlshp10n643x25issnqbkxza1fxa3wd8nl";
-      name = "plasma-framework-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/plasma-framework-5.94.0.tar.xz";
+      sha256 = "0apd2n453yk8ifv6zq6845rwsacm1vpw9xwv26a221k1gfggpsvc";
+      name = "plasma-framework-5.94.0.tar.xz";
     };
   };
   prison = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/prison-5.93.0.tar.xz";
-      sha256 = "0mpvhbxxsnanf41cclhdbadw14979qbh3a7rf5mkq9ng49kdwhqz";
-      name = "prison-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/prison-5.94.0.tar.xz";
+      sha256 = "1jyi0vd5msj7cf2jv21ibpp8lkn5yvd5wv3rbnkdnqwzamw7jq4r";
+      name = "prison-5.94.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/purpose-5.93.0.tar.xz";
-      sha256 = "1i1cx5s6mdrfvabvqkllycv5lmck73mwwck1hlhpxcnrqp3w02yw";
-      name = "purpose-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/purpose-5.94.0.tar.xz";
+      sha256 = "1axk852xpiz1a67b5zh08r01zr6x15k0sd7np9564s9agybzzbbk";
+      name = "purpose-5.94.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/qqc2-desktop-style-5.93.0.tar.xz";
-      sha256 = "1a597chr7awbmg2d64gylg1v9rsih33j6xyvp8r3bqi9ln2w07hn";
-      name = "qqc2-desktop-style-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/qqc2-desktop-style-5.94.0.tar.xz";
+      sha256 = "0j3y1vnqv12lz33vrif6fb5nc3sk5z52fsw77i12xhlkpq6j258b";
+      name = "qqc2-desktop-style-5.94.0.tar.xz";
     };
   };
   solid = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/solid-5.93.0.tar.xz";
-      sha256 = "1skb1lzib230crrhzbgzl0lch51a0bcrgq1jnpn3yy888vwz7vr2";
-      name = "solid-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/solid-5.94.0.tar.xz";
+      sha256 = "01qiz8l12jw9rd085swx2kbbjaci6lnqx323a6g4nskbwc0x93lx";
+      name = "solid-5.94.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/sonnet-5.93.0.tar.xz";
-      sha256 = "170d460vhm42vi21prjg5792h34flcbb2j5wx3r3pr6ybsj6n51w";
-      name = "sonnet-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/sonnet-5.94.0.tar.xz";
+      sha256 = "0k27nxk20i4r9sa6gy56r4s7dnn51igbyvzz3nwvcswdfij0lmwc";
+      name = "sonnet-5.94.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/syndication-5.93.0.tar.xz";
-      sha256 = "08ysirymi5j6as8syvx3rxc7yh12ylwxz1a7yh6ifq370wv4xw9m";
-      name = "syndication-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/syndication-5.94.0.tar.xz";
+      sha256 = "0nv88hhdy8r42ghm2r0pskshihjqc46zx8x61rk5x3c9skj153j5";
+      name = "syndication-5.94.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/syntax-highlighting-5.93.0.tar.xz";
-      sha256 = "06vixhzmmqvbgmzsrhgx0ncfxm80crp3gpy7axscjardjbw53nzb";
-      name = "syntax-highlighting-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/syntax-highlighting-5.94.0.tar.xz";
+      sha256 = "19p5vn6rrhqlhzjs73zagzzdbcrj5jl37n7x35lq6m83llr171yg";
+      name = "syntax-highlighting-5.94.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.93.0";
+    version = "5.94.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.93/threadweaver-5.93.0.tar.xz";
-      sha256 = "11gi0rfd02zjnn8fizhwzgxbaz0jw8m7jhrba56vqbh5fv9bf3bc";
-      name = "threadweaver-5.93.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.94/threadweaver-5.94.0.tar.xz";
+      sha256 = "1ig1m00bpil0qixa3kshd8smijyasr7svps97d1pwfy5c8d47n47";
+      name = "threadweaver-5.94.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/loki/default.nix
+++ b/pkgs/development/libraries/loki/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     make build-shared
   '';
 
+  NIX_CFLAGS_COMPILE = [
+    "-std=c++11"
+  ];
+
   enableParallelBuilding = true;
 
   meta = with lib; {

--- a/pkgs/development/libraries/plasma-wayland-protocols/default.nix
+++ b/pkgs/development/libraries/plasma-wayland-protocols/default.nix
@@ -7,11 +7,11 @@
 
 mkDerivation rec {
   pname = "plasma-wayland-protocols";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-t0/6yWnvBn5HGA50imejoYFrcVf/TqYg7UQy9Ztw8B8=";
+    sha256 = "sha256-CE4mhcqmHZTG/obc4AayJHTXu0s0xMuWvXY7l+MF+tY=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];


### PR DESCRIPTION
###### Description of changes
Bump KDE Frameworks to [5.94, released in 13 May 2022](https://kde.org/announcements/frameworks/5/5.94.0/)
- Calligra build failure fixed by #172733
- KDE Plasma Mobile Gear failures fixed by ~`#173264`~ #153329

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @NixOS/qt-kde 