### PR TITLE
rscw: init at 0.1e

### DIFF
--- a/pkgs/applications/radio/rscw/default.nix
+++ b/pkgs/applications/radio/rscw/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchurl
+, fftw
+, gtk2
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rscw";
+  version = "0.1e";
+
+  src = fetchurl {
+    url = "https://www.pa3fwm.nl/software/${pname}/${pname}-${version}.tgz";
+    sha256 = "1hxwxmqc5jinr14ya1idigqigc8qhy1vimzcwy2vmwdjay2sqik2";
+  };
+
+  setSourceRoot = "sourceRoot=`pwd`";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk2 fftw ];
+
+  installPhase = ''
+    install -D -m 0755 noisycw $out/bin/noisycw
+    install -D -m 0755 rs12tlmdec $out/bin/rs12tlmdec
+    install -D -m 0755 rscw $out/bin/rscw
+    install -D -m 0755 rscwx $out/bin/rscwx
+  '';
+
+  meta = with lib; {
+    description = "Receive CW through the soundcard";
+    homepage = "https://www.pa3fwm.nl/software/rscw/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ earldouglas ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9983,6 +9983,8 @@ with pkgs;
 
   rrdtool = callPackage ../tools/misc/rrdtool { };
 
+  rscw = callPackage ../applications/radio/rscw { };
+
   rset = callPackage ../tools/admin/rset { };
 
   rshijack = callPackage ../tools/networking/rshijack { };


### PR DESCRIPTION
###### Description of changes

Add a new package `rscw` for receiving CW through the soundcard.  See the project's homepage at <https://www.pa3fwm.nl/software/rscw/>

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).