### PR TITLE
python3Packages.airtouch4pyapi: make compatible with Home Assistant

### DIFF
--- a/pkgs/development/python-modules/airtouch4pyapi/default.nix
+++ b/pkgs/development/python-modules/airtouch4pyapi/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , numpy
 , pythonOlder
 }:
@@ -19,6 +20,14 @@ buildPythonPackage rec {
     rev = "34783888846783c058fe79cec16feda45504f701";
     sha256 = "17c7fm72p085pg9msvsfdggbskvm12a6jlb5bw1cndrqsqcrxywx";
   };
+
+  patches = [
+    # https://github.com/LonePurpleWolf/airtouch4pyapi/pull/10
+    (fetchpatch {
+      url = "https://github.com/LonePurpleWolf/airtouch4pyapi/commit/5b5d91fad63495c83422e7a850897946ac95b25d.patch";
+      hash = "sha256-tVlCLXuOJSqjbs0jj0iHCIXWZE8wmMV3ChzmE6uq3SM=";
+    })
+  ];
 
   propagatedBuildInputs = [
     numpy

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -71,7 +71,6 @@ in lib.listToAttrs (map (component: lib.nameValuePair component (
 
     meta = old.meta // {
       broken = lib.elem component [
-        "airtouch4"
         "bsblan"
         "dnsip"
         "efergy"


### PR DESCRIPTION
https://github.com/home-assistant/core/pull/71319 is not making progress

###### Description of changes
The wheel on PyPI differs from the source on GitHub, let's make them the same by using a commit from https://github.com/LonePurpleWolf/airtouch4pyapi/pull/10.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
