### PR TITLE
postgresqlPackages.wal2json: init at 2.4

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/wal2json.nix
+++ b/pkgs/servers/sql/postgresql/ext/wal2json.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, bison, flex, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "wal2json";
+  version = "2.4";
+
+  src = fetchFromGitHub {
+    owner = "eulerto";
+    repo = "wal2json";
+    rev = "wal2json_${builtins.replaceStrings ["."] ["_"] version}";
+    sha256 = "sha256-EB+tCaILWsU9fDhqosl6EyMoYBd6SHISFfyxiZ9pNOk=";
+  };
+
+  buildInputs = [ postgresql ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  installPhase = ''
+    install -D -t $out/lib *.so
+    install -D -t $out/share/postgresql/extension sql/*.sql
+  '';
+
+  meta = with lib; {
+    description = "PostgreSQL JSON output plugin for changeset extraction";
+    homepage = "https://github.com/eulerto/wal2json";
+    changelog = "https://github.com/eulerto/wal2json/releases/tag/wal2json_${version}";
+    maintainers = with maintainers; [ euank ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -65,4 +65,6 @@ self: super: {
     repmgr = super.callPackage ./ext/repmgr.nix { };
 
     rum = super.callPackage ./ext/rum.nix { };
+
+    wal2json = super.callPackage ./ext/wal2json.nix { };
 }


### PR DESCRIPTION
###### Description of changes

This adds the postgresql wal2json extension.

It was requested in https://github.com/NixOS/nixpkgs/issues/134452, and I also have use of it for myself. (Closes #134452)

I manually tested it worked by doing the following:

```
# configuration.nix

 services.postgresql = {
   enable = true;
   package = pkgs.postgresql;
   extraPlugins = with pkgs.postgresqlPackages; [ wal2json ];
   settings = {
     wal_level = "logical";
     max_replication_slots = 10;
     max_wal_senders = 10;
   };
 };


# terminal 1
$ sudo --user postgres pg_recvlogical -d postgres --slot test_slot --create-slot -P wal2json
$ sudo --user postgres pg_recvlogical -d postgres --slot test_slot --start -o pretty-print=1 -o add-msg-prefixes=wal2json -f -

# termianl 2
$ sudo --user=postgres -- psql <<< "CREATE TABLE test(a SERIAL); INSERT INTO test VALUES(1);"

# terminal 1 outputs json blob
```

The above steps to test this were taken from the wal2json readme more or less: https://github.com/eulerto/wal2json

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
