### PR TITLE
pridefetch: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8418,6 +8418,17 @@
       fingerprint = "3196 83D3 9A1B 4DE1 3DC2  51FD FEA8 88C9 F5D6 4F62";
     }];
   };
+  minion3665 = {
+    name = "Skyler Grey";
+    email = "skyler3665@gmail.com";
+    matrix = "@minion3665:matrix.org";
+    github = "Minion3665";
+    githubId = 34243578;
+    keys = [{
+      longkeyid = "rsa4096/0x1AFD10256B3C714D";
+      fingerprint = "D520 AC8D 7C96 9212 5B2B  BD3A 1AFD 1025 6B3C 714D";
+    }];
+  };
   mir06 = {
     email = "armin.leuprecht@uni-graz.at";
     github = "mir06";

--- a/pkgs/tools/misc/pridefetch/default.nix
+++ b/pkgs/tools/misc/pridefetch/default.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchFromGitHub, python3, zip }: let
+  version = "1.0.0";
+  sha256 = "sha256-/o4er8bO/3HUFXzP+sC+5DYv9EwmxW05o1RT5fEulEg=";
+
+  pname = "pridefetch";
+  src = fetchFromGitHub {
+    owner = "SpyHoodle";
+    repo = pname;
+    rev = "v" + version;
+    inherit sha256;
+  };
+in stdenv.mkDerivation {
+  inherit pname version src;
+  nativeBuildInputs = [
+    zip
+  ];
+  buildInputs = [
+    (python3.withPackages (pythonPackages: with pythonPackages; [
+      distro
+    ]))
+  ];
+  buildPhase = ''
+    runHook preBuild
+    pushd src
+    zip -r ../pridefetch.zip ./*
+    popd
+    echo '#!/usr/bin/env python' | cat - pridefetch.zip > pridefetch
+    rm pridefetch.zip
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv pridefetch $out/bin/pridefetch
+    chmod +x $out/bin/pridefetch
+    runHook postInstall
+  '';
+  meta = with lib; {
+    description = "Print out system statistics with pride flags";
+    longDescription = ''
+      Pridefetch prints your system statistics (similarly to neofetch, screenfetch or pfetch) along with a pride flag.
+      The flag which is printed is configurable, as well as the width of the output.
+    '';
+    homepage = "https://github.com/SpyHoodle/pridefetch";
+    license = licenses.mit;
+    maintainers = [
+      maintainers.minion3665
+    ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -406,6 +406,8 @@ with pkgs;
 
   pridecat = callPackage ../tools/misc/pridecat { };
 
+  pridefetch = callPackage ../tools/misc/pridefetch { };
+
   proto-contrib = callPackage ../development/tools/proto-contrib { };
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc { };


### PR DESCRIPTION
###### Description of changes

- Add myself to the maintainer-list.nix
- Create the pridefetch package at [version 1.0.0](https://github.com/SpyHoodle/pridefetch/releases/tag/v1.0.0)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
