### PR TITLE
nixos/appvm: init at unstable-2021-12-20

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -38,8 +38,9 @@
     <itemizedlist spacing="compact">
       <listitem>
         <para>
-          Please remove this line when you add the first item since
-          docbook requires the section to be non-empty
+          <link xlink:href="https://github.com/jollheef/appvm">appvm</link>,
+          Nix based app VMs. Available as
+          <link xlink:href="options.html#opt-virtualisation.appvm.enable">virtualisation.appvm</link>.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -21,7 +21,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## New Services {#sec-release-22.11-new-services}
 
-- Please remove this line when you add the first item since docbook requires the section to be non-empty
+- [appvm](https://github.com/jollheef/appvm), Nix based app VMs. Available as [virtualisation.appvm](options.html#opt-virtualisation.appvm.enable).
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1234,6 +1234,7 @@
   ./tasks/powertop.nix
   ./testing/service-runner.nix
   ./virtualisation/anbox.nix
+  ./virtualisation/appvm.nix
   ./virtualisation/build-vm.nix
   ./virtualisation/container-config.nix
   ./virtualisation/containerd.nix

--- a/nixos/modules/virtualisation/appvm.nix
+++ b/nixos/modules/virtualisation/appvm.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.virtualisation.appvm;
+
+in {
+
+  options = {
+    virtualisation.appvm = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          This enables AppVMs and related virtualisation settings.
+        '';
+      };
+      user = mkOption {
+        type = types.str;
+        description = ''
+          AppVM user login. Currenly only AppVMs are supported for a single user only.
+        '';
+      };
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    virtualisation.libvirtd = {
+      enable = true;
+      qemu.verbatimConfig = ''
+        namespaces = []
+        user = "${cfg.user}"
+        group = "users"
+        remember_owner = 0
+      '';
+    };
+
+    users.users."${cfg.user}" = {
+      packages = [ pkgs.appvm ];
+      extraGroups = [ "libvirtd" ];
+    };
+
+  };
+
+}
+

--- a/pkgs/applications/virtualization/appvm/0001-Remove-menu-bar.patch
+++ b/pkgs/applications/virtualization/appvm/0001-Remove-menu-bar.patch
@@ -1,0 +1,12 @@
+diff --git a/src/resources/ui/virt-viewer.ui b/src/resources/ui/virt-viewer.ui
+index 430f879..68856fc 100644
+--- a/src/resources/ui/virt-viewer.ui
++++ b/src/resources/ui/virt-viewer.ui
+@@ -137,7 +137,6 @@
+     </child>
+     <child type="titlebar">
+       <object class="GtkHeaderBar" id="header">
+-        <property name="visible">True</property>
+         <property name="can-focus">False</property>
+         <property name="show-close-button">True</property>
+         <child>

