### PR TITLE
waybar: 0.9.12 -> 0.9.13

### DIFF
--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -25,18 +25,19 @@
 , swaySupport     ? true,  sway
 , mpdSupport      ? true,  libmpdclient
 , rfkillSupport   ? true
+, upowerSupport   ? true, upower
 , withMediaPlayer ? false, glib, gobject-introspection, python3, python38Packages, playerctl
 }:
 
 stdenv.mkDerivation rec {
   pname = "waybar";
-  version = "0.9.12";
+  version = "0.9.13";
 
   src = fetchFromGitHub {
     owner = "Alexays";
     repo = "Waybar";
     rev = version;
-    sha256 = "sha256-NQ/d+eXmc+GRxl5zby97S4U/YQnsRWGpwNZZL0Sqby8=";
+    sha256 = "sha256-Uzg2IrCDD8uUdGAveA8IjvonJnnnobOrAgjGG1kQ3pU=";
   };
 
   nativeBuildInputs = [
@@ -52,14 +53,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = with lib;
     [ wayland wlroots gtkmm3 libsigcxx jsoncpp spdlog gtk-layer-shell howard-hinnant-date libxkbcommon ]
-    ++ optional  traySupport  libdbusmenu-gtk3
-    ++ optional  pulseSupport libpulseaudio
-    ++ optional  sndioSupport sndio
-    ++ optional  nlSupport    libnl
-    ++ optional  udevSupport  udev
-    ++ optional  evdevSupport libevdev
-    ++ optional  swaySupport  sway
-    ++ optional  mpdSupport   libmpdclient;
+    ++ optional  traySupport   libdbusmenu-gtk3
+    ++ optional  pulseSupport  libpulseaudio
+    ++ optional  sndioSupport  sndio
+    ++ optional  nlSupport     libnl
+    ++ optional  udevSupport   udev
+    ++ optional  evdevSupport  libevdev
+    ++ optional  swaySupport   sway
+    ++ optional  mpdSupport    libmpdclient
+    ++ optional  upowerSupport upower;
 
   checkInputs = [ catch2 ];
   doCheck = runTests;
@@ -74,6 +76,7 @@ stdenv.mkDerivation rec {
       libudev = udevSupport;
       mpd = mpdSupport;
       rfkill = rfkillSupport;
+      upower_glib = upowerSupport;
       tests = runTests;
     }
   ) ++ [


### PR DESCRIPTION
###### Description of changes

Updated to latest version.

Added upower support, enabled by default

Changes: https://github.com/Alexays/Waybar/compare/0.9.12...0.9.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>waybar</li>
  </ul>
</details>