### PR TITLE
difftastic: patch bundled mimalloc source to build on older macos

### DIFF
--- a/pkgs/tools/text/difftastic/default.nix
+++ b/pkgs/tools/text/difftastic/default.nix
@@ -1,4 +1,11 @@
-{ lib, fetchFromGitHub, rustPlatform, tree-sitter, difftastic, testers }:
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, rustPlatform
+, tree-sitter
+, difftastic
+, testers
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "difftastic";
@@ -11,7 +18,29 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-jdkyDsuOOG1dJmgRmMp2KhY9ermccjrxK2JAIzpO6nw=";
   };
 
-  cargoSha256 = "sha256-qHG3ve8HoMWBS/x6mRbXMsrpcqNqfVcbAkfYOk7Su/0=";
+  depsExtraArgs = {
+    postBuild = let
+      mimallocPatch = (fetchpatch {
+        name = "mimalloc-older-macos-fixes.patch";
+        url = "https://github.com/microsoft/mimalloc/commit/40e0507a5959ee218f308d33aec212c3ebeef3bb.patch";
+        stripLen = 1;
+        extraPrefix = "libmimalloc-sys/c_src/mimalloc/";
+        sha256 = "1cqgay6ayzxsj8v1dy8405kwd8av34m4bjc84iyg9r52amlijbg4";
+      });
+    in ''
+      pushd $name
+      patch -p1 < ${mimallocPatch}
+      substituteInPlace libmimalloc-sys/.cargo-checksum.json \
+        --replace \
+          '6a2e9f0db0d3de160f9f15ddc8a870dbc42bba724f19f1e69b8c4952cb36821a' \
+          '201ab8874d9ba863406e084888e492b785a7edae00a222f395c079028d21a89a' \
+        --replace \
+          'a87a27e8432a63e5de25703ff5025588afd458e3a573e51b3c3dee2281bff0d4' \
+          'ab98a2da81d2145003a9cba7b7025efbd2c7b37c7a23c058c150705a3ec39298'
+      popd
+    '';
+  };
+  cargoSha256 = "12a12ng9wz2rrj3xzhgrqlg3lxpqxwdgvkz3fxny17nysmmpnhvv";
 
   passthru.tests.version = testers.testVersion { package = difftastic; };
 


### PR DESCRIPTION
###### Description of changes
Add same patch as introduced to our own mimalloc in #162042

This is a little ugly as it's patching a copy of mimalloc embedded in a rust crate. If you have a neater way of doing this I'm all ears.

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
