### PR TITLE
Mark broken kernel packages for Linux 5.18

### DIFF
--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ freezeboy ];
     platforms = platforms.linux;
     license = licenses.gpl2Only;
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -64,5 +64,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Bumblebee-Project/bbswitch";
     maintainers = with maintainers; [ abbradar ];
     license = licenses.gpl2Plus;
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/dddvb/default.nix
+++ b/pkgs/os-specific/linux/dddvb/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ hexa ];
     platforms = platforms.linux;
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/dpdk-kmods/default.nix
+++ b/pkgs/os-specific/linux/dpdk-kmods/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = [ maintainers.mic92 ];
     platforms = platforms.linux;
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -91,5 +91,6 @@ in stdenv.mkDerivation rec {
     license = with licenses; [ lgpl21 gpl2 bsd2 ];
     platforms =  platforms.linux;
     maintainers = with maintainers; [ magenbluten orivej mic92 zhaofengli ];
+    broken = mod && kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ womfoo grahamc kraem ];
     platforms = [ "i686-linux" "x86_64-linux" ];
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/intel-speed-select/default.nix
+++ b/pkgs/os-specific/linux/intel-speed-select/default.nix
@@ -16,5 +16,6 @@ stdenv.mkDerivation {
     homepage = "https://www.kernel.org/";
     license = licenses.gpl2;
     platforms = [ "i686-linux" "x86_64-linux" ]; # x86-specific
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/kvdo/default.nix
+++ b/pkgs/os-specific/linux/kvdo/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/dm-vdo/kvdo";
     description = "A pair of kernel modules which provide pools of deduplicated and/or compressed block storage";
     platforms = platforms.linux;
+    broken = kernel.kernelOlder "5.15" || kernel.kernelAtLeast "5.17";
   };
 }

--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ j-brn ];
     platforms = [ "x86_64-linux" ];
-    broken = kernel.kernelOlder "5.3";
+    broken = kernel.kernelOlder "5.3" && kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ lgpl21Only gpl2Only mit ];
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/nvidiabl/default.nix
+++ b/pkgs/os-specific/linux/nvidiabl/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ yorickvp ];
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://github.com/Mange/rtl8192eu-linux-driver";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    broken = stdenv.hostPlatform.isAarch64;
+    broken = stdenv.hostPlatform.isAarch64 || kernel.kernelAtLeast "5.18";
     maintainers = with maintainers; [ troydm ];
   };
 }

--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tomaspinho/rtl8821ce";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    broken = stdenv.isAarch64;
+    broken = stdenv.isAarch64 || kernel.kernelAtLeast "5.18";
     maintainers = with maintainers; [ hhm ivar ];
   };
 }

--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = [ maintainers.jethro ];
     platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation {
 
   meta = virtualbox.meta // {
     description = virtualbox.meta.description + " (kernel modules)";
+    broken = kernel.kernelAtLeast "5.18";
   };
 }

--- a/pkgs/os-specific/linux/vmware/default.nix
+++ b/pkgs/os-specific/linux/vmware/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mkubecek/vmware-host-modules";
     license = licenses.gpl2Only;
     platforms = [ "x86_64-linux" ];
-    broken = kernel.kernelOlder "5.5" && kernel.isHardened;
+    broken = (kernel.kernelOlder "5.5" && kernel.isHardened) || kernel.kernelAtLeast "5.18";
     maintainers = with maintainers; [ deinferno ];
   };
 }

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -103,6 +103,6 @@ stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = with maintainers; [ maggesi spacefrogg ];
-    broken = kernel.isHardened;
+    broken = kernel.isHardened || kernel.kernelAtLeast "5.18";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

These are all the kernel packages for which there was no clear fix available for the brokenness.  For the kernel packages that are fixable, I will be making follow-up PRs fixing them instead of marking them as broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
