### PR TITLE
vkdisplayinfo: init at 0.1

### DIFF
--- a/pkgs/tools/graphics/vkdisplayinfo/default.nix
+++ b/pkgs/tools/graphics/vkdisplayinfo/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, meson
+, ninja
+, vulkan-loader
+, vulkan-headers
+, fetchFromGitHub
+}:
+stdenv.mkDerivation rec {
+  pname = "vkdisplayinfo";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "ChristophHaag";
+    repo = "vkdisplayinfo";
+    rev = version;
+    hash = "sha256-n6U7T5aOYTpgWE2WGPBPHtQKzitf9PxAoXJNWyz4rYw=";
+  };
+
+  postInstall = ''
+    install vkdisplayinfo -Dm755 -t $out/bin
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    ($out/bin/vkdisplayinfo 2>&1 || true) | grep -q vkdisplayinfo
+    runHook postInstallCheck
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    vulkan-loader
+    vulkan-headers
+  ];
+
+  meta = with lib; {
+    description = "Print displays and modes enumerated with the Vulkan function vkGetPhysicalDeviceDisplayPropertiesKHR";
+    homepage = "https://github.com/ChristophHaag/vkdisplayinfo";
+    platforms = platforms.linux;
+    license = licenses.boost;
+    maintainers = [ maintainers.LunNova ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20975,6 +20975,8 @@ with pkgs;
     hdf5 = hdf5.override { usev110Api = true; };
   };
 
+  vkdisplayinfo = callPackage ../tools/graphics/vkdisplayinfo { };
+
   vlock = callPackage ../misc/screensavers/vlock { };
 
   vmime = callPackage ../development/libraries/vmime { };


### PR DESCRIPTION
###### Description of changes

https://github.com/ChristophHaag/vkdisplayinfo - Print displays and modes enumerated with the Vulkan function vkGetPhysicalDeviceDisplayPropertiesKHR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
