### PR TITLE
iproute_mptcp: fix build for -fno-common toolchains

### DIFF
--- a/pkgs/os-specific/linux/iproute/mptcp.nix
+++ b/pkgs/os-specific/linux/iproute/mptcp.nix
@@ -1,4 +1,4 @@
-{ lib, iproute2, fetchFromGitHub }:
+{ lib, iproute2, fetchFromGitHub, fetchpatch }:
 
 iproute2.overrideAttrs (oa: rec {
   pname = "iproute_mptcp";
@@ -15,8 +15,19 @@ iproute2.overrideAttrs (oa: rec {
     patchShebangs configure
   '';
 
-  # We override "patches" to never apply any iproute2 patches:
-  patches = [ ];
+  patches = [
+    # We override "patches" to never apply any iproute2 patches:
+  ] ++ [
+    # iproute-mptcp patches:
+
+    # Pull upstream fix for -fno-common toolchain support:
+    #   https://github.com/multipath-tcp/iproute-mptcp/pull/8
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/multipath-tcp/iproute-mptcp/commit/7aebfde8624c978f6f73b03142892f802d21cc0b.patch";
+      sha256 = "098402sjdm10r9xggz6naygnfjs74d9k3s2wc2aczx0d2zayhff8";
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/multipath-tcp/iproute-mptcp";


### PR DESCRIPTION
Without the change build on upstream gcc-10 fals as:

    ld: ipxfrm.o:(.bss+0x0): multiple definition of `filter'; ipmroute.o:(.bss+0x0): first defined here
    ld: xfrm_monitor.o:(.bss+0x0): multiple definition of `listen_all_nsid'; ipmonitor.o:(.bss+0x0): first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
