### PR TITLE
python310Packages.rstcheck: 3.3.1 -> 5.0.0

### DIFF
--- a/pkgs/development/python-modules/rstcheck/default.nix
+++ b/pkgs/development/python-modules/rstcheck/default.nix
@@ -1,18 +1,50 @@
-{ lib, fetchFromGitHub, buildPythonPackage, docutils }:
+{ lib
+, buildPythonPackage
+, docutils
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, types-docutils
+, typing-extensions
+}:
 
 buildPythonPackage rec {
   pname = "rstcheck";
-  version = "3.3.1";
+  version = "5.0.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "myint";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-4AhENuT+LtUMCi+aaI/rKa2gHti8sKGLdVGjdRithXI=";
+    hash = "sha256-vTUa/eP6/flxRLBuzdHoNoPoGAg6XWwu922az8tLgJM=";
   };
 
-  pythonImportsCheck = [ "rstcheck" ];
-  propagatedBuildInputs = [ docutils ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    docutils
+    types-docutils
+    typing-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "rstcheck"
+  ];
+
+  preCheck = ''
+    # The tests need to find and call the rstcheck executable
+    export PATH="$PATH:$out/bin";
+  '';
 
   meta = with lib; {
     description = "Checks syntax of reStructuredText and code blocks nested within it";

--- a/pkgs/development/python-modules/types-docutils/default.nix
+++ b/pkgs/development/python-modules/types-docutils/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-docutils";
+  version = "0.18.3";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oO+DHcIGNfNQ+pz/WRIxwx0n51dx5Z/WyXm2wMfgMpI=";
+  };
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "docutils-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for docutils";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9813,6 +9813,8 @@ with pkgs;
 
   rst2html5 = callPackage ../tools/text/rst2html5 { };
 
+  rstcheck = with python3Packages; toPythonApplication rstcheck;
+
   rt = callPackage ../servers/rt { };
 
   rtmpdump = callPackage ../tools/video/rtmpdump { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10570,6 +10570,8 @@ in {
 
   types-decorator = callPackage ../development/python-modules/types-decorator { };
 
+  types-docutils = callPackage ../development/python-modules/types-docutils { };
+
   types-enum34 = callPackage ../development/python-modules/types-enum34 { };
 
   types-freezegun = callPackage ../development/python-modules/types-freezegun { };


### PR DESCRIPTION
###### Description of changes
https://github.com/myint/rstcheck#id2

- enable tests
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
