### PR TITLE
openvpn3: refactor the build

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6709,6 +6709,13 @@
     githubId = 8211181;
     name = "Kevin Kandlbinder";
   };
+  kfears = {
+    email = "kfearsoff@gmail.com";
+    github = "KFearsoff";
+    githubId = 66781795;
+    matrix = "@kfears:matrix.org";
+    name = "KFears";
+  };
   kfollesdal = {
     email = "kfollesdal@gmail.com";
     github = "kfollesdal";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -197,6 +197,7 @@
   ./programs/npm.nix
   ./programs/noisetorch.nix
   ./programs/oblogout.nix
+  ./programs/openvpn3.nix
   ./programs/pantheon-tweaks.nix
   ./programs/partition-manager.nix
   ./programs/plotinus.nix

--- a/nixos/modules/programs/openvpn3.nix
+++ b/nixos/modules/programs/openvpn3.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.openvpn3;
+in
+{
+  options.programs.openvpn3 = {
+    enable = mkEnableOption "the openvpn3 client";
+  };
+
+  config = mkIf cfg.enable {
+    services.dbus.packages = with pkgs; [
+      openvpn3
+    ];
+
+    users.users.openvpn = {
+      isSystemUser = true;
+      uid = config.ids.uids.openvpn;
+      group = "openvpn";
+    };
+
+    users.groups.openvpn = {
+      gid = config.ids.gids.openvpn;
+    };
+
+    environment.systemPackages = with pkgs; [
+      openvpn3
+    ];
+  };
+
+}

--- a/pkgs/tools/networking/openvpn3/default.nix
+++ b/pkgs/tools/networking/openvpn3/default.nix
@@ -1,0 +1,125 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, asio
+, autoconf-archive
+, autoreconfHook
+, fetchpatch
+, glib
+, gtest
+, jsoncpp
+, libcap_ng
+, libnl
+, libuuid
+, lz4
+, openssl
+, pkg-config
+, protobuf
+, python3
+, tinyxml-2
+, wrapGAppsHook
+}:
+
+let
+  openvpn3-core = fetchFromGitHub {
+    owner = "OpenVPN";
+    repo = "openvpn3";
+    rev = "7765540e581c48721752bcad0b3d74b8397b1f73";
+    sha256 = "sha256-v/suF/tWfuukQO1wFiHRzC7ZW+3Gh1tav6qj0uYUP4E=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "openvpn3";
+  # also update openvpn3-core
+  version = "17_beta";
+
+  src = fetchFromGitHub {
+    owner = "OpenVPN";
+    repo = "openvpn3-linux";
+    rev = "v${version}";
+    sha256 = "sha256-ITSnC105YNYFW1M2bOASFemPZAh+HETIzX2ofABWTho=";
+  };
+
+  patches = [
+    # remove when v18_beta hits
+    (fetchpatch {
+      name = "dont-hardcode-gio.patch";
+      url = "https://github.com/OpenVPN/openvpn3-linux/commit/f7d6d3ae1d52b18b398d3d3b6e21c720c98d0e89.patch";
+      sha256 = "sha256-Bo5uaHadMTDROpwM7Y5aXhCoGUrsAAkSxeXLLhvOeEg=";
+    })
+  ];
+
+  postPatch = ''
+    rm -r ./vendor/googletest
+    cp -r ${gtest.src} ./vendor/googletest
+    rm -r ./openvpn3-core
+    ln -s ${openvpn3-core} ./openvpn3-core
+
+    chmod -R +w ./vendor/googletest
+    shopt -s globstar
+
+    patchShebangs **/*.py **/*.sh ./src/python/{openvpn2,openvpn3-as,openvpn3-autoload} \
+    ./distro/systemd/openvpn3-systemd ./src/tests/dbus/netcfg-subscription-test
+
+    echo "3.git:v${version}:unknown" > openvpn3-core-version
+  '';
+
+  preAutoreconf = ''
+    substituteInPlace ./update-version-m4.sh --replace 'VERSION="$(git describe --always --tags)"' "VERSION=v${version}"
+    ./update-version-m4.sh
+  '';
+
+  nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
+    python3.pkgs.docutils
+    python3.pkgs.jinja2
+    pkg-config
+    wrapGAppsHook
+    python3.pkgs.wrapPython
+  ] ++ pythonPath;
+
+  buildInputs = [
+    asio
+    glib
+    jsoncpp
+    libcap_ng
+    libnl
+    libuuid
+    lz4
+    openssl
+    protobuf
+    tinyxml-2
+  ];
+
+  # runtime deps
+  pythonPath = with python3.pkgs; [
+    dbus-python
+    pygobject3
+  ];
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  configureFlags = [
+    "--enable-bash-completion"
+    "--enable-addons-aws"
+    "--disable-selinux-build"
+    "--disable-build-test-progs"
+  ];
+
+  NIX_LDFLAGS = "-lpthread";
+
+  meta = with lib; {
+    description = "OpenVPN 3 Linux client";
+    license = licenses.agpl3Plus;
+    homepage = "https://github.com/OpenVPN/openvpn3-linux/";
+    maintainers = with maintainers; [ shamilton kfears ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9063,6 +9063,8 @@ with pkgs;
     openvpn_24
     openvpn;
 
+  openvpn3 = callPackage ../tools/networking/openvpn3 { };
+
   openvpn_learnaddress = callPackage ../tools/networking/openvpn/openvpn_learnaddress.nix { };
 
   openvpn-auth-ldap = callPackage ../tools/networking/openvpn/openvpn-auth-ldap.nix {


### PR DESCRIPTION
###### Description of changes

Closes #120116

This is a continuation of #120352 and #171678 PRs, intended to improve upon the build  quality of the latter. It adds Bash completions, AWS addon and adds the unit test suit from upstream.

Tested this locally:
- on top 3c31489 commit on NixOS Unstable
- added following config:
```
services.openvpn3.enable = true;
```
- switch installation (works on switching configuration):
```
nixos-rebuild switch -I nixpkgs=/path/to/nixpkgs
```
- test Bash completion in Bash
- test commands:
```
# import VPN file
openvpn3 config-import -c path/to/config.ovpn
# run with VPN file
openvpn3 session-start -c path/to/config.ovpn
# check status
openvpn3 session-stats -c path/to/config.ovpn
# man works
man openvpn3
man openvpn2
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).