### PR TITLE
python39Packages.tensorly: disable failing test

### DIFF
--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -1,9 +1,9 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
-, isPy27
 , numpy
+, pytestCheckHook
+, pythonOlder
 , scipy
 , sparse
 }:
@@ -11,32 +11,51 @@
 buildPythonPackage rec {
   pname = "tensorly";
   version = "0.7.0";
-  disabled = isPy27;
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "VcX3pCczZQUYZaD7xrrkOcj0QPJt28cYTwpZm5D/X3c=";
+    sha256 = "sha256-VcX3pCczZQUYZaD7xrrkOcj0QPJt28cYTwpZm5D/X3c=";
   };
 
-  # nose is not actually required for anything
-  # (including testing with the minimal dependencies)
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    sparse
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   postPatch = ''
-    substituteInPlace setup.py --replace ", 'nose'" ""
+    # nose is not actually required for anything
+    # (including testing with the minimal dependencies)
+    substituteInPlace setup.py \
+      --replace ", 'nose'" ""
   '';
 
-  propagatedBuildInputs = [ numpy scipy sparse ];
+  pythonImportsCheck = [
+    "tensorly"
+  ];
 
-  checkInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tensorly" ];
+  pytestFlagsArray = [
+    "tensorly"
+  ];
 
-  pythonImportsCheck = [ "tensorly" ];
+  disabledTests = [
+    # AssertionError: Partial_SVD took too long, maybe full_matrices set wrongly
+    "test_svd_time"
+  ];
 
   meta = with lib; {
     description = "Tensor learning in Python";
     homepage = "https://tensorly.org/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.bcdarwin ];
+    maintainers = with maintainers; [ bcdarwin ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/177831838)

ZHF: #172160


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
