### PR TITLE
python310Packages.pg8000: 1.28.0 -> 1.29.1

### DIFF
--- a/pkgs/development/python-modules/pg8000/default.nix
+++ b/pkgs/development/python-modules/pg8000/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pg8000";
-  version = "1.28.0";
-  format = "setuptools";
+  version = "1.28.2";
+  format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-Q1E949TjeOc6xEKpOQa6qdNWJFqmeqf2FgXFbjmn9ZE=";
+    sha256 = "sha256-4aJLqJobQeLSCVuf188W2vm1vf8g85WNmX3fg2GkyLU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pg8000/default.nix
+++ b/pkgs/development/python-modules/pg8000/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, importlib-metadata
 , passlib
 , pythonOlder
 , scramp
@@ -8,19 +9,21 @@
 
 buildPythonPackage rec {
   pname = "pg8000";
-  version = "1.28.2";
+  version = "1.28.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-4aJLqJobQeLSCVuf188W2vm1vf8g85WNmX3fg2GkyLU=";
+    sha256 = "sha256-1hA3s/Iff8fVz+TupoN4klnnzLnu9fcinLxi8x6mujI=";
   };
 
   propagatedBuildInputs = [
     passlib
     scramp
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
   ];
 
   # Tests require a running PostgreSQL instance

--- a/pkgs/development/python-modules/pg8000/default.nix
+++ b/pkgs/development/python-modules/pg8000/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "pg8000";
-  version = "1.28.3";
+  version = "1.29.1";
   format = "pyproject";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-1hA3s/Iff8fVz+TupoN4klnnzLnu9fcinLxi8x6mujI=";
+    hash = "sha256-gLT03ksCVIMreUhRHg3UY0LRwERszU/diStj0C5PvHs=";
   };
 
   propagatedBuildInputs = [
@@ -25,6 +25,10 @@ buildPythonPackage rec {
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
   ];
+
+  postPatch = ''
+    sed '/^\[metadata\]/a version = ${version}' setup.cfg
+  '';
 
   # Tests require a running PostgreSQL instance
   doCheck = false;

--- a/pkgs/development/python-modules/testing-postgresql/default.nix
+++ b/pkgs/development/python-modules/testing-postgresql/default.nix
@@ -1,17 +1,40 @@
-{ lib, buildPythonPackage, fetchFromGitHub, postgresql, testing-common-database
-, pg8000, pytestCheckHook, psycopg2, sqlalchemy }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pg8000
+, postgresql
+, psycopg2
+, pytestCheckHook
+, pythonOlder
+, sqlalchemy
+, testing-common-database
+}:
 
 buildPythonPackage rec {
-  pname = "testing.postgresql";
+  pname = "testing-postgresql";
   # Version 1.3.0 isn't working so let's use the latest commit from GitHub
   version = "unstable-2017-10-31";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "tk0miya";
-    repo = pname;
+    repo = "testing.postgresql";
     rev = "c81ded434d00ec8424de0f9e1f4063c778c6aaa8";
-    sha256 = "1asqsi38di768i1sc1qm1k068dj0906ds6lnx7xcbxws0s25m2q3";
+    sha256 = "sha256-A4tahAaa98X66ZYa3QxIQDZkwAwVB6ZDRObEhkbUWKs=";
   };
+
+  propagatedBuildInputs = [
+    testing-common-database
+    pg8000
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    psycopg2
+    sqlalchemy
+  ];
 
   # Add PostgreSQL to search path
   prePatch = ''
@@ -19,13 +42,18 @@ buildPythonPackage rec {
       --replace "/usr/local/pgsql" "${postgresql}"
   '';
 
-  propagatedBuildInputs = [ testing-common-database pg8000 ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pg8000 >= 1.10" "pg8000"
+  '';
+
+  pythonImportsCheck = [
+    "testing.postgresql"
+  ];
 
   # Fix tests for Darwin build. See:
   # https://github.com/NixOS/nixpkgs/pull/74716#issuecomment-598546916
   __darwinAllowLocalNetworking = true;
-
-  checkInputs = [ pytestCheckHook psycopg2 sqlalchemy ];
 
   meta = with lib; {
     description = "Use temporary postgresql instance in testing";


### PR DESCRIPTION
###### Description of changes
https://github.com/tlocke/pg8000#version-1282-2022-05-17
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
