### PR TITLE
sunpaper: init at unstable-2022-04-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5937,6 +5937,12 @@
     githubId = 1667473;
     name = "Jethro Kuan";
   };
+  jevy = {
+    email = "jevin@quickjack.ca";
+    github = "jevy";
+    githubId = 110620;
+    name = "Jevin Maltais";
+  };
   jfb = {
     email = "james@yamtime.com";
     github = "tftio";

--- a/pkgs/tools/X11/sunpaper/default.nix
+++ b/pkgs/tools/X11/sunpaper/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, sunwait
+, wallutils
+, rPackages
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "sunpaper";
+  version = "unstable-2022-04-01";
+
+  src = fetchFromGitHub {
+    owner = "hexive";
+    repo = "sunpaper";
+    rev = "8d518dfddb5e80215ef3b884ff009df1d4bb74c2";
+    sha256 = "sCG7igD2ZwfHoRpR3Kw7dAded4hG2RbMLR/9nH+nZh8=";
+  };
+
+  buildInputs = [
+    wallutils
+    sunwait
+  ];
+
+  postPatch = ''
+    substituteInPlace sunpaper.sh \
+      --replace "sunwait" "${sunwait}/bin/sunwait" \
+      --replace "setwallpaper" "${wallutils}/bin/setwallpaper" \
+      --replace '$HOME/sunpaper/images/' "$out/share/sunpaper/images/"
+    '';
+
+  installPhase = ''
+    mkdir -p "$out/bin" "$out/share/sunpaper/images"
+    cp sunpaper.sh $out/bin/sunpaper
+    cp -R images $out/share/sunpaper/
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/sunpaper --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A utility to change wallpaper based on local weather, sunrise and sunset times";
+    homepage = "https://github.com/hexive/sunpaper";
+    license = lib.licenses.unfree;
+    maintainers = with maintainers; [ jevy ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10496,6 +10496,8 @@ with pkgs;
 
   sunwait = callPackage ../applications/misc/sunwait { };
 
+  sunpaper = callPackage ../tools/X11/sunpaper { };
+
   surface-control = callPackage ../applications/misc/surface-control { };
 
   syntex = callPackage ../tools/graphics/syntex {};


### PR DESCRIPTION
###### Description of changes

A utility to change the wallpaper based on the local sun location, moon phase or weather

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).