### PR TITLE
patchShebangs: ignore `-S` after `/usr/bin/env`

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -61,6 +61,12 @@ patchShebangs() {
             fi
         fi
 
+        # ignore fancy shebangs like "#! -*- python -*-"
+        if [[ "$oldPath" == "-"* ]]; then
+            echo "$f: ignore unsupported interpreter directive \"$oldInterpreterLine\"" >&2
+            continue
+        fi
+
         if [[ "$oldPath" == *"/bin/env" ]]; then
             # ignore -S
             if [[ $arg0 == "-S" ]]; then

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -62,6 +62,11 @@ patchShebangs() {
         fi
 
         if [[ "$oldPath" == *"/bin/env" ]]; then
+            # ignore -S
+            if [[ $arg0 == "-S" ]]; then
+               read -r oldPath argS arg0 args <<< "${oldInterpreterLine:3}"
+            fi
+
             # Check for unsupported 'env' functionality:
             # - options: something starting with a '-'
             # - environment variables: foo=bar


### PR DESCRIPTION
it happens quite often that package sources have scripts with shebang like `#!/usr/bin/env -S make -f` or `#!/usr/bin/env -S python3 -B`, where `-S` is meaningless.

`patchShebangs` fails to process those scripts
