### PR TITLE
python: use optional-dependencies instead of extras-require

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -982,12 +982,13 @@ in python.withPackages(ps: [ps.blaze])).env
 #### Optional extra dependencies
 
 Some packages define optional dependencies for additional features. With
-`setuptools` this is called `extras_require` and `flit` calls it `extras-require`. A
+`setuptools` this is called `extras_require` and `flit` calls it
+`extras-require`, while PEP 621 calls these `optional-dependencies`. A
 method for supporting this is by declaring the extras of a package in its
 `passthru`, e.g. in case of the package `dask`
 
 ```nix
-passthru.extras-require = {
+passthru.optional-dependencies = {
   complete = [ distributed ];
 };
 ```
@@ -997,7 +998,7 @@ and letting the package requiring the extra add the list to its dependencies
 ```nix
 propagatedBuildInputs = [
   ...
-] ++ dask.extras-require.complete;
+] ++ dask.optional-dependencies.complete;
 ```
 
 Note this method is preferred over adding parameters to builders, as that can

--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -14,7 +14,7 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs = [ twisted certifi ]
-    ++ twisted.extras-require.tls
+    ++ twisted.optional-dependencies.tls
     ++ lib.optional enableGUI pyside2;
   nativeBuildInputs = lib.optionals enableGUI [ qt5.wrapQtAppsHook ];
 

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -122,7 +122,7 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     threadpoolctl
     tika
     tqdm
-    twisted.extras-require.tls
+    twisted.optional-dependencies.tls
     txaio
     tzlocal
     urllib3

--- a/pkgs/development/python-modules/Mako/default.nix
+++ b/pkgs/development/python-modules/Mako/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     markupsafe
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     babel = [
       babel
     ];
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
     mock
-  ] ++ passthru.extras-require.babel;
+  ] ++ passthru.optional-dependencies.babel;
 
   disabledTests = lib.optionals isPyPy [
     # https://github.com/sqlalchemy/mako/issues/315

--- a/pkgs/development/python-modules/adb-shell/default.nix
+++ b/pkgs/development/python-modules/adb-shell/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     rsa
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     async = [
       aiofiles
     ];
@@ -47,8 +47,8 @@ buildPythonPackage rec {
     pycryptodome
     pytestCheckHook
   ]
-  ++ passthru.extras-require.async
-  ++ passthru.extras-require.usb;
+  ++ passthru.optional-dependencies.async
+  ++ passthru.optional-dependencies.usb;
 
   disabledTests = lib.optionals (pythonAtLeast "3.10") [
     # Tests are failing with Python 3.10

--- a/pkgs/development/python-modules/androidtv/default.nix
+++ b/pkgs/development/python-modules/androidtv/default.nix
@@ -28,19 +28,19 @@ buildPythonPackage rec {
     pure-python-adb
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     async = [
       aiofiles
     ];
-    inherit (adb-shell.extras-require) usb;
+    inherit (adb-shell.optional-dependencies) usb;
   };
 
   checkInputs = [
     mock
     pytestCheckHook
   ]
-  ++ passthru.extras-require.async
-  ++ passthru.extras-require.usb;
+  ++ passthru.optional-dependencies.async
+  ++ passthru.optional-dependencies.usb;
 
   disabledTests = [
     # Requires git but fails anyway

--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -68,8 +68,8 @@ buildPythonPackage rec {
     mock
     pytest-asyncio
     pytestCheckHook
-  ] ++ passthru.extras-require.scram
-  ++ passthru.extras-require.serialization;
+  ] ++ passthru.optional-dependencies.scram
+  ++ passthru.optional-dependencies.serialization;
 
   postPatch = ''
     substituteInPlace setup.py \
@@ -89,7 +89,7 @@ buildPythonPackage rec {
     "autobahn"
   ];
 
-  passthru.extras-require = rec {
+  passthru.optional-dependencies = rec {
     all = accelerate ++ compress ++ encryption ++ nvx ++ serialization ++ scram ++ twisted ++ ui ++ xbr;
     accelerate = [ /* wsaccel */ ];
     compress = [ python-snappy ];

--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -54,7 +54,7 @@ let
       pyyaml
     ]
       # tls
-      ++ twisted.extras-require.tls;
+      ++ twisted.optional-dependencies.tls;
 
     checkInputs = [
       treq

--- a/pkgs/development/python-modules/clize/default.nix
+++ b/pkgs/development/python-modules/clize/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     six
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     datetime = [
       python-dateutil
     ];

--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -98,7 +98,7 @@ buildPythonPackage rec {
     "dask.diagnostics"
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     complete = [ distributed ];
   };
 

--- a/pkgs/development/python-modules/datashader/default.nix
+++ b/pkgs/development/python-modules/datashader/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     param
     pyct
     scipy
-  ] ++ dask.extras-require.complete;
+  ] ++ dask.optional-dependencies.complete;
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/django_modelcluster/default.nix
+++ b/pkgs/development/python-modules/django_modelcluster/default.nix
@@ -27,11 +27,11 @@ buildPythonPackage rec {
     pytz
   ];
 
-  passthru.extras-require.taggit = [
+  passthru.optional-dependencies.taggit = [
     django-taggit
   ];
 
-  checkInputs = passthru.extras-require.taggit;
+  checkInputs = passthru.optional-dependencies.taggit;
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytest-asyncio
     sqlalchemy
     trio
-  ] ++ passlib.extras-require.bcrypt;
+  ] ++ passlib.optional-dependencies.bcrypt;
 
   patches = [
     # Bump starlette, https://github.com/tiangolo/fastapi/pull/4483

--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     passlib
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     babel = [
       babel
       flask-babel
@@ -95,10 +95,10 @@ buildPythonPackage rec {
     pytestCheckHook
     zxcvbn
   ]
-  ++ passthru.extras-require.babel
-  ++ passthru.extras-require.common
-  ++ passthru.extras-require.fsqla
-  ++ passthru.extras-require.mfa;
+  ++ passthru.optional-dependencies.babel
+  ++ passthru.optional-dependencies.common
+  ++ passthru.optional-dependencies.fsqla
+  ++ passthru.optional-dependencies.mfa;
 
 
   pythonImportsCheck = [ "flask_security" ];

--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     sniffio
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     http2 = [ h2 ];
     socks = [ socksio ];
   };
@@ -56,8 +56,8 @@ buildPythonPackage rec {
     trio
     trustme
     uvicorn
-  ] ++ passthru.extras-require.http2
-    ++ passthru.extras-require.socks;
+  ] ++ passthru.optional-dependencies.http2
+    ++ passthru.optional-dependencies.socks;
 
   pythonImportsCheck = [ "httpcore" ];
 

--- a/pkgs/development/python-modules/httpx-socks/default.nix
+++ b/pkgs/development/python-modules/httpx-socks/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     python-socks
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     asyncio = [ async-timeout ];
     trio = [ trio ];
   };

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     async_generator
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     http2 = [ h2 ];
     socks = [ socksio ];
     brotli = if isPyPy then [ brotlicffi ] else [ brotli ];
