### PR TITLE
pkgsi686Linux.gdb: fix formatting for 32-bit systems

### DIFF
--- a/pkgs/development/tools/misc/gdb/32-bit-BFD_VMA-format.patch
+++ b/pkgs/development/tools/misc/gdb/32-bit-BFD_VMA-format.patch
@@ -1,0 +1,68 @@
+Fix iWerror=format build for 32-bit systems.
+https://sourceware.org/pipermail/gdb-patches/2022-May/189288.html
+--- a/sim/cris/sim-if.c
++++ b/sim/cris/sim-if.c
+@@ -257,7 +257,8 @@ cris_load_elf_file (SIM_DESC sd, struct bfd *abfd, sim_write_fn do_write)
+ 
+       if (verbose)
+ 	sim_io_printf (sd,
+-		       "Loading segment at 0x%" BFD_VMA_FMT "x, size 0x%lx\n",
++		       "Loading segment at 0x%" BFD_VMA_FMT "x, "
++		       "size 0x%" BFD_VMA_FMT "x\n",
+ 		       lma, phdr[i].p_filesz);
+ 
+       if (bfd_seek (abfd, phdr[i].p_offset, SEEK_SET) != 0
+@@ -265,7 +266,7 @@ cris_load_elf_file (SIM_DESC sd, struct bfd *abfd, sim_write_fn do_write)
+ 	{
+ 	  sim_io_eprintf (sd,
+ 			  "%s: could not read segment at 0x%" BFD_VMA_FMT "x, "
+-			  "size 0x%lx\n",
++			  "size 0x%" BFD_VMA_FMT "x\n",
+ 			  STATE_MY_NAME (sd), lma, phdr[i].p_filesz);
+ 	  free (buf);
+ 	  return FALSE;
+@@ -275,7 +276,7 @@ cris_load_elf_file (SIM_DESC sd, struct bfd *abfd, sim_write_fn do_write)
+ 	{
+ 	  sim_io_eprintf (sd,
+ 			  "%s: could not load segment at 0x%" BFD_VMA_FMT "x, "
+-			  "size 0x%lx\n",
++			  "size 0x%" BFD_VMA_FMT "x\n",
+ 			  STATE_MY_NAME (sd), lma, phdr[i].p_filesz);
+ 	  free (buf);
+ 	  return FALSE;
+@@ -572,7 +573,8 @@ cris_handle_interpreter (SIM_DESC sd, struct bfd *abfd)
+ 	 memory area, so we go via a temporary area.  Luckily, the
+ 	 interpreter is supposed to be small, less than 0x40000
+ 	 bytes.  */
+-      sim_do_commandf (sd, "memory region 0x%" BFD_VMA_FMT "x,0x%lx",
++      sim_do_commandf (sd, "memory region 0x%" BFD_VMA_FMT "x,"
++		       "0x%" BFD_VMA_FMT "x",
+ 		       interp_load_addr, interpsiz);
+ 
+       /* Now that memory for the interpreter is defined, load it.  */
+--- a/sim/m32c/syscalls.c
++++ b/sim/m32c/syscalls.c
+@@ -299,8 +299,8 @@ m32c_syscall (int id)
+ 
+ 	rv = gettimeofday (&tv, 0);
+ 	if (trace)
+-	  printf ("gettimeofday: %ld sec %ld usec to 0x%x\n", tv.tv_sec,
+-		  tv.tv_usec, tvaddr);
++	  printf ("gettimeofday: %lld sec %lld usec to 0x%x\n",
++		  (long long)tv.tv_sec, (long long)tv.tv_usec, tvaddr);
+ 	mem_put_si (tvaddr, tv.tv_sec);
+ 	mem_put_si (tvaddr + 4, tv.tv_usec);
+ 	put_reg (r0, rv);
+--- a/sim/rx/syscalls.c
++++ b/sim/rx/syscalls.c
+@@ -270,8 +270,8 @@ rx_syscall (int id)
+ 
+ 	rv = gettimeofday (&tv, 0);
+ 	if (trace)
+-	  printf ("gettimeofday: %ld sec %ld usec to 0x%x\n", tv.tv_sec,
+-		  tv.tv_usec, tvaddr);
++	  printf ("gettimeofday: %lld sec %lld usec to 0x%x\n",
++		  (long long)tv.tv_sec, (long long)tv.tv_usec, tvaddr);
+ 	mem_put_si (tvaddr, tv.tv_sec);
+ 	mem_put_si (tvaddr + 4, tv.tv_usec);
+ 	put_reg (1, rv);

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation rec {
     ./debug-info-from-env.patch
   ] ++ lib.optionals stdenv.isDarwin [
     ./darwin-target-match.patch
+  # Does not nave to be conditional. We apply it conditionally
+  # to speed up inclusion to nearby nixos release.
+  ] ++ lib.optionals stdenv.is32bit [
+    ./32-bit-BFD_VMA-format.patch
   ];
 
   nativeBuildInputs = [ pkg-config texinfo perl setupDebugInfoDirs ];


### PR DESCRIPTION
A few rare targets don't have clean format strings on 32-bit systems:
https://github.com/NixOS/nixpkgs/pull/171216#issuecomment-1133541978

    /build/gdb-12.1/_build/sim/../../sim/cris/sim-if.c:575:28:
      error: format '%lx' expects argument of type 'long unsigned int',
        but argument 4 has type 'bfd_size_type' {aka 'long long unsigned int'} [-Werror=format=]

Let's disable format hardening on 32-bit systems until it's fixed upstream.

While at it disabled -Werror to avoid failures on newer and exotic
toolchain versions.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
