### PR TITLE
libimobiledevice and friends: upgrade and cleanup

### DIFF
--- a/pkgs/development/libraries/libimobiledevice-glue/default.nix
+++ b/pkgs/development/libraries/libimobiledevice-glue/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libplist
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libimobiledevice-glue";
+  version = "0.pre+date=2022-05-22";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = "d2ff7969dcd0a12e4f18f63dab03e6cd03054fcb";
+    hash = "sha256-BAdpJK6/iUKCNYLaCJQo0VK63AdIafO8wGbNhnvEc/o=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    libplist
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/libimobiledevice/libimobiledevice-glue";
+    description = "Library with common code used by the libraries and tools around the libimobiledevice project.";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ infinisil ];
+  };
+}

--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -2,45 +2,52 @@
 , stdenv
 , fetchFromGitHub
 , autoreconfHook
-, libtool
 , pkg-config
 , gnutls
 , libgcrypt
-, libtasn1
-, glib
 , libplist
+, libtasn1
 , libusbmuxd
+, libimobiledevice-glue
+, SystemConfiguration
+, CoreFoundation
 }:
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice";
-  version = "unstable-2021-06-02";
-
-  src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "ca324155f8b33babf907704828c7903608db0aa2";
-    sha256 = "sha256-Q7THwld1+elMJQ14kRnlIJDohFt7MW7JeyIUGC0k52I=";
-  };
+  version = "1.3.0+date=2022-05-22";
 
   outputs = [ "out" "dev" ];
 
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = "12394bc7be588be83c352d7441102072a89dd193";
+    hash = "sha256-2K4gZrFnE4hlGlthcKB4n210bTK3+6NY4TYVIoghXJM=";
+  };
+
+  postPatch = ''
+    echo '${version}' > .tarball-version
+  '';
+
   nativeBuildInputs = [
     autoreconfHook
-    libtool
     pkg-config
   ];
 
   propagatedBuildInputs = [
-    glib
     gnutls
     libgcrypt
     libplist
     libtasn1
     libusbmuxd
+    libimobiledevice-glue
+  ] ++ lib.optionals stdenv.isDarwin [
+    SystemConfiguration
+    CoreFoundation
   ];
 
-  configureFlags = [ "--disable-openssl" "--without-cython" ];
+  configureFlags = [ "--with-gnutls" "--without-cython" ];
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/libimobiledevice";
@@ -58,7 +65,7 @@ stdenv.mkDerivation rec {
       devices to the Linux Desktop.
     '';
     license = licenses.lgpl21Plus;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/development/libraries/libirecovery/default.nix
+++ b/pkgs/development/libraries/libirecovery/default.nix
@@ -1,34 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, automake, autoconf, libtool, pkg-config
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
 , libusb1
 , readline
+, libimobiledevice-glue
 }:
 
 stdenv.mkDerivation rec {
   pname = "libirecovery";
-  version = "1.0.0";
+  version = "1.0.0+date=2022-04-04";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = version;
-    sha256 = "0p9ncqnz5kb7qisw00ynvasw1hax5qx241h9nwppi2g544i9lbnr";
+    rev = "82d235703044c5af9da8ad8f77351fd2046dac47";
+    hash = "sha256-OESN9qme+TlSt+ZMbR4F3z/3RN0I12R7fcSyURBqUVk=";
   };
 
-  outputs = [ "out" "dev" ];
-
   nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
+    autoreconfHook
     pkg-config
   ];
 
   buildInputs = [
     libusb1
     readline
+    libimobiledevice-glue
   ];
-
-  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   # Packager note: Not clear whether this needs a NixOS configuration,
   # as only the `idevicerestore` binary was tested so far (which worked
