### PR TITLE
emacsPackages.melpaBuild: Update package-build, avoid monkey-patch

### DIFF
--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -38,8 +38,8 @@ import ./generic.nix { inherit lib stdenv emacs texinfo writeText gcc; } ({
   packageBuild = fetchFromGitHub {
     owner = "melpa";
     repo = "package-build";
-    rev = "047801d301a73d4932f33f768d94a8ed26b8d524";
-    sha256 = "0ygzkpg7xc3mjjbxg1kcyz6fwbkb0prvca499f0ffmhfaiv28h59";
+    rev = "35017a2d87376c70c3239f48bdbac7efca85aa10";
+    sha256 = "07hdmam85452v4r2vaabj1qfyami1hgbh0jgj9dcwbkpr0y1gvqj";
   };
 
   elpa2nix = ./elpa2nix.el;

--- a/pkgs/build-support/emacs/melpa2nix.el
+++ b/pkgs/build-support/emacs/melpa2nix.el
@@ -11,12 +11,22 @@
 ;; Allow installing package tarfiles larger than 10MB
 (setq large-file-warning-threshold nil)
 
+(defun melpa2nix-build-package-1 (rcp version commit)
+  (let ((source-dir (package-recipe--working-tree rcp)))
+    (unwind-protect
+        (let ((files (package-build-expand-files-spec rcp t)))
+          (cond
+           ((= (length files) 1)
+            (package-build--build-single-file-package
+             rcp version commit files source-dir))
+           ((> (length files) 1)
+            (package-build--build-multi-file-package
+             rcp version commit files source-dir))
+           (t (error "Unable to find files matching recipe patterns")))))))
+
 (defun melpa2nix-build-package ()
   (if (not noninteractive)
       (error "`melpa2nix-build-package' is to be used only with -batch"))
   (pcase command-line-args-left
     (`(,package ,version ,commit)
-     ;; Monkey-patch package-build so it doesn't shell out to git/hg.
-     (defun package-build--get-commit (&rest _)
-       commit)
-     (package-build--package (package-recipe-lookup package) version))))
+     (melpa2nix-build-package-1 (package-recipe-lookup package) version commit))))


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`melpa/package-build` was updated along with ~130 recipes in https://github.com/melpa/melpa/pull/8032. The change removed the explicit `:files` list from these packages. `melpa2nix` depends on an older version of `package-build` that does not construct the default files list, breaking these packages. 

This change updates the version of `package-build` to the version committed to `melpa/melpa`. 

In addition, `package-build` was updated to run `git clean -fdx` in the source tree after building, which also broke `melpa2nix`. To fix this, remove the monkey-patch from `melpa2nix.el`, and add our own `package-build--package` analogue which passes through the `commit` argument to the inner build functions, and avoids invoking `git` via a shell.

I've tested this with my rather large Emacs configuration (~75 leaf packages) with both nixpkgs and the emacs-overlay, and the configuration builds in both scenarios.

cc @adisbladis (Emacs maintainer)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
