### PR TITLE
hubicfuse: pull upstream fix for -fno-common tollchains

### DIFF
--- a/pkgs/tools/filesystems/hubicfuse/default.nix
+++ b/pkgs/tools/filesystems/hubicfuse/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/TurboGit/hubicfuse/commit/b460f40d86bc281a21379158a7534dfb9f283786.patch";
       sha256 = "0nqvcbrgbc5dms8fkz3brlj40yn48p36drabrnc26gvb3hydh5dl";
     })
+    # UPstream fix for build failure on -fno-common toolchains
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/TurboGit/hubicfuse/commit/34a6c3e57467b5f7e9befe2171bf4292893c5a18.patch";
+      sha256 = "0k1jz2h8sdhmi0srx0adbyrcrm57j4annj84yw6hdrly5hsf7bzc";
+    })
   ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Without the change build fails on upstream gcc-10 as:

    ld: /build/ccadKet8.o:/build/source/cloudfsapi.h:73: multiple definition of
      `public_container'; /build/ccoYHN4x.o:/build/source/cloudfsapi.h:73: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
