### PR TITLE
zoneminder: 1.36.10 -> 1.36.15

### DIFF
--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -78,13 +78,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "zoneminder";
-  version = "1.36.10";
+  version = "1.36.15";
 
   src = fetchFromGitHub {
     owner  = "ZoneMinder";
     repo   = "zoneminder";
     rev    = version;
-    sha256 = "sha256-MmBnbVDitKOctPe2dNe1sMNNs/qEYGVq3UMJxAkLlCc=";
+    sha256 = "1qlsg7gd9kpjdbq9d5yrjmc7g1pbscrg4sws7xrdln1z8509sv50";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Description of changes
Security update (https://nvd.nist.gov/vuln/detail/CVE-2022-29806)

Closes #172530.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).