### PR TITLE
haskellPackages: Add buildFromCabalSdist (faster, tested)

### DIFF
--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -299,6 +299,9 @@ rec {
      directly. The effect is that the package is built as if it were published
      on hackage. This can be used as a test for the source distribution,
      assuming the build fails when packaging mistakes are in the cabal file.
+
+     A faster implementation using `cabal-install` is available as
+     `buildFromCabalSdist` in your Haskell package set.
    */
   buildFromSdist = pkg: overrideCabal (drv: {
     src = "${sdistTarball pkg}/${pkg.pname}-${pkg.version}.tar.gz";

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -538,4 +538,44 @@ in package-set { inherit pkgs lib callPackage; } self // {
       withHoogle = self.ghcWithHoogle;
     };
 
+    /*
+      Run `cabal sdist` on a source.
+
+      Unlike `haskell.lib.sdistTarball`, this does not require any dependencies
+      to be present, as it uses `cabal-install` instead of building `Setup.hs`.
+      This makes `cabalSdist` faster than `sdistTarball`.
+    */
+    cabalSdist = {
+      src,
+      name ? if src?name then "${src.name}-sdist.tar.gz" else "source.tar.gz"
+    }:
+      pkgs.runCommandNoCCLocal name
+        {
+          inherit src;
+          nativeBuildInputs = [ buildHaskellPackages.cabal-install ];
+          dontUnpack = false;
+        } ''
+        unpackPhase
+        cd "''${sourceRoot:-.}"
+        patchPhase
+        mkdir out
+        HOME=$PWD cabal sdist --output-directory out
+        mv out/*.tar.gz $out
+      '';
+
+    /*
+      Like `haskell.lib.buildFromSdist`, but using `cabal sdist` instead of
+      building `./Setup`.
+
+      Unlike `haskell.lib.buildFromSdist`, this does not require any dependencies
+      to be present. This makes `buildFromCabalSdist` faster than `haskell.lib.buildFromSdist`.
+    */
+    buildFromCabalSdist = pkg:
+      haskellLib.overrideSrc
+        {
+          src = self.cabalSdist { inherit (pkg) src; };
+          version = pkg.version;
+        }
+        pkg;
+
   }

--- a/pkgs/test/haskell/cabalSdist/default.nix
+++ b/pkgs/test/haskell/cabalSdist/default.nix
@@ -1,0 +1,28 @@
+{ lib, haskellPackages, runCommand }:
+
+let
+  localRaw = haskellPackages.callCabal2nix "local" ./local {};
+in
+lib.recurseIntoAttrs rec {
+
+  helloFromCabalSdist = haskellPackages.buildFromCabalSdist haskellPackages.hello;
+
+  # A more complicated example with a cabal hook.
+  hercules-ci-cnix-store = haskellPackages.buildFromCabalSdist haskellPackages.hercules-ci-cnix-store;
+
+  localFromCabalSdist = haskellPackages.buildFromCabalSdist localRaw;
+
+  assumptionLocalHasDirectReference = runCommand "localHasDirectReference" {
+    drvPath = builtins.unsafeDiscardOutputDependency localRaw.drvPath;
+  } ''
+    grep ${./local} $drvPath >/dev/null
+    touch $out
+  '';
+
+  localHasNoDirectReference = runCommand "localHasNoDirectReference" {
+    drvPath = builtins.unsafeDiscardOutputDependency localFromCabalSdist.drvPath;
+  } ''
+    grep -v ${./local} $drvPath >/dev/null
+    touch $out
+  '';
+}

--- a/pkgs/test/haskell/cabalSdist/default.nix
+++ b/pkgs/test/haskell/cabalSdist/default.nix
@@ -1,7 +1,7 @@
 { lib, haskellPackages, runCommand }:
 
 let
-  localRaw = haskellPackages.callCabal2nix "local" ./local {};
+  localRaw = haskellPackages.callPackage ./local/generated.nix {};
 in
 lib.recurseIntoAttrs rec {
 

--- a/pkgs/test/haskell/cabalSdist/local/CHANGELOG.md
+++ b/pkgs/test/haskell/cabalSdist/local/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for local
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/pkgs/test/haskell/cabalSdist/local/app/Main.hs
+++ b/pkgs/test/haskell/cabalSdist/local/app/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/pkgs/test/haskell/cabalSdist/local/generated.nix
+++ b/pkgs/test/haskell/cabalSdist/local/generated.nix
@@ -1,0 +1,12 @@
+# nix run ../../../../..#cabal2nix -- ./.
+{ mkDerivation, base, lib }:
+mkDerivation {
+  pname = "local";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [ base ];
+  description = "Nixpkgs test case";
+  license = lib.licenses.mit;
+}

--- a/pkgs/test/haskell/cabalSdist/local/local.cabal
+++ b/pkgs/test/haskell/cabalSdist/local/local.cabal
@@ -1,0 +1,13 @@
+cabal-version:      2.4
+name:               local
+version:            0.1.0.0
+
+synopsis: Nixpkgs test case
+license:  MIT
+extra-source-files: CHANGELOG.md
+
+executable local
+    main-is:          Main.hs
+    build-depends:    base
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/pkgs/test/haskell/default.nix
+++ b/pkgs/test/haskell/default.nix
@@ -2,6 +2,7 @@
 
 lib.recurseIntoAttrs {
   shellFor = callPackage ./shellFor { };
+  cabalSdist = callPackage ./cabalSdist { };
   documentationTarball = callPackage ./documentationTarball { };
   setBuildTarget = callPackage ./setBuildTarget { };
   writers = callPackage ./writers { };


### PR DESCRIPTION
###### Description of changes

A faster `buildFromSdist`, with tests. For use in out-of-tree projects. Triggered by https://github.com/NixOS/nixpkgs/pull/173800#issuecomment-1133597710

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
