### PR TITLE
feedbackd: 0.0.0+git20211018 -> 0.0.0+git20220520

### DIFF
--- a/pkgs/applications/misc/feedbackd/default.nix
+++ b/pkgs/applications/misc/feedbackd/default.nix
@@ -22,15 +22,15 @@ let
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "feedbackd-device-themes";
-    rev = "v0.0.20210909";
-    sha256 = "1d041wnq39sa0sl08xya4yp3n7j6aw560i38chl10vgpmwk9mmhr";
+    rev = "v0.0.20220523";
+    sha256 = "sha256-RyUZj+tpJSYhyoK+E98CTIoHwXwBdB1YHVnO5821exo=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "feedbackd";
   # Not an actual upstream project release,
   # only a Debian package release that is tagged in the upstream repo
-  version = "0.0.0+git20211018";
+  version = "0.0.0+git20220520";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     owner = "Librem5";
     repo = "feedbackd";
     rev = "v${version}";
-    hash = "sha256-jqKRHcxISK54xq/tQm6zV+J+U71eKh04OVTNHDDy65E=";
+    hash = "sha256-4ftPC6LnX0kKFYVyH85yCH43B3YjuaZM5rzr8TGgZvc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

* https://source.puri.sm/Librem5/feedbackd/-/releases#v0.0.0+git20220520
* I bumped the data repo https://source.puri.sm/Librem5/feedbackd-device-themes too, to include PinePhone Pro support.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).