### PR TITLE
zchaff: init at 2004.5.13

### DIFF
--- a/pkgs/applications/science/logic/zchaff/default.nix
+++ b/pkgs/applications/science/logic/zchaff/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "zchaff";
+  version = "2004.5.13";
+
+  src = fetchurl {
+    url = "https://www.princeton.edu/~chaff/zchaff/zchaff.${version}.tar.gz";
+    sha256 = "sha256-IgOdb2KsFbRV3gPvIPkHa71ixnYRxyx91vt7m0jzIAw=";
+  };
+
+  patches = [ ./sat_solver.patch ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}c++" ];
+  installPhase= ''
+    runHook preInstall
+    install -Dm755 -t $out/bin zchaff
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.princeton.edu/~chaff/zchaf";
+    description = "Accelerated SAT Solver from Princeton";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/science/logic/zchaff/sat_solver.patch
+++ b/pkgs/applications/science/logic/zchaff/sat_solver.patch
@@ -1,0 +1,12 @@
+diff --git a/sat_solver.cpp b/sat_solver.cpp
+index e191881..07c0926 100644
+--- a/sat_solver.cpp
++++ b/sat_solver2.cpp
+@@ -43,6 +43,7 @@
+ #include <vector>
+ #include <dirent.h>
+ #include "SAT.h"
++#include <cstring>
+ 
+ using namespace std;
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33411,6 +33411,8 @@ with pkgs;
   };
   z3-tptp = callPackage ../applications/science/logic/z3/tptp.nix {};
 
+  zchaff = callPackage ../applications/science/logic/zchaff { };
+
   tlaplus = callPackage ../applications/science/logic/tlaplus {
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
