### PR TITLE
libbitcoin: fix gcc11 compilation by patch

### DIFF
--- a/pkgs/tools/misc/libbitcoin/fix-gcc11-compilation.patch
+++ b/pkgs/tools/misc/libbitcoin/fix-gcc11-compilation.patch
@@ -1,0 +1,12 @@
+diff --git a/include/bitcoin/bitcoin/wallet/dictionary.hpp b/include/bitcoin/bitcoin/wallet/dictionary.hpp
+index 632f1afc..63a51764 100644
+--- a/include/bitcoin/bitcoin/wallet/dictionary.hpp
++++ b/include/bitcoin/bitcoin/wallet/dictionary.hpp
+@@ -19,6 +19,7 @@
+ #ifndef LIBBITCOIN_WALLET_DICTIONARY_HPP
+ #define LIBBITCOIN_WALLET_DICTIONARY_HPP
+ 
++#include <cstddef>
+ #include <array>
+ #include <vector>
+ #include <bitcoin/bitcoin/compat.hpp>

--- a/pkgs/tools/misc/libbitcoin/libbitcoin.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin.nix
@@ -21,6 +21,8 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  patches = [ ./fix-gcc11-compilation.patch ];
+
   configureFlags = [
     "--with-tests=no"
     "--with-boost=${boost.dev}"


### PR DESCRIPTION
###### Description of changes

Compilation of libbitcoin fails since commit 52f8cf58a4504e5e219faebffa51033e400e3aec, found out by git bisect. 
Compiler error message:

```
In file included from src/wallet/dictionary.cpp:19:
./include/bitcoin/bitcoin/wallet/dictionary.hpp:32:21: error: 'size_t' does not name a type
   32 | static BC_CONSTEXPR size_t dictionary_size = 2048;
      |                     ^~~~~~
./include/bitcoin/bitcoin/wallet/dictionary.hpp:25:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
   24 | #include <bitcoin/bitcoin/compat.hpp>
  +++ |+#include <cstddef>
   25 |
./include/bitcoin/bitcoin/wallet/dictionary.hpp:40:33: error: 'dictionary_size' was not declared in this scope
   40 | typedef std::array<const char*, dictionary_size> dictionary;
      |                                 ^~~~~~~~~~~~~~~
./include/bitcoin/bitcoin/wallet/dictionary.hpp:40:48: error: template argument 2 is invalid
   40 | typedef std::array<const char*, dictionary_size> dictionary;
      |                                                ^
src/wallet/dictionary.cpp:2077:1: error: too many braces around scalar initializer for type 'const dictionary' {aka 'const int'}
 2077 | };
```

suggests adding `#include <cstddef>` to `./include/bitcoin/bitcoin/wallet/dictionary.hpp`. So i patched the file accordingly => build succeeds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

ZHF: https://github.com/NixOS/nixpkgs/issues/172160

ping https://github.com/orgs/NixOS/teams/nixos-release-managers