### PR TITLE
nixos/tests/os-prober: fix

### DIFF
--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -75,21 +75,30 @@ in {
       # The test cannot access the network, so any packages
       # nixos-rebuild needs must be included in the VM.
       system.extraDependencies = with pkgs;
-        [ sudo
-          libxml2.bin
-          libxslt.bin
+        [
+          brotli
+          brotli.dev
+          brotli.lib
           desktop-file-utils
           docbook5
           docbook_xsl_ns
-          unionfs-fuse
-          ntp
-          nixos-artwork.wallpapers.simple-dark-gray-bottom
-          perlPackages.XMLLibXML
-          perlPackages.ListCompare
-          shared-mime-info
-          texinfo
-          xorg.lndir
           grub2
+          kmod.dev
+          libarchive
+          libarchive.dev
+          libxml2.bin
+          libxslt.bin
+          nixos-artwork.wallpapers.simple-dark-gray-bottom
+          ntp
+          perlPackages.ListCompare
+          perlPackages.XMLLibXML
+          python3Minimal
+          shared-mime-info
+          stdenv
+          sudo
+          texinfo
+          unionfs-fuse
+          xorg.lndir
 
           # add curl so that rather than seeing the test attempt to download
           # curl's tarball, we see what it's trying to download


### PR DESCRIPTION
synchronize the list of extraDependencies with the installer test
