### PR TITLE
nodejs: backport all including v18

### DIFF
--- a/pkgs/development/web/nodejs/v12.nix
+++ b/pkgs/development/web/nodejs/v12.nix
@@ -8,7 +8,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "12.22.11";
-    sha256 = "sha256-XoHaJv1bH4lxRIOrqmjj2jBFI+QzTHjEm/p6A+541vE=";
+    version = "12.22.12";
+    sha256 = "1whl0zi6fs9ay33bhcn2kh9xynran05iipahg1zzr6sv97wbfhmw";
     patches = lib.optional stdenv.isDarwin ./bypass-xcodebuild.diff;
   }

--- a/pkgs/development/web/nodejs/v14.nix
+++ b/pkgs/development/web/nodejs/v14.nix
@@ -7,7 +7,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "14.19.1";
-    sha256 = "sha256-4a4J3YYas5rwRIO7XA+lTd2CtrFVQ76aJ+pnBKi6ndk=";
+    version = "14.19.3";
+    sha256 = "sha256-XPRbHxrKd1I6zzYkDB1TqZknkHCncR6r8jNG+IsMyZQ=";
     patches = lib.optional stdenv.isDarwin ./bypass-xcodebuild.diff;
   }

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchpatch, openssl, python3, enableNpm ? true }:
+{ callPackage, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -8,15 +8,9 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "16.14.2";
-    sha256 = "sha256-6SLiFcxo61+U0z6KC2HiyGO3cxzIYAq5VdOCLakP+NE=";
+    version = "16.15.0";
+    sha256 = "sha256-oPgS78Q/eDIeygiVeWCkj15r+XAE1QWMjdOwPGRupPc=";
     patches = [
       ./disable-darwin-v8-system-instrumentation.patch
-      # Fixes node incorrectly building vendored OpenSSL when we want system OpenSSL.
-      # https://github.com/nodejs/node/pull/40965
-      (fetchpatch {
-        url = "https://github.com/nodejs/node/commit/65119a89586b94b0dd46b45f6d315c9d9f4c9261.patch";
-        sha256 = "sha256-dihKYEdK68sQIsnfTRambJ2oZr0htROVbNZlFzSAL+I=";
-      })
     ];
   }

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -1,0 +1,15 @@
+{ callPackage, python3, enableNpm ? true }:
+
+let
+  buildNodejs = callPackage ./nodejs.nix {
+    python = python3;
+  };
+in
+buildNodejs {
+  inherit enableNpm;
+  version = "18.2.0";
+  sha256 = "sha256-IwWxXr9VR0dOkFtQAvm6mcfu7wHXOU3+bzhGzGvK1m0=";
+  patches = [
+    ./disable-darwin-v8-system-instrumentation.patch
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7173,10 +7173,13 @@ with pkgs;
   nodejs-slim-17_x = callPackage ../development/web/nodejs/v17.nix {
     enableNpm = false;
   };
+  nodejs-18_x = callPackage ../development/web/nodejs/v18.nix { };
+  nodejs-slim-18_x = callPackage ../development/web/nodejs/v18.nix {
+    enableNpm = false;
+  };
   # Update this when adding the newest nodejs major version!
-  # Do not set to nodejs-17_x because it requires 10.13 SDK on Darwin
-  nodejs_latest = nodejs-16_x;
-  nodejs-slim_latest = nodejs-slim-16_x;
+  nodejs_latest = nodejs-18_x;
+  nodejs-slim_latest = nodejs-slim-18_x;
 
   nodePackages_latest = dontRecurseIntoAttrs nodejs_latest.pkgs;
 


### PR DESCRIPTION
Backport of all node versions currently on master, without removing v17 as to not break scripts.

I did update nodejs-latest, because it's the latest. Is that ok @jonringer or should it stay on 16 since it's a stable branch?