### PR TITLE
python310Packages.django-rest-auth: adopt, prepare to run tests

### DIFF
--- a/pkgs/development/python-modules/django-rest-auth/default.nix
+++ b/pkgs/development/python-modules/django-rest-auth/default.nix
@@ -1,29 +1,51 @@
-{ lib,
-  fetchPypi,
-  django,
-  djangorestframework,
-  six,
-  buildPythonPackage
+{ lib
+ , buildPythonPackage
+, fetchFromGitHub
+, django
+, django-allauth
+, djangorestframework
+, drf-jwt
+, responses
+, six
 }:
 
 buildPythonPackage rec {
   pname = "django-rest-auth";
   version = "0.9.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f11e12175dafeed772f50d740d22caeab27e99a3caca24ec65e66a8d6de16571";
+  src = fetchFromGitHub {
+    owner = "Tivix";
+    repo = "django-rest-auth";
+    rev = version;
+    sha256 = "sha256-rCChUHv8sTEFErDCZnPN5b5XVtMJ7JNVZwBYF3d99mY=";
   };
 
-  propagatedBuildInputs = [ django djangorestframework six ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "djangorestframework-jwt" "drf-jwt"
+  '';
 
-  # pypi release does not include tests
+  propagatedBuildInputs = [
+    django
+    djangorestframework
+    six
+  ];
+
+  checkInputs = [
+    django-allauth
+    drf-jwt
+    responses
+  ];
+
+  # tests are icnompatible with current django version
   doCheck = false;
+
+  pythonImportsCheck = [ "rest_auth" ];
 
   meta = with lib; {
     description = "Django app that makes registration and authentication easy";
     homepage = "https://github.com/Tivix/django-rest-auth";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
