### PR TITLE
titanion: init at 0.3

### DIFF
--- a/pkgs/games/titanion/default.nix
+++ b/pkgs/games/titanion/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchpatch
+, fetchurl
+, unzip
+, gdc
+, SDL
+, SDL_mixer
+, bulletml
+}:
+
+let
+debianPatch = patchname: hash: fetchpatch {
+  name = "${patchname}.patch";
+  url = "https://sources.debian.org/data/main/t/titanion/0.3.dfsg1-7/debian/patches/${patchname}";
+  sha256 = hash;
+};
+
+in stdenv.mkDerivation rec {
+  pname = "titanion";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "http://abagames.sakura.ne.jp/windows/ttn${lib.replaceStrings ["."] ["_"] version}.zip";
+    sha256 = "sha256-fR0cufi6dU898wP8KGl/vxbfQJzMmMxlYZ3QNGLajfM=";
+  };
+
+  patches = [
+    (debianPatch
+      "imports.patch"
+      "sha256-kSXpaTpYq6w9e0yLES2QGNQ8+vFIiOpw2P9MA8gZr8s=")
+    (debianPatch
+      "fix.diff"
+      "sha256-0WkkfuhJaAMY46VVyc3ldMQwgOVoQJDw/8zbm6H2sHU=")
+    (debianPatch
+      "directories.patch"
+      "sha256-fhQJuy2+r0YOQNwMqG85Gr7fJehmf00Scran+NPYQrw=")
+    (debianPatch
+      "windowed.patch"
+      "sha256-xouXIuIKfKFGsoOEJqL9jdsdnkX4nqwPGcoB+32Wvgo=")
+    (debianPatch
+      "dotfile.patch"
+      "sha256-sAml53Hh0ltbqN8xZDZuUJcaPfjK56jf4ymFXYD38v0=")
+    (debianPatch
+      "window-resize.patch"
+      "sha256-WwAi1aU4CmaX+O8fw0TfLhNSXFaObExrn7nuhesVkKM=")
+    (debianPatch
+      "makefile.patch"
+      "sha256-g0jDPmc0SWXkTLhiczeTse/WGCtgMUsbyPNZzwK3U+o=")
+    (debianPatch
+      "dlang_v2.patch"
+      "sha256-tfTAAKlPFSjbfAK1EjeB3unj9tbMlNaajJ+VVSMMiYw=")
+    (debianPatch
+      "gdc-8.patch"
+      "sha256-BxkPfSEymq7TDA+yjJHaYsjtGr0Tuu1/sWLwRBAMga4=")
+  ];
+
+  postPatch = ''
+    rm *.dll ttn.exe
+    rm -r lib
+    for f in src/abagames/ttn/screen.d src/abagames/util/sdl/sound.d src/abagames/util/sdl/texture.d; do
+      substituteInPlace $f \
+        --replace "/usr/" "$out/"
+    done
+  '';
+
+  nativeBuildInputs = [
+    unzip
+    gdc
+  ];
+
+  buildInputs = [
+    SDL
+    SDL_mixer
+    bulletml
+  ];
+
+  installPhase = ''
+    install -Dm755 titanion $out/bin/titanion
+    mkdir -p $out/share/games/titanion
+    cp -r sounds images $out/share/games/titanion/
+  '';
+
+  meta = with lib; {
+    homepage = "http://www.asahi-net.or.jp/~cs8k-cyu/windows/ttn_e.html";
+    description = "Strike down super high-velocity swooping insects";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32297,6 +32297,8 @@ with pkgs;
 
   tinyfugue = callPackage ../games/tinyfugue { };
 
+  titanion = callPackage ../games/titanion { };
+
   tome2 = callPackage ../games/tome2 { };
 
   tome4 = callPackage ../games/tome4 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

More stuff from Kenta Cho :)

cc @aidalgol 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
