### PR TITLE
ocamlPackages.cooltt: unstable-2021-05-25 → unstable-2022-04-28

### DIFF
--- a/pkgs/development/ocaml-modules/bwd/default.nix
+++ b/pkgs/development/ocaml-modules/bwd/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildDunePackage, qcheck-core }:
+
+buildDunePackage rec {
+  pname = "bwd";
+  version = "2.0.0";
+
+  minimalOCamlVersion = "4.12";
+
+  src = fetchFromGitHub {
+    owner = "RedPRL";
+    repo = "ocaml-bwd";
+    rev = version;
+    sha256 = "sha256:0zgi8an53z6wr6nzz0zlmhx19zhqy1w2vfy1sq3sikjwh74jjq60";
+  };
+
+  doCheck = true;
+  checkInputs = [ qcheck-core ];
+
+  meta = {
+    description = "Backward Lists";
+    inherit (src.meta) homepage;
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/cooltt/default.nix
+++ b/pkgs/development/ocaml-modules/cooltt/default.nix
@@ -1,41 +1,92 @@
 { lib
 , fetchFromGitHub
+, fetchurl
 , buildDunePackage
-, cmdliner
+, bwd
+, cmdliner_1_1
+, containers
+, ezjsonm
 , menhir
 , menhirLib
 , ppx_deriving
 , ppxlib
 , uuseg
 , uutf
+, yuujinchou
 }:
+
+let
+  bantorra = buildDunePackage rec {
+    pname = "bantorra";
+    version = "unstable-2022-04-20";
+    src = fetchFromGitHub {
+      owner = "RedPRL";
+      repo = "bantorra";
+      rev = "1e78633d9a2ef7104552a24585bb8bea36d4117b";
+      sha256 = "sha256:15v1cggm7awp11iwl3lzpaar91jzivhdxggp5mr48gd28kfipzk2";
+    };
+
+    propagatedBuildInputs = [ ezjsonm ];
+
+    meta = {
+      description = "Extensible Library Management and Path Resolution";
+      homepage = "https://github.com/RedPRL/bantorra";
+      license = lib.licenses.asl20;
+    };
+  };
+  kado = buildDunePackage rec {
+    pname = "kado";
+    version = "unstable-2022-04-30";
+    src = fetchFromGitHub {
+      owner = "RedPRL";
+      repo = "kado";
+      rev = "8dce50e7d759d482b82565090e550d3860d64729";
+      sha256 = "sha256:1xb754fha4s0bgjfqjxzqljvalmkfdwdn5y4ycsp51wiah235bsy";
+    };
+
+    propagatedBuildInputs = [ bwd ];
+
+    doCheck = true;
+
+    meta = {
+      description = "Cofibrations in Cartecian Cubical Type Theory";
+      homepage = "https://github.com/RedPRL/kado";
+      license = lib.licenses.asl20;
+    };
+  };
+in
 
 buildDunePackage {
   pname = "cooltt";
-  version = "unstable-2021-05-25";
+  version = "unstable-2022-04-28";
 
-  minimumOCamlVersion = "4.10";
-
-  useDune2 = true;
+  minimalOCamlVersion = "4.13";
 
   src = fetchFromGitHub {
     owner = "RedPRL";
     repo = "cooltt";
-    rev = "8ac06cbf7e05417d777f3ac6a471fe3576249f79";
-    sha256 = "sha256-JBLNJaRuP/gwlg8RS3cpOpzxChOVKfmFulf5HKhhHh4=";
+    rev = "88511e10cb9e17286f585882dee334f3d8ace47c";
+    sha256 = "sha256:1n9bh86r2n9s3mm7ayfzwjbnjqcphpsf8yqnf4whd3yi930sqisw";
   };
 
   nativeBuildInputs = [
-    cmdliner
+    cmdliner_1_1
     menhir
     ppxlib
   ];
 
+  buildInputs = [ containers ];
+
   propagatedBuildInputs = [
+    bantorra
+    bwd
+    ezjsonm
+    kado
     menhirLib
     ppx_deriving
     uuseg
     uutf
+    yuujinchou
   ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/yuujinchou/default.nix
+++ b/pkgs/development/ocaml-modules/yuujinchou/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, buildDunePackage, qcheck-alcotest }:
+
+buildDunePackage rec {
+  pname = "yuujinchou";
+  version = "2.0.0";
+
+  minimalOCamlVersion = "4.12";
+
+  src = fetchFromGitHub {
+    owner = "RedPRL";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:1nhz44cyipy922anzml856532m73nn0g7iwkg79yzhq6yb87109w";
+  };
+
+  doCheck = true;
+  checkInputs = [ qcheck-alcotest ];
+
+  meta = {
+    description = "Name pattern combinators";
+    inherit (src.meta) homepage;
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -93,6 +93,8 @@ let
 
     brisk-reconciler = callPackage ../development/ocaml-modules/brisk-reconciler { };
 
+    bwd = callPackage ../development/ocaml-modules/bwd { };
+
     bz2 = callPackage ../development/ocaml-modules/bz2 { };
 
     ca-certs = callPackage ../development/ocaml-modules/ca-certs { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1457,6 +1457,8 @@ let
 
     yuscii = callPackage ../development/ocaml-modules/yuscii { };
 
+    yuujinchou = callPackage ../development/ocaml-modules/yuujinchou { };
+
     z3 = callPackage ../development/ocaml-modules/z3 {
       inherit (pkgs) z3;
     };


### PR DESCRIPTION
###### Description of changes

Ensure compatibility with recent versions of menhir.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

