### PR TITLE
gnupg: fix bugs in EdDSA/YubiKey support

### DIFF
--- a/pkgs/tools/security/gnupg/0001-agent-Fix-signing-messages-over-475-bytes.patch
+++ b/pkgs/tools/security/gnupg/0001-agent-Fix-signing-messages-over-475-bytes.patch
@@ -1,0 +1,56 @@
+From e286d67461051a204d456f9d54514ed8066d4d4b Mon Sep 17 00:00:00 2001
+From: Puck Meerburg <puck@puckipedia.com>
+Date: Mon, 13 Jan 2020 17:08:37 +0000
+Subject: [PATCH] agent: Fix signing messages over 475 bytes.
+
+* agent/call-scd.c (agent_card_pksign): Use SETDATA --append.
+--
+
+EdDSA signatures require the actual message, rather than just the hash,
+so the data might not fit in a single SETDATA command. This patch
+implements the required changes.
+---
+ agent/call-scd.c | 25 ++++++++++++++++++-------
+ 1 file changed, 18 insertions(+), 7 deletions(-)
+
+diff --git a/agent/call-scd.c b/agent/call-scd.c
+index 154ea34d9..d1d6391e6 100644
+--- a/agent/call-scd.c
++++ b/agent/call-scd.c
+@@ -489,15 +489,26 @@ agent_card_pksign (ctrl_t ctrl,
+   if (!mdalgo)
+     return gpg_error (GPG_ERR_NOT_IMPLEMENTED);
+ 
+-  if (indatalen*2 + 50 > DIM(line))
+-    return unlock_scd (ctrl, gpg_error (GPG_ERR_GENERAL));
++  size_t processed_data = 0;
++  while (processed_data < indatalen) {
++    size_t bytes = (DIM(line) - 50) / 2;
++    if (indatalen - processed_data < bytes)
++        bytes = indatalen - processed_data;
+ 
+-  bin2hex (indata, indatalen, stpcpy (line, "SETDATA "));
++    char *start;
++    if (processed_data == 0)
++      start = stpcpy (line, "SETDATA ");
++    else
++      start = stpcpy (line, "SETDATA --append ");
+ 
+-  rc = assuan_transact (daemon_ctx (ctrl), line,
+-                        NULL, NULL, NULL, NULL, pincache_put_cb, NULL);
+-  if (rc)
+-    return unlock_scd (ctrl, rc);
++    bin2hex (indata + processed_data, bytes, start);
++    rc = assuan_transact (daemon_ctx (ctrl), line,
++                          NULL, NULL, NULL, NULL, pincache_put_cb, NULL);
++    if (rc)
++      return unlock_scd (ctrl, rc);
++
++    processed_data += bytes;
++  }
+ 
+   init_membuf (&data, 1024);
+   inqparm.ctx = daemon_ctx (ctrl);
+-- 
+2.35.3
+

--- a/pkgs/tools/security/gnupg/0002-scd-openpgp-Fix-signing-large-messages-with-EdDSA-ke.patch
+++ b/pkgs/tools/security/gnupg/0002-scd-openpgp-Fix-signing-large-messages-with-EdDSA-ke.patch
@@ -1,0 +1,31 @@
+From dac6de55652c5c181b02df1eebefefad2a467c81 Mon Sep 17 00:00:00 2001
+From: Puck Meerburg <puck@puckipedia.com>
+Date: Mon, 13 Jan 2020 17:09:38 +0000
+Subject: [PATCH] scd:openpgp: Fix signing large messages with EdDSA keys.
+
+* scd/app-openpgp.c (do_sign): Use exmode=1 for EdDSA.
+---
+ scd/app-openpgp.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/scd/app-openpgp.c b/scd/app-openpgp.c
+index 76a15d00e..0280923c8 100644
+--- a/scd/app-openpgp.c
++++ b/scd/app-openpgp.c
+@@ -5336,6 +5336,13 @@ do_sign (app_t app, ctrl_t ctrl, const char *keyidstr, int hashalgo,
+       exmode = 1;    /* Use extended length.  */
+       le_value = app->app_local->keyattr[0].rsa.n_bits / 8;
+     }
++  else if (app->app_local->cardcap.ext_lc_le
++           && app->app_local->keyattr[0].key_type == KEY_TYPE_ECC
++           && app->app_local->keyattr[0].ecc.flags & ECC_FLAG_DJB_TWEAK)
++    {
++      exmode = 1;
++      le_value = 0;
++    }
+   else
+     {
+       exmode = 0;
+-- 
+2.35.3
+

--- a/pkgs/tools/security/gnupg/0003-agent-Support-MD-less-operation.patch
+++ b/pkgs/tools/security/gnupg/0003-agent-Support-MD-less-operation.patch
@@ -1,0 +1,36 @@
+From 2a694bda325f84276d7bb0fa8e28cfd31ee10bd2 Mon Sep 17 00:00:00 2001
+From: edef <edef@edef.eu>
+Date: Sun, 15 May 2022 01:38:54 +0000
+Subject: [PATCH] agent: Support MD-less operation.
+
+---
+ agent/call-scd.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/agent/call-scd.c b/agent/call-scd.c
+index d1d6391e6..07ea83a39 100644
+--- a/agent/call-scd.c
++++ b/agent/call-scd.c
+@@ -448,6 +448,7 @@ hash_algo_option (int algo)
+ {
+   switch (algo)
+     {
++    case 0             : return "--hash=none";
+     case GCRY_MD_MD5   : return "--hash=md5";
+     case GCRY_MD_RMD160: return "--hash=rmd160";
+     case GCRY_MD_SHA1  : return "--hash=sha1";
+@@ -484,11 +485,6 @@ agent_card_pksign (ctrl_t ctrl,
+   if (rc)
+     return rc;
+ 
+-  /* FIXME: In the mdalgo case (INDATA,INDATALEN) might be long and
+-   * thus we can't convey it on a single Assuan line.  */
+-  if (!mdalgo)
+-    return gpg_error (GPG_ERR_NOT_IMPLEMENTED);
+-
+   size_t processed_data = 0;
+   while (processed_data < indatalen) {
+     size_t bytes = (DIM(line) - 50) / 2;
+-- 
+2.35.3
+

--- a/pkgs/tools/security/gnupg/0004-scd-app-openpgp-Permit-MD-less-do_sign.patch
+++ b/pkgs/tools/security/gnupg/0004-scd-app-openpgp-Permit-MD-less-do_sign.patch
@@ -1,0 +1,49 @@
+From 1fd11aca9859675a4c3e79d6a26337906a598906 Mon Sep 17 00:00:00 2001
+From: edef <edef@edef.eu>
+Date: Sun, 15 May 2022 02:09:34 +0000
+Subject: [PATCH] scd/app-openpgp: Permit MD-less do_sign.
+
+---
+ scd/app-openpgp.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/scd/app-openpgp.c b/scd/app-openpgp.c
+index 0280923c8..fda5bb4dd 100644
+--- a/scd/app-openpgp.c
++++ b/scd/app-openpgp.c
+@@ -5230,6 +5230,8 @@ do_sign (app_t app, ctrl_t ctrl, const char *keyidstr, int hashalgo,
+             || indatalen == 48 || indatalen ==64)
+            && app->app_local->extcap.is_v2)
+     ;  /* Assume a plain SHA-3 digest has been given.  */
++  else if (!hashalgo)
++    ;
+   else
+     {
+       log_error (_("card does not support digest algorithm %s\n"),
+@@ -5273,6 +5275,8 @@ do_sign (app_t app, ctrl_t ctrl, const char *keyidstr, int hashalgo,
+       else
+         return gpg_error (GPG_ERR_UNSUPPORTED_ALGORITHM);
+     }
++  else if (!hashalgo)
++    ;
+   else
+     {
+       datalen = indatalen;
+@@ -5348,8 +5352,12 @@ do_sign (app_t app, ctrl_t ctrl, const char *keyidstr, int hashalgo,
+       exmode = 0;
+       le_value = 0;
+     }
+-  rc = iso7816_compute_ds (app_get_slot (app), exmode, data, datalen, le_value,
+-                           outdata, outdatalen);
++  if (hashalgo)
++    rc = iso7816_compute_ds (app_get_slot (app), exmode, data, datalen, le_value,
++                             outdata, outdatalen);
++  else
++    rc = iso7816_compute_ds (app_get_slot (app), exmode, indata, indatalen, le_value,
++                             outdata, outdatalen);
+   if (gpg_err_code (rc) == GPG_ERR_TIMEOUT)
+     clear_chv_status (app, ctrl, 1);
+   else if (!rc && app->force_chv1)
+-- 
+2.35.3
+

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     ./tests-add-test-cases-for-import-without-uid.patch
     ./allow-import-of-previously-known-keys-even-without-UI.patch
     ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
+    ./0001-agent-Fix-signing-messages-over-475-bytes.patch
+    ./0002-scd-openpgp-Fix-signing-large-messages-with-EdDSA-ke.patch
   ];
   postPatch = ''
     sed -i 's,\(hkps\|https\)://keyserver.ubuntu.com,hkps://keys.openpgp.org,g' configure configure.ac doc/dirmngr.texi doc/gnupg.info-1

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
       frontend applications and libraries are available.  Version 2 of GnuPG
       also provides support for S/MIME.
     '';
-    maintainers = with maintainers; [ fpletz vrthra ];
+    maintainers = with maintainers; [ fpletz vrthra edef ];
     platforms = platforms.all;
     mainProgram = "gpg";
   };

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
     ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
     ./0001-agent-Fix-signing-messages-over-475-bytes.patch
     ./0002-scd-openpgp-Fix-signing-large-messages-with-EdDSA-ke.patch
+    ./0003-agent-Support-MD-less-operation.patch
+    ./0004-scd-app-openpgp-Permit-MD-less-do_sign.patch
   ];
   postPatch = ''
     sed -i 's,\(hkps\|https\)://keyserver.ubuntu.com,hkps://keys.openpgp.org,g' configure configure.ac doc/dirmngr.texi doc/gnupg.info-1


### PR DESCRIPTION
###### Description of changes

Non-invasive usability fixes for using GnuPG with Ed25519 on OpenPGP smartcards, eg YubiKeys.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
