### PR TITLE
python3.pkgs.deepdiff: 5.7.0 -> 5.8.0

### DIFF
--- a/pkgs/development/python-modules/deepdiff/default.nix
+++ b/pkgs/development/python-modules/deepdiff/default.nix
@@ -12,16 +12,15 @@
 
 buildPythonPackage rec {
   pname = "deepdiff";
-  version = "5.7.0";
+  version = "5.8.2";
   format = "setuptools";
 
   # pypi source does not contain all fixtures required for tests
   src = fetchFromGitHub {
     owner = "seperman";
     repo = "deepdiff";
-    # 5.7.0 release not tagged https://github.com/seperman/deepdiff/issues/300
-    rev = "f2ffdb83b2993f4f0bb7e854620f0acd0bf6339e";
-    hash = "sha256-0UBx7sH2iMrLVl5FtHNTwoecLHi8GbInn75G3FSg4gk=";
+    rev = "v${version}";
+    hash = "sha256:0hpys88vj0c7srd1ghpss4d4xcgc78nxz542zzf9czsym6xs1rpd";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes
#172160

> Fixed Tests fail after 2022-05-14
https://github.com/seperman/deepdiff/releases

cc @NixOS/nixos-release-managers 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)