### PR TITLE
transmission-remote-gtk: 1.4.1 -> 1.5.1

### DIFF
--- a/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
@@ -1,40 +1,30 @@
-{ lib, stdenv, autoconf, automake, libtool, wrapGAppsHook, fetchFromGitHub, pkg-config
-, intltool, gtk3, json-glib, curl, glib, autoconf-archive, appstream-glib, fetchpatch }:
-
+{ lib, stdenv, wrapGAppsHook, fetchFromGitHub, pkg-config, gtk3, json-glib, curl
+, glib, appstream-glib, desktop-file-utils, meson, ninja, geoip, gettext
+, libappindicator, libmrss, libproxy }:
 
 stdenv.mkDerivation rec {
   pname = "transmission-remote-gtk";
-  version = "1.4.1";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "transmission-remote-gtk";
     repo = "transmission-remote-gtk";
     rev = version;
-    sha256 = "1pipc1f94jdppv597mqmcj2kw2rdvaqcbl512v7z8vir76p1a7gk";
+    sha256 = "4/ID12JukDDvJzWupc76r7W8Us5erwv8oXZhDnB6VDk=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/transmission-remote-gtk/transmission-remote-gtk/commit/0f5cc8a9942e220ea0f7d0b17db4a78d094e3b65.patch";
-      sha256 = "195rsjpbc0gzmr9bycvq4mra7abp3hd9by3a5vvcmxsh5ipikycf";
-    })
-  ];
+  nativeBuildInputs =
+    [ desktop-file-utils wrapGAppsHook meson ninja pkg-config appstream-glib ];
 
-  preConfigure = "./autogen.sh";
+  buildInputs =
+    [ gtk3 json-glib curl glib gettext libmrss geoip libproxy libappindicator ];
 
-  nativeBuildInputs= [
-    autoconf automake libtool wrapGAppsHook
-    pkg-config intltool autoconf-archive
-    appstream-glib
-  ];
-
-  buildInputs = [ gtk3 json-glib curl glib ];
-
-  doCheck = false; # fails with style validation error
+  doCheck = false; # Requires network access
 
   meta = with lib; {
     description = "GTK remote control for the Transmission BitTorrent client";
-    homepage = "https://github.com/ajf8/transmission-remote-gtk";
+    homepage =
+      "https://github.com/transmission-remote-gtk/transmission-remote-gtk";
     license = licenses.gpl2;
     maintainers = [ maintainers.ehmry ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:
- 1.4.1 -> 1.4.2: https://github.com/transmission-remote-gtk/transmission-remote-gtk/releases/tag/1.4.2
- 1.4.2 -> 1.5.0: https://github.com/transmission-remote-gtk/transmission-remote-gtk/releases/tag/1.5.0
- 1.5.0 -> 1.5.1: https://github.com/transmission-remote-gtk/transmission-remote-gtk/releases/tag/1.5.1

This update includes an upstream fix for the -fno-common migration, see #110571 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
