### PR TITLE
[wip] gvisor: 20210518.0 -> 20220516.0

### DIFF
--- a/pkgs/applications/virtualization/gvisor/build-rule.patch
+++ b/pkgs/applications/virtualization/gvisor/build-rule.patch
@@ -1,0 +1,36 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 9fd92eda8..a212e4b12 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -58,20 +58,21 @@ http_archive(
+     ],
+ )
+ 
+-load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies")
++load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+ 
+ go_rules_dependencies()
+ 
+-go_download_sdk(
+-    name = "go_sdk",
+-    # This implements a fix in the types package which dramatically speeds up
+-    # analysis. Without this fix, the nogo rules will often fail to run in
+-    # time on our continuous integration.
+-    patch = "//tools:go_types_memoize.patch",
+-    patch_strip = 2,
+-    version = "1.17.6",
+-)
++#go_download_sdk(
++#    name = "go_sdk",
++#    # This implements a fix in the types package which dramatically speeds up
++#    # analysis. Without this fix, the nogo rules will often fail to run in
++#    # time on our continuous integration.
++#    patch = "//tools:go_types_memoize.patch",
++#    patch_strip = 2,
++#    version = "1.17.6",
++#)
++go_register_toolchains(go_version = "host")
+ 
+ gazelle_dependencies()
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26920,9 +26920,7 @@ with pkgs;
 
   gv = callPackage ../applications/misc/gv { };
 
-  gvisor = callPackage ../applications/virtualization/gvisor {
-    go = go_1_16;
-  };
+  gvisor = callPackage ../applications/virtualization/gvisor {};
 
   gvisor-containerd-shim = callPackage ../applications/virtualization/gvisor/containerd-shim.nix { };
 


### PR DESCRIPTION
###### Description of changes

I tried upgrading to a newer version because we are dropping go 1.16.
If someone wants to take this over, feel free to build upon my changes.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
