### PR TITLE
dtc: fix static building on aarch64

### DIFF
--- a/pkgs/development/compilers/dtc/0001-Depend-on-.a-instead-of-.so-when-building-static.patch
+++ b/pkgs/development/compilers/dtc/0001-Depend-on-.a-instead-of-.so-when-building-static.patch
@@ -1,0 +1,90 @@
+From c1d426bdd477ffeb3dfa03501de089a341b85d0b Mon Sep 17 00:00:00 2001
+From: Tero Tervala <tero.tervala@unikie.com>
+Date: Wed, 15 Jun 2022 13:44:55 +0300
+Subject: [PATCH] Depend on .a instead of .so when building static
+
+Static build needs to be indicated with environment variable:
+STATIC_BUILD=1
+
+Checks are skipped on static builds
+
+Signed-off-by: Tero Tervala <tero.tervala@unikie.com>
+---
+ Makefile             | 12 +++++++++---
+ tests/Makefile.tests | 11 ++++++++---
+ 2 files changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index ee77115..9f550b4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -198,6 +198,12 @@ LIBFDT_lib = $(LIBFDT_dir)/$(LIBFDT_LIB)
+ LIBFDT_include = $(addprefix $(LIBFDT_dir)/,$(LIBFDT_INCLUDES))
+ LIBFDT_version = $(addprefix $(LIBFDT_dir)/,$(LIBFDT_VERSION))
+ 
++ifeq ($(STATIC_BUILD),1)
++	LIBFDT_dep = $(LIBFDT_archive)
++else
++	LIBFDT_dep = $(LIBFDT_lib)
++endif
++
+ include $(LIBFDT_dir)/Makefile.libfdt
+ 
+ .PHONY: libfdt
+@@ -261,11 +267,11 @@ convert-dtsv0: $(CONVERT_OBJS)
+ 
+ fdtdump:	$(FDTDUMP_OBJS)
+ 
+-fdtget:	$(FDTGET_OBJS) $(LIBFDT_lib)
++fdtget:	$(FDTGET_OBJS) $(LIBFDT_dep)
+ 
+-fdtput:	$(FDTPUT_OBJS) $(LIBFDT_lib)
++fdtput:	$(FDTPUT_OBJS) $(LIBFDT_dep)
+ 
+-fdtoverlay: $(FDTOVERLAY_OBJS) $(LIBFDT_lib)
++fdtoverlay: $(FDTOVERLAY_OBJS) $(LIBFDT_dep)
+ 
+ dist:
+ 	git archive --format=tar --prefix=dtc-$(dtc_version)/ HEAD \
+diff --git a/tests/Makefile.tests b/tests/Makefile.tests
+index 2f78952..f13b16d 100644
+--- a/tests/Makefile.tests
++++ b/tests/Makefile.tests
+@@ -60,17 +60,17 @@ TESTS_CLEANDIRS = $(TESTS_CLEANDIRS_L:%=$(TESTS_PREFIX)%)
+ .PHONY: tests
+ tests:	$(TESTS) $(TESTS_TREES)
+ 
+-$(LIB_TESTS): %: $(TESTS_PREFIX)testutils.o util.o $(LIBFDT_lib)
++$(LIB_TESTS): %: $(TESTS_PREFIX)testutils.o util.o $(LIBFDT_dep)
+ 
+ # Not necessary on all platforms; allow -ldl to be excluded instead of forcing
+ # other platforms to patch it out.
+ LIBDL = -ldl
+-$(DL_LIB_TESTS): %: %.o $(TESTS_PREFIX)testutils.o util.o $(LIBFDT_lib)
++$(DL_LIB_TESTS): %: %.o $(TESTS_PREFIX)testutils.o util.o $(LIBFDT_dep)
+ 	@$(VECHO) LD [libdl] $@
+ 	$(LINK.c) -o $@ $^ $(LIBDL)
+ 
+ $(LIBTREE_TESTS): %: $(TESTS_PREFIX)testutils.o $(TESTS_PREFIX)trees.o \
+-		util.o $(LIBFDT_lib)
++		util.o $(LIBFDT_dep)
+ 
+ $(TESTS_PREFIX)dumptrees: $(TESTS_PREFIX)trees.o
+ 
+@@ -83,8 +83,13 @@ tests_clean:
+ 	rm -f $(TESTS_CLEANFILES)
+ 	rm -rf $(TESTS_CLEANDIRS)
+ 
++ifeq ($(STATIC_BUILD),1)
++check:
++	@echo Skipping checks for static build
++else
+ check:	tests ${TESTS_BIN} $(TESTS_PYLIBFDT)
+ 	cd $(TESTS_PREFIX); ./run_tests.sh
++endif
+ 
+ ifeq ($(NO_VALGRIND),1)
+ checkm:
+-- 
+2.33.3
+

--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
     # based on without requiring the setup.py rework
     # https://git.kernel.org/pub/scm/utils/dtc/dtc.git/commit/?id=383e148b70a47ab15f97a19bb999d54f9c3e810f
     ./python-3.10.patch
+
+    # fix dtc static building
+    ./0001-Depend-on-.a-instead-of-.so-when-building-static.patch
   ];
 
   nativeBuildInputs = [ flex bison pkg-config which ]
@@ -38,7 +41,7 @@ stdenv.mkDerivation rec {
     patchShebangs pylibfdt/
   '';
 
-  makeFlags = [ "PYTHON=python" ];
+  makeFlags = [ "PYTHON=python" "STATIC_BUILD=${toString stdenv.hostPlatform.isStatic}" ];
   installFlags = [ "INSTALL=install" "PREFIX=$(out)" "SETUP_PREFIX=$(out)" ];
 
   # Checks are broken on aarch64 darwin


### PR DESCRIPTION
Signed-off-by: Tero Tervala <tero.tervala@unikie.com>

###### Description of changes
Makefile change, binaries depend on archive (.a) instead of shared object (.so) when built statically.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
