### PR TITLE
kssd: pull upstream fix for -fno-common tollchains

### DIFF
--- a/pkgs/applications/science/biology/kssd/default.nix
+++ b/pkgs/applications/science/biology/kssd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, zlib, automake, autoconf, libtool }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, zlib, automake, autoconf, libtool }:
 
 stdenv.mkDerivation rec {
   pname = "kssd";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-8jzYqo9LXF66pQ1EIusm+gba2VbTYpJz2K3NVlA3QxY=";
   };
+
+  patches = [
+    # Pull upstream patch for -fno-common toolchain support:
+    #   https://github.com/yhg926/public_kssd/pull/9
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/yhg926/public_kssd/commit/cdd1e8aae256146f5913a3b4c723b638d53bdf27.patch";
+      sha256 = "sha256-HhaTRqPfKR+ouh0PwEH6u22pbuqbX2OypRzw8BXm0W4=";
+    })
+  ];
 
   nativeBuildInputs = [ autoconf automake ];
   buildInputs = [ zlib libtool ];


### PR DESCRIPTION
Without the change build fails on upstream gcc-10 as:

    ld: ccD2iWhk.o:(.bss+0x8): multiple definition of `domain';
      ccgA4lYl.o:(.bss+0x8): first defined here
    ld: ccD2iWhk.o:(.bss+0x0): multiple definition of `long_domain';
      ccgA4lYl.o:(.bss+0x0): first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
