### PR TITLE
networkmanager_strongswan: 1.5.2 → 1.6.0

### DIFF
--- a/pkgs/tools/networking/networkmanager/strongswan/default.nix
+++ b/pkgs/tools/networking/networkmanager/strongswan/default.nix
@@ -1,5 +1,15 @@
-{ lib, stdenv, fetchurl, intltool, pkg-config, networkmanager, strongswanNM
-, gtk3, gnome, libsecret, libnma }:
+{ stdenv
+, lib
+, fetchurl
+, intltool
+, pkg-config
+, networkmanager
+, strongswanNM
+, gtk3
+, gnome
+, libsecret
+, libnma
+}:
 
 stdenv.mkDerivation rec {
   pname = "NetworkManager-strongswan";
@@ -10,25 +20,34 @@ stdenv.mkDerivation rec {
     sha256 = "0sc1yzlxjfvl58hjjw99bchqc4061i3apw254z61v22k4sajnif8";
   };
 
-  buildInputs = [ networkmanager strongswanNM libsecret gtk3 libnma ];
+  nativeBuildInputs = [
+    intltool
+    pkg-config
+  ];
 
-  nativeBuildInputs = [ intltool pkg-config ];
-
-  # glib-2.62 deprecations
-  NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
+  buildInputs = [
+    networkmanager
+    strongswanNM
+    libsecret
+    gtk3
+    libnma
+  ];
 
   configureFlags = [
     "--without-libnm-glib"
     "--with-charon=${strongswanNM}/libexec/ipsec/charon-nm"
-    "--with-nm-libexecdir=$(out)/libexec"
-    "--with-nm-plugindir=$(out)/lib/NetworkManager"
+    "--with-nm-libexecdir=${placeholder "out"}/libexec"
+    "--with-nm-plugindir=${placeholder "out"}/lib/NetworkManager"
   ];
+
+  PKG_CONFIG_LIBNM_VPNSERVICEDIR = "${placeholder "out"}/lib/NetworkManager/VPN";
+
+  # glib-2.62 deprecations
+  NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
 
   passthru = {
     networkManagerPlugin = "VPN/nm-strongswan-service.name";
   };
-
-  PKG_CONFIG_LIBNM_VPNSERVICEDIR = "$(out)/lib/NetworkManager/VPN";
 
   meta = with lib; {
     description = "NetworkManager's strongswan plugin";

--- a/pkgs/tools/networking/networkmanager/strongswan/default.nix
+++ b/pkgs/tools/networking/networkmanager/strongswan/default.nix
@@ -6,18 +6,20 @@
 , networkmanager
 , strongswanNM
 , gtk3
+, gtk4
 , gnome
 , libsecret
 , libnma
+, libnma-gtk4
 }:
 
 stdenv.mkDerivation rec {
   pname = "NetworkManager-strongswan";
-  version = "1.5.2";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://download.strongswan.org/NetworkManager/${pname}-${version}.tar.bz2";
-    sha256 = "0sc1yzlxjfvl58hjjw99bchqc4061i3apw254z61v22k4sajnif8";
+    sha256 = "bbyA9qCboM9hBKMXhJWXgEFN13Fl4pY6zWZXwowlRMI=";
   };
 
   nativeBuildInputs = [
@@ -30,14 +32,16 @@ stdenv.mkDerivation rec {
     strongswanNM
     libsecret
     gtk3
+    gtk4
     libnma
+    libnma-gtk4
   ];
 
   configureFlags = [
-    "--without-libnm-glib"
     "--with-charon=${strongswanNM}/libexec/ipsec/charon-nm"
     "--with-nm-libexecdir=${placeholder "out"}/libexec"
     "--with-nm-plugindir=${placeholder "out"}/lib/NetworkManager"
+    "--with-gtk4"
   ];
 
   PKG_CONFIG_LIBNM_VPNSERVICEDIR = "${placeholder "out"}/lib/NetworkManager/VPN";

--- a/pkgs/tools/networking/networkmanager/strongswan/default.nix
+++ b/pkgs/tools/networking/networkmanager/strongswan/default.nix
@@ -42,9 +42,6 @@ stdenv.mkDerivation rec {
 
   PKG_CONFIG_LIBNM_VPNSERVICEDIR = "${placeholder "out"}/lib/NetworkManager/VPN";
 
-  # glib-2.62 deprecations
-  NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
-
   passthru = {
     networkManagerPlugin = "VPN/nm-strongswan-service.name";
   };


### PR DESCRIPTION
###### Description of changes

Update to support GNOME 42.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- [x] Verified that it is visible in Control Center, did not test since I do not have compatible VPN server.

![Strongswan connection in Control Center](https://user-images.githubusercontent.com/705123/168654737-1f3d92d3-7cea-4705-8755-1bad0063ccef.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
