### PR TITLE
gnomeExtensions.dash-to-dock: 71+date=2022-02-23 → 72

### DIFF
--- a/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
@@ -4,19 +4,19 @@
 , glib
 , gettext
 , sassc
-, unstableGitUpdater
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-dash-to-dock";
-  version = "71+date=2022-02-23";
+  version = "72";
 
   # Temporarily switched to commit hash because stable version is buggy.
   src = fetchFromGitHub {
     owner = "micheleg";
     repo = "dash-to-dock";
-    rev = "6f717302747931de6bf35bc9839fb3bd946e2c2f";
-    sha256 = "1J8t0R43jBbqpXyH2uVyEK+OvhrCw18WWheflqwe100=";
+    rev = "extensions.gnome.org-v${version}";
+    sha256 = "Cds5Fc+rnvoy01GTZBS7qPh8UC9ekrNBOs+IEkDNkJw=";
   };
 
   nativeBuildInputs = [
@@ -33,9 +33,10 @@ stdenv.mkDerivation rec {
     extensionUuid = "dash-to-dock@micxgx.gmail.com";
     extensionPortalSlug = "dash-to-dock";
 
-    updateScript = unstableGitUpdater {
-      stableVersion = true;
-      tagPrefix = "extensions.gnome.org-v";
+    updateScript = gitUpdater {
+      pname = "gnomeExtensions.dash-to-dock";
+      inherit version;
+      rev-prefix = "extensions.gnome.org-v";
     };
   };
 


### PR DESCRIPTION
###### Description of changes

Supports GNOME 42.

https://github.com/micheleg/dash-to-dock/compare/extensions.gnome.org-v71...extensions.gnome.org-v72

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested in GNOME VM. Minor visual glitches but otherwise works.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
