### PR TITLE
cgit-pink: 1.3.0 -> 1.4.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/cgit/pink.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/pink.nix
@@ -2,19 +2,19 @@
 
 callPackage (import ./common.nix rec {
   pname = "cgit-pink";
-  version = "1.3.0";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "https://git.causal.agency/cgit-pink/snapshot/cgit-pink-${version}.tar.gz";
-    sha256 = "sha256-oL46NWgqi1VqKNEt0QGBWNXbi2l7nOQDZy1aMivcWuM=";
+    sha256 = "1ma6j3r4ba5fhd47pc6xn5bmxaqr8ci2pvky9v100n1hh5n6q97i";
   };
 
   # cgit-pink is tightly coupled with git and needs a git source tree to build.
   # IMPORTANT: Remember to check which git version cgit-pink needs on every
   # version bump (look for "GIT_VER" in the top-level Makefile).
   gitSrc = fetchurl {
-    url    = "mirror://kernel/software/scm/git/git-2.35.1.tar.xz";
-    sha256 = "sha256-12hSjmRD9logMDYmbxylD50Se6iXUeMurTcRftkZEIA=";
+    url    = "mirror://kernel/software/scm/git/git-2.36.1.tar.xz";
+    sha256 = "0w43a35mhc2qf2gjkxjlnkf2lq8g0snf34iy5gqx2678yq7llpa0";
   };
 
   homepage = "https://git.causal.agency/cgit-pink/about/";

--- a/pkgs/applications/version-management/git-and-tools/cgit/pink.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/pink.nix
@@ -19,5 +19,5 @@ callPackage (import ./common.nix rec {
 
   homepage = "https://git.causal.agency/cgit-pink/about/";
   description = "cgit fork aiming for better maintenance";
-  maintainers = with lib.maintainers; [ qyliss sternenseemann ];
+  maintainers = with lib.maintainers; [ sternenseemann ];
 }) {}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
We skipped 1.4.0 because it had a stack free bug.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
