### PR TITLE
rkdeveloptool-pine64: init at unstable-2021-09-04

### DIFF
--- a/pkgs/misc/rkdeveloptool-pine64/default.nix
+++ b/pkgs/misc/rkdeveloptool-pine64/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchurl
+, meson
+, pkg-config
+, libusb1
+, scdoc
+, ninja
+, cmake
+}:
+
+let
+  rev = "cce7d2a5c4efd4e7727c440868141229354b327b";
+in
+stdenv.mkDerivation {
+  pname = "rkdeveloptool";
+  version = "unstable-2021-09-04";
+
+  src = fetchurl {
+    url = "https://gitlab.com/pine64-org/quartz-bsp/rkdeveloptool/-/archive/${rev}/rkdeveloptool-${rev}.tar.gz";
+    sha256 = "sha256-u/x1Y1zZ19SYwNLVAvpqjH247RijyDJ1HTDWIsmqlFk=";
+  };
+
+  postPatch = ''
+    substituteInPlace meson.build --replace \
+      "udev_rules_dir = udev.get_pkgconfig_variable('udevdir') + '/rules.d'" \
+      "udev_rules_dir = '$out/lib/udev'"
+  '';
+
+  nativeBuildInputs = [ meson ninja cmake pkg-config scdoc ];
+
+  buildInputs = [ libusb1 ];
+
+  meta =
+    let
+      inherit (lib) maintainers;
+    in
+    {
+      homepage = "https://gitlab.com/pine64-org/quartz-bsp/rkdeveloptool/";
+      description = "A tool from Rockchip to communicate with Rockusb devices (pine64 fork)";
+      license = lib.licenses.gpl2;
+      maintainers = [ maintainers.adisbladis ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29361,6 +29361,8 @@ with pkgs;
 
   rkdeveloptool = callPackage ../misc/rkdeveloptool { };
 
+  rkdeveloptool-pine64 = callPackage ../misc/rkdeveloptool-pine64 { };
+
   rocketchat-desktop = callPackage ../applications/networking/instant-messengers/rocketchat-desktop { };
 
   rofi-unwrapped = callPackage ../applications/misc/rofi { };


### PR DESCRIPTION
###### Description of changes

Pine64 maintains their own fork of `rkdeveloptool`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @samueldr