### PR TITLE
qjoypad: 4.1.0 -> 4.3.1

### DIFF
--- a/pkgs/tools/misc/qjoypad/default.nix
+++ b/pkgs/tools/misc/qjoypad/default.nix
@@ -1,21 +1,19 @@
-{ lib, stdenv, fetchurl, pkg-config, libX11, libXtst, qt4 }:
-stdenv.mkDerivation rec {
+{ lib, mkDerivation, fetchFromGitHub, pkg-config, cmake, libX11, libXtst, qtbase, qttools, qtx11extras }:
+mkDerivation rec {
   pname = "qjoypad";
-  version = "4.1.0";
-  src = fetchurl {
-    url = "mirror://sourceforge/qjoypad/qjoypad-${version}.tar.gz";
-    sha256 = "1jlm7i26nfp185xrl41kz5z6fgvyj51bjpz48cg27xx64y40iamm";
+  version = "4.3.1";
+
+  src = fetchFromGitHub {
+    owner = "panzi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256:1w26ddxb1xirb7qjf7kv9llxzjhbhcb7warnxbx41qhbni46g26y";
   };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libX11 libXtst qt4 ];
-  NIX_LDFLAGS = "-lX11";
-  patchPhase = ''
-    cd src
-    substituteInPlace config --replace /bin/bash ${stdenv.shell}
-    mkdir -p $out
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath ${libX11}/lib"
-  '';
-  meta = {
+
+  nativeBuildInputs = [ pkg-config cmake ];
+  buildInputs = [ libX11 libXtst qtbase qttools qtx11extras ];
+
+  meta = with lib; {
     description = "A program that lets you use gaming devices anywhere";
     longDescription = ''
       A simple Linux/QT program that lets you use your gaming devices
@@ -33,9 +31,9 @@ stdenv.mkDerivation rec {
       of gaming devices in Linux, and makes the Linux gaming
       experience just a little bit nicer.
     '';
-    homepage = "http://qjoypad.sourceforge.net";
+    homepage = "https://github.com/panzi/qjoypad/";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ astsmtl ];
-    platforms = with lib.platforms; linux;
+    maintainers = with maintainers; [ astsmtl ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9675,7 +9675,7 @@ with pkgs;
 
   qjournalctl = libsForQt5.callPackage ../applications/system/qjournalctl { };
 
-  qjoypad = callPackage ../tools/misc/qjoypad { };
+  qjoypad = libsForQt5.callPackage ../tools/misc/qjoypad { };
 
   qmk = callPackage ../tools/misc/qmk { };
 


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).