### PR TITLE
 airgeddon: init at 11.01 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9860,6 +9860,12 @@
     githubId = 8641;
     name = "Pierre Carrier";
   };
+  pedrohlc = {
+    email = "root@pedrohlc.com";
+    github = "PedroHLC";
+    githubId = 1368952;
+    name = "Pedro Lara Campos";
+  };
   penguwin = {
     email = "penguwin@penguwin.eu";
     github = "penguwin";

--- a/pkgs/tools/networking/airgeddon/default.nix
+++ b/pkgs/tools/networking/airgeddon/default.nix
@@ -1,0 +1,166 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+  # Required
+, aircrack-ng
+, bash
+, coreutils-full
+, gawk
+, gnugrep
+, gnused
+, iproute2
+, iw
+, pciutils
+, procps
+, tmux
+  # X11 Front
+, xterm
+, xorg
+  # what the author calls "Internals"
+, usbutils
+, wget
+, ethtool
+, util-linux
+, ccze
+  # Optionals
+  # Missing in nixpkgs: beef, hostapd-wpe, asleap
+, bettercap
+, bully
+, crunch
+, dhcp
+, dnsmasq
+, ettercap
+, hashcat
+, hcxdumptool
+, hcxtools
+, hostapd
+, john
+, lighttpd
+, mdk4
+, nftables
+, openssl
+, pixiewps
+, reaverwps-t6x # Could be the upstream version too
+, wireshark-cli
+  # Undocumented requirements (there is also ping)
+, apparmor-bin-utils
+, curl
+, glibc
+, ncurses
+, networkmanager
+, systemd
+  # Support groups
+, supportWpaWps ? true # Most common use-case
+, supportHashCracking ? false
+, supportEvilTwin ? false
+, supportX11 ? false # Allow using xterm instead of tmux, hard to test
+}:
+let
+  deps = [
+    aircrack-ng
+    bash
+    coreutils-full
+    curl
+    gawk
+    glibc
+    gnugrep
+    gnused
+    iproute2
+    iw
+    networkmanager
+    ncurses
+    pciutils
+    procps
+    tmux
+    usbutils
+    wget
+    ethtool
+    util-linux
+    ccze
+    systemd
+  ] ++ lib.optionals supportWpaWps [
+    bully
+    pixiewps
+    reaverwps-t6x
+  ] ++ lib.optionals supportHashCracking [
+    crunch
+    hashcat
+    hcxdumptool
+    hcxtools
+    john
+    wireshark-cli
+  ] ++ lib.optionals supportEvilTwin [
+    bettercap
+    dhcp
+    dnsmasq
+    ettercap
+    hostapd
+    lighttpd
+    openssl
+    mdk4
+    nftables
+    apparmor-bin-utils
+  ] ++ lib.optionals supportX11 [
+    xterm
+    xorg.xset
+    xorg.xdpyinfo
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "airgeddon";
+  version = "11.01";
+
+  src = fetchFromGitHub {
+    owner = "v1s1t0r1sh3r3";
+    repo = "airgeddon";
+    rev = "v${version}";
+    sha256 = "3TjaLEcerRk69Ys4kj7vOMCRUd0ifFJzL4MB5ifoK68=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  # What these replacings do?
+  # - Disable the auto-updates (we'll run from a read-only directory);
+  # - Silence the checks (NixOS will enforce the PATH, it will only see the tools as we listed);
+  # - Use "tmux", we're not patching XTerm commands;
+  # - Remove PWD and $0 references, forcing it to use the paths from store;
+  # - Force our PATH to all tmux sessions.
+  postPatch = ''
+    patchShebangs airgeddon.sh
+    sed -i '
+      s|AIRGEDDON_AUTO_UPDATE=true|AIRGEDDON_AUTO_UPDATE=false|
+      s|AIRGEDDON_SILENT_CHECKS=false|AIRGEDDON_SILENT_CHECKS=true|
+      s|AIRGEDDON_WINDOWS_HANDLING=xterm|AIRGEDDON_WINDOWS_HANDLING=tmux|
+      ' .airgeddonrc
+
+    sed -Ei '
+      s|\$\(pwd\)|${placeholder "out"}/share/airgeddon;scriptfolder=${placeholder "out"}/share/airgeddon/|
+      s|\$\{0\}|${placeholder "out"}/bin/airgeddon|
+      s|tmux send-keys -t "([^"]+)" "|tmux send-keys -t "\1" "export PATH=\\"$PATH\\"; |
+      ' airgeddon.sh
+  '';
+
+  # ATTENTION: No need to chdir around, we're removing the occurrences of "$(pwd)"
+  postInstall = ''
+    wrapProgram $out/bin/airgeddon --prefix PATH : ${lib.makeBinPath deps}
+  '';
+
+  # Install only the interesting files
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 airgeddon.sh "$out/bin/airgeddon"
+    install -dm 755 "$out/share/airgeddon"
+    cp -dr .airgeddonrc known_pins.db language_strings.sh plugins/ "$out/share/airgeddon/"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Multi-use TUI to audit wireless networks. ";
+    homepage = "https://github.com/v1s1t0r1sh3r3/airgeddon";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pedrohlc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1071,6 +1071,8 @@ with pkgs;
 
   airfield = callPackage ../tools/networking/airfield { };
 
+  airgeddon = callPackage ../tools/networking/airgeddon { };
+
   apache-airflow = with python3.pkgs; toPythonApplication apache-airflow;
 
   airsonic = callPackage ../servers/misc/airsonic { };


### PR DESCRIPTION
###### Description of changes

As a red team member, I used to run everything by hand since most of the helpers gave me more headaches than actually automating something. But years ago, I found [airgeddon](https://github.com/v1s1t0r1sh3r3/airgeddon), which is pretty KISS and mostly helps in most simple scenarios. Script kiddies will be happy!

Darwin is not compatible, according to [the author's wiki](https://github.com/v1s1t0r1sh3r3/airgeddon/wiki/Known%20incompatibilities). WSL neither.

Related to https://github.com/NixOS/nixpkgs/issues/81418

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).