### PR TITLE
[21.11] grafana: fix CVE-2022-29170

### DIFF
--- a/pkgs/servers/monitoring/grafana/CVE-2022-29170.patch
+++ b/pkgs/servers/monitoring/grafana/CVE-2022-29170.patch
@@ -1,0 +1,119 @@
+diff --git a/pkg/infra/httpclient/httpclientprovider/host_redirect_validation_middleware.go b/pkg/infra/httpclient/httpclientprovider/host_redirect_validation_middleware.go
+new file mode 100644
+index 0000000..7bffa11
+--- /dev/null
++++ b/pkg/infra/httpclient/httpclientprovider/host_redirect_validation_middleware.go
+@@ -0,0 +1,37 @@
++package httpclientprovider
++
++import (
++	"errors"
++	"net/http"
++
++	"github.com/grafana/grafana/pkg/models"
++
++	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
++)
++
++const HostRedirectValidationMiddlewareName = "host-redirect-validation"
++
++func RedirectLimitMiddleware(reqValidator models.PluginRequestValidator) sdkhttpclient.Middleware {
++	return sdkhttpclient.NamedMiddlewareFunc(HostRedirectValidationMiddlewareName, func(opts sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
++		return sdkhttpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
++			res, err := next.RoundTrip(req)
++			if err != nil {
++				return nil, err
++			}
++			if res.StatusCode >= 300 && res.StatusCode < 400 {
++				location, locationErr := res.Location()
++				if errors.Is(locationErr, http.ErrNoLocation) {
++					return res, nil
++				}
++				if locationErr != nil {
++					return nil, locationErr
++				}
++
++				if validationErr := reqValidator.Validate(location.String(), nil); validationErr != nil {
++					return nil, validationErr
++				}
++			}
++			return res, nil
++		})
++	})
++}
+diff --git a/pkg/infra/httpclient/httpclientprovider/http_client_provider.go b/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
+index 8c6d602..2e58eb7 100644
+--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
++++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
+@@ -5,6 +5,8 @@ import (
+ 	"net/http"
+ 	"time"
+ 
++	"github.com/grafana/grafana/pkg/models"
++
+ 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+ 	"github.com/grafana/grafana/pkg/infra/log"
+ 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
+@@ -17,7 +19,7 @@ import (
+ var newProviderFunc = sdkhttpclient.NewProvider
+ 
+ // New creates a new HTTP client provider with pre-configured middlewares.
+-func New(cfg *setting.Cfg, tracer tracing.Tracer, features featuremgmt.FeatureToggles) *sdkhttpclient.Provider {
++func New(cfg *setting.Cfg, validator models.PluginRequestValidator, tracer tracing.Tracer, features featuremgmt.FeatureToggles) *sdkhttpclient.Provider {
+ 	logger := log.New("httpclient")
+ 	userAgent := fmt.Sprintf("Grafana/%s", cfg.BuildVersion)
+ 
+@@ -28,6 +30,7 @@ func New(cfg *setting.Cfg, tracer tracing.Tracer, features featuremgmt.FeatureTo
+ 		sdkhttpclient.BasicAuthenticationMiddleware(),
+ 		sdkhttpclient.CustomHeadersMiddleware(),
+ 		ResponseLimitMiddleware(cfg.ResponseLimit),
++		RedirectLimitMiddleware(validator),
+ 	}
+ 
+ 	if cfg.SigV4AuthEnabled {
+diff --git a/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go b/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go
+index 9fbafaa..eb18d8c 100644
+--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go
++++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go
+@@ -3,6 +3,8 @@ package httpclientprovider
+ import (
+ 	"testing"
+ 
++	"github.com/grafana/grafana/pkg/services/validations"
++
+ 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+ 	"github.com/grafana/grafana/pkg/infra/tracing"
+ 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+@@ -23,10 +25,10 @@ func TestHTTPClientProvider(t *testing.T) {
+ 		})
+ 		tracer, err := tracing.InitializeTracerForTest()
+ 		require.NoError(t, err)
+-		_ = New(&setting.Cfg{SigV4AuthEnabled: false}, tracer, featuremgmt.WithFeatures())
++		_ = New(&setting.Cfg{SigV4AuthEnabled: false}, &validations.OSSPluginRequestValidator{}, tracer, featuremgmt.WithFeatures())
+ 		require.Len(t, providerOpts, 1)
+ 		o := providerOpts[0]
+-		require.Len(t, o.Middlewares, 6)
++		require.Len(t, o.Middlewares, 7)
+ 		require.Equal(t, TracingMiddlewareName, o.Middlewares[0].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 		require.Equal(t, DataSourceMetricsMiddlewareName, o.Middlewares[1].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 		require.Equal(t, SetUserAgentMiddlewareName, o.Middlewares[2].(sdkhttpclient.MiddlewareName).MiddlewareName())
+@@ -47,16 +49,16 @@ func TestHTTPClientProvider(t *testing.T) {
+ 		})
+ 		tracer, err := tracing.InitializeTracerForTest()
+ 		require.NoError(t, err)
+-		_ = New(&setting.Cfg{SigV4AuthEnabled: true}, tracer, featuremgmt.WithFeatures())
++		_ = New(&setting.Cfg{SigV4AuthEnabled: true}, &validations.OSSPluginRequestValidator{}, tracer, featuremgmt.WithFeatures())
+ 		require.Len(t, providerOpts, 1)
+ 		o := providerOpts[0]
+-		require.Len(t, o.Middlewares, 7)
++		require.Len(t, o.Middlewares, 8)
+ 		require.Equal(t, TracingMiddlewareName, o.Middlewares[0].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 		require.Equal(t, DataSourceMetricsMiddlewareName, o.Middlewares[1].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 		require.Equal(t, SetUserAgentMiddlewareName, o.Middlewares[2].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 		require.Equal(t, sdkhttpclient.BasicAuthenticationMiddlewareName, o.Middlewares[3].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 		require.Equal(t, sdkhttpclient.CustomHeadersMiddlewareName, o.Middlewares[4].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 		require.Equal(t, ResponseLimitMiddlewareName, o.Middlewares[5].(sdkhttpclient.MiddlewareName).MiddlewareName())
+-		require.Equal(t, SigV4MiddlewareName, o.Middlewares[6].(sdkhttpclient.MiddlewareName).MiddlewareName())
++		require.Equal(t, SigV4MiddlewareName, o.Middlewares[7].(sdkhttpclient.MiddlewareName).MiddlewareName())
+ 	})
+ }

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -18,6 +18,12 @@ buildGo117Module rec {
     sha256 = "1wi28v1xhav8p2jqkf2gmk1accfcf1w0d6h312d4pns6pkhdabxv";
   };
 
+  patches = [
+    # https://github.com/grafana/grafana/commit/2f756845006820de4ad2b33e4be8338b81217d41, but
+    # rebased onto 8.4.x
+    ./CVE-2022-29170.patch
+  ];
+
   vendorSha256 = "sha256-7ZeOncdiA/0Awg+olJvsLneLQH4zBQka4M81jsxwUdE=";
 
   nativeBuildInputs = [ wire ];


### PR DESCRIPTION

###### Description of changes

See #173747 for the fix on master.

We're still using 8.4.x on 21.11 because 8.5 contained a few breaking
changes[1]. The patch for 8.5[2] was almost compatible with 8.4, but had
to be modified a bit because `New` in `http_client_provider` had a
slightly different signature:

    func New(cfg *setting.Cfg, tracer tracing.Tracer, features featuremgmt.FeatureToggles) *sdkhttpclient.Provider

on 8.4.7 vs

    func New(cfg *setting.Cfg, tracer tracing.Tracer) *sdkhttpclient.Provider

on 8.5.2.

I only had to adjust the signature in the test (because `PluginRequestValidator`
was added), but nothing else because these calls are automatically
resolved via `wire`.

[1] https://github.com/grafana/grafana/releases/tag/v8.5.0
[2] https://github.com/grafana/grafana/commit/2f756845006820de4ad2b33e4be8338b81217d41

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
