### PR TITLE
bats: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -18,13 +18,13 @@
 
 resholve.mkDerivation rec {
   pname = "bats";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "bats-core";
     repo = "bats-core";
     rev = "v${version}";
-    sha256 = "sha256-s+SAqX70WeTz6s5ObXYFBVPVUEqvD1d7AX2sGHkjVQ4=";
+    sha256 = "sha256-joNne/dDVCNtzdTQ64rK8GimT+DOWUa7f410hml2s8Q=";
   };
 
   patchPhase = ''
@@ -77,6 +77,8 @@ resholve.mkDerivation rec {
           "${placeholder "out"}/lib/bats-core/common.bash"
           "${placeholder "out"}/lib/bats-core/semaphore.bash"
           "${placeholder "out"}/lib/bats-core/formatter.bash"
+          "${placeholder "out"}/lib/bats-core/warnings.bash"
+          "$setup_suite_file" # via cli arg
         ];
         "$report_formatter" = true;
         "$formatter" = true;
@@ -105,6 +107,7 @@ resholve.mkDerivation rec {
 
   passthru.tests.upstream = bats.unresholved.overrideAttrs (old: {
     name = "${bats.name}-tests";
+    dontInstall = true; # just need the build directory
     installCheckInputs = [
       ncurses
       parallel # skips some tests if it can't detect
@@ -115,8 +118,6 @@ resholve.mkDerivation rec {
     installCheckPhase = ''
       # TODO: cut if https://github.com/bats-core/bats-core/issues/418 allows
       sed -i '/test works even if PATH is reset/a skip "disabled for nix build"' test/bats.bats
-      # TODO: cut when https://github.com/bats-core/bats-core/pull/554 allows
-      substituteInPlace test/parallel.bats --replace '&& type -p shlock' '|| type -p shlock'
 
       # skip tests that assume bats `install.sh` will be in BATS_ROOT
       rm test/root.bats
@@ -126,7 +127,6 @@ resholve.mkDerivation rec {
         "/usr/bin/env bash" "${bash}/bin/bash"
 
       ${bats}/bin/bats test
-      rm -rf $out
       touch $out
     '';
   });


### PR DESCRIPTION
###### Description of changes

https://github.com/bats-core/bats-core/releases/tag/v1.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>bash-preexec</li>
    <li>bats</li>
  </ul>
</details>

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>bash-preexec</li>
    <li>bats</li>
  </ul>
</details>
