### PR TITLE
firefox{,-bin}: 100.0.1 -> 100.0.2; firefox-esr: 91.9.0esr -> 91.9.1esr; thunderbird{,-bin}: 91.9.0 -> 91.9.1; spidermonkey_91: 91.9.0 -> 91.9.1;  firefox-devedition-bin-unwrapped: 101.0b6 -> 101.0b9 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "99.0b6";
+  version = "101.0b9";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ach/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ach/firefox-101.0b9.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "a540c52dbb973a85ee0f9fb116f7812e624d925dce77fe14a310f4bf5e6a0b58";
+      sha256 = "3b6976610aecdcea2e4067875cd99948f3b90a19ba5c9cdc28a6468baedd9a91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/af/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/af/firefox-101.0b9.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "0f15edf10fc6ccb9f8bfba5cd6bbe83ac11df1b01fe9d5a1888f9b83a20b6d49";
+      sha256 = "3e0fcee8180c294477cd331080bc47a09619b6ac326f1da2f404469d71aab65b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/an/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/an/firefox-101.0b9.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "769c936702fd344395e2fb949ddd2782f0e35096889c7c84027edfd9f08f5790";
+      sha256 = "25d1afb8220d1b75dbc582590a05731396cbc09272f4bf4526a4ddee8df5ccc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ar/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ar/firefox-101.0b9.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "401b84fb1ce243e657018b0f6c98acc7838c7abcb0ed93772d56b1082135b479";
+      sha256 = "c7889add14aa4bba4f8c6ef9ead2041abc09f0141dc1ce01643f740d13537b3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ast/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ast/firefox-101.0b9.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "2876d7dc456ead1a0efd867e3f683ea432589049ad85adf7ca5e7824f9dcfe66";
+      sha256 = "1f96dba635dfc3db01409320352aa0b81c6c3fbb8e6a697fa1403e72b87547f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/az/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/az/firefox-101.0b9.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "c83d7bf96d74241657ae84dcd0b63328dc521cdb4be639577473305bc0d024b7";
+      sha256 = "0e46fbd9c55f13757cb3b98c10bf52385ab47a20f2913cc95717592ee0c284c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/be/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/be/firefox-101.0b9.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "35942f40d0604f382a383a9f737d59bdd6141ec6066d7da54422fe02928c46f2";
+      sha256 = "905a7f1f7a395defc7d4cfe0991ae70c1541d4fa6237af983f5b0090d67add2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/bg/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/bg/firefox-101.0b9.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f55d30618fd8eccfba51fc82fbcf37fa3eed550b168ed603a14a69511ee4955c";
+      sha256 = "cfd4fa55ca17f629f1d643a33bd3c265eb2630e1a80af4d73a3277f8b208d949";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/bn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/bn/firefox-101.0b9.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "462741a2dd135d7f0cbe12ca93bba398a621613af5611f1cae364a281863388f";
+      sha256 = "b96a410a998c29ac62b2b0c5ad63b7021c718e3eed849cbc694a746fa2788637";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/br/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/br/firefox-101.0b9.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "2f08c5b70e49b9151757a80821011cc6ac8bb9d68b282aeb33b9928bec2609f2";
+      sha256 = "f52535396b2d872f70f80b66747d4884b4cd69e5f2475a85c13170773a08d5ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/bs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/bs/firefox-101.0b9.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "08802aa569f3e4c9307dbdf0216cc96e851ee88d663d52f22559bae99df3c551";
+      sha256 = "8538ca13db07a08cdef23263dc4312cce72152e7b2c51e28a1c690bdae60a99e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ca-valencia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ca-valencia/firefox-101.0b9.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "49fc70e96542fb26e536570395f6f8302e4271306f0298739c537a7d03af3585";
+      sha256 = "37bc2096537d42963393f6405906b7ff4c1c185a52c5c6c73561f3d64da96489";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ca/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ca/firefox-101.0b9.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "c1a1ae01536b9b885ee66033f8d828ef63cf3211fa3ec52ad8cd8c688e8bb1cf";
+      sha256 = "59712cd3ef6184598cbe8c9b82c6b4a881dcf9d44bef7d1a057889f8592fc889";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/cak/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/cak/firefox-101.0b9.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "536ebd5224b5a53b4660d9113172fcd73862307da6c41f007a2cdb71b35a6dc5";
+      sha256 = "2e6a523a9860ede12c6cac9b8a03886e886f198d732dda8eae01082d088953c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/cs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/cs/firefox-101.0b9.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "3d25003533ce79e9a32e4dccb92235994b076dce620a73b4f3efac2c04887596";
+      sha256 = "dd3269c941177d144f408553378edcd7c24f0dac14396e5fb826bd524ccfc569";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/cy/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/cy/firefox-101.0b9.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "04e5c7f3195ee0a55b3c2c27cf030a1cebeabfcb833e77a2b099916bfac07b8a";
+      sha256 = "37b7e0a28c1cdd93866088cf5aaa68786ef64531857f6498186ca9423e8efbaf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/da/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/da/firefox-101.0b9.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "707a9d7991c925989af516681542ba7cf1f4cabeaa3eea7d8be44a76184ae440";
+      sha256 = "e14ad5cfc9a150279b41c94be7b7217c246de861f5694a7dc9b9033e8cccd0f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/de/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/de/firefox-101.0b9.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "e2601df88ee67fc7d4d0d675f53dfb96f34a2c2e3dffdf1ee811561e3ddfa7a3";
+      sha256 = "2d4b294c3a09da9f948ce81a157139ff8da7b628b70c083a18230fa8ca71516b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/dsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/dsb/firefox-101.0b9.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "479ec9ec8fc128dc971976611b31d12ea58b1a3119c9019c8fcf4e224486b8dd";
+      sha256 = "21cc6912fa90883c8d82eba67cc2ea5125833e2c61f57a9d7275571ac767ccdc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/el/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/el/firefox-101.0b9.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "fc0075428e18c918bbeb1b25e367e7bf0a4aacc7a27c6acd382f326dfefa65d0";
+      sha256 = "0b1350c98686fa689cc9f164fc3392f711305eb76210da4f9c481e53c096b439";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/en-CA/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/en-CA/firefox-101.0b9.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "1f1f10900d3c3ecfc1ec55e06d38bbe89462abc25bf2aa97bad2a785970b52fa";
+      sha256 = "70f61a52894c08bb6d62a34fd67c69e737c505fb24aa59caacd0bb94d8505c73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/en-GB/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/en-GB/firefox-101.0b9.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "36ec8955482e37178f6b333681ae3e998a65701b90541ed6f98b452d04515b27";
+      sha256 = "864dcc9ca375bdaaf98f25223b8f6fa24ba20d08cc4b83f07d57ac1dceffd7d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/en-US/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/en-US/firefox-101.0b9.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "e316f005fbefcec2c55d9dd2452392c82155b080abb51d36eddcccfead742ca8";
+      sha256 = "a222ae9a1799e81f99a6d394c83feb5a90ecb64f551a80cbcb4b512260f4f73e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/eo/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/eo/firefox-101.0b9.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0fab5a6ed664f3be18c9aa81c51015b75b3cb9a8bed5bae3322eca57d76fa0b7";
+      sha256 = "472fdb8de55303b14fa55c39503d0874fcc5a51976703abdd88a139fda6fcddb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/es-AR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/es-AR/firefox-101.0b9.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e24a821243c0f2ba758c00334ee40900b3d8eec2d137db774512a1b5907dd0e3";
+      sha256 = "f099234d94a654923a0a0dd365bf7ff8f4d878cccf5f1cd8e592c72aeb528247";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/es-CL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/es-CL/firefox-101.0b9.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "5ba1376f6c47b8afb320f7aa36ae1bc6a6dd45350a843f641889fa0f9bd6d4f1";
+      sha256 = "316a667ac49ce5664b6055ef4bd2dd9581ce2517e2fad7351e56d14d942c7c42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/es-ES/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/es-ES/firefox-101.0b9.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "73d3f8a7ad44d175fc73993ad1ddf2115cda48d33422493e80f5f5fcb0805f13";
+      sha256 = "728adea6eba648e2bb12af6062d0ff24b53b77095bc329e9d191b8e77e9c2c1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/es-MX/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/es-MX/firefox-101.0b9.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "cd3267b82d6a02a1f2797069373e95726262c603902a655fb138699b5546e34b";
+      sha256 = "e9b004f11f5efabd7c940d37b69376fbb5eee11798cf89a26054f63fa44d064b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/et/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/et/firefox-101.0b9.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "07f95fc1bef61d7c1f8b85ae9e774cab7c79c8d8e2d1d82fe80ea6b8f33e7a6b";
+      sha256 = "ea67ddbf2865bea034a985e6c8cba14f4414597a4140525c2f27645a2a9231c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/eu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/eu/firefox-101.0b9.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "da979dfebd9e18d524e20f05c04dcb9abf42eced67d0d59b2e2b8fd0f2860d4c";
+      sha256 = "25dabe2c47e85b0fba1356a24c67934c533129a2295a429b0d45a5245b86e130";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/fa/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/fa/firefox-101.0b9.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "7afddd9ca0568fc844e68f67325ceb2f5a4bf8ed35095076b60e98e334001575";
+      sha256 = "8fd9f27662de06b3611820e2bcfad63a1334abedf1960f9870612c664cc56aca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ff/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ff/firefox-101.0b9.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "291a80a59157da3eee5f8f8c4c4647713fa639e940200dee7a6f2ff6d44dc55a";
+      sha256 = "f30f7380e53cf2ee014b2c8256cd8959510a07f7a0b57ec4dbfcdf0fc2d1b77b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/fi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/fi/firefox-101.0b9.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "b5d42423703cbf205fab56d64125d5d68c5466553dbdf47d05e29c98a1bf4c56";
+      sha256 = "f1a47149f5b104bfc457d7cee285e3886f85742bf52660d11075e94a43b2b8a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/fr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/fr/firefox-101.0b9.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "95ac9b6b2be9e5996dd3ed3a84c62bf1f29715063c0af3475c02fe5614436800";
+      sha256 = "2ff37caa3fa38da1eade172c4b445e3a1364cf95ab6fdb91730dcab78c16068c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/fy-NL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/fy-NL/firefox-101.0b9.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "d4b0eaa62170cf651d92b3feb361632a2a202b971661e1111cd343c54abfe98c";
+      sha256 = "deea3a15a2ced0bdccc80a0f83a70befd73011d59f00ce833482f6f909e49799";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ga-IE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ga-IE/firefox-101.0b9.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "01e383677c6fe5d3c73b29339d62b8cc5e8fa6120a6c1f31509eac9020eb7a42";
+      sha256 = "f90208d5995fec5ca2f4de183727b1d1650312e9db4aff10fab21b9ce952bab5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/gd/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/gd/firefox-101.0b9.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "ba0c05f8ccb21224781824178b41794f04585dc22c60bb4b3db3a230be304eaa";
+      sha256 = "aa0cf6d529f93400c79f70c8f088938b5ec06a4f50bbcc644354a5d55a7c4d82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/gl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/gl/firefox-101.0b9.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "540cf483ba69cb35eb0878d07af059f023e453359962217fa4f91ed6e9ceeb8c";
+      sha256 = "7572b5870ca24e8f5c5f22966368e72f5bf2209d4bbfe6ffb552b9d38357c32b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/gn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/gn/firefox-101.0b9.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "222de0e732642bb0ab30687312bbd2fe83b0ca42497a1e8aab2a56658b1f3fa0";
+      sha256 = "f8c8682adc0e2f6292a85ecb2a93b9435038a39b38a10a70e363b5319c0e027c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/gu-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/gu-IN/firefox-101.0b9.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "c2d5751f5b5d3c419c4a5bc61ecf900638f2f4f93e44dfe4b888c467e17ae368";
+      sha256 = "c782a8f038c19459272322075a996a4635868b87f7e5f5b71f1ef2426bff2f55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/he/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/he/firefox-101.0b9.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "00e4b80dbe25ff5daee56b2eeca471b5bda4186b50a676b72ee3b6dd85f52935";
+      sha256 = "c85c83456a0476ae472ad583211a2c21595ba9cc868de6b2f0fd0e638e38e0f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/hi-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/hi-IN/firefox-101.0b9.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "cc762a99b9443f45c326971dd3f0fbe10c46abc4ab54a31916d8f344942fe645";
+      sha256 = "343cc02d860bb59549f2113e637d8d35bc5514fbc8a9d5c167b68af9f18be218";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/hr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/hr/firefox-101.0b9.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "6f935f65ef177e330b53c35818d14cdc135436f79497b6e59e748365a2942767";
+      sha256 = "185c43871cb203bf25975099be162a73e07984873fe36ffce2acc8067f13eb77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/hsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/hsb/firefox-101.0b9.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "4ec5aaf93f6bebd218817ee6552b352822c016209e5b528bb96f65fc1b89ec69";
+      sha256 = "3c161e86e08571ae7f3c6049cbd447cba55a81b2c9f8e02cf3993521cca2f865";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/hu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/hu/firefox-101.0b9.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5042f7330efadd917d38f9e5415477f507258ba8462e5600ab1ab15755707db2";
+      sha256 = "b254b389f2234858a5991c920c782abc3de42bef9b55f26f672653afd55e77b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/hy-AM/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/hy-AM/firefox-101.0b9.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "479d9f677b0dc81f9286e4b9b8c89cc3a34de3c51d1e2088c7463adcb8cc7d35";
+      sha256 = "f6a3d683b0b40f75ade047b3097c6ff7a82d32b7528776187c816f02c209693c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ia/firefox-101.0b9.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "42a882486fdd29a89220c3a2604873d338b9187d5545fac9da59929a4f865deb";
+      sha256 = "ca8913e3e1ef29fab4f55d8acca63a3dc4126df89297eba26244b130a9172ed4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/id/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/id/firefox-101.0b9.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "483885d63782b4dc2f6444438f5f4c4f291600a5ca669b2630c6ee5fccdd4382";
+      sha256 = "87eaa28653f77b8239df3c1b911431fc290e4ec8e604dbc5b0e4a40b0944ec4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/is/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/is/firefox-101.0b9.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "23c62d13ce11f8c5497ab32a80e0f6b49e56f711c9e42673baf37022e3feb364";
+      sha256 = "0bd3a38a5a9659d0565b829c7491ea8e369eb9fb01bc7c0b991a70a67221663b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/it/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/it/firefox-101.0b9.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "7a3006a99a20a54ad104389c7203bfd6c24b0aa53c02ca4d14a24e34503cf6a1";
+      sha256 = "901eb6195e9dba8ba44aea36358d7927b55c6356e21c705a1c6ad3f59a95818c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ja/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ja/firefox-101.0b9.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "05ca3af44e2d723edd2777c91714962459b889122dd669d72c91d83ecefded54";
+      sha256 = "1546b415c858ce0ce896154ac9b678dbfaacee18c5bfed3f6ac659f991acb25c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ka/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ka/firefox-101.0b9.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9979bd999157dcbca6b70ca967401b61c574ed3a6d2dd62d436692dbd26fa0b6";
+      sha256 = "f3b1f72309cd3839de8c15c57004822ad6f42c239a6f9df986746ef94c8a9c7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/kab/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/kab/firefox-101.0b9.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e2e5c9220501b8c481cc2c1a159b49b5adc243bdaad715afd7cf32aae89237c2";
+      sha256 = "43fc789b365928ec9f7bd8c2a5ae0b45b832d562a54147641051061bf2b2ce3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/kk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/kk/firefox-101.0b9.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "67a0794f7ff2206955d47a2af2f9eeeb0b308526348e86845ec9fcaaaeff9ede";
+      sha256 = "1b3f8ecc8789f013cbd49524b27d4517f8fb2ec00816160123b22db289d64725";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/km/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/km/firefox-101.0b9.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "79de967bb49baaf50633e11c03487b9f696eb924a6c2cb4ca776849c03709f71";
+      sha256 = "1a19b71b66ffd534d39860c959ed2c6f3aa96ca2a956dfa01cc1ed2b3a59435f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/kn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/kn/firefox-101.0b9.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "acf8833a43bbca67be2f7c883e8c9fd3b65b5e43f61e803a5ac188ca2724273a";
+      sha256 = "d1fb6768e2fabb7dfb6c747484492673d5b651e4da60dba98ee351cc9195cf40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ko/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ko/firefox-101.0b9.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "669aeb1fc430810d5347cb85df3e1f53240573c3b37c621c5ab9f384b2883f31";
+      sha256 = "dcd8e6b915509b12007e773cfdd23bd2c0cca78a6f83df7db6516bc6653bb1a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/lij/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/lij/firefox-101.0b9.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "1c29ba78ad9834ce598c31fc40999861556d91e3a43a3a39b8eef08eac59a8f4";
+      sha256 = "6c5adb927ea168706ec60b51d2f0876c85ddcf176c3d30a66c7de426e1a21b34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/lt/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/lt/firefox-101.0b9.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "caf5e72d891e001b5874cd9eb39359535d0e7a3e9e806bdf6c9bbc2ad5cb1543";
+      sha256 = "03404c37d32c8ff3862a50b7faa2eebd1943b89049cf2a3a00063de997a72431";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/lv/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/lv/firefox-101.0b9.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "48e2e31c5fe889be4ff3cbdf1bab671537ca66a55c59f63ae9f09a31f4222c9b";
+      sha256 = "cc7c783e1b96d3b031d0c11217f494231f12e4b818dba5566ebca7dee1a22d72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/mk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/mk/firefox-101.0b9.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "cb26ff5fd9f9b4dbda62b173459173a5d0d39fd4caada1877a1f9750080f239a";
+      sha256 = "51148c255b1bb434423021152770b004bc5df110946ae97cf1353fa3e067957d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/mr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/mr/firefox-101.0b9.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "d8c95476b496d42e876080d2809fb349442f159afd385bdaa0444ae776f2bfb5";
+      sha256 = "0a8d169ce3275d174c4a93d40ed6b297c5b9556a673da54a0b26b1aaece85fb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ms/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ms/firefox-101.0b9.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "3be2c35dc0d5cb98b616eb573d436326238ea0f03b6dbb5ec3c6e9f0b6d3f677";
+      sha256 = "c8297bf48a736289b45128949e0c6d6470f635bf7f3667021bbe2d5c69b16c4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/my/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/my/firefox-101.0b9.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "f24161a028dd225cc9e57636544fdf2fece02129e65388bf63bee752b23be712";
+      sha256 = "9f6007d047ac53edb7ad896605918204b2c560fe25b5cfa38900b9909e02c1de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/nb-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/nb-NO/firefox-101.0b9.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "1699b0cdfd96cef9193bbee9a461b3867783d93ca98974efec4e998ecd430847";
+      sha256 = "31b3293b2dfbba19e48a5dc02a8cb71ec7bdb616c0a23d775143b9601ba03b08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ne-NP/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ne-NP/firefox-101.0b9.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "c0d6ed8fa1ad7853adb10c83d6422fe2a41254522655d52e1ac4fbe88412996f";
+      sha256 = "790fba7bc871c59bf462011e123a555d278c41ea131c568df4cfd08d8533c037";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/nl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/nl/firefox-101.0b9.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "cfc70746d63c465066e924ac3740e5c0ab7d19dfade9d32698e9c3903dfb8bfc";
+      sha256 = "9cbf14615f35b0943648b6004c42ecaf1562e036d3b2f47b832a02ae4a485203";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/nn-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/nn-NO/firefox-101.0b9.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "700145c367d4177fabcbb183653498d4c3c0d23fa1686456f564912a62b1550c";
+      sha256 = "acd608b3305833014a53c51ace00859fd112fc54eca525fb98fff17f7f34d3ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/oc/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/oc/firefox-101.0b9.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a657ab1229f0f670d113efe6ee7f008544682f60ce936edbb4d68a2a81b60a8d";
+      sha256 = "dbf3610aa0413b7679ec5440551339684a9cd6b14cb3f04dcb3d64759351072b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/pa-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/pa-IN/firefox-101.0b9.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "a3641a38f87342e9511baf1866226da4875160c30b573893fa85eba644c5195a";
+      sha256 = "e40eba4bac0d2fb46f61834e77152807812685973a6a9f1ba657b94bab774469";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/pl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/pl/firefox-101.0b9.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "045ebe8f05147249b6516b412b1d1fbd9208f894e503000228a0e630c63f444f";
+      sha256 = "cb6e0e2fe62a2d719ca40ad3a9238eea8671015bf6b96098c5955a679dc21718";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/pt-BR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/pt-BR/firefox-101.0b9.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "23c50ecf3cf14217fa8c865f7ab1d7321c6815ff4c68c10630fef9d72904883e";
+      sha256 = "d6802045cd943260b4d270d1e7032d41ecca261d338b6e5eebacf66ba28d6322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/pt-PT/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/pt-PT/firefox-101.0b9.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "17c937a8afa36f4260ce6d3ea79a07b9119ba12b1710c43d27ff05538e6971a8";
+      sha256 = "63bc9d7b3c0bd4c42416f1f17fa0a19f9e0077a5138acd48031173bcd562ebca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/rm/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/rm/firefox-101.0b9.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "836195c4a54dd90d7a32c031114a56fa561d1c2e3b8f930227871e6325dc6262";
+      sha256 = "78073c1cbaad746f47e499d6c09242a526e68603715fc1e55ce5df4c3c43664e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ro/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ro/firefox-101.0b9.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "6c0c29c8b91013897b03866e242f9dd6a67c44440f1405c4b356dbb7a935a09a";
+      sha256 = "c0f50f7dc3748f991ff37b6573594b1f3eb304a8a2617261534d596aaf9fa5d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ru/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ru/firefox-101.0b9.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "73e15ebb5ceefe5d76ec3563378cb7c7704fb821fcf5b583fb709995a0efcb7e";
+      sha256 = "66c7933d2beccf62a31ad7ac70b30d7cd4f2d0ddd74fb2a891c552ebf7d01639";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/sco/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/sco/firefox-101.0b9.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "2f8ba8588f33fc783976617d662a29acbf41a78851dd781dfc26d7e0ac4d97e2";
+      sha256 = "99aab380a45efd711f3e5d0a8202bc0aa9b0c924344e39f9e8d09e9fc9076896";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/si/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/si/firefox-101.0b9.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "5fa2169531665633c3481c177490110cb6a9bd959172f0ae94b2e5a6475a1bd6";
+      sha256 = "7b64b790d4e33bcd671d3a7b54a1a27fee776f84a2e6db85f499e37a743ba3eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/sk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/sk/firefox-101.0b9.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "abeb0a6de0522a4e2aa47c8ce02b8c478a21165153fc3c6edda8642777cba266";
+      sha256 = "5f1a19fbcd96057b47b8954680b5951ca929b9da940b6c61d632c53b03987c8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/sl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/sl/firefox-101.0b9.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c0019a21096573635aae9f2b97c50557dc011b670f05f1fcf0779732e2f7dc92";
+      sha256 = "c25a3cd8f931671674387a92c7f066df519193aead18f42acfff4bb3e34dce4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/son/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/son/firefox-101.0b9.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ccd58c05db49f4e5295794c73248bb267bb87173aa7e0dcaa63cbe6593e9fc85";
+      sha256 = "7aa9c489b7b685a02b1156cbf659f673a6fbe9771b66faa89924e6b3d46880c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/sq/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/sq/firefox-101.0b9.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "5ff7791b6d9ff215e8e466b27902716a9de6018ee9ef0efd639579847178760f";
+      sha256 = "8ee95b2aece9bb308550b2523a45735b8d241ff99436baa1a0859b3f8e30c2bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/sr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/sr/firefox-101.0b9.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "709df8593b8257191313b456288de9952a9e6308a3663a21e40733b4eb3b7353";
+      sha256 = "793ddbe11e0cca9cd4b8c049c093664ea8c551b100aa195e986a7644b308b91d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/sv-SE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/sv-SE/firefox-101.0b9.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "ff25b85789453457aa9c035395bd5588c252804d5801d8e111a24e64d69e4d1d";
+      sha256 = "f9b650f593dc6830d40c7aac92db1e7d78f5675cef1048331ac431a5c4109113";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/szl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/szl/firefox-101.0b9.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "1da12d4d2046e953010fd5d064dfe468fd97e65f5003c8d746cb70479bd66187";
+      sha256 = "6f63629e32e82e2d7c64ef7882c27b2452561d6b6f78345751dfd3a3e7c669b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ta/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ta/firefox-101.0b9.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "494d240702bbcb9124d56c835ac4e3642e37bd873a5209ba9b99bcb338f40fda";
+      sha256 = "0c4b1886161fd3c6adee625edaa615dd06ba8b9c868aecfe00d530b08a74b637";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/te/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/te/firefox-101.0b9.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "acebd79510550d690adb1444e906dc82d9f38e86bd5a93e5e72f711d2d3e49f4";
+      sha256 = "0cd91eeb24cf2ef76bfeb27b12d449158817254a27372f0e55ebcee4d854aa72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/th/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/th/firefox-101.0b9.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "b6f90c5a89a8116c1049da7a3a34fb6d82114b261f978f0a2237dd32a10462bb";
+      sha256 = "65d5c828ed89099d90917b27510871fce6ac82f6ab7e8cc127847cda0746a0f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/tl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/tl/firefox-101.0b9.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "961afa78a723382ef7e4cb49cd0f32cca39dd921dbe8168a8e835bbb244ff4a1";
+      sha256 = "7ca34250aef8cbc80f3e18e623232210a39b7c0b6a2bc14aa16301b4838f19e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/tr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/tr/firefox-101.0b9.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "15efd87bb2654ebd7921b72e0653639c4a3da51af7bee06b284d9abd0e395c1a";
+      sha256 = "754fb7a838bf93962167e647bf7df93e7a5c0b89306356b2803d0273f1b96a5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/trs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/trs/firefox-101.0b9.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "78bffcf079bb4e9518fb7ae6deddf395837c16e5a942b66fdeef67c9137d950b";
+      sha256 = "9a2a6303cb55a53e91636090feb419242f4ab9451f40a8b9be4c86a13489a30d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/uk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/uk/firefox-101.0b9.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "08995e6b88aaa2af8dab0a95d27312f5e97df3ad7e1a6f0096b0803d835ef6c5";
+      sha256 = "5ac5d442b54fc53a6ecbfa9cd58c39afb54b679d3191f7610461d1f5879b9c43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/ur/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/ur/firefox-101.0b9.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8530f5bcb6bdcc1f5a3127d0ab6c94f19e4a28df2a6c4291c821aaf9c85f379a";
+      sha256 = "48f2cb5fa1cc6c2e1c8976a4471d21dbf98a3afeaa3a2f9b076a8a8cd4a95173";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/uz/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/uz/firefox-101.0b9.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "67c7aa4e6095f8073cb94339f63aef2eedf51e096985ca175e983bbca4089498";
+      sha256 = "def78f252455fc9ae075759dc7f078df3300bea26bc729ba66689cb3c93b9b86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/vi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/vi/firefox-101.0b9.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "14ee8e4ab854e5443f537fa05ca83befc679c5c78db4323c54dc85ed58702435";
+      sha256 = "2a32efcd688ac5484687a1bd4c9f15e4c3dc28dd923bf094c38081a1c4a794b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/xh/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/xh/firefox-101.0b9.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "ff4c8b2e0bc0a5231ba19bf058baaa7b455b2d8469f56ec97283d26539405641";
+      sha256 = "1fd1a8bdfa554fdf9e9aeb4b9d99f84acddc90aabe5ba516adc6fa497f55db01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/zh-CN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/zh-CN/firefox-101.0b9.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "0a9228bb1a0629351a62636db29ce428bfb1ed704222b66d1dd369e6fdb3d503";
+      sha256 = "af70a09341b9b9766d41dabfaa560f1b7db2964c1eb06aaa89cd89bc2a412134";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-x86_64/zh-TW/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-x86_64/zh-TW/firefox-101.0b9.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "42531087bef983024116ee5eb4d42197ddf6252c798944e7674648b76fdf57b8";
+      sha256 = "8e3c08489faada8281afe0dd48381843a987779bdb3e95749268fc30a195a2c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ach/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ach/firefox-101.0b9.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "15488bccadd886bea058313e062b811120f42978ab5d9f7ed05ccef88026bdf9";
+      sha256 = "2341d71374b8859eb3c75494dc56a200e9fe521de6d2ecfdbd5752a2dd51a3b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/af/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/af/firefox-101.0b9.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "7a8a204badfb379007c116d4e7476111d19e72928ae3ed8557b1a7de7535d4d3";
+      sha256 = "fa1874c00747fea84026057937a40c0254219c0be767e7704bc5c6809174717c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/an/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/an/firefox-101.0b9.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "4fdcb8886f89c586b1f58eee2300276536bc06d024aa9864a447235e74f5e31c";
+      sha256 = "aec0241d98ca3c9a7b01bbd78b747af64b1b6bcda83728f4a15931b2ee9d6577";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ar/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ar/firefox-101.0b9.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "dc621abab4c6e678e8910569b21fbb01c4ca54e0ca80b0585c5ae2124f199e8d";
+      sha256 = "9d739a0595c6c114c0d20a9d74c0b0b19ddba77b78d34abaae340fbdbf1a7c17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ast/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ast/firefox-101.0b9.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "afbe9810b9f326ee8b561acff2e2cb809793177daf00bd467bbfae245648fc56";
+      sha256 = "10ff7239d7c574386a33a0be0145e5cbf0db893a7e46a4a0e04e09fe08961dee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/az/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/az/firefox-101.0b9.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "806a98e46682d180348f772de1aacad415948e77845d00087d4717c40a4814cf";
+      sha256 = "323a1808075d2f9cd51a8d8f6be06211f1093c8d1ec63c4515bc2c03904e7923";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/be/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/be/firefox-101.0b9.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "ecaeb8a69b0c1a8330748e9db299bab7920c3f7f0e3825a35cc0ac6e06ee35a6";
+      sha256 = "ad6796736e7a07d0892b30a2dbb537a3329d3e968929261dfb814a4786ab95c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/bg/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/bg/firefox-101.0b9.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "cf499eb69e98f38eb211c1c962ea81a8617bf169b4e6309fe900f82ce38b8c45";
+      sha256 = "18ffe90d491bfbfa98128c3ba0067d6770d444e349e268293acb30eb26597c0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/bn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/bn/firefox-101.0b9.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "40d828000019191f9a5f45ac49eae01f66b3251326cdffdc395089bec2396f66";
+      sha256 = "555a9503aaab6cb7c6aca368063937f3076179d7b72e55cdde92ff68a6bf3125";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/br/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/br/firefox-101.0b9.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "8ea216bc32179311769ec3eb9e8fa25aac44f75502a9f6d9b20c3ac0c2f6c336";
+      sha256 = "e5b65fc5624c89c4e9210da90b1c7a89e76b7592c6bb0a726507e0edd4febb1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/bs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/bs/firefox-101.0b9.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "d85c1085e8dd29f69ee7a41bebcbc6ef85118423e1684026a47e71b2072d74b2";
+      sha256 = "4ee1dbccc10336aafa9218b5768904b823ec951690539df0316b3c85a014302b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ca-valencia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ca-valencia/firefox-101.0b9.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "ef80441301799de2d0043eaac8537a4e994e232666a315db4acfb3cbdfdd70d2";
+      sha256 = "6a842b5ff4537ca51c96dde356da8000d0cf44f832889ef14c51da55b4d8dc14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ca/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ca/firefox-101.0b9.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "f5888c5c06b29afc8314f7c4bd3201c511cd8fa07322f990d7f58978e5a9d31f";
+      sha256 = "5382dfc6913e69c6778534b19f59e2846bbf21facd92129238f51f01e162830c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/cak/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/cak/firefox-101.0b9.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "4ad994ecb37604cf9caa8035750325853fd9a87072439e17b2bd0cb4b6066634";
+      sha256 = "2758f30ed49f1a936d4f7bbb6dd7c5dd579515e7476535946f32dc9c0c82a054";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/cs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/cs/firefox-101.0b9.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "688096996df92cc3d070c43ceea6abebc8dec53d458fb3bcecda0a63bb048269";
+      sha256 = "bfa22b10ad0ab4bffb01172e2bf04c35a0e90ad960a30d48ab42270aa15d1a90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/cy/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/cy/firefox-101.0b9.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "c10ab338b8785a0937d6ace161c36f3c05a8016d5b3d7051155eb412985c71cc";
+      sha256 = "a89bfcae1941d7dc5a032ca2aefe378f40cda73c8e8d41461f707fa07feb71ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/da/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/da/firefox-101.0b9.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "04a25829cd6f56b5d05c0ccd2d26fd1e28838902388b8dd1fa2472eb84770360";
+      sha256 = "d77554be4873cece00669d97195440d648022b9f278bfa1732cf8626ea0b4e5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/de/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/de/firefox-101.0b9.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "ee5530c4477d8a0df77f4fec8112ce1f606aee109e97cbd37aca6ddf25c4f52c";
+      sha256 = "cf62aacf9e57fa0392391ebae982a31e90dfec65fdab21f52f38ccb00e5ade17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/dsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/dsb/firefox-101.0b9.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "0f85121b622f28c84bf76666dac0282528a1d380506f03ddd0944de7f2b07afd";
+      sha256 = "59a9522f26b26aed47d2bd6fbcd5fe3e9c9b1089571bfd2a0e07811e0998eba8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/el/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/el/firefox-101.0b9.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "99bdc3c28894fa8141e5e1cf9585717b91686ab0082a57b4d7aa43e8a6394505";
+      sha256 = "054d5eae5b1374c8298afc24f34082f7125d467cb5158f9d1b83c7a1fba51ca0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/en-CA/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/en-CA/firefox-101.0b9.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "5facba35ff29bee9609c94df4672df4375b7d20ea424b1b64e911bdeba5db26e";
+      sha256 = "5517dd83c75e1ed94c776c26d86c0f1d96834e722f734bdc6849b367a4437327";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/en-GB/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/en-GB/firefox-101.0b9.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "e2ffe099d47813c705422758e78ddccc97fe99673379b2a6115d9e298df32074";
+      sha256 = "43418924b152c85efa7b870e743b7e0e3604bad290c146d2b021e4f932c6e798";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/en-US/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/en-US/firefox-101.0b9.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "edd09800502881bb1a3e49042c0eb1c0618bf2a0507a38dca9dc4e3fb391dc97";
+      sha256 = "65a2906b98807e0a5fa7baf4e4d1c4f6f91e9f869d1d713ec120e30b3ce92df3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/eo/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/eo/firefox-101.0b9.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "678f340edfc6cfc8ca9b88032856119c0474f6944e8d67778e098100154f9a9d";
+      sha256 = "c879fc9e45a8ce6334c57fea38a1878e200c5725c1bdce4e6de454508c28a9a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/es-AR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/es-AR/firefox-101.0b9.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "2d2fc35fae3617bfa1ea2ac466211b64ce58b13fdcda8f301ad31f13f90d968b";
+      sha256 = "b1882a26a9eca96c0b78c9afd214afb3c20d5b1f232065bb73aadf949d533982";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/es-CL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/es-CL/firefox-101.0b9.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "df84c0a9ca7a896b02d83d13ffb238e90cf69926feb3c8e0d6edfca842f8defc";
+      sha256 = "085608b8ab5443c627ebda0d8df7ff37b512a6aa317f9ddb791c5526232db12c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/es-ES/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/es-ES/firefox-101.0b9.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1f87c85a46b57f99ae9bf98256fd115a15e1a86a4c9860cd3faa3c9bcc424806";
+      sha256 = "fc754e339dc0341e8a4c014dff510721559869fc2c8aa3d8c0e54232a10669af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/es-MX/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/es-MX/firefox-101.0b9.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "eb865eff70bd7042cd5e54e2251b9111b18d484fe1dea4d4ba57e7dc9ea2a5db";
+      sha256 = "28a2a3fa7867205adb118b83241d1c2dcad7be7639ecc488fa87035e6420ccf4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/et/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/et/firefox-101.0b9.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "beb51d1ea549633f09feaf220e96c3b0506c3b38baaa0772079b0f7efad2b281";
+      sha256 = "c5a1d9d3eeb4275694617a86138016c0512601b3a2be076089844129283964c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/eu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/eu/firefox-101.0b9.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "d7da5f728c7858e8773ceff7e30ca28f238af7aa618711de1286100512fa2378";
+      sha256 = "3a7bd404dc71dd70d6133022283aefac934e87f2a4f5edbd365af4420b347bc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/fa/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/fa/firefox-101.0b9.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "606190d0434108a4f8c2bf87629ca119339211856ec9fda619a0bc6c2bfc620c";
+      sha256 = "adaef725b8a555556292a01cc79945a8b1981c57a6663c18261c161e2961232b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ff/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ff/firefox-101.0b9.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "2b3a7038abaa4ba5ffbdc48eba4e6cd2c03bdf438f8ea9b70f15c1968bb59b80";
+      sha256 = "9d66e8567195df41dd25ae552f3800faeee9acb38be8f745402b3530cd2a6d21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/fi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/fi/firefox-101.0b9.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "a2025ddf884826afea3a16a87716398658bf55fb5ac5b647331f4f25166555ba";
+      sha256 = "d64e78e535bdcf02102a9608fe6ac9d55963cfa682cb13832f4d8bf0df28b4c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/fr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/fr/firefox-101.0b9.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "31adba6a0615ff23388686959327ee0e68812c4341bcf92878fb58a7c01712fa";
+      sha256 = "1fbf1d49cbcd8f2e3f883f82d6f755da654f7f97b571d84140f8433c39325900";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/fy-NL/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/fy-NL/firefox-101.0b9.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "8f691e303e2d1fe5e7548184d1186f4d4a811b65cbbe6e839243a12ecef8eced";
+      sha256 = "c5ff61b1e1a085cabff4f6a4a8b7f39f151f0bb78dcddd8a673b50c8986cb82f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ga-IE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ga-IE/firefox-101.0b9.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "e8a4903ceb272389a7e1461693a7e6727990432ba4a6d5c98898af5475e6d164";
+      sha256 = "268d2467317b9b626bdf275ad97d066882a229f866b52fcf5a19d17fb0e747e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/gd/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/gd/firefox-101.0b9.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "bf6f72c6a2ecf977dc2b14be911c13f59951dea4a4d6c40cd16afd38ffc63553";
+      sha256 = "982c2d1cfeb71792eb3a46e2382f967df373ddb5abda16fb0c6137fd337fdf57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/gl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/gl/firefox-101.0b9.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "af31f670691de33b3943d5a1e9f12b9b64fe53d25ef45eb44cdc44430208c201";
+      sha256 = "f622030a837dc78ced46adabde1b5af2ab5925fa208b9f1fa5bd44844410b85e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/gn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/gn/firefox-101.0b9.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "f1a554806a9f51f8c4892eb23c65aa53f96390ca7e5e032f2c96cb26f9deb077";
+      sha256 = "bc151f4b0632614bc42fa0b3be28e0750fcb8b593805c5c2b3471fefc92c424d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/gu-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/gu-IN/firefox-101.0b9.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "2686a4fea05aee55741ef0333c916d4be8c5573f6e7e80b587a8d2bce3c2dacc";
+      sha256 = "fbbf415fee3292a26ebec8ca2998a3c5dee78794082af0c37c2a89911286f9ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/he/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/he/firefox-101.0b9.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "f4c18f2cc00f93636db310f9d9279d43bea6ef193aa693c7761ff1066e9b46fc";
+      sha256 = "f0d6666370769f995049b9374a7ccb3411c278ffbc0852414b523d7a6d76d327";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/hi-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/hi-IN/firefox-101.0b9.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "8a2646bcd741965d8a6835ca8d38dfbe66b607c87d9cd3b32b861dabc5e7b916";
+      sha256 = "fc6f9e8d51f081ee80e1f0d23cdc6588e524501fa848e31155d3fbc203404370";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/hr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/hr/firefox-101.0b9.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "46b59ab47cc8fb194c6f5f20a1ccc2f2fb963f2c3944e91aeabdb829c1e3d483";
+      sha256 = "998dab22f5f8bd1ead669a9f4b023d78017ab42a155e31f0cc303ab9ab575739";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/hsb/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/hsb/firefox-101.0b9.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "f4bac6b25259c55d7892477dfe7bde36d09ee85399096eebfcb3a0c5bba54d1c";
+      sha256 = "0ecb7490da9b5585214864988ee435165e1edc20ddbe9da0a8d2e92b573188e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/hu/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/hu/firefox-101.0b9.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "d14bc01ca1936e05f9f58a6516f1af98029d71e41f6cac7aeb6055c3a25455b8";
+      sha256 = "06583503232b0b7b73f028410f741b3566d2d184100c3479bd03fb409da4c132";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/hy-AM/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/hy-AM/firefox-101.0b9.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "90f4b0aa50a353109ce313543abee0606c4155a2610105ef9537319e3bf9f137";
+      sha256 = "3c9b2ad5dfd3c61b868449f901ff58944a619a119e37f0d987c7fcd66f3b2514";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ia/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ia/firefox-101.0b9.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "384c3a0db8fe5448c17815d5ecab4e18ab25ec4ae75319b4b0075741d285fc4a";
+      sha256 = "cc0be3022aa6ee824b3ee6cdf5a9517bc9205aa237e3559f0c933789aec0dfe7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/id/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/id/firefox-101.0b9.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "c8067e2bbe42bc9b639098e463f69c53475d949ce883dc2f108a80d62424c0f5";
+      sha256 = "aac16ad0d7e1972d087bad5bcc2669e2a293e5599ef49501452a9757b59bb931";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/is/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/is/firefox-101.0b9.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "33b049fb59684b094b919646994c446c29d4d3c533ef97ed5c592b86b621ca2e";
+      sha256 = "98c58a4b6a1f78ae875c88bc56043341c8c2e6c55c504111e7dc69b180d75c59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/it/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/it/firefox-101.0b9.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "1f3e0d9fc78f51946f2d35ca6ab977f53fd58ad0f80412dbba23fe97c9b8bb0c";
+      sha256 = "a18c972f87d00838d845d26afd98f1552d997e35a2f21caf5baa123e8b378be5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ja/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ja/firefox-101.0b9.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "41fd54681fa8ff564fbc202cef68cf4f63b44764dca8090386eef4f0d7395de8";
+      sha256 = "8bde7abe3175f378605cdbbe642b9f22c0da6a8b527297c44017e50a154eacd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ka/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ka/firefox-101.0b9.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "a46ee22485e1a51c0a955a66a388a4afcad842ba162fdfa4ccf8826fab26cc55";
+      sha256 = "0c48bb947c061665973f9174a6654ab7c84947c00d0e1dcba30a55355c9d802f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/kab/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/kab/firefox-101.0b9.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "33192258d78d383eebcd465bf333d3a59b92dcd87fce6dca72bbe59fd10ffc4f";
+      sha256 = "e0a1bfab26d0e5a85643196e611fc0d36292b8921480eed197a0ec81f3fb781f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/kk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/kk/firefox-101.0b9.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "90bb4cab46a5827bc2e9abbcc79952f033b132fae628fb0f9697a55c69b9e049";
+      sha256 = "3ab50e337956a85f3eed1efbfa1aceb352c01af35b9b6eab8e9802a7e968a27a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/km/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/km/firefox-101.0b9.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "0b70f38800d315af8377a8a7db8f1769b559ba06f92fc90bea3ef9c07dcda86e";
+      sha256 = "b3fe2a4ac6efb397d40914c99eafb21cbcb7f5c0eb01865a1584eac2a701683e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/kn/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/kn/firefox-101.0b9.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "dcb383343a002dec453abe185c02735d52e0f579e940104af9311b701a4a1d81";
+      sha256 = "82851a784b06360af3703076a4bafe0332920db5d30a3e77e511aab16dee4304";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ko/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ko/firefox-101.0b9.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a60f64fcb7fe7456ce76f696bc17e1bfb6c2a3997ff79e090ed49735c6443a44";
+      sha256 = "be15acf337f72f52a5536efd10956ee7a212d0148c4a2eb305932032e1966cf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/lij/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/lij/firefox-101.0b9.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "a2dcd9632c637a52695a0d2aa085c329a7ecd19443bbba27c232839f9b64ed6a";
+      sha256 = "ec94ff3d26a6de292bac97af985f966c2c1864c05ac3050491f5a1e19859cf3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/lt/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/lt/firefox-101.0b9.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "c6113f95e4c8387b9de8373838fd08638c25438995f27380f30e2e22bb211877";
+      sha256 = "cb6139fb6bc1f393832b78fedaf43e1c86b2fc704221f1fba4dcbb9e70e04ab5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/lv/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/lv/firefox-101.0b9.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "302a146408cd24bd215ab2a1ada0b6306e30e549663f9ab85cdce528a79eb088";
+      sha256 = "994a7e0e7b425f41024a4aee7603c4c241ff6e89f27c1c7d92907df9c054744d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/mk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/mk/firefox-101.0b9.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "72288455347b225f2e773df5bfc82d51709b493a2f7aa46b78da0b5fb4d89b35";
+      sha256 = "8aa4f6d76f7187713fd34482d280a94115abdc24a566ec0a1d05d09972fe680a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/mr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/mr/firefox-101.0b9.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "f67ebc75fcebc1ef25ab6838ff34a27395d3babed0e08014c47b213a4724b9d7";
+      sha256 = "43ddf0bff2404b97fe87c8fa66362a653ddc69475e272cfbb5766c9294e930d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ms/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ms/firefox-101.0b9.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "612625f0ef927d42b9ab526c10f67c443d60bf0714f57570eb76ce97f84c2f4e";
+      sha256 = "f9e79a74fb263b27c3360a1e51e94fe9c554a02fc039f707a4ec861b779a6b2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/my/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/my/firefox-101.0b9.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "b3bc2ffb890f6ae3316be0cf7a987b186268cca8d9df4cd1ee6f390e689f1148";
+      sha256 = "516308b634800aed937c47723039e11700a39b81be661a1072fd19303d880aaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/nb-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/nb-NO/firefox-101.0b9.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "0751f4007a434ad1241459e13841f66c32664b1c2eba53fe936c559acb609a36";
+      sha256 = "3003668aed8415cbc7a3f27c2a08a7cf13b7093d74c0d0a1134c368f48c3dc9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ne-NP/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ne-NP/firefox-101.0b9.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "72e278fbb6e073166de952f70c9542e5de2fbda9615205a5ca8e4abfcaf2a199";
+      sha256 = "07d23009316018189a0d25f5d42bbb5e6d4fdd353f7e83f0310d5a0fdba9a6ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/nl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/nl/firefox-101.0b9.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "5fc45ef4391c93b081e5690d9c759547e47bfba389bb6143c5f00353a18cf22e";
+      sha256 = "8f6eba3559269aaa6c96cda529cb20284d19c50db4f663c5f2386e3af711353d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/nn-NO/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/nn-NO/firefox-101.0b9.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "1d7182f883569941f4a7c2e7445f5b2f39f2b9ace02b42c7f4c18108539c2778";
+      sha256 = "e0a3920c73b5b9ca5d67faeb0df7e52155ff76a196e24c6539face7b16f3687f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/oc/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/oc/firefox-101.0b9.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "5a9100e569886a334cd5f6518f279a537482fa0a32ae0e663ddb3afc47b3f405";
+      sha256 = "13d2aa642d28cd3be64d13f9ba15eed52779906a780ad288863bb17f651809dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/pa-IN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/pa-IN/firefox-101.0b9.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "fd310dab3a60759d98059ed81cf6c2cbf9a422ec9b56a590ce774e1a5377576c";
+      sha256 = "f1b3719e423828eed2bb6d5fc4e0d2a1b1c9f491cc511cb799b742ea2c1e0fd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/pl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/pl/firefox-101.0b9.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "79a8d53d9143d9208af8f63c96385b94a2b4ff2bcad40bfbc8250d792b1b3688";
+      sha256 = "f33a9e8473786d0edd9436e59320f015992e5ffc2c14a94f3e975af94b6e4b7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/pt-BR/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/pt-BR/firefox-101.0b9.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "bbd6b280549cc9b446346e5a3bb3bf7d091782c6b17d27e22767cb5056bfa789";
+      sha256 = "6ce5d183b5559351fb03f8cfbfee1c3f7633c316acad0c3ecd1384195df66653";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/pt-PT/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/pt-PT/firefox-101.0b9.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "7b246df8ad2f65bf29d97dab9d8f78a66fd7f5287820d4db21ca284b82ebf939";
+      sha256 = "0c2a4dc6e857d852c6bcb2377815709bba08486fb1d0049eb35009fa0747bf1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/rm/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/rm/firefox-101.0b9.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "a721ab8316ad1a3dd12407a2b68986dbbf32632b40c1151640dedae9ad7815c9";
+      sha256 = "b69f2aaf1570551ad54f917cdfc1211bc5d69d272424de5f5f5cf345ce70f542";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ro/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ro/firefox-101.0b9.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "66d9d112528b9b6f01cde01d7a251c28821e30b435316f5bc0afaaf9436052af";
+      sha256 = "c513e2f949089afa5ce25cb8ac28cf10700c94ec7af6430b75ca954685c2bc27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ru/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ru/firefox-101.0b9.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "a7de24d79cf333da45b474d8ef9eb5b5034f18eb79b8d8590cd5f39c7d5de130";
+      sha256 = "7fe916f0299a0fdc8a7199066996f593ad364d4c4defd7e022fd22b5291d6506";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/sco/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/sco/firefox-101.0b9.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "9d8754c1a5e2c4f22d1ff5cfbd39f5092840e9910f58f0468fcdf8df4306639d";
+      sha256 = "2737424b3e5d170b368731842b6e3f7582e8f151bfbaafd741d594d4a59805af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/si/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/si/firefox-101.0b9.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "9dec327ac9b519dad9d61cfbebdff117f61f3a44715379ddd1db38891a13346a";
+      sha256 = "18e6cd6c5bbc22108df818c294764dd4f5ce9181206faed40508b223803f75d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/sk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/sk/firefox-101.0b9.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "8b8a8278d15d848361a854f898c021e2ba875da54921cb5c5aef260929134b11";
+      sha256 = "f15cb6651f34728e419d3db98d206220cb098c5156b64024ff27c9dd1a4cdac4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/sl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/sl/firefox-101.0b9.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "f605f1d0e94e3ebda1491efde196bdf33c35ec6c34703a6d5559afbc47dc4c17";
+      sha256 = "5262f936643a798c42c9ea4e7d9929f9989b9d0e1407690369ab7efa0def8d42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/son/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/son/firefox-101.0b9.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "7d0b0338f9ed0dd5e214199cc4eb10624d07078beb9945281f01721a829dbf9a";
+      sha256 = "dba232f97f7281d7db69d9af1cc7e00477ac3307b4c1c1e38b736b49738dd5b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/sq/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/sq/firefox-101.0b9.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "546c338eb2cb4d185e597f0ab94186856ddcad7a7725837e9f0d3b6460363242";
+      sha256 = "7feecfc1ad5c93dd9f1a16a34d6bdf1f82a2edf11036d358782a7b2df8c95cc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/sr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/sr/firefox-101.0b9.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "851482b831381a8fee93e7f2bf627675d6a0a39b6024b613c319e28341211bff";
+      sha256 = "447b1722eccc890b187f343dbca7ac54aea9d990d28a3fa521b481f39c27c145";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/sv-SE/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/sv-SE/firefox-101.0b9.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "5116d06eee5bfe3d906ce833ad5ee6ec01df739ede6d2a0bb742964f5142b695";
+      sha256 = "afc8450e122ccd3556d7cb8141e37e6d64e4298846b9f901704d53fb21bc2ed4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/szl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/szl/firefox-101.0b9.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "503a4fedd181a8fa1b5ce578a6e950d7c8e8c9d641a04bac617a4d5505c54802";
+      sha256 = "32e8e492fa65c19d413b154b67b1c16c01abd8f533226ffc0cc8e457bc11667b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ta/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ta/firefox-101.0b9.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "8291466aba0e6bc86665a605e81e01ab2fdc3e94310f90284319a585a7688d1b";
+      sha256 = "1fce4f6137f83861636405651c6dbb3cd65efa2b21d2c897f5518906e285a768";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/te/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/te/firefox-101.0b9.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "6d5e52745638471ace3790e1d162f3eec0814f7f38e49e3041cdbdde84c14ebb";
+      sha256 = "4d0468b9131cdbf27747165731d3155af2d9dee306c3091832b75d9d4ef486cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/th/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/th/firefox-101.0b9.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "1983264e9e0681edfbfb1425a24af506b9c451bb2947d153aeab4d421a2dad94";
+      sha256 = "e2961e8403dee552e4229560f94880739b929b586935728aef470d432a327c1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/tl/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/tl/firefox-101.0b9.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "42b44c25ad8c5e7f69f4500411d41575a44efb943fb62da5c2a0844a79f1bbec";
+      sha256 = "1fca14fd54605caa8cbdef36a30cb6f86e9814e420d6ca6f181930621cbce0b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/tr/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/tr/firefox-101.0b9.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "68e01ef5fe17667548b218b1b69b7ad9b9017647b5695623e6ab6b2ee7e704a1";
+      sha256 = "d3aca0838f9cad9d89a64a1931c3eed797e18dc92d2a55c7492a0915a2c225bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/trs/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/trs/firefox-101.0b9.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "29adf4bc2783130d5b64edd8ea812000748938538b90f47e1f9ec704cf183752";
+      sha256 = "d9a12fa029eacae9f8da979123d45aad8b5bfa266c242522b7afa63a060ab337";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/uk/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/uk/firefox-101.0b9.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "6953e34511ccb537fbbf2a6cca6369c2f8252e3025dc459bb809ffd44f602ea1";
+      sha256 = "c15733c5a391ca5248626fff6eab633ae556d828f10395633ede013bc066a6a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/ur/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/ur/firefox-101.0b9.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "6479f088e60bc401346ba93be6711d83f42e113c3cd9c71e02fe72e2fee18d2b";
+      sha256 = "e30a0d3dab7355a3f96aaa7a648fab419cb8f92d9cc119d6b3d4b70e7ae7d179";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/uz/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/uz/firefox-101.0b9.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "99217c54b034c995203bcb290b6b07ddcf8dfe3f0d4f67876656e5930a813e75";
+      sha256 = "c4cda21f12e63e51b2a58229a5102c4747706296ddd2df64c1e5682c2e3a1674";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/vi/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/vi/firefox-101.0b9.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "0b714adab63f4551e2837b6fe439f1193d2c097cccd0d938e6ee069bf6273cf3";
+      sha256 = "4886b762811649fe9c0ee970e48cd7fb58c9e9afa8ce24f8b071b74232be93c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/xh/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/xh/firefox-101.0b9.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "f15315fdc1e03b0bb2f834240f35a695b3f1173494b2ee1eaa36d7b154fcca4e";
+      sha256 = "95f75a06bf14c603d41728892fe7cd942f36083134469125c64e3c4a61e5fbd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/zh-CN/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/zh-CN/firefox-101.0b9.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "a959f20cea8596ef0447f0823056a6e500fdc6d38fe9bdbea06fdbb8ebe93973";
+      sha256 = "86990983cb6143b8da7a88291964cd89d232d64b8b808c7e3e9dd41817b59460";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0b6/linux-i686/zh-TW/firefox-99.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/101.0b9/linux-i686/zh-TW/firefox-101.0b9.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "e2c8da8c23fbb7817ef215c035042d04f6a2a0705de9924c66c80759deb67e1c";
+      sha256 = "a855bead500cdfbd85386f63a98fcf7f13c7f457291d1b913c5b2083dcff2759";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "101.0b6";
+  version = "101.0b9";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ach/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ach/firefox-101.0b9.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "35ea1c2469983f97091d61dca34bfc24525ff8d33a91e840a0cd2b41445b9270";
+      sha256 = "51b1754ae3d864c9f535938163287a4b40e9274493b5740119a2ee8e29860aa8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/af/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/af/firefox-101.0b9.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "0eae6ca2ba7acb54aa2d9f1da6fb5a6c0e37de1f81ae3d4249d471b05d3e4784";
+      sha256 = "e29565c3caab8f9f16a07059bccacb6d64cd656e69f2ef14e3b7380e358427c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/an/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/an/firefox-101.0b9.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "8fd96e0261251b84eb4bf05c82d6a53a58ceb09fe6633b5c15694d6429241d50";
+      sha256 = "6acfa2c566be141ed7372d55654c1be2346a4cbb84fbf36eb9b21d3727d728e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ar/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ar/firefox-101.0b9.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "0821a5ebceff38fa9a56f57730fe5b88e9ef69f3b9ac254c3c2e6a7d663ca149";
+      sha256 = "b249ceea6a6ad19505d243c9e018cb8c21d35b949c1b01b04c75fce4b874f5f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ast/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ast/firefox-101.0b9.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "27a18fbb0f56f4b870434c2dd1be3f1aaa7d737f5fbd360da7fc38c4646a8872";
+      sha256 = "da027d237755963910a8d361c27213cf3cca1c9211d0c58b9a4c46a4fd0b29a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/az/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/az/firefox-101.0b9.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "36d73756079af0989974043310a81d260adb4cd4bc9804876988a2e713590da3";
+      sha256 = "7bda9277819b76215c0e938042d6e5398aab3d22ec5e4cff1746436ddb097139";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/be/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/be/firefox-101.0b9.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "10093c2bf9ab674fea1805653b6a1dc011435490b4cd421674a8098b44748d9b";
+      sha256 = "3d9cddaa1b83001014f7c0021eb48d66331b5bee91bfbad6eded5072248c4505";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/bg/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/bg/firefox-101.0b9.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b3d5674d5a761daa2ec957fce0a3fd96d596bb6797884ab6d8445b456e204fc9";
+      sha256 = "8c6cd54c990c289cb77e1b1eea59f1ce37331d374f2ef19360075fdd21ea3a04";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/bn/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/bn/firefox-101.0b9.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "b8f4890b18a89f9d974d617bafd4dd842b73491ccfad5ada8e92da203ba84dcd";
+      sha256 = "53d52004c3307582e1ae1607363a6c92e8ecd1910a61211d3721ddb7126db0d4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/br/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/br/firefox-101.0b9.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "70dd3b8b95955a4fa63b6a00216388378c72a52c89c8b95deea7911341c9c691";
+      sha256 = "80a9e8a8bc216c931880320cc19f854965accd27e49a44a38f1fa5101899def8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/bs/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/bs/firefox-101.0b9.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "ccaa40ec92084ea45b74d4578ae1d0e22e8769c66643fe6fea6933861f90e631";
+      sha256 = "beb82789240aa1b560ac3480536335d50697ee06307a69c5ff9b2daf224b849d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ca-valencia/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ca-valencia/firefox-101.0b9.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "08a4ee92be6f0096b0e8f39ec382704bc98441d04a6d822d2f9b1ad15d0570a2";
+      sha256 = "9d10b6ce6dfbf123389210d7ed61b2929b7b4721d99f3cf653003ea5e13f40a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ca/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ca/firefox-101.0b9.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "e7547a427aa19a33ad4d60af5a9de21862bf547f36e8846e49f8404a2d12d6f8";
+      sha256 = "ea34e445d4e59e3df3df71af13b40e659a53208c540090d8580662209d2d6685";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/cak/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/cak/firefox-101.0b9.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "dd3634a402aaa7617d0733a91826b581cac2dcc76a6f93d0cc13f808d5edebd7";
+      sha256 = "ad350d6511f8ef95c9487aa9899e33e99fefd9e3ed99530701bb7ef4c0b27a15";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/cs/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/cs/firefox-101.0b9.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "5826dda236e1feff127b5b34fa9dbba766ba52af202107aebcb6473b71ccc5e9";
+      sha256 = "0cf08cbbdc86d7f6762fd734b44bb66ef27a7d9ec98bb7f9c0b770dd16e9493b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/cy/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/cy/firefox-101.0b9.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "55038dbea8f9d287c97eff976694bed3d80d89b85e77aa29a9d0ea086aa3a0ed";
+      sha256 = "c5c6047e3345af863d05d929ac98b6f4f7e4dc04a949d3f942010009da45228f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/da/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/da/firefox-101.0b9.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "f0299f3f49ab789f436b388343787009876f1f5a970068d9433ec1f3c838f2ff";
+      sha256 = "3f4f43a2eec19c2523c4adfc02ec10bd10687a7613c3482107f6ad8be1be1a06";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/de/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/de/firefox-101.0b9.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "eae102610ba1574e20c1b2c567e88c583246ada29113a28de9af775faab7ecb7";
+      sha256 = "b490052b41cbd11c48e1c4e61263cc7200996e4cad3a6302c36986f14d6e7e7e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/dsb/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/dsb/firefox-101.0b9.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "fd3a8b2579d93ef8628b74b606c9c7374799484ea92e9ef340f3ad48bcdd6ebe";
+      sha256 = "2fd7e45b4af689addcb1434f5c0e00703b54e2e35ed7ce266d948ed4a3439cca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/el/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/el/firefox-101.0b9.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "6dd99da93bce6beaad1e6576c9821f0b7a307a12cfc4d1df1e180fe43901e1cc";
+      sha256 = "656f3d9feb45b1925d38eac50bb15be1c5af266431a19343f57c485a845112d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/en-CA/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/en-CA/firefox-101.0b9.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "51ffb0b22b973cd83233db9dc6504eee85e2cb8d855bbc981a65ad57400063e3";
+      sha256 = "3e2d42955700bebe09f2db19f96475b6d257ac007a10ca22dbcd8e2bf7a8ba80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/en-GB/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/en-GB/firefox-101.0b9.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "1008a4f5e4043f0e7ac004d5ab9b0848a32a9b9af61f9e29ab528da769059650";
+      sha256 = "1283522310cf6b80d31f9877f27b2129fba243f0bcc5363de259d42d836ea515";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/en-US/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/en-US/firefox-101.0b9.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "feaf2e2a3ec7395fc8c499535baab87b4fcb55947c1a5027bd0160180442dff7";
+      sha256 = "f63b448c20fe3acb759e635cfffb91263a30c60262273f0f096bad4714197e86";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/eo/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/eo/firefox-101.0b9.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0f7cae5594e67097e0fce15a684de6bf47d5f778f294e5c8fbd380450a7737fe";
+      sha256 = "faf800699f24cee014b9557b5277d18f162eede9e9cf9909dfcdc2d1e81457ca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-AR/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/es-AR/firefox-101.0b9.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "f5d3e13d762e4ae984f368a1a0b4abff423f350431d5e5d4e3844d6a6994f155";
+      sha256 = "16c90172eaef02ede80768af15a224d1d5eb152d814767ce5dddcf3b356c4eb8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-CL/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/es-CL/firefox-101.0b9.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "a45550be772a3e17a7f658305685017da70453df865bf0088705f9700ead21ef";
+      sha256 = "8c09f45e8e2d1f312af0db99b906c5ca4a7559ec5f752d574b4c2bf5065064d8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-ES/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/es-ES/firefox-101.0b9.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "868957d9cf2ef87b5595cbcf3611c1b395f5024f98d1fc0b1bb6a9b0151059c9";
+      sha256 = "d6186d9e5f6092e2d838bafb63b07cf2e149a7d7b08e81c7c60e189dbfac3bb4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/es-MX/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/es-MX/firefox-101.0b9.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "1da2c98d69b20547497e9ad235225171ffdc05581222e27963ac88b5a9b11e36";
+      sha256 = "04e29557a075140f8eb29c26bd5b0dc950c1451ce7cc4f3877ad2a68432f2199";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/et/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/et/firefox-101.0b9.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "0e99f6f8cf19233f8c4810869b002b580d7d4ec4d273abcea3d2656ffeb656f9";
+      sha256 = "e4094095142e0e620abf7874bf2744594aad4e7a4ead4b21b2670973260267bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/eu/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/eu/firefox-101.0b9.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "9b7d0583120b35f24f9db76dca1e4fb3409ee8fc9cf67282257d8378efd1780d";
+      sha256 = "37bc71769f33b3878c26cd3401c285ac5378bae1c9ca96ebc59b0c74b62646f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fa/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/fa/firefox-101.0b9.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "9afb28fcaec8be5ccc2a4e4bff9ff332706a01f8413b92c02bb2fcb0df1f56f9";
+      sha256 = "7ed72ea62c701451e0b4ca0112fbe7f66f0ef1d3c9abbcd9538dc4028badaf71";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ff/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ff/firefox-101.0b9.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "c34208d25830c2cd107acb7c41369bf64944e54c2099788c39522734d19d3ce1";
+      sha256 = "a35db256a2ac71844ee7c5cba868aff9452c1f7fbb6f0a6812c325781d0e1926";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fi/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/fi/firefox-101.0b9.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "9b6a577f06f1da58ddd4c9b618907a08477630f50ee05dcb7151116e70e0138c";
+      sha256 = "9b4dcbeea88282095390a0ee9cb85b725a1b4c56bb6fdfa426871ab89508a5b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/fr/firefox-101.0b9.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "85b7b57c27bfe9dd40bfb51425f1c601253713b3287f339150129adc0ae874e0";
+      sha256 = "b5c650f4b60a505a31f0ae75fe123bfb9ec81af632ad8faa3f6fc4782a077867";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/fy-NL/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/fy-NL/firefox-101.0b9.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "be51352afd27cb224428b3b659cc469aa735fdcbd27bdb0922c08defe5d3f8c5";
+      sha256 = "58d10008c70293b2704a5e99a364c614febe6ad7a62d647d0953cceaa0ee16e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ga-IE/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ga-IE/firefox-101.0b9.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "0ce7dd080035623e151a3f89c17a705f3565c92a8d361808b64efdba4ca2ec9f";
+      sha256 = "825a2048b6d8163f30e110dfcb72bd73eb259d9958d185d1bd3f80330597148f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gd/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/gd/firefox-101.0b9.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "72c61136484c5fc07bbd8571a2d1bf9adda5debc09b3b2a80073b6417e43eadd";
+      sha256 = "02e1e2921c383a7803df028507e4e87366f62d044e5c5097ae9dd56c28ccfa90";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/gl/firefox-101.0b9.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "167be0a528fe6185f5c656efbda8b6cb2cd107a83a21de8749490c285c168c90";
+      sha256 = "518ed85359766042e332aea5752851d40dc77c47a1af77b4d4606c63713af17e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gn/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/gn/firefox-101.0b9.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "0558cf95eb7b071307333123bdcdb0a4a76557f64c267cbfa1e8c24de2679a75";
+      sha256 = "df5de0bbbef549d67a23c467f68dd81c236e66f40bb3c9bee116e71d38adbc1c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/gu-IN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/gu-IN/firefox-101.0b9.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "a0fef36b0034e4dfec26b3e34ca532447e4b19da38fc66d015744a813a0ba4fd";
+      sha256 = "0093b50851bca18b15773cc36737a2543832cf046f58bf4ba2746c461151ab1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/he/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/he/firefox-101.0b9.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b77302bc16b7eb804d696cf1748e8fab2f9512b40f63a3d6a14d2fcbebeaf966";
+      sha256 = "15b18fe81d4cfd04a8a537e6d5a86e8d21d8f169d82e5b29a46beb4f96ac53f4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hi-IN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/hi-IN/firefox-101.0b9.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "0f5820f233ca1ef094e84780c9c44456709682993f556bcb83885d0eb0513164";
+      sha256 = "aee1cbcfebdafe9c71b12889a5c55abd9637152d2d00d45be7422e073f7ad616";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/hr/firefox-101.0b9.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "dcf756c4a06764a858922a6edd32d6f3c587f94db8478cf71c057572df913b4c";
+      sha256 = "4072b4a0b9df99a1cb2432e2099cef01a239974c98bbc6075bcd2ab72752e40c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hsb/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/hsb/firefox-101.0b9.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "d502a44237b683d57f8c999373a22a2f5897b4a77fb9921926a51ab8071c41e4";
+      sha256 = "1c40dcddf098d970be57d58f5a3f5b5439c66d3a99201156f4af2c7a45708215";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hu/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/hu/firefox-101.0b9.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4fadefa0133dcb1f762b7f7a3c9a0e5b13a3fd7f9eb7c9ee70910523f6ca27dd";
+      sha256 = "761d54bb685a6ed144bcdc2caeeab6bd044c770856cb35e166f27ad4b03b6aab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/hy-AM/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/hy-AM/firefox-101.0b9.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "62a3c25ebe7e6f39b51743c8c4818552aba4aa2f2e0c0be908f48910a56f8550";
+      sha256 = "0935ff231fb52e149944448a76a30cb5de9105748901a5b942de6f672db9ef1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ia/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ia/firefox-101.0b9.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "3f047d50f4a4143ebe31984a6f3881be30af675541b42021dd0732c0a0c01f8a";
+      sha256 = "137c25267b7f3ea080cab852ad4852d1bafa19b01af67d4fc1031e857c924ac5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/id/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/id/firefox-101.0b9.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "de6cfbaeda8bd3c149ad14f06f9a6a2c26f81fd13bec07e24664da4c956509c2";
+      sha256 = "52c10e10f7c09c1da9de02da8c82fe7b971a94fbcb7f4ab216c6d1a75e33668d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/is/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/is/firefox-101.0b9.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "b18fcb0783152f156db7491a80005e51ce0c70afac2810a4c2e48a21548b65f1";
+      sha256 = "8688168ea4e7099caf7141c815b3a6470080a2a2976b86f4415b1f56d3940fa7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/it/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/it/firefox-101.0b9.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "9a5134b2b676acd9eaf8fe2288d9128d1c8df1db74e0a5b11bdd5ec7c85214ac";
+      sha256 = "5fa83bac7df59ba6f7be8c7321d67c7d1c64cf246d52abc2a3b7dd81c9347fcd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ja/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ja/firefox-101.0b9.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3ce0ce5d43ddbf6af0561d468a1c292e2b6bb20c3dea8501c4214b800ceacfab";
+      sha256 = "4f6d06374574fe242145f0ea84dc7b4430463083786b509a6835245b1a071bfe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ka/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ka/firefox-101.0b9.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "e360403486f3ad3a889b9cd3e0a69424887fe2bba7b700a29a904ac078ae9e27";
+      sha256 = "1aa8571648641b73d82a5e9da04f6b62230fd43be951e788b8d5d88226cc5f51";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/kab/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/kab/firefox-101.0b9.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "dcefe66625c3359e93e6c844eabf5ba509b28e70f84a0ac65083fc2fded88d9c";
+      sha256 = "213bb6fa88425de0df3ade49ffe84a562cfa02d38e367662659b4828036fc094";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/kk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/kk/firefox-101.0b9.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "4fd5d16eeae79fef7365d6e42979b7b3ab409a85dbc6f08797f04c29a6ad8917";
+      sha256 = "38deb01d3c044ecdba59639e5c50549c55acf88a48774ab665714bb12cfa908a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/km/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/km/firefox-101.0b9.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "f204b64d5601cd3e469741070bfb18596968bfdbd881818f5dc27e961f940f41";
+      sha256 = "a28cac2089e9d4605670df2b55993f4519b15a2a94e98a09d867f9e6e682e3b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/kn/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/kn/firefox-101.0b9.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "5657446336b013b1e31df2f06844e4e92be828e7d0aa5a058dd77b30fc282957";
+      sha256 = "03c1ab57d433615b6a4a7a4e0499ff271ec0985cc0b3dde795320753b4210109";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ko/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ko/firefox-101.0b9.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "d7b7d644742ab4d02912a1eb0c4ba934482a8e5ccb12eec3921046646a82c742";
+      sha256 = "457f0ef990ace5b977d620728af74862c605a30ca8005441042e0134b2d10948";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/lij/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/lij/firefox-101.0b9.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b50a4257bd3a8ebfea78c0d1f715e7e67af090b36e7a704acfc761e361e01662";
+      sha256 = "ad02358c944bf2519ed2f3d0ee646fe82a63dce049ec31b6e00d0cdde0d4be52";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/lt/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/lt/firefox-101.0b9.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "4a6fcb8f3c275dc5f3b2bd8b16672494fc5577a562dfa88f2908b0376f687fab";
+      sha256 = "47180658f8a6c7be6863f3c75d8cf09632367b29a9359dd6f7eb1f396d3a2389";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/lv/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/lv/firefox-101.0b9.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "e03bb3940710768efab9a307c2f6cd539cb1e6fe75d5ed703285d66a10cbe1c3";
+      sha256 = "a669f30e0bee7a8c1a729775508e5a15ae0ef582eca0dccb8968aea5758103ae";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/mk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/mk/firefox-101.0b9.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "b837ec9858521b4a9b5fe7b2199d8b624089dea99d0b6602ba4e697e4a9f1c7a";
+      sha256 = "da3fd784ba213b90da55fd6a807f0620872e0a51eeb62a5e026e1439383c9ea2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/mr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/mr/firefox-101.0b9.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "48b2c90ec63bc70d7e6db50cce59c128ca32187dcca46317bdef27639236d69d";
+      sha256 = "b5ac685b23bd00080f7e8133e7f99cd0c71bc8428c1fb80b568ad3c91afbd05f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ms/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ms/firefox-101.0b9.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "b34b90dd02a3f3870e15bbb187b1e6a2a08cf3e9552034f584babb393a141b26";
+      sha256 = "988b4684f396eda8934a4ae2eb82d02c7445e73002af315ac703ab7f78db605f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/my/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/my/firefox-101.0b9.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "1a663490165f5cf756e1b7d51370a069b645beb0e5514bd24d282bbd8c3b292d";
+      sha256 = "837fe9791a8d4bba89be9cd32aaa794f721999a13950d44333241c305703ef4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/nb-NO/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/nb-NO/firefox-101.0b9.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "134bfd08e127e9074f96f440e957d99369c74e0ffbbfcab05e76635cbaac91dd";
+      sha256 = "d0b231b936dfefba9b45a5b044b63373c8e3c87eeebd5b785346dd4ff53fefdc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ne-NP/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ne-NP/firefox-101.0b9.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "10b47f134e8c7ba0f62a925fa8c6f70c297793d117a5cf6f5f259db8c2d2efdf";
+      sha256 = "dd0f9b9867c55b69c3e725dfb718c8551942d5571d63e8216b53b9f83de26b0f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/nl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/nl/firefox-101.0b9.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "c9f41b4133d56f13417b9fd9484efaa235c53828638be0e7dd4898b971c609c5";
+      sha256 = "2f1eb60500ebc47723e66d24d6293ef36719a774f2dfbe2d9747d3bf4225e1e3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/nn-NO/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/nn-NO/firefox-101.0b9.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "1374307aff0e4621dacd5faaf4e2ccec7313de973c83578c92b945f7316ab340";
+      sha256 = "a413040866fe257ffc0fc09f7503a84f22719cb788624c1417955402ad43a7dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/oc/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/oc/firefox-101.0b9.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "2b49081e9bf9d7839ab687af1bdb5e2cfffaa91d0082f8f85110a072325fc32d";
+      sha256 = "f49e7cb85d5df810975f73c5d6f50475829d499804c082ea04421c554cae485a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pa-IN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/pa-IN/firefox-101.0b9.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "bfe75dcda4bdb1bb1f2a1e546fbbfe84c272bec276167cadc042d8aa18e3da13";
+      sha256 = "114d20a66b320b9bd7cd1189c7348742794ac8cf00c5528c8bab3d87a1778d4b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/pl/firefox-101.0b9.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "940b0b8231e15ee72b91b47cbde9b2ec5ae01e6543f185994e2d6dfc2d54266e";
+      sha256 = "a1d2a08da0a167173054e0e15d30ca39c832d6d3755f1b109796b77965c1cd28";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pt-BR/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/pt-BR/firefox-101.0b9.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "a348c1bdf5913668baf8d0db6aabae722625ed1a054b8368db51602289698380";
+      sha256 = "78ee67985cb75261421498d370ce8530a1f9fd1cbf8988d70410fdcc21908eeb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/pt-PT/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/pt-PT/firefox-101.0b9.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "5852f75c3f29d245748d7a71c6ce30dbb1c1a93894a0793bf2eef56af510e0d3";
+      sha256 = "5da39633a6b500d98c64af27812aa568053d5240317e464586097d4563f1ca3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/rm/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/rm/firefox-101.0b9.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "0a92e611ffc5e2a8eb0fc65b031b8158124cb637ee7fc72abd108599e2dc5a40";
+      sha256 = "53a652b2ee5b0610bbdd54bc34bf125ece0712fbac783581242a2ca4565439b7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ro/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ro/firefox-101.0b9.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "de99fa30311c87b71341457f3b27d9119451fd702da4c3a48b16c6739b9bca49";
+      sha256 = "2d039e0a8228d9ebee4507f46de09459e9c5bf1e953a239d6523e2a3a8c498c7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ru/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ru/firefox-101.0b9.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "4a52e23c1ad4d3b980aec067e5fdcb9dd5996698884f3141ea4d282ce2cc8709";
+      sha256 = "9e2777201b4389bdcaee8d6f4888b5d92a699bb2f78153e779a9961ca896bfe8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sco/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/sco/firefox-101.0b9.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "9628b1ba661ebeda1d828df7f2ab444496a2f15133e906893eea797cc61e1131";
+      sha256 = "a063fef6bf12d39245d436ca7269bfe02b9d964b0bf18e90c8438a3f9fd1a88a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/si/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/si/firefox-101.0b9.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "675f86652bfc99d5107ef705309dce5eb16fd529a03479b0ed725a0582f1d636";
+      sha256 = "1748fa8998e3b65fb0e2dbe0c4a5c13a7cd0ab573cc2d1eee9e049acba1c1461";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/sk/firefox-101.0b9.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "5d1c909fa7078a2b213b61f54a9380c63501b9ed7a56104cb3ae954575a31c2e";
+      sha256 = "7af81d1755789a5e96e657e623c8b4e048e3a78327edd6e3986af0761cb39d3d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/sl/firefox-101.0b9.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "12f7d050d6480ca368d9eaf0c7f33ef95149791667f38d82ab44d0d9fbec6450";
+      sha256 = "b838972bbd89bbc9d015263422140ea11cb4e4a3556722b9c4733b16288d501f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/son/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/son/firefox-101.0b9.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "b1f3fce98e6b82f46f45070928e9049af5a5498692d46774654f8950f035e99c";
+      sha256 = "6f123c54e64c26a44c33bf7ccd0b331b7e25744e0ea27c3cce7ba7edbaa704b7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sq/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/sq/firefox-101.0b9.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "95ddf7ea1b961828e4fe39469e0ec3d576ef4bf7444583b98b798c9fafa84547";
+      sha256 = "ee988b4f94fc63163f967726b5caa301e63a86e3629b8312a72840a309c149df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/sr/firefox-101.0b9.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "577ff957dfc31db345c7555eb11c64412b0efde4f659ff5de3bb7fb0c4da0a6c";
+      sha256 = "402d7134120a462e1a0cb4cfb9d3173ece443f0230aaf17c684d23d303d28e47";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/sv-SE/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/sv-SE/firefox-101.0b9.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "b52cecaf1ba436082fd73395e1fb0ac1cdf70663630ded1a4ea739021e820989";
+      sha256 = "a12bf6d6b0ab7db2251c454929765516c52291901be2e3f3b6aefbcff4a13ba5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/szl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/szl/firefox-101.0b9.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "f77f5bfac61d567500c984e2b48906f168d34b22d514174c9c11d414434aa306";
+      sha256 = "fa54a3d25dd2e24baf72cf9f4a34255fba063708a3e047d78167be9efe2a962d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ta/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ta/firefox-101.0b9.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "299d97b80c0326ada876c453f9bb69dbb4365d124c12e1c7ce92cfc1216cb2f6";
+      sha256 = "856e55fb2fc64267a7421f55c760fda0c4e200959447349e37e1aacabc76276e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/te/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/te/firefox-101.0b9.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "ff722708c7a5646877278ff37ba401a909e1685934625c6926c043f437c15f21";
+      sha256 = "b419c6967f62845c441fe19908dff490e0ecc91aeb6a5360d455c18c623a0bac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/th/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/th/firefox-101.0b9.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "42b43c84169473d25a4a84f21f9a3af8aded03446901b8cedfa63b4e21b7c2fe";
+      sha256 = "c3a3b04f8ce2a5bf7d592926fdea63a4039714791e7f0a48541ee9de73a17c8e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/tl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/tl/firefox-101.0b9.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "3f2f0d96c337d78889049a7b23eedca9deb9e376c1a23aef68378f297401b273";
+      sha256 = "a848c97e8ba510fe98b4da98c96a7ecfdcca215e0a475d40ab808d14dc2ba774";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/tr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/tr/firefox-101.0b9.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "cea3871ce5b325d7dce5e1884ace2534e7a30dfe9c7754f80869b493daf4937b";
+      sha256 = "0952a7053bb3e64eecbfc522b2422d1322d22e22a4ff531038d72da87357d82d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/trs/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/trs/firefox-101.0b9.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "558fc1282268a67bae66677df56f222907d8d06232f5f03ee275bd71fc1e0ed7";
+      sha256 = "c51991039eeacf7a094581724e3c31636579762abf6c00c3ab24a52397c739ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/uk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/uk/firefox-101.0b9.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "4e049ee7770c94122e6b789ca80cda28a41dd848dec3faf189c71856506d804c";
+      sha256 = "32d6896a26105b60e8a9d5e9c0cfbcc3e0a225f969a1b1b66af8072219f02cf8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/ur/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/ur/firefox-101.0b9.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "03139cbd273b22c50387c7a05a8529eb711d68dd6b272ee7f72dff68d341925e";
+      sha256 = "30c5c04ceca1996ff51df5ead63d5ededec2a393d06b4216d58f8b32deb48238";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/uz/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/uz/firefox-101.0b9.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d5c6719320ba141b9d3ce087bea71d53e405eb589ce57fc1976de76116059ed0";
+      sha256 = "c99c9442c0ec73c7965d90994295bf2d349076613b09528ec705d058eb7a9ec0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/vi/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/vi/firefox-101.0b9.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "37f9b3d4d3bf163c3364e4cbc0a27a4a95f1e4f9d8404cba72ad2eaa362a0c64";
+      sha256 = "cd7c90d30ea1aa4a9ad6426917aa85f54ce1f88abedbb54777f104f84d264f7b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/xh/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/xh/firefox-101.0b9.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "f46c96ae7a759144e31d3a18339d7b1b0ec071d242936972a330722485d027a6";
+      sha256 = "3afba7baea1f7ee7d8b0f8a1cd7af26921b30e94c582d4fe774b35302b6a9476";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/zh-CN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/zh-CN/firefox-101.0b9.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "4e5eab279a056efc524730043b8746b6acfc4b070c46cf872295eb564f4ec15f";
+      sha256 = "882ea861902ccc8698cec041ac9b27ec4164876fca18569eaf5ef4398410fc3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-x86_64/zh-TW/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-x86_64/zh-TW/firefox-101.0b9.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7b72a4c65d32e8121fe70ef5bb11a55011a252520d23d67f3d11f0742271d415";
+      sha256 = "53bacc7e75669499538381441dcca7270054e15c8626332f9f87f3804499e40e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ach/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ach/firefox-101.0b9.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "c1792f25decfe86f8eca2cc9e158846fccd4e445833eb3721c44087d0b5dcf16";
+      sha256 = "40c2e9d80c7e4bb225e14f0fc35403c6605180eea9d0ce0fe690e17a83f441b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/af/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/af/firefox-101.0b9.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "35a75b213291b016184321da09522d62885b82ba63af3d9ccdfbedc339a512a8";
+      sha256 = "d88dc2dd027b90ecdd27e2293484c0a89c9dc026d56684a2873a25ae18ccd90f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/an/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/an/firefox-101.0b9.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "97e3f9e55a4fd5b7ac9e3f45047177d5972f6b8dc79bde79e621cbc61320a178";
+      sha256 = "0e958410815e2054f1ccd49e038281112fc0fb68de4a3f4b317d701a9cabac27";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ar/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ar/firefox-101.0b9.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "205fe9d4a4dca32c9470590a649d082f1e32e237a6297752e25932417d195003";
+      sha256 = "5db4690752f171bd3314f02556d5a4443c564b4b1962cb48fb8206ecf85c77f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ast/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ast/firefox-101.0b9.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "d647e11555898cd89a9f85159ae3c477d69ad4c5341bc4c3d505735250865771";
+      sha256 = "b5f716347e17c88f72ae770489c1e22ea7ccf7c88537d1139c238e03302897f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/az/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/az/firefox-101.0b9.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "dc9dab8cdfc33ad54d4cb50139ceb361a515da855c9540e08ec2754d77094c8b";
+      sha256 = "62b543e89a0f6f66cb6524adf22665965b01173298f6501737b60f7f7ab67d0f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/be/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/be/firefox-101.0b9.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "4db146f0f4c73ca1f4e8a91a18da133ee7c65bb81db3f5e122b66daa2667cea7";
+      sha256 = "fab20786e0817d4947302f8b256c41dacedd643926a8e39c9ed2fd3c4e6d5396";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/bg/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/bg/firefox-101.0b9.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "0428a713ea8fedc4af9907bf303e1bdd7716025abcbc52cf404a50e29743cf9d";
+      sha256 = "aa500f768044be8c7aa94eeba9a3d43a32375d8d75e3fb8a7b7e864aaf0ca6b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/bn/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/bn/firefox-101.0b9.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "cc90412d57780f5438b2c27b3dfebc244809ef33cefab7322fe89baaa3700746";
+      sha256 = "af36728b49e0bb6c5d1071720170576a2ebf72e652503a0ed5a9681bc93143fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/br/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/br/firefox-101.0b9.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "93dc7ba679adae2bd6d5468c31965ef9bbbd12ac8f80d351a558a9a0ed66b614";
+      sha256 = "de57869f78250f3e79bbe97539a368d0cfb1f3db50ea7a0a6eed0f6be10c4dca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/bs/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/bs/firefox-101.0b9.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "898b62ca81a2c165c4410787ce81d1a58b9177e9f747d2c14b64c98bf44ad185";
+      sha256 = "008d7f95e124683a6f086a0b77f2749bc52e6afa2ede62c4609c01185c6db5d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ca-valencia/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ca-valencia/firefox-101.0b9.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "496fcfc25242a4fca065d842c036bcc815a90904286d2add60c4f9bd6d29470b";
+      sha256 = "3b80603f7d38fdf32a4a64cf5e54f3d4413850a0ca6174b26565f9f437e56227";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ca/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ca/firefox-101.0b9.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e9cc4362a5c6dcf43ab719a808c4e5faf0b4b320179a372ba03864719c9c44dc";
+      sha256 = "f692f580fa6bece8d1a0aef9f55ebf091fcb3b5f0991cba7cdaab14131ff9aad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/cak/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/cak/firefox-101.0b9.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "eb63f5439364d1d8e6feed4acb6df4584dd44711cd0573ecb25bfe702726e248";
+      sha256 = "56096c3944e828f1c345b4cb5c4c4db39d87d5d056d7dba5435da86245ee298c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/cs/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/cs/firefox-101.0b9.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "bbb971333127ebd66c3489523d2a5e0d1272255cd699fe546aa0c54474e84b94";
+      sha256 = "7965b459056f4bfae8b162119f0c8a4a88fd9e18b7fc4d65b9782b2de2b61cf9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/cy/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/cy/firefox-101.0b9.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "97b48236085d110ce1dd6d4dcdcb9e212df16b785eafa2d61e271e9db89de74d";
+      sha256 = "c50094be3fea5a75c4a7965c79d6fc640a375a958f907c5ab950a63270a111d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/da/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/da/firefox-101.0b9.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "ee7f75da2cbc14db369e21eff246049e5d2ed4425b614bc8dce97e44e6cb6bf3";
+      sha256 = "89f5ff2433f1f2306b46c708123757284e178d257f15fa02d59c5af2cb2a5b41";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/de/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/de/firefox-101.0b9.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "3ff4fe9fcab61ac606111a5637326e9b49461f5959542d1a557479fa881cedaf";
+      sha256 = "c66945dcdabb3aabb120b7af826870b0b9c2163a9372c2b35e6da4a467389622";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/dsb/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/dsb/firefox-101.0b9.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "84cd0d196fd04557fa1de6673aafb6d42bbe2d299f5e14c28a57d0a51ac657da";
+      sha256 = "57a0c5447d8a77cf6a59b69d6652e9348edec1b8f7e7a0612b4b177a5628035f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/el/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/el/firefox-101.0b9.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "91ad9d28e1a25a0a27721ceeeb5da3b2550573f354b667c5ce90d78803c82c3c";
+      sha256 = "bec4c447b48be53dc444a10fb8e2024f03aeca28d0c1f924545b32f031187c0b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/en-CA/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/en-CA/firefox-101.0b9.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "1f86f8464fc1d660a88d5c5edba540c1ee65b143c65d9a9a6ea472ae91bb5ab8";
+      sha256 = "f0f5acca315896921a7585ae8a065971779678420f1eb6c9282894736e64172c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/en-GB/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/en-GB/firefox-101.0b9.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "661344deb98582b390a8d9108721bf44d511cb61beccd1e1beffb0c1fba4d72d";
+      sha256 = "91e283cf7039ada850dba22fd4cfbc2f22dfa1a1388ab1f9d8d67d4a42b9b8c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/en-US/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/en-US/firefox-101.0b9.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "d49c7b31c087f359e39442100f8727f95a6d4cb972fa5b1c9680f336a8654c1e";
+      sha256 = "31c02a25efc179f0512957de2d3a979d7a82c875bc0773d8a3afd4e27edbf22c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/eo/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/eo/firefox-101.0b9.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "3a80310c70d3acaa5ff6c3dc30b0070da346209a7b17cb347b6414883580d019";
+      sha256 = "3fc680fc56d628b35e989d51c4559d78d510cedb6a60f4f44526c30dbe2601d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-AR/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/es-AR/firefox-101.0b9.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "c30f0236aed9bd57c97bccd09fbbea401565ad110a5575d1f33642a9a0c9d0d0";
+      sha256 = "8b1433dafc4174c0f939c80ed5b61ae8eb1d01719126c7b311f91cb3c71abc5f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-CL/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/es-CL/firefox-101.0b9.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "91fd193a1f4036c51db8e9a48f82b06c312c04c0b7e453662ecea1683ba591b2";
+      sha256 = "a60f5017f68cd48476c9aee40e4041c60c1f0434530313e374e6da39e00c41ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-ES/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/es-ES/firefox-101.0b9.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "cfdf87531b32ef0e8d32dabae0be7af673d4bffa6e7f61c396e721eda57b70ba";
+      sha256 = "3e69135395aecac514b1bf2bbf1fbc7c9ab1bdaea712136423c0f0296c8f2338";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/es-MX/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/es-MX/firefox-101.0b9.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "de7dae42b15d22244d581f2f7308b589d567947bc1a0d65333e7e817819dcc89";
+      sha256 = "fd16ed8120365b053593fd4317faad82b22e538ee2fb5c1232c4fea414b551e4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/et/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/et/firefox-101.0b9.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "ef2b64f55f5aa53e2116eab02b46414b4ac856d7fcaece56954ce49d3df36be6";
+      sha256 = "9fa08caf69cbe2aca5738df9e2b1b0cd79513f1dfee638f352cd754c3b17dd0e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/eu/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/eu/firefox-101.0b9.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "7e23ffb76461673d9e42851a7313ed7347c103161af088f836ef6dac1547831a";
+      sha256 = "94a5097df79182cf3a7f7a0740936beda02b666de005daab93d119011ed2372e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fa/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/fa/firefox-101.0b9.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "6a6dc59e089687c0b4d281d77c8913a0511b49d7892920a51335b624203d9d46";
+      sha256 = "927bf74effee01adbe4e73ee1adf3a8846ca7f8648679016fccd83f0fcf6211a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ff/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ff/firefox-101.0b9.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "f0e77eb65dd5ef0740b1fd4422e822ac1fc6ce3b57ab7ae6810b50e95a6f2138";
+      sha256 = "fc3d4cfda60737d244190fd77483f635102016728d57540b2ede2beccdafa3ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fi/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/fi/firefox-101.0b9.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "93af35692199f18e3bc7e3525c3b338885a30a649dba0a0c4bf2b2bfa36e7bbb";
+      sha256 = "51c65fab027ec69d1261c4917d1c082b656306c0b5a1e64c771df6035ca89adf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/fr/firefox-101.0b9.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "e9cabbe91cc99e5d86952dfe24e19f081ef6c5cc98a72bcd5cca084c8ee7b0ce";
+      sha256 = "3e7380db9a56c624e04c66f50b7167a1b6932c64bb687d723b035f34d0e7837e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/fy-NL/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/fy-NL/firefox-101.0b9.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "5c4e2f31c02cab88f511095648aba78841e5ba2cd526cd1cabc00be255c6af74";
+      sha256 = "aed3d04d0198c4449861a15e35392bbe3e05d043c92d63a34cb204a63515bad2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ga-IE/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ga-IE/firefox-101.0b9.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4002c60cc3e1493a8f65e898a7ece1dfb116b9fa4ff4220063670165be496047";
+      sha256 = "b8c2328f8793d1ae930aa0aae77f144a71c007eea8fb22867bbfacfa7e6c51a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gd/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/gd/firefox-101.0b9.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "98e49248e91050b5ef3f08896605820a426e77e277e7e2f67fc6fd04d28982af";
+      sha256 = "02e8a9ac80aa7c35395e9b8d071cd3ec392285a66b929dd14b76d90e6994a698";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/gl/firefox-101.0b9.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "f483302c2d074c32d010edc3665de2dc098f5a02f7d71817f681eb88f450aa21";
+      sha256 = "8a3e1429021228a616a6c309ca52e2606a319fde5bab64859d5ce2b7a471aacd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gn/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/gn/firefox-101.0b9.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "709bab16d8b811d53e7a62918aa179e2a542dd668ed7b09c09f480d00d45cae2";
+      sha256 = "198a1cfbbc143ba4a509877837efa3b777a56a0a2bb753f0feb84eae0e9c1631";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/gu-IN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/gu-IN/firefox-101.0b9.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "3d4ca55cb965be9d9dbe573fdfb815e6ca1d3c7faba23948e6f9efbf7616554b";
+      sha256 = "eac041f094375ccef72cd1f3064b2913522bc6f1c7857f4eb3e64684e19730c7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/he/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/he/firefox-101.0b9.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d3c2d301ff6498ca252054f6e677f1cda5cd35fa60ee0627abc8c21104b59820";
+      sha256 = "a68ade36b290e63052720325f5aa22976761c9c2e295510af6ab0dd5661d6da7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hi-IN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/hi-IN/firefox-101.0b9.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "9f08ccb5b89de2f05f321f9205af529deb577ee4a01ce3ae55223a304a67f1ad";
+      sha256 = "8825e8254b6772d51720e122c9ee709a3b1ea564d4fb29a8a6ba929fcfc5437c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/hr/firefox-101.0b9.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "590352d0c31e2710d3a315458b0ceac000644fb5cfd7ee95de3e3734c6ac95be";
+      sha256 = "762de5ec6480b9a860d998427ae821f06b1396bd1243561ff5e4c7d03be6fa06";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hsb/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/hsb/firefox-101.0b9.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "744802853f3743f4dc5595a2bcae65bda00a2bd820f035c0ab96c74654251aaf";
+      sha256 = "e857edad50260853c45f28628b2d995bb91350c16ad255ae796942784b5b482a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hu/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/hu/firefox-101.0b9.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "3783e09ee52fff1955f811c3393f043fd77ead18374e6f111011f22990f8837f";
+      sha256 = "08d7e05caf74c5738d1cf739a485450b2f6412a16fc8f3a823822fb53d796ec2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/hy-AM/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/hy-AM/firefox-101.0b9.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "2922d8ef833e4f378c1c457bee3fde892bd3637c74dc880ed9d6fa82a09d37a4";
+      sha256 = "e963239a29db7c532110a53411f0c8d22c92f4bc82d8ffd3827d129e8913665a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ia/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ia/firefox-101.0b9.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "1dfc6c2bf5eafbb6e8655a2ef2bd960c12bde5ea0d83971afb97c1f49e64d945";
+      sha256 = "2fe4b8500d98ff61e621659df71bbe67f18a005a7e235e0793f8740c6b453b2d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/id/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/id/firefox-101.0b9.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "8bda0b0f5650b92cf242ae3bd7b0240a72a154b553f4c09f05df927d27929d94";
+      sha256 = "c25f563b35ff9544c7024f6b66e2d2b1314fcb43a5b2307f2a15ac1186a5b11a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/is/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/is/firefox-101.0b9.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "40be6971110ccab8c08eb3e0d580597762cabc585ec19bd866d08d9f8e4a8b44";
+      sha256 = "90ef654ae1601e97c7fb474216d35938cb25e9a9e36551389c5294f615bc1352";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/it/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/it/firefox-101.0b9.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "e4bbff7cbf6a33a25022de324f2c7fb8cbc26aee5a88fdf4f0b8e82fd4ec7409";
+      sha256 = "5c7b23d95b3179942e03ab1f1e26b20e677e75e19c257b5eb474d21d2d74161d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ja/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ja/firefox-101.0b9.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "cbf0a90515f98336d1a31b20cd6bceeca9a36f3d1c6bfe4a3933ae47c71fa119";
+      sha256 = "e20483525772a203c6468a807d7ef6f39a17edb1f00b3a39adca0e5c32c2b11b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ka/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ka/firefox-101.0b9.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "74633b44e282b2896e24505ec40cb162e8069333786d8a84aa6a2f633c3e257e";
+      sha256 = "7679fce7930cdd9f1fff4cb31bc1bc51fd2fa7ebb4236703e0aa60381bc1c62b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/kab/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/kab/firefox-101.0b9.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "48324d9272031eb01bbf0c366ee62e7eae24dc199aeba434f53e4f70b9559ba1";
+      sha256 = "1ab08ecf7cb3f21e48b2fbbd4dc2eb1e9a0065644aba22a71ed58e0247009022";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/kk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/kk/firefox-101.0b9.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "19e61accbbd82757f928465d8fc2f509e63605fb5b662d316d4bc1ccb5268e8c";
+      sha256 = "48832d04c96272bfdb14eea01789fd487cc18b1e9904b074b4aa9d729644e2cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/km/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/km/firefox-101.0b9.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "4cce3981e2ba564a09a097c3b7b5fd56a1c2dd29556428e842e1fc296b14af92";
+      sha256 = "e4d3a9bede49e675e6b0f1afa3637adfbe29e1693ba2985cb45c20ffc279b8c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/kn/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/kn/firefox-101.0b9.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "2a5f3c17c3e168eee06838eaeab1f4226bc84264e124054c20c7602be5e024ea";
+      sha256 = "11a27061c8599edf173970683b596d24848c99f160d9d0ba29bdb9294064ec6d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ko/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ko/firefox-101.0b9.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "27652d87f6d6fa27cc8b78bce04ddb30678dc5739fae189262d515163b9efa9e";
+      sha256 = "90b5cf8e356293e96a0a016d04afe0db4066d9f31ab1493e506f64ebb2e85a7d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/lij/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/lij/firefox-101.0b9.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "5d78b30ae0a63ba0d90bdedb38d2e2bb001473a21f653dc89a367a338b27dc25";
+      sha256 = "b66ac05f2abc62c8b417f3d9f8d5d86c8664ada139e369fc06a8919d2f9c1892";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/lt/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/lt/firefox-101.0b9.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "58540f2673fae77aaceb74687210ae4422fe3a2b02800e34e83fa94e849a45e2";
+      sha256 = "bfcd0f7e9e9079e6bfea626bf14eb807527def8095173a769ef98e35e44427ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/lv/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/lv/firefox-101.0b9.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "8d57ab0cc8429496539e4ae00f2b667620665f374e319cd3b6200dca593c65cb";
+      sha256 = "cce7fb3ced85549d7833749e6c24be0642d56929586f3d13be434c662a29d085";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/mk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/mk/firefox-101.0b9.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "3fa8c1d4f130e2d19783308e79308d8e8c7a22a6d7d377097908b2b2e913b502";
+      sha256 = "70d85396e328d74be237bcf1a0780b2aff480038ea5c3d56f26c5123c8258f53";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/mr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/mr/firefox-101.0b9.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "e507cfd3b29ee574a5a50c4a907e181a5caa30a8894697b191c5894e0005da4a";
+      sha256 = "5564c7293c9fcbe25e894cc8d1f8f4a07c63fae20067ecdb073a63dec3b213fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ms/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ms/firefox-101.0b9.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "f2a50d8d5bf8c023fb196050507d08585c9de656882ba923189423ea1fb125db";
+      sha256 = "697d805d838834b516a90ecea22d15bff7a4de3c1a787b048522feed1ad7a813";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/my/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/my/firefox-101.0b9.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a463f7ebfa97ffcd02c17375722463ad030a8364cd5a89d9b88f94877c7498f4";
+      sha256 = "ef20a125e732c27541c299a02e3883cde2b52e46bf2eb15b744f32e2163bf6c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/nb-NO/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/nb-NO/firefox-101.0b9.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "626e61c82232021d91109f454e348ee17e1e1190e5f00443e161f32b6177d80e";
+      sha256 = "9cabd3dd614e014e179510c5d46b0faec737be27f669be08bb0b0f9f636f9d3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ne-NP/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ne-NP/firefox-101.0b9.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "1eb31a8504b1e7729223c6c80f209d13f37b98d8fdbbe7b0dfbfed6dbbb0805e";
+      sha256 = "9dfb4e5787523517f2084e447c2226b1c696e4cd30d3f74c1277235aab9c7ad5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/nl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/nl/firefox-101.0b9.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "7b751e56de902cb60c2d74da40845e7db914a10760514f6d96350a181de0016d";
+      sha256 = "a847671ad6728c3e4cbaec7db3b65d82bff007f9532957273cda2c15ea2a9855";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/nn-NO/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/nn-NO/firefox-101.0b9.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "083d2601e9b9363ce0557e75118d4da90abcac209e14442fe8adbb26c0cc0776";
+      sha256 = "0a70eea06255bb9fb507c4168660484a8ff8ec1f3bc5f3b27328adf7dfea0b7d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/oc/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/oc/firefox-101.0b9.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "c136ebffe703893ee7cd393e361dcab3948f8766729228977342eb4b275810d8";
+      sha256 = "5a75fd0d96ead0b7a4e835b50e9663a3d2cf328a7f9a8031de9bd787b320a004";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pa-IN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/pa-IN/firefox-101.0b9.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "3e0a781064f9d1522c446259c6446287bad4740b633a792020455ba31df5f99c";
+      sha256 = "5764236d5c0100a8d3125e5b71def40a6fd1bceda1e4e488f29e4ce583532ee7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/pl/firefox-101.0b9.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "03763b006ce67d79dd62923a9cbfd4e521f08622d8a78467e2e747e883497230";
+      sha256 = "3b6e73f2155797cbfde8569969fac4769d594ec3e5e3572259ff45e06ac0b1b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pt-BR/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/pt-BR/firefox-101.0b9.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "44a3dce9250c9d88452c52729d85ad8fc83ebc4ec7a14f96b45ec525d246ed63";
+      sha256 = "7e8ec8d7ad729b2f7451a3cb9c3e965c9eeb9f173dd371e774a8738ed7c3cf7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/pt-PT/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/pt-PT/firefox-101.0b9.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "0c84ac122fd151eb519f9fad7a13121e3121a5c87ab599a27e881aa7869c18a5";
+      sha256 = "d68b4d0fb8073beec30db808d6cfd3c160305a14bb5a6141ae6e2101af2a0ede";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/rm/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/rm/firefox-101.0b9.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "6150790b2abaf22e301e35e7ff9acabf6ae3004ba7880511b59ab89a4221d0fd";
+      sha256 = "e1a2854a0f463dd07e40f28e056bf6f94a445fb85fe2e2cc520b69c9c0d078ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ro/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ro/firefox-101.0b9.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "534e4c1396410351b80fc176005fdeaeccf0e0d3cce32901e6514d71a4976653";
+      sha256 = "73e6752bea75727451516a0aef9566abff583741fd512b6b0c480d6fd10aa416";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ru/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ru/firefox-101.0b9.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "dacc87ed313bbbae096040008d55c390e0e379a6ed63e94dcf8b1ece728e33f0";
+      sha256 = "56a5488e9b56f8100921ebfeda2ed983fde74efaf9b261ba6ccde8097d268d39";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sco/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/sco/firefox-101.0b9.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "c73de2e7aee09703156f9190394386f958f6b6b3b4e4fb0025adda3ee0424782";
+      sha256 = "f82204131daf34e49ede6f3d06e9da8ea52167e860c09358b63d54546d1a8eee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/si/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/si/firefox-101.0b9.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8cf170b5741ae909ccd8fdbde2c53ee73edccb10fc5a525fef27a2b9b752ad14";
+      sha256 = "500285c2acb758aecd84cf029dd2a0cc961ca897a54fb7ffc5a85344e6573758";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/sk/firefox-101.0b9.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "d18ae5d2f8f7cc950de839f8a5715229f9d06fec3350a9cc1c62222ecb8780a4";
+      sha256 = "53358b16d382b1c843ee75c6d60276bd4c28648fceb7e3cf9d526fa9bc98e899";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/sl/firefox-101.0b9.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "6a129039d181988b9464ca40ece4089ac93b7bb7d15bc65306d9eb446b507e68";
+      sha256 = "0f3e08fe4c298fe9311b35d2e856c28e3e659c0a5f7a7726bd95b5f2c904b28c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/son/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/son/firefox-101.0b9.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "2bd08442fca77a45766b7f9bdf024c10b21f6d7c8da64a4c40500e4b7e1e105e";
+      sha256 = "1001ef5c55c9c409cdda832adf41bae783b91c55e59a6704a14eca03fc7cecb5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sq/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/sq/firefox-101.0b9.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "56d99d1e355cfe2c3f7086d8dca78c194fc2d2a2409aa66c35a1d7571ed38a1b";
+      sha256 = "5f066ae630a65c0c9d8b0fcedf4bbfc190156272f992892e42d18d8adf3a7106";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/sr/firefox-101.0b9.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "833c067513c4a2d235e030409ee356307c9d73de439d502c7470e1ecbb41fde7";
+      sha256 = "6f1efb8804631b8a35dbad650e355ba525c12b63f561734006fd9eac5a0edb7f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/sv-SE/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/sv-SE/firefox-101.0b9.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "2c84063838384de54c808efc11927beb33359c2a20b268380cdc553216d38a3d";
+      sha256 = "f570e2af2fa662642ea2ffb61e13d907862b154d9c6f8a15920f4f17bd6ddada";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/szl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/szl/firefox-101.0b9.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "f298cf6e397978f1562f00918301c0e1702cbca6f867f2485ff69f1a2b0c2a4e";
+      sha256 = "1594ba0f331b813023167c56d7c6bd75132fe6a50f3bfbb4cc6562aaa983819c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ta/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ta/firefox-101.0b9.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "71f2dd3a5ea0df37b819acf3e5b4ec763247d2f763275dabb150b41b5f40c782";
+      sha256 = "417e61b3ed39def1afd7e3905a4229bc17ea7eeec4d3a849401af48995a7da60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/te/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/te/firefox-101.0b9.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "bf8e272305ac553c0715f6098dd56a87f2fa7c500966910996fc00483cbc60de";
+      sha256 = "d3f69da2ea3b6552496ea88de644af21e25c59c3ef1141ca8e0f8d67e6cb384d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/th/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/th/firefox-101.0b9.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "804988c92b1b2cfe0281594438c4aaf4f323e371ee80cacd4b249e09adec0b50";
+      sha256 = "1d9c3fc39dd51087fdf1e841ab0c256ef8d7081f4cd837e05085f434150a101f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/tl/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/tl/firefox-101.0b9.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "f60150033304c70eec51e821b10facb3680455273853ea451a4d6a02f4c9337f";
+      sha256 = "e60422b379dc3646b597979fe2a0afdda49be87ec021e16e1d2f8fbb4041fac3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/tr/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/tr/firefox-101.0b9.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "04bcf58bcba4b67e732bad7a7a448baa95c4885b793aa14eeb0d8b97e968a4bb";
+      sha256 = "4e10d3efa80426fd6f8213715d028fcdb4c611e1b66e698dc31d47ce77fa9c78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/trs/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/trs/firefox-101.0b9.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "def30527b0034fd72599502771387fcb595898ce3c92fee3a8d6a7944716512e";
+      sha256 = "73cb3c95e4e0657e24100a4164da9f66e79f1327ecb7a1786368c57e9825940b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/uk/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/uk/firefox-101.0b9.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b91a4047cc9d6dd09601e1228b947359a07556c68b31715615cb10aa704d2d50";
+      sha256 = "c4a6980744b64a6577df515a51bd9c90510b08de98efa14118d1c14de86458c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/ur/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/ur/firefox-101.0b9.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "1e70b055dca6b9a2c53381127b5372ba4fe7271b36a270d4d40130320ec315a7";
+      sha256 = "2c2f7c47bfd37f86c9d3850ab57041f87c612a0fb247a2cd19c35b8e3e443ec3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/uz/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/uz/firefox-101.0b9.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "af236bb72a7c4d9cb87d2120bb68fae63b86505eb080ebca41a7e204a7c89785";
+      sha256 = "e2ff4caf5379e4edf867c7c2e39785ff2f7426c524ae6b20915fd94e061ed8cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/vi/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/vi/firefox-101.0b9.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "9933b6c77accc651437fc5ad0ca538921708fbc27ed0ca181b05b28d9e0094da";
+      sha256 = "57c595c8c22709065795430586b2762edb67d2ca573232bc626952fb7abc6b3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/xh/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/xh/firefox-101.0b9.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "820a745cb391875e8630173c7497a385982d62fa81e32af5a8247c5cce4035de";
+      sha256 = "bdb23fab3ef55f03bc4c3ac4488fdb30b174ffbbcbc89d9387ccf9cd1528e91b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/zh-CN/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/zh-CN/firefox-101.0b9.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "3b6da1d0fea706d59d85661d89c202fb26bfb3b84fe5d27ef01c7132cd9670d7";
+      sha256 = "3019768b3a9115b07a2e3d05868598c656f0ced8c50500fdf55a4db959ebc4f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b6/linux-i686/zh-TW/firefox-101.0b6.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/101.0b9/linux-i686/zh-TW/firefox-101.0b9.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "2c72900dfbcd8d083c0ed6127bbaa1646d7f7a4e907b32ef1f60eecd90bed1df";
+      sha256 = "73e243126bfa419e310f5f3aafa119b2ac516bea23c37e653193fa6bd75172a4";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "100.0.1";
+  version = "100.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ach/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ach/firefox-100.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "6ada3d7eeffb7b9e1be26a0d21236e0d1dc6b77743854dac1a7677e1fac1af52";
+      sha256 = "c780a37812ae0aa875c3057a6bb6a7490912e1acf9b505558244347f5822a08e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/af/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/af/firefox-100.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "8e3da7449094c66e48bdcec44289711786f920e9ebd70e9968c92fcd18135d4d";
+      sha256 = "0d29189c4f25852317cc37b0daab3e7f240371ce1d2dcc19a9e069411c48f57d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/an/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/an/firefox-100.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "5976e5e1cec347202cd2d11d56e9edf6bb1932859fad534c8344c97dfb2d0c2b";
+      sha256 = "b30da8be85534cf005412c8714bd6b4a8be80278b55d953a662d14d6637ab1f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ar/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ar/firefox-100.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "bddc80f4e86e714a808b068e6970ca9fce2bfe86b1e729e5a7f8cd6b091491b1";
+      sha256 = "f31dbcfcd091e6c8d1f13ee606e09e8c378d7f56cfe9aa4748512acfc29a5bd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ast/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ast/firefox-100.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "7c0561731c31b69c17185e7ea9f032d45f9f5f7217541dd867a71e6864632964";
+      sha256 = "b86f64c68e65f1955f3753b8f005888787188c668b8e968da40e08cdaf5673d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/az/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/az/firefox-100.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "62505ac8a5543eb163535414e69c5d122097479e9a00d3b9c9f1907f1dc456bc";
+      sha256 = "e4420f829a30c18f06ce5d1460992497d7652b07ed34b8cbc78c16617f9b1ee9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/be/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/be/firefox-100.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "32ae1685ddeea2acb044db016bddfeceff189b98cd1904a5412debfb194f47a3";
+      sha256 = "bd615ccb833b44d6b6e45b04d94b2124d7c0468c27536c82cf3370d66d4bcb56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/bg/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/bg/firefox-100.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "98f8d8a0d804183cd74204145173f855534bf8af87d7be91f08c6fdd9be3df9e";
+      sha256 = "1137d03ce1dbafa7bbacb139f05eb45b370df4d218cf292d6d9408a2c0a65806";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/bn/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/bn/firefox-100.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "af53e108f0134f85bde8d6c29d513fb7d5e0f3903d12cb4058dc680f3cf8738a";
+      sha256 = "f01e8ce4b227a96fe5d74dc10558d3fd930dfc3de101360f5c9145fb818f6a76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/br/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/br/firefox-100.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "0bc0db14942ba3a448745ef3f1850fd5a7974dba246c4b7ba0398d7abd142bee";
+      sha256 = "5c425762b69702287977245e5ae5873b83ef404bf30c6f5eed9db71af3ab166a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/bs/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/bs/firefox-100.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "b896e6fed373f5104dfe7b3bc0c3e066c4a57a10c7b9ac19802b5d4c1f0938aa";
+      sha256 = "c7e54c5317d9612de77aa1e66cc1a97d0e5638fde5dabd7c0b90b5aedd357f73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ca-valencia/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ca-valencia/firefox-100.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "b5bbd6eac96ce13d1c979041fd1cb4b5e8ba9cc36d3d966ee2363a6487b1181a";
+      sha256 = "dcf5011207d1e3b4c3a6597821ec9472d6b329e66fb03f2f648631003037e45f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ca/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ca/firefox-100.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "3b5552c60fe25d1d972a5872ecf93614f0fb7c5ca9ed46e0746eeb9f271ab1a7";
+      sha256 = "061b69726b40e5f47b0d9319ca81a4137b62240303c4f4000523707243ebc914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/cak/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/cak/firefox-100.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "6362c8cfd78b3287f940bc3664bbd93465b603fb96832cde9abfd41ae14c09c7";
+      sha256 = "a7d5bcd79465b280ce9901d4825f7aef361e3d8019a3659da69b484a76068556";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/cs/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/cs/firefox-100.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "9b90cc81784eddaf88a6a668f8c5e80adacf74bd6257a58e5e65e5b9284c1a51";
+      sha256 = "341022099d92bdb0445d181522281c819fd441825c330d06218d15bf29dd3fde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/cy/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/cy/firefox-100.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "fa152ba20395e703a66c8909d41c897566e66e8d40df449d5aa411abd2df3dea";
+      sha256 = "094d87c9ca25b4a1ec3ad28a6721b7c712627ff20cf268b208a66ea19143a905";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/da/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/da/firefox-100.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "69da786e7acf0f829d432de555d057c75265cd8d8e5abafcae62d80e64a7e9aa";
+      sha256 = "14484560f67d8edb395bcb6c5d97372fc40f389a5fd9baf1afbbed2c8c3c4a45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/de/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/de/firefox-100.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "aa51cec598a71e4f23822cefa2a331160ea813284a32ea919269b94bfcf81330";
+      sha256 = "693a2ef07ad927d94f9eb2ba91fb02c2ae0eb7239ebc5c146f6475a2ba9e67a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/dsb/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/dsb/firefox-100.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "40bf083cb656f524ad8db69751c481321bfc9f3d1f2e4b3b58434cc8f49f31d2";
+      sha256 = "8c1014642041c9d74ae2d3a5f7d68ea0d4e67d9ac55cbf0d645f14071a43966f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/el/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/el/firefox-100.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "c716d294f368139dabc3bd950e5b5fabf0b89be97ed3da70966d80b00c578667";
+      sha256 = "299ea488d9654798cee04483ee7171e14a6869184df23d3a47924e70356e627a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/en-CA/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/en-CA/firefox-100.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "71fb8ec0723f4e65e3cd81db107173f3f591de376a32c7bdb655d7a9a65e87f5";
+      sha256 = "0599d3566e6d23ab400116ef3bfb21f1f2cf50e196977def75fd573647541d1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/en-GB/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/en-GB/firefox-100.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "ca4e13f6d65e2f38e5b2bf01192aeca3d01db9f55442c4e8f614584cfe60e974";
+      sha256 = "7495a84b63760213f66b5c23a41435c7e3d081178e365996b3a6ed78c52a0539";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/en-US/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/en-US/firefox-100.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "e36ced1a9f836bdba45b4a657b541e53432ea8540982e137fbd19f2e62734c22";
+      sha256 = "e7b42e9fd82bcd569cbca1fc95b7e1a364c3dbf4d44a0624b4466ec1bd67f836";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/eo/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/eo/firefox-100.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "81a2d2f08cd5f9739eaf14e22290f485a86f1eb6b8122b65687f00931a2effa3";
+      sha256 = "c34ae185dcb4e1adebb5acd0bddaf3201cd2873b9661ae2a31a2aed25036ecc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-AR/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/es-AR/firefox-100.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "bfdde9f6407c5d9e9cc551a83f7036bcc9e84d1aa8f12513a2234698d186f164";
+      sha256 = "b6dd7deb95fe13341c5e47d7d4c0eba8751421af02a2f8d51500522fdeb688b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-CL/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/es-CL/firefox-100.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "af26356904b0d303c54a67fb3d0cc3c08e752f9ad3c2c163133addcbc9c11bc7";
+      sha256 = "dc89f4a7d99d62f998bfd3c73197b279a2edb20da8a2954c96413c64f5b47226";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-ES/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/es-ES/firefox-100.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "6ea51a5a857fb48ac780faf8b69358fadfb646be5c429fe83921b7dd6cf806aa";
+      sha256 = "6e52ac53a02df76bb56106ac8418e6f54f089b65ebbe9ec339d8aad209535721";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/es-MX/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/es-MX/firefox-100.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "4eeb15ded4bed74b5f364bbadf616c64615d60d8a1c42270f156d34f7ec29607";
+      sha256 = "0650233bbd7a672f4d4bd1f1ac274f68ee47515447a6eaa4cae7a138f72a3249";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/et/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/et/firefox-100.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d54a20731435be1e06efdba1583b82dc6fa92430dc96359c4f0f545d4785b09c";
+      sha256 = "bf607b4c76342da084597d0d2c92972236b847cbb1dd62d4c255a11de2b25ce5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/eu/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/eu/firefox-100.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "15dfb9380881f0d37147b27597c624c3a93e714dd9cd67a0195b253a67741780";
+      sha256 = "4c1c3576cb9c151e81c0baefb854165dc00de39ccefede65f1f423a5438ffb43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fa/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/fa/firefox-100.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c03b048fd67a01591a3dd10f7b2c7cd4baddf843b55f566623a4c358f73380aa";
+      sha256 = "39b0a53b67628f7a03c955da4a0cd66bd7d9d07cb7100134ea27dc57a8e84485";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ff/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ff/firefox-100.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "3777542f6f56e03f58ca5ba34e372648e72261a28290c1af4769891069d5471e";
+      sha256 = "f72efc16d5ccddec83d93e7600c99dea4fa45aee1f706b1cd1fa569aa58819aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fi/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/fi/firefox-100.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "ec237a6b72cfcdf6d485e6adddbdfca2dadbd3c380a930b2d17d1d769c503e1e";
+      sha256 = "7f61b5f4c8835f62ec07e285fc2801e66911f498d2dfac1b4d8662955b32c107";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/fr/firefox-100.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "08c668bf7f89851861acf067b3c3a48d00ba02d4ccb001fe4e0973c677d62632";
+      sha256 = "dd8ba0017a12593395dbf3331227b7e849c9605ec7576339a6c7899b6cd841bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/fy-NL/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/fy-NL/firefox-100.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "b4485bceb5b98e08afeffdf2e93fd9f0b15c3174fd98716045ac360d76d18a96";
+      sha256 = "53e79bff1b1f3a7140ec5d267b373bbed2e85e755fef75a847c8fb457a5679a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ga-IE/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ga-IE/firefox-100.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "d5b1eaee16406e4f6acf77c2e7813b84d3796d68eadd796f8ec3c625aa67724b";
+      sha256 = "e991b794d1b2ae0b87a52c5e55336bfa3b735e79d7bf84afbeead49d1b2ea92f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gd/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/gd/firefox-100.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "04da8612852941a4a53d38707a275fe6b72d5e49973148de9afce55a3611f570";
+      sha256 = "95303d605278ab5bd8d1990fa262724756a30043b274b0ce51ceb496767ecd72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/gl/firefox-100.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "7b2360ea8beb7388fff23c76aa9e6712d15e425afa2505e4cff7723d2eb121d1";
+      sha256 = "f3d72b39e375272922804c6bc9036e243554a6d2014ce4f4fb2db57fc9ecd00e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gn/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/gn/firefox-100.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "d7caa55e48cb1bf622a18d92324ef4fa2f043fa87c2c8b8b5aa9490b7c3c72aa";
+      sha256 = "9557215a185992ebd4105f578a1ce24eaa795ed3fe59cd4c41dc5a0d35339459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/gu-IN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/gu-IN/firefox-100.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "ca54efbc7e381f14dd33809594b09a6192ca50a662e9d042e73979a4b06f90f2";
+      sha256 = "f45ce9ebb0f773ceb6ec1bafe71f30625e7e90bdafb527ad26d54cfe6a17ea37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/he/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/he/firefox-100.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "89cd1649a9333840eb27ed47047c3c0f363b4a4490862ca53ba5ba3d41cefd75";
+      sha256 = "ecfa6544e19c4550e52bedd739d67248a9ef282752699285c83cb139e1c3d7de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hi-IN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/hi-IN/firefox-100.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "86f879f17d580dafc2f7d3a1ffdeb42223398b5e7d551aeb2472c4d2d8cfe3c5";
+      sha256 = "6af2cbc926375ad508fc8d436b9de24ffc6dda0d2520af2696e5df517920c62d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/hr/firefox-100.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "08f976fe7afb5752dcea56464399ec64fe645a042f6a00ab5b0ae553ef9c0952";
+      sha256 = "49d90776c8fd2f68383cacc7b56e0f7d010ed68a2bdd3f1e985117fa6861a498";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hsb/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/hsb/firefox-100.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "98b55e66b9a2e5570046341a9ef142bde6347ba66650a499db96fd2d73c8e36f";
+      sha256 = "566f07a2f0cf51b52b0031f80b224b952b4f49d3651295cc9f810f24f658adaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hu/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/hu/firefox-100.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5a629c221ff19cebf9a9e4572688d7f3fda4bd6aca487457cc4b143bec266065";
+      sha256 = "43f71c5bfd0a928d78dbc6f62f5ce34c1f156c75b5b500cf965617b651d5ac2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/hy-AM/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/hy-AM/firefox-100.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "039b211ec8ee00bede3685782d0be71c8914937dc5eecf0df4cc9d34922a969b";
+      sha256 = "e16d68212052cc83de8d35056cff7d0e9a774ecd77603d199e61cf90b6c11474";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ia/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ia/firefox-100.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "fa82e2574af2c672836bf71e526f81064fcb9c6f5f31d9574d73b6585da24a7a";
+      sha256 = "a3f7718cc9ec80e0398bf3276d2ca2ea0db6e4026bf2fa21300f9e5bc7c1902f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/id/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/id/firefox-100.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "14064c53c93c6768da1c655b24638dc52e4d6e2399f4dcd9cafec222ca18d843";
+      sha256 = "4b837ccb4e78e92552c0da74f9af9478b96a38560681d12ddf9842980772d6a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/is/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/is/firefox-100.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "19b5b8869af023c7dd8df6ed57a9756658569a2488586ba023ce33633339f669";
+      sha256 = "64e95ecaec980bd97551e328f0ed878c92120588ed24bd3a155e8443e7e4767f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/it/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/it/firefox-100.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "1fa2597bc637f274b3c4a7dcafe38f13e3a8cb024deea2221a6c7560887306ce";
+      sha256 = "234f09fce994adcb53a9d11c68cf7ccb1b0bde15992da05242b0be79b0dbb247";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ja/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ja/firefox-100.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3df4f4a4dfc9827e2b036b57f993b2de579babee21b7f53747f340cf5f4dc80e";
+      sha256 = "1989bff3e8e70c5804048e1e2f738cf42adc3d6a19c56ed3b580400e2d7459e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ka/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ka/firefox-100.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "c8b0fe0d2bdc97cbb8f3674f8ab86272ede370e79029e3ea3095d9e75e5cde7d";
+      sha256 = "b4c06e751f8fcfd5bb1b1142e961fb46826e3e15f37085caa65af7bac7109351";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/kab/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/kab/firefox-100.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "046dd7439c464d2c8b7a2623db9faa3a532f1793494c5ab4480ce188589684fa";
+      sha256 = "9b3fccea1c5b44e51e6cfd5e6f7b08254296a6106fbbf39f242795741ff0692a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/kk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/kk/firefox-100.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "521fea48d9e42afc75644141010f134abe58dd9ff256dfe5ea58dd504517ff82";
+      sha256 = "38d09329bc5c08e4a518d9ac026d5af449bba8fc210c6903f748902e0a013f92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/km/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/km/firefox-100.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "dc0ca54c9f7e31f3bf068c936469b4a17cd45758048cdb97fc72da7a0be876e8";
+      sha256 = "bc7d6215affefc5d6b474603f698b431b5dcbadf5d305705be8d83b169b07416";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/kn/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/kn/firefox-100.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "e18f235c3bdb701541d369a226a67d198b9838676d6dfa89506c610ffa18bd49";
+      sha256 = "af8613118b280e481250bdfb0e0ca53fbfd337a783c712b69fde707754c557f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ko/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ko/firefox-100.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "9cd09c7055aa8fdf3ea4561093385810bb751c7e46a991079ad2dabe6b692e4f";
+      sha256 = "1d20212da26b9ed952ce6ea60c6f769b1b737d35cc3e0ab095b5aab9b3c447da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/lij/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/lij/firefox-100.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "46b17f8cb3a8840346325148101a636fd82fa99b34b3fa6812c2f0ba2b8c1291";
+      sha256 = "61521146ef77f25dd205187a03fc26c1bd527c7fedc831e9b8b6703ef37ee9ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/lt/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/lt/firefox-100.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "cdc25ffdad5e09db643ecb51b8b615e7c6ea0690d954d35e5b87085e90ba0c48";
+      sha256 = "808dd0fcc4e2b96ad5c83087827065fbab0c62b4eb9b49cbf865f3b6fe0972cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/lv/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/lv/firefox-100.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "36fb350e44e31e647af95722a859605edf4450658cdcce89fc5654ccaefce3c7";
+      sha256 = "4684218cb17a75c2b622dc83deb3380f7eea4b8a580d07e9f60bb0bd3d59f1bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/mk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/mk/firefox-100.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "72370de9282bd6068f85adc5d85e146e79a8ad5f6a50bdce9484c47f7f34c608";
+      sha256 = "906affcb5603ecf006a24f02d9d7d83c5543c658d6ffc589a4d9ac103c1d8d83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/mr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/mr/firefox-100.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "f2f5008338e1458cb0067c0cb7d153cdfd982810c92f6f82f5719e5bfd87cfd4";
+      sha256 = "18f2eb581b5f2e0a5b2403a04db05e4be95b94221627d0b9ab163edbf09af320";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ms/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ms/firefox-100.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "865fea23b01442d6f1aebbe3653a6c98b9831ca3aa3473e4cab594950550e84a";
+      sha256 = "a0464688640cbd8b5221c0d48f8d4147c59754b0657b771ddda5651a7fa341e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/my/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/my/firefox-100.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "c4c75ba9afc055c66917e4bbb80f2d0def181ac32405420c49a4bef3fc5593b1";
+      sha256 = "0121fa63fc9c2486101239cc09d3795fa461a36dba957a37ebc3a44228bfe590";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/nb-NO/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/nb-NO/firefox-100.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "3deb7db3fec4607c31b32988982871eb4be6b493221a6fe52491f58ad703b242";
+      sha256 = "7a91d9022e166e67259e8b5879d6a7a803e249830594c5796fef08ce1accb5f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ne-NP/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ne-NP/firefox-100.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "c69598bb2526122404e3d79058f305fdfb9664f8be66eaef7b772a0614f1acf2";
+      sha256 = "0c7febc07fc27e2d68426436a1fb72781db5b4a5d5d078cde0dc1648cd8cd5c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/nl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/nl/firefox-100.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4cfddb0dbd9f2583c9684344f0ff1baec4ef9d6bf2529e1adf89fd68bffac29e";
+      sha256 = "8e833fbfcbd681e89bdc3d6b75fcd8432c12d820aea9a5adf8ecfa45dfcd260c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/nn-NO/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/nn-NO/firefox-100.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "e2d45e33bb117493c923ce76ead2e74e823fbb611c952d1fe1959d9ec5e30a57";
+      sha256 = "af1ad4071c51ccc7a9621637dc97e99cdcfc62f32c5bed3bfbafb16230218fb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/oc/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/oc/firefox-100.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "217abdc711b1494d604f34c2b44961721120429f5e3e6d6c49a1ef99d6cf2c5c";
+      sha256 = "b0cc307c384070d292953e9a81b49a742caed18e01e2da19404feceffa917f10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pa-IN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/pa-IN/firefox-100.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "3556bae814e84afd49c205e72a7cad36adafb9881f2f5a334ceb8c8d95f24d72";
+      sha256 = "4cc6dadf08119dd67098a5d65248306e3970ccec15450000a61bf5dda109e045";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/pl/firefox-100.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "ca2e5a7c6bb2ff194166a8e396b8fce59a4e7925ff02f483e11ba71d9295ee14";
+      sha256 = "619a694dd537ac2bd94eed9debc72f1bf9e8d35f617727f43f7defdc2804f063";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pt-BR/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/pt-BR/firefox-100.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "9a100fe3b01a07e0c17c39b3601fc3a863793bba5edfe1eef3e4eeceb7b025d2";
+      sha256 = "21c3b85c4b936f1f5f4e1ee7f9aa3a42ceb2049dc752f2dd27c71dc4fc5e7408";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/pt-PT/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/pt-PT/firefox-100.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9fa6de674e0a7d7eae29702a9f2269ae0de2b90b5afd6158090536d23922537b";
+      sha256 = "ae7a09bd78dfe0c4a7ab9c003cc3987ec68d481fc1cd13960b9ae08900e47ab3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/rm/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/rm/firefox-100.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "c8d7dce153de2b56c8ee4b67215afec78030170202b8cdaf78aed488a780e2c1";
+      sha256 = "6c1a34331c8c09dbb9fac083f6f4dee3e80cc6fbbfc3bda82ddadc9546dfb8ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ro/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ro/firefox-100.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "37ef8251d538e6a7666b261e032e74fe15131f4264ded564621b092744469069";
+      sha256 = "3722ddfafc4e69c6268d8e5d289bf64b691eedd34cb0e9a5986c33ec3fec1d75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ru/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ru/firefox-100.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "57a1da9aa5437571789cbc86b7176088768bd2729a344495430b898de0e6fa78";
+      sha256 = "3dad696e2bf507be93c9ebe24f52daf801fb2db49607b22101f7a9e63afb47a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sco/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/sco/firefox-100.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "0b7537211ff107faf6b94b18479f0a03d695a5fd58fe17496aca910ffd33487e";
+      sha256 = "fe387073c83a77f004c3219a3d22ee228e7437884e1488073ae3549370cf42d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/si/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/si/firefox-100.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "2598b094ba5d970c09d910a5122e8d569d8a429d7ce841cfbfb87df96add5e44";
+      sha256 = "6dc9a38665cd5da3f2c6ee1e814a452c3c647932ce6352a540bdad78b076aee4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/sk/firefox-100.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "146bd774e0586a22a6010e03ac36d147bda493b9e815a88a428c719b23532e09";
+      sha256 = "b03321858d4cb8fd95f8cae16169e5fa8df042dba2459589eda8ddf60a8328e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/sl/firefox-100.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "b0f578235541419a1651a6b2b984c6ad8cef196f8747c2edbdbe4e6bdc401b45";
+      sha256 = "334c0ff537a6af1dd46fb145a0ea5bdd343ef12693c563a37dfcf4f6ac59c395";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/son/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/son/firefox-100.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "2ebece0a0d69405a766783cadba2e39f1e2fd773f0cd1df91d6273e77b38dc9b";
+      sha256 = "98dc720c267a7eb72a1b676f5d7bcdc1ed5bf08e4c5728fec34e73825f0b5490";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sq/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/sq/firefox-100.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "cad14d9094286613eda3adb3a60d7db5423b2466ebdaa05f54d9b5984108de22";
+      sha256 = "f1ed88e2cb6b3e5e8f5d73df6605c76f46bb435c0e05524c54435d5d83db30c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/sr/firefox-100.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "97bcd1f7fe26bb4347fc685eb8706e1ffe75224363c782d666f6efa85ea51d78";
+      sha256 = "5359c2fa8496d67874681d66a694e943f92edfe01f6413aa0ba2529707461c38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/sv-SE/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/sv-SE/firefox-100.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e96f49fd65a18738c6f835bdfadb46085dafeeab800378a8258060d8ecb43266";
+      sha256 = "ca15b8f2764c7f23450f6bfd9cf48f41d8beda50e8e9edd248d229c279f51518";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/szl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/szl/firefox-100.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "bbc7ae8588435a896003a590ec23f03a73df473108c42c371af94790cc790ae2";
+      sha256 = "2f9647af8b549c218199d497c71412badfcf95e6b9ff8e5635933b474d584b5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ta/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ta/firefox-100.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "62fc3626284d1cbb196c9f4e3bc90ccfabf94c477d8e733f555ffd0ea444777e";
+      sha256 = "26d229ea43e636d241b3904cd395ebf9b7df817751315578fc09f0e32f89973b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/te/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/te/firefox-100.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "6a982566ca6b127b16ad73cd59ed21a884eba58dfa33f8f2b3dd24427ed7f9fc";
+      sha256 = "0523980454e94b4d06493e57099d1e4100fe71b739d16b7221f2fdab6c2837ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/th/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/th/firefox-100.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "dc6f630bb651869a04531022a3b17b1fec42a6fbc450e6639e9f4d93f2e60027";
+      sha256 = "29c8d2c2113f964902a7aa26c23a4698366d3e8fc92d29867bab06fcb3412bb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/tl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/tl/firefox-100.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "0210844f4f6000b4aaedc259acd3c00cd1c92bc79a6b5bbc4688ab96f5e244a0";
+      sha256 = "2f3371d833de8e225d6b697404b769c3db240d87c8635120872a1ce01b3f8fa7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/tr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/tr/firefox-100.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "a3da6b5cb4557d51a90d6d70614d5895e4910b07d33347dfc23607bd0e1c9820";
+      sha256 = "9bf81a49a73faa431add2918120256beff97e2f5a18f3f2f0f650ee94b74adf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/trs/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/trs/firefox-100.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "931d0b84a4ca86a25b5500c20584c446f2f52fe5aeb1506fc33ac18afbae36f5";
+      sha256 = "ef360e374b83af8718aaed412b4b53dd75fdbb075066ef5dd4109304de6538b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/uk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/uk/firefox-100.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "7fcde2b430e1bcae291c7ab8bed21d1b72d3c9565a2129f73d3fc63d5574a946";
+      sha256 = "40d7305062cea9f154e74d0ca2b13173423aee72600bf1bbc7dae0a8e34bb23e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/ur/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/ur/firefox-100.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "3ae4339545e6f04b34430f56ed44363a0afb688988e72b8574bb0a6d402beae5";
+      sha256 = "acca93d14b7dcca56e764c3fe45a7fb162042b3c0135b35da98aa7c6d25299ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/uz/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/uz/firefox-100.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "98b1af516b139a005d7ff925c94ec2f8f91dcfd8a8144a5026509f63525a6b67";
+      sha256 = "4ed0df0b2695c85fea1559bf2e66b5afd1dfcb6af1f3a4fce6fd002c1fcfd3aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/vi/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/vi/firefox-100.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "2bf7b52cc505201a493824fcc36807c9aa6f712557e6a053aee691a6012978c6";
+      sha256 = "14de32ad78a699ba0081d8086048070a66a0703897c5bca4325b81705c7911a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/xh/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/xh/firefox-100.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "5381ea1b5a97e643243cfaac928e36c286ca8252ee8338bdd3ca1d4ceaa3cbb7";
+      sha256 = "16436cb5dcc4376320157f299bd7cb6a16ca4dd309db484acb805ddc052b06ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/zh-CN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/zh-CN/firefox-100.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "738eacf9518b80e6f653d2b7717ac1948b22de62ad6b3ea7b931f28670dd2487";
+      sha256 = "b4c0b35289313033c828327fccdeda48d153b55a6ca575ec04ef181dd1ca3a96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-x86_64/zh-TW/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/zh-TW/firefox-100.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "79fe50565241c2fae2ad7b0f88100392663549b266a7c532bf4276e7681cf6b9";
+      sha256 = "44123156fee60e38c66174ea3d4d3b1e9fb896b9fb1b724f37f243cd91aeb9a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ach/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ach/firefox-100.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "24ce38b5868c80e3994c0e5ba4aabc17ba7b4c5d1166b9d3c3cd77e043392db6";
+      sha256 = "3730091d837d6ce8929d67f2a75b3eac0e3429177d73f351897a21c0a957e533";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/af/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/af/firefox-100.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "f1625660a3bde1cbf437c0fc74ce29393a9d08b344b12ac4b31356284ee84370";
+      sha256 = "15126a658b2611fa62a393b90b80510ffdffe75c3f169be48aa48f7c4adaf417";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/an/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/an/firefox-100.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "e48e52c6e04c17cdb8e21adc92f031fe5b29abec58f296a3fecb076703bbe450";
+      sha256 = "d1ccd4db01db49faf062f6b5c5cf4026c30bb86b0f7b7ed7450630f0214a73b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ar/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ar/firefox-100.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "1dd7c29e3955730b4abe1997a0d2ef4745b4b7d91407a8332357e9cd0eb2c5eb";
+      sha256 = "66506e827292032df317ed27d9232479c0dfa4192009efd9d8bfd72353503992";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ast/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ast/firefox-100.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "5f4d6f9963d51a1671f9018e86b904f0cf95a2fe4a5d25c728c45e75b2c1a5d5";
+      sha256 = "5a7dd3da57c35cb496853a3bb630a6f04fa352642fb7a2a63e525c4d0c70d61c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/az/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/az/firefox-100.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "3a75c419702efcb7aa6ab2e834ad4fe4cb15a1a65b08903b507336da7429063a";
+      sha256 = "72de1f6a586c30ecfe6d9071bc745da99d5f250934689ddcd43b367941c0e36c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/be/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/be/firefox-100.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "346375d800e68f445a857f65cf44acbef85d950434f0c5e641d6a3d96ff0661e";
+      sha256 = "b0383fe35a2a6670d5f470f9e63251e2d703dc16b1afc707522bff6ad9ec9ab9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/bg/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/bg/firefox-100.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "77e25564ac2a0c88b18c2fba10b43a89f52876226611ab29a9fac276f736bf99";
+      sha256 = "74b69784aefe4ba9fc8a45573385655bc9223a0d0d878266eda3cdc9474d795d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/bn/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/bn/firefox-100.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "f8975d4f080e0e304913fa9f3ca385dc2fd3053c5360cc9bc28b09556bd62d17";
+      sha256 = "5c38263647a72cce19602b027015bbd826779717b7d54b60fe2cdc9c54db7b93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/br/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/br/firefox-100.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "86bf713dc9f9c1ec03a5b5c34689f8ec6b2f417c8880f89734b3b4dc3d7e608d";
+      sha256 = "8088dc85a7f875b80c9c5deab139d78fe91a35dec09dfe114ace00424c6084bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/bs/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/bs/firefox-100.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "e265b3d0f30da9011601eb3397ff92235a65f1d0aa01bd50aaf9d1b53eff8859";
+      sha256 = "3dc170d87e780e495818907921dbd0fc95a9e83979767b69a48b844ebd242958";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ca-valencia/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ca-valencia/firefox-100.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "dc8d8093d8eb47fc86697ac3c5952446b6e5c399a5dbbe0903bb62f6544f12c3";
+      sha256 = "eb1c20effdb474054c84722ee2e4b37a7b45ec7403268edcfdd39f3cecce8431";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ca/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ca/firefox-100.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "64e59c43843cd0f17ba5505ad19a4a3fcb207bdcc0543d10ac0232bb05b2b698";
+      sha256 = "ddf1b8f12b7fe29873cb1031a8be746b165932db2c758f1194c6fcaca31c1e95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/cak/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/cak/firefox-100.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "1600ee686b486f9d76c6fccd072f9764ec36a95cf8d1773c7dbebffb06d0f7f9";
+      sha256 = "083c850720c6607f469059d76393e0794679789c03242c394ef92ee2926e91d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/cs/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/cs/firefox-100.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "bb99d2cad57a56b63de7d07f767a3c18c99322c128b1ae291065e1de7e58ade1";
+      sha256 = "ad509e0556df3eccf6f93689abf2d47bdb9774994de6d69a900933c748cbf836";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/cy/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/cy/firefox-100.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "3f5b740653c9a24e0baf641d73f4f9ebff2d81d5ebd65ae4693d026c7a72d66e";
+      sha256 = "76cb0b781283f55204b4fbca5707000db9394205286298a16faf7223a0ef72ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/da/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/da/firefox-100.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "132513dc8e51bd169152ba55b8f78243ef2bebd51e60f67f86e22c2215dafad8";
+      sha256 = "a43c8b82a3c3728dbd18f9bb631b48bc8ffb2180988b00744bf6002934652520";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/de/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/de/firefox-100.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "f89ca6f7b71fc47a09204f698b4b002f2398b883c39ecb7213afbc9563d14a8f";
+      sha256 = "7fcf3e841085502ef3be08e189e5a625a4f5e3f7781bac1e9af07bdc8d5d8991";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/dsb/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/dsb/firefox-100.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "2b59020559917bb713d55fb260852a3608b2ebf50e17be09426f9a5e9d6f6795";
+      sha256 = "5bf2bc5c5e984f7e4f9f098e13ff8ffe68e52c4a35f240bc8e0c0c5c3363ffc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/el/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/el/firefox-100.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "53b0f26d985cd4fd9ce03c56ab1ff6649eab5dd10227803f52a6994758342d2a";
+      sha256 = "a2f111852f4d16f7ac14dc4bf57d95a1e67a6e45926beccdd5738e803dffaad5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/en-CA/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/en-CA/firefox-100.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "feaf69d30202bb414c8e9e940e012b701d9221f129f71ab97b048d0afd3e698f";
+      sha256 = "863befdc4085eb9a13cfaba07f5d5f3cefd03ea4e0f9f24baca3ecdcedf44166";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/en-GB/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/en-GB/firefox-100.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "04b848deee052a727f428b2293d5e0bc3236048068a67318ee056d81773869dd";
+      sha256 = "a1e39a64862fc3652e02dab5b69f20d10c06d23f5443bf7b1a51e583da7c85ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/en-US/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/en-US/firefox-100.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "8257e96d135b32e7b8f0a500f2d5ecbc833a58112cd77491209224311f48518b";
+      sha256 = "fe4155a4a0c7ef39d9dd4b21158ddf54db5cee8e1937c8f92222030a072a5e96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/eo/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/eo/firefox-100.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "6c21f77bda58250aa7931d566b2259b1a78d5d333e97a21a9c9e3a1667ce6753";
+      sha256 = "6265123c726cd2632c757c960fb53227e191851a67fe46d2b6b17837e6e96f16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-AR/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/es-AR/firefox-100.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "9765a1cbb05caeb3b581c934ca58adb74e9a219648578059975e12b5f6fbdcd0";
+      sha256 = "d8ca4ff428a197afca38b4d574c32d75ad53098b426ea607f9e65e1e4b1937e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-CL/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/es-CL/firefox-100.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "5a9f1f670a7c324ad84ffdc04d79a822b53c1ebf5ff31c74dc00ada6ec871cf6";
+      sha256 = "83e3717dfcf0a8c7dedbdb9406d46d59d74c49e6d4f906ea7fe91ead38e5563b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-ES/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/es-ES/firefox-100.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "7861def3da7db4f1f1bb8e9f6e3c5913fe00b8d109e320cc27e86c3b890adb3a";
+      sha256 = "5138926d7929c6bc9593129d84b9826d413c3d581ac9c724ed60c0fa00a199b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/es-MX/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/es-MX/firefox-100.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "82453536bdbbb709ca314de9d4ab5e0b5eae79a00cbf9a034ee85b95c53b0953";
+      sha256 = "82ba6b83d431f90d9cc085cc5da06d7225e959821b6d4044f522a9064dcc210f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/et/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/et/firefox-100.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "5599fddbf92f9308da984a4f8a2b11c2e1a4c5f890e286f3f5b31cbed1436356";
+      sha256 = "c5a18532919764b5eb1a6c3d57451691d978fdba19edd08f6cfd628db0a8ebb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/eu/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/eu/firefox-100.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "6a25ab3cda70e355d4c013e4be42a96c6151749d4906a399d7f57082612bc752";
+      sha256 = "9998f18a3fcb4adb00af2d75cd04516d2a98c2ffff95e3ae7a9b0867ab564d5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fa/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/fa/firefox-100.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "a6f245cb675b13b9ce93eb33c48008626705eaf7854d685c066aacf61339e812";
+      sha256 = "ab3f03e446861f63e5d939d428c91ab4ae5703c10c523c64852f4ef6323ec7ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ff/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ff/firefox-100.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "6fb187a3c5bb3dc7ac783f0f541e052fdd7e11668a4cdb1109f61b4aeb6c8000";
+      sha256 = "5a9177363814dcd79b119323e3b1c40ff57eee9b079bc1caa563f8ed10673ce0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fi/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/fi/firefox-100.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "e8a59d35683d47b8f2e378d771e7f3484f0471f50d90ea98bb5a6abb4131e02f";
+      sha256 = "7938c33f9940b9243f4b9c30392904270ff48556b4f391f1d725a35ad9cf3ef6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/fr/firefox-100.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "906b61eed97a446ba70b04810aa7ba57adf1434935f2b9e5d8c38b5c3b535913";
+      sha256 = "005818dfba4e42cd2ab19032c67da52bbbd3fdee5af32363da0364b12cca0520";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/fy-NL/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/fy-NL/firefox-100.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "195a6d20b629fce7cac7f7bc63d91a192ad879b49d5399eb64101fa809c17de8";
+      sha256 = "30e8ccb6abc250d91e05a128e49e93bec1bbd9837ad22531110fe876105fd2e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ga-IE/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ga-IE/firefox-100.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "423ca6ca999511e83b82e137812294381434650a574990e52448f081fd81ab9e";
+      sha256 = "6f94e7bc7ce2f939e172287f5e3dd7a919be3a3e51d3cc6e4d04f7d19f7c4311";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gd/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/gd/firefox-100.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "c06f81e488a8845aac61495aba82a61ab7852804def21e6873b3b4dd1b495ce4";
+      sha256 = "54314836fc112ed38af0e67c0d06549e8f1360fd129e82f35e6679bf47e40bc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/gl/firefox-100.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "760eb80e6ee37b5aa0dc48a64e192c64cd896fca6849438542aedb85b6aab69e";
+      sha256 = "3bb7f7c2295f80094a9413a2dbd2632ae3185e82288ffba2f94c89b9207113f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gn/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/gn/firefox-100.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "f8ff0112426366d2ae811b9a0882b64229e27d5f3c3aa530d0c02458f784cb38";
+      sha256 = "c109e5109eb6bf908bfb40eaf209887e96cf0e6fa9f215eed1192a83c471a9c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/gu-IN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/gu-IN/firefox-100.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "852f4765df495e61ff01ac29e71cc9d5f891212fcb1be33f40fd32b39cdd80ae";
+      sha256 = "b46a52077ec16056c47db5e77e78e6ebd63c079eef13eb106c4547e6757add49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/he/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/he/firefox-100.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "f9f951a34d1248c887911f1c668495efd0c7e1d398ac2c807ef06f2cbe038f77";
+      sha256 = "ed8cdcbe05a11bdc5d366679ee8ea8fbbb62db74dc451b5a3a1cfb7706d73231";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hi-IN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/hi-IN/firefox-100.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "322c3a6c88afb2e89e6e00a524044cb6716b27ff177ab29c962eec6db01a6b1d";
+      sha256 = "fec133a50d9c0ef91b24231e6eb1bfe91a66224bdbe985773312f6d14a1ffaef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/hr/firefox-100.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "159692c9c8243641696bce5b1e29548aabdaaf980eb7f4ee2189804fc74a0cc1";
+      sha256 = "f95594469af643f49fae13e48a40c0c4a9e3bf81f1ac9a7e4f42002c464fd7c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hsb/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/hsb/firefox-100.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "898f4c2196e487b0c39184c5215cb5d45cb5bf2318da1c8c4c2611d9d7235902";
+      sha256 = "218df4ce22d93f0487346de842d83c6175c1301c68a3990ed79a1d307bf38074";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hu/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/hu/firefox-100.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "2efb0f45bfbd19f8e4e419f33f7a4902cace0dc6d6e0d2bc83ed9d050eba08fd";
+      sha256 = "1db15330db682da2332958848cbdc6e3c89038ceac65050911f2fac75c00bf51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/hy-AM/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/hy-AM/firefox-100.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "b9597fa6f653cf7103b1ea316280ae57e2a7f53b6b72a88a3ddf9639afdc52ae";
+      sha256 = "71bcda0474fa2e5546bb55b6cf1199baac1c277258b2be015b6a0d833be2514f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ia/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ia/firefox-100.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "80196e2fb1838c5f69a8fcc9b5b70e2b6511a815a34101d9b4fb12c8f20169be";
+      sha256 = "d02299856a2508098141ad78ccbf15c5f827f5e8a0cdd33f39028e99059513ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/id/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/id/firefox-100.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "72ef1d83d52ba585ffd45544e7f378f007b9b7cafbf4f4720c9ec03f2638e120";
+      sha256 = "d79ebf284b2c503083335c3c953b4ff382cc611f8a5a2cb4a037a349bae25bf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/is/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/is/firefox-100.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "5b0e468c75003fe6abb3695d19dd19e843cce4c47fdc836811624716e3787f44";
+      sha256 = "5f430fd77ce8a6a4c21aca62b58e095e1a9ae02c9d3694de49447f32226fef83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/it/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/it/firefox-100.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "596a68e101e6531d56bb8d0c2a0854820b2e5841276040b851cf7ed2ad2a1e89";
+      sha256 = "79aed49e98d5798c65f268ad8506f89ffbed3b980a289af6ecbfa265f3790ef8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ja/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ja/firefox-100.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "482dcf07335ec9b0b7b63d71c5d6a3300b1f54271a663338c51b33b5e977e3fc";
+      sha256 = "ec4c928f3fab6366105e722478b997c53102fca980071548c2d60902387891ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ka/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ka/firefox-100.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "27879b1f25158a13ade851481739177cd5ac4f77a952f35ca55514070c16c0cc";
+      sha256 = "d2763ea580ea6d1cdcbd753f1d4bc3358bcc08a97658d1a05969ecfa22eca653";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/kab/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/kab/firefox-100.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "7d3b4ba9f636c3fa61febca9c2661fa196de6daabafc63a9a793a38d918f3637";
+      sha256 = "a41ebdfa04d63d892e114ca31a666fee61d369640a9509b2ff94f05f7b656add";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/kk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/kk/firefox-100.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "9e74469c19d01a2f385ed9c3e565699c2585e24355964d4aab44f85c12c87d5f";
+      sha256 = "79a80098990c0d103d4733ab0a541187f719b0bfead5f30f332f6c941bea3e22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/km/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/km/firefox-100.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "60feaf0bc9ec8525d9bb3b1fe06019e92f45fa746835c8e7e5aab3defe1acd03";
+      sha256 = "afa21a83356769a9ddc74ddfb2598809485a3f89e4c7063e1bc18180e3ac9464";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/kn/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/kn/firefox-100.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "f2f30c130331586378b7ff34f61f2ff9184be15b2d2ddc028f69d1f0b6a1ced4";
+      sha256 = "9eae9e16db05c2ba1bcbb8613885b358ecb295c6e220fb53d59ad7cf067016a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ko/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ko/firefox-100.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "b6912e5f2541003e8eb806b61fde091e3ad6764940d6ccd94ab9df6afa4167db";
+      sha256 = "d043c244d9e91d606095ea08d3e197cda8fe5d78c07230f13f99d751c1e324f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/lij/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/lij/firefox-100.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "98df2438c65cef3f7093587c9e5d376695af56ba0097ef9f6d50328ceedde314";
+      sha256 = "cf3d5899bd663ab15afa357ac32e7871d86f3f7f4c0e447dabb6fa71bbbe1ba3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/lt/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/lt/firefox-100.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "049cf802b99fb218db3a1ea5d5709120d139a40e10619f7e859df469ba506b68";
+      sha256 = "82ecbeb020e63b5bced7571ba93c2e3ce73be85bc9d186f40e9f201e1bff2876";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/lv/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/lv/firefox-100.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "b774821e5e5abc1d9cb0b023b011dcb82b551351684ddc29bb8a1abf59d9e09f";
+      sha256 = "7439b7ce1ae5aed8179729664a6b4ef3bcea62735bc0a0d009efa036977df069";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/mk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/mk/firefox-100.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "bec25ffa39198d9a4f2fc5f69e3a0bab7b2eada13912787aa6b135b0aef2336c";
+      sha256 = "126798aafbc5d36c2ee20ce5af940d25aed23aba0d7d24c8548830711d6ba33a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/mr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/mr/firefox-100.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "0bb35cc0198feceb8a794b905437d823ff692740095919d9a5d95b8d130f51fe";
+      sha256 = "407d3a3a41cd6aadb8cbb10c1a759b14238f9e1fcc72b26a9bc5c6e48003705c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ms/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ms/firefox-100.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "592dce9e358601c01fbd93b7dd4d2b6b8cf9b07be7fdd193478e4c220a134aa8";
+      sha256 = "f68179a547c53c3fb4abface982b36948bdda51ae45fc77782a8b2ffc5c289fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/my/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/my/firefox-100.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "bc5a831a7d2f107e2706b5f961dea62588dd65c02d549b04e399676d74e7e01b";
+      sha256 = "55ffa1b1ab79073acb88dc1cc2a28641b6e4d237c60ae2fc21ccd5112ea75e80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/nb-NO/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/nb-NO/firefox-100.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "337930769e9c2a59fb06e58fe75cda8327df7c172fb63cde6939427f1b476024";
+      sha256 = "538e77cd9ddce689aa117668ad75968b010025e6b400fc7bd96b5204ce9a9537";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ne-NP/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ne-NP/firefox-100.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "cf893e5a61a9d70bc5d9daa9f385a1e03a5023c2eb2baded93726b1b3aef07a0";
+      sha256 = "ccd76c2e71b2d96481a75070ffec326c42e20b8024a0f99ca86056bdb67f2e7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/nl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/nl/firefox-100.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "a98042f35aeb7b040e63259bb86a86608af79e9edf50f5b23a11896a97f7045e";
+      sha256 = "682076a78e8d7fb7b2575e55dc78274299cd909ec5c9ff3d543092c98b9c9f40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/nn-NO/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/nn-NO/firefox-100.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "94413cf0f5e40598f203ab6425d080718704fdd5fc4a85be463ce653060b3faf";
+      sha256 = "6f8506ffcafc4508833a753f8df3f329a0b5f5ba452ecefca8a0b8f224398421";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/oc/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/oc/firefox-100.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "5800a59ea116c594aa4c362e927379a497b3c3f1baf1f107d3a703ac0b265e54";
+      sha256 = "8ae874315a44ac0e0de348082529e307ded81aae9252e2bb267b5eceddce65f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pa-IN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/pa-IN/firefox-100.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "7ff731e1b3d41fbc6a79fe53451e7cc4072ae9c887a62e92251d81a3cf9224ec";
+      sha256 = "d8c59bc7d2ce3f983fd8b0871d2f9a3ba59c4c6d82704923f5372b5e27be0d1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/pl/firefox-100.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "406af31b7fc942eb16c64c2806cd5b73baa8579a5485908b0e840d09e0f7042d";
+      sha256 = "a4e8fb0156d7b3826adf9fd232caa548bc855926eae1ef67503ef76f72f216e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pt-BR/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/pt-BR/firefox-100.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "aee93d65a4b17c020572e1152d4cc19d4674cf116f047c76a87dd8ad26bd6847";
+      sha256 = "938817deabf50ffbf3aac9aff7da7c97a9ce3758a6c78524fee99b24db2528a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/pt-PT/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/pt-PT/firefox-100.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "eb2039bb0858f3d311676d1452c8bdf590450f8a189b3701829a979dd41736f6";
+      sha256 = "0f3dc9df4946e917b6d3f5ba59cb5224c5b10ea03f0769dfbb62560774fdde8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/rm/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/rm/firefox-100.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "afe95de3ebb394257b09e790afedd324250e099e53ddc301ed68f93f5dd2b33e";
+      sha256 = "957f9794b99fddc4b778e5f0aac854d5310e2e4c8f157f3d96602abb20a8e3fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ro/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ro/firefox-100.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "6475e10dc4c37c780b4b3544500f9583f4a8d45f11f64089ffc25a261b20296e";
+      sha256 = "5fce2289eee60f15fc6c868192f571fa4faac863702bd35fcc65ba4b2b3270ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ru/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ru/firefox-100.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "72cdb657fa263fa475297620d87e38c26dc64c979e07be81cbe0ab7129a11e70";
+      sha256 = "2c226a1da278e8924296c190c7e9cbd6f0d986652b4536ecc017626434507e50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sco/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/sco/firefox-100.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "4193be83fcc2b792bcc3025500172aac0c2123569967f2e645bdb37d907ed440";
+      sha256 = "5cb621b1686672305bc9c597a8f11dd44f205054ffe5690994cfff3907a0ab22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/si/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/si/firefox-100.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "67d3f460bf9156b4715390247f7f4481cdee8b25583055cef0e4ba18daef1159";
+      sha256 = "bb2ac6167632254f04ea446f5f819cab31fca61c630a9e2b17253f581017d27f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/sk/firefox-100.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "67a16caf8b1e1d23a99a038c58f33cbdc942e04e497afd117dd96fae417e6e4f";
+      sha256 = "e9740de798e369179a5b963f650ea003de3d8d2959989cd7a5a39ec49ca69016";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/sl/firefox-100.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "61c12adb77007ea54c3dae44d174d86f31486a7cb6b45e69370dd6897a2ff792";
+      sha256 = "881ba248e489edee338aca98792d206cb8f749ef957197a9d6498595ed85e721";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/son/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/son/firefox-100.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "0529e0adc9ed86507ebdc8ab129529ab4457d7987b205c746e0899a8727336a4";
+      sha256 = "7a9774c565cafaa531b43cda5242f2d0d7fbf3c5daa595f53e1de4019125a7b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sq/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/sq/firefox-100.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "c773d92b78498d544337cfc05e61342ccf51faddcba5f28394d3d1decc31f468";
+      sha256 = "2ed96996f3dd7a6da33403af096dbf8e077c141a8d7930384b916c43b606fbb8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/sr/firefox-100.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "40192e74663678ebb06c19af919d765ed11692df8cbc4dc75ef4d5e5d865c096";
+      sha256 = "15c96cc5f76b9067a0f7e7adb58ae23a37f9b06a5094c14bab382577fc4629db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/sv-SE/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/sv-SE/firefox-100.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "611190e442f223b5502c1631725c7058f8c5dae094bf0510b6e59e603787e152";
+      sha256 = "608945e00e5322c6e7ca814154d3e6df333f8114ad21f0ffd8a9d87efd2a8972";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/szl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/szl/firefox-100.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "f465417b16937405f084dd8b61233fb13e9abc2bdef5f2914d91b45c89afaa58";
+      sha256 = "5fa3b0bc14887479c7a82ba17d2f6a63a3715b63ac5e19d4576af89f8c84ea10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ta/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ta/firefox-100.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "d20fa90ba3eb82e8c4322eb96baffa5b74a22ae9d5b9225b4fff0031d3756d24";
+      sha256 = "08f646c6d6e64b954923cc02fdd820e413f3e3dc120b4d4fc189f52d70d7b6e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/te/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/te/firefox-100.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "cc0ab7a9a27a8899fd693f9f040b0e5c954d21c63cc54bf89ca4205e0fe03fad";
+      sha256 = "514f5a8927a82c0b5ec4746554daffeac2403c10e7c76833d2d3cf77557820d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/th/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/th/firefox-100.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "f8530e492521e3426573c3bb642d714ba3368d1a5f0ebd0e29655e868a19a2d1";
+      sha256 = "93a6bcad7acf3588b13ee7e7537d68988785d04a245dcb2bb6bee7644d0bed73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/tl/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/tl/firefox-100.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "0e9fda135f96c8c6b0a515e5027613076c7969f70eb480aef9bbfa516fa109ba";
+      sha256 = "7c1ccf221ed095d7c8afbf8903ced04f908f90bc3c83cfb207b5c4c2c3155053";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/tr/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/tr/firefox-100.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "12a9d9f4fc5f330b6b98c7ba40e61d764cd9d3dffccc3797113ddaf57efe55be";
+      sha256 = "010dc56e6966947dd1a4a1b7462e7db842df03da955228e7d1a36906e7fbacfc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/trs/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/trs/firefox-100.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "e91ab97279eb6e814775984c88c20a3c00654d7ec9d6972c0d460f3f39098c74";
+      sha256 = "c684639b05c2cac1b569ec22ae8a559dd4ef3f1f27bcbf350424142f752541fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/uk/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/uk/firefox-100.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f3b39c7919e83c0dd1293e76e48d7f97aacf83ce0ee5971880ca752c2b31bdc4";
+      sha256 = "799d73d67f45ece8ea1e30ab7b99a263c8a79cebb9cd47fbc373a6a145782a88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/ur/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/ur/firefox-100.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "a2653a31b730d3b76b0d785f861c85ea817b55632fffc172bb3d207e62b801f5";
+      sha256 = "429b7fc64018c271a4177b746cb7a757cd1c3027e49a3f7e2cec25164b7d1950";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/uz/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/uz/firefox-100.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "2842862fb1579833e629aec52ff883dc630966c260fe18f88978cfc500abd8ab";
+      sha256 = "9f1fde31d699fcefd001eb80aa3fb20fffacddd69cf9dcc83f16d20dec809444";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/vi/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/vi/firefox-100.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "595a53c656a2e4ba03490e1da994f6db8d3d08d8033204fee1678b98e9d0a5ef";
+      sha256 = "1286ea53f633fc126134f6f1787f72c676c8ef33668dc331d1fa9d02ddff015a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/xh/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/xh/firefox-100.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "e76d00d6e119afd9e567f9d22dccf3a01886b0b61d65ecc114704d03022fba3f";
+      sha256 = "ae793a6c51bf274b5fa7f802325db70cd1d4aea5fef310dedd67d1945bebe3fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/zh-CN/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/zh-CN/firefox-100.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "9e4d863b6b1d614e0c53247b7bc38af5b2ec606d851e00f33f3524fde9f50e53";
+      sha256 = "e7fc147e67eb25a1c5a4d7aebcaaed6830c3c532dc0c79568f5932c0b30f7399";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.1/linux-i686/zh-TW/firefox-100.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/100.0.2/linux-i686/zh-TW/firefox-100.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "9c26d129e3454867c1284ee410ed12eef163c6df71306322bac3ec38b77e79fb";
+      sha256 = "cddc2580b752569d6a71e96fb0c5f9f9fb93dbcdb25c64cdb66645731c415839";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -28,11 +28,11 @@ rec {
 
   firefox-esr-91 = buildMozillaMach rec {
     pname = "firefox-esr";
-    version = "91.9.0esr";
+    version = "91.9.1esr";
     applicationName = "Mozilla Firefox ESR";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "fd69d489429052013d2c1b8b766a47920ecee62f0688505758f593b27ae66d6343b9107163749406251aedebdf836147e4d562415a811b04d7ab2ae31e32f133";
+      sha512 = "d432d559f2c5f4b0bc66a755db7d61585e24a727cd8d18630854b3fb8633d54baf61ed65b580345b13d52b66288aa15ca8ca5cfcde8231e88108241f0b007683";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "100.0.1";
+    version = "100.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "6ba09542d1573e903978f8e63f39381dcf2180219e80e7401c62c8347100d6d4a973208b8094cff07d76106636cdfef93829fff3398011fd9536dac477ef118e";
+      sha512 = "6d9922e35e496fa63833ba03d1466e075287e40e50854ddc4f4a2036d9c7ca1f35c03bc6f708a3c469e0ec3b389b3346ac754bb84df0fecb86955fc21c05e00f";
     };
 
     meta = {

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,655 +1,655 @@
 {
-  version = "91.9.0";
+  version = "91.9.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/af/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/af/thunderbird-91.9.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "9a7e2e7501710134294798d2d7d5ba9d11b18440e6f0a09f398baa3b9c5e8aa1";
+      sha256 = "f06c5e87bc9dcbb0d4aa374e262a8bd4b7bb94d5b2aa71e1ba5a61794a07af4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ar/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ar/thunderbird-91.9.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "2b77f10e1152158cfee96c840d86a64e3fe831c675482ef63b2220cc65565599";
+      sha256 = "67178dac2f315ba13806c8056f041f083952b4ebab1054a8eb66d97b4d1c5fd2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ast/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ast/thunderbird-91.9.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "e3aa8dd11bfc018c0025628020aeb77e17ad975baaa84441464c704afb7d0555";
+      sha256 = "2858ddc2d594d12a1def62c05bb23c3f91633a866004a9a184b4ad06e294c761";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/be/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/be/thunderbird-91.9.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f78c3ade5637eba2dacb34437cd2b158f7e5f1a95988bd400ca284a04a283fea";
+      sha256 = "e5fbb0bcc2066dabf1a6d1dcfbf92d1ad4af606aaddce00c2820d84b2bb2005b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/bg/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/bg/thunderbird-91.9.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "85c411d57556a0365d46174ea1fe7c0fd19a697a9ddd9dad0a83644749782b7f";
+      sha256 = "de456b442aac187d49573572c45609b0e0b5f17e9e30a253ff803f9691c4fcc8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/br/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/br/thunderbird-91.9.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "2767877f299b4c871ecfe861d84975cb7e1d17715a249410b6d1252c3df42611";
+      sha256 = "9139317b57b529a3151571274aa37c72790b68c2e310c302b87a490f6e6a2512";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ca/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ca/thunderbird-91.9.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "020ee30e402972f341620c7e37981a6a197378c1cafaeead0af71bde56a66af3";
+      sha256 = "bfdef191af0ab0622847a751be29449e3ed5b3ad5abd801aa466370a621fa457";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/cak/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/cak/thunderbird-91.9.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "11b911c4dd1cbafe84406f0209379e911d047833a126c47523889f62e9a2b512";
+      sha256 = "59fbda2666b1fca61f222fc5394742ce1b712390a6452bd6bd4317254a83ee90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/cs/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/cs/thunderbird-91.9.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "834e66f9f2f8cede63df9d84b66024f6b848a847fcce7229d74880d47751b7b3";
+      sha256 = "cec215709a2ebc17b25658a640c119a3475409ab4c89d1eae92f24d612bfd07c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/cy/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/cy/thunderbird-91.9.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "df5fbca74bc8f1f42c4f20402822b9b0811c4df7e740336c51853d83dabf54c8";
+      sha256 = "7685a6e54ec1b9f79c92230da7c6f9b102fda697e833d465c212fe53008c20e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/da/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/da/thunderbird-91.9.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "d836561fdfdf1ce984aba8913d5d7d8709a1b4a929774bb23d12ede7208be9ca";
+      sha256 = "dc8ebeb29651025c19ae876b3a500ccd35e137b0ddc862467ba667bac2417426";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/de/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/de/thunderbird-91.9.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a24ef049b9b14f89421144f883ddd19af3854339b74d7c9ffeeb85a15fb7bc0d";
+      sha256 = "3750041376f16133da7c8452427acd8d4414eab1f0af84b7349dd2341f679493";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/dsb/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/dsb/thunderbird-91.9.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "741cb5362255fac4f5fd087f057cfbe2a6f11e21dab45acded8f217a2be4de5a";
+      sha256 = "b052464be29215c315ade6793233b2f16bb5874f34890e0a93002c0dc389a677";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/el/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/el/thunderbird-91.9.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "26bcbad1471e262c34125eb8f7671b0dbcb44dea78c5a03e235e1708d052efcd";
+      sha256 = "cd7a84a8d8c3f11d121abe46174fc5c49328007a27397b945549bf942a54fdce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/en-CA/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/en-CA/thunderbird-91.9.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "22b90cbb168b0992523205e4f7af1b4acf3008c4ee84f5afd8249dbe31122178";
+      sha256 = "087fa8164027256f86f162205292004e9e4f15dc87f35e49d23876e8b8ce23ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/en-GB/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/en-GB/thunderbird-91.9.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "ba13594d0a4f612000c278a6c0ce45fc83cc16be8f6f792e783b9e4097fb657e";
+      sha256 = "83bf95ac23c269e00dcbd5f4322bdf9adcb2b83bb4ab10e18e4bae435f36878d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/en-US/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/en-US/thunderbird-91.9.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "8815aa634aa4ecd7663f65b4d101d9eefd719debc0f18a76aa631637a515788a";
+      sha256 = "de2fa8b336e485205f578442fb64fa37c45e6f7d6263648b9dea1556de696df8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/es-AR/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/es-AR/thunderbird-91.9.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "5e6ea5a2849dc6885d671a16dd120e711e0462defc79292c46cc473cf87683bc";
+      sha256 = "178bf7bafe1f1f2056a5d301107bad4f69fb6e82417544d6ac4afaa541c6b6ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/es-ES/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/es-ES/thunderbird-91.9.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "d1bf062fd21eb99e88b5a506cc73874d77571bdf37d4836174844537653186d2";
+      sha256 = "269fe6cde594cb429c69e8a7209874b973259feb954856b30193fab0eb6b9cbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/et/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/et/thunderbird-91.9.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c841f7987818ba478ea74beca578cfd689016b55d3a1eaf53e250a5b30d60e31";
+      sha256 = "05bc8d02b11bafa75dffb15e14636bd8ec7080be71b0e94d1106bc2802cc571d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/eu/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/eu/thunderbird-91.9.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "d415edd9c0bf60d15f504ef12ee24ee7a63cf09a0e4c069ff6ab9695e3359ce2";
+      sha256 = "b6e26cf5fa4b02f6559f1e631b88118a422fd6d957742e2a29269a6a7c5a439a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/fi/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/fi/thunderbird-91.9.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "b6685d1ea83fc5b3dabe8db910e0f76eb85cfdf45d6f508a558fe38b0adc3daa";
+      sha256 = "b4e63104dacef2de6bb1e3fd81765aab27d2c14c0f22a6fa25e7566251fe2a86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/fr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/fr/thunderbird-91.9.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "848e77ec6c0e8a0d8b66c5984d56c4fcd270351b942aba72984105a661f77e36";
+      sha256 = "60aa0128fcd364f1c2aa9b5523a47a97fbdd0786dd530ae47a1c2524e105e2f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/fy-NL/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/fy-NL/thunderbird-91.9.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f977281f87c12fabb61a1bc73b3adf9b5a6a9ae6abe7c3bff590162388313809";
+      sha256 = "fe0e864e069dd2a3839bd57aa12fe6bdede11413d0c6d3427682b778d656384a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ga-IE/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ga-IE/thunderbird-91.9.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "98b0e23dcd4a4759427cbbdffa6cf306d0e6bbda246041614f0824f7fc35c487";
+      sha256 = "f7732439d4f11dc6b04a8b6c49677cb00b02cb1d5ee3029d494b101f8d8854c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/gd/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/gd/thunderbird-91.9.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "316f05c861afd02e8d8f84c65d4d4e9cf3c110cdb92d5bc1f5e675e9cb5247b7";
+      sha256 = "e7350fe4363bc840bf2cb782838951eb26809fbfce1ff7d79bf62e5b227b6229";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/gl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/gl/thunderbird-91.9.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a75a9fddfd57dce2d31c8d13adaa3268aff11ae4b40c3ac4434df55d0fb467da";
+      sha256 = "e17f22daf65a19fa89e98f6af699339deb3f908c475e15c6dfc20bc23d6054d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/he/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/he/thunderbird-91.9.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b553ff588c310175aa06d8783c740522ee0dcc4cfb26fb173731bc993f67b818";
+      sha256 = "1a3896d479ff72a68af9a03349bf34bd4fec68e643888f5546c87406e4939d74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/hr/thunderbird-91.9.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "18e46ba1050ff7cbda89e3eb6e4fbc1bd5f80dd06506fa0d122a659edde0f29a";
+      sha256 = "8bcd244d7d51495b794d65617be5dfb372c7736f484aa3172465d2c88d670b48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hsb/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/hsb/thunderbird-91.9.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "bb8422e3ea7c8b9ef2a3fac6dd2e76b8944b426cdd6bb711dc90d34900bf69b2";
+      sha256 = "d79b7265f0f43116f716d0e0038fee6260179edd9c3dc638ba749a719958c876";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hu/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/hu/thunderbird-91.9.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "fc3ef5d1f1a1b0f3d1cb960520a1c64d649b974d7ac00a9425ca9b15df721b20";
+      sha256 = "c7834d0c25dc031b5e6fdda930779eeb022c048f66982c1fc389f5857da2d16e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/hy-AM/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/hy-AM/thunderbird-91.9.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "beb591f7fc7b724924bc3470b9b09c76d027b3a0f0839e0dbec50b30619861bb";
+      sha256 = "4b40f15014d95cf48ec88a9023d9b265b3b8718cbaebff19fc502d79219e2511";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/id/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/id/thunderbird-91.9.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "763b014909a2859a8c3e95b12b38ad481e2418b635fa76bc95863e0a05fb2f7f";
+      sha256 = "71d5a4f1f97f99b3d6237bec1fe1d22506e30322b9afed3f0a57a285c93ce0f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/is/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/is/thunderbird-91.9.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "13ea8123543ff8a14da10e619e71f71d091d953d05a16ae6eef628b223eb1e8a";
+      sha256 = "dd041da805c3ad9b64ac99a18170b48b2cbee88eeafc4317f3675732699193a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/it/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/it/thunderbird-91.9.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "797c7e71a2189ee4b306aeed63c7c3781cf2a056dc0c654cb163b120531f2052";
+      sha256 = "2d7ec87d3cc0bb5a37d989c54770d7faeeb3c142bc108c86e222b2e61883be88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ja/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ja/thunderbird-91.9.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "1c96839f767eaff3edb4478aad1871b5353380c3279063e06cfca9ec8b584974";
+      sha256 = "06fa0ec26eee35b483e056e94f851f052ebec7b8bce7768ced573a4e74c19032";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ka/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ka/thunderbird-91.9.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "fe537966801a2943d098c12112c21f23665c43d36f74ceea4f133dd584c29902";
+      sha256 = "af56172d4f9cab608e286e5955a6faeda694a9bb27206c527dd07e3ce0f0c1ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/kab/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/kab/thunderbird-91.9.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "8f73600ff6cf691c70dab81014b1dd561fc6dd24760b7b299d2c4cfb3d302c0d";
+      sha256 = "98ab11719e9830691fb258174b73bfb3ef496f7654ab87115718326b451187f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/kk/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/kk/thunderbird-91.9.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "66da7b225492be2f8eed83d3babc8a0a13eca244b2b0d5b7437a8e74b75c1959";
+      sha256 = "75b98581fdbbb0d5292e1d9658b84652702d973d57fd0aa262a60741a60b489d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ko/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ko/thunderbird-91.9.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "8157a73e18b899f99f2a71430300b329ae8faca13ba668270f216f0a43a1e5bb";
+      sha256 = "79a7d5557420e452e605283766aebb1c474e171f8890c1606a94364f422bff2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/lt/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/lt/thunderbird-91.9.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "188c85d228bec3abaae34d1d6f90f986ca956834feee84804c4495626deda52b";
+      sha256 = "e8b544082d722ed2913264d7f19508e3ba4cf4f3af801fea74f75e790e558d9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/lv/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/lv/thunderbird-91.9.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "2abf6f28470ccfcdaa742012edb1f5c5041c6590b5c49204527a59983291d7f6";
+      sha256 = "210ac6d6a4cc603aad294a81821c160051b81cf5078e1db637c908f4b1d326a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ms/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ms/thunderbird-91.9.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "99d02d8a0a17f01749aff5dc0785fa4a22c556ddb4ae80b6d629d19beca5f9c4";
+      sha256 = "8f068734975c03df942cf9d77e9e6479ab8a4e05f1520fcd377eb7579fec9e3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/nb-NO/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/nb-NO/thunderbird-91.9.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "82c0ec62f1c6c6b4862656556371b9dad8804eb3199e0c357ba2f5e491897d32";
+      sha256 = "d8dd4e72ace1ec1ee377e845a51d6621da8f79ba231c8de9c1b5c0adc2f00e8c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/nl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/nl/thunderbird-91.9.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "48a4cb7792ccfe6fcd364734efadef7dbdf37e93695537b3bad25e54f4863e97";
+      sha256 = "e31679930f2e74c70d9d474481976f6d633dba8265c368bb1bcea9cbdfa2a674";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/nn-NO/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/nn-NO/thunderbird-91.9.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "dd3b69bcc83296beb03a1fec9675062be98c4eefcf67074691d1474d5d9a8265";
+      sha256 = "cfcaf1584954c3c8b97c8a18905129273c6dd028fffb168f9f614bc519d724d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pa-IN/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/pa-IN/thunderbird-91.9.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "212c9ee1beac598d885425d4960b5f479f87df8a8ca0e362b288cd2a5dfbc0b5";
+      sha256 = "b5ebabb96c4cc6df5f7804b62540b9a823089c65e13f3475e16e2e75582dbfe4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/pl/thunderbird-91.9.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "75c2a144e3217a73827868ef130efb5f16d1924739a9cc3ca44ba80f0eb28ce6";
+      sha256 = "d8ec7636ade35f3128e5076d95a49ff194fe749d8eb8705669894fa91c3743ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pt-BR/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/pt-BR/thunderbird-91.9.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "61ef799e1364b35c2a795626fed3bbfa525ce4a78c88a505afd86d87efd00a11";
+      sha256 = "92ed3cd78c2845116dc04d06a4bb1b5f3eb41c01256fdbbe0db83ad51c3fe617";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/pt-PT/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/pt-PT/thunderbird-91.9.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "3f8f817fa8358990bc95fe2ece3541eefd3d782bf82116af3a6a555b1b01fc59";
+      sha256 = "010cd55542a6564e7df0d720deb1f3fea2094ca6cb0a202448145b25c166b2e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/rm/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/rm/thunderbird-91.9.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "31dfb6c6a9d77d22d49a077003be98c6228c52aee541e2f31c407c9d7cd45c24";
+      sha256 = "c4e6c659a9668c88f049cbe2c47bf9f70604a23ad40f4b6b52d6b8891ad09a2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ro/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ro/thunderbird-91.9.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "19dcff1362dc909d70311402c798b6359ea8da9b3fdbddb18114c71f47226ef9";
+      sha256 = "09a9a803b6a25dc429bef4f9f1e81cc7500b8493307c8462b855c0045fd32ef1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/ru/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/ru/thunderbird-91.9.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "231b1f5e0ce7a502581c7cae0ab327b867e96cbe1ec49a7c24522c38d69ec370";
+      sha256 = "332ee8695f3fa74ae952ce55a4d91e26c789e8f95d13d05a5eadfff149d2e36c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sk/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/sk/thunderbird-91.9.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "ce2b6fb7f4d3204f2b11b73847d06705ac5df064e65291f2f505cb59108ebb7d";
+      sha256 = "788a802d157cba9957b6724431143e69519b7d02ef1537c89b9a32220a35045c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/sl/thunderbird-91.9.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d8b7585b7161004c700f3aed7d70f24bca77fe680cc43150c03802f2ddb8a4ce";
+      sha256 = "4a2d9398e4944cb658d2b5ef16b4521123e6a0146b5eb70ebd45c20edb53edfc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sq/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/sq/thunderbird-91.9.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "3b70ea054b82c6477e9b1d32cd369a040bc7fe7a82964ab3b4508d14a86cc6dc";
+      sha256 = "a587c265f6ccde0e1acfef1f196a1a0a81041c9ef58dd829f189508af167727c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/sr/thunderbird-91.9.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "49c3b1c67411e2750cde324db4bc0e5c8e3f71fb3cab584a6d568584e32df5c1";
+      sha256 = "e9f7dd607472504762f568d544b6a34a0e1ffe58c012f7116214fcdeb9c350e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/sv-SE/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/sv-SE/thunderbird-91.9.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "bfbf94b605d477c8c65daefec9578d248fd46b28c9a28e698a7595486082cd3c";
+      sha256 = "c8fe1447f93e4eed8c3da48efc53de313b86558b4fe6f83f8fc49a87da15385a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/th/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/th/thunderbird-91.9.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "7374e4dcc99e02d1fe08010b9139ce0d4147ea6ff1716046e163a8d50974b9ff";
+      sha256 = "cde4dfc3593003fb4c2e10bb9b8b532079766a19b21598f48be55c1e374b12bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/tr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/tr/thunderbird-91.9.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "442f818b275905964e228f90eb68048adaec4e4031f082cf679828d9b08c1cf9";
+      sha256 = "f8279a10c110e85f2ad5da42a0fb7597261137fffe1a6b3fc885cd7b9b4fb7f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/uk/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/uk/thunderbird-91.9.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "60963d1c0cc62cb487a19442406c6628eb33b79ca5e3a02113acc0fb1d1582be";
+      sha256 = "13f6d38d8e12d031988e01affc8bacff6e9b747ea0b84c7b3cecff0a981f2d25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/uz/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/uz/thunderbird-91.9.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "97c54746a2aa415f14d1ea7b70f9f7f6e2ee19f789372a406dd01b1e84727620";
+      sha256 = "c0f39cf07b4f7ba6c327a1d00d28c2f67d7b84311ee8e7d95f9c69c7040e9b7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/vi/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/vi/thunderbird-91.9.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "ad05455a8aae0eb0e5ee7735d61e1ed9e37acfb96aba51eaf4c8067e54ee9681";
+      sha256 = "faf7e817bcea9415b7e4ab90d0db710c83524db188dd61e46c8d9698fd2b66ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/zh-CN/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/zh-CN/thunderbird-91.9.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "558fdfa5539597ee19d7912b18309ff87b85596642d1387a12711d107cb7f697";
+      sha256 = "0ac8f96c7f47c64019e2b3df1c0eadfbc91e4ad118bf758498918225638a8563";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-x86_64/zh-TW/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-x86_64/zh-TW/thunderbird-91.9.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "0df3944210faab8ce41dae7464c4932b66aac74f631afbd36feec22d0cb930a1";
+      sha256 = "9a91601a9dd0bae489dd8f8654413cdc2cbd5655ed19bb7f8c73082ea00274ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/af/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/af/thunderbird-91.9.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e66231f6a08cad94c5f1106c798590a422d8c8ba50b72e1159b6364d8542ed4d";
+      sha256 = "bb9fdc595c8744910d5f15a1a15b5428adf33b50ccccb60286267497b435bbdf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ar/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ar/thunderbird-91.9.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "f31dddbdb4bdcd2b7ac2393093af3f05a20b0d9021574517fe791aa4106cf20a";
+      sha256 = "3e368cd81a31f381c1297ee795589a0965b411b7244342f77a528defa68aa38d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ast/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ast/thunderbird-91.9.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "489cd880a24798032ea2d2f6718c5ec26d443d93fe49003f776b12c04d66f3c6";
+      sha256 = "475b32d53927258e065fde96aba88eda57f5a24c55fa1ed5b5a95e3f8cad0fbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/be/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/be/thunderbird-91.9.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "57f0a27259797967d3d32fb8583dd5788dc8f48c817d3c67e1b6fc724d365510";
+      sha256 = "7b5e4571043d3118147f52db032d123be071528e80742bf2b8ce55879df83e9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/bg/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/bg/thunderbird-91.9.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "7faaff4eb705d05ed28147b447bd5d3e633034d2eeabca03b9825f83757e8548";
+      sha256 = "2b6ac5a76ff80a09a7888150c9a99e2844c5b88bcace220a0422799774e90bab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/br/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/br/thunderbird-91.9.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "2631a5c137f0520c35628241006e48b57c2115c57f0c6f67c96cc0c4be8182cb";
+      sha256 = "16ed5fbe1963ce35d8c81e47509cc57b8ca9dae57203bc951563e1b56d8ff50a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ca/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ca/thunderbird-91.9.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "bac12f398fac2be718b26276c082fc201ee05005802a09dea5b374db86496edf";
+      sha256 = "e9e3dea7f36ceb031f0cc3aa200c1dd5c0ef1794b52744ab67ba620b1b547d8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/cak/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/cak/thunderbird-91.9.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "fc20f1147e9b924d06666c30f0b33d8c9369af3e8bb751bf0ed885d07b92deb3";
+      sha256 = "c149d046e0170c81a206664117fe3c6b80c33a8f1197077fc7509f14abc9cfb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/cs/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/cs/thunderbird-91.9.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "0341bd367ba45396762cb9d614f5b9e87cc8c5f7de6197a50e37e17abef517c2";
+      sha256 = "459cc60f8154379365f5cf5c7404bbc05336fe896306c4449a96867f4a75632d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/cy/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/cy/thunderbird-91.9.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "6a489b731883f4a2579a576ffa571e735dfe2a165a7553e61859ed5eee2c9f9c";
+      sha256 = "275c63bb06a93328b5463c57d1c58d58bf6c44b8b8eccac6721a16151081862f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/da/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/da/thunderbird-91.9.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "cfa573a68f3e7ba870f5cc5cf36088efb2220389b20190671a02babb4213c51f";
+      sha256 = "81ed21119de61e828bfec4edebfb01033d650710318bb06f82d873c647a1f692";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/de/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/de/thunderbird-91.9.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "b39140f5baf32c12473e0a10333025e255ea995516e4582ea98905808e148b50";
+      sha256 = "9bd615839704aade1dc694d83884ef5b30ba55245bb2d3a4be6117684652da95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/dsb/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/dsb/thunderbird-91.9.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "fd0b1a4012f46a5bf5c20ab38d7ab8adf3cdda405bae986f727b1cfc96cc77a1";
+      sha256 = "a308bfba61442aa857dbe118e202fba0b8087af7835e61b8913ad31dce53d9db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/el/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/el/thunderbird-91.9.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "85f2196748e34f860327412b2f82ae500738da2e8304be589a3c554c47789950";
+      sha256 = "052c90e718185132c939453e397344b6e3c096cca136d12e8b2d9f93055ca8f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/en-CA/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/en-CA/thunderbird-91.9.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "4b64e7bc90ffb0e0d245616c6118d890fc4d0e48936b2e59f69200580dc675af";
+      sha256 = "000b5958418f22cf0daf32b67842f8a0f05ba679e502b4b8df2dba08cbe51319";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/en-GB/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/en-GB/thunderbird-91.9.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "a361abc8f7deba8bb86afaed722043e601e1eded41d913ff21ec44e081aceb12";
+      sha256 = "c39adcf0ad4eb94d95b703b1fd369ee0d6d0037492c0ad9441b2c07190ce6bec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/en-US/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/en-US/thunderbird-91.9.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "c00b81beaccfba7472392c6c09b6867ded00fdddf7bd9e1b3d79fa7a34c92ae2";
+      sha256 = "7f7658da73a125074822bf560bbc17220adc7d5e0f636e55f62aab48332bdc64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/es-AR/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/es-AR/thunderbird-91.9.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "a8c42e78867bf7cde2aee765a1d25545bd25daa185029d6eb472d1aae2e34b87";
+      sha256 = "f4ce57dc193ceca6b5b37686e1b2584555b9a9ebb44ac9120434fc424ea7e94f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/es-ES/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/es-ES/thunderbird-91.9.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "adcdf96e70c2153ec918007384104f13221d96ec7439c9e553ea673de80cdc9a";
+      sha256 = "bcf930f5a54abd8b0776bfdf435ec7ed680c15ecce5196eea22abdbdb80db88e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/et/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/et/thunderbird-91.9.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "b2051a281105ac081c0dd52dcfbda86eaa3b1f589fae308e3c6a7bbe641623f6";
+      sha256 = "f1ea30df791704f46ccbac71eba1c78004ad7e2a334bfd730519f046b3a5d7cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/eu/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/eu/thunderbird-91.9.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "feee691079859e3b82b70c87d9838dcf4d1cccf609bd96547902c7b08b980c40";
+      sha256 = "e97be105f43e7489ba439a8b32c0e27756270a6a2b8cb1961fc153050163b76e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/fi/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/fi/thunderbird-91.9.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "5a88a2e3e265c705eb569ed4004c60be3c9bca7ea90010ad560c5261db415779";
+      sha256 = "ddaaee356e7ae031f6727eba22b3d5d2773133a5e5bdac18a4bcc98277a2b729";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/fr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/fr/thunderbird-91.9.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "61f9507bcc5a8538fac0118ae5fad9a8a515f90fe3c417fbf43974f9eab55e91";
+      sha256 = "ff68f1262723449204431790abbc287112457aa44c5cd7eb8364c067fdc74f60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/fy-NL/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/fy-NL/thunderbird-91.9.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "03bf28a074999f0e2ed06ece50484cf8b2ed92dfba82aedd2e2382ed4399765c";
+      sha256 = "01cabd0e2f9d342781104d7621f8d40ee66abe1c6f1068c47af6cc8915a39c69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ga-IE/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ga-IE/thunderbird-91.9.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "89d0092430a7a71ac7f985d050a8d1ff62aeddcdca4fc267b1bef693e31814f9";
+      sha256 = "c456e890575932351e0a62279c3e4bf512968963251ed653569db42d6ef1db88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/gd/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/gd/thunderbird-91.9.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "1aa98c5ccc1788d839fea37dc48cedff39425075a434abadcf79b6aef24fe0bd";
+      sha256 = "eedc9c0f3787504e93e0c38527f47784ee088bc2d9fcc7ed804b52138bc3d774";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/gl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/gl/thunderbird-91.9.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "c0cd9773a7bee196c3231677c1a0644d04ceea01ce5be591ea26a0f700750ba1";
+      sha256 = "ce75d1222c1050820c7a43c930c58a71cc8bf8123a5868fb6dd438f23eb1a9a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/he/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/he/thunderbird-91.9.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "4719f0d0ebd8fde4103bfce65a598839325818f4ed9b97e3c59bc4e35794413b";
+      sha256 = "645cd8cd584a2c3d610ca2659a1ae320352d296f2cfe55fd8d612cbeb38abe9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/hr/thunderbird-91.9.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "884f4cdfb559d4d611d18d18cd9c35469b8656816af4d3347fc01bbe70419143";
+      sha256 = "17191b00917692eba111da1a01284c52e28cfe22690f6632616b8e304db81e5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hsb/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/hsb/thunderbird-91.9.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "d8a773542b5033c0ec305652ce94fadeed905494226ed63816e5ef6f288e2218";
+      sha256 = "f402328a7e331760de91f1eb7acaa7a445cbc50e7f5e00b6c0f02497fc571e4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hu/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/hu/thunderbird-91.9.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "665cabba7b182c7a85e932997e504dfe1485b32709a0c9fde25c1ec565ad0fd9";
+      sha256 = "ce8b189d0afd1f9a1276cdc1c54b4ff0fbaf0ea14645538a39a40eb6c5a26baa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/hy-AM/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/hy-AM/thunderbird-91.9.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "c4a0f8e4c0def83c8b8bae39dca8e493a60af7348942f6d1999cf2c3d2e0c5d8";
+      sha256 = "3dba03a75431f7f054a46a610337518e93a7cfb9a8bde7bfe0f3c2aef0df46fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/id/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/id/thunderbird-91.9.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "1b44a02defba8f27835d5429dc77ffe55db5d22a4ee98b06ab593e26f0a6a6d2";
+      sha256 = "e3269270781a76ff3ccb013d40e4b18f22a733048016ca9dfd7b82bd6e98e39d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/is/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/is/thunderbird-91.9.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "672249813fe8efd3be4dc89a2366d935fa4ef6da648e7f9411b7286a6e0afbad";
+      sha256 = "0db05ecd5d192868743fdc534f76b3d96e1484bf4d196ee459ba2d53fd5ac4a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/it/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/it/thunderbird-91.9.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "89e554e40f3038d4754c22a67839480a16aac5bc4c550de8707f4401fd94793b";
+      sha256 = "99acc3cd6a1c81885a565ea09c6668aea1a946b0fced9db475655fba7d0473c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ja/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ja/thunderbird-91.9.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "06e1723de2de13c79af0094dad06838067919adead28f659af0155d91b39d677";
+      sha256 = "5ca41905a895b8ad236fc667a5bb01d1ddde37381a65374feb2549f2f21f501d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ka/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ka/thunderbird-91.9.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "f1c215e0c6725539c039f6d1c4ad97c5ae1b322a5cdedbb7c45af59e33a85b2a";
+      sha256 = "460434b2096ddbcd58abccdde445a8e06963e5bddc45bb88442781fbcd7b92ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/kab/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/kab/thunderbird-91.9.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "76b51a10a530ce127f079c2c37b859313a57bda456a2e44c7d742e4f11a4c3bd";
+      sha256 = "8d3877852ebbf78bf637dccc29c9e075757376cc0f0eac8109d0909a7a84531b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/kk/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/kk/thunderbird-91.9.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "4d6b9db8cf3b52474f183adb5638030a3072f970b888f910fd3dd2bd19e5c05e";
+      sha256 = "7d51c30a43e3b56ae467fb81704323902d852e2ec98d0551aec500ddfe79829a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ko/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ko/thunderbird-91.9.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "32dc2eef4cbb3a6ea483ef5cac66a75ca4ccfe5091f5dbb7921f171ea0edcb3d";
+      sha256 = "a61eaaeb6fab5a40b7a3ec25c9aef82364c3de7b6132bf1a0201afca7279ff79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/lt/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/lt/thunderbird-91.9.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "f2382f9a49d52e7e5574a72e8daee5a5e209a25f188e76a438c15cbc6b27d2de";
+      sha256 = "c09b1b265f0c214eaaa864e09584c8b18270b3e1c22101dfaaf8ff0bca930f04";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/lv/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/lv/thunderbird-91.9.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "57fe94803333b8efe57b752334f3fa56e66663f03abfb1c683663a155abe4300";
+      sha256 = "7579ec4f5a58f716bc94eb3333672350361d1a3ac11e2434eb7a2026f13d90e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ms/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ms/thunderbird-91.9.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "288358a22ef7cef6a2d521416dec846835195904ea6f347b2eec0632eddd8ec8";
+      sha256 = "e5dc0ae6d2d0c99a14fa811030b11b90b5b53b6b9b329d6d642d5c4ab18e550a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/nb-NO/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/nb-NO/thunderbird-91.9.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "17085e1c350d86573ee6f2033deb2ca2ccbe5508315fab1d5a9eea0697a20c7d";
+      sha256 = "dc4838ccdfe5c59ac7438fbeea01ff675801b14c216c6f1342206f7826bfa846";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/nl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/nl/thunderbird-91.9.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "3df971e99e9f797676b1d5b1b827e1134f25dd96d3d2f9cc131e67388d02401b";
+      sha256 = "d82604da582c5d3980eda14c488575810ccf20713024e0e0845dbf224cc6e61b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/nn-NO/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/nn-NO/thunderbird-91.9.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "ead88f4e76979f38866527dd67f9c1c3187f28126f48dbf9b176290bf5ab0f20";
+      sha256 = "d47e71a9c2ee42d9f379aa44100a403d89929c1b668a286aa189a5a087898f58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pa-IN/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/pa-IN/thunderbird-91.9.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "561c5b20f4bb0a175495d8da9140a130d876df07d097cc6674a0d665ef875a1a";
+      sha256 = "5aa634d92d4937f628e50ab796ffb65123db63b2392918481eb8a63d14ca5bc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/pl/thunderbird-91.9.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "bd52618c81ef5a98dbdbd47d5dad062144c4ea55ddbfc5694e9d5d71a9d00ccd";
+      sha256 = "56b80fc669ed97371706a1eb13e151362f0b312df531d9832835fb12611e9310";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pt-BR/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/pt-BR/thunderbird-91.9.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "c51999a9581e89b3e901dea88e102e86ff8f906b0c6b4f75af01e5ec96c71038";
+      sha256 = "801d998fc5544c1cdf68b5b7269638dcd8cf0a7c2d4c8e9fc2cd5f78fa19a9b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/pt-PT/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/pt-PT/thunderbird-91.9.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "148ead072bbcaf700c2a5b5c6160d5dcf45632c205b01f4da7912fa47bbb32fe";
+      sha256 = "35839a406cb8656ed4625f74e9711419ac91c76952975892fab99b8d175dd768";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/rm/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/rm/thunderbird-91.9.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "b0af2b91e243016f03d376361b497783568ae91f8790b4fc1e630e430d9b935f";
+      sha256 = "86fc3237284821f4f9ca16b7d8aeca3b843b5c9269e42422dd451e39cec6ceef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ro/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ro/thunderbird-91.9.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c43a7f827b71f680c2edeec47e047b075e00c136c68cc3939ed53d9a34d99b00";
+      sha256 = "ad3dcceec9d00c964b6b5529eb049c8130fdc8c945eced774e6cbf49c6cd2702";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/ru/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/ru/thunderbird-91.9.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "09fce7f1f8b0c97a843254ffbd9ff4337aa690791379e58d66dcdeb016cc04f5";
+      sha256 = "21d61b1b417263236134a8c666103dd1a0dbcf9db23af2ca0fede2710541fc30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sk/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/sk/thunderbird-91.9.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "724bebdcaee664a6e816f2a84c402eb781ddc9030e1bb94b130b9e0b86718a86";
+      sha256 = "c0c9ce86af798fa0693a382b9df0c3b5d9067c917af16afc46c7e85ee8e96a24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sl/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/sl/thunderbird-91.9.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "939bf67c268617a16283f173169462e6d929b7cbf73e1cb9d079af5bbc5145ef";
+      sha256 = "df974a11f9b1cbcec5252443c53cc653080b1ed5dec80e76461585ee355302de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sq/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/sq/thunderbird-91.9.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "4c84dd39f46c082679bcba75fd268a976cd7ba71e1616a837f0fba54bd8d9b68";
+      sha256 = "9c837fec2ad71217761eaa90ab009230eb32a45f8e7eda46a98df57dc623e4f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/sr/thunderbird-91.9.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "038d5349d895484e1df3dc0d4f89a9d833c94465590e6c4cd210cf78d379dc59";
+      sha256 = "9c952da9ffed908873231c34048eac64f1213cbf7ba322da7cff3dddc33d8859";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/sv-SE/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/sv-SE/thunderbird-91.9.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "1ebd35eeaa07af867dc21594cc40c41d50485139e27836ebb3a5c3d09743169f";
+      sha256 = "3ebdbe94b678e306e84967d6ab627eb0a5256dd4eb0b80b0c1ead10663679c7a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/th/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/th/thunderbird-91.9.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "7fecc47a7d0244fe1c0498e964b950ecdad4b740d6591291d36ceed0fb40979a";
+      sha256 = "96651e467785e0a56662b98aff11b08db1a1ff4ac93af52b797e2617b286db06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/tr/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/tr/thunderbird-91.9.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "2439b401b71e826ea849514a9f9fc2218dd515b67880155ac3d8e7cb858af910";
+      sha256 = "5b5df531ca83c13f317ec88a1cdb643c915dc5d14ef5e7b03c7dd68c1f21ad0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/uk/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/uk/thunderbird-91.9.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "bec6c00c743557c5cb68ec38143e9b5289e724725127c61058b02349534ebfac";
+      sha256 = "058fc28badd07216bc892c3318c021871d8d7937e2bda126a3f390a7ddca7bb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/uz/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/uz/thunderbird-91.9.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "15de16cc6cb131f3a2c517a754f2128bfb92cced786cdea789821c04405c2e07";
+      sha256 = "0bb4706398f75ec0704da00c0a9d8e0cff6e7d8105927799898d04b2a7d3b53f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/vi/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/vi/thunderbird-91.9.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "2328b631bec6bbea52d9c11b20371b06ce70c31fa8077adf786d901a57a4c6a0";
+      sha256 = "8e10bd3577f736c41823203fbbb7738c2f1c9849ba0437a3bf58c06c168abc52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/zh-CN/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/zh-CN/thunderbird-91.9.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "206da1db9b057d22f5bc3e26c718b82434ff59eedd94d1881b6e83dc7a9dcf09";
+      sha256 = "94c9f500b85b9276057cfa24bf9f3650b461c002d083e87b5ab0b567cf7a292e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.0/linux-i686/zh-TW/thunderbird-91.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.9.1/linux-i686/zh-TW/thunderbird-91.9.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "805867514c008cfceb5312663005672cbbc81fcd337af2828328ba4da85249e6";
+      sha256 = "1d5e6bd0689e51af1a162d4a599d560631df32f867d34ea451e39348b89ec4cd";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -3,13 +3,13 @@
 rec {
   thunderbird = (buildMozillaMach rec {
     pname = "thunderbird";
-    version = "91.9.0";
+    version = "91.9.1";
     application = "comm/mail";
     applicationName = "Mozilla Thunderbird";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "474b5aca9c5e54fdc72eebff938f0d217bc039c3ac8d1caf965fb61bd1cf349f389a1df751a525de567a1eeabd7bb1bf2246014e84c7aab89edce059fe2e72d1";
+      sha512 = "997751056ad44367a128aef13ddd55f80798f262644253f814e6e607b3bfc3e33070ed072fa7062586378234cabc7ad106efa26befc3ecb843c5dd02c1498f0f";
     };
     extraPatches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation rec {
   pname = "spidermonkey";
-  version = "91.9.0";
+  version = "91.9.1";
 
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz";
-    sha512 = "fd69d489429052013d2c1b8b766a47920ecee62f0688505758f593b27ae66d6343b9107163749406251aedebdf836147e4d562415a811b04d7ab2ae31e32f133";
+    sha512 = "d432d559f2c5f4b0bc66a755db7d61585e24a727cd8d18630854b3fb8633d54baf61ed65b580345b13d52b66288aa15ca8ca5cfcde8231e88108241f0b007683";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/100.0.2/releasenotes/
https://www.mozilla.org/en-US/firefox/91.9.1/releasenotes/
https://www.thunderbird.net/en-US/thunderbird/91.9.1/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2022-19/

Fixes: CVE-2022-1802, CVE-2022-1529 throughout all products

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
