### PR TITLE
lib/types: allow custom `submoduleWith` descriptions

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -568,6 +568,7 @@ rec {
       { modules
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false
+      , description ? null
 
         # Internal variable to avoid `_key` collisions regardless
         # of `extendModules`. Wired through by `evalModules`.
@@ -616,10 +617,14 @@ rec {
 
         freeformType = base._module.freeformType;
 
-      in
-      mkOptionType rec {
         name = "submodule";
-        description = freeformType.description or name;
+
+      in
+      mkOptionType {
+        inherit name;
+        description =
+          if description != null then description
+          else freeformType.description or name;
         check = x: isAttrs x || isFunction x || path.check x;
         merge = loc: defs:
           (base.extendModules {
@@ -645,9 +650,7 @@ rec {
         functor = defaultFunctor name // {
           type = types.submoduleWith;
           payload = {
-            modules = modules;
-            specialArgs = specialArgs;
-            shorthandOnlyDefinesConfig = shorthandOnlyDefinesConfig;
+            inherit modules specialArgs shorthandOnlyDefinesConfig description;
           };
           binOp = lhs: rhs: {
             modules = lhs.modules ++ rhs.modules;
@@ -664,6 +667,14 @@ rec {
               else if lhs.shorthandOnlyDefinesConfig == rhs.shorthandOnlyDefinesConfig
               then lhs.shorthandOnlyDefinesConfig
               else throw "A submoduleWith option is declared multiple times with conflicting shorthandOnlyDefinesConfig values";
+            description =
+              if lhs.description == null
+              then rhs.description
+              else if rhs.description == null
+              then lhs.description
+              else if lhs.description == rhs.description
+              then lhs.description
+              else throw "A submoduleWith option is declared multiple times with conflicting descriptions";
           };
         };
       };


### PR DESCRIPTION
Currently the only way to set the description for a submodule type is to use `freeformType`. This is not ideal as it requires setting a freeform type, and evaluates the submodule config unnecessarily. Instead, add a `description` argument to `submoduleWith`.

The motivation for this is to be able to evaluate [Home Manager's NixOS module options](https://github.com/nix-community/home-manager/blob/cb9f03d519cf96fcd7dfb990cc0e586a62ca6e69/nixos/default.nix#L51-L113) in nixos-search with minimal evaluation. To get the description for the `attrsOf hmModule` type, we currently need to evaluate the whole HM module stack in order to know whether there's a `freeformType` to get the description from, which requires access to the `pkgs` argument.

I also added a trivial `lib.maybe` function to simplify the `if x != null then x else y` pattern. The name is inspired by Haskell (well, `fromMaybe` is more accurate) but I'm open to better suggestions.

--------

We really need to simplify the `payload`/`binOp` logic at some point... something like
```nix
{
  op = {
    modules = concatLists;
    specialArgs = mergeDisjointAttrs;
    description = mergeEqualValues;
    # ...
  };
}
```
would be nice, short of a meta-type system.