### PR TITLE
duplicity: S3 backups fail with "boto" not being found.

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -70,6 +70,7 @@ pythonPackages.buildPythonApplication rec {
 
   pythonPath = with pythonPackages; [
     b2sdk
+    boto
     boto3
     cffi
     cryptography


### PR DESCRIPTION
It seems that duplicity needs boto instead of boto3.

###### Description of changes

When using duplicity, I got this error:
```
May 23 15:08:32 tm-staging duplicity-start[1732598]: + /nix/store/232nsxa0wa5w4091yjiklpij01apwj6d-duplicity-0.8.20/bin/duplicity cleanup s3://s3-de-central.profitbricks.co>
May 23 15:08:33 tm-staging duplicity-start[1732599]: BackendException: Could not initialize backend: No module named 'boto'
```

Adding boto to the list fixed the problem. I kept both as I am unsure if boto3 is actually needed.

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

We are running this in production already.