### PR TITLE
unibilium, libtermkey: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/libtermkey/default.nix
+++ b/pkgs/development/libraries/libtermkey/default.nix
@@ -2,7 +2,6 @@
 
 stdenv.mkDerivation rec {
   pname = "libtermkey";
-
   version = "0.22";
 
   src = fetchzip {
@@ -10,11 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "02dks6bj7n23lj005yq41azf95wh3hapmgc2lzyh12vigkjh67rg";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ]
-    ++ lib.optional stdenv.isDarwin "LIBTOOL=${libtool}/bin/libtool";
+  makeFlags = [ "PREFIX=$(out)" "LIBTOOL=${libtool}/bin/libtool" ];
 
   nativeBuildInputs = [ libtool pkg-config ];
   buildInputs = [ ncurses unibilium ];
+
+  strictDeps = true;
 
   meta = with lib; {
     description = "Terminal keypress reading library";

--- a/pkgs/development/libraries/unibilium/default.nix
+++ b/pkgs/development/libraries/unibilium/default.nix
@@ -1,22 +1,22 @@
 { stdenv, lib, fetchFromGitHub, libtool, pkg-config, perl, ncurses }:
 
 stdenv.mkDerivation rec {
-  pname = "unibilium-unstable";
-
-  version = "20190811";
+  pname = "unibilium";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "neovim";
     repo = "unibilium";
-    rev = "92d929fabaf94ea4feb48149bbc3bbea77c4fab0";
-    sha256 = "1l8p3fpdymba62x1f5d990v72z3m5f5g2yf505g0rlf2ysc5r1di";
+    rev = "v${version}";
+    sha256 = "sha256-A/WECvma7u/Mmecvzi0cP168dt4v+zwC8CiFBkqWezA=";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ]
-    ++ lib.optional stdenv.isDarwin "LIBTOOL=${libtool}/bin/libtool";
+  makeFlags = [ "PREFIX=$(out)" "LIBTOOL=${libtool}/bin/libtool" ];
 
-  nativeBuildInputs = [ pkg-config perl ];
-  buildInputs = [ libtool ncurses ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config perl libtool ];
+  buildInputs = [ ncurses ];
 
   meta = with lib; {
     description = "A very basic terminfo library";


### PR DESCRIPTION
###### Description of changes
Fix cross-compilation:
```
$ nix build --print-build-logs .#pkgsCross.aarch64-multiplatform.unibilium
...
       > libtool --mode=compile --tag=CC aarch64-unknown-linux-gnu-gcc -I. -Wall -std=c99 -O2  -o unibilium.lo -c unibilium.c
       > /nix/store/14lypyys4gfcl982rjddxa6jg7msqz9q-bash-5.1-p16/bin/bash: line 1: libtool: command not found
       > make: *** [Makefile:69: unibilium.lo] Error 127
$ nix build --print-build-logs .#pkgsCross.aarch64-multiplatform.libtermkey
...
       > libtool --mode=compile --tag=CC aarch64-unknown-linux-gnu-gcc -I. -Wall -std=c99 -O2  -o unibilium.lo -c unibilium.c
       > /nix/store/14lypyys4gfcl982rjddxa6jg7msqz9q-bash-5.1-p16/bin/bash: line 1: libtool: command not found
       > make: *** [Makefile:69: unibilium.lo] Error 127
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
