### PR TITLE
python3Packages.cgal: init at unstable-20220516

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5749,6 +5749,10 @@
     githubId = 938744;
     name = "John Chadwick";
   };
+  jcomcl = {
+    name = "J. CoMcL";
+    email = "jordan.conwaymcl@gmail.com";
+  };
   jcouyang = {
     email = "oyanglulu@gmail.com";
     github = "jcouyang";

--- a/pkgs/development/python-modules/cgal/default.nix
+++ b/pkgs/development/python-modules/cgal/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, python
+, toPythonModule
+, fetchFromGitHub
+, cmake
+, swig
+, cgal_5
+}:
+
+toPythonModule (stdenv.mkDerivation rec {
+  pname = "cgal";
+  version = "unstable-20220516";
+
+  src = fetchFromGitHub {
+    owner = "CGAL";
+    repo = "cgal-swig-bindings";
+    rev = version;
+    sha256 = "sha256-OBPm/VCeqGskmpkgaYWHuGhaDycOOTyWDhPt1Bi8Zns=";
+  };
+
+  buildInputs = [ cgal_5 python ] ++ cgal_5.buildInputs;
+  nativeBuildInputs = [ cmake swig ];
+
+  cmakeFlags =  [
+    "-DCGAL_DIR=${cgal_5}/lib/cmake/CGAL"
+    "-DBUILD_JAVA=OFF"
+    "-DPYTHON_OUTDIR_PREFIX=${placeholder "out"}/${python.sitePackages}/CGAL"
+  ];
+
+  meta = with lib; {
+    description = "CGAL bindings using SWIG";
+    homepage = "https://github.com/CGAL/cgal-swig-bindings";
+    license = licenses.gpl3Plus;
+  };
+})
+

--- a/pkgs/development/python-modules/cgal/default.nix
+++ b/pkgs/development/python-modules/cgal/default.nix
@@ -32,6 +32,7 @@ toPythonModule (stdenv.mkDerivation rec {
     description = "CGAL bindings using SWIG";
     homepage = "https://github.com/CGAL/cgal-swig-bindings";
     license = licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ jcomcl ];
   };
 })
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1581,6 +1581,8 @@ in {
 
   cftime = callPackage ../development/python-modules/cftime { };
 
+  cgal = callPackage ../development/python-modules/cgal { };
+
   cgen = callPackage ../development/python-modules/cgen { };
 
   cgroup-utils = callPackage ../development/python-modules/cgroup-utils { };


### PR DESCRIPTION
###### Description of changes
Package [CGAL](https://github.com/CGAL/cgal) SWIG bindings. The project also supports Java bindings though I've only packaged it for Python.
Let me know if the pakcage name ought to change, it could be any combination of:
- cgal_5
- cgal-python
- cgal-bindings
I just defaulted to the most succinct one
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on `x86_64-linux`
- Tested that module could be imported
- Tested some [example code](https://github.com/CGAL/cgal-swig-bindings/blob/main/examples/python/polygonal_triangulation.py)
- Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

