### PR TITLE
nginx: take care not to pull in module sources as runtime deps

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -22,7 +22,7 @@ outer@{ lib, stdenv, fetchurl, fetchpatch, openssl, zlib, pcre, libxml2, libxslt
 , extraPatches ? []
 , fixPatch ? p: p
 , preConfigure ? ""
-, postInstall ? null
+, postInstall ? ""
 , meta ? null
 , nginx-doc ? outer.nginx-doc
 , passthru ? { tests = {}; }
@@ -165,9 +165,7 @@ stdenv.mkDerivation {
   postInstall =
     let
       noSourceRefs = lib.concatMapStrings (m: "remove-references-to -t ${m.src} $out/sbin/nginx\n") modules;
-    in noSourceRefs + (if postInstall != null then postInstall else ''
-      mv $out/sbin $out/bin
-    '');
+    in noSourceRefs + postInstall;
 
   passthru = {
     modules = modules;


### PR DESCRIPTION
Nginx likes to print the "configured with ..." stuff on startup,
containing the full configure command line. When built with
modules (which it seems to be by default), this causes the
module sources to appear as runtime dependencies. So just use
the remove-references-to script to patch those out.

For a default installation, the rtmp, dav and moreheaders
module sources are gone, for special cases potentially more.