### PR TITLE
wasmtime: remove unneeded dependencies

### DIFF
--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -1,4 +1,4 @@
-{ rustPlatform, fetchFromGitHub, lib, stdenv, v8 }:
+{ rustPlatform, fetchFromGitHub, lib }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wasmtime";
@@ -14,18 +14,11 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-X+KDeWavFTBaxbSPlIiyuiBC7wg1/5C/NXp+VEY8Mk8=";
 
-  # This environment variable is required so that when wasmtime tries
-  # to run tests by using the rusty_v8 crate, it does not try to
-  # download a static v8 build from the Internet, what would break
-  # build hermetism.
-  RUSTY_V8_ARCHIVE = lib.optionalString stdenv.isLinux "${v8}/lib/libv8.a";
-
   doCheck = true;
   checkFlags = [
     "--skip=cli_tests::run_cwasm"
-    "--skip=commands::compile::test::test_successful_compile"
     "--skip=commands::compile::test::test_aarch64_flags_compile"
-    "--skip=commands::compile::test::test_unsupported_flags_compile"
+    "--skip=commands::compile::test::test_successful_compile"
     "--skip=commands::compile::test::test_x64_flags_compile"
     "--skip=commands::compile::test::test_x64_presets_compile"
     "--skip=traps::parse_dwarf_info"
@@ -35,7 +28,7 @@ rustPlatform.buildRustPackage rec {
     description = "Standalone JIT-style runtime for WebAssembly, using Cranelift";
     homepage = "https://github.com/bytecodealliance/wasmtime";
     license = licenses.asl20;
-    maintainers = [ maintainers.matthewbauer ];
+    maintainers = with maintainers; [ ereslibre matthewbauer ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

wasmtime: remove unneeded dependencies

Also, add `ereslibre` as a maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
