### PR TITLE
androidenv: include autoPatchelfHook only on Linux

### DIFF
--- a/pkgs/development/mobile/androidenv/cmake.nix
+++ b/pkgs/development/mobile/androidenv/cmake.nix
@@ -1,8 +1,8 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs}:
+{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs, stdenv}:
 
 deployAndroidPackage {
   inherit package os;
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
   buildInputs = lib.optional (os == "linux") [ pkgs.stdenv.cc.libc pkgs.stdenv.cc.cc pkgs.ncurses5 ];
   patchInstructions = lib.optionalString (os == "linux") ''
     autoPatchelf $packageBaseDir/bin

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -171,7 +171,7 @@ rec {
 
   cmake = map (version:
     import ./cmake.nix {
-      inherit deployAndroidPackage os autoPatchelfHook pkgs lib;
+      inherit deployAndroidPackage os autoPatchelfHook pkgs lib stdenv;
       package = packages.cmake.${version};
     }
   ) cmakeVersions;
@@ -179,7 +179,7 @@ rec {
   # Creates a NDK bundle.
   makeNdkBundle = ndkVersion:
     import ./ndk-bundle {
-      inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgsHostHost lib platform-tools;
+      inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgsHostHost lib platform-tools stdenv;
       package = packages.ndk-bundle.${ndkVersion};
     };
 

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -2,33 +2,35 @@
 
 deployAndroidPackage {
   inherit package os;
-  buildInputs = [ autoPatchelfHook makeWrapper ]
-  ++ lib.optionals (os == "linux") [
-    pkgs.glibc
-    pkgs.xorg.libX11
-    pkgs.xorg.libXext
-    pkgs.xorg.libXdamage
-    pkgs.xorg.libXfixes
-    pkgs.xorg.libxcb
-    pkgs.xorg.libXcomposite
-    pkgs.xorg.libXcursor
-    pkgs.xorg.libXi
-    pkgs.xorg.libXrender
-    pkgs.xorg.libXtst
-    pkgs.libcxx
-    pkgs.libGL
-    pkgs.libpulseaudio
-    pkgs.libuuid
-    pkgs.zlib
-    pkgs.ncurses5
-    pkgs.stdenv.cc.cc
-    pkgs_i686.glibc
-    pkgs.expat
-    pkgs.freetype
-    pkgs.nss
-    pkgs.nspr
-    pkgs.alsa-lib
-  ];
+  buildInputs = [ makeWrapper ]
+    ++ lib.optionals (os == "linux") (with pkgs; [
+      autoPatchelfHook
+      glibc
+      libcxx
+      libGL
+      libpulseaudio
+      libuuid
+      zlib
+      ncurses5
+      stdenv.cc.cc
+      i686.glibc
+      expat
+      freetype
+      nss
+      nspr
+      alsa-lib
+    ]) ++ (with pkgs.xorg; [
+      libX11
+      libXext
+      libXdamage
+      libXfixes
+      libxcb
+      libXcomposite
+      libXcursor
+      libXi
+      libXrender
+      libXtst
+    ]);
   patchInstructions = lib.optionalString (os == "linux") ''
     addAutoPatchelfSearchPath $packageBaseDir/lib
     addAutoPatchelfSearchPath $packageBaseDir/lib64

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, pkgsHostHost, makeWrapper, autoPatchelfHook
+{ stdenv, lib, pkgs, pkgsHostHost, makeWrapper, autoPatchelfHook
 , deployAndroidPackage, package, os, platform-tools
 }:
 
@@ -9,7 +9,8 @@ let
 in
 deployAndroidPackage {
   inherit package os;
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
   autoPatchelfIgnoreMissingDeps = true;
   buildInputs = lib.optional (os == "linux") [ pkgs.glibc pkgs.stdenv.cc.cc pkgs.python2 pkgs.ncurses5 pkgs.zlib pkgs.libcxx.out pkgs.libxml2 ];
   patchInstructions = lib.optionalString (os == "linux") (''

--- a/pkgs/development/mobile/androidenv/tools/26.nix
+++ b/pkgs/development/mobile/androidenv/tools/26.nix
@@ -3,8 +3,12 @@
 deployAndroidPackage {
   name = "androidsdk";
   inherit os package;
-  buildInputs = [ autoPatchelfHook makeWrapper ]
-    ++ lib.optional (os == "linux") [ pkgs.glibc pkgs.xorg.libX11 pkgs.xorg.libXrender pkgs.xorg.libXext pkgs.fontconfig pkgs.freetype pkgs_i686.glibc pkgs_i686.xorg.libX11 pkgs_i686.xorg.libXrender pkgs_i686.xorg.libXext pkgs_i686.fontconfig.lib pkgs_i686.freetype pkgs_i686.zlib pkgs.fontconfig.lib ];
+  buildInputs = [ makeWrapper ]
+    ++ lib.optional (os == "linux") (
+      (with pkgs; [ autoPatchelfHook glibc freetype fontconfig fontconfig.lib])
+      ++ (with pkgs.xorg; [ libX11 libXrender libXext ])
+      ++ (with pkgs_i686; [ glibc xorg.libX11 xorg.libXrender xorg.libXext fontconfig.lib freetype zlib ])
+    );
 
   patchInstructions = ''
     ${lib.optionalString (os == "linux") ''


### PR DESCRIPTION
###### Description of changes

This is supposed to fix an issue caused by this PR:

* https://github.com/NixOS/nixpkgs/pull/163924

Which made `autoPatchelfHook` available only on Linux, resulting in builds of Android packages failing with:
```
error: Package ‘auto-patchelf-hook’ in /nix/store/...-nixpkgs-source/pkgs/build-support/trivial-builders.nix:73
    is not supported on ‘x86_64-darwin’, refusing to evaluate.
```
I have tested these changes by building an Android app on Linux and MacOS:

* https://github.com/status-im/status-react/pull/13405

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).