### PR TITLE
ruby: Expose generic builder

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -256,6 +256,9 @@ let
     ) args; in self;
 
 in {
+  mkRubyVersion = rubyVersion;
+  mkRuby = generic;
+
   ruby_2_7 = generic {
     version = rubyVersion "2" "7" "6" "";
     sha256 = "042xrdk7hsv4072bayz3f8ffqh61i8zlhvck10nfshllq063n877";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14419,6 +14419,8 @@ with pkgs;
     inherit (darwin) libiconv libobjc libunwind;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   })
+    mkRubyVersion
+    mkRuby
     ruby_2_7
     ruby_3_0
     ruby_3_1;


### PR DESCRIPTION
I'd like to maintain a repository of ruby versions. To avoid duplicating
all the ruby compilation code, I've exposed two functions `rubyVersion`
and `rubyGenericBuilder`, which can be used in an overlay to build any
past or current ruby version. I don't know if this is the right way to
go. It feels awkward to me to put those helper functions at the top
level, so I'm looking for suggestions on how to accomplish this.

An example overlay:
```nix
self: super:

{
  ruby_2_7_6 = super.rubyGenericBuilder {
    version = super.rubyVersion "2" "7" "6" "";
    sha256 = "042xrdk7hsv4072bayz3f8ffqh61i8zlhvck10nfshllq063n877";
  };

  ruby_3_1_2 = super.rubyGenericBuilder {
    version = super.rubyVersion "3" "1" "2" "";
    sha256 = "0gm84ipk6mrfw94852w5h7xxk2lqrxjbnlwb88svf0lz70933131";
  };
}
```

This is my first attempt to contribute to Nix, so I appreciate the
feedback :) Thanks.