### PR TITLE
awless: avoid building on aarch64-linux

### DIFF
--- a/pkgs/tools/virtualization/awless/default.nix
+++ b/pkgs/tools/virtualization/awless/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   meta = with lib; {
     homepage = "https://github.com/wallix/awless/";
     description = "A Mighty CLI for AWS";
-    platforms = with platforms; linux ++ darwin;
+    platforms = with platforms; [ "i686-linux" "x86_64-linux" ]++ darwin;
     license = licenses.asl20;
     maintainers = with maintainers; [ pradeepchhetri swdunlop ];
   };


### PR DESCRIPTION
###### Description of changes

Disables build of Awless on `aarch64-linux`, leaving it enabled for other platforms where it currently builds in 21.11 and master.  The upstream project has not updated since 2018 and needs to update its version of [x/sys/unix](https://pkg.go.dev/golang.org/x/sys/unix) to build on `aarch64-linux`.  

We could probably patch its `go.mod` and `go.sum`, but since I do not actively use `aarch64-linux`, I cannot assume it is backward compatible.  (Especially since `x/sys/unix` does not guarantee backward compatibility.)

Relevant discussions and issues:

- ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