@@ -63,9 +63,9 @@ buildPythonPackage rec {
     trustme
     typing-extensions
     uvicorn
-  ] ++ passthru.extras-require.http2
-    ++ passthru.extras-require.brotli
-    ++ passthru.extras-require.socks;
+  ] ++ passthru.optional-dependencies.http2
+    ++ passthru.optional-dependencies.brotli
+    ++ passthru.optional-dependencies.socks;
 
   postPatch = ''
     substituteInPlace setup.py \

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -99,7 +99,7 @@ buildPythonPackage rec {
     pytest-mock
     pytest-randomly
     pytest-xdist
-  ] ++ lib.concatMap (name: passthru.extras-require.${name}) testBackends;
+  ] ++ lib.concatMap (name: passthru.optional-dependencies.${name}) testBackends;
 
   preBuild = ''
     # setup.py exists only for developer convenience and is automatically generated
@@ -139,7 +139,7 @@ buildPythonPackage rec {
   ] ++ map (backend: "ibis.backends.${backend}") testBackends;
 
   passthru = {
-    extras-require = {
+    optional-dependencies = {
       clickhouse = [ clickhouse-cityhash clickhouse-driver lz4 ];
       dask = [ dask pyarrow ];
       datafusion = [ datafusion ];

--- a/pkgs/development/python-modules/ldaptor/default.nix
+++ b/pkgs/development/python-modules/ldaptor/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     six
     twisted
     zope_interface
-  ] ++ twisted.extras-require.tls;
+  ] ++ twisted.optional-dependencies.tls;
 
   checkInputs = [
     twisted

--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -25,8 +25,8 @@ buildPythonPackage rec {
     six
     twisted
     autobahn
-  ] ++ autobahn.extras-require.twisted
-  ++ twisted.extras-require.tls;
+  ] ++ autobahn.optional-dependencies.twisted
+  ++ twisted.optional-dependencies.tls;
 
   checkInputs = [
     treq

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -42,8 +42,8 @@ buildPythonPackage rec {
     click
     humanize
     txtorcon
-  ] ++ autobahn.extras-require.twisted
-  ++ twisted.extras-require.tls;
+  ] ++ autobahn.optional-dependencies.twisted
+  ++ twisted.optional-dependencies.tls;
 
   checkInputs = [
     mock

--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04";
   };
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     argon2 = [ argon2-cffi ];
     bcrypt = [ bcrypt ];
     totp = [ cryptography ];
@@ -24,9 +24,9 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-  ] ++ passthru.extras-require.argon2
-    ++ passthru.extras-require.bcrypt
-    ++ passthru.extras-require.totp;
+  ] ++ passthru.optional-dependencies.argon2
+    ++ passthru.optional-dependencies.bcrypt
+    ++ passthru.optional-dependencies.totp;
 
   meta = with lib; {
     description = "A password hashing library for Python";

--- a/pkgs/development/python-modules/pure-python-adb/default.nix
+++ b/pkgs/development/python-modules/pure-python-adb/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "0kdr7w2fhgjpcf1k3l6an9im583iqkr6v8hb4q1zw30nh3bqkk0f";
   };
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     async = [
       aiofiles
     ];
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
   ]
