### PR TITLE
citra: rename to citra-nightly, init citra-canary

### DIFF
--- a/pkgs/applications/emulators/citra/default.nix
+++ b/pkgs/applications/emulators/citra/default.nix
@@ -1,93 +1,45 @@
-{ lib
-, stdenv
+{ branch
+, libsForQt5
 , fetchFromGitHub
-, cmake
-, wrapQtAppsHook
-, boost17x
-, pkg-config
-, libusb1
-, zstd
-, libressl
-, enableSdl2 ? true, SDL2
-, enableQt ? true, qtbase, qtmultimedia
-, enableQtTranslation ? enableQt, qttools
-, enableWebService ? true
-, enableCubeb ? true, libpulseaudio
-, enableFfmpegAudioDecoder ? true
-, enableFfmpegVideoDumper ? true
-, ffmpeg
-, useDiscordRichPresence ? true, rapidjson
-, enableFdk ? false, fdk_aac
+, fetchurl
 }:
-assert lib.assertMsg (!enableFfmpegAudioDecoder || !enableFdk) "Can't enable both enableFfmpegAudioDecoder and enableFdk";
 
-stdenv.mkDerivation {
-  pname = "citra";
-  version = "2021-11-01";
+let
+  # Fetched from https://api.citra-emu.org/gamedb, last updated 2022-05-02
+  # Please make sure to update this when updating citra!
+  compat-list = fetchurl {
+    name = "citra-compat-list";
+    url = "https://web.archive.org/web/20220502114622/https://api.citra-emu.org/gamedb/";
+    sha256 = "sha256-blIlaYaUQjw7Azgg+Dd7ZPEQf+ddZMO++Yxinwe+VG0=";
+  };
+in {
+  nightly = libsForQt5.callPackage ./generic.nix rec {
+    pname = "citra-nightly";
+    version = "1765";
 
-  src = fetchFromGitHub {
-    owner = "citra-emu";
-    repo = "citra";
-    rev = "5a7d80172dd115ad9bc6e8e85cee6ed9511c48d0";
-    sha256 = "sha256-vy2JMizBsnRK9NBEZ1dxT7fP/HFhOZSsC+5P+Dzi27s=";
-    fetchSubmodules = true;
+    src = fetchFromGitHub {
+      owner = "citra-emu";
+      repo = "citra-nightly";
+      rev = "nightly-${version}";
+      sha256 = "0d3dfh63cmsy5idbypdz3ibydmb4a35sfv7qmxxlcpc390pp9cvq";
+      fetchSubmodules = true;
+    };
+
+    inherit branch compat-list;
   };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-  ]
-  ++ lib.optionals enableQt [ wrapQtAppsHook ];
+  canary = libsForQt5.callPackage ./generic.nix rec {
+    pname = "citra-canary";
+    version = "2146";
 
-  buildInputs = [
-    boost17x
-    libusb1
-  ]
-  ++ lib.optionals enableSdl2 [ SDL2 ]
-  ++ lib.optionals enableQt [ qtbase qtmultimedia ]
-  ++ lib.optionals enableQtTranslation [ qttools ]
-  ++ lib.optionals enableCubeb [ libpulseaudio ]
-  ++ lib.optionals (enableFfmpegAudioDecoder || enableFfmpegVideoDumper) [ ffmpeg ]
-  ++ lib.optionals useDiscordRichPresence [ rapidjson ]
-  ++ lib.optionals enableFdk [ fdk_aac ];
+    src = fetchFromGitHub {
+      owner = "citra-emu";
+      repo = "citra-canary";
+      rev = "canary-${version}";
+      sha256 = "1wnym0nklngimf5gaaa2703nz4g5iy572wlgp88h67rrh9b4f04r";
+      fetchSubmodules = true;
+    };
 
-  cmakeFlags = [
-    "-DUSE_SYSTEM_BOOST=ON"
-  ]
-  ++ lib.optionals (!enableSdl2) [ "-DENABLE_SDL2=OFF" ]
-  ++ lib.optionals (!enableQt) [ "-DENABLE_QT=OFF" ]
-  ++ lib.optionals enableQtTranslation [ "-DENABLE_QT_TRANSLATION=ON" ]
-  ++ lib.optionals (!enableWebService) [ "-DENABLE_WEB_SERVICE=OFF" ]
-  ++ lib.optionals (!enableCubeb) [ "-DENABLE_CUBEB=OFF" ]
-  ++ lib.optionals enableFfmpegAudioDecoder [ "-DENABLE_FFMPEG_AUDIO_DECODER=ON"]
-  ++ lib.optionals enableFfmpegVideoDumper [ "-DENABLE_FFMPEG_VIDEO_DUMPER=ON" ]
-  ++ lib.optionals useDiscordRichPresence [ "-DUSE_DISCORD_PRESENCE=ON" ]
-  ++ lib.optionals enableFdk [ "-DENABLE_FDK=ON" ];
-
-  postPatch = ''
-    # We already know the submodules are present
-    substituteInPlace CMakeLists.txt \
-      --replace "check_submodules_present()" ""
-
-    # Devendoring
-    rm -rf externals/zstd externals/libressl
-    cp -r ${zstd.src} externals/zstd
-    tar xf ${libressl.src} -C externals/
-    mv externals/${libressl.name} externals/libressl
-    chmod -R a+w externals/zstd
-  '';
-
-  # Fixes https://github.com/NixOS/nixpkgs/issues/171173
-  postInstall = lib.optionalString (enableCubeb && enableSdl2) ''
-    wrapProgram "$out/bin/citra" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio ]}
-  '';
-
-  meta = with lib; {
-    homepage = "https://citra-emu.org";
-    description = "An open-source emulator for the Nintendo 3DS";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ abbradar ];
-    platforms = platforms.linux;
+    inherit branch compat-list;
   };
-}
+}.${branch}

