### PR TITLE
fetchzip: extraPostFetch -> postFetch && tests

### DIFF
--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -345,7 +345,7 @@ rec {
     src = fetchzip {
       url = "https://download.jboss.org/drools/release/${version}/droolsjbpm-tools-distribution-${version}.zip";
       sha512 = "2qzc1iszqfrfnw8xip78n3kp6hlwrvrr708vlmdk7nv525xhs0ssjaxriqdhcr0s6jripmmazxivv3763rnk2bfkh31hmbnckpx4r3m";
-      extraPostFetch = ''
+      postFetch = ''
         # update site is a couple levels deep, alongside some other irrelevant stuff
         cd $out;
         find . -type f -not -path ./binaries/org.drools.updatesite/\* -exec rm {} \;
@@ -507,7 +507,7 @@ rec {
       stripRoot = false;
       url = "https://github.com/${owner}/${repo}/archive/${rev}.zip";
       sha256 = "1xfj4j27d1h4bdf2v7f78zi8lz4zkkj7s9kskmsqx5jcs2d459yp";
-      extraPostFetch =
+      postFetch =
         ''
           mv "$out/${repo}-${rev}/releases/local-repo/"* "$out/"
         '';

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -39,7 +39,7 @@ let
     rev = version;
     sha256 = "sha256-BoikYSsQZAv8WswIr5nmBsGmjZbTXaLAbdO2QtPvc7c=";
 
-    extraPostFetch = ''
+    postFetch = ''
       mv $out ./all
       mv ./all/electrum/tests $out
     '';

--- a/pkgs/applications/misc/electrum/ltc.nix
+++ b/pkgs/applications/misc/electrum/ltc.nix
@@ -38,7 +38,7 @@ let
     rev = version;
     sha256 = "sha256-oZjQnrnj8nCaQjrIz8bWNt6Ib8Wu2ZMXHEPfCCy2fjk=";
 
-    extraPostFetch = ''
+    postFetch = ''
       mv $out ./all
       mv ./all/electrum_ltc/tests $out
     '';

--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -15,7 +15,7 @@ rec {
     sha256 = "1zw9azwmxr4991nq5kl527lbwlj7psrissgvrkl1kxxbfbdncbhh";
 
     stripRoot = false;
-    extraPostFetch = ''
+    postFetch = ''
       cd $out
       mv ring-project/* ./
       rm -r ring-project.rst ring-project client-android client-ios client-macosx client-uwp

--- a/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
@@ -6,7 +6,7 @@ let
     owner = "kogakure";
     repo = "gitweb-theme";
     rev = "049b88e664a359f8ec25dc6f531b7e2aa60dd1a2";
-    extraPostFetch = ''
+    postFetch = ''
       mkdir -p "$TMPDIR/gitwebTheme"
       mv "$out"/* "$TMPDIR/gitwebTheme/"
       mkdir "$out/static"

--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -43,7 +43,7 @@ let
     repo = "rules_proto";
     rev = "f7a30f6f80006b591fa7c437fe5a951eb10bcbcf";
     sha256 = "10bcw0ir0skk7h33lmqm38n9w4nfs24mwajnngkbs6jb5wsvkqv8";
-    extraPostFetch = ''
+    postFetch = ''
       sed -i 's|name = "protoc"|name = "_protoc_original"|' $out/proto/private/BUILD.release
       cat <<EOF >>$out/proto/private/BUILD.release
       alias(name = "protoc", actual = "@com_github_protocolbuffers_protobuf//:protoc", visibility = ["//visibility:public"])

--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -38,7 +38,7 @@ let
       fetch = fetchzip;
       arguments = baseArgs // {
         url = "${baseUrl}/archive/${rev}.tar.gz";
-        extraPostFetch = optionalString (vc == "hg") ''
+        postFetch = optionalString (vc == "hg") ''
           rm -f "$out/.hg_archival.txt"
         ''; # impure file; see #12002
       };

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -12,6 +12,7 @@
 , url ? ""
 , urls ? []
 , extraPostFetch ? ""
+, postFetch ? ""
 , name ? "source"
 , nativeBuildInputs ? [ ]
 , # Allows to set the extension for the intermediate downloaded
@@ -20,6 +21,8 @@
   extension ? null
 , ... } @ args:
 
+
+lib.warnIf (extraPostFetch != "") "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub'."
 (fetchurl (let
   tmpFilename =
     if extension != null
@@ -60,11 +63,14 @@ in {
       mv "$unpackDir" "$out"
     '')
     + ''
+      ${postFetch}
+    '' + ''
       ${extraPostFetch}
     ''
+
     # Remove non-owner write permissions
     # Fixes https://github.com/NixOS/nixpkgs/issues/38649
     + ''
       chmod 755 "$out"
     '';
-} // removeAttrs args [ "stripRoot" "extraPostFetch" "extension" "nativeBuildInputs" ]))
+} // removeAttrs args [ "stripRoot" "extraPostFetch" "postFetch" "extension" "nativeBuildInputs" ]))

--- a/pkgs/build-support/fetchzip/tests.nix
+++ b/pkgs/build-support/fetchzip/tests.nix
@@ -1,0 +1,25 @@
+{ testers, fetchzip, ... }:
+
+let
+  zipUrl = "https://gist.github.com/glandium/01d54cefdb70561b5f6675e08f2990f2/archive/2f430f0c136a69b0886281d0c76708997d8878af.zip";
+in
+{
+  simple = testers.invalidateFetcherByDrvHash fetchzip {
+    inherit zipUrl;
+    sha256 = "sha256-0ecwgL8qUavSj1+WkaxpmRBmu7cvj53V5eXQV71fddU=";
+  };
+
+  postFetch = testers.invalidateFetcherByDrvHash fetchzip {
+    inherit zipUrl;
+    sha256 = "sha256-7sAOzKa+9vYx5XyndHxeY2ffWAjOsgCkXC9anK6cuV0=";
+    postFetch = ''touch $out/filee'';
+  };
+
+  #extraPostFetch = testers.invalidateFetcherByDrvHash fetchzip {
+  #  inherit url;
+  #  sha256 = "sha256-UC8oJqojqpjqa72UpT0QTME+UwQhVVk5/d9mgRPDR20=";
+  #  extraPostFetch = ''
+  #    touch $out/afile
+  #  '';
+  #};
+}

--- a/pkgs/build-support/fetchzip/tests.nix
+++ b/pkgs/build-support/fetchzip/tests.nix
@@ -1,25 +1,17 @@
 { testers, fetchzip, ... }:
 
 let
-  zipUrl = "https://gist.github.com/glandium/01d54cefdb70561b5f6675e08f2990f2/archive/2f430f0c136a69b0886281d0c76708997d8878af.zip";
+  url = "https://gist.github.com/glandium/01d54cefdb70561b5f6675e08f2990f2/archive/2f430f0c136a69b0886281d0c76708997d8878af.zip";
 in
 {
   simple = testers.invalidateFetcherByDrvHash fetchzip {
-    inherit zipUrl;
+    inherit url;
     sha256 = "sha256-0ecwgL8qUavSj1+WkaxpmRBmu7cvj53V5eXQV71fddU=";
   };
 
   postFetch = testers.invalidateFetcherByDrvHash fetchzip {
-    inherit zipUrl;
+    inherit url;
     sha256 = "sha256-7sAOzKa+9vYx5XyndHxeY2ffWAjOsgCkXC9anK6cuV0=";
     postFetch = ''touch $out/filee'';
   };
-
-  #extraPostFetch = testers.invalidateFetcherByDrvHash fetchzip {
-  #  inherit url;
-  #  sha256 = "sha256-UC8oJqojqpjqa72UpT0QTME+UwQhVVk5/d9mgRPDR20=";
-  #  extraPostFetch = ''
-  #    touch $out/afile
-  #  '';
-  #};
 }

--- a/pkgs/data/fonts/input-fonts/default.nix
+++ b/pkgs/data/fonts/input-fonts/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       sha256 = "BESZ4Bjgm2hvQ7oPpMvYSlE8EqvQjqHZtXWIovqyIzA=";
       stripRoot = false;
 
-      extraPostFetch = ''
+      postFetch = ''
         # Reset the timestamp to release date for determinism.
         PATH=${lib.makeBinPath [ python3.pkgs.fonttools ]}:$PATH
         for ttf_file in $out/Input_Fonts/*/*/*.ttf; do

--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -32,7 +32,7 @@ let
       # without making a new release. We simply substitute the possibly changed fields
       # with their content from when we last updated, and thus get a deterministic output
       # hash.
-      extraPostFetch = ''
+      postFetch = ''
         echo "${metadata}" | base64 --decode > $out/metadata.json
       '';
     };

--- a/pkgs/development/compilers/zasm/default.nix
+++ b/pkgs/development/compilers/zasm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     repo = "zasm";
     rev = version;
     sha256 = "sha256-Zbno8kmzss1H2FjwzHB4U7UXxa6oDfsPV80MVVFfM68=";
-    extraPostFetch = ''
+    postFetch = ''
       # remove folder containing files with weird names (causes the hash to turn out differently under macOS vs. Linux)
       rm -rv $out/Test
     '';

--- a/pkgs/development/libraries/java/swt/default.nix
+++ b/pkgs/development/libraries/java/swt/default.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
       "R-${fullVersion}/${pname}-${version}-${metadata.platform}.zip";
     inherit (metadata) sha256;
     stripRoot = false;
-    extraPostFetch = ''
+    postFetch = ''
       mkdir "$unpackDir"
       cd "$unpackDir"
 

--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1cxj6r85d5f3qxdwzxrmkx8z875hig4cr8zsi30w6vj23cyds3l2";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
-    extraPostFetch = ''
+    postFetch = ''
       rm -r $out/test/e2e/unicode-pwd
     '';
   };

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -70,7 +70,7 @@ rec {
         Note: -f is necessary to keep it from being a pain to update
         hash on rev updates. Command will fail w/o and not print hash.
       */
-      extraPostFetch = ''
+      postFetch = ''
         rm -rf Python-2.7.13 benchmarks metrics py-yajl rfc gold web testdata services demo devtools cpp
       '';
     };

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     # Upstream uses versioneer, which relies on git attributes substitution.
     # This leads to non-reproducible archives on github. Remove the substituted
     # file here, and recreate it later based on our version info.
-    extraPostFetch = ''
+    postFetch = ''
       rm "$out/limits/_version.py"
     '';
     hash = "sha256-ja+YbRHCcZ5tFnoofdR44jbkkdDroVUdKeDOt6yE0LI=";

--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     # The content of .git_archival.txt is substituted upon tarball creation,
     # which creates indeterminism if master no longer points to the tag.
     # See https://github.com/jbarlow83/OCRmyPDF/issues/841
-    extraPostFetch = ''
+    postFetch = ''
       rm "$out/.git_archival.txt"
     '';
     hash = "sha256-uFKnohUxh17h6u0vwVB7EaTEh5NRowP8a6za63Ehodk=";

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     hash = "sha256-ZBGzsyCtFt5uj9mpOpGdTzGJET0iwOAgDTy80P6anRU=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
-    extraPostFetch = ''
+    postFetch = ''
       rm -r $out/pelican/tests/output/custom_locale/posts
     '';
   };

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     # The content of .git_archival.txt is substituted upon tarball creation,
     # which creates indeterminism if master no longer points to the tag.
     # See https://github.com/jbarlow83/OCRmyPDF/issues/841
-    extraPostFetch = ''
+    postFetch = ''
       rm "$out/.git_archival.txt"
     '';
     hash = "sha256-jkAwc1bQ1jRDf/qY+xAjiLXXO98qKjyX+J7Lu4tYWoI=";

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     # filesystems because of unicode normalisation. The documentation
     # has such files and will be removed.
     sha256 = "sha256-v1z6caEMJNXqbcbTmFXoy3KQewHiz6qK4vhNU6Qbukk=";
-    extraPostFetch = "rm -rf $out/docs/reST";
+    postFetch = "rm -rf $out/docs/reST";
   };
 
   patches = [

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-Lw9yZWCQpt02SL/McWPcyFRfVhQHC0TejcYRbVw+VxY=";
-    extraPostFetch = ''
+    postFetch = ''
       cd $out
       mv tests/roots/test-images/testimäge.png \
         tests/roots/test-images/testimæge.png

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-JlTmUPY3yo/uROyd3nW1dJa23zbLhgQTwcmqZkPOrHs=";
     name = "${pname}-${version}-source";
-    extraPostFetch = ''
+    postFetch = ''
       cd $out
       mv tests/testdata/unicode.dist/unicodedist/åäö_日本語.py \
         tests/testdata/unicode.dist/unicodedist/æɐø_日本價.py

--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -101,7 +101,7 @@ let
                                else "0ixv9qyqq40pzyqy6v9jf5rxrvivjb0z0zn260nbmb9gk765bacy";
     stripRoot = false;
     # Removing PE signatures reduces this from 3.8GB -> 642MB (uncompressed)
-    extraPostFetch = lib.optionalString (!withPEPatterns) ''
+    postFetch = lib.optionalString (!withPEPatterns) ''
       rm -r "$out/generic/yara_patterns/static-code/pe"
     '';
   } // {

--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -43,7 +43,7 @@ let
   callWithName = name: value: if isFunction value then value name else value;
   buildOpenRASet = f: args: pkgs.recurseIntoAttrs (mapAttrs callWithName (f ({
     inherit (pkgs) fetchFromGitHub;
-    extraPostFetch = ''
+    postFetch = ''
       sed -i 's/curl/curl --insecure/g' $out/thirdparty/{fetch-thirdparty-deps,noget}.sh
       $out/thirdparty/fetch-thirdparty-deps.sh
     '';

--- a/pkgs/games/openra/engines.nix
+++ b/pkgs/games/openra/engines.nix
@@ -1,4 +1,4 @@
-{ buildOpenRAEngine, fetchFromGitHub, extraPostFetch }:
+{ buildOpenRAEngine, fetchFromGitHub, postFetch }:
 
 let
   buildUpstreamOpenRAEngine = { version, rev, sha256 }: name: (buildOpenRAEngine {
@@ -9,7 +9,7 @@ let
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "OpenRA" ;
-      inherit rev sha256 extraPostFetch;
+      inherit rev sha256 postFetch;
     };
   } name).overrideAttrs (origAttrs: {
     postInstall = ''

--- a/pkgs/games/openra/mods.nix
+++ b/pkgs/games/openra/mods.nix
@@ -1,4 +1,4 @@
-{ buildOpenRAMod, fetchFromGitHub, extraPostFetch }:
+{ buildOpenRAMod, fetchFromGitHub, postFetch }:
 
 let
   unsafeBuildOpenRAMod = attrs: name: (buildOpenRAMod attrs name).overrideAttrs (_: {
@@ -25,7 +25,7 @@ in {
         rev = "b8a7dd52ff893ed8225726d4ed4e14ecad748404";
         sha256 = "0dyk861qagibx8ldshz7d2nrki9q550f6f0wy8pvayvf1gv1dbxj";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -50,7 +50,7 @@ in {
         rev = version;
         sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''
@@ -78,7 +78,7 @@ in {
         rev = "f91d3f2603bbf51afaa89357e4defcdc36138102";
         sha256 = "05g900ri6q0zrkrk8rmjaz576vjggmi2y6jm0xz3cwli54prn11w";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -102,7 +102,7 @@ in {
         rev = version;
         sha256 = "1x6byz37s8qcpqj902zvkvbv95rv2mv2kj35c12gbpyc92xkqkq0";
         name = "generals-alpha-engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -127,7 +127,7 @@ in {
         rev = "4e8eab4ca00d1910203c8a103dfd2c002714daa8";
         sha256 = "1yyqparf93x8yzy1f46gsymgkj5jls25v2yc7ighr3f7mi3igdvq";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   } name).overrideAttrs (origAttrs: {
@@ -156,7 +156,7 @@ in {
         rev = "52109c0910f479753704c46fb19e8afaab353c83";
         sha256 = "0ga3855j6bc7h81q03cw6laiaiz12915zg8aqah1idvxbzicfy7l";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -180,7 +180,7 @@ in {
         rev = version;
         sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''
@@ -208,7 +208,7 @@ in {
         rev = version;
         sha256 = "15pvn5cx3g0nzbrgpsfz8dngad5wkzp5dz25ydzn8bmxafiijvcr";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -233,7 +233,7 @@ in {
         rev = "f3873ae242803051285994d77eb26f4b951594b5";
         sha256 = "02rv29wja0p5d083pd087daz7x7pp5b9ym7sci2fhg3mrnaqgwkp";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''
@@ -262,7 +262,7 @@ in {
         rev = "bb0930008a57c07f3002421023f6b446e3e3af69";
         sha256 = "1jvgpbf56hd02ikhklv49br4d1jiv5hphc5kl79qnjlaacnj222x";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -286,7 +286,7 @@ in {
         rev = "6de92de8d982094a766eab97a92225c240d85493";
         sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -310,7 +310,7 @@ in {
         rev = version;
         sha256 = "1p5hgxxvxlz8480vj0qkmnxjh7zj3hahk312m0zljxfdb40652w1";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -334,7 +334,7 @@ in {
         rev = version;
         sha256 = "15pvn5cx3g0nzbrgpsfz8dngad5wkzp5dz25ydzn8bmxafiijvcr";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''

--- a/pkgs/games/openra/packages.nix
+++ b/pkgs/games/openra/packages.nix
@@ -32,7 +32,7 @@ let
   */
   buildOpenRASet = f: args: builtins.mapAttrs (name: value: if builtins.isFunction value then value name else value) (f ({
     inherit (pkgs) fetchFromGitHub;
-    extraPostFetch = ''
+    postFetch = ''
       sed -i 's/curl/curl --insecure/g' $out/thirdparty/{fetch-thirdparty-deps,noget}.sh
       $out/thirdparty/fetch-thirdparty-deps.sh
     '';

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -147,7 +147,7 @@ in rec {
     name = "xonotic-data";
     url = "https://dl.xonotic.org/xonotic-${version}.zip";
     sha256 = "15caj11v9hhr7w55w3rs1rspblzr9lg1crqivbn9pyyq0rif8cpl";
-    extraPostFetch = ''
+    postFetch = ''
       cd $out
       rm -rf $(ls | grep -v "^data$" | grep -v "^key_0.d0pk$")
     '';

--- a/pkgs/servers/dns/ncdns/default.nix
+++ b/pkgs/servers/dns/ncdns/default.nix
@@ -22,7 +22,7 @@ let
     rev = "fb9f2b7bc9fcba954d70f63857cc0c3841b1cf47";
     sha256 = "1arkbpbzvhcmz5fhjqg34x2jbjnwmlisapk22rjki17qpamh7zks";
     # ncdns must be put in a subdirectory for this to work.
-    extraPostFetch = ''
+    postFetch = ''
       cp -r --no-preserve=mode "${ncdns}" "$out/ncdns"
     '';
   };

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -37,7 +37,7 @@ buildBazelPackage rec {
     inherit (srcVer) rev;
     hash = "sha256:11mm72zmb479ss585jzqzhklyyqmdadnvr91ghzvjxc0j2a1hrr4";
 
-    extraPostFetch = ''
+    postFetch = ''
       chmod -R +w $out
       rm $out/.bazelversion
       echo ${srcVer.rev} > $out/SOURCE_VERSION

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -28,6 +28,7 @@ with pkgs;
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };
 
   fetchpatch = callPackages ../build-support/fetchpatch/tests.nix { };
+  fetchzip = callPackages ../build-support/fetchzip/tests.nix { };
   fetchgit = callPackages ../build-support/fetchgit/tests.nix { };
   fetchFirefoxAddon = callPackages ../build-support/fetchfirefoxaddon/tests.nix { };
 

--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     # > the license requires that you agree to these use restrictions,
     # > or you must remove the software (source and binary) from your hard disks
     # https://fedoraproject.org/wiki/Licensing:Unrar
-    extraPostFetch = lib.optionalString (!enableUnfree) ''
+    postFetch = lib.optionalString (!enableUnfree) ''
       rm -r $out/CPP/7zip/Compress/Rar*
       find $out -name makefile'*' -exec sed -i '/Rar/d' {} +
     '';

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ffDJJWe/SzG+lppXEiyfXXL5KLdZgnMjv1SYnuYnh4c=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
-    extraPostFetch = ''
+    postFetch = ''
       rm -r $out/test/test-suite/images/
     '';
   };

--- a/pkgs/tools/misc/dua/default.nix
+++ b/pkgs/tools/misc/dua/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-dpkUbZz/bIiTMhZalXHGct77qMzYB6LATs7MPVyW1GY=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
-    extraPostFetch = ''
+    postFetch = ''
       rm -r $out/tests/fixtures
     '';
   };

--- a/pkgs/tools/misc/dust/default.nix
+++ b/pkgs/tools/misc/dust/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-qC8AlLyg8MU9ZON0hITTaM5AmRFZMOqJVt7PJ5fCtus=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
-    extraPostFetch = ''
+    postFetch = ''
       rm -r $out/tests/test_dir_unicode/
     '';
   };

--- a/pkgs/tools/misc/dutree/default.nix
+++ b/pkgs/tools/misc/dutree/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "17lm8jd07bi499mywg2iq669im34j4x4yhc8a3adxn12f8j0dfg7";
     # test directory has files with unicode names which causes hash mismatches
     # It is also not used by any tests or parts of build process
-    extraPostFetch = ''
+    postFetch = ''
       rm -r $out/test
     '';
   };

--- a/pkgs/tools/misc/jdupes/default.nix
+++ b/pkgs/tools/misc/jdupes/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     # Unicode file names lead to different checksums on HFS+ vs. other
     # filesystems because of unicode normalisation. The testdir
     # directories have such files and will be removed.
-    extraPostFetch = "rm -r $out/testdir";
+    postFetch = "rm -r $out/testdir";
   };
 
   dontConfigure = true;

--- a/pkgs/tools/misc/mutagen/default.nix
+++ b/pkgs/tools/misc/mutagen/default.nix
@@ -18,7 +18,7 @@ buildGo118Module rec {
     # The package architecture does not matter since all packages contain identical mutagen-agents.tar.gz.
     url = "https://github.com/mutagen-io/mutagen/releases/download/v${version}/mutagen_linux_amd64_v${version}.tar.gz";
     stripRoot = false;
-    extraPostFetch = ''
+    postFetch = ''
       rm $out/mutagen # Keep only mutagen-agents.tar.gz.
     '';
     sha256 = "sha256-AlAo55/ewTE04WfS0beVonGA97AmpR1pAw/QxKAYjv8=";

--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0bwv6x651gyq703pywrhb7lfby6xwnd1iwnrzzjihipn7x3v2hz9";
     # the stat call has to be in a subshell or we get the current date
-    extraPostFetch = ''
+    postFetch = ''
       echo $(stat -c %Y $out) > $out/.timestamp
     '';
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -723,7 +723,10 @@ with pkgs;
     inherit curl stdenv;
   };
 
-  fetchzip = callPackage ../build-support/fetchzip { };
+  fetchzip = callPackage ../build-support/fetchzip { }
+    // {
+      tests = pkgs.tests.fetchzip;
+    };
 
   fetchCrate = callPackage ../build-support/rust/fetchcrate.nix { };
 


### PR DESCRIPTION
###### Description of changes
Closes https://github.com/NixOS/nixpkgs/issues/158629
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
