### PR TITLE
terraform-providers.b2: init at 0.8.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -135,6 +135,15 @@
     "vendorSha256": null,
     "version": "0.10.0"
   },
+  "b2": {
+    "owner": "Backblaze",
+    "provider-source-address": "registry.terraform.io/Backblaze/b2",
+    "repo": "terraform-provider-b2",
+    "rev": "v0.8.0",
+    "sha256": "sha256-2yyAKrDO7X5yujfrHhYuvXbuKk3yY1sCXRZ8U/9OnrM=",
+    "vendorSha256": "sha256-f5bvk0p7AU1i/xeapxyVRXIUARju6mNQokejaDnT/GI=",
+    "version": "0.8.0"
+  },
   "baiducloud": {
     "owner": "baidubce",
     "provider-source-address": "registry.terraform.io/baidubce/baiducloud",


### PR DESCRIPTION
###### Description of changes

This PR adds a new Terraform provider, for [Backblaze B2](https://www.backblaze.com/b2/cloud-storage.html). The Terraform registry page can be found [here](https://registry.terraform.io/providers/Backblaze/b2/latest). The source code for the provider is [here](https://github.com/Backblaze/terraform-provider-b2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
