### PR TITLE
python3Packages.sqlalchemy-utils: run tests

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -1,7 +1,19 @@
-{ lib, fetchPypi, buildPythonPackage
-, six, sqlalchemy
-, mock, pytz, isort, flake8, jinja2, pg8000, pyodbc, pytest, pymysql, python-dateutil
-, docutils, flexmock, psycopg2, pygments }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, sqlalchemy
+, colour
+, flexmock
+, jinja2
+, mock
+, pg8000
+, phonenumbers
+, pygments
+, pymysql
+, pytestCheckHook
+, python-dateutil
+}:
 
 buildPythonPackage rec {
   pname = "sqlalchemy-utils";
@@ -13,33 +25,32 @@ buildPythonPackage rec {
     sha256 = "9e01d6d3fb52d3926fcd4ea4a13f3540701b751aced0316bff78264402c2ceb4";
   };
 
+  patches = [
+    # We don't run MySQL, MSSQL, or PostgreSQL
+    ./skip-database-tests.patch
+  ];
+
   propagatedBuildInputs = [
     six
     sqlalchemy
   ];
 
-  # Attempts to access localhost and there's also no database access
-  doCheck = false;
   checkInputs = [
-    mock
-    pytz
-    isort
-    flake8
-    jinja2
-    pg8000
-    pyodbc
-    pytest
-    pymysql
-    python-dateutil
-    docutils
+    colour
     flexmock
-    psycopg2
+    jinja2
+    mock
+    pg8000
+    phonenumbers
     pygments
+    pymysql
+    pytestCheckHook
+    python-dateutil
   ];
 
-  checkPhase = ''
-    pytest tests
-  '';
+  disabledTests = [
+    "test_literal_bind"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/kvesteri/sqlalchemy-utils";

--- a/pkgs/development/python-modules/sqlalchemy-utils/skip-database-tests.patch
+++ b/pkgs/development/python-modules/sqlalchemy-utils/skip-database-tests.patch
@@ -1,0 +1,98 @@
+diff --git a/conftest.py b/conftest.py
+index 9e146cd..8dbc9a5 100644
+--- a/conftest.py
++++ b/conftest.py
+@@ -61,16 +61,12 @@ def mysql_db_user():
+ 
+ @pytest.fixture
+ def postgresql_dsn(postgresql_db_user, postgresql_db_password, db_name):
+-    return 'postgresql://{0}:{1}@localhost/{2}'.format(
+-        postgresql_db_user,
+-        postgresql_db_password,
+-        db_name
+-    )
++    pytest.skip()
+ 
+ 
+ @pytest.fixture
+ def mysql_dsn(mysql_db_user, db_name):
+-    return 'mysql+pymysql://{0}@localhost/{1}'.format(mysql_db_user, db_name)
++    pytest.skip()
+ 
+ 
+ @pytest.fixture
+@@ -108,8 +104,7 @@ def mssql_db_driver():
+ 
+ @pytest.fixture
+ def mssql_dsn(mssql_db_user, mssql_db_password, mssql_db_driver, db_name):
+-    return 'mssql+pyodbc://{0}:{1}@localhost/{2}?driver={3}'\
+-        .format(mssql_db_user, mssql_db_password, db_name, mssql_db_driver)
++    pytest.skip()
+ 
+ 
+ @pytest.fixture
+diff --git a/tests/functions/test_database.py b/tests/functions/test_database.py
+index 0ad6721..83f208d 100644
+--- a/tests/functions/test_database.py
++++ b/tests/functions/test_database.py
+@@ -76,28 +76,6 @@ class TestDatabasePostgres(DatabaseTest):
+                 "TEMPLATE my_template") in str(excinfo.value)
+ 
+ 
+-class TestDatabasePostgresPg8000(DatabaseTest):
+-
+-    @pytest.fixture
+-    def dsn(self, postgresql_db_user, postgresql_db_password):
+-        return 'postgresql+pg8000://{0}:{1}@localhost/{2}'.format(
+-            postgresql_db_user,
+-            postgresql_db_password,
+-            'db_to_test_create_and_drop_via_pg8000_driver'
+-        )
+-
+-
+-class TestDatabasePostgresPsycoPG2CFFI(DatabaseTest):
+-
+-    @pytest.fixture
+-    def dsn(self, postgresql_db_user, postgresql_db_password):
+-        return 'postgresql+psycopg2cffi://{0}:{1}@localhost/{2}'.format(
+-            postgresql_db_user,
+-            postgresql_db_password,
+-            'db_to_test_create_and_drop_via_psycopg2cffi_driver'
+-        )
+-
+-
+ @pytest.mark.usefixtures('postgresql_dsn')
+ class TestDatabasePostgresWithQuotedName(DatabaseTest):
+ 
+@@ -116,31 +94,6 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
+                 'TEMPLATE "my-template"') in str(excinfo.value)
+ 
+ 
+-class TestDatabasePostgresCreateDatabaseCloseConnection(object):
+-    def test_create_database_twice(
+-        self,
+-        postgresql_db_user,
+-        postgresql_db_password
+-    ):
+-        dsn_list = [
+-            'postgresql://{0}:{1}@localhost/db_test_sqlalchemy-util-a'.format(
+-                postgresql_db_user,
+-                postgresql_db_password
+-            ),
+-            'postgresql://{0}:{1}@localhost/db_test_sqlalchemy-util-b'.format(
+-                postgresql_db_user,
+-                postgresql_db_password
+-            ),
+-        ]
+-        for dsn_item in dsn_list:
+-            assert not database_exists(dsn_item)
+-            create_database(dsn_item, template="template1")
+-            assert database_exists(dsn_item)
+-        for dsn_item in dsn_list:
+-            drop_database(dsn_item)
+-            assert not database_exists(dsn_item)
+-
+-
+ @pytest.mark.usefixtures('mssql_dsn')
+ class TestDatabaseMssql(DatabaseTest):
+ 


### PR DESCRIPTION
###### Description of changes
Skip tests that require running a database server.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
