### PR TITLE
python310Packages.vulture: 2.3 -> 2.4

### DIFF
--- a/pkgs/development/python-modules/vulture/default.nix
+++ b/pkgs/development/python-modules/vulture/default.nix
@@ -1,32 +1,39 @@
 { lib
 , buildPythonPackage
-, coverage
 , fetchPypi
-, isPy27
-, pytest-cov
+, pythonOlder
 , pytestCheckHook
 , toml
 }:
 
 buildPythonPackage rec {
   pname = "vulture";
-  version = "2.3";
-  disabled = isPy27;
+  version = "2.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ryrmsm72z3fzaanyblz49q40h9d3bbl4pspn2lvkkp9rcmsdm83";
+    hash = "sha256-gZQ5KUp2tOC44Ixw11VlqM49wfbgNVjtEjpfK7c3wOo=";
   };
 
-  propagatedBuildInputs = [ toml ];
+  propagatedBuildInputs = [
+    toml
+  ];
 
   checkInputs = [
-    coverage
-    pytest-cov
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "vulture" ];
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace " --cov vulture --cov-report=html --cov-report=term --cov-report=xml --cov-append" ""
+  '';
+
+  pythonImportsCheck = [
+    "vulture"
+  ];
 
   meta = with lib; {
     description = "Finds unused code in Python programs";


### PR DESCRIPTION
###### Description of changes
https://github.com/jendrikseipp/vulture/releases/tag/v2.4
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @mcwitt 