### PR TITLE
python3Packages.pandas: skip test_rolling_var_numerical_issues

### DIFF
--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -90,6 +90,10 @@ buildPythonPackage rec {
     "test_comparison_invalid"
     # AssertionError: Regex pattern '"quotechar" must be string, not int'
     "python-kwargs2"
+    # Tests for rounding errors and fails if we have better precision
+    # than expected, e.g. on amd64 with FMA or on arm64
+    # https://github.com/pandas-dev/pandas/issues/38921
+    "test_rolling_var_numerical_issues"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_locale"
     "test_clipboard"


### PR DESCRIPTION
###### Description of changes

I observed that on amd64, the pandas build does not fail on nixpkgs by default, but does fail if you build everything with e.g. `-march=haswell -mtune=haswell`, which enables FMA and increases (?) the float precision. I confirmed that disabling this test fixes the build in this case.

The comment I added is based on https://github.com/gentoo/gentoo/blob/8fdec261accb804285ccbc6ac485fdc8b454947d/dev-python/pandas/pandas-1.4.2.ebuild#L152-L155

The upstream issue is https://github.com/pandas-dev/pandas/issues/38921

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainers @7c6f434c @fridh @knedlsepp