-  ++ passthru.extras-require.async;
+  ++ passthru.optional-dependencies.async;
 
   pythonImportsCheck = [
     "ppadb.client"

--- a/pkgs/development/python-modules/pygatt/default.nix
+++ b/pkgs/development/python-modules/pygatt/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     pyserial
   ];
 
-  passthru.extras-require.GATTTOOL = [
+  passthru.optional-dependencies.GATTTOOL = [
     pexpect
   ];
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     nose
     pytestCheckHook
   ]
-  ++ passthru.extras-require.GATTTOOL;
+  ++ passthru.optional-dependencies.GATTTOOL;
 
   postPatch = ''
     # Not support for Python < 3.4

--- a/pkgs/development/python-modules/python-barcode/default.nix
+++ b/pkgs/development/python-modules/python-barcode/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     images = [
       pillow
     ];
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-  ] ++ passthru.extras-require.images;
+  ] ++ passthru.optional-dependencies.images;
 
   pythonImportsCheck = [ "barcode" ];
 

--- a/pkgs/development/python-modules/pytradfri/default.nix
+++ b/pkgs/development/python-modules/pytradfri/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     hash = "sha256-12ol+2CnoPfkxmDGJJAkoafHGpQuWC4lh0N7lSvx2DE=";
   };
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     async = [
       aiocoap
       dtlssocket
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
   ]
-  ++ passthru.extras-require.async;
+  ++ passthru.optional-dependencies.async;
 
   pythonImportsCheck = [
     "pytradfri"

--- a/pkgs/development/python-modules/rdflib/default.nix
+++ b/pkgs/development/python-modules/rdflib/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     html = [
       html5lib
     ];
@@ -55,8 +55,8 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
   ]
-  ++ passthru.extras-require.networkx
-  ++ passthru.extras-require.html;
+  ++ passthru.optional-dependencies.networkx
+  ++ passthru.optional-dependencies.html;
 
   pytestFlagsArray = [
     # requires network access

--- a/pkgs/development/python-modules/redis/default.nix
+++ b/pkgs/development/python-modules/redis/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     hidredis = [
       hiredis
     ];

--- a/pkgs/development/python-modules/relatorio/default.nix
+++ b/pkgs/development/python-modules/relatorio/default.nix
@@ -27,14 +27,14 @@ buildPythonPackage rec {
     lxml
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     chart = [ /* pycha */ pyyaml ];
     fodt = [ python-magic ];
   };
 
   checkInputs = [
     pytestCheckHook
-  ] ++ passthru.extras-require.fodt;
+  ] ++ passthru.optional-dependencies.fodt;
 
   pythonImportsCheck = [ "relatorio" ];
 

--- a/pkgs/development/python-modules/requests-aws4auth/default.nix
+++ b/pkgs/development/python-modules/requests-aws4auth/default.nix
@@ -28,13 +28,13 @@ buildPythonPackage rec {
     six
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     httpx = [ httpx ];
   };
 
   checkInputs = [
     pytestCheckHook
-  ] ++ passthru.extras-require.httpx;
+  ] ++ passthru.optional-dependencies.httpx;
 
   pythonImportsCheck = [
     "requests_aws4auth"

--- a/pkgs/development/python-modules/samsungctl/default.nix
+++ b/pkgs/development/python-modules/samsungctl/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "0ipz3fd65rqkxlb02sql0awc3vnslrwb2pfrsnpfnf8bfgxpbh9g";
   };
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     websocket = [
       websocket-client
     ];

