### PR TITLE
box64: init at 0.1.8

### DIFF
--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "box64";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "ptitSeb";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-6k8Enbafnj19ATtgmw8W7LxtRpM3Ousj1bpZbbtq8TM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  cmakeFlags = [
+    "-DNOGIT=1"
+  ] ++ (
+    if stdenv.hostPlatform.system == "aarch64-linux" then
+      [
+        "-DARM_DYNAREC=ON"
+      ]
+    else [
+      "-DLD80BITS=1"
+      "-DNOALIGN=1"
+    ]
+  );
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 0755 box64 "$out/bin/box64"
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    ctest
+    runHook postCheck
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/box64 -v
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://box86.org/";
+    description = "Lets you run x86_64 Linux programs on non-x86_64 Linux systems";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1255,6 +1255,8 @@ with pkgs;
     wxGTK = wxGTK30;
   };
 
+  box64 = callPackage ../applications/emulators/box64 { };
+
   caprice32 = callPackage ../applications/emulators/caprice32 { };
 
   ccemux = callPackage ../applications/emulators/ccemux { };


### PR DESCRIPTION
###### Description of changes

Init for x86_64 emulator on aarch64 systems. Fixes #173686

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


