### PR TITLE
openldap: 2.4.58 -> 2.6.2

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -674,6 +674,18 @@
       </listitem>
       <listitem>
         <para>
+          <literal>openldap</literal> (and therefore the slapd LDAP
+          server) were updated to version 2.6.2. The project introduced
+          backwards-incompatible changes, namely the removal of the bdb,
+          hdb, ndb, and shell backends in slapd. Therefore before
+          updating, dump your database <literal>slapcat -n 1</literal>
+          in LDIF format, and reimport it after updating your
+          <literal>services.openldap.settings</literal>, which
+          represents your <literal>cn=config</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>openssh</literal> has been update to 8.9p1, changing
           the FIDO security key middleware interface.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -238,6 +238,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - In the ncdns module, the default value of `services.ncdns.address` has been changed to the IPv6 loopback address (`::1`).
 
+- `openldap` (and therefore the slapd LDAP server) were updated to version 2.6.2. The project introduced backwards-incompatible changes, namely the removal of the bdb, hdb, ndb, and shell backends in slapd. Therefore before updating, dump your database `slapcat -n 1` in LDIF format, and reimport it after updating your `services.openldap.settings`, which represents your `cn=config`.
+
 - `openssh` has been update to 8.9p1, changing the FIDO security key middleware interface.
 
 - `git` no longer hardcodes the path to openssh' ssh binary to reduce the amount of rebuilds. If you are using git with ssh remotes and do not have a ssh binary in your enviroment consider adding `openssh` to it or switching to `gitFull`.

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.openldap.org/";
     description = "An open source implementation of the Lightweight Directory Access Protocol";
     license = licenses.openldap;
-    maintainers = with maintainers; [ lovek323 ];
+    maintainers = with maintainers; [ ajs124 das_j hexa ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -1,33 +1,48 @@
-{ lib, stdenv, fetchurl, openssl, db, groff, libtool, libsodium
-, withCyrusSasl ? true
+{ lib
+, stdenv
+, fetchurl
+
+# dependencies
 , cyrus_sasl
+, db
+, groff
+, libsodium
+, libtool
+, openssl
+, systemdMinimal
 }:
 
 stdenv.mkDerivation rec {
   pname = "openldap";
-  version = "2.4.58";
+  version = "2.6.2";
 
   src = fetchurl {
     url = "https://www.openldap.org/software/download/OpenLDAP/openldap-release/${pname}-${version}.tgz";
-    sha256 = "sha256-V7WSVL4V0L9qmrPVFMHAV3ewISMpFTMTSofJRGj49Hs=";
+    hash = "sha256-gdCTRSMutiSG7PWsrNLFbAxFtKbIwGZhLn9CGiOhz4c";
   };
 
   # TODO: separate "out" and "bin"
-  outputs = [ "out" "dev" "man" "devdoc" ];
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "devdoc"
+  ];
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ groff ];
+  nativeBuildInputs = [
+    groff
+  ];
 
-  buildInputs = [ openssl cyrus_sasl db libsodium libtool ];
-
-  # Disable install stripping as it breaks cross-compiling.
-  # We strip binaries anyway in fixupPhase.
-  makeFlags= [
-    "STRIP="
-    "prefix=$(out)"
-    "moduledir=$(out)/lib/modules"
-    "CC=${stdenv.cc.targetPrefix}cc"
+  buildInputs = [
+    cyrus_sasl
+    db
+    libsodium
+    libtool
+    openssl
+  ] ++ lib.optionals (stdenv.isLinux) [
+    systemdMinimal
   ];
 
   preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''
@@ -35,56 +50,61 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--enable-overlays"
-    "--disable-dependency-tracking"   # speeds up one-time build
-    "--enable-modules"
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
+    "--enable-argon2"
     "--enable-crypt"
+    "--enable-modules"
+    "--enable-overlays"
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "--with-yielding_select=yes"
     "ac_cv_func_memcmp_working=yes"
-  ] ++ lib.optional (!withCyrusSasl) "--without-cyrus-sasl"
-    ++ lib.optional stdenv.isFreeBSD "--with-pic";
+  ] ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
-  postBuild = ''
-    make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/sha2
-    make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/pbkdf2
-    make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/argon2
-  '';
-
-  doCheck = false; # needs a running LDAP server
-
-  installFlags = [
-    "sysconfdir=$(out)/etc"
-    "localstatedir=$(out)/var"
-    "moduledir=$(out)/lib/modules"
-    # The argon2 module hardcodes /usr/bin/install as the path for the
-    # `install` binary, which is overridden here.
-    "INSTALL=install"
+  makeFlags= [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "STRIP="  # Disable install stripping as it breaks cross-compiling. We strip binaries anyway in fixupPhase.
+    "prefix=${placeholder "out"}"
+    "sysconfdir=${placeholder "out"}/etc"
+    "systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+    # contrib modules require these
+    "moduledir=${placeholder "out"}/lib/modules"
+    "mandir=${placeholder "out"}/share/man"
   ];
 
-  # 1. Libraries left in the build location confuse `patchelf --shrink-rpath`
-  #    Delete these to let patchelf discover the right path instead.
-  #    FIXME: that one can be removed when https://github.com/NixOS/patchelf/pull/98
-  #    is in Nixpkgs patchelf.
-  # 2. Fixup broken libtool for openssl and cyrus_sasl (if it is not disabled)
-  preFixup = ''
-    rm -r $out/var
-    rm -r libraries/*/.libs
-    rm -r contrib/slapd-modules/passwd/*/.libs
-    for f in $out/lib/libldap.la $out/lib/libldap_r.la; do
-      substituteInPlace "$f" --replace '-lssl' '-L${lib.getLib openssl}/lib -lssl'
-  '' + lib.optionalString withCyrusSasl ''
-      substituteInPlace "$f" --replace '-lsasl2' '-L${cyrus_sasl.out}/lib -lsasl2'
-  '' + ''
+  extraContribModules = [
+    # https://git.openldap.org/openldap/openldap/-/tree/master/contrib/slapd-modules
+    "passwd/sha2"
+    "passwd/pbkdf2"
+    "passwd/totp"
+  ];
+
+  postBuild = ''
+    for module in ${lib.concatStringsSep " " extraContribModules}; do
+      make $makeFlags CC=$CC -C contrib/slapd-modules/$module
     done
   '';
 
+  preCheck = ''
+    substituteInPlace tests/scripts/all \
+      --replace "/bin/rm" "rm"
+  '';
+
+  doCheck = true;
+
+  # The directory is empty and serve no purpose.
+  preFixup = ''
+    rm -r $out/var
+  '';
+
+  installFlags = [
+    "prefix=${placeholder "out"}"
+    "moduledir=${placeholder "out"}/lib/modules"
+    "INSTALL=install"
+  ];
+
   postInstall = ''
-    make $installFlags install -C contrib/slapd-modules/passwd/sha2
-    make $installFlags install -C contrib/slapd-modules/passwd/pbkdf2
-    make $installFlags install-lib -C contrib/slapd-modules/passwd/argon2
+    for module in ${lib.concatStringsSep " " extraContribModules}; do
+      make $installFlags install -C contrib/slapd-modules/$module
+    done
     chmod +x "$out"/lib/*.{so,dylib}
   '';
 


### PR DESCRIPTION
https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_5/ANNOUNCEMENT
https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_6/ANNOUNCEMENT

Co-Authored-By: Andreas Schrägle <nix@ajs124.de>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
