### PR TITLE
menu-cache: pull patch pending upstream inclusion for -fno-common too…

### DIFF
--- a/pkgs/development/libraries/menu-cache/default.nix
+++ b/pkgs/development/libraries/menu-cache/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, glib, pkg-config, libfm-extra }:
+{ lib, stdenv, fetchurl, fetchpatch, glib, pkg-config, libfm-extra }:
 
 stdenv.mkDerivation rec {
   pname = "menu-cache";
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/lxde/menu-cache-${version}.tar.xz";
     sha256 = "1iry4zlpppww8qai2cw4zid4081hh7fz8nzsp5lqyffbkm2yn0pd";
   };
+
+  patches = [
+    # Pull patch pending upstream inclusion for -fno-common toolchain support:
+    #   https://github.com/lxde/menu-cache/pull/19
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/lxde/menu-cache/commit/1ce739649b4d66339a03fc0ec9ee7a2f7c141780.patch";
+      sha256 = "08x3h0w2pl8ifj83v9jkf4j3zxcwsyzh251divlhhnwx0rw1pyn7";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
…lchains

Without the change build fails on upstream gcc-10 as:

    ld: menu-compose.o:/build/menu-cache-1.1.0/menu-cache-gen/menu-tags.h:25: multiple definition of
      `menuTag_Menu'; main.o:/build/menu-cache-1.1.0/menu-cache-gen/menu-tags.h:25: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
