### PR TITLE
esptool: 3.3.1 -> 4.4

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -2,7 +2,7 @@
 , python3
 , fetchFromGitHub
 , platformio
-, esptool
+, esptool_3
 , git
 }:
 
@@ -66,7 +66,7 @@ with python.pkgs; buildPythonApplication rec {
     # platformio is used in esphomeyaml/platformio_api.py
     # esptool is used in esphomeyaml/__main__.py
     # git is used in esphomeyaml/writer.py
-    "--prefix PATH : ${lib.makeBinPath [ platformio esptool git ]}"
+    "--prefix PATH : ${lib.makeBinPath [ platformio esptool_3 git ]}"
     "--set ESPHOME_USE_SUBPROCESS ''"
   ];
 

--- a/pkgs/tools/misc/esptool/3.nix
+++ b/pkgs/tools/misc/esptool/3.nix
@@ -1,0 +1,63 @@
+{ lib, fetchFromGitHub, python3, openssl }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "esptool";
+  version = "3.3.2";
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esptool";
+    rev = "v${version}";
+    hash = "sha256-hpPL9KNPA+S57SJoKnQewBCOybDbKep0t5RKw9a9GjM=";
+  };
+
+  postPatch = ''
+    substituteInPlace test/test_imagegen.py \
+      --replace "sys.executable, ESPTOOL_PY" "ESPTOOL_PY"
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    bitstring
+    cryptography
+    ecdsa
+    pyserial
+    reedsolo
+  ];
+
+  # wrapPythonPrograms will overwrite esptool.py with a bash script,
+  # but espefuse.py tries to import it. Since we don't add any binary paths,
+  # use patchPythonScript directly.
+  dontWrapPythonPrograms = true;
+  postFixup = ''
+    buildPythonPath "$out $pythonPath"
+    for f in $out/bin/*.py; do
+        echo "Patching $f"
+        patchPythonScript "$f"
+    done
+  '';
+
+  checkInputs = with python3.pkgs; [
+    pyelftools
+  ];
+
+  # tests mentioned in `.github/workflows/test_esptool.yml`
+  checkPhase = ''
+    runHook preCheck
+
+    export ESPTOOL_PY=$out/bin/esptool.py
+    ${python3.interpreter} test/test_imagegen.py
+    ${python3.interpreter} test/test_espsecure.py
+    ${python3.interpreter} test/test_merge_bin.py
+    ${python3.interpreter} test/test_modules.py
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "ESP8266 and ESP32 serial bootloader utility";
+    homepage = "https://github.com/espressif/esptool";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ hexa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -1,20 +1,22 @@
-{ lib, fetchFromGitHub, python3, openssl }:
+{ lib
+, fetchFromGitHub
+, python3
+}:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "esptool";
-  version = "3.3.1";
+  version = "4.4";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    hash = "sha256-9WmiLji7Zoad5WIzgkpvkI9t96sfdkCtFh6zqVxF7qo=";
+    hash = "sha256-haLwf3loOvqdqQN/iuVBciQ6nCnuc9AqqOGKvDwLBHE=";
   };
 
-  postPatch = ''
-    substituteInPlace test/test_imagegen.py \
-      --replace "sys.executable, ESPTOOL_PY" "ESPTOOL_PY"
-  '';
+  patches = [
+    ./test-call-bin-directly.patch
+  ];
 
   propagatedBuildInputs = with python3.pkgs; [
     bitstring
@@ -24,26 +26,16 @@ python3.pkgs.buildPythonApplication rec {
     reedsolo
   ];
 
-  # wrapPythonPrograms will overwrite esptool.py with a bash script,
-  # but espefuse.py tries to import it. Since we don't add any binary paths,
-  # use patchPythonScript directly.
-  dontWrapPythonPrograms = true;
-  postFixup = ''
-    buildPythonPath "$out $pythonPath"
-    for f in $out/bin/*.py; do
-        echo "Patching $f"
-        patchPythonScript "$f"
-    done
-  '';
-
   checkInputs = with python3.pkgs; [
     pyelftools
+    pytest
   ];
 
   # tests mentioned in `.github/workflows/test_esptool.yml`
   checkPhase = ''
     runHook preCheck
 
+    export ESPSECURE_PY=$out/bin/espsecure.py
     export ESPTOOL_PY=$out/bin/esptool.py
     ${python3.interpreter} test/test_imagegen.py
     ${python3.interpreter} test/test_espsecure.py

--- a/pkgs/tools/misc/esptool/test-call-bin-directly.patch
+++ b/pkgs/tools/misc/esptool/test-call-bin-directly.patch
@@ -1,0 +1,89 @@
+diff --git a/test/test_espsecure.py b/test/test_espsecure.py
+index 25b0b87..627005c 100755
+--- a/test/test_espsecure.py
++++ b/test/test_espsecure.py
+@@ -35,7 +35,7 @@ class EspSecureTestCase:
+         Returns output as a string if there is any,
+         raises an exception if espsecure.py fails
+         """
+-        cmd = [sys.executable, ESPSECURE_PY] + args.split(" ")
++        cmd = [ESPSECURE_PY] + args.split(" ")
+         print("\nExecuting {}...".format(" ".join(cmd)))
+ 
+         try:
+diff --git a/test/test_esptool.py b/test/test_esptool.py
+index 042a1ce..b294e26 100755
+--- a/test/test_esptool.py
++++ b/test/test_esptool.py
+@@ -57,7 +57,10 @@ try:
+     ESPTOOL_PY = os.environ["ESPTOOL_PY"]
+ except KeyError:
+     ESPTOOL_PY = os.path.join(TEST_DIR, "..", "esptool/__init__.py")
+-ESPSECURE_PY = os.path.join(TEST_DIR, "..", "espsecure/__init__.py")
++try:
++    ESPSECURE_PY = os.environ["ESPSECURE_PY"]
++except KeyError:
++    ESPSECURE_PY = os.path.join(TEST_DIR, "..", "espsecure/__init__.py")
+ ESPRFC2217SERVER_PY = os.path.join(TEST_DIR, "..", "esp_rfc2217_server.py")
+ 
+ RETURN_CODE_FATAL_ERROR = 2
+@@ -74,7 +77,6 @@ class ESPRFC2217Server(object):
+     def __init__(self, rfc2217_port=None):
+         self.port = rfc2217_port or self.get_free_port()
+         self.cmd = [
+-            sys.executable,
+             ESPRFC2217SERVER_PY,
+             "-p",
+             str(self.port),
+@@ -130,7 +132,7 @@ class ESPRFC2217Server(object):
+ class EsptoolTestCase:
+     def run_espsecure(self, args):
+ 
+-        cmd = [sys.executable, ESPSECURE_PY] + args.split(" ")
++        cmd = [ESPSECURE_PY] + args.split(" ")
+         print("\nExecuting {}...".format(" ".join(cmd)))
+         try:
+             output = subprocess.check_output(
+@@ -155,7 +157,7 @@ class EsptoolTestCase:
+         Raises an exception if esptool.py fails.
+         """
+         trace_args = ["--trace"] if arg_trace else []
+-        cmd = [sys.executable, ESPTOOL_PY] + trace_args
++        cmd = [ESPTOOL_PY] + trace_args
+         if chip_name or arg_chip is not None and chip_name != "auto":
+             cmd += ["--chip", chip_name or arg_chip]
+         if rfc2217_port or arg_port is not None:
+diff --git a/test/test_imagegen.py b/test/test_imagegen.py
+index a1feec2..01bd59c 100755
+--- a/test/test_imagegen.py
++++ b/test/test_imagegen.py
+@@ -108,7 +108,7 @@ class BaseTestCase:
+         Run esptool.py image_info on a binary file,
+         assert no red flags about contents.
+         """
+-        cmd = [sys.executable, ESPTOOL_PY, "--chip", chip, "image_info", binpath]
++        cmd = [ESPTOOL_PY, "--chip", chip, "image_info", binpath]
+         try:
+             output = subprocess.check_output(cmd)
+             output = output.decode("utf-8")
+@@ -123,7 +123,7 @@ class BaseTestCase:
+ 
+     def run_elf2image(self, chip, elf_path, version=None, extra_args=[]):
+         """Run elf2image on elf_path"""
+-        cmd = [sys.executable, ESPTOOL_PY, "--chip", chip, "elf2image"]
++        cmd = [ESPTOOL_PY, "--chip", chip, "elf2image"]
+         if version is not None:
+             cmd += ["--version", str(version)]
+         cmd += [elf_path] + extra_args
+diff --git a/test/test_merge_bin.py b/test/test_merge_bin.py
+index 8230069..2df5f8c 100755
+--- a/test/test_merge_bin.py
++++ b/test/test_merge_bin.py
+@@ -39,7 +39,6 @@ class TestMergeBin:
+             output_file.close()
+ 
+             cmd = [
+-                sys.executable,
+                 ESPTOOL_PY,
+                 "--chip",
+                 chip,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3987,6 +3987,8 @@ with pkgs;
 
   esptool = callPackage ../tools/misc/esptool { };
 
+  esptool_3 = callPackage ../tools/misc/esptool/3.nix { };
+
   esptool-ck = callPackage ../tools/misc/esptool-ck { };
 
   ephemeralpg = callPackage ../development/tools/database/ephemeralpg {};


### PR DESCRIPTION

###### Description of changes
https://github.com/espressif/esptool/releases/tag/v4.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
