### PR TITLE
xfitter: fix for gfortran10+

### DIFF
--- a/pkgs/applications/science/physics/xfitter/0001-src-GetChisquare.f-use-correct-types-in-calls-to-DSY.patch
+++ b/pkgs/applications/science/physics/xfitter/0001-src-GetChisquare.f-use-correct-types-in-calls-to-DSY.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -54,21 +54,7 @@ endif()
+ endif()
+ 
+ #Use c preprocessor with fortran
+-
+-if(UNIX AND NOT APPLE)
+-  set(CMAKE_Fortran_FLAGS "-cpp -Wno-argument-mismatch")
+-endif()
+-
+-if(APPLE)
+-  set(CMAKE_Fortran_FLAGS "-cpp -fallow-argument-mismatch")
+-endif()
+-
+-
+-if (CMAKE_MAJOR_VERSION VERSION_GREATER_EQUAL "3")
+-if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "10")
+-  set(CMAKE_Fortran_FLAGS "-cpp -fallow-argument-mismatch")
+-endif()
+-endif()
++set(CMAKE_Fortran_FLAGS "-cpp")
+ 
+ 
+ #For Fortran
+diff --git a/src/GetChisquare.f b/src/GetChisquare.f
+index b21413fe..28391bcb 100644
+--- a/src/GetChisquare.f
++++ b/src/GetChisquare.f
+@@ -2418,8 +2418,8 @@ C> @Brief Interface to lapack, to dynamically allocate work arrays
+       integer NCovar, NDimCovar
+       double precision Covar(NDimCovar,NDimCovar), EigenValues(NCovar)
+       integer IFail
+-      double precision Work
+-      integer IWork
++      double precision Work(1)
++      integer IWork(1)
+       Character*80 msg
+ C---------------------------------------------------------------
+ C Determine optimal size of the work array:
+@@ -2432,7 +2432,7 @@ C Determine optimal size of the work array:
+      $     int(work)+1, iwork
+       call HF_ERRLOG(14121701,msg)
+       call MyDSYEVD2(NCovar,Covar,NDimCovar, EigenValues,
+-     $     int(work)+1,iwork,ifail)
++     $     int(work(1))+1,iwork(1),ifail)
+ 
+       end
+ 

--- a/pkgs/applications/science/physics/xfitter/default.nix
+++ b/pkgs/applications/science/physics/xfitter/default.nix
@@ -31,10 +31,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZHIQ5hOY+k0/wmpE0o4Po+RZ4MkVMk+bK1Rc6eqwwH0=";
   };
 
-  preConfigure = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "-fallow-argument-mismatch" ""
-  '';
+  patches = [
+    # Avoid need for -fallow-argument-mismatch
+    ./0001-src-GetChisquare.f-use-correct-types-in-calls-to-DSY.patch
+  ];
 
   nativeBuildInputs = [ cmake gfortran pkg-config ];
   buildInputs =


### PR DESCRIPTION
###### Description of changes

For ZHF #172160
patch sent to the upstream by email

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
