### PR TITLE
apkid: 2.1.1 -> 2.1.3

### DIFF
--- a/pkgs/development/tools/apkid/default.nix
+++ b/pkgs/development/tools/apkid/default.nix
@@ -5,13 +5,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "apkid";
-  version = "2.1.1";
+  version = "2.1.3";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "rednaga";
     repo = "APKiD";
     rev = "v${version}";
-    sha256 = "1p6kdjjw2jhwr875445w43k46n6zwpz0l0phkl8d3y1v4gi5l6dx";
+    hash = "sha256-U4CsPTA0fXCzj5iLTbLFGudAvewVCzxe4xl0osoBy5A=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -28,12 +29,14 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   postPatch = ''
-    # The next release will have support for later yara-python releases
+    # We have dex support enabled in yara-python
     substituteInPlace setup.py \
-      --replace "yara-python==3.11.0" "yara-python"
+      --replace "yara-python-dex>=1.0.1" "yara-python"
   '';
 
-  pythonImportsCheck = [ "apkid" ];
+  pythonImportsCheck = [
+    "apkid"
+  ];
 
   meta = with lib; {
     description = "Android Application Identifier";


### PR DESCRIPTION
###### Description of changes

https://github.com/rednaga/APKiD/releases/tag/v2.1.3

Not using the forked `yara-python` module as we build with `--dynamic-linking`. Detection seems to work.

```bash
...~/nixpkgs]$ ./result/bin/apkid InsecureBankv2.apk 
[+] APKiD 2.1.3 :: from RedNaga :: rednaga.io
[*] InsecureBankv2.apk!classes.dex
 |-> anti_vm : Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check
 |-> compiler : dx (possible dexmerge)
 |-> manipulator : dexmerge
```

Fixes #173001

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
