### PR TITLE
html-tidy: fix cross-compilation

### DIFF
--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libxslt }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, libxslt, html-tidy }:
 
 stdenv.mkDerivation rec {
   pname = "html-tidy";
@@ -11,9 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZMz0NySxzX2XHiqB8f5asvwjIG6kdIcq8Gb3EbAxBaU=";
   };
 
-  nativeBuildInputs = [ cmake libxslt/*manpage*/ ];
+  # https://github.com/htacg/tidy-html5/pull/1036
+  patches = (fetchpatch {
+    url = "https://github.com/htacg/tidy-html5/commit/e9aa038bd06bd8197a0dc049380bc2945ff55b29.diff";
+    sha256 = "sha256-Q2GjinNBWLL+HXUtslzDJ7CJSTflckbjweiSMCnIVwg=";
+  });
 
-  cmakeFlags = [];
+  nativeBuildInputs = [ cmake libxslt/*manpage*/ ]
+    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) html-tidy;
+
+  cmakeFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "-DHOST_TIDY=tidy"
+  ];
 
   # ATM bin/tidy is statically linked, as upstream provides no other option yet.
   # https://github.com/htacg/tidy-html5/issues/326#issuecomment-160322107


### PR DESCRIPTION
###### Description of changes
Fix cross-compilation, upstream PR https://github.com/htacg/tidy-html5/pull/1036.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
