### PR TITLE
octoprint: 1.8.0rc5 -> 1.8.0

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -74,13 +74,13 @@ let
           self: super: {
             octoprint = self.buildPythonPackage rec {
               pname = "OctoPrint";
-              version = "1.8.0rc5";
+              version = "1.8.0";
 
               src = fetchFromGitHub {
                 owner = "OctoPrint";
                 repo = "OctoPrint";
                 rev = version;
-                sha256 = "sha256-FeT45w6VXaFV4BsuOMk58nxxiu9jhCNnA2F7Uh/3sB0=";
+                sha256 = "sha256-GDKXHLigMAork+KAFOs8znNhaTYVTWVB2Tb+4sAqF8o=";
               };
 
               propagatedBuildInputs = with super; [


### PR DESCRIPTION
###### Description of changes

Update to [current](https://github.com/OctoPrint/OctoPrint/releases) version of octoprint.

This includes security updates (taken from the official release statement above):

Security fixes
[CVE-2022-1430](https://nvd.nist.gov/vuln/detail/CVE-2022-1430) - Fixed a Cross Site Scripting vulnerability in the login dialog. An attacker could send a login URL with a specially crafted redirect parameter to an instance admin that if used to login would allow the attacker to steal the "remember me" cookie. This could have then be used to gain access to the OctoPrint instance with the victim's credentials, if somehow reachable by the attacker (e.g. if you have exposed your OctoPrint instance on the public internet or another hostile network contrary to the project's recommendations). Thanks to "rajbabai8" for reporting and disclosing this reponsibly.
[CVE-2022-1432](https://nvd.nist.gov/vuln/detail/CVE-2022-1432) - Fixed a Cross Site Scripting vulnerability in the webcam stream URL test. An attacker could talk an instance administrator into inserting a specially crafted HTML/JS snippet into the webcam settings and then ask them to click "test", making the JS code run and potentially steal the remember me token. This could have then been used to gain access to the OctoPrint instance if somehow reachable by the attacker (e.g. if you have exposed your OctoPrint instance on the public internet or another hostile network contrary to the project's recommendations). Thanks to "rajbabai8" for reporting and disclosing this reponsibly.
Fixed an open redirect vulnerability in the login dialog. An attacker could send a login URL with a redirect parameter pointing to an external page under their control to an instance admin that if used to login would redirect this URL, allowing the attacker to start a phishing attack. This is not directly exploitable by the attacker, but after a successful phishing attack and thus obtained credentials could be used to gain access to the OctoPrint instance if somehow reachable by the attacker (e.g. if you have exposed your OctoPrint instance on the public internet or another hostile network contrary to the project's recommendations). Thanks to "rajbabai8" for reporting and disclosing this reponsibly.
Fixed a Cross Site Scripting vulnerability in the login dialog regarding the userId parameter. It is currently unconfirmed if this could have been used for an attack.
Set the "remember me" cookie to http only. This prevents an attacker from accessing the cookie via JavaScript, e.g. in the context of Cross Site Scripting attacks.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).