### PR TITLE
vivaldi-widevine: hash update for upstream zip

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/widevine.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/widevine.nix
@@ -1,21 +1,15 @@
-{ lib, stdenv, fetchurl
-, unzip
+{ lib, stdenv, fetchzip
 }:
 
 stdenv.mkDerivation rec {
   pname = "widevine";
   version = "4.10.2449.0";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://dl.google.com/widevine-cdm/${version}-linux-x64.zip";
-    sha256 = "sha256-XZuXK3NCfqbaQ1tuMOXj/U4yJC18futqo1WjuMqMrRA=";
+    sha256 = "sha256-f2kAkP+s3fB+krEZsiujEoI4oznkzSyaIB/CRJZWlXE=";
+    stripRoot = false;
   };
-
-  nativeBuildInputs = [ unzip ];
-
-  unpackPhase = ''
-    unzip $src
-  '';
 
   installPhase = ''
     install -vD manifest.json $out/share/google/chrome/WidevineCdm/manifest.json


### PR DESCRIPTION
Seems like the upstream distro had been updated w/o version bump.

See https://github.com/NixOS/nixpkgs/issues/82469#issuecomment-1128991410=