### PR TITLE
crow-translate: 2.9.5 -> 2.9.8

### DIFF
--- a/pkgs/applications/misc/crow-translate/default.nix
+++ b/pkgs/applications/misc/crow-translate/default.nix
@@ -1,11 +1,11 @@
 { lib
 , stdenv
-, nix-update-script
-, fetchFromGitHub
+, fetchzip
 , substituteAll
 , cmake
 , extra-cmake-modules
 , qttools
+, kwayland
 , leptonica
 , tesseract4
 , qtmultimedia
@@ -16,14 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "crow-translate";
-  version = "2.9.5";
+  version = "2.9.8";
 
-  src = fetchFromGitHub {
-    owner = "crow-translate";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-AzwJJ85vxXsc0+W3QM8citN5f0AD6APQVd9628cfLgI=";
-    fetchSubmodules = true;
+  src = fetchzip {
+    url = "https://github.com/${pname}/${pname}/releases/download/${version}/${pname}-${version}-source.tar.gz";
+    hash = "sha256-ZqiQVpKwGpglSc05Y1r6uScZyG4qnklPXqTGKxpS3f8=";
   };
 
   patches = [
@@ -34,20 +31,25 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake extra-cmake-modules qttools wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    qttools
+    wrapQtAppsHook
+  ];
 
-  buildInputs = [ leptonica tesseract4 qtmultimedia qtx11extras ];
+  buildInputs = [
+    kwayland
+    leptonica
+    tesseract4
+    qtmultimedia
+    qtx11extras
+  ];
 
   postInstall = ''
     substituteInPlace $out/share/applications/io.crow_translate.CrowTranslate.desktop \
       --replace "Exec=qdbus" "Exec=${lib.getBin qttools}/bin/qdbus"
   '';
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = pname;
-    };
-  };
 
   meta = with lib; {
     description = "A simple and lightweight translator that allows to translate and speak text using Google, Yandex and Bing";


### PR DESCRIPTION
###### Description of changes

Now the icon works on GNOME!

###### Things done

I use fetchzip for faster downloading. update script is removed because it seems it's broken Recently updates are done manully.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