--- a/pkgs/development/python-modules/samsungtvws/default.nix
+++ b/pkgs/development/python-modules/samsungtvws/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     websocket-client
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     async = [
       aiohttp
       websockets
@@ -55,8 +55,8 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ passthru.extras-require.async
-  ++ passthru.extras-require.encrypted;
+  ++ passthru.optional-dependencies.async
+  ++ passthru.optional-dependencies.encrypted;
 
   pythonImportsCheck = [ "samsungtvws" ];
 

--- a/pkgs/development/python-modules/treq/default.nix
+++ b/pkgs/development/python-modules/treq/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     requests
     incremental
     twisted
-  ] ++ twisted.extras-require.tls;
+  ] ++ twisted.optional-dependencies.tls;
 
   checkInputs = [
     httpbin

--- a/pkgs/development/python-modules/trytond/default.nix
+++ b/pkgs/development/python-modules/trytond/default.nix
@@ -53,9 +53,9 @@ buildPythonPackage rec {
     weasyprint
     gevent
     pillow
-  ] ++ relatorio.extras-require.fodt
-    ++ passlib.extras-require.bcrypt
-    ++ passlib.extras-require.argon2
+  ] ++ relatorio.optional-dependencies.fodt
+    ++ passlib.optional-dependencies.bcrypt
+    ++ passlib.optional-dependencies.argon2
     ++ lib.optional withPostgresql psycopg2;
 
   checkPhase = ''

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ zope_interface incremental automat constantly hyperlink pyhamcrest attrs setuptools typing-extensions ];
 
-  passthru.extras-require = rec {
+  passthru.optional-dependencies = rec {
     tls = [ pyopenssl service-identity idna ];
     conch = [ pyasn1 cryptography appdirs bcrypt ];
     conch_nacl = conch ++ [ pynacl ];

--- a/pkgs/development/python-modules/txtorcon/default.nix
+++ b/pkgs/development/python-modules/txtorcon/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     incremental twisted automat zope_interface
-  ] ++ twisted.extras-require.tls
+  ] ++ twisted.optional-dependencies.tls
   ++ lib.optionals (!isPy3k) [ ipaddress ];
 
   checkInputs = [ pytestCheckHook mock lsof GeoIP ];

--- a/pkgs/development/python-modules/vivisect/default.nix
+++ b/pkgs/development/python-modules/vivisect/default.nix
@@ -43,9 +43,9 @@ buildPythonPackage rec {
     cxxfilt
     msgpack
     pycparser
-  ] ++ lib.optionals (withGui) passthru.extras-require.gui;
+  ] ++ lib.optionals (withGui) passthru.optional-dependencies.gui;
 
-  passthru.extras-require.gui = [
+  passthru.optional-dependencies.gui = [
     pyqt5
     pyqtwebengine
   ];

--- a/pkgs/development/python-modules/volvooncall/default.nix
+++ b/pkgs/development/python-modules/volvooncall/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     aiohttp
   ];
 
-  passthru.extras-require = {
+  passthru.optional-dependencies = {
     console = [
       certifi
       docopt
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     asynctest
     pytest-asyncio
     pytestCheckHook
-  ] ++ passthru.extras-require.mqtt;
+  ] ++ passthru.optional-dependencies.mqtt;
 
   pythonImportsCheck = [ "volvooncall" ];
 

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -46,7 +46,7 @@ buildPythonApplication rec {
     pyramid
     strictyaml
     waitress
-  ] ++ passlib.extras-require.argon2;
+  ] ++ passlib.optional-dependencies.argon2;
 
   checkInputs = [
     beautifulsoup4

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -118,9 +118,9 @@
       androidtv
       pure-python-adb
     ]
