### PR TITLE
GNOME updates

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -41,11 +41,11 @@
 
 stdenv.mkDerivation rec {
   pname = "shotwell";
-  version = "0.30.15";
+  version = "0.30.16";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-OlKtYLEC2g31902wMcRdTM8mNRPJVGFu4WZL9PTpvck=";
+    sha256 = "sha256-yYgs+9rTA8uBYbFJrLtMYX++fKn2q24i0XTiRH51GPo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -34,13 +34,13 @@
 
 buildPythonApplication rec {
   pname = "orca";
-  version = "42.0";
+  version = "42.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "LCUXmrQbJgsY8f+Jm+uv5olDi0nf/SEd78l2olCT9zo=";
+    sha256 = "6p6dLehwg4ewUqe+FqXmnOqfZ2jfrrRee9meRmNxYt4=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome/apps/seahorse/default.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
     gcr
     gsettings-desktop-schemas
     gnupg
-    gnome.adwaita-icon-theme
     gpgme
     libsecret
     avahi
@@ -76,6 +75,13 @@ stdenv.mkDerivation rec {
     addToSearchPath XDG_DATA_DIRS "${glib.getSchemaDataDirPath gcr}"
     # The same test also requires home directory so that it can store settings.
     export HOME=$TMPDIR
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Pick up icons from Gcr
+      --prefix XDG_DATA_DIRS : "${gcr}/share"
+    )
   '';
 
   passthru = {

--- a/pkgs/desktops/gnome/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome/apps/seahorse/default.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation rec {
   pname = "seahorse";
-  version = "41.0";
+  version = "42.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-5u7AnoEESClfVH8YwdV3K2XD7cHZ5aJZXxC13eaJKfU=";
+    hash = "sha256-xQys6/jeen4uXx2uC5gjIRR0Epar6NVD45I9YqFT1jA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/evince/default.nix
+++ b/pkgs/desktops/gnome/core/evince/default.nix
@@ -43,13 +43,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evince";
-  version = "42.2";
+  version = "42.3";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evince/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "/3+B8wjPjUlW7Zf7ckp+SUSMIUvuq5mIEu+e+7ON+K4=";
+    sha256 = "Sa7PhFyUbJbbF7qJ11yAAsWuiWP1BKmwYm0SZ1kUZF4=";
   };
 
   postPatch = ''

--- a/pkgs/desktops/gnome/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-keyring/default.nix
@@ -10,6 +10,7 @@
 , libxslt
 , gettext
 , gcr
+, autoreconfHook
 , libcap_ng
 , libselinux
 , p11-kit
@@ -22,19 +23,21 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-keyring";
-  version = "40.0";
+  version = "42.1";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-keyring/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "0cdrlcw814zayhvlaxqs1sm9bqlfijlp22dzzd0g5zg2isq4vlm3";
+    sha256 = "x/TQQMx2prf+Z+CO+RBpEcPIDUD8iMv8jiaEpMlG4+Y=";
   };
 
   nativeBuildInputs = [
     pkg-config
     gettext
     libxslt
+    # Upstream uses ancient autotools to pre-generate the scripts.
+    autoreconfHook
     docbook-xsl-nons
     docbook_xml_dtd_43
     wrapGAppsHook

--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gupnp-tools";
-  version = "0.10.2";
+  version = "0.10.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "beSe9LN1uKFk90t2YWixGE4NKBlrawek9TQfCN/YXWw=";
+    sha256 = "RX9Nkjk1sHhBXNK6iNeNtgB5tyWSa37hBuRWXv4yBN4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

- gnome.seahorse: 41.0 → 42.0
- orca: 42.0 → 42.1
- shotwell: 0.30.15 → 0.30.16
- evince: 42.2 → 42.3
- gupnp-tools: 0.10.2 → 0.10.3

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
