### PR TITLE
asterisk: 16.25.1 -> 16.26.1, 18.11.1 -> 18.12.1, 19.3.1 -> 19.4.1

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -93,9 +93,9 @@ let
     };
   };
 
-  pjproject_2_10 = fetchurl {
-    url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.10/pjproject-2.10.tar.bz2";
-    sha256 = "14qmddinm4bv51rl0wwg5133r64x5bd6inwbx27ahb2n0151m2if";
+  pjproject_2_12 = fetchurl {
+    url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.12/pjproject-2.12.tar.bz2";
+    hash = "sha256-T3q4r/4WCAZCNGnULxMnNKH9wEK7gkseV/sV8IPasHQ=";
   };
 
   mp3-202 = fetchsvn {
@@ -116,7 +116,7 @@ let
   versions = lib.mapAttrs (_: {version, sha256}: common {
     inherit version sha256;
     externals = {
-      "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
+      "externals_cache/pjproject-2.12.tar.bz2" = pjproject_2_12;
       "addons/mp3" = mp3-202;
     };
   }) (lib.importJSON ./versions.json);
@@ -138,8 +138,7 @@ in {
   # 19.x    Standard   2021-11-02  2022-11-02  2023-11-02
   asterisk-lts = versions.asterisk_18;
   asterisk-stable = versions.asterisk_19;
-  asterisk = versions.asterisk_19.overrideAttrs (o: let
-  in {
+  asterisk = versions.asterisk_19.overrideAttrs (o: {
     passthru = (o.passthru or {}) // { inherit updateScript; };
   });
 

--- a/pkgs/servers/asterisk/update.py
+++ b/pkgs/servers/asterisk/update.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i python3 -p python39 python39.pkgs.packaging python39.pkgs.beautifulsoup4 python39.pkgs.requests
+# mirrored in ./default.nix
 from packaging import version
 from bs4 import BeautifulSoup
 import re, requests, json
+import os, sys
+from pathlib import Path
 
 URL = "https://downloads.asterisk.org/pub/telephony/asterisk"
 
@@ -23,8 +26,10 @@ for mv in major_versions.keys():
         "sha256": sha
     }
 
+versions_path = Path(sys.argv[0]).parent / "versions.json"
+
 try:
-    with open("versions.json", "r") as in_file:
+    with open(versions_path, "r") as in_file:
         in_data = json.loads(in_file.read())
         for v in in_data.keys():
             print(v + ":", in_data[v]["version"], "->", out[v]["version"])
@@ -32,5 +37,5 @@ except:
     # nice to have for the PR, not a requirement
     pass
 
-with open("versions.json", "w") as out_file:
+with open(versions_path, "w") as out_file:
     out_file.write(json.dumps(out, sort_keys=True, indent=2) + "\n")

--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,14 +1,14 @@
 {
   "asterisk_16": {
-    "sha256": "379c5529b9957c28734192999543486a0b0b24f6671b2e02e77cc809774e7ba9",
-    "version": "16.25.1"
+    "sha256": "201c92e591fc1db2c71b264907beef594d62d660168d42b5e83f9dc593b1bce0",
+    "version": "16.26.1"
   },
   "asterisk_18": {
-    "sha256": "9db0e94e005a91a5433fc11173247065a5c40c9a7ca946577908f65d130b888e",
-    "version": "18.11.1"
+    "sha256": "acbb58e5c3cd2b9c7c4506fa80b717c3c3c550ce9722ff0177b4f11f98725563",
+    "version": "18.12.1"
   },
   "asterisk_19": {
-    "sha256": "3e1fa31ef1de7813365dd8b98ef93744ff87902255472814d0232b955c794706",
-    "version": "19.3.1"
+    "sha256": "6b0b985163f20fcc8f8878069b8a9ee725eef4cfbdb1c1031fe3840fb32d7abe",
+    "version": "19.4.1"
   }
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Fixed update script to work with `maintainers/scripts/update.nix`
- Bump asterisk versions

Fixes #172476
Fixes #172474
Fixes #172473

Backport for nixos 21.11: #172475, #172472

###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
