### PR TITLE
box86: init at 0.2.6

### DIFF
--- a/pkgs/applications/emulators/box86/default.nix
+++ b/pkgs/applications/emulators/box86/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "box86";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "ptitSeb";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rLh29Li3vyvaVaqg4USUNJ/Xm8YWpEZCLVMENxlOx9c=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  cmakeFlags = [
+    "-DNOGIT=1"
+  ] ++ (
+    if stdenv.hostPlatform.system == "armv7l-linux" then
+      [
+        "-DARM_DYNAREC=ON"
+      ]
+    else
+      [
+        "-DCMAKE_C_FLAGS=\"-m32\""
+        "-DLD80BITS=1"
+        "-DNOALIGN=1"
+      ]
+  );
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 0755 box86 "$out/bin/box86"
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    ctest
+    runHook postCheck
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/box86 -v
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://box86.org/";
+    description = "Lets you run 32-bit Linux programs on arch 32-bit Linux systems";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+    platforms = [ "armv7l-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1257,6 +1257,8 @@ with pkgs;
 
   box64 = callPackage ../applications/emulators/box64 { };
 
+  box86 = callPackage ../applications/emulators/box86 { };
+
   caprice32 = callPackage ../applications/emulators/caprice32 { };
 
   ccemux = callPackage ../applications/emulators/ccemux { };


### PR DESCRIPTION
###### Description of changes

Init of Box86, analog to #173987

Testing doesn't work for me, since I don't have 32bit (ARM) hardware. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [ ] i686-linux
  - [ ] armv7l-linux <-- Needs testing
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
