### PR TITLE
libsurvive: 0.4 -> 1.0

### DIFF
--- a/pkgs/development/libraries/libsurvive/default.nix
+++ b/pkgs/development/libraries/libsurvive/default.nix
@@ -7,17 +7,20 @@
 , libusb1
 , blas
 , zlib
+, eigen
 }:
 
 stdenv.mkDerivation rec {
   pname = "libsurvive";
-  version = "0.4";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "cntools";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-atX7QsCjKGa6OVSApnx3seBvZv/mlpV3jWRB9+v7Emc=";
+    # Fixes 'Unknown CMake command "cnkalman_generate_code"'
+    fetchSubmodules = true;
+    sha256 = "sha256-I8Wx9avfMyDic+Bk/1IjzZiiHj+l3XqpRwxYbWlsG/Q=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -28,6 +31,7 @@ stdenv.mkDerivation rec {
     libusb1
     blas
     zlib
+    eigen
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

https://github.com/cntools/libsurvive/releases/tag/v1.0

> With recent improvements to tracking and reliability it seemed time to commit to non beta status. This also means the "SimpleApi" portion of the library will be no longer be subject to breaking API changes.

Tested dependent packages, monado still works. Will be updating monado next as it now depends on this update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
