### PR TITLE
libfreeaptx: avoid rebuilding on Linux for now

### DIFF
--- a/pkgs/development/libraries/libfreeaptx/default.nix
+++ b/pkgs/development/libraries/libfreeaptx/default.nix
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-eEUhOrKqb2hHWanY+knpY9FBEnjkkFTB+x6BZgMBpbo=";
   };
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = if stdenv.isDarwin then ''
     substituteInPlace Makefile \
       --replace '-soname' '-install_name' \
       --replace 'lib$(NAME).so' 'lib$(NAME).dylib'
-  '';
+  '' else null;
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
@@ -27,12 +27,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  postInstall = lib.optionalString stdenv.isDarwin ''
+  postInstall = if stdenv.isDarwin then ''
     install_name_tool -change libfreeaptx.dylib.0 $out/lib/libfreeaptx.dylib.0 $out/bin/freeaptxdec
     install_name_tool -change libfreeaptx.dylib.0 $out/lib/libfreeaptx.dylib.0 $out/bin/freeaptxenc
     install_name_tool -id $out/lib/libfreeaptx.dylib $out/lib/libfreeaptx.dylib
     install_name_tool -id $out/lib/libfreeaptx.dylib.0 $out/lib/libfreeaptx.dylib.0
-  '';
+  '' else null;
 
   meta = with lib; {
     description = "Free Implementation of Audio Processing Technology codec (aptX)";


### PR DESCRIPTION
Commit 152765ca8b caused thousands of rebuilds;
let's save doing that work on nixpkgs master.

###### Things done

The usual checklist doesn't apply.  This commit returns hashes on non-darwin to the state before PR #173689.  It's a bit counter-intuitive that empty strings do not get filtered but `null` values do...