### PR TITLE
picoscope, openrazer, it87, esptool: move maintainership to new LumiGuide team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -355,6 +355,16 @@ with lib.maintainers; {
     shortName = "Linux Kernel";
   };
 
+  lumiguide = {
+    # Verify additions by approval of an already existing member of the team.
+    members = [
+      roelvandijk
+      lucus16
+    ];
+    scope = "Group registration for LumiGuide employees who collectively maintain packages.";
+    shortName = "Lumiguide employees";
+  };
+
   lumina = {
     members = [
       romildo

--- a/pkgs/applications/science/electronics/picoscope/default.nix
+++ b/pkgs/applications/science/electronics/picoscope/default.nix
@@ -18,7 +18,7 @@ let
   shared_meta = lib:
     with lib; {
       homepage = "https://www.picotech.com/downloads/linux";
-      maintainers = with maintainers; [ expipiplus1 yorickvp wirew0rm ];
+      maintainers = with maintainers; [ expipiplus1 wirew0rm ] ++ teams.lumiguide.members;
       platforms = [ "x86_64-linux" ];
       license = licenses.unfree;
     };

--- a/pkgs/development/python-modules/openrazer/common.nix
+++ b/pkgs/development/python-modules/openrazer/common.nix
@@ -11,7 +11,7 @@
   meta = with lib; {
     homepage = "https://openrazer.github.io/";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ roelvandijk evanjs ];
+    maintainers = with maintainers; [ evanjs ] ++ teams.lumiguide.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/hannesha/it87";
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = with maintainers; [ yorickvp ];
+    maintainers = teams.lumiguide.members;
   };
 }

--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -57,7 +57,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "ESP8266 and ESP32 serial bootloader utility";
     homepage = "https://github.com/espressif/esptool";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ dezgeg dotlambda ];
+    maintainers = with maintainers; [ dezgeg dotlambda ] ++ teams.lumiguide.members;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

I no longer work at LumiGuide, but inherited maintainership of a few packages. This PR adds a lumiguide team and adds it as maintainer to the packages they use and maintain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
