### PR TITLE
treewide: enable strictDeps in bootstrap packages

### DIFF
--- a/pkgs/build-support/expand-response-params/default.nix
+++ b/pkgs/build-support/expand-response-params/default.nix
@@ -3,6 +3,7 @@
 stdenv.mkDerivation {
   name = "expand-response-params";
   src = ./expand-response-params.c;
+  strictDeps = true;
   # Work around "stdenv-darwin-boot-2 is not allowed to refer to path
   # /nix/store/...-expand-response-params.c"
   unpackPhase = ''

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -14,6 +14,7 @@ let
   mirrorsFile =
     buildPackages.stdenvNoCC.mkDerivation ({
       name = "mirrors-list";
+      strictDeps = true;
       builder = ./write-mirror-list.sh;
       preferLocalBuild = true;
     } // mirrors);

--- a/pkgs/build-support/nuke-references/default.nix
+++ b/pkgs/build-support/nuke-references/default.nix
@@ -14,6 +14,7 @@ in
 stdenvNoCC.mkDerivation {
   name = "nuke-references";
 
+  strictDeps = true;
   dontUnpack = true;
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
     inherit pkg-config;
   };
 
+  strictDeps = true;
   dontBuild = true;
   dontConfigure = true;
 
@@ -79,8 +80,6 @@ stdenv.mkDerivation {
     + ''
       ln -s ${pkg-config}/share $out/share
     '';
-
-  strictDeps = true;
 
   wrapperName = "PKG_CONFIG_WRAPPER";
 

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -528,6 +528,7 @@ rec {
     runCommand name
       (substitutions // {
         inherit meta;
+        strictDeps = true;
       })
       (''
         mkdir -p $out/nix-support

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -68,6 +68,7 @@ rec {
     # extra arguments to pass to stdenv.mkDerivation
     , name
     # name of the resulting derivation
+    # TODO(@Artturin): enable strictDeps always
     }: buildCommand:
     stdenv.mkDerivation ({
       inherit buildCommand name;

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -27,6 +27,7 @@ let
       inherit sha256;
     };
 
+    strictDeps = true;
     # TODO: Add a "dev" output containing the header files.
     outputs = [ "out" "man" "devdoc" ] ++
       optional crossCompiling "mini";

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -104,8 +104,6 @@ let
 
   version = with sourceVersion; "${major}.${minor}.${patch}${suffix}";
 
-  strictDeps = true;
-
   nativeBuildInputs = optionals (!stdenv.isDarwin) [
     autoreconfHook
     pkg-config
@@ -186,7 +184,8 @@ in with passthru; stdenv.mkDerivation {
   pname = "python3";
   inherit version;
 
-  inherit buildInputs nativeBuildInputs;
+  inherit nativeBuildInputs;
+  buildInputs = [ bash ] ++ buildInputs; # bash is only for patchShebangs
 
   src = fetchurl {
     url = with sourceVersion; "https://www.python.org/ftp/python/${major}.${minor}.${patch}/Python-${version}.tar.xz";
@@ -465,7 +464,7 @@ in with passthru; stdenv.mkDerivation {
 
   preFixup = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     # Ensure patch-shebangs uses shebangs of host interpreter.
-    export PATH=${lib.makeBinPath [ "$out" bash ]}:$PATH
+    export PATH=${lib.makeBinPath [ "$out" ]}:$PATH
   '';
 
   # Add CPython specific setup-hook that configures distutils.sysconfig to

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -231,6 +231,8 @@ in {
     enableLTO = false;
     mimetypesSupport = false;
   } // sources.python39)).overrideAttrs(old: {
+    # TODO(@Artturin): Add this to the main cpython expr
+    strictDeps = true;
     pname = "python3-minimal";
     meta = old.meta // {
       maintainers = [];

--- a/pkgs/development/interpreters/python/setup-hook.nix
+++ b/pkgs/development/interpreters/python/setup-hook.nix
@@ -5,6 +5,7 @@ sitePackages:
 let
   hook = ./setup-hook.sh;
 in runCommand "python-setup-hook.sh" {
+  strictDeps = true;
   inherit sitePackages;
 } ''
   cp ${hook} hook.sh

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-95uPkEt0nj4NIK/q3s+CScVbLjLU67CJrjeN9HncryU=";
   };
 
+  strictDeps = true;
+
   outputs = [ "out" "dev" ]; # TODO: fix referrers
   outputBin = "dev";
 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -203,6 +203,7 @@ stdenv.mkDerivation ({
 
   outputs = [ "out" "bin" "dev" "static" ];
 
+  strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ bison python3Minimal ] ++ extraNativeBuildInputs;
   buildInputs = [ linuxHeaders ] ++ lib.optionals withGd [ gd libpng ] ++ extraBuildInputs;

--- a/pkgs/development/libraries/glibc/info.nix
+++ b/pkgs/development/libraries/glibc/info.nix
@@ -7,7 +7,7 @@ callPackage ./common.nix {} {
 
   configureFlags = [ "--enable-add-ons" ];
 
-  buildInputs = [ texinfo perl ];
+  extraNativeBuildInputs = [ texinfo perl ];
 
   buildPhase = "make info";
 

--- a/pkgs/development/libraries/glibc/mtrace.nix
+++ b/pkgs/development/libraries/glibc/mtrace.nix
@@ -8,7 +8,7 @@
 # `glibc` needs to be overridden here because it's still needed to `./configure` the source in order
 # to have a build environment where we can call the needed make target.
 
-glibc.overrideAttrs ({ meta ? {}, ... }: {
+glibc.overrideAttrs (oldAttrs: {
   pname = "glibc-mtrace";
 
   buildPhase = ''
@@ -25,14 +25,16 @@ glibc.overrideAttrs ({ meta ? {}, ... }: {
     mv malloc/mtrace $out/bin/
   '';
 
-  # Perl interpreter used for `mtrace`.
-  buildInputs = [ perl ];
+  # Perl checked during configure
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ perl ];
+  # Perl shebang used for `mtrace`.
+  buildInputs = oldAttrs.buildInputs ++ [ perl ];
 
   # Reset a few things declared by `pkgs.glibc`.
   outputs = [ "out" ];
   separateDebugInfo = false;
 
-  meta = meta // {
+  meta = oldAttrs.meta // {
     description = "Perl script used to interpret and provide human readable output of the trace log contained in the file mtracedata, whose contents were produced by mtrace(3).";
   };
 })

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -28,6 +28,7 @@ let self = stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "info" ];
   passthru.static = self.out;
 
+  strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ m4 ];
 

--- a/pkgs/development/libraries/isl/generic.nix
+++ b/pkgs/development/libraries/isl/generic.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation {
 
   inherit patches;
 
+  strictDeps = true;
   buildInputs = [ gmp ];
 
   inherit configureFlags;

--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
        # on Darwin, so disable NLS for now.
     ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-nls";
 
+  strictDeps = true;
   nativeBuildInputs =
     if stdenv.hostPlatform.isNetBSD then [ netbsd.gencat ] else [ gettext ]
        # Need to regenerate configure script with newer version in order to pass

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
 
   patches = [];
 
+  strictDeps = true;
   outputs = [ "out" "dev" "man" "info" ];
 
   configureFlags = [

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dpQM1Od46Ak1eanRlbJf/16Tbp3GJCBoUotDenZ2T5E=";
   };
 
+  strictDeps = true;
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];
 
   patches = optional stdenv.isDarwin ./fix-error-darwin.patch;

--- a/pkgs/development/libraries/libmpc/default.nix
+++ b/pkgs/development/libraries/libmpc/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "0n846hqfqvmsmim7qdlms0qr86f1hck19p12nq3g3z2x74n3sl0p";
   };
 
+  strictDeps = true;
   buildInputs = [ gmp mpfr ];
 
   doCheck = true; # not cross;

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "info" "doc" ];
 
+  strictDeps = true;
   propagatedBuildInputs = lib.optional (!stdenv.isLinux) libiconv;
 
   configureFlags = [

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "doc" "info" ];
 
+  strictDeps = true;
   # mpfr.h requires gmp.h
   propagatedBuildInputs = [ gmp ];
 

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation (rec {
     ./fix-configure-issue-cross.patch
   ];
 
+  strictDeps = true;
   outputs = [ "out" "dev" ]
     ++ lib.optional splitStaticOutput "static";
   setOutputFlags = false;

--- a/pkgs/development/tools/misc/autoconf-archive/default.nix
+++ b/pkgs/development/tools/misc/autoconf-archive/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-6KbrnSjdy6j/7z+iEWUyOem/I5q6agGmt8/Hzq7GnL0=";
   };
 
+  strictDeps = true;
   buildInputs = [ xz ];
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     ./2.71-fix-race.patch
   ];
 
+  strictDeps = true;
   nativeBuildInputs = [ m4 perl texinfo ];
   buildInputs = [ m4 ];
   postBuild = "

--- a/pkgs/development/tools/misc/automake/automake-1.16.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.16.x.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0sdl32qxdy7m06iggmkkvf7j520rmmgbsjzbm7fgnxwxdp6mh7gh";
   };
 
+  strictDeps = true;
   nativeBuildInputs = [ autoconf perl ];
   buildInputs = [ autoconf ];
 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -109,6 +109,7 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "info" "man" ];
 
+  strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [
     bison

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-swapHA/ZO8QoDPwumMt6s5gf91oYe+oyk4EfRSyJqMg=";
   };
 
+  strictDeps = true;
   doCheck = false;
 
   configureFlags = [ "--with-syscmd-shell=${stdenv.shell}" ]

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     substituteInPlace build-aux/ltmain.in --replace '#! /usr/bin/env sh' '#!${runtimeShell}'
   '';
 
+  strictDeps = true;
   nativeBuildInputs = [ autoconf automake help2man m4 perl ];
   propagatedBuildInputs = [ m4 file ];
 

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-uaRvKYkyLrifpPYjfiCDbFe0VapDoyVF6gk7Qx2YL1w=";
   };
 
+  strictDeps = true;
   setupHook = [ ./setup-hook.sh ];
 
   # fails 8 out of 24 tests, problems when loading libc.so.6

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "man" "doc" ];
+  strictDeps = true;
 
   # Process Requires.private properly, see
   # http://bugs.freedesktop.org/show_bug.cgi?id=4738, migrated to

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -1,6 +1,6 @@
 { version, sha256, patches ? [] }:
 
-{ lib, stdenv, buildPackages, fetchurl, perl, xz, gettext
+{ lib, stdenv, buildPackages, fetchurl, perl, xz, libintl, bash
 
 # we are a dependency of gcc, this simplifies bootstraping
 , interactive ? false, ncurses, procps
@@ -33,13 +33,13 @@ stdenv.mkDerivation {
   NATIVE_TOOLS_CFLAGS = if crossBuildTools then "-I${getDev buildPackages.ncurses}/include" else null;
   NATIVE_TOOLS_LDFLAGS = if crossBuildTools then "-L${getLib buildPackages.ncurses}/lib" else null;
 
+  strictDeps = true;
   # We need a native compiler to build perl XS extensions
   # when cross-compiling.
   depsBuildBuild = [ buildPackages.stdenv.cc perl ];
 
-  buildInputs = [ xz.bin ]
+  buildInputs = [ xz.bin bash libintl ]
     ++ optionals stdenv.isSunOS [ libiconv gawk ]
-    ++ optionals stdenv.isDarwin [ gettext ]
     ++ optional interactive ncurses;
 
   configureFlags = [ "PERL=${buildPackages.perl}/bin/perl" ]

--- a/pkgs/development/tools/parsing/bison/default.nix
+++ b/pkgs/development/tools/parsing/bison/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation rec {
   # Otherwise tests fail due to incorrect unicode symbol oconversion.
   configurePlatforms = [ "build" "host" ];
 
+  # there's a /bin/sh shebang in bin/yacc which when no strictDeps is patched with the build stdenv shell
+  # however when cross-compiling it would still be patched with the build stdenv shell which would be wrong
+  # cannot add bash to buildInputs due to infinite recursion
+  strictDeps = stdenv.hostPlatform != stdenv.buildPlatform;
+
   nativeBuildInputs = [ m4 perl ] ++ lib.optional stdenv.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];
 

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -14,6 +14,7 @@ let
 
     ARCH = stdenvNoCC.hostPlatform.linuxArch;
 
+    strictDeps = true;
     # It may look odd that we use `stdenvNoCC`, and yet explicit depend on a cc.
     # We do this so we have a build->build, not build->host, C compiler.
     depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -162,6 +162,7 @@ in
       # stage1.
       ${localSystem.libc} = self.stdenv.mkDerivation {
         pname = "bootstrap-stage0-${localSystem.libc}";
+        strictDeps = true;
         version = "bootstrap";
         buildCommand = ''
           mkdir -p $out
@@ -269,6 +270,7 @@ in
           inherit (prevStage.bintools.bintools) name;
           dontUnpack = true;
           dontBuild = true;
+          strictDeps = true;
           # We wouldn't need to *copy* all, but it's easier and the result is temporary anyway.
           installPhase = ''
             mkdir -p "$out"/bin

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-FnhwNy4OHe8d5M6iYCClkxzcB/EHXg0veXwv43ZlxbA=";
   };
 
+  strictDeps = true;
   nativeBuildInputs = [ autoreconfHook ];
 
   patches = [

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ps2i8i212n0f4xpq6clp7h13q7m1y8slqvxha9i8d0bj0qgj5si";
   };
 
+  strictDeps = true;
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   configureFlags = lib.optional enableStatic "--disable-shared";

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-E+Uyx7Nk99V+I9/uoxRxAxUMuQWTpXr4bBDk9uQRYD8=";
   };
 
+  strictDeps = true;
   nativeBuildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
   buildInputs = [ zlib ]
     ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;

--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1bgafvy3ypbhhfznwjv1lxmd6mci3x1byilnnkc7gcr486wlb8pl";
   };
 
+  strictDeps = true;
+
   meta = with lib; {
     homepage = "https://www.gnu.org/software/which/";
     description = "Shows the full path of (shell) commands";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18833,7 +18833,7 @@ with pkgs;
   glibcIconv = libc: let
     inherit (libc) pname version;
     libcDev = lib.getDev libc;
-  in runCommand "${pname}-iconv-${version}" {} ''
+  in runCommand "${pname}-iconv-${version}" { strictDeps = true; } ''
     mkdir -p $out/include
     ln -sv ${libcDev}/include/iconv.h $out/include
   '';

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12373,6 +12373,7 @@ let
   LocaleGettext = buildPerlPackage {
     pname = "gettext";
     version = "1.07";
+    strictDeps = true;
     buildInputs = [ pkgs.gettext ];
     src = fetchurl {
       url = "mirror://cpan/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
