### PR TITLE
badrobot: init at 0.1.2

### DIFF
--- a/pkgs/tools/security/badrobot/default.nix
+++ b/pkgs/tools/security/badrobot/default.nix
@@ -1,0 +1,45 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "badrobot";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "controlplaneio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-LGoNM8wu1qaq4cVEzR723/cueZlndE1Z2PCYEOU+nPQ=";
+  };
+  vendorSha256 = "sha256-FS4kFVi+3NOJOfWfy5m/hDrQvCzpmsNSB/PliF6cVps=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/controlplaneio/badrobot/cmd.version=v${version}"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd badrobot \
+      --bash <($out/bin/badrobot completion bash) \
+      --fish <($out/bin/badrobot completion fish) \
+      --zsh <($out/bin/badrobot completion zsh)
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/controlplaneio/badrobot";
+    changelog = "https://github.com/controlplaneio/badrobot/blob/v${version}/CHANGELOG.md";
+    description = "Operator Security Audit Tool";
+    longDescription = ''
+      Badrobot is a Kubernetes Operator audit tool. It statically analyses
+      manifests for high risk configurations such as lack of security
+      restrictions on the deployed controller and the permissions of an
+      associated clusterole. The risk analysis is primarily focussed on the
+      likelihood that a compromised Operator would be able to obtain full
+      cluster permissions.
+    '';
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2577,6 +2577,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  badrobot = callPackage ../tools/security/badrobot {};
+
   bao = callPackage ../tools/security/bao {};
 
   bar = callPackage ../tools/system/bar {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package badrobot for nixpkgs - Kubernetes Operator Security Audit Tool

https://github.com/controlplaneio/badrobot

[Tweezering Kubernetes Resources: Operating on Operators - Kevin Ward, ControlPlane](https://kccnceu2022.sched.com/event/ytpr)

15:25 - 16:00 CEST - KubeCon Valencia


<details>
  <summary>Spoiler warning</summary>

  [slides](https://static.sched.com/hosted_files/kccnceu2022/33/KubeCon_EU_2022_Tweezering_Kubernetes_Resources_Operating_on_Operators.pptx.pdf)

</details>



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
