### PR TITLE
curtail: init at 1.3.0

### DIFF
--- a/pkgs/applications/graphics/curtail/default.nix
+++ b/pkgs/applications/graphics/curtail/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, fetchFromGitHub
+, meson
+, ninja
+, python3
+, gettext
+, gtk3
+, optipng
+, pngquant
+, jpegoptim
+, libwebp
+, glib
+, wrapGAppsHook
+, gobject-introspection
+, pango
+, appstream-glib
+, pkg-config
+, desktop-file-utils
+}:
+
+python3.pkgs.buildPythonApplication rec {
+
+  pname = "curtail";
+  version = "1.3.0";
+  src = fetchFromGitHub {
+    owner = "Huluti";
+    repo = "Curtail";
+    rev = version;
+    sha256 = "sha256-tNk+KI+DEMR63zfcBpfPTxAFKzvGWvpa9erK9SAAtPc=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    appstream-glib
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    pkg-config
+  ];
+  buildInputs = [
+    appstream-glib
+    gettext
+    glib
+    gobject-introspection
+    gtk3
+    jpegoptim
+    libwebp
+    optipng
+    pango
+    pngquant
+  ];
+
+  propagatedBuildInputs = [ python3.pkgs.pygobject3 ];
+
+  # This is needed to let gobject-introspection’s setup hook run
+  # Disabling this breaks icon themes (at least)
+  strictDeps = false;
+
+  # Tells the Python builder to use normal building methods instead of using a setup.py
+  format = "other";
+
+  preInstall = ''
+    patchShebangs --build /build/source/build-aux/meson/postinstall.py
+  '';
+
+  meta = with lib; {
+    description = "Simple & useful image compressor";
+    homepage = "https://github.com/Huluti/Curtail";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ anselschmueler ];
+  };
+}

--- a/pkgs/applications/graphics/curtail/default.nix.orig
+++ b/pkgs/applications/graphics/curtail/default.nix.orig
@@ -1,0 +1,47 @@
+{ fetchFromGitHub, meson, ninja, python3, gettext, gtk3, optipng, pngquant
+, jpegoptim, libwebp, glib, wrapGAppsHook, gobject-introspection, pango
+, appstream-glib, pkg-config, desktop-file-utils }:
+python3.pkgs.buildPythonApplication {
+  strictDeps = false;
+    # ^ This is needed to let gobject-introspection’s setup hook run
+    # Disabling this breaks icon themes (at least)
+  pname = "curtail";
+  version = "1.3.0";
+  src = fetchFromGitHub {
+    owner = "Huluti";
+    repo = "Curtail";
+    rev = "master";
+    sha256 = "sha256-DqCfhpiIsHbUwe7DsI2RSblV7Pc3PcZwsQiJUzXkQqg=";
+  };
+    # | The division between native and foreign inputs isn’t 100% clear to me
+    # Feel free to clean up, but this package cannot be cross-compiled anyways
+  nativeBuildInputs = [
+    wrapGAppsHook
+    appstream-glib
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    pkg-config
+  ];
+  buildInputs = [
+    appstream-glib
+    gettext
+    glib
+    gobject-introspection
+    gtk3
+    jpegoptim
+    libwebp
+    optipng
+    pango
+    pngquant
+  ];
+  propagatedBuildInputs = [ python3.pkgs.pygobject3 ];
+    # ^ Passes this to the Python wrapper
+    # Needed so the resulting Python script runs
+  format = "other";
+    # ^ Tells the Python builder to use normal building methods instead of using a setup.py
+  preInstall = ''
+    patchShebangs --build /build/source/build-aux/meson/postinstall.py
+  '';
+}

--- a/pkgs/applications/graphics/curtail/default.nix.rej
+++ b/pkgs/applications/graphics/curtail/default.nix.rej
@@ -1,0 +1,91 @@
+--- /dev/null
++++ /dev/null
+@@ -1,20 +1,38 @@
+-{ fetchFromGitHub, meson, ninja, python3, gettext, gtk3, optipng, pngquant
+-, jpegoptim, libwebp, glib, wrapGAppsHook, gobject-introspection, pango
+-, appstream-glib, pkg-config, desktop-file-utils }:
+-python3.pkgs.buildPythonApplication {
+-  strictDeps = false;
+-    # ^ This is needed to let gobject-introspection’s setup hook run
+-    # Disabling this breaks icon themes (at least)
++{ lib
++, fetchFromGitHub
++, meson
++, ninja
++, python3
++, gettext
++, gtk3
++, optipng
++, pngquant
++, jpegoptim
++, libwebp
++, glib
++, wrapGAppsHook
++, gobject-introspection
++, pango
++, appstream-glib
++, pkg-config
++, desktop-file-utils
++}:
++
++python3.pkgs.buildPythonApplication rec {
+   pname = "curtail";
+   version = "1.3.0";
++
+   src = fetchFromGitHub {
+     owner = "Huluti";
+     repo = "Curtail";
+-    rev = "master";
+-    sha256 = "sha256-DqCfhpiIsHbUwe7DsI2RSblV7Pc3PcZwsQiJUzXkQqg=";
++    rev = version;
++    sha256 = "sha256-tNk+KI+DEMR63zfcBpfPTxAFKzvGWvpa9erK9SAAtPc=";
+   };
+-    # | The division between native and foreign inputs isn’t 100% clear to me
+-    # Feel free to clean up, but this package cannot be cross-compiled anyways
++
++  # This is needed to let gobject-introspection’s setup hook run
++  # Disabling this breaks icon themes (at least)
++  strictDeps = false;
++
+   nativeBuildInputs = [
+     wrapGAppsHook
+     appstream-glib
+@@ -23,25 +41,32 @@ python3.pkgs.buildPythonApplication {
+     meson
+     ninja
+     pkg-config
++    gtk3
+   ];
++
+   buildInputs = [
+-    appstream-glib
+-    gettext
+     glib
+     gobject-introspection
+-    gtk3
+     jpegoptim
+     libwebp
+     optipng
+     pango
+     pngquant
+   ];
++
+   propagatedBuildInputs = [ python3.pkgs.pygobject3 ];
+-    # ^ Passes this to the Python wrapper
+-    # Needed so the resulting Python script runs
++
++  # Tells the Python builder to use normal building methods instead of using a setup.py
+   format = "other";
+-    # ^ Tells the Python builder to use normal building methods instead of using a setup.py
++
+   preInstall = ''
+     patchShebangs --build /build/source/build-aux/meson/postinstall.py
+   '';
++
++  meta = with lib; {
++    description = "Simple & useful image compressor";
++    homepage = "https://github.com/Huluti/Curtail";
++    license = licenses.gpl3Only;
++    maintainers = with maintainers; [ anselschmueler ];
++  };
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35371,4 +35371,6 @@ with pkgs;
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
 
   mictray = callPackage ../tools/audio/mictray { };
+
+  curtail = callPackage ../applications/graphics/curtail { };
 }


### PR DESCRIPTION
###### Description of changes

Added Curtail, a simple GTK image compression utility, as `curtail`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
