### PR TITLE
mozillavpn: 2.8.0 → 2.8.3

### DIFF
--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -47,19 +47,19 @@ let
   };
 
   pname = "mozillavpn";
-  version = "2.8.0";
+  version = "2.8.3";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-UmLYs/J6syfMrjA66K33h8ubYqzvmcGf5spIilVVdVk=";
+    hash = "sha256-eKgoRE/JDEQEFp7xYY60ARDgw/n5VoZpD/Gb/CWzHuo=";
   };
 
   patches = [
     # Rust bridge: Add Cargo.lock file
     (fetchpatch {
-      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/pull/3341/commits/718c7f52756b5a88511da91dafad7af312bb2473.patch";
+      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/commit/05c9a366cf9dc4e378485c8e9d494f77c35dbb8c.patch";
       hash = "sha256-fG+SATbJpGqpCFXSWEiBo4dYx6RLtJYR0yTdBqN6Fww=";
     })
   ];
@@ -103,7 +103,7 @@ stdenv.mkDerivation {
     inherit src patches;
     name = "${pname}-${version}";
     preBuild = "cd ${cargoRoot}";
-    hash = "sha256-dnbF1hfm3qoZaPrIimhY2bUzlrYaNVUZ+nyp6NbgP3Y=";
+    hash = "sha256-C0wPmGVXbhUs0IzeIMZD6724P0XTOzeK1bzrnUMPlWo=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Upgrade the Mozilla VPN client from 2.8.0 to 2.8.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
