### PR TITLE
slack: 4.25.1 -> 4.26.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -44,14 +44,14 @@ let
 
   pname = "slack";
 
-  x86_64-darwin-version = "4.25.0";
-  x86_64-darwin-sha256 = "1ffg003ic0jhkis9ai2873axwzqj9yvjab8212zwhvr3a23zzr5c";
+  x86_64-darwin-version = "4.26.1";
+  x86_64-darwin-sha256 = "0883nnnwjaii89x6idqcl68acw1fbijyhhrwy7inwgrdw233qqcd";
 
-  x86_64-linux-version = "4.25.1";
-  x86_64-linux-sha256 = "sha256-ndDVipgcLELRZ2siIAurq7umL62+g3yRL0U311DC8Ik=";
+  x86_64-linux-version = "4.26.1";
+  x86_64-linux-sha256 = "0nw3cfypinzp8csli1myh3b9hvv2pg1d8p9izg7znfpnlwps8gy1";
 
-  aarch64-darwin-version = "4.25.0";
-  aarch64-darwin-sha256 = "0s4c66bzi42y2r1c94r4ds5fyzzgvzkvrria0z45ysa47lnldp0f";
+  aarch64-darwin-version = "4.26.1";
+  aarch64-darwin-sha256 = "1p5qn5zyibpyiv5is70g1la9y6wc038j3sxjyxflgqsdvania7vq";
 
   version = {
     x86_64-darwin = x86_64-darwin-version;


### PR DESCRIPTION
###### Description of changes

https://slack.com/release-notes/linux
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
