### PR TITLE
deadbeef 1.8.4 -> 1.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2415,6 +2415,12 @@
     githubId = 20808761;
     name = "cmfwyp";
   };
+  cmm = {
+    email = "repo@cmm.kakpryg.net";
+    github = "cmm";
+    githubId = 718298;
+    name = "Michael Livshin";
+  };
   cobbal = {
     email = "andrew.cobb@gmail.com";
     github = "cobbal";

--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -1,10 +1,11 @@
-{ config, lib, stdenv, fetchFromGitHub
+{ lib, config, clangStdenv, fetchFromGitHub
 , autoconf
 , automake
 , libtool
 , intltool
 , pkg-config
 , jansson
+, swift-corelibs-libdispatch
 # deadbeef can use either gtk2 or gtk3
 , gtk2Support ? false, gtk2
 , gtk3Support ? true, gtk3, gsettings-desktop-schemas, wrapGAppsHook
@@ -26,7 +27,7 @@
 , osdSupport ? true, dbus
 # output plugins
 , alsaSupport ? true, alsa-lib
-, pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio
+, pulseSupport ? config.pulseaudio or true, libpulseaudio
 # effect plugins
 , resamplerSupport ? true, libsamplerate
 , overloadSupport ? true, zlib
@@ -36,40 +37,70 @@
 
 assert gtk2Support || gtk3Support;
 
-stdenv.mkDerivation rec {
+let
+  inherit (lib) optionals;
+
+  version = "1.9.1";
+in clangStdenv.mkDerivation {
   pname = "deadbeef";
-  version = "1.8.4";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "DeaDBeeF-Player";
     repo = "deadbeef";
+    fetchSubmodules = true;
     rev = version;
-    sha256 = "161b0ll8v4cjgwwmk137hzvh0jidlkx56vjkpnr70f0x4jzv2nll";
+    sha256 = "sha256-e3bAGpkRPIqVWl0nvSZ61JpIQZw24mqE9218SWHBCFo=";
   };
 
-  buildInputs = with lib; [ jansson ]
-    ++ optional gtk2Support gtk2
-    ++ optionals gtk3Support [ gtk3 gsettings-desktop-schemas ]
-    ++ optional vorbisSupport libvorbis
-    ++ optional mp123Support libmad
-    ++ optional flacSupport flac
-    ++ optional wavSupport libsndfile
-    ++ optionals cdaSupport [ libcdio libcddb ]
-    ++ optional aacSupport faad2
-    ++ optional opusSupport opusfile
-    ++ optional zipSupport libzip
-    ++ optional ffmpegSupport ffmpeg
-    ++ optional apeSupport yasm
-    ++ optional artworkSupport imlib2
-    ++ optional hotkeysSupport libX11
-    ++ optional osdSupport dbus
-    ++ optional alsaSupport alsa-lib
-    ++ optional pulseSupport libpulseaudio
-    ++ optional resamplerSupport libsamplerate
-    ++ optional overloadSupport zlib
-    ++ optional wavpackSupport wavpack
-    ++ optional remoteSupport curl
-    ;
+  buildInputs = [
+    jansson
+    swift-corelibs-libdispatch
+  ] ++ optionals gtk2Support [
+    gtk2
+  ] ++ optionals gtk3Support [
+    gtk3
+    gsettings-desktop-schemas
+  ] ++ optionals vorbisSupport [
+    libvorbis
+  ] ++ optionals mp123Support [
+    libmad
+  ] ++ optionals flacSupport [
+    flac
+  ] ++ optionals wavSupport [
+    libsndfile
+  ] ++ optionals cdaSupport [
+    libcdio
+    libcddb
+  ] ++ optionals aacSupport [
+    faad2
+  ] ++ optionals opusSupport [
+    opusfile
+  ] ++ optionals zipSupport [
+    libzip
+  ] ++ optionals ffmpegSupport [
+    ffmpeg
+  ] ++ optionals apeSupport [
+    yasm
+  ] ++ optionals artworkSupport [
+    imlib2
+  ] ++ optionals hotkeysSupport [
+    libX11
+  ] ++ optionals osdSupport [
+    dbus
+  ] ++ optionals alsaSupport [
+    alsa-lib
+  ] ++ optionals pulseSupport [
+    libpulseaudio
+  ] ++ optionals resamplerSupport [
+    libsamplerate
+  ] ++ optionals overloadSupport [
+    zlib
+  ] ++ optionals wavpackSupport [
+    wavpack
+  ] ++ optionals remoteSupport [
+    curl
+  ];
 
   nativeBuildInputs = [
     autoconf
@@ -77,7 +108,9 @@ stdenv.mkDerivation rec {
     intltool
     libtool
     pkg-config
-  ] ++ lib.optional gtk3Support wrapGAppsHook;
+  ] ++ optionals gtk3Support [
+    wrapGAppsHook
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/audio/deadbeef/plugins/mpris2.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/mpris2.nix
@@ -1,21 +1,38 @@
-{ lib, stdenv, fetchurl, pkg-config, deadbeef, glib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, deadbeef
+, autoreconfHook
+, pkg-config
+, glib
+}:
 
-stdenv.mkDerivation rec {
+let
   pname = "deadbeef-mpris2-plugin";
-  version = "1.12";
+  version = "1.14";
+in stdenv.mkDerivation {
+  inherit pname version;
 
-  src = fetchurl {
-    url = "https://github.com/Serranya/deadbeef-mpris2-plugin/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "0s3y4ka4qf38cypc0xspy79q0g5y1kqx6ldad7yr6a45nw6j95jh";
+  src = fetchFromGitHub {
+    owner = "DeaDBeeF-Player";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-w7ccIhcPjbjs18kb3ZdM9JtSail9ik3uyAc40T8lHho=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
-  buildInputs = [ deadbeef glib ];
+  buildInputs = [
+    deadbeef
+    glib
+  ];
 
   meta = with lib; {
     description = "MPRISv2 plugin for the DeaDBeeF music player";
-    homepage = "https://github.com/Serranya/deadbeef-mpris2-plugin/";
+    homepage = "https://github.com/DeaDBeeF-Player/deadbeef-mpris2-plugin/";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.abbradar ];

--- a/pkgs/applications/audio/deadbeef/plugins/playlist-manager.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/playlist-manager.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, deadbeef
+, gtk3
+}:
+
+stdenv.mkDerivation {
+  pname = "deadbeef-playlist-manager-plugin";
+  version = "unstable-2021-05-02";
+
+  src = fetchFromGitHub {
+    owner = "kpcee";
+    repo = "deadbeef-playlist-manager";
+    rev = "b1393022b2d9ea0a19b845420146e0fc56cd9c0a";
+    sha256 = "sha256-dsKthlQ0EuX4VhO8K9VTyX3zN8ytzDUbSi/xSMB4xRw=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    deadbeef
+    gtk3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/deadbeef/
+    cp *.so $out/lib/deadbeef/
+
+    runHook postInstall
+  '';
+
+  buildFlags = [
+    "CFLAGS=-I${deadbeef}/include/deadbeef"
+    "gtk3"
+  ];
+
+  meta = with lib; {
+    description = "Removes duplicate and vanished files from the current playlist";
+    homepage = "https://github.com/kpcee/deadbeef-playlist-manager";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.cmm ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/swift-corelibs-libdispatch/default.nix
+++ b/pkgs/development/libraries/swift-corelibs-libdispatch/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, clangStdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, libbsd
+, libsystemtap
+}:
+
+let
+  version = "5.5";
+in clangStdenv.mkDerivation {
+  pname = "swift-corelibs-libdispatch";
+  inherit version;
+
+  outputs = [ "out" "dev" "man" ];
+
+  src = fetchFromGitHub {
+    owner = "apple";
+    repo = "swift-corelibs-libdispatch";
+    rev = "swift-${version}-RELEASE";
+    sha256 = "sha256-MbLgmS6qRSRT+2dGqbYTNb5MTM4Wz/grDXFk1kup+jk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    libbsd
+    libsystemtap
+  ];
+
+  meta = {
+    description = "Grand Central Dispatch";
+    homepage = "https://github.com/apple/swift-corelibs-libdispatch";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.cmm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25719,6 +25719,7 @@ with pkgs;
     lyricbar = callPackage ../applications/audio/deadbeef/plugins/lyricbar.nix { };
     mpris2 = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
     statusnotifier = callPackage ../applications/audio/deadbeef/plugins/statusnotifier.nix { };
+    playlist-manager = callPackage ../applications/audio/deadbeef/plugins/playlist-manager.nix { };
   };
 
   deadbeef-with-plugins = callPackage ../applications/audio/deadbeef/wrapper.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35356,4 +35356,6 @@ with pkgs;
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
 
   mictray = callPackage ../tools/audio/mictray { };
+
+  swift-corelibs-libdispatch = callPackage ../development/libraries/swift-corelibs-libdispatch { };
 }


### PR DESCRIPTION
###### Description of changes

This updates Deadbeef to 1.9.1 (in the hope of solving the problem of playback/shuffle mode sporadically resetting itself to random values, for one, and also 1.8.4 is old).

Had to package libdispatch in order to enable that (it's sort of present in Nixkpgs already as part of (at least) Swift and Zig, but not usable as a build input).

Also upgraded deabeefPlugins.mpris2 while at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [v ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [v ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
