### PR TITLE
python3Packages.twisted: remove dropin.cache files

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -155,6 +155,14 @@ in rec {
       };
     } ./setuptools-build-hook.sh) {};
 
+  twistedRemoveDropinCacheHook = callPackage ({ }:
+    makeSetupHook {
+      name = "twisted-remove-dropin-cache-hook";
+      substitutions = {
+        inherit pythonSitePackages;
+      };
+    } ./twisted-remove-dropin-cache-hook.sh) { };
+
   setuptoolsCheckHook = callPackage ({ setuptools }:
     makeSetupHook {
       name = "setuptools-check-hook";

--- a/pkgs/development/interpreters/python/hooks/twisted-remove-dropin-cache-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/twisted-remove-dropin-cache-hook.sh
@@ -1,0 +1,15 @@
+# Setup hook for removing dropin.cache from the plugins folder
+echo "Sourcing twisted-remove-dropin-cache-hook.sh"
+
+# dropin.cache files are used to cache information about what plugins are
+# present in the directory which contains them. See
+# https://twistedmatrix.com/documents/current/core/howto/plugin.html#plugin-caching
+# They can lead to collisions in e.g. python3.withPackages environments.
+
+twistedRemoveDropinCachePhase () {
+    rm -f $out/@pythonSitePackages@/twisted/plugins/dropin.cache
+}
+
+if [ -z "${dontUseTwistedRemoveDropinCache-}" ]; then
+    preDistPhases+=" twistedRemoveDropinCachePhase"
+fi

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -4,6 +4,7 @@
 , pythonOlder
 , fetchPypi
 , python
+, twistedRemoveDropinCacheHook
 , appdirs
 , attrs
 , automat
@@ -56,6 +57,10 @@ buildPythonPackage rec {
     sha256 = "sha256-oEeZD1ffrh4L0rffJSbU8W3NyEN3TcEIt4xS8qXxNoA=";
   };
 
+  propagatedNativeBuildInputs = [
+    twistedRemoveDropinCacheHook
+  ];
+
   propagatedBuildInputs = [
     attrs
     automat
@@ -104,13 +109,6 @@ buildPythonPackage rec {
     # twisted.python.runtime.platform.supportsINotify() == False
     substituteInPlace src/twisted/python/_inotify.py --replace \
       "ctypes.util.find_library(\"c\")" "'${stdenv.glibc.out}/lib/libc.so.6'"
-  '';
-
-  # Generate Twisted's plug-in cache. Twisted users must do it as well. See
-  # http://twistedmatrix.com/documents/current/core/howto/plugin.html#auto3
-  # and http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=477103 for details.
-  postFixup = ''
-    $out/bin/twistd --help > /dev/null
   '';
 
   checkInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -125,6 +125,7 @@ in {
     pythonRemoveTestsDirHook
     setuptoolsBuildHook
     setuptoolsCheckHook
+    twistedRemoveDropinCacheHook
     venvShellHook
     wheelUnpackHook;
 


### PR DESCRIPTION

###### Motivation for changes
They can lead to conflicts in python3.withPackages environments.
fixes https://github.com/NixOS/nixpkgs/issues/164775

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Should this be backported?
cc @NixOS/release-engineers 