### PR TITLE
lagrange: 1.13.3 → 1.13.5

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lagrange";
-  version = "1.13.3";
+  version = "1.13.5";
 
   src = fetchFromGitHub {
     owner = "skyjake";
     repo = "lagrange";
     rev = "v${version}";
-    sha256 = "sha256-ZCG7i5WmhONockaTt/YCww7N+WvxCX2DIwQIFjAk+K8=";
+    sha256 = "sha256-HZGI9vWSYCDH0lW+k6hvPm3UVW6lR8Lhr3H7blNupNk=";
   };
 
   nativeBuildInputs = [ cmake pkg-config zip ];

--- a/pkgs/development/libraries/sealcurses/default.nix
+++ b/pkgs/development/libraries/sealcurses/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "sealcurses";
-  version = "unstable-2022-04-28"; # No release yet
+  version = "unstable-2022-05-18"; # No release yet
 
   src = fetchFromGitea {
     domain = "git.skyjake.fi";
     owner = "skyjake";
     repo = pname;
-    rev = "abf27cfd2567a0765aaa115cabab0abb7f862253";
-    hash = "sha256-c4zi/orHyr1hkuEisqZ9V8SaiH1IoxIbeGMrLBEkZ0A=";
+    rev = "417d77d790ede990b4c149f21c58fd13b8f273cc";
+    hash = "sha256-yOrJYy9vBv5n8yK6u7tfMq56LBBw5rmhUjORINW8gxo=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).