### PR TITLE
scantailor-advanced: fix build with qt5.15 by switching to a maintained fork

### DIFF
--- a/pkgs/applications/graphics/scantailor/advanced.nix
+++ b/pkgs/applications/graphics/scantailor/advanced.nix
@@ -4,21 +4,21 @@
 
 mkDerivation rec {
   pname = "scantailor-advanced";
-  version = "1.0.16";
+  version = "1.0.18";
 
   src = fetchFromGitHub {
-    owner = "4lex4";
+    owner = "vigri";
     repo = "scantailor-advanced";
     rev = "v${version}";
-    sha256 = "0lc9lzbpiy5hgimyhl4s4q67pb9gacpy985gl6iy8pl79zxhmcyp";
+    sha256 = "sha256-4/QSjgHvRgIduS/AXbT7osRTdOdgR7On3CbjRnGbwHU=";
   };
 
   nativeBuildInputs = [ cmake qttools ];
   buildInputs = [ libjpeg libpng libtiff boost qtbase ];
 
   meta = with lib; {
-    homepage = "https://github.com/4lex4/scantailor-advanced";
-    description = "Interactive post-processing tool for scanned pages";
+    homepage = "https://github.com/vigri/scantailor-advanced";
+    description = "Interactive post-processing tool for scanned pages (vigri's fork)";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jfrankenau ];
     platforms = with platforms; gnu ++ linux ++ darwin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29408,7 +29408,7 @@ with pkgs;
 
   scantailor = callPackage ../applications/graphics/scantailor { };
 
-  scantailor-advanced = libsForQt514.callPackage ../applications/graphics/scantailor/advanced.nix { };
+  scantailor-advanced = libsForQt515.callPackage ../applications/graphics/scantailor/advanced.nix { };
 
   sc-im = callPackage ../applications/misc/sc-im { };
 


### PR DESCRIPTION
https://github.com/4lex4/scantailor-advanced/issues/170#issuecomment-1030857156

changelog: https://github.com/vigri/scantailor-advanced/releases


ZHF: https://github.com/NixOS/nixpkgs/issues/172160
