### PR TITLE
buildFHSUserEnvBubblewrap: add etcdFiles argument

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -16,6 +16,47 @@ args @ {
 , unshareUts ? true
 , unshareCgroup ? true
 , dieWithParent ? true
+, etcFiles ? [
+    # NixOS Compatibility
+    "static"
+    "nix" # mainly for nixUnstable users, but also for access to nix/netrc
+    # Shells
+    "bashrc"
+    "zshenv"
+    "zshrc"
+    "zinputrc"
+    "zprofile"
+    # Users, Groups, NSS
+    "passwd"
+    "group"
+    "shadow"
+    "hosts"
+    "resolv.conf"
+    "nsswitch.conf"
+    # User profiles
+    "profiles"
+    # Sudo & Su
+    "login.defs"
+    "sudoers"
+    "sudoers.d"
+    # Time
+    "localtime"
+    "zoneinfo"
+    # Other Core Stuff
+    "machine-id"
+    "os-release"
+    # PAM
+    "pam.d"
+    # Fonts
+    "fonts"
+    # ALSA
+    "alsa"
+    "asound.conf"
+    # SSL
+    "ssl/certs"
+    "ca-certificates"
+    "pki"
+  ]
 , ...
 }:
 
@@ -25,53 +66,11 @@ let
 
   env = buildFHSEnv (removeAttrs args [
     "runScript" "extraInstallCommands" "meta" "passthru" "extraBwrapArgs" "dieWithParent"
-    "unshareUser" "unshareCgroup" "unshareUts" "unshareNet" "unsharePid" "unshareIpc"
+    "unshareUser" "unshareCgroup" "unshareUts" "unshareNet" "unsharePid" "unshareIpc" "etcFiles"
   ]);
 
-  etcBindFlags = let
-    files = [
-      # NixOS Compatibility
-      "static"
-      "nix" # mainly for nixUnstable users, but also for access to nix/netrc
-      # Shells
-      "bashrc"
-      "zshenv"
-      "zshrc"
-      "zinputrc"
-      "zprofile"
-      # Users, Groups, NSS
-      "passwd"
-      "group"
-      "shadow"
-      "hosts"
-      "resolv.conf"
-      "nsswitch.conf"
-      # User profiles
-      "profiles"
-      # Sudo & Su
-      "login.defs"
-      "sudoers"
-      "sudoers.d"
-      # Time
-      "localtime"
-      "zoneinfo"
-      # Other Core Stuff
-      "machine-id"
-      "os-release"
-      # PAM
-      "pam.d"
-      # Fonts
-      "fonts"
-      # ALSA
-      "alsa"
-      "asound.conf"
-      # SSL
-      "ssl/certs"
-      "ca-certificates"
-      "pki"
-    ];
-  in concatStringsSep "\n  "
-  (map (file: "--ro-bind-try $(${coreutils}/bin/readlink -f /etc/${file}) /etc/${file}") files);
+  etcBindFlags = concatStringsSep "\n  "
+  (map (file: "--ro-bind-try $(${coreutils}/bin/readlink -f /etc/${file}) /etc/${file}") etcFiles);
 
   # Create this on the fly instead of linking from /nix
   # The container might have to modify it and re-run ldconfig if there are


### PR DESCRIPTION
###### Description of changes

This commit fix a bug using `buildFHSUserEnvBubblewrap` during `nix build`.

In the build sandbox, only `passwd` `group` `hosts` exist in `/etcd` folder but bubblewrap tries to `--ro-bind-try` multiple files in the default list.

Most of them would not cause problem except `ssl/certs`.

`readlink` would return an error so `--ro-bind-try $(${coreutils}/bin/readlink -f /etc/ssl/certs) /etc/ssl/certs` became `--ro-bind-try /etc/ssl/certs` instead of `--ro-bind-try /etc/ssl/certs /etc/ssl/certs`. The missing argument would break all the binds afterwards.

We could fix the issue by giving a default return for `readlink` but I think moving the etcd file list to an argument could cover more use cases.

 * Bind only limited files during build process
 * Bind `/etc/{kubernetes,cni}` for `kubelet` running in FHS
 * Bind more custom configuration files when user is using nix as a package manager in other linux distros.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
