### PR TITLE
apksigner: build from source

### DIFF
--- a/pkgs/development/tools/apksigner/default.nix
+++ b/pkgs/development/tools/apksigner/default.nix
@@ -1,15 +1,91 @@
-{ runCommand
+{ lib
+, stdenv
+, fetchgit
+, openjdk17_headless
+, gradle
+, perl
 , makeWrapper
-, jre
-, build-tools
 }:
-let
-  tools = builtins.head build-tools;
-in
-runCommand "apksigner" {
-  nativeBuildInputs = [ makeWrapper ];
-} ''
-  mkdir -p $out/bin
-  makeWrapper "${jre}/bin/java" "$out/bin/apksigner" \
-    --add-flags "-jar ${tools}/libexec/android-sdk/build-tools/${tools.version}/lib/apksigner.jar"
-''
+
+stdenv.mkDerivation rec {
+  pname = "apksigner";
+  version = "33.0.1";
+
+  src = fetchgit {
+    # use pname here because the final jar uses this as the filename
+    name = pname;
+    url = "https://android.googlesource.com/platform/tools/apksig";
+    rev = "platform-tools-${version}";
+    hash = "sha256-CKvwB9Bb12QvkL/HBOwT6DhA1PI45+QnTNfwnvReGUQ=";
+  };
+
+  postPatch = ''
+    cat >> build.gradle <<EOF
+
+    apply plugin: 'application'
+    sourceSets.main.java.srcDirs = [ 'src/apksigner/java', 'src/main/java' ]
+    jar {
+        manifest { attributes "Main-Class": "com.android.apksigner.ApkSignerTool" }
+        from { (configurations.runtimeClasspath).collect { it.isDirectory() ? it : zipTree(it) } } {
+            exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/native/*.dll'
+        }
+        from('src/apksigner/java') {
+            include 'com/android/apksigner/*.txt'
+        }
+    }
+    EOF
+    sed -i -e '/conscrypt/s/testImplementation/implementation/' build.gradle
+  '';
+
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit src version postPatch;
+    nativeBuildInputs = [ gradle perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon build
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/''${\($5 =~ s/okio-jvm/okio/r)}" #e' \
+        | sh
+    '';
+    # Don't move info to share/
+    forceShare = [ "dummy" ];
+    outputHashMode = "recursive";
+    # Downloaded jars differ by platform
+    outputHash = "sha256-cs95YI0SpvzCo5x5trMXlVUGepNKIH9oZ95AfLErKIU=";
+  };
+
+  preBuild = ''
+    # Use the local packages from -deps
+    sed -i -e '/repositories {/a maven { url uri("${deps}") }' build.gradle
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --offline --no-daemon build
+
+    runHook postBuild
+  '';
+
+  nativeBuildInputs = [ gradle makeWrapper ];
+
+  installPhase = ''
+    install -Dm444 build/libs/apksigner.jar -t $out/lib
+    makeWrapper "${openjdk17_headless}/bin/java" "$out/bin/apksigner" \
+      --add-flags "-jar $out/lib/apksigner.jar"
+  '';
+
+  meta = with lib; {
+    description = "Command line tool to sign and verify Android APKs";
+    homepage = "https://developer.android.com/studio/command-line/apksigner";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ linsui ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1733,9 +1733,7 @@ with pkgs;
 
   apksigcopier = callPackage ../development/tools/apksigcopier { };
 
-  apksigner = callPackage ../development/tools/apksigner {
-    inherit (androidenv.androidPkgs_9_0) build-tools;
-  };
+  apksigner = callPackage ../development/tools/apksigner { };
 
   apktool = callPackage ../development/tools/apktool {
     inherit (androidenv.androidPkgs_9_0) build-tools;


### PR DESCRIPTION
###### Description of changes
I thought that the binary is licensed under the Android SDK license. Building it from source make it license under the Apache license.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
@obfusk 