### PR TITLE
glabels: pull fix pending upstream inclusion for -fno-common toolchai…

### DIFF
--- a/pkgs/applications/graphics/glabels/default.nix
+++ b/pkgs/applications/graphics/glabels/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, barcode, gnome, autoreconfHook
+{ lib, stdenv, fetchurl, fetchpatch, barcode, gnome, autoreconfHook
 , gtk3, gtk-doc, libxml2, librsvg , libtool, libe-book, gsettings-desktop-schemas
 , intltool, itstool, makeWrapper, pkg-config, yelp-tools
 }:
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0f2rki8i27pkd9r0gz03cdl1g4vnmvp0j49nhxqn275vi8lmgr0q";
   };
+
+  patches = [
+    # Pull patch pending upstream inclusion for -fno-common toolchain support:
+    #   https://github.com/jimevins/glabels/pull/76
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/jimevins/glabels/commit/f64e3f34e3631330fff2fb48ab271ff9c6160229.patch";
+      sha256 = "13q6g4bxzvzwjnvzkvijds2b6yvc4xqbdwgqnwmj65ln6ngxz8sa";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper intltool ];
   buildInputs = [


### PR DESCRIPTION
…n support

Without the change builds fails on upstream gcc-10 as:

    ld: label.o:src/template-history.h:31: multiple definition of `gl_template_history'; glabels-batch.o:src/template-history.h:31: first defined here
    ld: label-text.o:src/font-history.h:31: multiple definition of `gl_font_history'; glabels-batch.o:src/font-history.h:31: first defined here
    ld: font-history.o:src/font-history.h:31: multiple definition of `gl_font_history'; glabels-batch.o:src/font-history.h:31: first defined here
    ld: template-history.o:src/template-history.h:31: multiple definition of `gl_template_history'; glabels-batch.o:src/template-history.h:31: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
