### PR TITLE
lhapdf: 6.4.0 -> 6.5.1

### DIFF
--- a/pkgs/development/libraries/physics/lhapdf/default.nix
+++ b/pkgs/development/libraries/physics/lhapdf/default.nix
@@ -16,10 +16,12 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ makeWrapper ]
-    ++ lib.optionals (lib.versionAtLeast python.version "3.10") [ python.pkgs.cython ];
+    ++ lib.optionals (python != null && lib.versionAtLeast python.version "3.10") [ python.pkgs.cython ];
   buildInputs = [ python ];
 
-  preBuild = lib.optionalString (lib.versionAtLeast python.version "3.10") ''
+  configureFlags = lib.optionals (python == null) [ "--disable-python" ];
+
+  preBuild = lib.optionalString (python != null && lib.versionAtLeast python.version "3.10") ''
     rm wrappers/python/lhapdf.cpp
   '';
 

--- a/pkgs/development/libraries/physics/lhapdf/default.nix
+++ b/pkgs/development/libraries/physics/lhapdf/default.nix
@@ -15,8 +15,13 @@ stdenv.mkDerivation rec {
     substituteInPlace src/GridPDF.cc --replace '#include <locale>' '#include <xlocale.h>'
   '';
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals (lib.versionAtLeast python.version "3.10") [ python.pkgs.cython ];
   buildInputs = [ python ];
+
+  preBuild = lib.optionalString (lib.versionAtLeast python.version "3.10") ''
+    rm wrappers/python/lhapdf.cpp
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/physics/lhapdf/default.nix
+++ b/pkgs/development/libraries/physics/lhapdf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "lhapdf";
-  version = "6.4.0";
+  version = "6.5.1";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/lhapdf/LHAPDF-${version}.tar.gz";
-    sha256 = "sha256-fS8CZ+LWWw3e4EhVOzQtfIk6bbq+HjJsrWLeABDdgQw=";
+    sha256 = "sha256-ElZBniIn0aT5M4f+HagF5kg1FBfTdV6K9aMKNaamZ1E=";
   };
 
   # The Apple SDK only exports locale_t from xlocale.h whereas glibc

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33164,7 +33164,7 @@ with pkgs;
 
   mcfm = callPackage ../applications/science/physics/MCFM {
     stdenv = gccStdenv;
-    lhapdf = lhapdf.override { stdenv = gccStdenv; };
+    lhapdf = lhapdf.override { stdenv = gccStdenv; python = null; };
   };
 
   nnpdf = callPackage ../applications/science/physics/nnpdf { };


### PR DESCRIPTION
###### Description of changes

https://gitlab.com/hepcedar/lhapdf/-/blob/dc8753b39d716078e8cae22e35500651e66a5e0e/ChangeLog#L1-51

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
