### PR TITLE
uim: remove qt4, fix qt5

### DIFF
--- a/nixos/modules/i18n/input-method/uim.nix
+++ b/nixos/modules/i18n/input-method/uim.nix
@@ -10,7 +10,7 @@ in
 
     i18n.inputMethod.uim = {
       toolbar = mkOption {
-        type    = types.enum [ "gtk" "gtk3" "gtk-systray" "gtk3-systray" "qt4" ];
+        type    = types.enum [ "gtk" "gtk3" "gtk-systray" "gtk3-systray" "qt5" ];
         default = "gtk";
         example = "gtk-systray";
         description = ''

--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -7,8 +7,7 @@
 , withGtk2 ? withGtk, gtk2 ? null
 , withGtk3 ? withGtk, gtk3 ? null
 , withQt ? true
-, withQt4 ? withQt, qt4 ? null
-, withQt5 ? false, qt5 ? null
+, withQt5 ? withQt, qt5 ? null
 , withLibnotify ? true, libnotify ? null
 , withSqlite ? true, sqlite ? null
 , withNetworking ? true, curl ? null, openssl ? null
@@ -22,13 +21,6 @@ with lib;
 
 assert withGtk2 -> gtk2 != null;
 assert withGtk3 -> gtk3 != null;
-
-# TODO(@oxij): ./configure can't find both qmakes at the same time
-# this can be fixed by adding an alias qmake -> qmaka${version} in qmake derivation
-assert withQt4 -> !withQt5 && qt4 != null;
-assert withQt5 -> !withQt4 && qt5 != null;
-
-assert !withQt5; # fails to build with "Makefile.qmake: No such file or directory"
 
 assert withAnthy -> anthy != null;
 assert withLibnotify -> libnotify != null;
@@ -62,8 +54,7 @@ stdenv.mkDerivation rec {
   ++ optional withAnthy anthy
   ++ optional withGtk2 gtk2
   ++ optional withGtk3 gtk3
-  ++ optional withQt4 qt4
-  ++ optionals withQt5 [ qt5.qtbase.bin qt5.qtbase.dev ]
+  ++ optionals withQt5 (with qt5; [ qtbase.bin qtbase.dev qtx11extras wrapQtAppsHook ])
   ++ optional withLibnotify libnotify
   ++ optional withSqlite sqlite
   ++ optionals withNetworking [
@@ -102,10 +93,6 @@ stdenv.mkDerivation rec {
   ++ optional withAnthy "--with-anthy-utf8"
   ++ optional withGtk2 "--with-gtk2"
   ++ optional withGtk3 "--with-gtk3"
-  ++ optionals withQt4 [
-    "--with-qt4"
-    "--with-qt4-immodule"
-  ]
   ++ optionals withQt5 [
     "--with-qt5"
     "--with-qt5-immodule"


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).