### PR TITLE
platformio: 5.2.5 -> 6.0.1

### DIFF
--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -9,32 +9,13 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      semantic-version = super.semantic-version.overridePythonAttrs (oldAttrs: rec {
-        version = "2.9.0";
-        src = fetchPypi {
-          pname = "semantic_version";
-          version = version;
-          sha256 = "1chjd8019wnwb5mnd4x4jw9f8nhzg0xnapsdznk0fpiyamrlixdb";
-        };
-      });
-
       starlette = super.starlette.overridePythonAttrs (oldAttrs: rec {
-        version = "0.18.0";
+        version = "0.20.0";
         src = fetchFromGitHub {
           owner = "encode";
           repo = "starlette";
           rev = version;
-          sha256 = "1dpj33cggjjvpd3qdf6hv04z5ckcn9f5dfn98p5a8hx262kgsr9p";
-        };
-      });
-
-      uvicorn = super.uvicorn.overridePythonAttrs (oldAttrs: rec {
-        version = "0.17.0";
-        src = fetchFromGitHub {
-          owner = "encode";
-          repo = "uvicorn";
-          rev = version;
-          sha256 = "142x8skb1yfys6gndfaay2r240j56dkr006p49pw4y9i0v85kynp";
+          sha256 = "sha256-bSgPjKqM262PSufz1LHwrdM+uU8xO55Mifv66HRN02Y=";
         };
       });
     };
@@ -75,6 +56,8 @@ with python.pkgs; buildPythonApplication rec {
   ];
 
   pytestFlagsArray = (map (e: "--deselect tests/${e}") [
+    "commands/pkg/test_exec.py::test_pkg_specified"
+    "commands/pkg/test_exec.py::test_unrecognized_options"
     "commands/test_ci.py::test_ci_boards"
     "commands/test_ci.py::test_ci_build_dir"
     "commands/test_ci.py::test_ci_keep_build_dir"
@@ -84,6 +67,7 @@ with python.pkgs; buildPythonApplication rec {
     "commands/test_init.py::test_init_duplicated_boards"
     "commands/test_init.py::test_init_enable_auto_uploading"
     "commands/test_init.py::test_init_ide_atom"
+    "commands/test_init.py::test_init_ide_clion"
     "commands/test_init.py::test_init_ide_eclipse"
     "commands/test_init.py::test_init_ide_vscode"
     "commands/test_init.py::test_init_incorrect_board"
@@ -112,9 +96,6 @@ with python.pkgs; buildPythonApplication rec {
     "commands/test_lib_complex.py::test_lib_show"
     "commands/test_lib_complex.py::test_lib_stats"
     "commands/test_lib_complex.py::test_search"
-    "commands/test_test.py::test_local_env"
-    "commands/test_test.py::test_multiple_env_build"
-    "commands/test_test.py::test_setup_teardown_are_compilable"
     "package/test_manager.py::test_download"
     "package/test_manager.py::test_install_force"
     "package/test_manager.py::test_install_from_registry"
@@ -132,12 +113,21 @@ with python.pkgs; buildPythonApplication rec {
     "test_misc.py::test_platformio_cli"
     "test_pkgmanifest.py::test_packages"
   ]) ++ (map (e: "--ignore=tests/${e}") [
+    "commands/pkg/test_install.py"
+    "commands/pkg/test_list.py"
+    "commands/pkg/test_outdated.py"
+    "commands/pkg/test_search.py"
+    "commands/pkg/test_show.py"
+    "commands/pkg/test_uninstall.py"
+    "commands/pkg/test_update.py"
     "commands/test_boards.py"
     "commands/test_check.py"
     "commands/test_platform.py"
+    "commands/test_run.py"
+    "commands/test_test.py"
     "commands/test_update.py"
-    "test_maintenance.py"
     "test_ino2cpp.py"
+    "test_maintenance.py"
   ]) ++ [
     "tests"
   ];

--- a/pkgs/development/embedded/platformio/default.nix
+++ b/pkgs/development/embedded/platformio/default.nix
@@ -4,14 +4,14 @@
 let
   callPackage = newScope self;
 
-  version = "5.2.5";
+  version = "6.0.1";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "1x1jqprwzpb09ca953rqbh2jvizh7bz8yj30krphb6007bnjilwy";
+    sha256 = "sha256-noLdQctAaMNmfuxI3iybHFx3Q9aTr3gZaUZ+/uO+fnA=";
   };
 
   self = {

--- a/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
+++ b/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
@@ -6,7 +6,7 @@ index 416dccfd..896c3649 100644
      @staticmethod
      @memoized(expire="1h")
      def load_spdx_licenses():
--        version = "3.16"
+-        version = "3.17"
 -        spdx_data_url = (
 -            "https://raw.githubusercontent.com/spdx/license-list-data/"
 -            "v%s/json/licenses.json" % version


### PR DESCRIPTION
###### Description of changes
Version bump:
<https://github.com/platformio/platformio-core/releases/tag/v6.0.0>
<https://github.com/platformio/platformio-core/releases/tag/v6.0.1>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
