### PR TITLE
ibus-engines.stt: init at unstable-2017-12-30

### DIFF
--- a/pkgs/development/libraries/gst-deepspeech/default.nix
+++ b/pkgs/development/libraries/gst-deepspeech/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, autoreconfHook
+, pkg-config
+, gst_all_1
+, stt
+, stt-models
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gst-deepspeech";
+  version = "unstable-2021-04-08";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "Elleo";
+    repo = "gst-deepspeech";
+    rev = "2aef372a7a1064c90ffb70c12721657bf92fca66";
+    sha256 = "9XGSUYV6jRMsMSA8TO7y7u9T7NihB4azzKJfZ/OPcLI=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    stt
+  ];
+
+  postPatch = ''
+    # https://github.com/Elleo/gst-deepspeech/pull/20
+    substituteInPlace src/gstdeepspeech.cc \
+      --replace "/usr/share/deepspeech/models/deepspeech-0.9.3-models.pbmm" "${stt-models.english.tflite}" \
+      --replace "/usr/share/deepspeech/models/deepspeech-0.9.3-models.scorer" "${stt-models.english.scorer}" \
+      --replace "#include <deepspeech.h>" "" \
+      --replace "DS_" "STT_"
+    substituteInPlace src/gstdeepspeech.h \
+      --replace '#include "deepspeech.h"' "#include <coqui-stt.h>"
+    substituteInPlace src/Makefile.am \
+      --replace "-ldeepspeech" "-lstt"
+  '';
+
+  passthru = {
+    updateScript = unstableGitUpdater {
+      url = "${src.meta.homepage}.git";
+    };
+  };
+
+  meta = {
+    description = "GStreamer plug-in for STT";
+    homepage = "https://github.com/Elleo/gst-deepspeech";
+    license = lib.licenses.lgpl2Plus;
+    maintainers = with lib.maintainers; [ jtojnar ];
+    platforms = stt.meta.platforms;
+  };
+}

--- a/pkgs/tools/audio/stt/default.nix
+++ b/pkgs/tools/audio/stt/default.nix
@@ -1,12 +1,18 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook }:
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, xz
+, bzip2
+}:
 
 stdenv.mkDerivation rec {
   pname = "stt";
-  version = "0.9.3";
+  version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/coqui-ai/STT/releases/download/v${version}/native_client.tf.Linux.tar.xz";
-    sha256 = "0axwys8vis4f0m7d1i2r3dfqlc8p3yj2nisvc7pdi5qs741xgy8w";
+    url = "https://github.com/coqui-ai/STT/releases/download/v${version}/native_client.tflite.Linux.tar.xz";
+    sha256 = "JsMrSNE0KlKpI998wPY6dMTyTggRtqu4JmucBmgirNs=";
   };
   setSourceRoot = "sourceRoot=`pwd`";
 
@@ -16,12 +22,20 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     stdenv.cc.cc.lib
+    xz # for lzma
+    bzip2
   ];
 
   installPhase = ''
+    runHook preInstall
+
     install -D stt $out/bin/stt
     install -D coqui-stt.h $out/include/coqui-stt.h
+    install -D libsox.so.3 $out/lib/libsox.so.3
+    install -D libkenlm.so $out/lib/libkenlm.so
     install -D libstt.so $out/lib/libstt.so
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/tools/audio/stt/models.nix
+++ b/pkgs/tools/audio/stt/models.nix
@@ -1,0 +1,18 @@
+{
+  fetchurl,
+}:
+
+{
+  english = {
+    # https://coqui.ai/english/coqui/v0.9.3
+    scorer = fetchurl {
+      url = "https://coqui.gateway.scarf.sh/english/coqui/v0.9.3/coqui-stt-0.9.3-models.scorer";
+      sha256 = "0M+SarnKtUqKfXAAO5MbLWLr2RBe05LR7JyEACmGd5k=";
+    };
+
+    tflite = fetchurl {
+      url = "https://coqui.gateway.scarf.sh/english/coqui/v0.9.3/model.tflite";
+      sha256 = "Coj5j/Fcm/dgv32gNbna+uJA5+sACvN2+H4FKq4zEgM=";
+    };
+  };
+}

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-stt/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-stt/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, gst_all_1
+, gst-deepspeech
+, ibus
+, pango
+, python3
+, gobject-introspection
+, wrapGAppsHook
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-deepspeech";
+  version = "unstable-2017-12-30";
+
+  src = fetchFromGitHub {
+    owner = "Elleo";
+    repo = "ibus-deepspeech";
+    rev = "3ea7c537e60e3ff66c566355c2b365febc91a91a";
+    sha256 = "51rSPqen40drSfB60q/unc2EbX5lgJnPCIRoH4qq/AM=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    gobject-introspection # for setup hook
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-good
+    gst-deepspeech
+    ibus
+    pango
+    (python3.withPackages (ps: [
+      ps.pygobject3
+      ps.gst-python
+      (ps.toPythonModule ibus)
+    ]))
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater {
+      url = "${src.meta.homepage}.git";
+    };
+  };
+
+  meta = with lib; {
+    isIbusEngine = true;
+    description = "IBus plugin to allow any Linux application to make use of speech recognition";
+    homepage = "https://github.com/Elleo/ibus-deepspeech";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32210,6 +32210,8 @@ with pkgs;
 
   stt = callPackage ../tools/audio/stt { };
 
+  stt-models = recurseIntoAttrs (callPackages ../tools/audio/stt/models.nix { });
+
   stuntrally = callPackage ../games/stuntrally {
     ogre = ogre1_9;
     mygui = mygui.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17564,6 +17564,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AudioToolbox AVFoundation Cocoa CoreFoundation CoreMedia CoreServices CoreVideo DiskArbitration Foundation IOKit MediaToolbox OpenGL VideoToolbox;
   });
 
