### PR TITLE
drawio-headless: extract from pandoc-drawio-filter

### DIFF
--- a/pkgs/applications/graphics/drawio/headless.nix
+++ b/pkgs/applications/graphics/drawio/headless.nix
@@ -1,0 +1,36 @@
+{ lib, writeTextFile, runtimeShell, drawio, xvfb-run }:
+
+writeTextFile {
+  name = "${drawio.pname}-headless-${drawio.version}";
+
+  executable = true;
+  destination = "/bin/drawio";
+  text = ''
+    #!${runtimeShell}
+
+    # Electron really wants a configuration directory to not die with:
+    # "Error: Failed to get 'appData' path"
+    # so we give it some temp dir as XDG_CONFIG_HOME
+    tmpdir=$(mktemp -d)
+
+    function cleanup {
+      rm -rf "$tmpdir"
+    }
+    trap cleanup EXIT
+
+    # Drawio needs to run in a virtual X session, because Electron
+    # refuses to work and dies with an unhelpful error message otherwise:
+    # "The futex facility returned an unexpected error code."
+    XDG_CONFIG_HOME="$tmpdir" ${xvfb-run}/bin/xvfb-run ${drawio}/bin/drawio $@
+  '';
+
+  meta = with lib; {
+    description = "xvfb wrapper around drawio";
+    longDescription = ''
+      A wrapper around drawio for running in headless environments.
+      Runs drawio under xvfb-run, with configuration going to a temporary
+      directory.
+    '';
+    maintainers = with maintainers; [ qyliss tfc ];
+  };
+}

--- a/pkgs/tools/misc/pandoc-drawio-filter/default.nix
+++ b/pkgs/tools/misc/pandoc-drawio-filter/default.nix
@@ -1,5 +1,5 @@
 { buildPythonApplication
-, drawio
+, drawio-headless
 , fetchFromGitHub
 , lib
 , pandoc
@@ -21,32 +21,13 @@ let
     sha256 = "sha256-2XJSAfxqEmmamWIAM3vZqi0mZjUUugmR3zWw8Imjadk=";
   };
 
-  wrappedDrawio = writeScriptBin "drawio" ''
-    #!${runtimeShell}
-
-    # Electron really wants a configuration directory to not die with:
-    # "Error: Failed to get 'appData' path"
-    # so we give it some temp dir as XDG_CONFIG_HOME
-    tmpdir=$(mktemp -d)
-
-    function cleanup {
-      rm -rf "$tmpdir"
-    }
-    trap cleanup EXIT
-
-    # Drawio needs to run in a virtual X session, because Electron
-    # refuses to work and dies with an unhelpful error message otherwise:
-    # "The futex facility returned an unexpected error code."
-    XDG_CONFIG_HOME="$tmpdir" ${xvfb-run}/bin/xvfb-run ${drawio}/bin/drawio $@
-  '';
-
   pandoc-drawio-filter = buildPythonApplication {
     pname = "pandoc-drawio-filter";
 
     inherit src version;
 
     propagatedBuildInputs = [
-      wrappedDrawio
+      drawio-headless
       pandocfilters
     ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25860,6 +25860,7 @@ with pkgs;
   drawing = callPackage ../applications/graphics/drawing { };
 
   drawio = callPackage ../applications/graphics/drawio {};
+  drawio-headless = callPackage ../applications/graphics/drawio/headless.nix { };
 
   drawpile = libsForQt5.callPackage ../applications/graphics/drawpile { };
   drawpile-server-headless = libsForQt5.callPackage ../applications/graphics/drawpile {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This wrapper is useful independently of pandoc-drawio-filter — it's
useful in any other situation in which somebody might want to use
draw.io diagrams in a build process.

So, make it accessible from the top level to facilitate reuse.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
