### PR TITLE
Shibboleth Service Provider packages: fix builds

### DIFF
--- a/pkgs/development/libraries/opensaml-cpp/default.nix
+++ b/pkgs/development/libraries/opensaml-cpp/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-xmltooling=${xml-tooling-c}" ];
 
+  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];
+
   enableParallelBuilding = true;
 
   meta = with lib; {

--- a/pkgs/development/libraries/shibboleth-sp/default.nix
+++ b/pkgs/development/libraries/shibboleth-sp/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     "--with-fastcgi"
   ];
 
+  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];
+
   enableParallelBuilding = true;
 
   meta = with lib; {

--- a/pkgs/development/libraries/xml-tooling-c/default.nix
+++ b/pkgs/development/libraries/xml-tooling-c/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost curl openssl log4shib xercesc xml-security-c ];
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
+  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];
+
   enableParallelBuilding = true;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Moved back to C++14 where dynamic exception specifications are deprecated but still present.

ZHF: https://github.com/NixOS/nixpkgs/issues/172160
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>opensaml-cpp</li>
    <li>shibboleth-sp</li>
    <li>xml-tooling-c</li>
  </ul>
</details>

@NixOS/nixos-release-managers