### PR TITLE
dbus: fix paths in catalog

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
   ] ++ (lib.optional stdenv.isSunOS ./implement-getgrouplist.patch);
 
   postPatch = ''
+    # We need to generate the file ourselves.
+    # https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/317
+    rm doc/catalog.xml
+
     substituteInPlace bus/Makefile.am \
       --replace 'install-data-hook:' 'disabled:' \
       --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run/dbus' ':'
@@ -97,6 +101,11 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
+
+  makeFlags = [
+    # Fix paths in XML catalog broken by mismatching build/install datadir.
+    "dtddir=${placeholder "out"}/share/xml/dbus-1"
+  ];
 
   installFlags = [
     "sysconfdir=${placeholder "out"}/etc"

--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -1,4 +1,8 @@
-{ runCommand, writeText, libxslt, dbus
+{ runCommand
+, writeText
+, libxslt
+, dbus
+, findXMLCatalogs
 , serviceDirectories ? []
 , suidHelper ? "/var/setuid-wrappers/dbus-daemon-launch-helper"
 , apparmor ? "disabled" # one of enabled, disabled, required
@@ -14,19 +18,15 @@ runCommand "dbus-1"
     inherit serviceDirectories suidHelper apparmor;
     preferLocalBuild = true;
     allowSubstitutes = false;
-    XML_CATALOG_FILES = writeText "dbus-catalog.xml" ''
-      <?xml version="1.0"?>
-      <!DOCTYPE catalog PUBLIC
-        "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN"
-        "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
 
-      <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-        <rewriteSystem
-          systemIdStartString="http://www.freedesktop.org/standards/dbus/1.0/"
-          rewritePrefix="file://${dbus}/share/xml/dbus-1/"/>
-      </catalog>
-    '';
-    nativeBuildInputs = [ libxslt.bin ];
+    nativeBuildInputs = [
+      libxslt
+      findXMLCatalogs
+    ];
+
+    buildInputs = [
+      dbus
+    ];
   }
   ''
     mkdir -p $out


### PR DESCRIPTION
###### Description of changes

Upstream is accidentally shipping a pre-generated catalog file in the tarball, which contains FHS paths. We need to remove it to re-generate it ourselves. Unfortunately, we are also overriding datadir to different values between build and installation for reasons, so we need to override dtddir manually.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @Artturin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
