### PR TITLE
nixos/xmonad: adjust to reflect v0.17.0 update of xmonad

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -518,6 +518,15 @@
       </listitem>
       <listitem>
         <para>
+          The update of the haskell package set brings with it a new
+          version of the <literal>xmonad</literal> module, which will
+          break your configuration if you use <literal>launch</literal>
+          as entrypoint. The example code the corresponding nixos module
+          was adjusted, you way want to have a look at it.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>home-assistant</literal> module now requires
           users that don’t want their configuration to be managed
           declaratively to set

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -163,6 +163,10 @@ In addition to numerous new and upgraded packages, this release has the followin
   `useLLVM`. So instead of `(ghc.withPackages (p: [])).override { withLLVM = true; }`,
   one needs to use `(ghc.withPackages.override { useLLVM = true; }) (p: [])`.
 
+- The update of the haskell package set brings with it a new version of the `xmonad`
+  module, which will break your configuration if you use `launch` as entrypoint. The
+  example code the corresponding nixos module was adjusted, you way want to have a look at it.
+
 - The `home-assistant` module now requires users that don't want their
   configuration to be managed declaratively to set
   `services.home-assistant.config = null;`. This is required

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -128,33 +128,34 @@ in {
             [ ( (mod4Mask,xK_r), compileRestart True)
             , ( (mod4Mask,xK_q), restart "xmonad" True ) ]
 
+          compileRestart resume = do
+            dirs  <- asks directories
+            whenX (recompile dirs True) $ do
+              when resume writeStateToFile
+              catchIO
+                  ( do
+                      args <- getArgs
+                      executeFile (cacheDir dirs </> compiledConfig) False args Nothing
+                  )
+
+          main = getDirectories >>= launch myConfig
+
           --------------------------------------------
-          {- version 0.17.0 -}
+          {- For versions before 0.17.0 use this instead -}
           --------------------------------------------
           -- compileRestart resume =
-          --   dirs <- io getDirectories
-          --   whenX (recompile dirs True) $
+          --   whenX (recompile True) $
           --     when resume writeStateToFile
           --       *> catchIO
           --         ( do
+          --             dir <- getXMonadDataDir
           --             args <- getArgs
-          --             executeFile (cacheDir dirs </> compiledConfig) False args Nothing
+          --             executeFile (dir </> compiledConfig) False args Nothing
           --         )
           --
-          -- main = getDirectories >>= launch myConfig
+          -- main = launch myConfig
           --------------------------------------------
 
-          compileRestart resume =
-            whenX (recompile True) $
-              when resume writeStateToFile
-                *> catchIO
-                  ( do
-                      dir <- getXMonadDataDir
-                      args <- getArgs
-                      executeFile (dir </> compiledConfig) False args Nothing
-                  )
-
-          main = launch myConfig
         '';
       };
 


### PR DESCRIPTION
###### Description of changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