--- a/pkgs/applications/emulators/citra/generic.nix
+++ b/pkgs/applications/emulators/citra/generic.nix
@@ -1,0 +1,107 @@
+{ pname
+, version
+, src
+, branch
+, compat-list
+
+, lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, boost17x
+, pkg-config
+, libusb1
+, zstd
+, libressl
+, enableSdl2 ? true, SDL2
+, enableQt ? true, qtbase, qtmultimedia, wrapQtAppsHook
+, enableQtTranslation ? enableQt, qttools
+, enableWebService ? true
+, enableCubeb ? true, libpulseaudio
+, enableFfmpegAudioDecoder ? true
+, enableFfmpegVideoDumper ? true
+, ffmpeg
+, useDiscordRichPresence ? true, rapidjson
+, enableFdk ? false, fdk_aac
+}:
+assert lib.assertMsg (!enableFfmpegAudioDecoder || !enableFdk) "Can't enable both enableFfmpegAudioDecoder and enableFdk";
+
+stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
+
+  buildInputs = [
+    boost17x
+    libusb1
+  ] ++ lib.optionals enableQt [ qtbase qtmultimedia ]
+    ++ lib.optional enableSdl2 SDL2
+    ++ lib.optional enableQtTranslation qttools
+    ++ lib.optional enableCubeb libpulseaudio
+    ++ lib.optional (enableFfmpegAudioDecoder || enableFfmpegVideoDumper) ffmpeg
+    ++ lib.optional useDiscordRichPresence rapidjson
+    ++ lib.optional enableFdk fdk_aac;
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_BOOST=ON"
+    "-DCITRA_USE_BUNDLED_FFMPEG=OFF"
+    "-DCITRA_USE_BUNDLED_QT=OFF"
+    "-DCITRA_USE_BUNDLED_SDL2=OFF"
+
+    # We dont want to bother upstream with potentially outdated compat reports
+    "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON"
+    "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=OFF" # We provide this deterministically
+  ] ++ lib.optional (!enableSdl2) "-DENABLE_SDL2=OFF"
+    ++ lib.optional (!enableQt) "-DENABLE_QT=OFF"
+    ++ lib.optional enableQtTranslation "-DENABLE_QT_TRANSLATION=ON"
+    ++ lib.optional (!enableWebService) "-DENABLE_WEB_SERVICE=OFF"
+    ++ lib.optional (!enableCubeb) "-DENABLE_CUBEB=OFF"
+    ++ lib.optional enableFfmpegAudioDecoder "-DENABLE_FFMPEG_AUDIO_DECODER=ON"
+    ++ lib.optional enableFfmpegVideoDumper "-DENABLE_FFMPEG_VIDEO_DUMPER=ON"
+    ++ lib.optional useDiscordRichPresence "-DUSE_DISCORD_PRESENCE=ON"
+    ++ lib.optional enableFdk "-DENABLE_FDK=ON";
+
+  postPatch = ''
+    # Prep compatibilitylist
+    ln -s ${compat-list} ./dist/compatibility_list/compatibility_list.json
+
+    # We already know the submodules are present
+    substituteInPlace CMakeLists.txt \
+      --replace "check_submodules_present()" ""
+
+    # Devendoring
+    rm -rf externals/zstd externals/libressl
+    cp -r ${zstd.src} externals/zstd
+    tar xf ${libressl.src} -C externals/
+    mv externals/${libressl.name} externals/libressl
+    chmod -R a+w externals/zstd
+  '';
+
+  # Fixes https://github.com/NixOS/nixpkgs/issues/171173
+  postInstall = lib.optionalString (enableCubeb && enableSdl2) ''
+    wrapProgram "$out/bin/citra" \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://citra-emu.org";
+    description = "The ${branch} branch of an open-source emulator for the Ninteno 3DS";
+    longDescription = ''
+      A Nintendo 3DS Emulator written in C++
+      Using the nightly branch is recommended for general usage.
+      Using the canary branch is recommended if you would like to try out
+      experimental features, with a cost of stability.
+    '';
+    mainProgram = if enableQt then "citra-qt" else "citra";
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [
+      abbradar
+      ashley
+      ivar
+    ];
+  };
+}

