### PR TITLE
signald: 0.17.0 -> 0.18.5, reduce closure

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signald/0001-Fetch-buildconfig-during-gradle-build-inside-Nix-FOD.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/0001-Fetch-buildconfig-during-gradle-build-inside-Nix-FOD.patch
@@ -1,17 +1,17 @@
-From 232c692240b9c52b95bd38ba7aecb11e7077cf31 Mon Sep 17 00:00:00 2001
+From 8ed5f3c9117e08f7c2e4e1e01c2eee501675049b Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Sat, 26 Feb 2022 12:33:13 +0100
 Subject: [PATCH] Fetch buildconfig during gradle build inside Nix FOD
 
 ---
- build.gradle | 5 +++++
- 1 file changed, 5 insertions(+)
+ build.gradle | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/build.gradle b/build.gradle
-index cbb587f..3b06e80 100644
+index eaa6e0e..63c2947 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -82,6 +82,9 @@ static String getVersion() {
+@@ -83,6 +83,9 @@ static String getVersion() {
  
  repositories {
      maven {url "https://gitlab.com/api/v4/groups/6853927/-/packages/maven"} // https://gitlab.com/groups/signald/-/packages
@@ -21,15 +21,22 @@ index cbb587f..3b06e80 100644
      mavenCentral()
  }
  
-@@ -102,6 +105,8 @@ dependencies {
-     implementation 'io.prometheus:simpleclient_httpserver:0.14.1'
+@@ -104,6 +107,8 @@ dependencies {
+     implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
      implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-     implementation 'io.sentry:sentry:5.6.1'
+     implementation 'io.sentry:sentry:5.7.3'
 +    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.0.3'
 +    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.4.31'
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
  }
  
+@@ -171,4 +176,4 @@ allprojects {
+ runtime {
+     options = ['--strip-java-debug-attributes', '--compress', '2', '--no-header-files', '--no-man-pages']
+     modules = ['java.base', 'java.management', 'java.naming', 'java.sql', 'java.xml', 'jdk.crypto.ec', 'jdk.httpserver', 'java.desktop', 'jdk.unsupported']
+-}
+\ No newline at end of file
++}
 -- 
-2.33.1
+2.36.0
 

--- a/pkgs/applications/networking/instant-messengers/signald/0002-buildconfig-local-deps-fixes.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/0002-buildconfig-local-deps-fixes.patch
@@ -1,19 +1,19 @@
-From 80277ce9e24d9efa8dfd6eb775187c823e0e528e Mon Sep 17 00:00:00 2001
+From f319e1db47ae1eeddb6021cafe7b4f8551a702d7 Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Sat, 26 Feb 2022 12:36:15 +0100
 Subject: [PATCH 2/2] buildconfig/local deps fixes
 
 ---
- build.gradle | 20 ++++++++++++++++++--
- 1 file changed, 18 insertions(+), 2 deletions(-)
+ build.gradle | 26 ++++++++++++++++++--------
+ 1 file changed, 18 insertions(+), 8 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index cbb587f..ad836cf 100644
+index eaa6e0e..9a2f4e2 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -9,10 +9,21 @@ import org.gradle.nativeplatform.platform.internal.ArchitectureInternal
- import org.gradle.nativeplatform.platform.internal.OperatingSystemInternal
+@@ -10,11 +10,21 @@ import org.gradle.nativeplatform.platform.internal.ArchitectureInternal
  import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+ import org.gradle.nativeplatform.platform.internal.OperatingSystemInternal
  
 +buildscript {
 +  repositories {
@@ -28,13 +28,14 @@ index cbb587f..ad836cf 100644
 +
  plugins {
 -   id 'com.github.gmazzo.buildconfig' version '3.0.3'
+-   id 'org.beryx.runtime' version '1.12.7'
     id 'application'
  }
 +apply plugin: "com.github.gmazzo.buildconfig"
  
  compileJava.options.encoding = 'UTF-8'
  
-@@ -82,7 +93,10 @@ static String getVersion() {
+@@ -83,7 +93,10 @@ static String getVersion() {
  
  repositories {
      maven {url "https://gitlab.com/api/v4/groups/6853927/-/packages/maven"} // https://gitlab.com/groups/signald/-/packages
@@ -46,15 +47,25 @@ index cbb587f..ad836cf 100644
  }
  
  dependencies {
-@@ -102,6 +116,8 @@ dependencies {
-     implementation 'io.prometheus:simpleclient_httpserver:0.14.1'
+@@ -104,6 +117,8 @@ dependencies {
+     implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
      implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-     implementation 'io.sentry:sentry:5.6.1'
+     implementation 'io.sentry:sentry:5.7.3'
 +    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.0.3'
 +    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.4.31'
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
  }
  
+@@ -167,8 +182,3 @@ allprojects {
+         }
+     }
+ }
+-
+-runtime {
+-    options = ['--strip-java-debug-attributes', '--compress', '2', '--no-header-files', '--no-man-pages']
+-    modules = ['java.base', 'java.management', 'java.naming', 'java.sql', 'java.xml', 'jdk.crypto.ec', 'jdk.httpserver', 'java.desktop', 'jdk.unsupported']
+-}
+\ No newline at end of file
 -- 
-2.33.1
+2.36.0
 

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "signald";
-  version = "0.17.0";
+  version = "0.18.5";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-eN6lEs6PuRczbzQZmGlNf6Ahp4FbWpA3EArlATEiZHU=";
+    sha256 = "sha256-2cb1pyBOoOlFqJsNKXA0Q9x4wCE4yzzcfrDDtTp7HMk=";
   };
 
   # fake build to pre-download deps into fixed-output derivation
@@ -35,8 +35,8 @@ let
     outputHashMode = "recursive";
     # Downloaded jars differ by platform
     outputHash = {
-      x86_64-linux = "sha256-kZ25p+lIkOqNoFFBgJRYFcvKJenKICVa1PasaaEHmRA=";
-      aarch64-linux = "sha256-CbFNigp3R7ETX0uXv6PNuhDpmPc4sowbWmwZ+5txXQs=";
+      x86_64-linux = "sha256-q1gzauIL7aKalvPSfiK5IvkNkidCh+6jp5bpwxR+PZ0=";
+      aarch64-linux = "sha256-cM+7MaV0/4yAzobXX9FSdl/ZfLddwySayao96UdDgzk=";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 


### PR DESCRIPTION
###### Description of changes

ChangeLogs:
* https://gitlab.com/signald/signald/-/blob/0.18.5/releases/0.18.0.md
* https://gitlab.com/signald/signald/-/blob/0.18.5/releases/0.18.1.md
* https://gitlab.com/signald/signald/-/blob/0.18.5/releases/0.18.2.md
* https://gitlab.com/signald/signald/-/blob/0.18.5/releases/0.18.3.md
* https://gitlab.com/signald/signald/-/blob/0.18.5/releases/0.18.4.md
* https://gitlab.com/signald/signald/-/blob/0.18.5/releases/0.18.5.md

Also included my changes from #150493 since the jlink approach is also implemented in the upstream project now: https://gitlab.com/signald/signald/-/commit/4e02d405bd5e52d2a1dede30912dbd727e1647fe

Closes #150493.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
