### PR TITLE
python310Packages.pyshark: 0.4.3 -> 0.4.5

### DIFF
--- a/pkgs/development/python-modules/pyshark/default.nix
+++ b/pkgs/development/python-modules/pyshark/default.nix
@@ -1,38 +1,53 @@
-{ lib, buildPythonPackage, fetchFromGitHub, py, lxml, pytestCheckHook, wireshark-cli }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, packaging
+, py
+, pytestCheckHook
+, pythonOlder
+, wireshark-cli
+}:
 
 buildPythonPackage rec {
   pname = "pyshark";
-  version = "0.4.3";
+  version = "0.4.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "KimiNewt";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-cveiFkkSplfQPgUEVWyV40KKHCtKJZsfvdV8JmEUmE4=";
+    # 0.4.5 was the last release which was tagged
+    # https://github.com/KimiNewt/pyshark/issues/541
+    rev = "8f8f13aba6ae716aa0a48175255063fe542fdc3b";
+    hash = "sha256-v9CC9hgTABAiJ0qiFZ/9/zMmHzJXKq3neGtTq/ucnT4=";
   };
+
+  sourceRoot = "${src.name}/src";
 
   propagatedBuildInputs = [
     py
     lxml
+    packaging
   ];
-
-  preConfigure = ''
-    cd src
-  '';
-
-  preCheck = ''
-    cd ..
-  '';
 
   checkInputs = [
     pytestCheckHook
     wireshark-cli
   ];
 
-  pythonImportsCheck = [ "pyshark" ];
+  pythonImportsCheck = [
+    "pyshark"
+  ];
+
+  pytestFlagsArray = [
+    "../tests/"
+  ];
 
   meta = with lib; {
-    description = "Python wrapper for tshark, allowing python packet parsing using wireshark dissectors";
+    description = "Python wrapper for tshark, allowing Python packet parsing using Wireshark dissectors";
     homepage = "https://github.com/KimiNewt/pyshark/";
     license = licenses.mit;
     maintainers = with maintainers; [ petabyteboy ];


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 0.4.5
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