-    ++ adb-shell.extras-require.async
-    ++ androidtv.extras-require.async
-    ++ pure-python-adb.extras-require.async;
+    ++ adb-shell.optional-dependencies.async
+    ++ androidtv.optional-dependencies.async
+    ++ pure-python-adb.optional-dependencies.async;
     "anel_pwrctrl" = ps: with ps; [
     ]; # missing inputs: anel_pwrctrl-homeassistant
     "anthemav" = ps: with ps; [
@@ -279,7 +279,7 @@
     "bluetooth_le_tracker" = ps: with ps; [
       pygatt
     ]
-    ++ pygatt.extras-require.GATTTOOL;
+    ++ pygatt.optional-dependencies.GATTTOOL;
     "bluetooth_tracker" = ps: with ps; [
       bt-proximity
       pybluez
@@ -2273,9 +2273,9 @@
       wakeonlan
       zeroconf
     ]
-    ++ samsungctl.extras-require.websocket
-    ++ samsungtvws.extras-require.async
-    ++ samsungtvws.extras-require.encrypted;
+    ++ samsungctl.optional-dependencies.websocket
+    ++ samsungtvws.optional-dependencies.async
+    ++ samsungtvws.optional-dependencies.encrypted;
     "satel_integra" = ps: with ps; [
     ]; # missing inputs: satel_integra
     "scene" = ps: with ps; [
@@ -2388,7 +2388,7 @@
     "skybeacon" = ps: with ps; [
       pygatt
     ]
-    ++ pygatt.extras-require.GATTTOOL;
+    ++ pygatt.optional-dependencies.GATTTOOL;
     "skybell" = ps: with ps; [
       skybellpy
     ];
@@ -2769,7 +2769,7 @@
     "tradfri" = ps: with ps; [
       pytradfri
     ]
-    ++ pytradfri.extras-require.async;
+    ++ pytradfri.optional-dependencies.async;
     "trafikverket_ferry" = ps: with ps; [
       pytrafikverket
     ];

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -103,13 +103,13 @@ def repository_root() -> str:
     return os.path.abspath(sys.argv[0] + "/../../../..")
 
 
-# For a package attribute and and an extra, check if the package exposes it via passthru.extras-require
+# For a package attribute and and an extra, check if the package exposes it via passthru.optional-dependencies
 def has_extra(package: str, extra: str):
     cmd = [
         "nix-instantiate",
         repository_root(),
         "-A",
-        f"{package}.extras-require.{extra}",
+        f"{package}.optional-dependencies.{extra}",
     ]
     try:
         subprocess.run(
@@ -209,7 +209,7 @@ def main() -> None:
                 attr_paths.append(pname)
                 for extra in extras:
                     # Check if package advertises extra requirements
-                    extra_attr = f"{pname}.extras-require.{extra}"
+                    extra_attr = f"{pname}.optional-dependencies.{extra}"
                     if has_extra(attr_path, extra):
                         extra_attrs.append(extra_attr)
                     else:

--- a/pkgs/servers/radicale/3.x.nix
+++ b/pkgs/servers/radicale/3.x.nix
@@ -21,7 +21,7 @@ python3.pkgs.buildPythonApplication rec {
     vobject
     python-dateutil
     pytz # https://github.com/Kozea/Radicale/issues/816
-  ] ++ passlib.extras-require.bcrypt;
+  ] ++ passlib.optional-dependencies.bcrypt;
 
   checkInputs = with python3.pkgs; [
     pytestCheckHook

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -60,8 +60,8 @@ python3Packages.buildPythonApplication rec {
     html5lib magic-wormhole netifaces pyasn1 pycrypto pyutil pyyaml recommonmark
     service-identity simplejson sphinx_rtd_theme testtools treq twisted zfec
     zope_interface
-  ] ++ twisted.extras-require.tls
-    ++ twisted.extras-require.conch;
+  ] ++ twisted.optional-dependencies.tls
+    ++ twisted.optional-dependencies.conch;
 
   checkInputs = with python3Packages; [ mock hypothesis twisted ];
 

--- a/pkgs/tools/security/wapiti/default.nix
+++ b/pkgs/tools/security/wapiti/default.nix
@@ -39,8 +39,8 @@ python3.pkgs.buildPythonApplication rec {
     yaswfp
   ] ++ lib.optionals (python3.pythonOlder "3.8") [
     importlib-metadata
-  ] ++ httpx.extras-require.brotli
-    ++ httpx.extras-require.socks;
+  ] ++ httpx.optional-dependencies.brotli
+    ++ httpx.optional-dependencies.socks;
 
   checkInputs = with python3.pkgs; [
     respx


### PR DESCRIPTION
This is the term that PEP 621 uses and it is less likely to be
misspelled.

https://peps.python.org/pep-0621/#dependencies-optional-dependencies

I was never sure if it was `extra` or `extras`, or `require` or
`requires` and finally committed a mistake in #167405.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
