### PR TITLE
dotnet ecosystem: fix cross compilation

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -94,9 +94,13 @@ in stdenvNoCC.mkDerivation (args // {
     dotnetInstallHook
     dotnetFixupHook
 
-    dotnet-sdk
     cacert
     makeWrapper
+    dotnet-sdk
+  ];
+
+  makeWrapperArgs = args.makeWrapperArgs or [ ] ++ [
+    "--prefix LD_LIBRARY_PATH : ${dotnet-sdk.icu}/lib"
   ];
 
   # Stripping breaks the executable

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
@@ -53,7 +53,7 @@
   dotnetFixupHook = callPackage ({ }:
     makeSetupHook {
       name = "dotnet-fixup-hook";
-      deps = [ dotnet-runtime makeWrapper ];
+      deps = [ dotnet-runtime ];
       substitutions = {
         dotnetRuntime = dotnet-runtime;
         runtimeDeps = lib.makeLibraryPath runtimeDeps;

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
@@ -1,6 +1,6 @@
 declare -a projectFile testProjectFile
 
-# inherit arguments from derivation
+# Inherit arguments from derivation
 dotnetFlags=( ${dotnetFlags[@]-} )
 dotnetRestoreFlags=( ${dotnetRestoreFlags[@]-} )
 

--- a/pkgs/development/compilers/dotnet/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/build-dotnet.nix
@@ -4,12 +4,14 @@
 , icu #passing icu as an argument, because dotnet 3.1 has troubles with icu71
 }:
 
-assert builtins.elem type [ "aspnetcore" "runtime" "sdk"];
+assert builtins.elem type [ "aspnetcore" "runtime" "sdk" ];
 
 { lib
 , stdenv
 , fetchurl
 , writeText
+, autoPatchelfHook
+, makeWrapper
 , libunwind
 , openssl
 , libuuid
@@ -19,19 +21,21 @@ assert builtins.elem type [ "aspnetcore" "runtime" "sdk"];
 }:
 
 let
-  pname = if type == "aspnetcore" then
-    "aspnetcore-runtime"
-  else if type == "runtime" then
-    "dotnet-runtime"
-  else
-    "dotnet-sdk";
+  pname =
+    if type == "aspnetcore" then
+      "aspnetcore-runtime"
+    else if type == "runtime" then
+      "dotnet-runtime"
+    else
+      "dotnet-sdk";
 
   descriptions = {
     aspnetcore = "ASP.NET Core Runtime ${version}";
     runtime = ".NET Runtime ${version}";
     sdk = ".NET SDK ${version}";
   };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   inherit pname version;
 
   # Some of these dependencies are `dlopen()`ed.
@@ -47,8 +51,19 @@ in stdenv.mkDerivation rec {
     lttng-ust_2_12
   ]);
 
-  src = fetchurl (srcs."${stdenv.hostPlatform.system}" or (throw
-    "Missing source (url and hash) for host system: ${stdenv.hostPlatform.system}"));
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc
+  ];
+
+  src = fetchurl (
+    srcs."${stdenv.hostPlatform.system}" or (throw
+      "Missing source (url and hash) for host system: ${stdenv.hostPlatform.system}")
+  );
 
   sourceRoot = ".";
 
@@ -68,10 +83,16 @@ in stdenv.mkDerivation rec {
     patchelf --set-rpath "${rpath}" $out/dotnet
     find $out -type f -name "*.so" -exec patchelf --set-rpath '$ORIGIN:${rpath}' {} \;
     find $out -type f \( -name "apphost" -or -name "createdump" \) -exec patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" --set-rpath '$ORIGIN:${rpath}' {} \;
+
+    wrapProgram $out/bin/dotnet \
+      --prefix LD_LIBRARY_PATH : ${icu}/lib
   '';
 
   doInstallCheck = true;
   installCheckPhase = ''
+    # Fixes cross
+    export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
     $out/bin/dotnet --info
   '';
 
@@ -84,6 +105,10 @@ in stdenv.mkDerivation rec {
     export DOTNET_NOLOGO=1 # Disables the welcome message
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
   '';
+
+  passthru = {
+    inherit icu;
+  };
 
   meta = with lib; {
     description = builtins.getAttr type descriptions;


### PR DESCRIPTION
###### Description of changes
Attempting to cross compile dotnet packages from for example `pkgsCross.aarch64-multiplatform.depotdownloader` used to not work for a few reasons, first it would fail because `makeWrapper` was in `makeSetupHook`'s `deps` attribute, which maps to `propagatedBuildInputs` instead of `nativeBuildInputs`.

Then, for whatever reason dotnet would fail to load `libstdc++.so.6` even though it was manually `patchelf`'d into its rpath, patching it in with `autoPatchelfHook` fixed that. Note that we cannot supply all dependencies through `autoPatchelfHook` since a few of them are `dlopen`'d which didn't seem to play nicely with it.

~~It also disables dotnet's globalisation support, which may help with deterministic builds. I would've expected this to be disabled already with the `Deterministic` msbuild property, but I noticed cross compiled binaries failed to run with globalisation support enabled.~~ Not required anymore.

cc @SuperSandro2000 @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
