### PR TITLE
oprofile: remove withGUI

### DIFF
--- a/pkgs/development/tools/profiling/oprofile/default.nix
+++ b/pkgs/development/tools/profiling/oprofile/default.nix
@@ -1,11 +1,7 @@
 { lib, stdenv, buildPackages
 , fetchurl, pkg-config
 , libbfd, popt, zlib, linuxHeaders, libiberty_static
-, withGUI ? false, qt4 ? null
 }:
-
-# libX11 is needed because the Qt build stuff automatically adds `-lX11'.
-assert withGUI -> qt4 != null;
 
 stdenv.mkDerivation rec {
   pname = "oprofile";
@@ -23,14 +19,12 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libbfd zlib popt linuxHeaders libiberty_static ]
-    ++ lib.optionals withGUI [ qt4 ];
+  buildInputs = [ libbfd zlib popt linuxHeaders libiberty_static ];
 
   configureFlags = [
-      "--with-kernel=${linuxHeaders}"
-      "--disable-shared"   # needed because only the static libbfd is available
-    ]
-    ++ lib.optional withGUI "--with-qt-dir=${qt4} --enable-gui=qt4";
+    "--with-kernel=${linuxHeaders}"
+    "--disable-shared"   # needed because only the static libbfd is available
+  ];
 
   meta = {
     description = "System-wide profiler for Linux";


### PR DESCRIPTION
###### Description of changes
hasn't been supported since 2014
see 0c142c3a096d3e9ec42cc9b0ddad994fea60d135 upstream

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).