### PR TITLE
clamav: Fix CLI clamav programs not finding configuration files

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -13,8 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-JwIDpUxFgEnbVPzZNoP/Wy2xkVHzY8SOgs7O/d4rNdQ=";
   };
 
-  # Flaky test, remove this when https://github.com/Cisco-Talos/clamav/issues/343 is fixed
-  patches = [ ./remove-freshclam-test.patch ];
+  patches = [
+    # Flaky test, remove this when https://github.com/Cisco-Talos/clamav/issues/343 is fixed
+    ./remove-freshclam-test.patch
+    ./sample-cofiguration-file-install-location.patch
+  ];
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkg-config rustc rust-bindgen rustfmt cargo python3 ];
@@ -25,6 +28,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DSYSTEMD_UNIT_DIR=${placeholder "out"}/lib/systemd"
+    "-DAPP_CONFIG_DIRECTORY=/etc/clamav"
   ];
 
   doCheck = true;

--- a/pkgs/tools/security/clamav/sample-cofiguration-file-install-location.patch
+++ b/pkgs/tools/security/clamav/sample-cofiguration-file-install-location.patch
@@ -1,0 +1,29 @@
+diff --git a/etc/CMakeLists.txt b/etc/CMakeLists.txt
+index 826fff1..3cefc34 100644
+--- a/etc/CMakeLists.txt
++++ b/etc/CMakeLists.txt
+@@ -6,14 +6,14 @@ install(
+     FILES
+         ${CMAKE_CURRENT_SOURCE_DIR}/clamd.conf.sample
+     DESTINATION
+-        ${APP_CONFIG_DIRECTORY}
++        ${CMAKE_INSTALL_PREFIX}/${APP_CONFIG_DIRECTORY}
+     COMPONENT programs)
+ 
+ install(
+     FILES
+         ${CMAKE_CURRENT_SOURCE_DIR}/freshclam.conf.sample
+     DESTINATION
+-        ${APP_CONFIG_DIRECTORY}
++        ${CMAKE_INSTALL_PREFIX}/${APP_CONFIG_DIRECTORY}
+     COMPONENT programs)
+ 
+ if(ENABLE_MILTER)
+@@ -21,6 +21,6 @@ if(ENABLE_MILTER)
+         FILES
+             ${CMAKE_CURRENT_SOURCE_DIR}/clamav-milter.conf.sample
+         DESTINATION
+-            ${APP_CONFIG_DIRECTORY}
++            ${CMAKE_INSTALL_PREFIX}/${APP_CONFIG_DIRECTORY}
+         COMPONENT programs)
+ endif()


### PR DESCRIPTION
###### Description of changes

Fixes errors such as:

```
❯ clamdscan
ERROR: Can't parse clamd configuration file /nix/store/q8ppba15a7qpxkm0xv1pbv86pyriw6w3-clamav-0.105.0/etc/clamd.conf
```

or the clamav service not starting, see clamav 0.13.5 -> 0.105.0 https://github.com/NixOS/nixpkgs/pull/172851#issuecomment-1130463588

@fpletz has done something similar for the old autotools config, see https://github.com/NixOS/nixpkgs/commit/9e1e3b288062abf37847307adeee17f3c8dddc42
@lheckemann you did the cmake update, any issues you spot?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
