### PR TITLE
dump_syms: unstable-2022-05-05 -> 1.0.0

### DIFF
--- a/pkgs/development/tools/dump_syms/default.nix
+++ b/pkgs/development/tools/dump_syms/default.nix
@@ -11,7 +11,7 @@
 
 let
   pname = "dump_syms";
-  version = "unstable-2022-05-05";
+  version = "1.0.0";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -19,11 +19,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = pname;
-    rev = "c2743d59b5aa321ade698f84b90f86b3d35a1b06";
-    hash = "sha256-hWK9KrYqbfrF8b7i33InlTa/XkoZs+h49kUsKeSaAok=";
+    rev = "v${version}";
+    hash = "sha256-cgLlCNNid7JIukdWKy3nPJwyZ84YpKrnCC4Rm6E7DDk=";
   };
 
-  cargoSha256 = "sha256:0vsr867nl156wpxpw01bv9fxsp6rhj9vvpz2i2yhx4kjgr1qk1kw";
+  cargoSha256 = "sha256-0qRaBgIoWXYnQkxY7hFkvj3v/7mEGGRzQV7JFib8JRk=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
https://github.com/mozilla/dump_syms/releases/tag/v1.0.0

###### Description of changes

Moving to a released version. after 0.0.7 was not sufficient for generating symbols on 91.9.0esr.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
