### PR TITLE
cloudcompare: 2.12.0 -> 2.12.1, fix build

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , mkDerivation
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , boost
 , cgal_5
@@ -24,23 +23,15 @@
 
 mkDerivation rec {
   pname = "cloudcompare";
-  version = "2.12.0";
+  version = "2.12.1";
 
   src = fetchFromGitHub {
     owner = "CloudCompare";
     repo = "CloudCompare";
     rev = "v${version}";
-    sha256 = "sha256-hu3ckVocExi9lvxelHAwKb/MZacH4CcCE+vIzElgP/A=";
+    sha256 = "sha256-gX07Km+DNnsz5eDAC2RueMHjmIfQvgGnNOujZ/yM/vE=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # fix issues compiling on aarch64. remove once upgraded past 2.12.0
-    (fetchpatch {
-      url = "https://github.com/CloudCompare/CloudCompare/commit/7e71861fdbd6ea704add5ba69343f47d8fc3d5ae.patch";
-      sha256 = "sha256-CRUPjxtKUbsqOyYsjKF+dRZ+E3rqrv5mS3ZaOay2wk8=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -115,6 +106,5 @@ mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ nh2 ];
     platforms = with platforms; linux; # only tested here; might work on others
-    broken = stdenv.isLinux; # plugins/core/IO/qPDALIO/CMakeFiles/QPDAL_IO_PLUGIN.dir/src/LASFilter.cpp.o] Error 1
   };
 }

--- a/pkgs/development/libraries/pdal/2_3.nix
+++ b/pkgs/development/libraries/pdal/2_3.nix
@@ -1,0 +1,89 @@
+{ lib, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, openscenegraph
+, curl
+, gdal
+, hdf5-cpp
+, LASzip
+, libe57format
+, libgeotiff
+, libxml2
+, postgresql
+, tiledb
+, xercesc
+, zlib
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pdal";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "PDAL";
+    repo = "PDAL";
+    rev = version;
+    sha256 = "sha256-DKIraCyp8fcgnVp5dFrtQ4Wq96cQGC9SiAPLS6htUZc=";
+  };
+
+  patches = [
+    # fix build with GCC 11
+    (fetchpatch {
+      url = "https://github.com/PDAL/PDAL/commit/47e1eb2dc884d1b8c5caa8e3b48ef90f4f12c68d.patch";
+      hash = "sha256-Ls2LkVpbwQAMt2Iuq0zq9D9l2eyP8m1IO3poCnbxGDU=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    openscenegraph
+    curl
+    gdal
+    hdf5-cpp
+    LASzip
+    libe57format
+    libgeotiff
+    libxml2
+    postgresql
+    tiledb
+    xercesc
+    zlib
+    zstd
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_PLUGIN_E57=ON"
+    "-DBUILD_PLUGIN_HDF=ON"
+    "-DBUILD_PLUGIN_PGPOINTCLOUD=ON"
+    "-DBUILD_PLUGIN_TILEDB=ON"
+
+    # Plugins can probably not be made work easily:
+    "-DBUILD_PLUGIN_CPD=OFF"
+    "-DBUILD_PLUGIN_FBX=OFF" # Autodesk FBX SDK is gratis+proprietary; not packaged in nixpkgs
+    "-DBUILD_PLUGIN_GEOWAVE=OFF"
+    "-DBUILD_PLUGIN_I3S=OFF"
+    "-DBUILD_PLUGIN_ICEBRIDGE=OFF"
+    "-DBUILD_PLUGIN_MATLAB=OFF"
+    "-DBUILD_PLUGIN_MBIO=OFF"
+    "-DBUILD_PLUGIN_MRSID=OFF"
+    "-DBUILD_PLUGIN_NITF=OFF"
+    "-DBUILD_PLUGIN_OCI=OFF"
+    "-DBUILD_PLUGIN_RDBLIB=OFF" # Riegl rdblib is proprietary; not packaged in nixpkgs
+    "-DBUILD_PLUGIN_RIVLIB=OFF"
+  ];
+
+  meta = with lib; {
+    description = "PDAL is Point Data Abstraction Library. GDAL for point cloud data";
+    homepage = "https://pdal.io";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nh2 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15174,7 +15174,9 @@ with pkgs;
 
   cloud-nuke = callPackage ../development/tools/cloud-nuke { };
 
-  cloudcompare = libsForQt5.callPackage ../applications/graphics/cloudcompare {};
+  cloudcompare = libsForQt5.callPackage ../applications/graphics/cloudcompare {
+    pdal = pdal_2_3;
+  };
 
   cloudflare-warp = callPackage ../tools/networking/cloudflare-warp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20027,6 +20027,8 @@ with pkgs;
 
   pdal = callPackage ../development/libraries/pdal { } ;
 
+  pdal_2_3 = callPackage ../development/libraries/pdal/2_3.nix { } ;
+
   pdf2xml = callPackage ../development/libraries/pdf2xml {} ;
 
   pe-parse = callPackage ../development/libraries/pe-parse { };


### PR DESCRIPTION
###### Description of changes

Updates CloudCompare to 2.12.1 and reintroduces PDAL 2.3.0 to unbreak it. LAS/LAZ file support is an essential feature so even though it could be turned off that would produce a useless build.

The breakage with PDAL 2.4.0 has been reported upstream: https://github.com/CloudCompare/CloudCompare/issues/1643

ZHF: #172160
@NixOS/nixos-release-managers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
