### PR TITLE
htmldoc: 1.9.15 -> 1.9.16

### DIFF
--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "htmldoc";
-  version = "1.9.15";
+  version = "1.9.16";
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = "htmldoc";
     rev = "v${version}";
-    sha256 = "sha256-WNsYJacZBYoZ8Bxj+InQ9ePvelqhU5y9nY7aikUNxEk=";
+    sha256 = "117cj5sfzl18gan53ld8lxb0wycizcp9jcakcs3nsvnss99rw3a6";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
###### Description of changes

Security update (#172495, https://nvd.nist.gov/vuln/detail/CVE-2022-28085)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. 
- [x] Tested basic functionality of all binary files (`htmldoc --version` works)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

nixpkgs-review:
```
1 package built:
htmldoc
```