### PR TITLE
crc: init at 2.4.1

### DIFF
--- a/pkgs/applications/networking/cluster/crc/default.nix
+++ b/pkgs/applications/networking/cluster/crc/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, stdenv
+, testers
+, crc
+, runtimeShell
+, coreutils
+}:
+
+let
+  openShiftVersion = "4.10.22";
+  podmanVersion = "4.1.0";
+  writeKey = "cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp";
+in
+buildGoModule rec {
+  version = "2.4.1";
+  pname = "crc";
+  gitCommit = "6b954d40ec3280ca63e825805503d4414a3ff55b";
+
+  src = fetchFromGitHub {
+    owner = "code-ready";
+    repo = "crc";
+    rev = "v${version}";
+    sha256 = "sha256-wjwTf+d19F1NLYmUORMU0PGJeQZd+IrlScm5DiFvAk0=";
+  };
+
+  vendorSha256 = null;
+
+  nativeBuildInputs = [ git ];
+
+  postPatch = ''
+    substituteInPlace pkg/crc/oc/oc_linux_test.go \
+      --replace "/bin/echo" "${coreutils}/bin/echo"
+
+    substituteInPlace Makefile \
+      --replace "/bin/bash" "${runtimeShell}"
+  '';
+
+  tags = [ "containers_image_openpgp" ];
+
+  ldflags = [
+    "-X github.com/code-ready/crc/pkg/crc/version.crcVersion=${version}"
+    "-X github.com/code-ready/crc/pkg/crc/version.bundleVersion=${openShiftVersion}"
+    "-X github.com/code-ready/crc/pkg/crc/version.podmanVersion=${podmanVersion}"
+    "-X github.com/code-ready/crc/pkg/crc/version.commitSha=${gitCommit}"
+    "-X github.com/code-ready/crc/pkg/crc/segment.WriteKey=${writeKey}"
+  ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # tests are currently broken on aarch64-darwin
+  # https://github.com/code-ready/crc/issues/3237
+  doCheck = !(stdenv.isDarwin && stdenv.isAarch64);
+  checkFlags = [ "-args --crc-binary=$out/bin/crc" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = crc;
+    command = ''
+      export HOME=$(mktemp -d)
+      crc version
+    '';
+  };
+
+  meta = with lib; {
+    description = "Manages a local OpenShift 4.x cluster or a Podman VM optimized for testing and development purposes";
+    homepage = "https://crc.dev";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ shikanime tricktron ];
+  };
+}

--- a/pkgs/applications/networking/cluster/crc/update.sh
+++ b/pkgs/applications/networking/cluster/crc/update.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq
+
+set -x -eu -o pipefail
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf ${WORKDIR}" EXIT
+
+NIXPKGS_CRC_FOLDER=$(
+    cd $(dirname ${BASH_SOURCE[0]})
+    pwd -P
+)
+cd ${NIXPKGS_CRC_FOLDER}
+
+LATEST_TAG_RAWFILE=${WORKDIR}/latest_tag.json
+curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+    https://api.github.com/repos/code-ready/crc/releases >${LATEST_TAG_RAWFILE}
+
+LATEST_TAG_NAME=$(jq 'map(.tag_name)' ${LATEST_TAG_RAWFILE} |
+    grep -v -e rc -e engine | tail -n +2 | head -n -1 | sed 's|[", ]||g' | sort -rV | head -n1)
+
+CRC_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')
+
+CRC_COMMIT=$(curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+    https://api.github.com/repos/code-ready/crc/tags |
+    jq -r "map(select(.name == \"${LATEST_TAG_NAME}\")) | .[0] | .commit.sha")
+
+FILE_MAKEFILE=${WORKDIR}/Makefile
+curl --silent https://raw.githubusercontent.com/code-ready/crc/${CRC_COMMIT}/Makefile >$FILE_MAKEFILE
+
+OPENSHIFT_VERSION=$(grep 'OPENSHIFT_VERSION' ${FILE_MAKEFILE} |
+    head -n1 | awk '{print $3}')
+
+PODMAN_VERSION=$(grep 'PODMAN_VERSION' ${FILE_MAKEFILE} |
+    head -n1 | awk '{print $3}')
+
+WRITE_KEY=$(grep '$(REPOPATH)/pkg/crc/segment.WriteKey' ${FILE_MAKEFILE} |
+    head -n1 | awk '{print $4}' | sed -e 's/$(REPOPATH)\/pkg\/crc\/segment.WriteKey=//g')
+
+sed -i "s|version = \".*\"|version = \"${CRC_VERSION:-}\"|" \
+    ${NIXPKGS_CRC_FOLDER}/default.nix
+
+sed -i "s|gitCommit = \".*\"|gitCommit = \"${CRC_COMMIT:-}\"|" \
+    ${NIXPKGS_CRC_FOLDER}/default.nix
+
+sed -i "s|openShiftVersion = \".*\"|openShiftVersion = \"${OPENSHIFT_VERSION:-}\"|" \
+    ${NIXPKGS_CRC_FOLDER}/default.nix
+
+sed -i "s|podmanVersion = \".*\"|podmanVersion = \"${PODMAN_VERSION:-}\"|" \
+    ${NIXPKGS_CRC_FOLDER}/default.nix
+
+sed -i "s|writeKey = \".*\"|writeKey = \"${WRITE_KEY:-}\"|" \
+    ${NIXPKGS_CRC_FOLDER}/default.nix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -374,6 +374,8 @@ with pkgs;
 
   containerpilot = callPackage ../applications/networking/cluster/containerpilot { };
 
+  crc = callPackage ../applications/networking/cluster/crc { };
+
   coordgenlibs  = callPackage ../development/libraries/coordgenlibs { };
 
   cp437 = callPackage ../tools/misc/cp437 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the most recent Red Hat OpenShift Local development tool similar to Minikube.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
