### PR TITLE
vscode-extensions.rust-lang.rust-analyzer: 0.2.1048 -> 0.3.1059

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
@@ -1,15 +1,16 @@
 {
   "name": "rust-analyzer",
-  "version": "0.2.1048",
+  "version": "0.3.1059",
   "dependencies": {
-    "vscode-languageclient": "8.0.0-next.14",
     "d3": "^7.3.0",
     "d3-graphviz": "^4.1.0",
+    "vscode-languageclient": "8.0.0-next.14",
     "@types/node": "~14.17.5",
     "@types/vscode": "~1.66.0",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "@vscode/test-electron": "^2.1.3",
+    "cross-env": "^7.0.3",
     "eslint": "^8.11.0",
     "tslib": "^2.3.0",
     "typescript": "^4.6.3",

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
@@ -15,18 +15,18 @@
 
 let
   pname = "rust-analyzer";
-  publisher = "matklad";
+  publisher = "rust-lang";
 
   # Use the plugin version as in vscode marketplace, updated by update script.
   inherit (vsix) version;
 
-  releaseTag = "2022-03-07";
+  releaseTag = "2022-05-17";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rust-analyzer";
     rev = releaseTag;
-    sha256 = "sha256-/qKh4utesAjlyG8A3hEmSx+HBgh48Uje6ZRtUGz5f0g=";
+    sha256 = "sha256-vrVpgQYUuJPgK1NMb1nxlCdxjoYo40YkUbZpH2Z2mwM=";
   };
 
   build-deps = nodePackages."rust-analyzer-build-deps-../../applications/editors/vscode/extensions/rust-analyzer/build-deps";

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
@@ -23,7 +23,7 @@ let
   releaseTag = "2022-03-07";
 
   src = fetchFromGitHub {
-    owner = "rust-analyzer";
+    owner = "rust-lang";
     repo = "rust-analyzer";
     rev = releaseTag;
     sha256 = "sha256-/qKh4utesAjlyG8A3hEmSx+HBgh48Uje6ZRtUGz5f0g=";
@@ -47,7 +47,7 @@ let
       darwin.apple_sdk.frameworks.Security
     ];
 
-    # Follows https://github.com/rust-analyzer/rust-analyzer/blob/41949748a6123fd6061eb984a47f4fe780525e63/xtask/src/dist.rs#L39-L65
+    # Follows https://github.com/rust-lang/rust-analyzer/blob/41949748a6123fd6061eb984a47f4fe780525e63/xtask/src/dist.rs#L39-L65
     postInstall = ''
       jq '
         .version = $ENV.version |
@@ -58,7 +58,7 @@ let
 
       mkdir -p $vsix
       # vsce ask for continue due to missing LICENSE.md
-      # Should be removed after https://github.com/rust-analyzer/rust-analyzer/commit/acd5c1f19bf7246107aaae7b6fe3f676a516c6d2
+      # Should be removed after https://github.com/rust-lang/rust-analyzer/commit/acd5c1f19bf7246107aaae7b6fe3f676a516c6d2
       echo y | npx vsce package -o $vsix/${pname}.zip
     '';
   };
@@ -80,7 +80,7 @@ vscode-utils.buildVscodeExtension {
 
   meta = with lib; {
     description = "An alternative rust language server to the RLS";
-    homepage = "https://github.com/rust-analyzer/rust-analyzer";
+    homepage = "https://github.com/rust-lang/rust-analyzer";
     license = with licenses; [ mit asl20 ];
     maintainers = with maintainers; [ ];
     platforms = platforms.all;

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
@@ -47,3 +47,5 @@ else
 
     ./"$node_packages"/generate.sh
 fi
+
+echo "Remember to also update the revisionTag and hash in default.nix!"


### PR DESCRIPTION
###### Description of changes

This PR updates the rust-analyzer vscode extension to the latest version. It also moves the extension from `vscode-extensions.matklad.rust-analyzer` to `vscode-extensions.rust-lang.rust-analyzer` because the extension's publisher was changed on the vscode marketplace. For backwards compatibility, `vscode-extensions.matklad.rust-analyzer` still points to the extension. I don't know how to deprecate it.

It seems like the vscode extension's update script was ran regularly, but the actual release tag and associated hash was not updated as frequently, so I added a reminder to the update script.

Closes  #173388.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
