### PR TITLE
Support cross-compiling for Renesas RX microcontrollers

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -41,7 +41,7 @@ let
     # none
     "aarch64_be-none" "aarch64-none" "arm-none" "armv6l-none" "avr-none" "i686-none"
     "msp430-none" "or1k-none" "m68k-none" "powerpc-none" "powerpcle-none"
-    "riscv32-none" "riscv64-none" "s390-none" "s390x-none" "vc4-none"
+    "riscv32-none" "riscv64-none" "rx-none" "s390-none" "s390x-none" "vc4-none"
     "x86_64-none"
 
     # OpenBSD
@@ -76,6 +76,7 @@ in {
   riscv         = filterDoubles predicates.isRiscV;
   riscv32       = filterDoubles predicates.isRiscV32;
   riscv64       = filterDoubles predicates.isRiscV64;
+  rx            = filterDoubles predicates.isRx;
   vc4           = filterDoubles predicates.isVc4;
   or1k          = filterDoubles predicates.isOr1k;
   m68k          = filterDoubles predicates.isM68k;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -145,6 +145,11 @@ rec {
     libc = "newlib";
   };
 
+  rx-embedded = {
+    config = "rx-none-elf";
+    libc = "newlib";
+  };
+
   msp430 = {
     config = "msp430-elf";
     libc = "newlib";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -26,6 +26,7 @@ rec {
     isRiscV        = { cpu = { family = "riscv"; }; };
     isRiscV32      = { cpu = { family = "riscv"; bits = 32; }; };
     isRiscV64      = { cpu = { family = "riscv"; bits = 64; }; };
+    isRx           = { cpu = { family = "rx"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
     isWasm         = { cpu = { family = "wasm"; }; };
     isMsp430       = { cpu = { family = "msp430"; }; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -116,6 +116,7 @@ rec {
 
     alpha    = { bits = 64; significantByte = littleEndian; family = "alpha"; };
 
+    rx       = { bits = 32; significantByte = littleEndian; family = "rx"; };
     msp430   = { bits = 16; significantByte = littleEndian; family = "msp430"; };
     avr      = { bits = 8; family = "avr"; };
 

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -213,6 +213,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isM68k then "m68k"
       else if targetPlatform.isS390 then "s390"
       else if targetPlatform.isRiscV then "lriscv"
+      else if targetPlatform.isRx then "rx"
       else throw "unknown emulation for platform: ${targetPlatform.config}";
     in if targetPlatform.useLLVM or false then ""
        else targetPlatform.bfdEmulation or (fmt + sep + arch);

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -197,6 +197,7 @@ in
   x86_64-embedded = mapTestOnCross lib.systems.examples.x86_64-embedded embedded;
   riscv64-embedded = mapTestOnCross lib.systems.examples.riscv64-embedded embedded;
   riscv32-embedded = mapTestOnCross lib.systems.examples.riscv32-embedded embedded;
+  rx-embedded = mapTestOnCross lib.systems.examples.rx-embedded embedded;
 
   x86_64-netbsd = mapTestOnCross lib.systems.examples.x86_64-netbsd common;
 


### PR DESCRIPTION
###### Description of changes

This PR enables cross-compilation for [RX microcontrollers](https://en.wikipedia.org/w/index.php?title=RX_microcontroller_family).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