--- a/pkgs/applications/emulators/citra/update.sh
+++ b/pkgs/applications/emulators/citra/update.sh
@@ -1,0 +1,84 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix nix-prefetch-git coreutils curl jq gnused
+
+set -euo pipefail
+
+# Will be replaced with the actual branch when running this from passthru.updateScript
+BRANCH="@branch@"
+
+if [[ ! "$(basename $PWD)" = "citra" ]]; then
+    echo "error: Script must be ran from citra's directory!"
+    exit 1
+fi
+
+getLocalVersion() {
+    pushd ../../../.. >/dev/null
+    nix eval --raw -f default.nix "$1".version
+    popd >/dev/null
+}
+
+getLocalHash() {
+    pushd ../../../.. >/dev/null
+    nix eval --raw -f default.nix "$1".src.drvAttrs.outputHash
+    popd >/dev/null
+}
+
+updateNightly() {
+    OLD_NIGHTLY_VERSION="$(getLocalVersion "citra-nightly")"
+    OLD_NIGHTLY_HASH="$(getLocalHash "citra-nightly")"
+
+    NEW_NIGHTLY_VERSION="$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+        "https://api.github.com/repos/citra-emu/citra-nightly/releases?per_page=1" | jq -r '.[0].name' | cut -d"-" -f2 | cut -d" " -f2)"
+
+    if [[ "${OLD_NIGHTLY_VERSION}" = "${NEW_NIGHTLY_VERSION}" ]]; then
+        echo "citra-nightly is already up to date!"
+
+        [ "$KEEP_GOING" ] && return || exit
+    else
+        echo "citra-nightly: ${OLD_NIGHTLY_VERSION} -> ${NEW_NIGHTLY_VERSION}"
+    fi
+
+    echo "  Fetching source code..."
+
+    NEW_NIGHTLY_HASH="$(nix-prefetch-git --quiet --fetch-submodules --rev "nightly-${NEW_NIGHTLY_VERSION}" "https://github.com/citra-emu/citra-nightly" | jq -r '.sha256')"
+
+    echo "  Succesfully fetched. hash: ${NEW_NIGHTLY_HASH}"
+
+    sed -i "s/${OLD_NIGHTLY_VERSION}/${NEW_NIGHTLY_VERSION}/" ./default.nix
+    sed -i "s/${OLD_NIGHTLY_HASH}/${NEW_NIGHTLY_HASH}/" ./default.nix
+}
+
+updateCanary() {
+    OLD_CANARY_VERSION="$(getLocalVersion "citra-canary")"
+    OLD_CANARY_HASH="$(getLocalHash "citra-canary")"
+
+    NEW_CANARY_VERSION="$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+        "https://api.github.com/repos/citra-emu/citra-canary/releases?per_page=1" | jq -r '.[0].name' | cut -d"-" -f2 | cut -d" " -f1)"
+
+    if [[ "${OLD_CANARY_VERSION}" = "${NEW_CANARY_VERSION}" ]]; then
+        echo "citra-canary is already up to date!"
+
+        [ "$KEEP_GOING" ] && return || exit
+    else
+        echo "citra-canary: ${OLD_CANARY_VERSION} -> ${NEW_CANARY_VERSION}"
+    fi
+
+    echo "  Fetching source code..."
+
+    NEW_CANARY_HASH="$(nix-prefetch-git --quiet --fetch-submodules --rev "canary-${NEW_CANARY_VERSION}" "https://github.com/citra-emu/citra-canary" | jq -r '.sha256')"
+
+    echo "  Succesfully fetched. hash: ${NEW_CANARY_HASH}"
+
+    sed -i "s/${OLD_CANARY_VERSION}/${NEW_CANARY_VERSION}/" ./default.nix
+    sed -i "s/${OLD_CANARY_HASH}/${NEW_CANARY_HASH}/" ./default.nix
+}
+
+if [[ "$BRANCH" = "nightly" ]]; then
+    updateNightly
+elif [[ "$BRANCH" = "early-access" ]]; then
+    updateCanary
+else
+    KEEP_GOING=1
+    updateNightly
+    updateCanary
+fi

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -168,6 +168,7 @@ mapAliases ({
   chunkwm = throw "chunkwm has been removed: abandoned by upstream"; # Added 2022-01-07
   cifs_utils = throw "'cifs_utils' has been renamed to/replaced by 'cifs-utils'"; # Converted to throw 2022-02-22
   cipherscan = throw "cipherscan was removed from nixpkgs, as it was unmaintained"; # added 2021-12-11
+  citra = citra-nightly; # added 2022-05-17
   ckb = throw "'ckb' has been renamed to/replaced by 'ckb-next'"; # Converted to throw 2022-02-22
   creddump = throw "creddump has been removed from nixpkgs as the upstream has abandoned the project"; # Added 2022-01-01
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1259,7 +1259,13 @@ with pkgs;
 
   cen64 = callPackage ../applications/emulators/cen64 { };
 
-  citra = libsForQt5.callPackage ../applications/emulators/citra { };
+  citra-canary = callPackage ../applications/emulators/citra {
+    branch = "canary";
+  };
+
+  citra-nightly = callPackage ../applications/emulators/citra {
+    branch = "nightly";
+  };
 
   collapseos-cvm = callPackage ../applications/emulators/collapseos-cvm { };
 


### PR DESCRIPTION
This updates the citra derivation to a stable release and also adds support for another branch, citra-nightly.
See the commit description for details.

This also enables fetching the in-app compatibility list.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
