### PR TITLE
rust-analyzer: 2022-05-02 -> 2022-05-17 and add tests

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -11,14 +11,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-analyzer-unwrapped";
-  version = "2022-05-02";
-  cargoSha256 = "sha256-uZCUruIBTNTKYWYb8xQgJ6FsKlRi+Sh5n7m7aVk+hHQ=";
+  version = "2022-05-17";
+  cargoSha256 = "sha256-H0nuS56mvo5YUAUOsEnR4Cv3iFKixoHK83BcM1PFMA8=";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rust-analyzer";
     rev = version;
-    sha256 = "sha256-5kAbd/tTc9vkr27ar44hnpXdS0vQg0OLJUMlp0FBjqA=";
+    sha256 = "sha256-vrVpgQYUuJPgK1NMb1nxlCdxjoYo40YkUbZpH2Z2mwM=";
   };
 
   patches = [

--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, callPackage
 , fetchFromGitHub
 , rustPlatform
 , CoreServices
@@ -54,7 +55,11 @@ rustPlatform.buildRustPackage rec {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    updateScript = ./update.sh;
+    # FIXME: Pass overrided `rust-analyzer` once `buildRustPackage` also implements #119942
+    tests.neovim-lsp = callPackage ./test-neovim-lsp.nix { };
+  };
 
   meta = with lib; {
     description = "A modular compiler frontend for the Rust language";

--- a/pkgs/development/tools/rust/rust-analyzer/test-neovim-lsp.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/test-neovim-lsp.nix
@@ -1,0 +1,49 @@
+{ runCommandNoCC, cargo, neovim, rust-analyzer, rustc }:
+runCommandNoCC "test-neovim-rust-analyzer" {
+  nativeBuildInputs = [ cargo neovim rust-analyzer rustc ];
+
+  testRustSrc = /* rust */ ''
+    fn main() {
+      let mut var = vec![None];
+      var.push(Some("hello".to_owned()));
+    }
+  '';
+
+  nvimConfig = /* lua */ ''
+    vim.lsp.buf_attach_client(vim.api.nvim_get_current_buf(), vim.lsp.start_client({
+      cmd = { "rust-analyzer" },
+      handlers = {
+        ["$/progress"] = function(_, msg, ctx)
+          if msg.token == "rustAnalyzer/Indexing" and msg.value.kind == "end" then
+            vim.cmd("goto 23") -- let mut |var =...
+            vim.lsp.buf.hover()
+          end
+        end,
+        ["textDocument/hover"] = function(_, msg, ctx)
+          -- Keep newlines.
+          io.write(msg.contents.value)
+          vim.cmd("q")
+        end,
+      },
+      on_error = function(code)
+        print("error: " .. code)
+        vim.cmd("q")
+      end
+    }))
+  '';
+
+} ''
+  # neovim requires a writable HOME.
+  export HOME="$(pwd)"
+
+  cargo new --bin test-rust-analyzer
+  cd test-rust-analyzer
+  cat <<<"$testRustSrc" >src/main.rs
+  cat <<<"$nvimConfig" >script.lua
+
+  # `-u` doesn't work
+  result="$(nvim --headless +'lua dofile("script.lua")' src/main.rs)"
+  echo "$result"
+  [[ "$result" == *"var: Vec<Option<String>>"* ]]
+  touch $out
+''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Regular version bump, plus a test using neovim to check the type inference functionality.

Changelog:
- https://rust-analyzer.github.io/thisweek/2022/05/17/changelog-129-5.html
- https://rust-analyzer.github.io/thisweek/2022/05/16/changelog-129.html
- https://rust-analyzer.github.io/thisweek/2022/05/09/changelog-128.html

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>rust-analyzer</li>
    <li>rust-analyzer-unwrapped</li>
    <li>vscode-extensions.matklad.rust-analyzer</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
