### PR TITLE
python310Packages.unittest-xml-reporting: enable tests, adopt

### DIFF
--- a/pkgs/development/python-modules/unittest-xml-reporting/default.nix
+++ b/pkgs/development/python-modules/unittest-xml-reporting/default.nix
@@ -1,26 +1,37 @@
-{lib, fetchPypi, buildPythonPackage, isPy27, six, lxml }:
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, lxml
+, pythonOlder
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "unittest-xml-reporting";
   version = "3.2.0";
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "xmlrunner";
+    repo = "unittest-xml-reporting";
+    rev = version;
+    sha256 = "sha256-lOJ/+8CVJUXdIaZLLF5PpPkG0DzlNgo46kRZ1Xy7Ju0=";
+  };
 
   propagatedBuildInputs = [
     lxml
-    six
   ];
 
-  # The tarball from Pypi doesn't actually contain the unit tests
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-7djTFwtAw6gbjPkQ9GxqMErihH7AEDbQLpwPm4V2LSg=";
-  };
+  pythonImportsCheck = [ "xmlrunner" ];
+
   meta = with lib; {
-    homepage = "https://github.com/xmlrunner/unittest-xml-reporting/tree/master/";
-    description = "A unittest runner that can save test results to XML files";
-    license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ rprospero ];
+    homepage = "https://github.com/xmlrunner/unittest-xml-reporting";
+    description = "unittest-based test runner with Ant/JUnit like XML reporting";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ rprospero SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
