### PR TITLE
weston: enable demo-clients

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -3,7 +3,7 @@
 , libXcursor, xlibsWrapper, udev, libdrm, mtdev, libjpeg, pam, dbus, libinput, libevdev
 , colord, lcms2, pipewire ? null
 , pango ? null, libunwind ? null, freerdp ? null, vaapi ? null, libva ? null
-, libwebp ? null, xwayland ? null, wayland-protocols
+, libwebp ? null, xwayland ? null, demo ? true, wayland-protocols
 # beware of null defaults, as the parameters *are* supplied by callPackage by default
 }:
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     "-Dremoting=false" # TODO
     "-Dpipewire=${boolToString (pipewire != null)}"
     "-Dimage-webp=${boolToString (libwebp != null)}"
-    "-Ddemo-clients=false"
+    "-Ddemo-clients=${boolToString (demo != null)}"
     "-Dsimple-clients="
     "-Dtest-junit-xml=false"
     # TODO:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30499,6 +30499,7 @@ with pkgs;
     libwebp = null;
     xwayland = null;
     pipewire = null;
+    demo = null;
   };
 
   chatterino2 = libsForQt5.callPackage ../applications/networking/instant-messengers/chatterino2 {};


### PR DESCRIPTION
###### Description of changes

Fixes #174076

weston-gears is still missing for some reason (upstream issue https://gitlab.freedesktop.org/wayland/weston/-/issues/620)

adds these demos:

``` diff
[davidak@gaming:~/code/nixpkgs]$ diff t2 t1
1c1
< /nix/store/5yg3qyvlzyld3cw3w7h1r6rshp9yzb6l-weston-10.0.0/
---
> result
5a6,9
> │   ├── weston-clickdot
> │   ├── weston-cliptest
> │   ├── weston-confine
> │   ├── weston-content_protection
6a11,16
> │   ├── weston-dnd
> │   ├── weston-editor
> │   ├── weston-eventdemo
> │   ├── weston-flower
> │   ├── weston-fullscreen
> │   ├── weston-image
7a18,21
> │   ├── weston-multi-resource
> │   ├── weston-presentation-shm
> │   ├── weston-resizor
> │   ├── weston-scaler
8a23,25
> │   ├── weston-smoke
> │   ├── weston-stacking
> │   ├── weston-subsurfaces
10c27,28
< │   └── weston-touch-calibrator
---
> │   ├── weston-touch-calibrator
> │   └── weston-transformed
118c136
< 21 directories, 94 files
---
> 21 directories, 112 files
```

does not affect westonLite

size before and after

```
[davidak@gaming:~/code/nixpkgs]$ nix path-info -sSh /nix/store/5yg3qyvlzyld3cw3w7h1r6rshp9yzb6l-weston-10.0.0/
/nix/store/5yg3qyvlzyld3cw3w7h1r6rshp9yzb6l-weston-10.0.0	   3.2M	 844.6M

[davidak@gaming:~/code/nixpkgs]$ nix path-info -sSh /nix/store/m12jlr6aqcymb5rn3cmskhq33713m9zj-weston-10.0.0
/nix/store/m12jlr6aqcymb5rn3cmskhq33713m9zj-weston-10.0.0	   5.8M	 847.6M
```

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
