### PR TITLE
lightwalletd: 0.4.9 -> 0.4.10

### DIFF
--- a/pkgs/applications/blockchains/lightwalletd/default.nix
+++ b/pkgs/applications/blockchains/lightwalletd/default.nix
@@ -1,14 +1,14 @@
-{ buildGoModule, fetchFromGitHub, lib }:
+{ buildGoModule, fetchFromGitHub, lib, lightwalletd, testers }:
 
 buildGoModule rec {
   pname = "lightwalletd";
-  version = "0.4.9";
+  version = "0.4.10";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo  = "lightwalletd";
-    rev = "v${version}";
-    sha256 = "sha256-IksA06V+mP7ZAXXFYLKLacxrDXeMXHAk5w4t7pmobq4=";
+    rev = "68789356fb1a75f62735a529b38389ef08ea7582";
+    sha256 = "sha256-7gZhr6YMarGdgoGjg+oD4nZ/SAJ5cnhEDKmA4YMqJTo=";
   };
 
   vendorSha256 = null;
@@ -16,22 +16,28 @@ buildGoModule rec {
   ldflags = [
     "-s" "-w"
     "-X github.com/zcash/lightwalletd/common.Version=v${version}"
-    "-X github.com/zcash/lightwalletd/common.GitCommit=v${version}"
+    "-X github.com/zcash/lightwalletd/common.GitCommit=${src.rev}"
     "-X github.com/zcash/lightwalletd/common.BuildDate=1970-01-01"
     "-X github.com/zcash/lightwalletd/common.BuildUser=nixbld"
   ];
 
-  postFixup = ''
-    shopt -s extglob
-    cd $out/bin
-    rm !(lightwalletd)
-  '';
+  excludedPackages = [
+    "genblocks"
+    "testclient"
+    "zap"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = lightwalletd;
+    command = "lightwalletd version";
+    version = "v${lightwalletd.version}";
+  };
 
   meta = with lib; {
     description = "A backend service that provides a bandwidth-efficient interface to the Zcash blockchain";
     homepage = "https://github.com/zcash/lightwalletd";
     maintainers = with maintainers; [ centromere ];
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

Bump to 0.4.10.

[Release notes](https://github.com/zcash/lightwalletd/releases/tag/v0.4.10).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).