### PR TITLE
makeBinaryWrapper: fix codesign on aarch64-darwin

### DIFF
--- a/pkgs/build-support/setup-hooks/make-binary-wrapper/default.nix
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, darwin
 , makeSetupHook
 , dieHook
 , writeShellScript
@@ -12,7 +11,7 @@
 makeSetupHook {
   deps = [ dieHook ]
     # https://github.com/NixOS/nixpkgs/issues/148189
-    ++ lib.optional (stdenv.isDarwin && stdenv.isAarch64) darwin.cctools;
+    ++ lib.optional (stdenv.isDarwin && stdenv.isAarch64) cc;
 
   substitutions = {
     cc = "${cc}/bin/cc ${lib.escapeShellArgs (map (s: "-fsanitize=${s}") sanitizers)}";


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/172749#issuecomment-1133759233

Reverts 8b79ef2c on aarch64-darwin, no-op on other platforms.

~I don't know for sure what's going on, but given that the issue involves code signing, and `cc` was originally added to `deps` to fix code signing issues, I think this is likely to fix the issue.~ https://github.com/NixOS/nixpkgs/pull/172749#issuecomment-1133997561

(Adding `cc` to the propagated build inputs is still not great, so unless https://github.com/NixOS/nixpkgs/issues/148189 gets fixed we will probably want to refine that to something like `buildEnv { paths = [ cctools ]; pathsToLink = [ "/bin/codesign_allocate" ]; }`, but now is not the time to experiment.)