### PR TITLE
domination: fix desktop items installation

### DIFF
--- a/pkgs/games/domination/default.nix
+++ b/pkgs/games/domination/default.nix
@@ -6,6 +6,7 @@
 , ant
 , makeWrapper
 , makeDesktopItem
+, copyDesktopItems
 , nixosTests
 }:
 
@@ -41,14 +42,23 @@ in stdenv.mkDerivation {
     jdk8
     ant
     makeWrapper
+    copyDesktopItems
   ];
 
   buildPhase = ''
+    runHook preBuild
     cd swingUI
     ant
+    runHook postBuild
   '';
 
+  desktopItems = [
+    desktopItem
+    editorDesktopItem
+  ];
+
   installPhase = ''
+    runHook preInstall
     # Remove unnecessary files and launchers (they'd need to be wrapped anyway)
     rm -r \
       build/game/src.zip \
@@ -69,13 +79,8 @@ in stdenv.mkDerivation {
       --chdir "$out/share/domination" \
       --add-flags "-cp $out/share/domination/Domination.jar net.yura.domination.ui.swinggui.SwingGUIFrame"
 
-    install -Dm644 \
-      ${desktopItem}/share/applications/Domination.desktop \
-      $out/share/applications/Domination.desktop
-    install -Dm644 \
-      "${editorDesktopItem}/share/applications/Domination Map Editor.desktop" \
-      "$out/share/applications/Domination Map Editor.desktop"
     install -Dm644 build/game/resources/icon.png $out/share/pixmaps/domination.png
+    runHook postInstall
   '';
 
   passthru.tests = {


### PR DESCRIPTION


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Use copyDesktopItems instead of copying them manually

ZHF: #172160

@NixOS/nixos-release-managers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
