### PR TITLE
python311: 3.11.0a7 -> 3.11.0b3

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.11/darwin-libutil.patch
+++ b/pkgs/development/interpreters/python/cpython/3.11/darwin-libutil.patch
@@ -1,0 +1,13 @@
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+index 40229bce0f..3cc604930e 100644
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -7258,7 +7258,7 @@ os_sched_getaffinity_impl(PyObject *module, pid_t pid)
+ #ifdef HAVE_UTMP_H
+ #include <utmp.h>
+ #endif /* HAVE_UTMP_H */
+-#elif defined(HAVE_LIBUTIL_H)
++#elif defined(HAVE_LIBUTIL_H) && !defined(__APPLE__)
+ #include <libutil.h>
+ #elif defined(HAVE_UTIL_H)
+ #include <util.h>

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -229,7 +229,7 @@ in with passthru; stdenv.mkDerivation {
     # * https://bugs.python.org/issue35523
     # * https://github.com/python/cpython/commit/e6b247c8e524
     ./3.7/no-win64-workaround.patch
-  ] ++ optionals (pythonAtLeast "3.7") [
+  ] ++ optionals (pythonAtLeast "3.7" && pythonOlder "3.11") [
     # Fix darwin build https://bugs.python.org/issue34027
     ./3.7/darwin-libutil.patch
   ] ++ optionals (pythonOlder "3.8") [

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -232,6 +232,8 @@ in with passthru; stdenv.mkDerivation {
   ] ++ optionals (pythonAtLeast "3.7" && pythonOlder "3.11") [
     # Fix darwin build https://bugs.python.org/issue34027
     ./3.7/darwin-libutil.patch
+  ] ++ optionals (pythonAtLeast "3.11") [
+    ./3.11/darwin-libutil.patch
   ] ++ optionals (pythonOlder "3.8") [
     # Backport from CPython 3.8 of a good list of tests to run for PGO.
     (

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -199,9 +199,9 @@ in {
       major = "3";
       minor = "11";
       patch = "0";
-      suffix = "b1";
+      suffix = "b3";
     };
-    sha256 = "sha256-3MrJsD3T/lzRC8VHV56wvoGh2JcewqhmsD3sU5H1rSU=";
+    sha256 = "sha256-ybmfUxXqMPjp/LzmgHo3Oeh1SA0pEk5tmUD2+ry3yQI=";
     inherit (darwin) configd;
     inherit passthruFun;
   };

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -199,9 +199,9 @@ in {
       major = "3";
       minor = "11";
       patch = "0";
-      suffix = "a7";
+      suffix = "b1";
     };
-    sha256 = "sha256-t8Vt10wvRy1Ja1qNNWvWrZ75sD8mKIwyN9P/aYqwPXQ=";
+    sha256 = "sha256-3MrJsD3T/lzRC8VHV56wvoGh2JcewqhmsD3sU5H1rSU=";
     inherit (darwin) configd;
     inherit passthruFun;
   };


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3110b1/
https://blog.python.org/2022/05/python-3110b1-is-now-available.html

The darwin-libutil.patch does not apply anymore, we'll see shortly if it is still required.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
