### PR TITLE
linux-pine64: init

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-pine64.nix
+++ b/pkgs/os-specific/linux/kernel/linux-pine64.nix
@@ -1,0 +1,30 @@
+# Kernel for https://wiki.pine64.org/wiki/PinePhone_Pro
+{ lib, stdenv, fetchFromGitLab, fetchpatch, buildLinux, ... } @ args:
+
+buildLinux (args // {
+  version = "5.16.0";
+
+  src = fetchFromGitLab {
+    owner = "pine64-org";
+    repo = "linux";
+    # https://gitlab.com/pine64-org/linux/-/tree/pine64-kernel-ppp-5.16.y
+    rev = "cbaae8db31215ed315a8e3f66a075c278a5777ea";
+    hash = "sha256-w+7MMdGpKs5YpCN6uOCaP0F0GxdiDPiECIm7LLPurGA=";
+  };
+
+  defconfig = "defconfig";
+
+  structuredExtraConfig = with lib.kernel; {
+    # Compilation error.
+    #     gcc: error: unrecognized command line option '-mfloat-abi=softfp'
+    #     gcc: error: unrecognized command line option '-mfpu=neon'
+    FB_SUN5I_EINK = no;
+
+    IP5XXX_POWER = module;
+
+    BATTERY_RK818 = yes;
+    CHARGER_RK818 = yes;
+  };
+
+  kernelPatches = [];
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -61,6 +61,8 @@ in {
       kernelPatches = linux_4_19.kernelPatches;
     };
 
+    linux_pine64 = callPackage ../os-specific/linux/kernel/linux-pine64.nix {};
+
     linux_rpi1 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
       kernelPatches = with kernelPatches; [
         bridge_stp_helper


### PR DESCRIPTION
###### Description of changes

Introduce https://gitlab.com/pine64-org/linux, which is a kernel maintained by a cross-distro project intended to mainline support for PinePhone Pro.

Typically mobile device-specific packages such as Linux kernels would go in Mobile NixOS, as I typically do: https://github.com/NixOS/mobile-nixos/pulls/tomfitzhenry.

However, Mobile NixOS has its own stage-1 and is opinionated on how generations should work, in a way that reduces uniformity between my systems.

Fortunately, samueldr's https://tow-boot.org/ has made "ARM booting boring", and so this allows people to use their preferred distro as-is.

This PR will allow PinePhone Pro users to benefit from recent improvement to NixOS boot/installation such as: systemd initrd, Calamares (https://github.com/NixOS/mobile-nixos/issues/474), installation docs, amongst other things.

I've been using this on my PinePhone Pro for >1 month.

What about PinePhone users? https://gitlab.com/pine64-org/linux only supports PinePhone Pro, not PinePhone. For PinePhone support, interested users would have to use its canonical kernel https://github.com/megous/linux/tree/orange-pi-5.17, but I'm not aware of cross-distro efforts to mainline that.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
