### PR TITLE
python3Packages.flask-wtf: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/applications/misc/archivy/default.nix
+++ b/pkgs/applications/misc/archivy/default.nix
@@ -61,7 +61,7 @@ buildPythonApplication rec {
     elasticsearch
     flask-compress
     flask_login
-    flask_wtf
+    flask-wtf
     html2text
     python-dotenv
     python-frontmatter

--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -28,7 +28,7 @@ let
     flask-bootstrap
     flask-paginate
     flask-reverse-proxy-fix
-    flask_wtf
+    flask-wtf
     arrow
     werkzeug
     click

--- a/pkgs/applications/misc/etesync-dav/default.nix
+++ b/pkgs/applications/misc/etesync-dav/default.nix
@@ -7,7 +7,7 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      flask_wtf = super.flask_wtf.overridePythonAttrs (old: rec {
+      flask-wtf = super.flask-wtf.overridePythonAttrs (old: rec {
         version = "0.15.1";
         src = old.src.override {
           inherit version;
@@ -29,7 +29,7 @@ in python.pkgs.buildPythonApplication rec {
     etebase
     etesync
     flask
-    flask_wtf
+    flask-wtf
     (python.pkgs.toPythonModule (radicale3.override { python3 = python; }))
   ];
 

--- a/pkgs/applications/misc/etesync-dav/default.nix
+++ b/pkgs/applications/misc/etesync-dav/default.nix
@@ -13,6 +13,26 @@ let
           inherit version;
           sha256 = "ff177185f891302dc253437fe63081e7a46a4e99aca61dfe086fb23e54fff2dc";
         };
+        disabledTests = [
+          "test_outside_request"
+        ];
+      });
+      werkzeug = super.werkzeug.overridePythonAttrs (old: rec {
+        version = "2.0.3";
+        src = old.src.override {
+          inherit version;
+          sha256 = "b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c";
+        };
+      });
+      wtforms = super.wtforms.overridePythonAttrs (old: rec {
+        version = "2.3.3";
+        src = old.src.override {
+          inherit version;
+          sha256 = "81195de0ac94fbc8368abbaf9197b88c4f3ffd6c2719b5bf5fc9da744f3d829c";
+        };
+        checkPhase = ''
+          ${self.python.interpreter} tests/runtests.py
+        '';
       });
     };
   };

--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -17,7 +17,7 @@
 , dill
 , flask
 , flask_login
-, flask_wtf
+, flask-wtf
 , flask-appbuilder
 , flask-caching
 , GitPython
@@ -126,7 +126,7 @@ buildPythonPackage rec {
     flask-appbuilder
     flask-caching
     flask_login
-    flask_wtf
+    flask-wtf
     GitPython
     graphviz
     gunicorn

--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -11,7 +11,7 @@
 , flask_login
 , flask-openid
 , flask_sqlalchemy
-, flask_wtf
+, flask-wtf
 , flask-jwt-extended
 , jsonschema
 , marshmallow
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     flask_login
     flask-openid
     flask_sqlalchemy
-    flask_wtf
+    flask-wtf
     flask-jwt-extended
     jsonschema
     marshmallow

--- a/pkgs/development/python-modules/flask-mongoengine/default.nix
+++ b/pkgs/development/python-modules/flask-mongoengine/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , flask
-, flask_wtf
+, flask-wtf
 , mongoengine
 , six
 , nose
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     email_validator
     flask
-    flask_wtf
+    flask-wtf
     mongoengine
     six
   ];

--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -27,7 +27,7 @@
 , flask
 , flask_login
 , flask_principal
-, flask_wtf
+, flask-wtf
 , itsdangerous
 , passlib
 
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     flask
     flask_login
     flask_principal
-    flask_wtf
+    flask-wtf
     itsdangerous
     passlib
   ];

--- a/pkgs/development/python-modules/flask-wtf/default.nix
+++ b/pkgs/development/python-modules/flask-wtf/default.nix
@@ -1,17 +1,36 @@
-{ lib, fetchPypi, buildPythonPackage, flask, wtforms, nose }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, flask
+, itsdangerous
+, wtforms
+, email_validator
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
-  pname = "Flask-WTF";
-  version = "1.0.0";
+  pname = "flask-wtf";
+  version = "1.0.1";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "872fbb17b5888bfc734edbdcf45bc08fb365ca39f69d25dc752465a455517b28";
+    pname = "Flask-WTF";
+    inherit version;
+    sha256 = "34fe5c6fee0f69b50e30f81a3b7ea16aa1492a771fe9ad0974d164610c09a6c9";
   };
 
-  propagatedBuildInputs = [ flask wtforms nose ];
+  propagatedBuildInputs = [
+    flask
+    itsdangerous
+    wtforms
+  ];
 
-  doCheck = false; # requires external service
+  passthru.optional-dependencies = {
+    email = [ email_validator ];
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "Simple integration of Flask and WTForms.";

--- a/pkgs/development/python-modules/ihatemoney/default.nix
+++ b/pkgs/development/python-modules/ihatemoney/default.nix
@@ -19,7 +19,7 @@
 , flask-restful
 , flask_sqlalchemy
 , flask-talisman
-, flask_wtf
+, flask-wtf
 , debts
 , idna
 , itsdangerous
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     flask
     flask_mail
     flask_migrate
-    flask_wtf
+    flask-wtf
     flask-babel
     flask-cors
     flask-restful

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -22,7 +22,7 @@ python3.pkgs.buildPythonApplication rec {
     flask-babel
     flask_login
     flask_principal
-    flask_wtf
+    flask-wtf
     iso-639
     lxml
     pypdf3

--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -34,7 +34,7 @@ let
     flask_mail
     flask_migrate
     flask_sqlalchemy
-    flask_wtf
+    flask-wtf
     flask-compress
     passlib
     pytz

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -67,6 +67,7 @@ mapAliases ({
   eebrightbox = throw "eebrightbox is unmaintained upstream and has therefore been removed"; # added 2022-02-03
   faulthandler = throw "faulthandler is built into ${python.executable}"; # added 2021-07-12
   flask_testing = flask-testing; # added 2022-04-25
+  flask_wtf = flask-wtf; # added 2022-05-24
   garminconnect-ha = garminconnect; # added 2022-02-05
   gitdb2 = throw "gitdb2 has been deprecated, use gitdb instead."; # added 2020-03-14
   glances = throw "glances has moved to pkgs.glances"; # added 2020-20-28

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3122,7 +3122,7 @@ in {
 
   flask-versioned = callPackage ../development/python-modules/flask-versioned { };
 
-  flask_wtf = callPackage ../development/python-modules/flask-wtf { };
+  flask-wtf = callPackage ../development/python-modules/flask-wtf { };
 
   flatbuffers = callPackage ../development/python-modules/flatbuffers {
     inherit (pkgs) flatbuffers;


### PR DESCRIPTION
###### Description of changes
Also change attribute name from flask_wtf to flask-wtf.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
