### PR TITLE
signald: 0.18.5 -> 0.20.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signald/0001-Fetch-buildconfig-during-gradle-build-inside-Nix-FOD.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/0001-Fetch-buildconfig-during-gradle-build-inside-Nix-FOD.patch
@@ -24,7 +24,7 @@ index eaa6e0e..63c2947 100644
 @@ -104,6 +107,8 @@ dependencies {
      implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
      implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-     implementation 'io.sentry:sentry:5.7.3'
+     implementation 'io.sentry:sentry:6.1.2'
 +    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.0.3'
 +    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.4.31'
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'

--- a/pkgs/applications/networking/instant-messengers/signald/0002-buildconfig-local-deps-fixes.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/0002-buildconfig-local-deps-fixes.patch
@@ -50,7 +50,7 @@ index eaa6e0e..9a2f4e2 100644
 @@ -104,6 +117,8 @@ dependencies {
      implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
      implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-     implementation 'io.sentry:sentry:5.7.3'
+     implementation 'io.sentry:sentry:6.1.2'
 +    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.0.3'
 +    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.4.31'
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -4,18 +4,18 @@
 
 let
   pname = "signald";
-  version = "0.18.5";
+  version = "0.20.0";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-2cb1pyBOoOlFqJsNKXA0Q9x4wCE4yzzcfrDDtTp7HMk=";
+    hash = "sha256-OSZpZZ4Ia2dKiC2Btvnafa4nXezZSlvxlDrseJ6OKrk=";
   };
 
   jre' = jre_minimal.override {
     jdk = jdk17_headless;
-    # from https://gitlab.com/signald/signald/-/blob/0.18.5/build.gradle#L173
+    # from https://gitlab.com/signald/signald/-/blob/0.19.0/build.gradle#L173
     modules = [
       "java.base"
       "java.management"
@@ -54,8 +54,8 @@ let
     outputHashMode = "recursive";
     # Downloaded jars differ by platform
     outputHash = {
-      x86_64-linux = "sha256-q1gzauIL7aKalvPSfiK5IvkNkidCh+6jp5bpwxR+PZ0=";
-      aarch64-linux = "sha256-cM+7MaV0/4yAzobXX9FSdl/ZfLddwySayao96UdDgzk=";
+      x86_64-linux = "sha256-Z6mPFIxx3WomaHVi2YEp6KPCL47Fj6m17K/8COuif4c=";
+      aarch64-linux = "sha256-Kow+m5m0X8+lqrJnFfXcDyyXqjbIaQeMMRuRvR4dIi4=";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 
@@ -73,6 +73,7 @@ in stdenv.mkDerivation rec {
     runHook preBuild
 
     export GRADLE_USER_HOME=$(mktemp -d)
+    export VERSION="${version}"
 
     gradle --offline --no-daemon distTar
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