@@ -46,10 +48,9 @@ stdenv.mkDerivation rec {
       provided.
     '';
     homepage = "https://github.com/libimobiledevice/libirecovery";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     maintainers = with maintainers; [ nh2 ];
     mainProgram = "irecovery";
-    # Upstream description says it works on more platforms, but packager hasn't tried that yet
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -1,34 +1,46 @@
-{ lib, stdenv, autoreconfHook, fetchFromGitHub, pkg-config, enablePython ? false, python ? null, glib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+
+, enablePython ? false
+, python3
+}:
 
 stdenv.mkDerivation rec {
   pname = "libplist";
-  version = "2.2.0";
+  version = "2.2.0+date=2022-04-05";
+
+  outputs = [ "bin" "dev" "out" ] ++ lib.optional enablePython "py";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = version;
-    sha256 = "1vxhpjxniybqsg5wcygmdmr5dv7p2zb34dqnd3bi813rnnzsdjm6";
+    rev = "db93bae96d64140230ad050061632531644c46ad";
+    hash = "sha256-8e/PFDhsyrOgmI3vLT1YhcROmbJgArDAJSe8Z2bZafo=";
   };
 
-  outputs = ["bin" "dev" "out" ] ++ lib.optional enablePython "py";
+  postPatch = ''
+    echo '${version}' > .tarball-version
+  '';
 
   nativeBuildInputs = [
-    pkg-config
     autoreconfHook
-  ] ++ lib.optionals enablePython [
-    python
-    python.pkgs.cython
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals enablePython [
+    python3
+    python3.pkgs.cython
   ];
 
   configureFlags = lib.optionals (!enablePython) [
     "--without-cython"
   ];
 
-  propagatedBuildInputs = [ glib ];
-
   postFixup = lib.optionalString enablePython ''
-    moveToOutput "lib/${python.libPrefix}" "$py"
+    moveToOutput "lib/${python3.libPrefix}" "$py"
   '';
 
   meta = with lib; {
@@ -36,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/libimobiledevice/libplist";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ infinisil ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libusbmuxd/default.nix
+++ b/pkgs/development/libraries/libusbmuxd/default.nix
@@ -1,24 +1,42 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libplist }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libplist
+, libimobiledevice-glue
+}:
 
 stdenv.mkDerivation rec {
   pname = "libusbmuxd";
-  version = "unstable-2021-02-06";
+  version = "2.0.2+date=2022-05-04";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "3eb50a07bad4c2222e76df93b23a0161922150d1";
-    sha256 = "sha256-pBPBgE6s8JYKJYEV8CcumNki+6jD5r7HzQ0nZ8yQLdM=";
+    rev = "36ffb7ab6e2a7e33bd1b56398a88895b7b8c615a";
+    hash = "sha256-41N5cSLAiPJ9FjdnCQnMvPu9/qhI3Je/M1VmKY+yII4=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ libplist ];
+  postPatch = ''
+    echo '${version}' > .tarball-version
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libplist
+    libimobiledevice-glue
+  ];
 
   meta = with lib; {
     description = "A client library to multiplex connections from and to iOS devices";
-    homepage    = "https://github.com/libimobiledevice/libusbmuxd";
-    license     = licenses.lgpl21Plus;
-    platforms   = platforms.linux ++ platforms.darwin;
+    homepage = "https://github.com/libimobiledevice/libusbmuxd";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/tools/filesystems/ifuse/default.nix
+++ b/pkgs/tools/filesystems/ifuse/default.nix
@@ -1,17 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, usbmuxd, fuse, libimobiledevice }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, fuse
+, usbmuxd
+, libimobiledevice
+}:
 
 stdenv.mkDerivation rec {
   pname = "ifuse";
-  version = "1.1.4";
+  version = "1.1.4+date=2022-04-04";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = version;
-    sha256 = "1r12y3h1j7ikkwk874h9969kr4ksyamvrwywx19ml6rsr01arw84";
+    rev = "6f5b8e410f9615b3369ca5eb5367745e13d83b92";
+    hash = "sha256-KbuJLS2BWua9DnhLv2KtsQObin0PQwXQwEdgi3lSAPk=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config fuse usbmuxd libimobiledevice ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    fuse
+    usbmuxd
+    libimobiledevice
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/ifuse";

--- a/pkgs/tools/misc/ideviceinstaller/default.nix
+++ b/pkgs/tools/misc/ideviceinstaller/default.nix
@@ -1,17 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, usbmuxd, libzip, libimobiledevice }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, usbmuxd
+, libimobiledevice
+, libzip
+}:
 
 stdenv.mkDerivation rec {
   pname = "ideviceinstaller";
-  version = "1.1.1";
+  version = "1.1.1+date=2022-05-09";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = version;
-    sha256 = "1xp0sjgfx2z19x9mxihn18ybsmrnrcfc55zbh5a44g3vrmagmlzz";
+    rev = "3909271599917bc4a3a996f99bdd3f88c49577fa";
+    hash = "sha256-dw3nda2PNddSFPzcx2lv0Nh1KLFXwPBbDBhhwEaB6d0=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config usbmuxd libimobiledevice libzip ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    usbmuxd
+    libimobiledevice
+    libzip
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/ideviceinstaller";
@@ -21,8 +38,8 @@ stdenv.mkDerivation rec {
       of an iOS device allowing to install, upgrade, uninstall, archive, restore
       and enumerate installed or archived apps.
     '';
-    license = licenses.gpl2;
-    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ aristid infinisil ];
   };
 }

--- a/pkgs/tools/misc/idevicerestore/default.nix
+++ b/pkgs/tools/misc/idevicerestore/default.nix
@@ -1,22 +1,29 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
 , curl
 , libimobiledevice
 , libirecovery
 , libzip
 , libusbmuxd
-, IOKit
 }:
 
 stdenv.mkDerivation rec {
   pname = "idevicerestore";
-  version = "1.0.0";
+  version = "1.0.0+date=2022-05-22";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = version;
-    sha256 = "1w7ywp77xc6v4hifi3j9ywrj447vv7fkwg2w26w0lq95f3bkblqr";
+    rev = "f80a876b3598de4eb551bafcb279947c527fae33";
+    hash = "sha256-I9zZQcZFd0hfeEJM7jltJtVJ6V5C5rA/S8gINiCnJdY=";
   };
