### PR TITLE
profiles/minimal: reduce size

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -197,6 +197,21 @@
       </listitem>
       <listitem>
         <para>
+          To reduce closure size in
+          <literal>nixos/modules/profiles/minimal.nix</literal> profile
+          disabled installation documentations and manuals. Also
+          disabled <literal>logrotate</literal> and
+          <literal>udisks2</literal> services.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The minimal ISO image now use
+          <literal>nixos/modules/profiles/minimal.nix</literal> profile.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           A new <literal>virtualisation.rosetta</literal> module was
           added to allow running <literal>x86_64</literal> binaries
           through

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -60,6 +60,10 @@ In addition to numerous new and upgraded packages, this release has the followin
   `services.dnsmasq.extraConfig` will be deprecated when NixOS 22.11 reaches
   end of life.
 
+- To reduce closure size in `nixos/modules/profiles/minimal.nix` profile disabled installation documentations and manuals. Also disabled `logrotate` and `udisks2` services.
+
+- The minimal ISO image now use `nixos/modules/profiles/minimal.nix` profile.
+
 - A new `virtualisation.rosetta` module was added to allow running `x86_64` binaries through [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) inside virtualised NixOS guests on Apple silicon. This feature works by default with the [UTM](https://docs.getutm.app/) virtualisation [package](https://search.nixos.org/packages?channel=unstable&show=utm&from=0&size=1&sort=relevance&type=packages&query=utm).
 
 - Resilio sync secret keys can now be provided using a secrets file at runtime, preventing these secrets from ending up in the Nix store.

--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
@@ -1,14 +1,17 @@
 # This module defines a small NixOS installation CD.  It does not
 # contain any graphical stuff.
 
-{ ... }:
+{ lib, ... }:
 
 {
-  imports =
-    [ ./installation-cd-base.nix
-    ];
+  imports = [
+    ../../profiles/minimal.nix
+    ./installation-cd-base.nix
+  ];
 
-  isoImage.edition = "minimal";
+  documentation.man.enable = lib.mkOverride 500 true;
 
   fonts.fontconfig.enable = false;
+
+  isoImage.edition = "minimal";
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
@@ -11,7 +11,7 @@
 
   documentation.man.enable = lib.mkOverride 500 true;
 
-  fonts.fontconfig.enable = false;
+  fonts.fontconfig.enable = lib.mkForce false;
 
-  isoImage.edition = "minimal";
+  isoImage.edition = lib.mkForce "minimal";
 }

--- a/nixos/modules/installer/netboot/netboot-minimal.nix
+++ b/nixos/modules/installer/netboot/netboot-minimal.nix
@@ -3,8 +3,10 @@
 { ... }:
 
 {
-  imports =
-    [ ./netboot-base.nix
-      ../../profiles/minimal.nix
-    ];
+  imports = [
+    ./netboot-base.nix
+    ../../profiles/minimal.nix
+  ];
+
+  documentation.man.enable = lib.mkOverride 500 true;
 }

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -10,6 +10,12 @@ with lib;
 
   documentation.enable = mkDefault false;
 
+  documentation.doc.enable = mkDefault false;
+
+  documentation.info.enable = mkDefault false;
+
+  documentation.man.enable = mkDefault false;
+
   documentation.nixos.enable = mkDefault false;
 
   programs.command-not-found.enable = mkDefault false;

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -22,6 +22,8 @@ with lib;
 
   services.logrotate.enable = mkDefault false;
 
+  services.udisks2.enable = mkDefault false;
+
   xdg.autostart.enable = mkDefault false;
   xdg.icons.enable = mkDefault false;
   xdg.mime.enable = mkDefault false;

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -20,6 +20,8 @@ with lib;
 
   programs.command-not-found.enable = mkDefault false;
 
+  services.logrotate.enable = mkDefault false;
+
   xdg.autostart.enable = mkDefault false;
   xdg.icons.enable = mkDefault false;
   xdg.mime.enable = mkDefault false;


### PR DESCRIPTION
###### Description of changes
Minimize size netboot and iso images.
Splitted this PR - https://github.com/NixOS/nixpkgs/pull/170460

cc @SuperSandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
