### PR TITLE
python310Packages.watchfiles: init at 0.14.1

### DIFF
--- a/pkgs/development/python-modules/dirty-equals/default.nix
+++ b/pkgs/development/python-modules/dirty-equals/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, pytz
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "dirty-equals";
+  version = "0.4";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "samuelcolvin";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rh7N/VRx4sv/MhhGPkaYCn2d19Sv5er2CkG6/fJuXX4=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    pytz
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    typing-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "dirty_equals"
+  ];
+
+  meta = with lib; {
+    description = "Module for doing dirty (but extremely useful) things with equals";
+    homepage = "https://github.com/samuelcolvin/dirty-equals";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/watchfiles/default.nix
+++ b/pkgs/development/python-modules/watchfiles/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, anyio
+, buildPythonPackage
+, fetchFromGitHub
+, rustPlatform
+, setuptools-rust
+, pythonOlder
+, dirty-equals
+, pytest-mock
+, pytest-timeout
+, pytestCheckHook
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "watchfiles";
+  version = "0.14.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "samuelcolvin";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-XjmmyL7ZRqkYwGGk6/KkxL7e/JA43tQN4W3knTtc7t0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "sha256-sZMj1HQ37gAG3WM+qBMhcCQ2MuUGom23lF8c4L0RQzM=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-rust
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  propagatedBuildInputs = [
+    anyio
+  ];
+
+  checkInputs = [
+    dirty-equals
+    pytest-mock
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "watchfiles"
+  ];
+
+  preCheck = ''
+    cd tests
+  '';
+
+  meta = with lib; {
+    description = "Simple, modern file watching and code reload";
+    homepage = "https://watchfiles.helpmanual.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2245,6 +2245,8 @@ in {
 
   directv = callPackage ../development/python-modules/directv { };
 
+  dirty-equals = callPackage ../development/python-modules/dirty-equals { };
+
   discid = callPackage ../development/python-modules/discid { };
 
   discogs-client = callPackage ../development/python-modules/discogs-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10954,6 +10954,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  watchfiles = callPackage ../development/python-modules/watchfiles { };
+
   watchgod = callPackage ../development/python-modules/watchgod { };
 
   waterfurnace = callPackage ../development/python-modules/waterfurnace { };


### PR DESCRIPTION
###### Description of changes
Simple, modern file watching and code reload

https://watchfiles.helpmanual.io

`watchfiles` is the the successor of `watchgod`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
