### PR TITLE
[21.11] podman: add patch for CVE-2022-27649

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -13,6 +13,7 @@
 , systemd
 , go-md2man
 , nixosTests
+, fetchpatch
 }:
 
 buildGoModule rec {
@@ -25,6 +26,15 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-SZHonZdUTJisFMjvUBst1HErvKWEcYZYhK++G+S4sEg=";
   };
+
+  patches = [
+    # Fix for capabilities bug: https://github.com/advisories/GHSA-qvf8-p83w-v58j
+    (fetchpatch {
+      name = "CVE-2022-27649.patch";
+      url = "https://github.com/containers/podman/commit/aafa80918a245edcbdaceb1191d749570f1872d0.patch";
+      sha256 = "sha256-d/5PGQ8yjLaE+6Sqo8p0yHe+mbrENFsbsaDXOF7cMsU=";
+    })
+  ];
 
   vendorSha256 = null;
 


### PR DESCRIPTION
"default inheritable capabilities for linux container not empty"
https://github.com/advisories/GHSA-qvf8-p83w-v58j

Fixes: CVE-2022-27649
Fixes #168680
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Built nixos/tests/podman.nix on x86 and aarch64
- [x] Deployed on personal machines running podman
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
