### PR TITLE
git-ignore: 1.1.1 -> 1.2.0 (fix build on aarch64-darwin)

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   pname = "git-ignore";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "sondr3";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-bKIBPqGKiS3ey8vH2F4EoleV1H2PTOp+71d/YW3jkT0=";
+    sha256 = "sha256-Bfr+4zDi6QqirlqccW1jU95eb4q82ZFG9LtT2mCPYLc=";
   };
 
-  cargoSha256 = "sha256-7jPNVBf5DYtE8nsh7LIywMCjU7ODZ3qFsmBie2mZ3h8=";
+  cargoSha256 = "sha256-ehEUI4M2IxqS6QhyqOncwP+w6IGbIlSFNIP/FEVH/JI=";
 
   nativeBuildInputs = [ pkg-config installShellFiles ];
   buildInputs = [ openssl ]
@@ -21,9 +21,8 @@ buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
   ];
 
-  outputs = [ "out" "man" ];
-  preFixup = ''
-    installManPage $releaseDir/build/git-ignore-*/out/git-ignore.1
+  postInstall = ''
+    installManPage assets/git-ignore.1
   '';
 
   meta = with lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -23,6 +23,8 @@ buildRustPackage rec {
 
   postInstall = ''
     installManPage assets/git-ignore.1
+    # There's also .elv and .ps1 completion files but I don't know where to install those
+    installShellCompletion assets/git-ignore.{bash,fish} --zsh assets/_git-ignore
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

1.1.1 does not build on `aarch64-darwin` on Hydra (https://hydra.nixos.org/build/176134395). This bump seems to fix the issue.

For ZHF https://github.com/NixOS/nixpkgs/issues/172160

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->