### PR TITLE
monado: 21.0.0 -> unstable-2022-05-28

### DIFF
--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -120,5 +120,6 @@ stdenv.mkDerivation rec {
     license = licenses.boost;
     maintainers = with maintainers; [ expipiplus1 prusnak ];
     platforms = platforms.linux;
+    mainProgram = "monado-cli";
   };
 }

--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitLab
-, fetchpatch
 , writeText
 , cmake
 , doxygen
@@ -46,24 +45,15 @@
 
 stdenv.mkDerivation rec {
   pname = "monado";
-  version = "21.0.0";
+  version = "unstable-2022-05-28";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
-    owner = pname;
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "07zxs96i3prjqww1f68496cl2xxqaidx32lpfyy0pn5am4c297zc";
+    owner = "monado";
+    repo = "monado";
+    rev = "011bcbdcff227e25507e5f2d81a83a2bbe478856";
+    sha256 = "sha256-8velNKSCZJtKO8ATwXDl1nU8RbxZ8TeyGiUQFOXifuI=";
   };
-
-  patches = [
-    # https://github.com/NixOS/nixpkgs/issues/137245
-    # Fix warning after Vulkan 1.2.174 VK_NULL_HANDLE change
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/monado/monado/-/commit/c47775a95d8e139a2f234063793eb6726f830510.patch";
-      sha256 = "093ymvi9ifpk4vyjcwhhci9cnscxwbv5f80xdbppcqa0j92nmkmp";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Upstream hasn't had a version bump in 1.5 years, lots of progress since then.

~~Following [version normalization RFC](https://github.com/AndersonTorres/rfcs/blob/my-rfc/rfcs/0107-version-normalization.md).~~

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
