### PR TITLE
npiperelay: init at 0.1.0

### DIFF
--- a/pkgs/development/compilers/go/1.18.nix
+++ b/pkgs/development/compilers/go/1.18.nix
@@ -18,7 +18,11 @@
 , buildPackages
 , pkgsBuildTarget
 , callPackage
+, threadsCross ? null # for MinGW
 }:
+
+# threadsCross is just for MinGW
+assert threadsCross != null -> stdenv.targetPlatform.isWindows;
 
 let
   go_bootstrap = buildPackages.callPackage ./bootstrap.nix { };
@@ -50,6 +54,8 @@ let
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
+
+  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
 in
 
 stdenv.mkDerivation rec {
@@ -70,6 +76,10 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [ xcbuild ];
 
   depsTargetTargetPropagated = lib.optionals stdenv.isDarwin [ Security Foundation ];
+
+  depsBuildTarget = lib.optional isCross targetCC;
+
+  depsTargetTarget = lib.optional (threadsCross != null) threadsCross;
 
   hardeningDisable = [ "all" ];
 
@@ -188,12 +198,12 @@ stdenv.mkDerivation rec {
   # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
   # to be different from CC/CXX
   CC_FOR_TARGET =
-    if (stdenv.buildPlatform != stdenv.targetPlatform) then
+    if isCross then
       "${targetCC}/bin/${targetCC.targetPrefix}cc"
     else
       null;
   CXX_FOR_TARGET =
-    if (stdenv.buildPlatform != stdenv.targetPlatform) then
+    if isCross then
       "${targetCC}/bin/${targetCC.targetPrefix}c++"
     else
       null;
@@ -217,7 +227,7 @@ stdenv.mkDerivation rec {
 
     export PATH=$(pwd)/bin:$PATH
 
-    ${lib.optionalString (stdenv.buildPlatform != stdenv.targetPlatform) ''
+    ${lib.optionalString isCross ''
     # Independent from host/target, CC should produce code for the building system.
     # We only set it when cross-compiling.
     export CC=${buildPackages.stdenv.cc}/bin/cc

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -37,6 +37,8 @@ lib.makeScope newScope (self: with self; {
     stdenv = crossThreadsStdenv;
   };
 
+  npiperelay = callPackage ./npiperelay { };
+
   pthreads = callPackage ./pthread-w32 { };
 
   wxMSW = callPackage ./wxMSW-2.8 { };

--- a/pkgs/os-specific/windows/npiperelay/default.nix
+++ b/pkgs/os-specific/windows/npiperelay/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "npiperelay";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jstarks";
+    repo = "npiperelay";
+    rev = "v${version}";
+    sha256 = "sha256-cg4aZmpTysc8m1euxIO2XPv8OMnBk1DwhFcuIFHF/1o=";
+  };
+
+  vendorSha256 = null;
+
+  meta = {
+    description = "Access Windows named pipes from WSL";
+    homepage = "https://github.com/jstarks/npiperelay";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.shlevy ];
+    platforms = lib.platforms.windows;
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