--- a/pkgs/applications/virtualization/appvm/0002-Do-not-grab-keyboard-mouse.patch
+++ b/pkgs/applications/virtualization/appvm/0002-Do-not-grab-keyboard-mouse.patch
@@ -1,0 +1,15 @@
+diff --git a/src/virt-viewer-display-spice.c b/src/virt-viewer-display-spice.c
+index 2265f02..1d60d81 100644
+--- a/src/virt-viewer-display-spice.c
++++ b/src/virt-viewer-display-spice.c
+@@ -317,8 +317,8 @@ virt_viewer_display_spice_new(VirtViewerSessionSpice *session,
+     gtk_container_add(GTK_CONTAINER(self), GTK_WIDGET(self->display));
+     gtk_widget_show(GTK_WIDGET(self->display));
+     g_object_set(self->display,
+-                 "grab-keyboard", TRUE,
+-                 "grab-mouse", TRUE,
++                 "grab-keyboard", FALSE,
++                 "grab-mouse", FALSE,
+                  "resize-guest", FALSE,
+                  "scaling", TRUE,
+                  NULL);

--- a/pkgs/applications/virtualization/appvm/0003-Use-name-of-appvm-applications-as-a-title.patch
+++ b/pkgs/applications/virtualization/appvm/0003-Use-name-of-appvm-applications-as-a-title.patch
@@ -1,0 +1,14 @@
+diff --git a/src/virt-viewer-window.c b/src/virt-viewer-window.c
+index fe740ce..d45fd4f 100644
+--- a/src/virt-viewer-window.c
++++ b/src/virt-viewer-window.c
+@@ -1342,6 +1342,9 @@ virt_viewer_window_update_title(VirtViewerWindow *self)
+                                     grabhint,
+                                     g_get_application_name());
+         }
++    } else if (g_str_has_prefix(self->subtitle, "appvm_")) {
++        /* Use name of the application as a title */
++        title = g_strdup_printf(_("%s"), &self->subtitle[strlen("appvm_")]);
+     } else if (self->subtitle) {
+         /* translators:
+          * This is "<subtitle> - <appname>"

--- a/pkgs/applications/virtualization/appvm/0004-Use-title-application-name-as-subtitle.patch
+++ b/pkgs/applications/virtualization/appvm/0004-Use-title-application-name-as-subtitle.patch
@@ -1,0 +1,12 @@
+diff --git a/src/virt-viewer-app.c b/src/virt-viewer-app.c
+index b977b7b..36bce34 100644
+--- a/src/virt-viewer-app.c
++++ b/src/virt-viewer-app.c
+@@ -976,6 +976,7 @@ virt_viewer_app_set_window_subtitle(VirtViewerApp *app,
+             *d = '%';
+         } else
+             subtitle = g_strdup_printf("%s (%s)", title, desc);
++	subtitle = g_strdup_printf("%s", title);
+         g_free(desc);
+     }
+ 

--- a/pkgs/applications/virtualization/appvm/default.nix
+++ b/pkgs/applications/virtualization/appvm/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nix
+, virt-viewer
+, fetchpatch
+, makeWrapper }:
+
+let
+  # Upstream patches fail with newer virt-viewer. These are own ports to the
+  # newest virt-viewer version, see:
+  # https://github.com/jollheef/appvm/issues/28
+  virt-manager-without-menu = virt-viewer.overrideAttrs(oldAttrs: {
+    patches = oldAttrs.patches ++ [
+      ./0001-Remove-menu-bar.patch
+      ./0002-Do-not-grab-keyboard-mouse.patch
+      ./0003-Use-name-of-appvm-applications-as-a-title.patch
+      ./0004-Use-title-application-name-as-subtitle.patch
+    ];
+  });
+in
+buildGoModule rec {
+  pname = "appvm";
+  version = "unstable-2021-12-20";
+
+  src = fetchFromGitHub {
+    owner = "jollheef";
+    repo = pname;
+    rev = "17f17be7846d872e7e26d5cb6759a52ea4113587";
+    sha256 = "sha256-FL5olOy1KufULyqI2dJeS0OnKzC3LfPWxnia2i4f4yY=";
+  };
+
+  vendorSha256 = "sha256-8eU+Mf5dxL/bAMMShXvj8I1Kdd4ysBTWvgYIXwLStPI=";
+
+  buildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/appvm \
+      --prefix PATH : "${lib.makeBinPath [ nix virt-manager-without-menu ]}"
+  '';
+
+  meta = with lib; {
+    description = "Nix-based app VMs";
+    homepage = "https://code.dumpstack.io/tools/${pname}";
+    maintainers = with maintainers; [ dump_stack cab404 onny ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25068,6 +25068,8 @@ with pkgs;
 
   adobe-reader = pkgsi686Linux.callPackage ../applications/misc/adobe-reader { };
 
+  appvm = callPackage ../applications/virtualization/appvm { };
+
   masterpdfeditor = libsForQt5.callPackage ../applications/misc/masterpdfeditor { };
 
   masterpdfeditor4 = libsForQt5.callPackage ../applications/misc/masterpdfeditor4 { };


### PR DESCRIPTION
###### Description of changes

This PR packages the program [appvm](https://github.com/jollheef/appvm) and a module to set the right user permissions. Using appvm you could seamlessly run applications inside a virtual machine.

Enable it:
```
services.virtualisation.appvm = {
  enable = true;
  user = "onny";
};
```

Run an application:
```
appvm start chromium
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
