### PR TITLE
 nixos/gitea: convert simple settings to freeform settings 

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -85,7 +85,7 @@ in
 
         port = mkOption {
           type = types.port;
-          default = (if !usePostgresql then 3306 else pg.port);
+          default = if !usePostgresql then 3306 else pg.port;
           defaultText = literalExpression ''
             if config.${opt.database.type} != "postgresql"
             then 3306
@@ -502,7 +502,7 @@ in
         replaceSecretBin = "${pkgs.replace-secret}/bin/replace-secret";
       in ''
         # copy custom configuration and generate a random secret key if needed
-        ${optionalString (cfg.useWizard == false) ''
+        ${optionalString (!cfg.useWizard) ''
           function gitea_setup {
             cp -f ${configFile} ${runConfig}
 
@@ -622,10 +622,10 @@ in
 
     # Create database passwordFile default when password is configured.
     services.gitea.database.passwordFile =
-      (mkDefault (toString (pkgs.writeTextFile {
+      mkDefault (toString (pkgs.writeTextFile {
         name = "gitea-database-password";
         text = cfg.database.password;
-      })));
+      }));
 
     systemd.services.gitea-dump = mkIf cfg.dump.enable {
        description = "gitea dump";

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -10,6 +10,7 @@ let
   useMysql = cfg.database.type == "mysql";
   usePostgresql = cfg.database.type == "postgres";
   useSqlite = cfg.database.type == "sqlite3";
+  format = pkgs.formats.ini { };
   configFile = pkgs.writeText "app.ini" ''
     APP_NAME = ${cfg.appName}
     RUN_USER = ${cfg.user}
@@ -22,6 +23,16 @@ let
 in
 
 {
+  imports = [
+    (mkRenamedOptionModule [ "services" "gitea" "cookieSecure" ] [ "services" "gitea" "settings" "session" "COOKIE_SECURE" ])
+    (mkRenamedOptionModule [ "services" "gitea" "disableRegistration" ] [ "services" "gitea" "settings" "service" "DISABLE_REGISTRATION" ])
+    (mkRenamedOptionModule [ "services" "gitea" "log" "level" ] [ "services" "gitea" "settings" "log" "LEVEL" ])
+    (mkRenamedOptionModule [ "services" "gitea" "log" "rootPath" ] [ "services" "gitea" "settings" "log" "ROOT_PATH" ])
+    (mkRenamedOptionModule [ "services" "gitea" "ssh" "clonePort" ] [ "services" "gitea" "settings" "server" "SSH_PORT" ])
+
+    (mkRemovedOptionModule [ "services" "gitea" "ssh" "enable" ] "services.gitea.ssh.enable has been migrated into freeform setting services.gitea.settings.server.DISABLE_SSH. Keep in mind that the setting is inverted")
+  ];
+
   options = {
     services.gitea = {
       enable = mkOption {
@@ -47,20 +58,6 @@ in
         default = "/var/lib/gitea";
         type = types.str;
         description = lib.mdDoc "gitea data directory.";
-      };
-
-      log = {
-        rootPath = mkOption {
-          default = "${cfg.stateDir}/log";
-          defaultText = literalExpression ''"''${config.${opt.stateDir}}/log"'';
-          type = types.str;
-          description = lib.mdDoc "Root path for log files.";
-        };
-        level = mkOption {
-          default = "Info";
-          type = types.enum [ "Trace" "Debug" "Info" "Warn" "Error" "Critical" ];
-          description = lib.mdDoc "General log level.";
-        };
       };
 
       user = mkOption {
@@ -192,25 +189,6 @@ in
         };
       };
 
-      ssh = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-          description = lib.mdDoc "Enable external SSH feature.";
-        };
-
-        clonePort = mkOption {
-          type = types.int;
-          default = 22;
-          example = 2222;
-          description = lib.mdDoc ''
-            SSH port displayed in clone URL.
-            The option is required to configure a service when the external visible port
-            differs from the local listening port i.e. if port forwarding is used.
-          '';
-        };
-      };
-
       lfs = {
         enable = mkOption {
           type = types.bool;
@@ -269,15 +247,6 @@ in
         description = lib.mdDoc "Configure Gitea to listen on a unix socket instead of the default TCP port.";
       };
 
-      cookieSecure = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Marks session cookies as "secure" as a hint for browsers to only send
-          them via HTTPS. This option is recommend, if gitea is being served over HTTPS.
-        '';
-      };
-
       staticRootPath = mkOption {
         type = types.either types.str types.path;
         default = gitea.data;
@@ -293,20 +262,7 @@ in
         description = lib.mdDoc "Path to a file containing the SMTP password.";
       };
 
-      disableRegistration = mkEnableOption "the registration lock" // {
-        description = ''
-          By default any user can create an account on this <literal>gitea</literal> instance.
-          This can be disabled by using this option.
-
-          <emphasis>Note:</emphasis> please keep in mind that this should be added after the initial
-          deploy unless <link linkend="opt-services.gitea.useWizard">services.gitea.useWizard</link>
-          is <literal>true</literal> as the first registered user will be the administrator if
-          no install wizard is used.
-        '';
-      };
-
       settings = mkOption {
-        type = with types; attrsOf (attrsOf (oneOf [ bool int str ]));
         default = {};
         description = lib.mdDoc ''
           Gitea configuration. Refer to <https://docs.gitea.io/en-us/config-cheat-sheet/>
@@ -330,6 +286,68 @@ in
             };
           }
         '';
+        type = with types; submodule {
+          freeformType = format.type;
+          options = {
+            log = {
+              ROOT_PATH = mkOption {
+                default = "${cfg.stateDir}/log";
+                defaultText = literalExpression ''"''${config.${opt.stateDir}}/log"'';
+                type = types.str;
+                description = "Root path for log files.";
+              };
+              LEVEL = mkOption {
+                default = "Info";
+                type = types.enum [ "Trace" "Debug" "Info" "Warn" "Error" "Critical" ];
+                description = "General log level.";
+              };
+            };
+
+            server = {
+              DISABLE_SSH = mkOption {
+                type = types.bool;
+                default = false;
+                description = "Disable external SSH feature.";
+              };
+
+              SSH_PORT = mkOption {
+                type = types.int;
+                default = 22;
+                example = 2222;
+                description = ''
+                  SSH port displayed in clone URL.
+                  The option is required to configure a service when the external visible port
+                  differs from the local listening port i.e. if port forwarding is used.
+                '';
+              };
+            };
+
+            service = {
+              DISABLE_REGISTRATION = mkEnableOption "the registration lock" // {
+                description = ''
+                  By default any user can create an account on this <literal>gitea</literal> instance.
+                  This can be disabled by using this option.
+
+                  <emphasis>Note:</emphasis> please keep in mind that this should be added after the initial
+                  deploy unless <link linkend="opt-services.gitea.useWizard">services.gitea.useWizard</link>
+                  is <literal>true</literal> as the first registered user will be the administrator if
+                  no install wizard is used.
+                '';
+              };
+            };
+
+            session = {
+              COOKIE_SECURE = mkOption {
+                type = types.bool;
+                default = false;
+                description = ''
+                  Marks session cookies as "secure" as a hint for browsers to only send
+                  them via HTTPS. This option is recommend, if gitea is being served over HTTPS.
+                '';
+              };
+            };
+          };
+        };
       };
 
       extraConfig = mkOption {
@@ -385,13 +403,6 @@ in
           HTTP_ADDR = cfg.httpAddress;
           HTTP_PORT = cfg.httpPort;
         })
-        (mkIf cfg.ssh.enable {
-          DISABLE_SSH = false;
-          SSH_PORT = cfg.ssh.clonePort;
-        })
-        (mkIf (!cfg.ssh.enable) {
-          DISABLE_SSH = true;
-        })
         (mkIf cfg.lfs.enable {
           LFS_START_SERVER = true;
           LFS_CONTENT_PATH = cfg.lfs.contentDir;
@@ -400,23 +411,13 @@ in
       ];
 
       session = {
-        COOKIE_NAME = "session";
-        COOKIE_SECURE = cfg.cookieSecure;
+        COOKIE_NAME = lib.mkDefault "session";
       };
 
       security = {
         SECRET_KEY = "#secretkey#";
         INTERNAL_TOKEN = "#internaltoken#";
         INSTALL_LOCK = true;
-      };
-
-      log = {
-        ROOT_PATH = cfg.log.rootPath;
-        LEVEL = cfg.log.level;
-      };
-
-      service = {
-        DISABLE_REGISTRATION = cfg.disableRegistration;
       };
 
       mailer = mkIf (cfg.mailerPasswordFile != null) {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
