### PR TITLE
sageWithDoc: clean up sagedoc.nix

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -78,8 +78,7 @@ let
 
   # The documentation for sage, building it takes a lot of ram.
   sagedoc = callPackage ./sagedoc.nix {
-    inherit sage-with-env;
-    inherit python3 maxima jupyter-kernel-specs;
+    inherit sage-with-env jupyter-kernel-specs;
   };
 
   # sagelib with added wrappers and a dependency on sage-tests to make sure thet tests were run.

--- a/pkgs/applications/science/math/sage/sagedoc.nix
+++ b/pkgs/applications/science/math/sage/sagedoc.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   # Building the documentation has many dependencies, because all documented
   # modules are imported and because matplotlib is used to produce plots.
   buildInputs = [
-    sage-with-env.env.lib
+    sage-with-env
     python3
     maxima
     tachyon

--- a/pkgs/applications/science/math/sage/sagedoc.nix
+++ b/pkgs/applications/science/math/sage/sagedoc.nix
@@ -2,10 +2,6 @@
 , sage-with-env
 , python3
 , jupyter-kernel-specs
-, maxima
-, tachyon
-, jmol
-, cddlib
 }:
 
 stdenv.mkDerivation rec {
@@ -13,30 +9,7 @@ stdenv.mkDerivation rec {
   pname = "sagedoc";
   src = sage-with-env.env.lib.src;
 
-
-  # Building the documentation has many dependencies, because all documented
-  # modules are imported and because matplotlib is used to produce plots.
-  buildInputs = [
-    sage-with-env
-    python3
-    maxima
-    tachyon
-    jmol
-    cddlib
-  ] ++ (with python3.pkgs; [
-    sage-docbuild
-    psutil
-    future
-    sphinx
-    scipy
-    sympy
-    matplotlib
-    pillow
-    networkx
-    ipykernel
-    ipywidgets
-    jupyter-client
-  ]);
+  strictDeps = true;
 
   unpackPhase = ''
     export SAGE_DOC_OVERRIDE="$PWD/share/doc/sage"


### PR DESCRIPTION
###### Description of changes

Since `pkg-config` was removed from `python3Packages.pkgconfig`'s `propagatedNativeBuildInputs` in #171270, our way of setting `PKG_CONFIG_PATH` in `sage-env.nix` was getting overridden (there are more details in #171270's comments) indirectly by having `sage-with-env.env.lib` as a `buildInput`. Everything works without it, and in fact docbuilding works without any build inputs at all because the wrapper (`sage-with-env`) takes care of everything.

Technical note: unlike the successful run in https://github.com/NixOS/nixpkgs/pull/171270#issuecomment-1130535367, where the wrapper changed `PKG_CONFIG_PATH` in a way that preserved our modification, the pkg-config wrapper does not touch our `PKG_CONFIG_PATH` at all with this PR (because `role_suffixes` is empty).

Fixes breakage introduced in #171270, so: ZHF #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
