### PR TITLE
python310Packages.qcs-api-client: 0.20.12 -> 0.20.17

### DIFF
--- a/pkgs/development/python-modules/qcs-api-client/default.nix
+++ b/pkgs/development/python-modules/qcs-api-client/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "qcs-api-client";
-  version = "0.20.14";
+  version = "0.20.17";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "rigetti";
     repo = "qcs-api-client-python";
     rev = "v${version}";
-    hash = "sha256-5xRjjy+4i2JgYOXK35d4uqAyJhQgm6VUx72YoooXgSk=";
+    hash = "sha256-5YGMBoykMtXZgdHubQJKwRqntDPnR6/qsWJc1cYk8CA=";
   };
 
   nativeBuildInputs = [
@@ -74,8 +74,9 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Test is outdated
-    "tests/test_client/test_client.py"
     "tests/test_client/test_additional_properties.py"
+    "tests/test_client/test_auth.py"
+    "tests/test_client/test_client.py"
     "tests/test_client/test_datetime.py"
     "tests/test_imports.py"
   ];

--- a/pkgs/development/python-modules/qcs-api-client/default.nix
+++ b/pkgs/development/python-modules/qcs-api-client/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "qcs-api-client";
-  version = "0.20.12";
+  version = "0.20.14";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "rigetti";
     repo = "qcs-api-client-python";
     rev = "v${version}";
-    hash = "sha256-4462T2WIBdWjtd51YfslYZOcJg9f0nrSOKTi2ed6WvI=";
+    hash = "sha256-5xRjjy+4i2JgYOXK35d4uqAyJhQgm6VUx72YoooXgSk=";
   };
 
   nativeBuildInputs = [
@@ -75,6 +75,9 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Test is outdated
     "tests/test_client/test_client.py"
+    "tests/test_client/test_additional_properties.py"
+    "tests/test_client/test_datetime.py"
+    "tests/test_imports.py"
   ];
 
   pythonImportsCheck = [
@@ -83,7 +86,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python library for accessing the Rigetti QCS API";
-    homepage = "https://pypi.org/project/qcs-api-client/";
+    homepage = "https://qcs-api-client-python.readthedocs.io/";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
###### Description of changes
https://github.com/rigetti/qcs-api-client-python/releases/tag/v0.20.17
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