+
+  postPatch = ''
+    echo '${version}' > .tarball-version
+  '';
 
   nativeBuildInputs = [
     autoreconfHook
@@ -32,7 +39,7 @@ stdenv.mkDerivation rec {
     # Not listing other dependencies specified in
     # https://github.com/libimobiledevice/idevicerestore/blob/8a882038b2b1e022fbd19eaf8bea51006a373c06/README#L20
     # because they are inherited `libimobiledevice`.
-  ] ++ lib.optionals stdenv.isDarwin [ IOKit ];
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/idevicerestore";
@@ -52,8 +59,7 @@ stdenv.mkDerivation rec {
       This will download and restore a device to the latest firmware available.
     '';
     license = licenses.lgpl21Plus;
-    # configure.ac suggests it should work for mingw as well but not tried yet
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ nh2 ];
   };
 }

--- a/pkgs/tools/misc/usbmuxd/default.nix
+++ b/pkgs/tools/misc/usbmuxd/default.nix
@@ -1,23 +1,37 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libusb1, libimobiledevice }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libimobiledevice
+, libusb1
+}:
 
 stdenv.mkDerivation rec {
   pname = "usbmuxd";
-  version = "unstable-2021-05-08";
+  version = "1.1.1+date=2022-04-04";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "5e484e18f1383b5a0bd6c353ab1d668b03e4ffab";
-    sha256 = "sha256-hhbfRmLEhVVuJNnw65PakPnvjSCrN3oSMK6D7Zwnw60=";
+    rev = "2839789bdb581ede7c331b9b4e07e0d5a89d7d18";
+    hash = "sha256-wYW6hI0Ti9gKtk/wxIbdY5KaPMs/p+Ve9ceeRqXihQI=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  propagatedBuildInputs = [ libimobiledevice libusb1 ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
-  preConfigure = ''
-    configureFlags="$configureFlags --with-udevrulesdir=$out/lib/udev/rules.d"
-    configureFlags="$configureFlags --with-systemdsystemunitdir=$out/lib/systemd/system"
-  '';
+  propagatedBuildInputs = [
+    libimobiledevice
+    libusb1
+  ];
+
+  configureFlags = [
+    "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/usbmuxd";
@@ -32,7 +46,7 @@ stdenv.mkDerivation rec {
       in parallel. The higher-level layers are handled by libimobiledevice.
     '';
     license = licenses.gpl2Plus;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18680,6 +18680,8 @@ with pkgs;
 
   libimobiledevice = callPackage ../development/libraries/libimobiledevice { };
 
+  libimobiledevice-glue = callPackage ../development/libraries/libimobiledevice-glue { };
+
   libindicator-gtk2 = libindicator.override { gtkVersion = "2"; };
   libindicator-gtk3 = libindicator.override { gtkVersion = "3"; };
   libindicator = callPackage ../development/libraries/libindicator { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7048,9 +7048,7 @@ with pkgs;
 
   ifuse = callPackage ../tools/filesystems/ifuse { };
   ideviceinstaller = callPackage ../tools/misc/ideviceinstaller { };
-  idevicerestore = callPackage ../tools/misc/idevicerestore {
-    inherit (darwin) IOKit;
-  };
+  idevicerestore = callPackage ../tools/misc/idevicerestore { };
 
   inherit (callPackages ../tools/filesystems/irods rec {
     stdenv = llvmPackages.libcxxStdenv;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18678,7 +18678,9 @@ with pkgs;
 
   libieee1284 = callPackage ../development/libraries/libieee1284 { };
 
-  libimobiledevice = callPackage ../development/libraries/libimobiledevice { };
+  libimobiledevice = callPackage ../development/libraries/libimobiledevice {
+    inherit (darwin.apple_sdk.frameworks) SystemConfiguration CoreFoundation;
+  };
 
   libimobiledevice-glue = callPackage ../development/libraries/libimobiledevice-glue { };
 


### PR DESCRIPTION
###### Description of changes

Upgrade and clean up the `libimobiledevice` library and everything in that ecosystem. The motivation for this is to get a version of `idevicerestore` and compatible libraries that is capable of fixing an unbootable Apple Silicon Mac. As NixOS gets support for these machines, it's critical to have support for fixing them without owning a second Mac.

I fully tested the restore process on both `x86_64-linux` and `aarch64-darwin` hosts. I didn't test the rest of `libimobiledevice` too much, ~~nor did I sit through the `nixpkgs-review` for all the bits of GNOME and friends that are rebuilt because of this.~~ I did check that `gtkpod` still works, so I don't expect there to be problems. I will check more comprehensively later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
