### PR TITLE
nomad_1_1 & nomad_1_2: security fixes

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/1.1.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.1.nix
@@ -6,7 +6,7 @@
 
 callPackage ./generic.nix {
   inherit buildGoModule nvidia_x11 nvidiaGpuSupport;
-  version = "1.1.12";
-  sha256 = "19y52sn4qz0vx9s188nf7rkr7y2cbq6h33l98sr4w85kmainn86s";
-  vendorSha256 = "0p582y2q6zpyn7vmv1p8p8r2gbh786pqc6lpipgr7rpxbnxf5v4b";
+  version = "1.1.14";
+  sha256 = "0jzcmv6kw555lz7mrm673qgjfmzm4pznibbz9qn3w1jj4x9ddncy";
+  vendorSha256 = "04nyd37viz521qb3frcy39alha0bpx029cy3kswldhh7wbyp7284";
 }

--- a/pkgs/applications/networking/cluster/nomad/1.2.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.2.nix
@@ -6,7 +6,7 @@
 
 callPackage ./generic.nix {
   inherit buildGoModule nvidia_x11 nvidiaGpuSupport;
-  version = "1.2.7";
-  sha256 = "13whyjl0shr00mn46f361ybz90zwkiyab9ygcs0hrs75lgvkmfm9";
-  vendorSha256 = "177gv0h8bhxd5j78sf4is86zzq8xl9schg1hbyh0hmwg4whhqm8a";
+  version = "1.2.8";
+  sha256 = "11yn8g9wsdb35q97wn5vy93kgbn5462k0a33wxlfdz14i5h00yj8";
+  vendorSha256 = "06wyfnlm37qjvd1pwzygflfpcp9p52f61wgi6pb9l7hnqy2ph6j5";
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/hashicorp/nomad/releases/tag/v1.1.14
https://github.com/hashicorp/nomad/releases/tag/v1.2.8

PR for 1.3.1 coming soon, keeping it separate as it can't be backported

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
