### PR TITLE
ocamlPackages.google-drive-ocamlfuse: 0.7.26 → 0.7.28

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,21 +1,21 @@
 { lib, buildDunePackage, fetchFromGitHub
 , ocaml_extlib, ocamlfuse, gapi_ocaml, ocaml_sqlite3
+, ounit
 }:
 
 buildDunePackage rec {
   pname = "google-drive-ocamlfuse";
-  version = "0.7.26";
-
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.06";
+  version = "0.7.27";
 
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "google-drive-ocamlfuse";
     rev = "v${version}";
-    sha256 = "sha256-8s3DnpdYIVyJj5rtsof3WpLvX9wCrWU47dp4D6c986s=";
+    sha256 = "sha256:0dnllnzdc1lg742a4rqhwscnhwm4kv0sqq35bmg59fyws08cj2z8";
   };
+
+  doCheck = true;
+  checkInputs = [ ounit ];
 
   buildInputs = [ ocaml_extlib ocamlfuse gapi_ocaml ocaml_sqlite3 ];
 

--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,23 +1,24 @@
 { lib, buildDunePackage, fetchFromGitHub
 , ocaml_extlib, ocamlfuse, gapi_ocaml, ocaml_sqlite3
+, tiny_httpd
 , ounit
 }:
 
 buildDunePackage rec {
   pname = "google-drive-ocamlfuse";
-  version = "0.7.27";
+  version = "0.7.28";
 
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "google-drive-ocamlfuse";
     rev = "v${version}";
-    sha256 = "sha256:0dnllnzdc1lg742a4rqhwscnhwm4kv0sqq35bmg59fyws08cj2z8";
+    sha256 = "sha256:1layxqz5iz6wnvk83579m1im9vzq608h7n1h04znpkan0fls6nad";
   };
 
   doCheck = true;
   checkInputs = [ ounit ];
 
-  buildInputs = [ ocaml_extlib ocamlfuse gapi_ocaml ocaml_sqlite3 ];
+  buildInputs = [ ocaml_extlib ocamlfuse gapi_ocaml ocaml_sqlite3 tiny_httpd ];
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/tiny_httpd/default.nix
+++ b/pkgs/development/ocaml-modules/tiny_httpd/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, result
+, seq
+}:
+
+buildDunePackage rec {
+  pname = "tiny_httpd";
+  version = "0.12";
+
+  minimalOCamlVersion = "4.04";
+
+  src = fetchFromGitHub {
+    owner = "c-cube";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256:1z9hzc0ib7pg9fsjmpggjqwrnip57izr2v0na7vc7s25lxsiag6a";
+  };
+
+  buildInputs = [ result ];
+  propagatedBuildInputs = [ seq ];
+
+  meta = {
+    description = "Minimal HTTP server using good old threads";
+    inherit (src.meta) homepage;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1165,6 +1165,8 @@ let
 
     tcpip = callPackage ../development/ocaml-modules/tcpip { };
 
+    tiny_httpd = callPackage ../development/ocaml-modules/tiny_httpd { };
+
     tsort = callPackage ../development/ocaml-modules/tsort { };
 
     tuntap = callPackage ../development/ocaml-modules/tuntap { };


### PR DESCRIPTION
###### Description of changes

cc maintainer @obadz

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
