### PR TITLE
qt6.qtbase: add patch: use qt.conf from NIXOS_QT_CONF

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -48,6 +48,9 @@ let
         withGtk3 = true;
         inherit (srcs.qtbase) src version;
         inherit bison cups harfbuzz libGL dconf gtk3 developerBuild cmake;
+        patches = [
+          ./qtbase-qtconf.patch
+        ];
       };
 
       qt3d = callPackage ./modules/qt3d.nix { };

--- a/pkgs/development/libraries/qt-6/qtbase-qtconf.patch
+++ b/pkgs/development/libraries/qt-6/qtbase-qtconf.patch
@@ -1,0 +1,86 @@
+set qt paths without modifying the filesystem
+
+usage:
+makeWrapper --set QT_CONF /path/to/qt.conf
+
+limitations:
+same as qt.conf:
+* every key can have only one path, not a list of paths
+* with an empty qt.conf, Prefix defaults to $PWD
+
+docs:
+https://doc.qt.io/qt-6/qt-conf.html
+
+--- qtbase-everywhere-src-6.3.0/src/corelib/global/qlibraryinfo.cpp
++++ qtbase-everywhere-src-6.3.0/src/corelib/global/qlibraryinfo.cpp
+@@ -54,6 +54,9 @@
+ #include "archdetect.cpp"
+ #include "qconfig.cpp"
+ 
++#include <iostream> // std::cerr
++#include <iomanip> // std::setw std::left
++
+ #ifdef Q_OS_DARWIN
+ #  include "private/qcore_mac_p.h"
+ #endif // Q_OS_DARWIN
+@@ -126,6 +129,26 @@
+     if (QLibraryInfoPrivate::qtconfManualPath)
+         return new QSettings(*QLibraryInfoPrivate::qtconfManualPath, QSettings::IniFormat);
+ 
++    // use qt.conf path from environment variable NIXOS_QT_CONF
++    // otherwise, use dirname(argv[0])/qt.conf
++    QString qtconfigNixos = qgetenv("NIXOS_QT_CONF");
++    QString qtconfigNixosDebug = qgetenv("NIXOS_QT_CONF_DEBUG");
++    if (!qtconfigNixos.isEmpty()) {
++        if (QFile::exists(qtconfigNixos)) {
++            if (qtconfigNixosDebug == "1")
++                std::cerr << "NIXOS_QT_CONF_DEBUG: loading qt.conf from " << qtconfigNixos.toStdString() << std::endl;
++            return new QSettings(qtconfigNixos, QSettings::IniFormat);
++        }
++        else {
++            if (qtconfigNixosDebug == "1")
++                std::cerr << "NIXOS_QT_CONF_DEBUG: not found qt.conf in " << qtconfigNixos.toStdString() << " -> ignoring" << std::endl;
++        }
++    }
++    else {
++        if (qtconfigNixosDebug == "1")
++            std::cerr << "NIXOS_QT_CONF_DEBUG: NIXOS_QT_CONF is empty" << std::endl;
++    }
++
+     QString qtconfig = QStringLiteral(":/qt/etc/qt.conf");
+     if (QFile::exists(qtconfig))
+         return new QSettings(qtconfig, QSettings::IniFormat);
+@@ -628,6 +651,33 @@
+         }
+         ret = QDir::cleanPath(baseDir + QLatin1Char('/') + ret);
+     }
++
++#if QT_CONFIG(settings)
++    static bool qtconfigNixosDebugDone = false;
++    if (!qtconfigNixosDebugDone) {
++        qtconfigNixosDebugDone = true;
++        QString qtconfigNixosDebug = qgetenv("NIXOS_QT_CONF_DEBUG");
++        if (qtconfigNixosDebug == "1") {
++            std::cerr << "NIXOS_QT_CONF_DEBUG: QLibraryInfo paths:" << std::endl;
++            #define P(K) std::cout << "NIXOS_QT_CONF_DEBUG: " << std::left << std::setw(22) \
++                << #K << " = " << QLibraryInfo::path(QLibraryInfo::K).toStdString() << std::endl;
++            P(PrefixPath)
++            P(DocumentationPath)
++            P(HeadersPath)
++            P(LibrariesPath)
++            P(LibraryExecutablesPath)
++            P(BinariesPath)
++            P(PluginsPath)
++            P(QmlImportsPath)
++            P(ArchDataPath)
++            P(DataPath)
++            P(TranslationsPath)
++            P(ExamplesPath)
++            P(TestsPath)
++            P(SettingsPath) // not on windows
++        }
++    }
++#endif // settings
+     return ret;
+ }
+ 


### PR DESCRIPTION
allow setting the path to qt.conf via environment variable NIXOS_QT_CONF

useful for wrapping and debugging

fix https://github.com/NixOS/nixpkgs/pull/174275#issuecomment-1136109814
based on https://github.com/NixOS/nixpkgs/pull/169296#issuecomment-1133896656

also implement NIXOS_QT_CONF_DEBUG. example output:

```
$ cat qt.conf 
[Paths]
Prefix = /some-prefix
Data = /other/path
ArchData = /other/path/arch-data

$ ( cd /tmp && NIXOS_QT_CONF_DEBUG=1 NIXOS_QT_CONF=/home/milahu/qt-cmake-template/qt.conf /nix/store/7ypi19gfb1jwkh1yzy6j3bx0asiznnqy-helloworld-1.0.0/bin/hello-qt6 )
hello
NIXOS_QT_CONF_DEBUG: loading qt.conf from /home/milahu/qt-cmake-template/qt.conf
NIXOS_QT_CONF_DEBUG: QLibraryInfo paths:
NIXOS_QT_CONF_DEBUG: PrefixPath             = /some-prefix
NIXOS_QT_CONF_DEBUG: DocumentationPath      = /some-prefix/doc
NIXOS_QT_CONF_DEBUG: HeadersPath            = /some-prefix/include
NIXOS_QT_CONF_DEBUG: LibrariesPath          = /some-prefix/lib
NIXOS_QT_CONF_DEBUG: LibraryExecutablesPath = /some-prefix/libexec
NIXOS_QT_CONF_DEBUG: BinariesPath           = /some-prefix/bin
NIXOS_QT_CONF_DEBUG: PluginsPath            = /some-prefix/plugins
NIXOS_QT_CONF_DEBUG: QmlImportsPath         = /some-prefix/qml
NIXOS_QT_CONF_DEBUG: ArchDataPath           = /other/path/arch-data
NIXOS_QT_CONF_DEBUG: DataPath               = /other/path
NIXOS_QT_CONF_DEBUG: TranslationsPath       = /some-prefix/translations
NIXOS_QT_CONF_DEBUG: ExamplesPath           = /some-prefix/examples
NIXOS_QT_CONF_DEBUG: TestsPath              = /some-prefix/tests
NIXOS_QT_CONF_DEBUG: SettingsPath           = /some-prefix
```

cc @NickCao 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
