### PR TITLE
python39Packages.functorch: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/expecttest/default.nix
+++ b/pkgs/development/python-modules/expecttest/default.nix
@@ -1,0 +1,34 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, hypothesis
+, lib
+, poetry
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "expecttest";
+  version = "0.1.3";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ezyang";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-5CnpVFSbf3FcAa06Y7atG8sxu8uevpfrliB2HuVcrx0=";
+  };
+
+  buildInputs = [ poetry ];
+
+  checkInputs = [ hypothesis pytestCheckHook ];
+
+  pythonImportsCheck = [ "expecttest" ];
+
+  meta = {
+    maintainers = [ lib.maintainers.SomeoneSerge ];
+    license = lib.licenses.mit;
+    description = ''EZ Yang "golden" tests (testing against a reference implementation)'';
+    homepage = "https://github.com/ezyang/expecttest";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/functorch/default.nix
+++ b/pkgs/development/python-modules/functorch/default.nix
@@ -1,0 +1,98 @@
+{ buildPythonPackage
+, expecttest
+, fetchFromGitHub
+, lib
+, ninja
+, pytestCheckHook
+, python
+, pytorch
+, which
+}:
+
+buildPythonPackage rec {
+  pname = "functorch";
+  version = "0.1.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-FidM04Q3hkGEDr4dthJv0MWtGiRfnWxJoyzu7Wl3SD8=";
+  };
+
+  # Somewhat surprisingly pytorch is actually necessary for the build process.
+  # `setup.py` imports `torch.utils.cpp_extension`.
+  nativeBuildInputs = [
+    ninja
+    pytorch
+    which
+  ];
+
+  preCheck = ''
+    rm -rf functorch/
+  '';
+
+  checkInputs = [
+    expecttest
+    pytestCheckHook
+  ];
+
+  # See https://github.com/pytorch/functorch/issues/835.
+  disabledTests = [
+    # RuntimeError: ("('...', '') is in PyTorch's OpInfo db ", "but is not in functorch's OpInfo db. Please regenerate ", '... and add the new tests to ', 'denylists if necessary.')
+    "test_coverage_bernoulli_cpu_float32"
+    "test_coverage_column_stack_cpu_float32"
+    "test_coverage_diagflat_cpu_float32"
+    "test_coverage_flatten_cpu_float32"
+    "test_coverage_linalg_lu_factor_cpu_float32"
+    "test_coverage_linalg_lu_factor_ex_cpu_float32"
+    "test_coverage_multinomial_cpu_float32"
+    "test_coverage_nn_functional_dropout2d_cpu_float32"
+    "test_coverage_nn_functional_feature_alpha_dropout_with_train_cpu_float32"
+    "test_coverage_nn_functional_feature_alpha_dropout_without_train_cpu_float32"
+    "test_coverage_nn_functional_kl_div_cpu_float32"
+    "test_coverage_normal_cpu_float32"
+    "test_coverage_normal_number_mean_cpu_float32"
+    "test_coverage_pca_lowrank_cpu_float32"
+    "test_coverage_round_decimals_0_cpu_float32"
+    "test_coverage_round_decimals_3_cpu_float32"
+    "test_coverage_round_decimals_neg_3_cpu_float32"
+    "test_coverage_scatter_reduce_cpu_float32"
+    "test_coverage_svd_lowrank_cpu_float32"
+
+    # >       self.assertEqual(len(functorch_lagging_op_db), len(op_db))
+    # E       AssertionError: Scalars are not equal!
+    # E
+    # E       Absolute difference: 19
+    # E       Relative difference: 0.03525046382189239
+    "test_functorch_lagging_op_db_has_opinfos_cpu"
+
+    # RuntimeError: PyTorch not compiled with LLVM support!
+    "test_bias_gelu"
+    "test_binary_ops"
+    "test_broadcast1"
+    "test_broadcast2"
+    "test_float_double"
+    "test_float_int"
+    "test_fx_trace"
+    "test_int_long"
+    "test_issue57611"
+    "test_slice1"
+    "test_slice2"
+    "test_transposed1"
+    "test_transposed2"
+    "test_unary_ops"
+  ];
+
+  pythonImportsCheck = [ "functorch" ];
+
+  meta = with lib; {
+    description = "JAX-like composable function transforms for PyTorch";
+    homepage = "https://pytorch.org/functorch";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ samuela ];
+    # See https://github.com/NixOS/nixpkgs/pull/174248#issuecomment-1139895064.
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3260,6 +3260,8 @@ in {
 
   functools32 = callPackage ../development/python-modules/functools32 { };
 
+  functorch = callPackage ../development/python-modules/functorch { };
+
   funcy = callPackage ../development/python-modules/funcy { };
 
   furl = callPackage ../development/python-modules/furl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2813,6 +2813,8 @@ in {
 
   expects = callPackage ../development/python-modules/expects { };
 
+  expecttest = callPackage ../development/python-modules/expecttest { };
+
   expiringdict = callPackage ../development/python-modules/expiringdict { };
 
   explorerscript = callPackage ../development/python-modules/explorerscript { };


### PR DESCRIPTION
###### Description of changes

See https://twitter.com/PyTorch/status/1528800506067288065.

cc @SomeoneSerge might also be interested?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
