### PR TITLE
mpris-scrobbler: 0.4.95 -> 0.5.0

### DIFF
--- a/pkgs/tools/audio/mpris-scrobbler/default.nix
+++ b/pkgs/tools/audio/mpris-scrobbler/default.nix
@@ -15,14 +15,18 @@
 
 stdenv.mkDerivation rec {
   pname = "mpris-scrobbler";
-  version = "0.4.95";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner  = "mariusor";
     repo   = "mpris-scrobbler";
     rev    = "v${version}";
-    sha256 = "sha256-Cqf0egS4XSDiKLdizNHPdS0Zt3jQxw9e78S7n23CuKI=";
+    sha256 = "sha256-HUEUkVL5d6FD698k8iSCJMNeSo8vGJCsExJW/E0EWpQ=";
   };
+
+  mesonFlags = [
+    "-Dwerror=false" "-Dversion=${version}"
+  ];
 
   postPatch = ''
     substituteInPlace src/signon.c \


### PR DESCRIPTION
###### Description of changes

Package bump to 0.5.0 release.

###### Things done

Build defaults to "-Werror" now, but doesn't build cleanly with newer gcc versions, so disabled "-Werror" via mesonFlags.
The build system also parses the revision from git now, so git is added to nativeBuildInputs. 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
