### PR TITLE
stash: init at 0.15.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -626,6 +626,7 @@
   ./services/misc/spice-vdagentd.nix
   ./services/misc/ssm-agent.nix
   ./services/misc/sssd.nix
+  ./services/misc/stash.nix
   ./services/misc/subsonic.nix
   ./services/misc/sundtek.nix
   ./services/misc/svnserve.nix

--- a/nixos/modules/services/misc/stash.nix
+++ b/nixos/modules/services/misc/stash.nix
@@ -1,0 +1,134 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.stash;
+  opt = options.services.stash;
+
+in {
+
+  options.services.stash = {
+    enable = lib.mkEnableOption "Enable Stash service";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "stash";
+      description = "User account under which Stash runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "stash";
+      description = "Group under which Stash runs.";
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "The ip address for the host that stash is listening to.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.int;
+      default = 9999;
+      description = "The port that stash serves to.";
+    };
+
+    externalHost = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Needed in some cases when you use a reverse proxy.";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/stash";
+      description = "Path where to store data files.";
+    };
+
+    ffmpegPkg = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.ffmpeg;
+      defaultText = lib.literalExpression "pkgs.ffmpeg";
+      description = "FFMpeg package to use.";
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.stash;
+      defaultText = lib.literalExpression "pkgs.stash";
+      description = "Stash package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable (let
+    stashPython = pkgs.python3.withPackages (ps: with ps; [
+      cloudscraper
+      configparser
+      # libpath
+      progressbar
+      requests
+      # youtube_dl
+    ]);
+    stashPackages = with pkgs; [
+      stashPython
+      bashInteractive
+      openssl
+      sqlite
+      cfg.ffmpegPkg
+    ];
+  in {
+    environment.systemPackages = stashPackages;
+
+    systemd.services.stash = {
+      enable = true;
+      description = "Stash daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartIfChanged = true; # Whether to restart on a nixos-rebuild
+      environment = {
+        STASH_HOST = cfg.host;
+        STASH_PORT = toString cfg.port;
+        STASH_EXTERNAL_HOST = toString cfg.externalHost;
+      };
+
+      path = stashPackages;
+
+      preStart = ''
+        mkdir -p ~/.stash && chmod 777 ~/.stash;
+        rm -f ~/.stash/ffmpeg && ln -s ${cfg.ffmpegPkg}/bin/ffmpeg ~/.stash/ffmpeg;
+        rm -f ~/.stash/ffprobe && ln -s ${cfg.ffmpegPkg}/bin/ffprobe ~/.stash/ffprobe;
+      '';
+
+      script = "${cfg.package}/bin/stash";
+      scriptArgs = "--nobrowser";
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        # User and group
+        User = cfg.user;
+        Group = cfg.group;
+      };
+    };
+
+    users.users = lib.mkMerge [
+      (lib.mkIf (cfg.user == "stash") {
+        stash = {
+          isSystemUser = true;
+          group = cfg.group;
+          home = cfg.dataDir;
+          createHome = true;
+        };
+      })
+      (lib.attrsets.setAttrByPath [ cfg.user "packages" ] ([ cfg.package ] ++ stashPackages))
+    ];
+
+    users.groups = lib.optionalAttrs (cfg.group == "stash") {
+      stash = {
+      };
+    };
+  });
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -509,6 +509,7 @@ in
   sslh = handleTest ./sslh.nix {};
   sssd = handleTestOn ["x86_64-linux"] ./sssd.nix {};
   sssd-ldap = handleTestOn ["x86_64-linux"] ./sssd-ldap.nix {};
+  stash = handleTest ./stash.nix {};
   starship = handleTest ./starship.nix {};
   step-ca = handleTestOn ["x86_64-linux"] ./step-ca.nix {};
   strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};

--- a/nixos/tests/stash.nix
+++ b/nixos/tests/stash.nix
@@ -1,0 +1,19 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "stash";
+  meta = with pkgs.lib; {
+    maintainers = with maintainers; [ nocoolnametom ];
+  };
+
+  nodes.machine = { pkgs, ... }: {
+    services.stash = {
+      enable = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("stash.service")
+    machine.wait_until_succeeds(
+        "curl --fail -L http://localhost:9999/"
+    )
+  '';
+})

--- a/pkgs/servers/stash/default.nix
+++ b/pkgs/servers/stash/default.nix
@@ -1,0 +1,81 @@
+{ pkgs, lib, stdenv
+, fetchurl
+, autoPatchelfHook
+, openssl
+, ffmpeg
+, sqlite
+, makeWrapper
+}:
+
+let
+  version = "0.15.0";
+
+  platforms = {
+    aarch64-darwin = {
+      name = "macos-applesilicon";
+      sha256 = "sha256-m2GzcfuhixCTur89HsAfpY0hT4C4j7nvdsOK5zjVPqQ=";
+    };
+    aarch64-linux = {
+      name = "linux-arm64v8";
+      sha256 = "sha256-P7HB5i0DAoNDFvBhrkvr8yrKvEEUX22WTstAlxmhcC8=";
+    };
+    armv6l-linux = {
+      name = "linux-arm32v6";
+      sha256 = "sha256-P/tj+P5m3xTZlEohe0VdWsJwuarpkNF00Z+bQHSRBHY=";
+    };
+    armv7l-linux = {
+      name = "linux-arm32v7";
+      sha256 = "sha256-B6ocSKrSJEcY+lTpaweTWyZ/uZhavlUv4DkZ0mq4gQU=";
+    };
+    x86_64-darwin = {
+      name = "macos-intel";
+      sha256 = "sha256-/T1GkQT/FB/+5nQahIfOi9S0ycO50buMqLwNyJm3uK0=";
+    };
+    x86_64-linux = {
+      name = "linux";
+      sha256 = "sha256-QC1/OJAjMqNAV20nmL+DfPlsbtjLib5XKiugdknGAHM=";
+    };
+  };
+
+  plat = if (lib.hasAttrByPath [ stdenv.hostPlatform.system ] platforms)
+    then platforms.${stdenv.hostPlatform.system}
+    else throw "Unsupported architecture: ${stdenv.hostPlatform.system}";
+in stdenv.mkDerivation rec {
+  inherit version;
+
+  name = "stash-${version}";
+
+  executable = fetchurl {
+    inherit (plat) sha256;
+    url = "https://github.com/stashapp/stash/releases/download/v${version}/stash-${plat.name}";
+    executable = true;
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    ffmpeg
+    openssl
+    sqlite
+    makeWrapper
+    (pkgs.python3.withPackages (p: with p; [ requests configparser progressbar cloudscraper ]))
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper "${executable}" "$out/bin/stash" \
+      --prefix PATH ":" "${lib.makeBinPath [ ffmpeg ]}"
+  '';
+
+  meta = with lib; {
+    description = "Private video and image server";
+    license = licenses.gpl3;
+    homepage = "https://stashapp.cc";
+    maintainers = with lib.maintainers; [ nocoolnametom ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22559,6 +22559,8 @@ with pkgs;
       # see also openssl, which has/had this same trick
   };
 
+  stash = callPackage ../servers/stash { };
+
   sickgear = callPackage ../servers/sickbeard/sickgear.nix { };
 
   sipwitch = callPackage ../servers/sip/sipwitch { };


### PR DESCRIPTION
Stash is a private video and image file organizer and server written in Go.

This is an initial attempt to add both a package and a service to run it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->