### PR TITLE
webkitgtk: 2.36.1 → 2.36.2

### DIFF
--- a/pkgs/development/libraries/libwpe/default.nix
+++ b/pkgs/development/libraries/libwpe/default.nix
@@ -6,7 +6,9 @@
 , libxkbcommon
 , libGL
 , ninja
-, libX11 }:
+, libX11
+, webkitgtk
+}:
 
 stdenv.mkDerivation rec {
   pname = "libwpe";
@@ -33,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "General-purpose library for WPE WebKit";
     license = licenses.bsd2;
     homepage = "https://wpewebkit.org";
-    maintainers = with maintainers; [ matthewbauer ];
+    maintainers = webkitgtk.meta.maintainers ++ (with maintainers; [ matthewbauer ]);
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libwpe/fdo.nix
+++ b/pkgs/development/libraries/libwpe/fdo.nix
@@ -10,7 +10,9 @@
 , libwpe
 , libxkbcommon
 , libGL
-, libX11 }:
+, libX11
+, webkitgtk
+ }:
 
 stdenv.mkDerivation rec {
   pname = "wpebackend-fdo";
@@ -46,7 +48,7 @@ stdenv.mkDerivation rec {
     description = "Freedesktop.org backend for WPE WebKit";
     license = licenses.bsd2;
     homepage = "https://wpewebkit.org";
-    maintainers = with maintainers; [ matthewbauer ];
+    maintainers = webkitgtk.meta.maintainers ++ (with maintainers; [ matthewbauer ]);
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -65,7 +65,7 @@
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.36.1";
+  version = "2.36.2";
 
   outputs = [ "out" "dev" ];
 
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "sha256-AUnqX7HSDyqZgWd9RclSoEczAAHqJKjcKQNSOfEsDI8=";
+    sha256 = "/pO920oCwONvkm77boHSiv0oi4gk9sXPanXPQCKOAI4=";
   };
 
   patches = lib.optionals stdenv.isLinux [

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -19,6 +19,8 @@
 , gtk3
 , wayland
 , libwebp
+, libwpe
+, libwpe-fdo
 , enchant2
 , xorg
 , libxkbcommon
@@ -82,7 +84,15 @@ stdenv.mkDerivation rec {
       inherit (builtins) storeDir;
       inherit (addOpenGLRunpath) driverLink;
     })
+
     ./libglvnd-headers.patch
+
+    # Hardcode path to WPE backend
+    # https://github.com/NixOS/nixpkgs/issues/110468
+    (substituteAll {
+      src = ./fdo-backend-path.patch;
+      wpebackend_fdo = libwpe-fdo;
+    })
   ];
 
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
@@ -160,6 +170,8 @@ stdenv.mkDerivation rec {
     libseccomp
     libmanette
     wayland
+    libwpe
+    libwpe-fdo
     xdg-dbus-proxy
   ] ++ lib.optionals systemdSupport [
     systemd
@@ -180,7 +192,6 @@ stdenv.mkDerivation rec {
     "-DENABLE_INTROSPECTION=ON"
     "-DPORT=GTK"
     "-DUSE_LIBHYPHEN=OFF"
-    "-DUSE_WPE_RENDERER=OFF"
     "-DUSE_SOUP2=${cmakeBool (lib.versions.major libsoup.version == "2")}"
     "-DUSE_LIBSECRET=${cmakeBool withLibsecret}"
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/webkitgtk/fdo-backend-path.patch
+++ b/pkgs/development/libraries/webkitgtk/fdo-backend-path.patch
@@ -1,0 +1,11 @@
+--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
++++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+@@ -89,7 +89,7 @@
+ #if PLATFORM(WAYLAND)
+     if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::Wayland) {
+ #if USE(WPE_RENDERER)
+-        wpe_loader_init("libWPEBackend-fdo-1.0.so.1");
++        wpe_loader_init("@wpebackend_fdo@/lib/libWPEBackend-fdo-1.0.so.1");
+         if (AcceleratedBackingStoreWayland::checkRequirements()) {
+             parameters.hostClientFileDescriptor = IPC::Attachment(UnixFileDescriptor(wpe_renderer_host_create_client(), UnixFileDescriptor::Adopt));
+             parameters.implementationLibraryName = FileSystem::fileSystemRepresentation(String::fromLatin1(wpe_loader_get_loaded_implementation_library_name()));


### PR DESCRIPTION
###### Description of changes

https://webkitgtk.org/2022/05/18/webkitgtk2.36.2-released.html

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
