### PR TITLE
wpa_supplicant: give wheel dbus access

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -4,6 +4,7 @@
 , withReadline ? true, readline
 , withPcsclite ? true, pcsclite
 , readOnlyModeSSIDs ? false
+, wheelDbusAccess ? false
 }:
 
 with lib;
@@ -23,6 +24,9 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals readOnlyModeSSIDs [
     # Allow read-only networks
     ./0001-Implement-read-only-mode-for-ssids.patch
+  ] ++ lib.optionals wheelDbusAccess [
+    # allow wheel to interact with wpa_supplicanat over dbus
+    ./wheel_dbus_access.patch
   ];
 
   # TODO: Patch epoll so that the dbus actually responds

--- a/pkgs/os-specific/linux/wpa_supplicant/wheel_dbus_access.patch
+++ b/pkgs/os-specific/linux/wpa_supplicant/wheel_dbus_access.patch
@@ -1,0 +1,22 @@
+diff --git a/wpa_supplicant/dbus/dbus-wpa_supplicant.conf b/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
+index e81b495f4..d1622c765 100644
+--- a/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
++++ b/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
+@@ -2,16 +2,11 @@
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+ <busconfig>
+-        <policy user="root">
++        <policy group="wheel">
+                 <allow own="fi.w1.wpa_supplicant1"/>
+ 
+                 <allow send_destination="fi.w1.wpa_supplicant1"/>
+                 <allow send_interface="fi.w1.wpa_supplicant1"/>
+                 <allow receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
+         </policy>
+-        <policy context="default">
+-                <deny own="fi.w1.wpa_supplicant1"/>
+-                <deny send_destination="fi.w1.wpa_supplicant1"/>
+-                <deny receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
+-        </policy>
+ </busconfig>


### PR DESCRIPTION
###### Description of changes

add a flag to derivation to give wheel permissions to interact with wpa_supplicant over dbus

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
