### PR TITLE
zeronet-conservancy: init, zeronet: mark as vulnerable

### DIFF
--- a/nixos/modules/services/networking/zeronet.nix
+++ b/nixos/modules/services/networking/zeronet.nix
@@ -19,6 +19,13 @@ in with lib; {
   options.services.zeronet = {
     enable = mkEnableOption "zeronet";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.zeronet;
+      defaultText = literalExpression "pkgs.zeronet";
+      description = "ZeroNet package to use";
+    };
+
     settings = mkOption {
       type = with types; attrsOf (oneOf [ str int bool (listOf str) ]);
       default = {};
@@ -80,7 +87,7 @@ in with lib; {
         DynamicUser = true;
         StateDirectory = "zeronet";
         SupplementaryGroups = mkIf cfg.tor [ "tor" ];
-        ExecStart = "${pkgs.zeronet}/bin/zeronet --config_file ${configFile}";
+        ExecStart = "${cfg.package}/bin/zeronet --config_file ${configFile}";
       };
     };
   };

--- a/nixos/modules/services/networking/zeronet.nix
+++ b/nixos/modules/services/networking/zeronet.nix
@@ -79,7 +79,7 @@ in with lib; {
 
     systemd.services.zeronet = {
       description = "zeronet";
-      after = [ "network.target" (optionalString cfg.tor "tor.service") ];
+      after = [ "network.target" ] ++ optional cfg.tor "tor.service";
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {

--- a/pkgs/applications/networking/p2p/zeronet-conservancy/default.nix
+++ b/pkgs/applications/networking/p2p/zeronet-conservancy/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "zeronet-conservancy";
+  version = "0.7.5";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "zeronet-conservancy";
+    repo = "zeronet-conservancy";
+    rev = "v${version}";
+    sha256 = "sha256-cq0q5hXEhazHPJODNJ8iL0qAB5DJW6ANST4r/rslvXk=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    gevent msgpack base58 merkletools rsa pysocks pyasn1 websocket-client
+    gevent-websocket rencode bitcoinlib maxminddb pyopenssl rich
+  ];
+
+  buildPhase = ''
+    ${python3Packages.python.interpreter} -O -m compileall .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp -r plugins src *.py $out/share/
+  '';
+
+  postFixup = ''
+    makeWrapper "$out/share/zeronet.py" "$out/bin/zeronet" \
+      --set PYTHONPATH "$PYTHONPATH" \
+      --set PATH ${python3Packages.python}/bin
+  '';
+
+  meta = with lib; {
+    description = "A fork/continuation of the ZeroNet project";
+    longDescription = ''
+      zeronet-conservancy is a fork/continuation of ZeroNet project (that has
+      been abandoned by its creator) that is dedicated to sustaining existing
+      p2p network and developing its values of decentralization and freedom,
+      while gradually switching to a better designed network.
+    '';
+    homepage = "https://github.com/zeronet-conservancy/zeronet-conservancy";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/applications/networking/p2p/zeronet/default.nix
+++ b/pkgs/applications/networking/p2p/zeronet/default.nix
@@ -37,5 +37,9 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://zeronet.io/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ fgaz ];
+    knownVulnerabilities = [ ''
+      Unmaintained. Probable XSS/code injection vulnerability.
+      Switching to the maintained zeronet-conservancy package is recommended
+    '' ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30954,6 +30954,8 @@ with pkgs;
 
   zeronet = callPackage ../applications/networking/p2p/zeronet { };
 
+  zeronet-conservancy = callPackage ../applications/networking/p2p/zeronet-conservancy { };
+
   zexy = callPackage ../applications/audio/pd-plugins/zexy {
     autoconf = buildPackages.autoconf269;
   };


### PR DESCRIPTION
###### Description of changes

Fixes: #173276

The service was already broken with:

    error: A definition for option `systemd.services.zeronet.after.[definition 1-entry 2]' is not of type `string matching the pattern [a-zA-Z0-9@%:_.\-]+[.](service|socket|device|mount|automount|swap|target|path|timer|scope|slice)'. Definition values:

I did not fix the error, I only addressed the vulnerability

edit: service fixed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
