### PR TITLE
Update http3 libraries

### DIFF
--- a/pkgs/development/libraries/nghttp3/default.nix
+++ b/pkgs/development/libraries/nghttp3/default.nix
@@ -1,18 +1,20 @@
 { lib, stdenv, fetchFromGitHub
-, autoreconfHook, pkg-config
-, cunit, file, ncurses
+, autoreconfHook, pkg-config, file
+, cunit, ncurses
 }:
 
 stdenv.mkDerivation rec {
   pname = "nghttp3";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-toGTkgJLdSLNWCPJFpT63IxF3xANbvtkhJo5NUg/ZBg=";
+    sha256 = "sha256-1+0ln0J8dqHqmE+fsawhbfbbMNlCkDpJx4xomUuoHdE=";
   };
+
+  outputs = [ "out" "dev" "doc" ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config file ];
   checkInputs = [ cunit ncurses ];
@@ -20,8 +22,6 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
   '';
-
-  outputs = [ "out" "dev" ];
 
   doCheck = true;
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -1,20 +1,22 @@
 { lib, stdenv, fetchFromGitHub
-, autoreconfHook, pkg-config
-, cunit, file, ncurses
+, autoreconfHook, pkg-config, file
 , libev, nghttp3, quictls
+, cunit, ncurses
 , withJemalloc ? false, jemalloc
 }:
 
 stdenv.mkDerivation rec {
   pname = "ngtcp2";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-nmVVK2lpz01hgSxPAMmBfF+nNVZu9PWRGzCWh/5yhj8=";
+    sha256 = "sha256-hpIGsQBJCOyaEqopdES/hRXc2makIERonUju9D/HvgE=";
   };
+
+  outputs = [ "out" "dev" "doc" ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config file ];
   buildInputs = [ libev nghttp3 quictls ] ++ lib.optional withJemalloc jemalloc;
@@ -23,8 +25,6 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
   '';
-
-  outputs = [ "out" "dev" ];
 
   doCheck = true;
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/quictls/default.nix
+++ b/pkgs/development/libraries/quictls/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "quictls";
-  version = "3.0.2+quick_unstable-2022-03.15";
+  version = "3.0.3+quick_unstable-2022-05.04";
 
   src = fetchFromGitHub {
     owner = "quictls";
     repo = "openssl";
-    rev = "7f2ab56a2b842b8e6fefc7b9d20eb5ff9c6ef151";
-    sha256 = "sha256-We4ow0mGJFXqYM4PqbGn8qY5IYH/MtNaefrSaJreoRA=";
+    rev = "368c9d581b17f0bbe425f8dedeaa7b864a7b29ce";
+    sha256 = "sha256-W3bILxhyeziWQNZUHUg/D9eV8LnmHJqEFwyzWjJrRuc=";
   };
 
   patches = [
@@ -156,7 +156,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://quictls.github.io/openssl/";
+    homepage = "https://quictls.github.io";
     description = "TLS/SSL and crypto library with QUIC APIs";
     license = licenses.openssl;
     platforms = platforms.all;


### PR DESCRIPTION
###### Description of changes
Update packages:
- quictls: 3.0.1+quick_unstable-2021-12.14 -> 3.0.3+quick_unstable-2022-05.04
- ngtcp2: 0.4.0 -> 0.5.0
- nghttp3: 0.4.0 -> 0.4.1

cc @SuperSandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
