### PR TITLE
go-modules/packages: Run unit tests under subdirs

### DIFF
--- a/pkgs/applications/networking/cluster/kompose/default.nix
+++ b/pkgs/applications/networking/cluster/kompose/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, kompose }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, kompose, git }:
 
 buildGoModule rec {
   pname = "kompose";
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-OR5U2PnebO0a+lwU09Dveh0Yxk91cmSRorTxQIO5lHc=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ installShellFiles git ];
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/applications/version-management/git-and-tools/gitbatch/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitbatch/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, git }:
 
 buildGoModule rec {
   pname = "gitbatch";
@@ -15,7 +15,15 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  checkFlags = [ "-short" ];
+  nativeBuildInputs = [
+    git # required by unit tests
+  ];
+
+  preCheck = ''
+    HOME=$(mktemp -d)
+    # Disable tests requiring network access to gitlab.com
+    buildFlagsArray+=("-run" "[^(Test(Run|Start|(Fetch|Pull)With(Go|)Git))]")
+  '';
 
   meta = with lib; {
     description = "Running git UI commands";

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -180,12 +180,22 @@ let
       exclude+='\)'
 
       buildGoDir() {
-        local d; local cmd;
-        cmd="$1"
-        d="$2"
+        local cmd="$1" dir="$2"
+
         . $TMPDIR/buildFlagsArray
+
+        declare -a flags
+        flags+=($buildFlags "''${buildFlagsArray[@]}")
+        flags+=(''${tags:+-tags=${lib.concatStringsSep "," tags}})
+        flags+=(''${ldflags:+-ldflags="$ldflags"})
+        flags+=("-v" "-p" "$NIX_BUILD_CORES")
+
+        if [ "$cmd" = "test" ]; then
+          flags+=($checkFlags)
+        fi
+
         local OUT
-        if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" ''${tags:+-tags=${lib.concatStringsSep "," tags}} ''${ldflags:+-ldflags="$ldflags"} -v -p $NIX_BUILD_CORES $d 2>&1)"; then
+        if ! OUT="$(go $cmd "''${flags[@]}" $dir 2>&1)"; then
           if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
             echo "$OUT" >&2
             return 1
@@ -243,7 +253,7 @@ let
       runHook preCheck
 
       for pkg in $(getGoDirs test); do
-        buildGoDir test $checkFlags "$pkg"
+        buildGoDir test "$pkg"
       done
 
       runHook postCheck

--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, makeWrapper }:
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, stdenv }:
 
 buildGoModule rec {
   pname = "delve";
@@ -17,7 +17,19 @@ buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  checkFlags = [ "-short" ];
+  hardeningDisable = [ "fortify" ];
+
+  preCheck = ''
+    XDG_CONFIG_HOME=$(mktemp -d)
+  '';
+
+  # Disable tests on Darwin as they require various workarounds.
+  #
+  # - Tests requiring local networking fail with or without sandbox,
+  #   even with __darwinAllowLocalNetworking allowed.
+  # - CGO_FLAGS warnings break tests' expected stdout/stderr outputs.
+  # - DAP test binaries exit prematurely.
+  doCheck = !stdenv.isDarwin;
 
   postInstall = ''
     # fortify source breaks build since delve compiles with -O0

--- a/pkgs/tools/filesystems/go-mtpfs/default.nix
+++ b/pkgs/tools/filesystems/go-mtpfs/default.nix
@@ -18,7 +18,11 @@ buildGoModule rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libusb1 ];
 
-  checkFlags = [ "-short" ];
+  preCheck = ''
+    # Only run tests under mtp/encoding_test.go
+    # Other tests require an Android deviced attached over USB.
+    buildFlagsArray+=("-run" "Test(Encode|Decode|Variant).*")
+  '';
 
   meta = with lib; {
     description = "A simple FUSE filesystem for mounting Android devices as a MTP device";

--- a/pkgs/tools/misc/mmake/default.nix
+++ b/pkgs/tools/misc/mmake/default.nix
@@ -15,7 +15,8 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  checkFlags = [ "-short" ];
+  # Almost all tests require non-local networking, trying to resolve githubusercontent.com.
+  doCheck = false;
 
   meta = with lib; {
     homepage = "https://github.com/tj/mmake";

--- a/pkgs/tools/text/gucci/default.nix
+++ b/pkgs/tools/text/gucci/default.nix
@@ -21,6 +21,14 @@ buildGoModule rec {
 
   checkFlags = [ "-short" ];
 
+  # Integration tests rely on Ginkgo but fail.
+  # Related: https://github.com/onsi/ginkgo/issues/602
+  #
+  # Disable integration tests.
+  preCheck = ''
+    buildFlagsArray+=("-run" "[^(TestIntegration)]")
+  '';
+
   meta = with lib; {
     description = "A simple CLI templating tool written in golang";
     homepage = "https://github.com/noqcks/gucci";


### PR DESCRIPTION
Bug Fix:
- Due to the way `buildGoDir` function was repurposed to also run `go
  test`, if `checkFlags` was defined, `go test` was ran only at the top
  level directory.

- Only the first element of `checkFlags` array would get passed to the
  `go test` command as arguments.

- Now the first parameter to `buildGoDir` is handled as the command.
  If the command is "test" `checkFlags` get passed as arguments along
  with other build flags like ldflags, tags, etc.

Readability:
- Iteratively build a flag array in `buildGoDir` instead of single long
  variable expansion command line.
- Bash style: Single line local assignment of positional parameters.

Fix broken packages with newly enabled tests:
- kompose: tests require git
- gitbatch: test require git & a writable HOME. disable tests requiring
  non-localhost networking.
- delve: tests require source to be a git repo. fix fortify issues with
  cgo.
- go-mtpfs: disable tests requiring an android devices connected over
  USB.
- mmake: disable test. almost all require non-localhost networking.
- skeema: tests require coreutils and substitutions. disable tests
  requiring non-localhost networking
- gucci: disable integrations tests.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
