### PR TITLE
_3proxy: fix cross-compilation

### DIFF
--- a/pkgs/applications/networking/3proxy/default.nix
+++ b/pkgs/applications/networking/3proxy/default.nix
@@ -1,21 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, coreutils, nixosTests }:
+{ lib, stdenv, fetchFromGitHub, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "3proxy";
   version = "0.9.4";
 
   src = fetchFromGitHub {
-    owner = "z3APA3A";
+    owner = "3proxy";
     repo = pname;
     rev = version;
     sha256 = "sha256-4bLlQ/ULvpjs6fr19yBBln5mRRc+yj+zVLiTs1e/Ypc=";
   };
 
+  # They use 'install -s', that calls the native strip instead of the cross.
+  # Don't strip binary on install, we strip it on fixup phase anyway.
+  postPatch = ''
+    substituteInPlace Makefile.Linux \
+      --replace "(INSTALL_BIN) -s" "(INSTALL_BIN)" \
+      --replace "/usr" ""
+  '';
+
   makeFlags = [
     "-f Makefile.Linux"
-    "INSTALL=${coreutils}/bin/install"
+    "INSTALL=install"
     "DESTDIR=${placeholder "out"}"
+    "CC:=$(CC)"
   ];
+
+  postInstall = ''
+    rm -fr $out/var
+  '';
 
   passthru.tests = {
     smoke-test = nixosTests._3proxy;
@@ -23,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Tiny free proxy server";
-    homepage = "https://github.com/z3APA3A/3proxy";
+    homepage = "https://github.com/3proxy/3proxy";
     license = licenses.bsd2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ misuzu ];


### PR DESCRIPTION
###### Description of changes
* Fix cross-compilation
* Change homepage

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
