### PR TITLE
blueprint-compiler: init at 0.1.0

### DIFF
--- a/pkgs/development/compilers/blueprint/default.nix
+++ b/pkgs/development/compilers/blueprint/default.nix
@@ -1,0 +1,51 @@
+{ python3
+, stdenv
+, fetchFromGitLab
+, gobject-introspection
+, lib
+, meson
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "blueprint-compiler";
+  version = "unstable-2022-05-27";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jwestman";
+    repo = pname;
+    rev = "cebd9ecadc53790cd547392899589dd5de0ac552";
+    sha256 = "sha256-mNR0ooJSRBIXy2E4avXYEdO1aSST+j41TsVg8+kitwo=";
+  };
+
+  # Requires pythonfuzz, which I've found difficult to package
+  doCheck = false;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    python3.pkgs.wrapPython
+  ];
+
+  buildInputs = [
+    python3
+  ];
+
+  propagatedBuildInputs = [
+    # So that the compiler can find GIR and .ui files
+    gobject-introspection
+  ];
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  meta = with lib; {
+    description = "A markup language for GTK user interface files";
+    homepage = "https://gitlab.gnome.org/jwestman/blueprint-compiler";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.ranfdev ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12327,6 +12327,8 @@ with pkgs;
 
   binaryen = callPackage ../development/compilers/binaryen { };
 
+  blueprint-compiler = callPackage ../development/compilers/blueprint { };
+
   bluespec = callPackage ../development/compilers/bluespec {
     gmp-static = gmp.override { withStatic = true; };
     tex = texlive.combined.scheme-full;


### PR DESCRIPTION
###### Description of changes
A markup language for GTK user interface files.

> GtkBuilder XML format is quite verbose, and many app developers don't like
using WYSIWYG editors for creating UIs. Blueprint files are intended to be a
concise, easy-to-read format that makes it easier to create and edit GTK UIs.

This package is needed to update some gtk apps, like Giara (#168842) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).