### PR TITLE
gajim: 1.3.3 → 1.4.1; pythonPackages.nbxmpp: 2.0.6 → 3.0.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -2,6 +2,7 @@
 
 # Native dependencies
 , python3, gtk3, gobject-introspection, gnome
+, gtksourceview4
 , glib-networking
 
 # Test dependencies
@@ -21,15 +22,16 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gajim";
-  version = "1.3.3";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "https://gajim.org/downloads/${lib.versions.majorMinor version}/gajim-${version}.tar.gz";
-    sha256 = "1337qkpcv7j0fgws9scnk82mn2l7s17060vmrbh3ihinmxmbxg6x";
+    sha256 = "sha256:0mbx7s1d2xgk7bkhwqcdss6ynshkqdiwh3qgv7d45frb4c3k33l2";
   };
 
   buildInputs = [
     gobject-introspection gtk3 gnome.adwaita-icon-theme
+    gtksourceview4
     glib-networking
   ] ++ lib.optionals enableJingle [ farstream gstreamer gst-plugins-base gst-libav gst-plugins-good libnice ]
     ++ lib.optional enableSecrets libsecret
@@ -74,7 +76,7 @@ python3.pkgs.buildPythonApplication rec {
   checkPhase = ''
     xvfb-run dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
-      ${python3.interpreter} -m unittest discover -s test/unit -v
+      ${python3.interpreter} -m unittest discover -s test/gtk -v
     ${python3.interpreter} -m unittest discover -s test/no_gui -v
   '';
 

--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "nbxmpp";
-  version = "2.0.6";
+  version = "3.0.2";
 
   disabled = pythonOlder "3.7";
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "gajim";
     repo = "python-nbxmpp";
     rev = "nbxmpp-${version}";
-    sha256 = "sha256:03iydz0r9m8559srawwnhaqzqm9liwrnc8v6abj4w3m1lil32bid";
+    sha256 = "sha256:0wvganymqw90y9mz5a5mh531r2s9z0vrkbfspx5akk98syaq6f5p";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

Major release.
https://dev.gajim.org/gajim/python-nbxmpp/-/blob/nbxmpp-3.0.2/ChangeLog
https://dev.gajim.org/gajim/gajim/-/blob/gajim-1.4.1/ChangeLog

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

