### PR TITLE
tigervnc: add support for darwin

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -1,10 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch
-, xorg, xkeyboard_config, zlib
-, libjpeg_turbo, pixman, fltk
-, cmake, gettext, libtool
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, xorg
+, xkeyboard_config
+, zlib
+, libjpeg_turbo
+, pixman
+, fltk
+, cmake
+, gettext
+, libtool
 , libGLU
-, gnutls, pam, nettle
-, xterm, openssh, perl
+, gnutls
+, gawk
+, pam
+, nettle
+, xterm
+, openssh
+, perl
 , makeWrapper
 , nixosTests
 }:
@@ -31,7 +45,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${xkeyboard_config}/etc/X11/xkb";' unix/vncserver/vncserver.in
     fontPath=
     substituteInPlace vncviewer/vncviewer.cxx \
@@ -39,6 +53,10 @@ stdenv.mkDerivation rec {
 
     cp unix/xserver21.1.1.patch unix/xserver211.patch
     source_top="$(pwd)"
+  '' + ''
+    # On Mac, do not build a .dmg, instead copy the .app to the source dir
+    gawk -i inplace 'BEGIN { del=0 } /hdiutil/ { del=2 } del<=0 { print } /$VERSION.dmg/ { del -= 1 }' release/makemacapp.in
+    echo "mv \"\$APPROOT\" \"\$SRCDIR/\"" >> release/makemacapp.in
   '';
 
   dontUseCmakeBuildDir = true;
@@ -49,7 +67,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBEXECDIR=${placeholder "out"}/bin"
   ];
 
-  postBuild = ''
+  postBuild = lib.optionalString stdenv.isLinux ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error=int-to-pointer-cast -Wno-error=pointer-to-int-cast"
     export CXXFLAGS="$CXXFLAGS -fpermissive"
     # Build Xvnc
@@ -76,9 +94,11 @@ stdenv.mkDerivation rec {
         --with-xkb-output=$out/share/X11/xkb/compiled
     make TIGERVNC_SRC=$src TIGERVNC_BUILDDIR=`pwd`/../.. -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES
     popd
+  '' + lib.optionalString stdenv.isDarwin ''
+    make dmg
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString stdenv.isLinux ''
     pushd unix/xserver/hw/vnc
     make TIGERVNC_SRC=$src TIGERVNC_BUILDDIR=`pwd`/../../../.. install
     popd
@@ -86,21 +106,55 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/vncserver \
       --prefix PATH : ${lib.makeBinPath (with xorg; [ xterm twm xsetroot xauth ]) }
+  '' + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv 'TigerVNC Viewer ${version}.app' $out/Applications/
+    rm $out/bin/vncviewer
+    echo "#!/usr/bin/env bash
+    open $out/Applications/TigerVNC\ Viewer\ ${version}.app --args \$@" >> $out/bin/vncviewer
+    chmod +x $out/bin/vncviewer
   '';
 
-  buildInputs = with xorg; [
-    libjpeg_turbo fltk pixman
-    gnutls pam nettle perl
+  buildInputs = [
+    fltk
+    gnutls
+    libjpeg_turbo
+    pixman
+    gawk
+  ] ++ lib.optionals stdenv.isLinux (with xorg; [
+    nettle
+    pam
+    perl
     xorgproto
-    utilmacros libXtst libXext libX11 libXext libICE libXi libSM libXft
-    libxkbfile libXfont2 libpciaccess
+    utilmacros
+    libXtst
+    libXext
+    libX11
+    libXext
+    libICE
+    libXi
+    libSM
+    libXft
+    libxkbfile
+    libXfont2
+    libpciaccess
     libGLU
-  ] ++ xorg.xorgserver.buildInputs;
+  ] ++ xorg.xorgserver.buildInputs
+  );
 
-  nativeBuildInputs = with xorg; [ cmake zlib gettext libtool utilmacros fontutil makeWrapper ]
-    ++ xorg.xorgserver.nativeBuildInputs;
+  nativeBuildInputs = [
+    cmake
+    gettext
+  ] ++ lib.optionals stdenv.isLinux (with xorg; [
+    fontutil
+    libtool
+    makeWrapper
+    utilmacros
+    zlib
+  ] ++ xorg.xorgserver.nativeBuildInputs);
 
-  propagatedBuildInputs = xorg.xorgserver.propagatedBuildInputs;
+  propagatedBuildInputs = lib.optional stdenv.isLinux
+    xorg.xorgserver.propagatedBuildInputs;
 
   passthru.tests.tigervnc = nixosTests.vnc.testTigerVNC;
 
@@ -109,7 +163,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     description = "Fork of tightVNC, made in cooperation with VirtualGL";
     maintainers = with lib.maintainers; [viric];
-    platforms = with lib.platforms; linux;
+    platforms = lib.platforms.unix;
     # Prevent a store collision.
     priority = 4;
   };

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -153,8 +153,7 @@ stdenv.mkDerivation rec {
     zlib
   ] ++ xorg.xorgserver.nativeBuildInputs);
 
-  propagatedBuildInputs = lib.optional stdenv.isLinux
-    xorg.xorgserver.propagatedBuildInputs;
+  propagatedBuildInputs = lib.optional stdenv.isLinux xorg.xorgserver.propagatedBuildInputs;
 
   passthru.tests.tigervnc = nixosTests.vnc.testTigerVNC;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds builds of tigervnc for macOS. For mac, replaces `$out/bin/vncviewer` binary with a small script calling out to the `.app` and passing all relevant arguments to ensure that the false setting for `NSHighResolutionCapable` from the `.plist` is respected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
