### PR TITLE
libdigidocpp: Fix PKCS11 module library path

### DIFF
--- a/pkgs/development/libraries/libdigidocpp/default.nix
+++ b/pkgs/development/libraries/libdigidocpp/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, minizip, pcsclite, opensc, openssl
+{ lib, stdenv, fetchurl, cmake, makeWrapper, minizip, pcsclite, opensc, openssl
 , xercesc, xml-security-c, pkg-config, xsd, zlib, xalanc, xxd }:
 
 stdenv.mkDerivation rec {
@@ -10,12 +10,19 @@ stdenv.mkDerivation rec {
      sha256 = "sha256-U5i5IAyJF4359q6M6mQemEuG7+inPYIXqLy8GHv4dkg=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config xxd ];
+  nativeBuildInputs = [ cmake makeWrapper pkg-config xxd ];
 
   buildInputs = [
     minizip pcsclite opensc openssl xercesc
     xml-security-c xsd zlib xalanc
   ];
+
+  # replace this hack with a proper cmake variable or environment variable
+  # once https://github.com/open-eid/cmake/pull/34 (or #35) gets merged.
+  postInstall = ''
+    wrapProgram $out/bin/digidoc-tool \
+      --prefix LD_LIBRARY_PATH : ${opensc}/lib/pkcs11/
+  '';
 
   meta = with lib; {
     description = "Library for creating DigiDoc signature files";

--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -35,6 +35,8 @@ mkDerivation rec {
     qttranslations
   ];
 
+  # replace this hack with a proper cmake variable or environment variable
+  # once https://github.com/open-eid/cmake/pull/34 (or #35) gets merged.
   qtWrapperArgs = [
       "--prefix LD_LIBRARY_PATH : ${opensc}/lib/pkcs11/"
   ];


### PR DESCRIPTION
By default, the OpenSC module is loaded as relative filename, i.e.
"opensc-pkcs11.so" is searched for in the default library path.

Point `LD_LIBRARY_PATH` for `digidoc-tool` to the OpenSC package just
like pkgs/tools/seurity/qdigidoc/deafult.nix already does.

This makes `digidoc-tool` work by default without manually setting
`LD_LIBRARY_PATH` or passing `--pkcs11=/path/to/module`.

@jagajaga @flokli
