### PR TITLE
hobbits: 0.52.0 → 0.53.1, fix build on aarch64-linux

### DIFF
--- a/pkgs/development/libraries/pffft/default.nix
+++ b/pkgs/development/libraries/pffft/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "pffft";
+  version = "unstable-2022-04-10";
+
+  src = fetchFromGitHub {
+    owner = "marton78";
+    repo = pname;
+    rev = "08f5ed2618ac06d7dcc83d209d7253dc215274d5";
+    sha256 = "sha256-9LfLQ17IRsbEwGQJZzhW2Av4en1KuJVicLrS2AyjUZY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Pretty Fast FFT (PFFFT) library";
+    homepage = "https://github.com/marton78/pffft";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/graphics/hobbits/default.nix
+++ b/pkgs/tools/graphics/hobbits/default.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, mkDerivation, fetchFromGitHub
-, cmake, pkg-config, fftw, libpcap, libusb1, python3
+, cmake, pkg-config, pffft, libpcap, libusb1, python3
 }:
 
 mkDerivation rec {
   pname = "hobbits";
-  version = "0.52.0";
+  version = "0.53.1";
 
   src = fetchFromGitHub {
     owner = "Mahlet-Inc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-GZHBkBRt1ySItV+h5rdvey7KwdUWh5+rgztXh6HW3Js=";
+    sha256 = "sha256-dMFsv2M96+65JxTOq0CG+vm7a75GkD7N7PmbsyZ2Fog=";
   };
 
   postPatch = ''
@@ -20,9 +20,11 @@ mkDerivation rec {
       --replace "[Mystery Build]" "${version}"
   '';
 
-  buildInputs = [ fftw libpcap libusb1 python3 ];
+  buildInputs = [ pffft libpcap libusb1 python3 ];
 
   nativeBuildInputs = [ cmake pkg-config ];
+
+  NIX_CFLAGS_COMPILE = lib.optional stdenv.hostPlatform.isAarch64 "-Wno-error=narrowing";
 
   meta = with lib; {
     description = "A multi-platform GUI for bit-based analysis, processing, and visualization";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8722,6 +8722,8 @@ with pkgs;
 
   pgbadger = perlPackages.callPackage ../tools/misc/pgbadger { };
 
+  pffft = callPackage ../development/libraries/pffft { };
+
   phash = callPackage ../development/libraries/phash { };
 
   pnmixer = callPackage ../tools/audio/pnmixer { };


### PR DESCRIPTION
###### Description of changes
* Fix build on aarch64-linux (https://hydra.nixos.org/build/177029907), ZHF: #172160
* [Changelog](https://github.com/Mahlet-Inc/hobbits/releases)
* replace FFTW with [PFFFT](https://github.com/marton78/pffft) (hobbits >= 0.53.0)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (pffft only)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
