### PR TITLE
mmh: unstable-2019-09-08 -> unstable-2020-08-21

### DIFF
--- a/pkgs/applications/networking/mailreaders/mmh/default.nix
+++ b/pkgs/applications/networking/mailreaders/mmh/default.nix
@@ -1,13 +1,13 @@
-{ lib, stdenv, fetchurl, ncurses, autoreconfHook, flex }:
-let rev = "431604647f89d5aac7b199a7883e98e56e4ccf9e";
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, autoreconfHook, flex }:
+let rev = "b17ea39dc17e5514f33b3f5c34ede92bd16e208c";
 in stdenv.mkDerivation rec {
   pname = "mmh";
-  version = "unstable-2019-09-08";
+  version = "unstable-2020-08-21";
 
   src = fetchurl {
     url = "http://git.marmaro.de/?p=mmh;a=snapshot;h=${rev};sf=tgz";
     name = "mmh-${rev}.tgz";
-    sha256 = "1q97p4g3f1q2m567i2dbx7mm7ixw3g91ww2rymwj42cxk9iyizhv";
+    sha256 = "1bqfxafw4l2y46pnsxgy4ji1xlyifzw01k1ykbsjj9p61q3nv6l6";
   };
 
   postPatch = ''


### PR DESCRIPTION
Among other things update fixes build failure on upstream gcc-10:

    ld: mhparse.o:(.bss+0x0): multiple definition of `tmp'; mhbuild.o:(.bss+0x10): first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
