### PR TITLE
tor-browser-bundle-bin: 11.0.11 -> 11.0.13

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -87,7 +87,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "11.0.11";
+  version = "11.0.13";
 
   lang = "en-US";
 
@@ -98,7 +98,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "1dx92jdnvs7w52mps4zhnnjym6jsl9vwfiav1jw8qq0g8hslgybd";
+      sha256 = "03pzwzgikc43pm0lga61jdzg46fanmvd1wsnb2xkq0y1ny8gsqfz";
     };
 
     i686-linux = fetchurl {
@@ -107,7 +107,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "165mg9gwmlqwskbk3i8lhjjqp4lmpq5vzdvd9zalx69xqh9v85i5";
+      sha256 = "0j8h2g404sagzjxnwf55n8hpvmwk52qhml98nyliajf1xg8v8k19";
     };
   };
 in


### PR DESCRIPTION
###### Description of changes

https://blog.torproject.org/new-release-tor-browser-11013/

> This version includes important [security updates](https://www.mozilla.org/en-US/security/advisories/mfsa2022-19/) to Firefox.
> We also updated Tor to 0.4.7.7 (the first stable Tor release with support for [congestion control](https://blog.torproject.org/congestion-contrl-047/)).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files: access to normal websites and onion sites works
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).