### PR TITLE
python3Packages.mkdocs-gitlab-plugin: init at 0.1.4

### DIFF
--- a/pkgs/development/python-modules/mkdocs-gitlab-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-gitlab-plugin/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, fetchzip
+, isPy3k
+, lib
+, mkdocs
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-gitlab-plugin";
+  version = "0.1.4";
+
+  disabled = !isPy3k;
+
+  src = fetchzip {
+    url = "https://gitlab.inria.fr/vidjil/mkdocs-gitlab-plugin/-/archive/fb87fbfd404839e661a799c540664b1103096a5f/mkdocs-gitlab-plugin-fb87fbfd404839e661a799c540664b1103096a5f.tar.gz";
+    sha256 = "sha256-z+U0PRwymDDXVNM7a2Yl4pNNVBxpx/BhJnlx6kgyvww=";
+  };
+
+  patches = [ ./mkdocs-gitlab-plugin.diff ];
+
+  propagatedBuildInputs = [ mkdocs ];
+
+  pythonImportsCheck = [ "mkdocs_gitlab_plugin" ];
+
+  meta = with lib; {
+    description = "MkDocs plugin to transform strings such as #1234, %56, or !789 into links to a Gitlab repository.";
+    homepage = "https://gitlab.inria.fr/vidjil/mkdocs-gitlab-plugin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ snpschaaf ];
+    longDescription = ''
+      Plugin for MkDocs.
+      Transform handles such as #1234, %56, !789, &12 or $34 into links to a gitlab repository,
+      given by the gitlab_url configuration option.
+      Before the #/%/!/&/$ is needed either a space, a '(', or a '['.
+    '';
+  };
+}

--- a/pkgs/development/python-modules/mkdocs-gitlab-plugin/mkdocs-gitlab-plugin.diff
+++ b/pkgs/development/python-modules/mkdocs-gitlab-plugin/mkdocs-gitlab-plugin.diff
@@ -1,0 +1,37 @@
+diff --git a/mkdocs_gitlab_plugin/plugin.py b/mkdocs_gitlab_plugin/plugin.py
+index e8d7ab7..8b883f5 100644
+--- a/mkdocs_gitlab_plugin/plugin.py
++++ b/mkdocs_gitlab_plugin/plugin.py
+@@ -3,7 +3,7 @@
+ import re
+ import mkdocs
+ 
+-from mkdocs.config import Config
++from mkdocs.config.config_options import Type
+ from mkdocs.plugins import BasePlugin
+ 
+ class GitlabLinksPlugin(BasePlugin):
+@@ -13,8 +13,8 @@ class GitlabLinksPlugin(BasePlugin):
+     '''
+ 
+     config_scheme = (
+-        ('gitlab_url', mkdocs.config.config_options.Type(str, default='http://gitlab.com/XXX')),
+-        ('verbose', mkdocs.config.config_options.Type(bool, default=False))
++        ('gitlab_url', Type(str, default='http://gitlab.com/XXX')),
++        ('verbose', Type(bool, default=False))
+     )
+ 
+     TOKEN_PATHS = {
+diff --git a/mkdocs_gitlab_plugin/test.py b/mkdocs_gitlab_plugin/test.py
+index 4a5c35f..d5a19c6 100644
+--- a/mkdocs_gitlab_plugin/test.py
++++ b/mkdocs_gitlab_plugin/test.py
+@@ -1,7 +1,7 @@
+ 
+ import sys
+ 
+-from plugin import GitlabLinksPlugin
++from .plugin import GitlabLinksPlugin
+ 
+ if __name__ == '__main__':
+     plugin = GitlabLinksPlugin()

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5383,6 +5383,7 @@ in {
 
   mkdocs = callPackage ../development/python-modules/mkdocs { };
   mkdocs-drawio-exporter = callPackage ../development/python-modules/mkdocs-drawio-exporter { };
+  mkdocs-gitlab = callPackage ../development/python-modules/mkdocs-gitlab-plugin { };
   mkdocs-macros = callPackage ../development/python-modules/mkdocs-macros { };
   mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
   mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };


### PR DESCRIPTION
###### Description of changes

Add python package: [mkdocs-gitlab-plugin](https://gitlab.inria.fr/vidjil).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
