### PR TITLE
linuxPackages.rtw88: 2021-04-19 to 2022-05-08, removed broken mark.

### DIFF
--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw88";
-    rev = "ce979583dff5fc2f6cbce354c3e2dceafee454ca";
-    hash = "sha256-/hEytY5kbOgH/fatboOO5yDxVq6kUtGFQeF2UO7OX28=";
+    rev = "dbcc43c31a4576f90e1e468d3a85c2dfdb25ec42";
+    hash = "sha256-IDHolspYtwjV5r5WArWl1g4zgKLvPd4ydKKH/aE5NSg=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     license = with licenses; [ bsd3 gpl2Only ];
     maintainers = with maintainers; [ tvorog atila ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "4.14" || kernel.kernelAtLeast "5.14";
+    broken = kernel.kernelOlder "4.14";
     priority = -1;
   };
 }

--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw88";
-  version = "unstable-2021-04-19";
+  version = "unstable-2022-05-08";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw88";
-    rev = "0f3cc6a5973bc386d9cb542fc85a6ba027edff5d";
-    hash = "sha256-PRzWXC1lre8gt1GfVdnaG836f5YK57P9a8tG20yef0w=";
+    rev = "ce979583dff5fc2f6cbce354c3e2dceafee454ca";
+    hash = "sha256-/hEytY5kbOgH/fatboOO5yDxVq6kUtGFQeF2UO7OX28=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     description = "The newest Realtek rtlwifi codes";
     homepage = "https://github.com/lwfinger/rtw88";
     license = with licenses; [ bsd3 gpl2Only ];
-    maintainers = with maintainers; [ tvorog ];
+    maintainers = with maintainers; [ tvorog atila ];
     platforms = platforms.linux;
     broken = kernel.kernelOlder "4.14" || kernel.kernelAtLeast "5.14";
     priority = -1;


### PR DESCRIPTION
###### Description of changes

This is the driver for my laptop wifi card. After trying out the new release-22.05 branch I noticed it has been marked as broken, on top of being quite outdated. The broken mark was given with the PR [#136171](https://github.com/NixOS/nixpkgs/pull/136171), given the package was severely outdated, lacking the commits bringing support for kernels >5.14. Thus I'm hereby creating this PR as a solution to both problems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
