### PR TITLE
oraclejdk17: init at 17.0.3.1

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk17-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk17-linux.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv
+, requireFile
+, xorg
+, zlib
+, freetype
+, alsa-lib
+, setJavaClassPath
+}:
+
+let result = stdenv.mkDerivation rec {
+  pname = "oraclejdk";
+  version = "17.0.3.1";
+
+  src = requireFile {
+    name = "jdk-${version}_linux-x64_bin.tar.gz";
+    url = "https://www.oracle.com/java/technologies/downloads/#java17";
+    sha256 = "1lwwksdpqw4j45mlp8s745y69cy6ndx20bwycni83yr1v96z9my5";
+  };
+
+  installPhase = ''
+    mv ../$sourceRoot $out
+
+    mkdir -p $out/nix-support
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '';
+
+  postFixup = ''
+    rpath="$out/lib/jli:$out/lib/server:$out/lib:${lib.strings.makeLibraryPath [ stdenv.cc.cc zlib xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXrender freetype alsa-lib]}"
+
+    for f in $(find $out -name "*.so") $(find $out -type f -perm -0100); do
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f" || true
+      patchelf --set-rpath   "$rpath"                                    "$f" || true
+    done
+
+    for f in $(find $out -name "*.so") $(find $out -type f -perm -0100); do
+      if ldd "$f" | fgrep 'not found'; then echo "in file $f"; fi
+    done
+  '';
+
+  passthru.jre = result;
+  passthru.home = result;
+
+  dontStrip = true; # See: https://github.com/NixOS/patchelf/issues/10
+
+  meta = with lib; {
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}; in result

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13233,6 +13233,8 @@ with pkgs;
 
   oraclejdk14 = callPackage ../development/compilers/oraclejdk/jdk14-linux.nix { };
 
+  oraclejdk17 = callPackage ../development/compilers/oraclejdk/jdk17-linux.nix { };
+
   jasmin = callPackage ../development/compilers/jasmin { };
 
   java-service-wrapper = callPackage ../tools/system/java-service-wrapper {


### PR DESCRIPTION
###### Description of changes
Init for Oracle JDK 17 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