+  gst-deepspeech = callPackage ../development/libraries/gst-deepspeech { };
+
   gusb = callPackage ../development/libraries/gusb { };
 
   qt-mobility = callPackage ../development/libraries/qt-mobility {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4778,6 +4778,8 @@ with pkgs;
 
     rime = callPackage ../tools/inputmethods/ibus-engines/ibus-rime { };
 
+    stt = callPackage ../tools/inputmethods/ibus-engines/ibus-stt { };
+
     table = callPackage ../tools/inputmethods/ibus-engines/ibus-table { };
 
     table-chinese = callPackage ../tools/inputmethods/ibus-engines/ibus-table-chinese {


### PR DESCRIPTION
###### Description of changes

Accidentally found a [Hackaday article](https://hackaday.com/2018/01/17/speech-recognition-for-linux-gets-a-little-closer/) mentioning ibus-deepspeech in the bookmarks of my RSS feed reader so decided to try it out. Updated stt while at it.

I managed to make the [example from gst-deepspeech](https://github.com/Elleo/gst-deepspeech/pull/20#issuecomment-1133557850) work with upstream audio samples but not with my microphone – perhaps. The ibus engine unfortunately does not seem to do anything for me either.

**Edit:** It must be some issue with the gstreamer pipeline since when I record my voice and play it, it works :

```ShellSession
$ nix-shell -I nixpkgs=$HOME/Projects/nixpkgs -p gst_all_1.gstreamer -p gst-deepspeech --run 'gst-launch-1.0 --messages filesrc location=$PWD/fox.flac ! decodebin ! audioconvert ! audiorate ! audioresample ! deepspeech silence-length=20 ! fakesink | grep -E deepspeech.+text'
TensorFlow: v2.8.0-8-g06c8fea58fd
 Coqui STT: v1.3.0-0-g148fa743
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
Got message #169 from element "deepspeech0" (element): deepspeech, timestamp=(guint64)18446744073709551615, stream-time=(guint64)18446744073709551615, running-time=(guint64)18446744073709551615, intermediate=(boolean)false, text=(string)"to\ be\ bound\ to\ jumped\ over\ the\ lazy\ dog";
```

Whereas the [pipeline from the ibus engine](https://github.com/Elleo/ibus-deepspeech/blob/3ea7c537e60e3ff66c566355c2b365febc91a91a/engine/engine.py#L45) is way too off:

```ShellSession
$ nix-shell -I nixpkgs=$HOME/Projects/nixpkgs -p gst_all_1.gstreamer -p gst-deepspeech --run 'gst-launch-1.0 --messages pulsesrc ! audioconvert ! audiorate ! audioresample ! deepspeech silence-length=20 ! fakesink | grep -E deepspeech.+text'
TensorFlow: v2.8.0-8-g06c8fea58fd
 Coqui STT: v1.3.0-0-g148fa743
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
Got message #62 from element "deepspeech0" (element): deepspeech, timestamp=(guint64)18446744073709551615, stream-time=(guint64)18446744073709551615, running-time=(guint64)18446744073709551615, intermediate=(boolean)true, text=(string)"for\ the\ ";
Got message #63 from element "deepspeech0" (element): deepspeech, timestamp=(guint64)18446744073709551615, stream-time=(guint64)18446744073709551615, running-time=(guint64)18446744073709551615, intermediate=(boolean)true, text=(string)"for\ the\ wise";
Got message #64 from element "deepspeech0" (element): deepspeech, timestamp=(guint64)18446744073709551615, stream-time=(guint64)18446744073709551615, running-time=(guint64)18446744073709551615, intermediate=(boolean)true, text=(string)"for\ the\ wise";
Got message #65 from element "deepspeech0" (element): deepspeech, timestamp=(guint64)18446744073709551615, stream-time=(guint64)18446744073709551615, running-time=(guint64)18446744073709551615, intermediate=(boolean)true, text=(string)"for\ the\ wise";
…
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
