### PR TITLE
python3Packages.pytesseract: 0.3.9 -> 0.3.10, enable tests

### DIFF
--- a/pkgs/development/python-modules/pytesseract/default.nix
+++ b/pkgs/development/python-modules/pytesseract/default.nix
@@ -8,8 +8,8 @@ buildPythonPackage rec {
   format = "pyproject";
 
   src = fetchFromGitHub {
-    repo = pname;
     owner = "madmaze";
+    repo = pname;
     rev = "v${version}";
     sha256 = "sha256-CyKXtaIE/8iPLqi0GHVUgTeJDYZyWBjkRvOKJJKCxZo=";
   };

--- a/pkgs/development/python-modules/pytesseract/default.nix
+++ b/pkgs/development/python-modules/pytesseract/default.nix
@@ -1,13 +1,17 @@
-{ buildPythonPackage, fetchPypi, lib, packaging, pillow, tesseract, substituteAll }:
+{ buildPythonPackage, fetchFromGitHub, lib, packaging, pillow, tesseract, substituteAll
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pytesseract";
-  version = "0.3.9";
+  version = "0.3.10";
   format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-fiuvx/SNG7cUQ85GM6VvXiGSWpjyIKNsM2KX7c0ZVtA=";
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "madmaze";
+    rev = "v${version}";
+    sha256 = "sha256-CyKXtaIE/8iPLqi0GHVUgTeJDYZyWBjkRvOKJJKCxZo=";
   };
 
   patches = [
@@ -26,8 +30,7 @@ buildPythonPackage rec {
     pillow
   ];
 
-  # the package doesn't have any tests.
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     homepage = "https://pypi.org/project/pytesseract/";


### PR DESCRIPTION

###### Description of changes
ChangeLog: https://github.com/madmaze/pytesseract/releases/tag/v0.3.10
Not published to PyPI, so switching to the GitHub source here.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
