### PR TITLE
pretendard: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12156,6 +12156,12 @@
     githubId = 12984845;
     name = "Subhrajyoti Sen";
   };
+  sudosubin = {
+    email = "sudosubin@gmail.com";
+    github = "sudosubin";
+    githubId = 32478597;
+    name = "Subin Kim";
+  };
   suhr = {
     email = "suhr@i2pmail.org";
     github = "suhr";

--- a/pkgs/data/fonts/pretendard/default.nix
+++ b/pkgs/data/fonts/pretendard/default.nix
@@ -1,0 +1,46 @@
+{ lib, fetchzip }:
+
+let
+  version = "1.3.0";
+
+  mkPretendard = { pname, typeface, sha256 }:
+    fetchzip {
+      name = "${pname}-${version}";
+
+      url = "https://github.com/orioncactus/pretendard/releases/download/v${version}/${typeface}-${version}.zip";
+      inherit sha256;
+
+      postFetch = ''
+        mkdir -p $out/share/fonts/opentype
+        unzip -j $downloadedFile "*.otf" -d $out/share/fonts/opentype
+      '';
+
+      meta = with lib; {
+        homepage = "https://github.com/orioncactus/pretendard";
+        description = "An alternative font to system-ui for all platforms";
+        license = licenses.ofl;
+        platforms = platforms.all;
+        maintainers = with maintainers; [ sudosubin ];
+      };
+    };
+
+in
+{
+  pretendard = mkPretendard {
+    pname = "pretendard";
+    typeface = "Pretendard";
+    sha256 = "sha256-4DM8PZjxW93sgQChs+qu5Svo+iGlFnpglu6acYMCkSQ=";
+  };
+
+  pretendard-jp = mkPretendard {
+    pname = "pretendard-jp";
+    typeface = "PretendardJP";
+    sha256 = "sha256-3OOUUDiurCpIGNIVjrr2KW0CB3fCXt11P+13teK5kOQ=";
+  };
+
+  pretendard-std = mkPretendard {
+    pname = "pretendard-std";
+    typeface = "PretendardStd";
+    sha256 = "sha256-iVAPdA6qAiE7pseaB0NKPJBPNGdw/nT6PzXIsLajJH4=";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24832,6 +24832,11 @@ with pkgs;
 
   poppler_data = callPackage ../data/misc/poppler-data { };
 
+  inherit (callPackages ../data/fonts/pretendard { })
+    pretendard
+    pretendard-jp
+    pretendard-std;
+
   quattrocento = callPackage ../data/fonts/quattrocento {};
 
   quattrocento-sans = callPackage ../data/fonts/quattrocento-sans {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`pretendard` is a system-ui alternative font for all cross-platform. It supports English, Korean, and Japanese. In `1.3.0`, it was differentiated into three typefaces (`Pretendard`, `PretendardJP`, `PretendardStd`).

https://github.com/orioncactus/pretendard

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
