### PR TITLE
turbovnc: 2.2.7 -> 3.0, unvendor libs

### DIFF
--- a/pkgs/tools/admin/turbovnc/default.nix
+++ b/pkgs/tools/admin/turbovnc/default.nix
@@ -4,7 +4,10 @@
 , nixosTests
 
 # Dependencies
+, bzip2
 , cmake
+, freetype
+, libGL
 , libjpeg_turbo
 , makeWrapper
 , mesa # for built-in 3D software rendering using swrast
@@ -14,21 +17,24 @@
 , openssl
 , pam
 , perl
+, python3
 , which
 , xkbcomp
 , xkeyboard_config
 , xorg
+, xterm
+, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "turbovnc";
-  version = "2.2.7";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "TurboVNC";
     repo = "turbovnc";
     rev = version;
-    sha256 = "sha256-mEdatfTBx4nNmMTgv1Z+xefPFEiE2rCrsxyB7Dd03rg=";
+    sha256 = "sha256-4/pfKb89ld32LvqTXjVpIJUCCDA+D7CLYMNFYytKVIE=";
   };
 
   # TODO:
@@ -47,20 +53,39 @@ stdenv.mkDerivation rec {
     cmake
     makeWrapper
     openjdk_headless
+    python3
   ];
 
   buildInputs = [
+    bzip2
+    freetype
+    libGL # for -DTVNC_SYSTEMX11=1
     libjpeg_turbo
     openssl
     pam
     perl
+    zlib
   ] ++ (with xorg; [
+    libfontenc # for -DTVNC_SYSTEMX11=1
     libSM
     libX11
+    libXdamage # for -DTVNC_SYSTEMX11=1
+    libXdmcp # for -DTVNC_SYSTEMX11=1
     libXext
+    libXfont2 # for -DTVNC_SYSTEMX11=1
+    libxkbfile # for -DTVNC_SYSTEMX11=1
     libXi
+    mesa # for -DTVNC_SYSTEMX11=1
+    pixman # for -DTVNC_SYSTEMX11=1
     xorgproto
+    xtrans # for -DTVNC_SYSTEMX11=1
   ]);
+
+  postPatch = ''
+    substituteInPlace unix/Xvnc/CMakeLists.txt --replace 'string(REGEX REPLACE "X11" "Xfont2" X11_Xfont2_LIB' 'set(X11_Xfont2_LIB ${xorg.libXfont2}/lib/libXfont2.so)  #'
+    substituteInPlace unix/Xvnc/CMakeLists.txt --replace 'string(REGEX REPLACE "X11" "fontenc" X11_Fontenc_LIB' 'set(X11_Fontenc_LIB ${xorg.libfontenc}/lib/libfontenc.so)  #'
+    substituteInPlace unix/Xvnc/CMakeLists.txt --replace 'string(REGEX REPLACE "X11" "pixman-1" X11_Pixman_LIB' 'set(X11_Pixman_LIB ${xorg.pixman}/lib/libpixman-1.so)  #'
+  '';
 
   cmakeFlags = [
     # For the 3D software rendering built into TurboVNC, pass the path
@@ -73,6 +98,10 @@ stdenv.mkDerivation rec {
     "-DTJPEG_JNILIBRARY=${libjpeg_turbo.out}/lib/libturbojpeg.so"
     "-DXKB_BASE_DIRECTORY=${xkeyboard_config}/share/X11/xkb"
     "-DXKB_BIN_DIRECTORY=${xkbcomp}/bin"
+    # use system libs
+    "-DTVNC_SYSTEMLIBS=1"
+    "-DTVNC_SYSTEMX11=1"
+    "-DTVNC_DLOPENSSL=0"
   ];
 
   postInstall = ''
@@ -85,15 +114,12 @@ stdenv.mkDerivation rec {
     # (This default is written by `vncserver` to `~/.vnc/xstartup.turbovnc`,
     # see https://github.com/TurboVNC/turbovnc/blob/ffdb57d9/unix/vncserver.in#L201.)
     # It checks for it using `which twm`.
+    # vncserver needs also needs `xauth` and we add in `xterm` for convenience
     wrapProgram $out/bin/vncserver \
-      --prefix PATH : ${lib.makeBinPath [ which xorg.twm ]}
+      --prefix PATH : ${lib.makeBinPath [ which xorg.twm xorg.xauth xterm ]}
 
     # Patch /usr/bin/perl
     patchShebangs $out/bin/vncserver
-
-    # vncserver needs `xauth`
-    wrapProgram $out/bin/vncserver \
-      --prefix PATH : ${lib.makeBinPath (with xorg; [ xauth ])}
 
     # The viewer is in Java and requires `JAVA_HOME` (which is a single
     # path, cannot be multiple separated paths).


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
