### PR TITLE
setroot: fix build

### DIFF
--- a/pkgs/tools/X11/setroot/default.nix
+++ b/pkgs/tools/X11/setroot/default.nix
@@ -1,8 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, libX11, imlib2
-, enableXinerama ? true, libXinerama ? null
+{ lib, stdenv, fetchFromGitHub, libX11, imlib2, pkg-config, fetchpatch
+, enableXinerama ? true, libXinerama
 }:
-
-assert enableXinerama -> libXinerama != null;
 
 stdenv.mkDerivation rec {
   version = "2.0.2";
@@ -15,12 +13,21 @@ stdenv.mkDerivation rec {
     sha256 = "0w95828v0splk7bj5kfacp4pq6wxpyamvyjmahyvn5hc3ycq21mq";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ttzhou/setroot/commit/d8ff8edd7d7594d276d741186bf9ccf0bce30277.patch";
+      sha256 = "sha256-e0iMSpiOmTOpQnp599fjH2UCPU4Oq1VKXcVypVoR9hw=";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [ libX11 imlib2 ]
-    ++ lib.optional enableXinerama libXinerama;
+    ++ lib.optionals enableXinerama [ libXinerama ];
 
-  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" (if enableXinerama then "xinerama=1" else "xinerama=0") ] ;
+  buildFlags = [ (if enableXinerama then "xinerama=1" else "xinerama=0") ] ;
 
-  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
     description = "Simple X background setter inspired by imlibsetroot and feh";


### PR DESCRIPTION
###### Description of changes

Fix build (https://hydra.nixos.org/build/177035710)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
