### PR TITLE
KDE/Spectacle: update kimageannotator to enable annotation in screenshots

### DIFF
--- a/pkgs/development/libraries/kcolorpicker/default.nix
+++ b/pkgs/development/libraries/kcolorpicker/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "kcolorpicker";
-  version = "0.1.6";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "ksnip";
     repo = "kColorPicker";
     rev = "v${version}";
-    sha256 = "1167xwk75yiz697vddbz3lq42l7ckhyl2cvigy4m05qgg9693ksd";
+    sha256 = "sha256-ahmMj/yzQiRP9oJwDuhJGxe849kxNsoGFDZ2CGQNhKs=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/kimageannotator/default.nix
+++ b/pkgs/development/libraries/kimageannotator/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "kimageannotator";
-  version = "0.5.3";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "ksnip";
     repo = "kImageAnnotator";
     rev = "v${version}";
-    sha256 = "sha256-dkZa+OhU3w4dUy/Edd0R2UFNYuIdeYe3H1SOtW5ario=";
+    sha256 = "sha256-fWMaat5IguEZwoEJiEjGrWIbOqdJhs25qOebxpWVQQk=";
   };
 
   nativeBuildInputs = [ cmake qttools ];


### PR DESCRIPTION
###### Description of changes
With kImageAnnotator version 0.6.0, this tool can be used by current Spectacle 22.04 to annotate and perform basic editing tasks on screenshots. It's already included as build dependency of spectacle, so just updating it and its dependency `kcolorpicker` is enough to trigger the rebuild and enable the feature.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
