### PR TITLE
unstableGitUpdater: fix updating fetchzip-based sources

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -92,4 +92,8 @@ stdenvNoCC.mkDerivation {
   ];
 
   inherit preferLocalBuild meta;
+
+  passthru = {
+    gitRepoUrl = url;
+  };
 }

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -42,11 +42,20 @@ let
     '';
     netrcImpureEnvVars = [ "${varBase}USERNAME" "${varBase}PASSWORD" ];
   };
+
+  gitRepoUrl = "${baseUrl}.git";
+
   fetcherArgs = (if useFetchGit
     then {
-      inherit rev deepClone fetchSubmodules sparseCheckout; url = "${baseUrl}.git";
+      inherit rev deepClone fetchSubmodules sparseCheckout; url = gitRepoUrl;
     } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
-    else { url = "${baseUrl}/archive/${rev}.tar.gz"; }
+    else {
+      url = "${baseUrl}/archive/${rev}.tar.gz";
+
+      passthru = {
+        inherit gitRepoUrl;
+      };
+    }
   ) // privateAttrs // passthruAttrs // { inherit name; };
 in
 

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -15,11 +15,17 @@ let
   useFetchGit = deepClone || fetchSubmodules || leaveDotGit;
   fetcher = if useFetchGit then fetchgit else fetchzip;
 
+  gitRepoUrl = "${protocol}://${domain}/${slug}.git";
+
   fetcherArgs = (if useFetchGit then {
     inherit rev deepClone fetchSubmodules leaveDotGit;
-    url = "${protocol}://${domain}/${slug}.git";
+    url = gitRepoUrl;
   } else {
     url = "${protocol}://${domain}/api/v4/projects/${escapedSlug}/repository/archive.tar.gz?sha=${escapedRev}";
+
+    passthru = {
+      inherit gitRepoUrl;
+    };
   }) // passthruAttrs // { inherit name; };
 in
 

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -49,7 +49,7 @@ let
     # By default we set url to src.url
     if [[ -z "$url" ]]; then
         url="$(${nix}/bin/nix-instantiate $systemArg --eval -E \
-                   "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.url or $UPDATE_NIX_ATTR_PATH.src.meta.homepage" \
+                   "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.gitRepoUrl" \
             | tr -d '"')"
     fi
 


### PR DESCRIPTION
###### Description of changes

a67950f20b97a293b2fefeecc349c6b785321e4b added `url` attribute from `fetchurl` and therefore also from `fetchzip`. We previously relied on `url` from fetchgit-based fetchers to find the repo URL but now it will just return tarballs in the case of `fetchFrom{GitHub,GitLab}`.

Let’s add an attribute to `fetch{git,FromGitHub,FromGitLab}` to expose a repo URL consistently.

cc @romildo
cc @SuperSandro2000 (who added `passthru.url` to `fetchurl`)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested updating treesheets.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
