### PR TITLE
phpExtensions.grpc: init at 1.45.0

### DIFF
--- a/pkgs/development/php-packages/grpc/default.nix
+++ b/pkgs/development/php-packages/grpc/default.nix
@@ -1,0 +1,20 @@
+{ buildPecl, zlib, lib }:
+
+buildPecl {
+  pname = "grpc";
+
+  version = "1.45.0";
+  sha256 = "sha256-SPnECBZ80sXfXYiVJjGfOsSxZBBZnasO9pPu9Q5klIg";
+
+  doCheck = true;
+  checkTarget = "test";
+
+  nativeBuildInputs = [ zlib ];
+
+  meta = with lib; {
+    description = "A high performance, open source, general RPC framework that puts mobile and HTTP/2 first.";
+    license = licenses.asl20;
+    homepage = "https://github.com/grpc/grpc/tree/master/src/php/ext/grpc";
+    maintainers = teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -212,6 +212,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     gnupg = callPackage ../development/php-packages/gnupg { };
 
+    grpc = callPackage ../development/php-packages/grpc { };
+
     igbinary = callPackage ../development/php-packages/igbinary { };
 
     imagick = callPackage ../development/php-packages/imagick { };


### PR DESCRIPTION
###### Description of changes

Needed at work, the GRPC extension for talking with the Go service

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


