### PR TITLE
home-assistant: support greeneye_monitor component

### DIFF
--- a/pkgs/development/python-modules/greeneye-monitor/default.nix
+++ b/pkgs/development/python-modules/greeneye-monitor/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, aiohttp
+, siobrultech-protocols
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "greeneye-monitor";
+  version = "3.0.3";
+
+  disabled = pythonOlder "3.5";
+
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "jkeljo";
+    repo = "greeneye-monitor";
+    rev = "v${version}";
+    hash = "sha256-weZTOVFBlB6TxFs8pLWfyB7WD/bn3ljBjX2tVi1Zc/I=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    siobrultech-protocols
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "greeneye.monitor" ];
+
+  meta = {
+    description = "Receive data packets from GreenEye Monitor";
+    homepage = "https://github.com/jkeljo/greeneye-monitor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/siobrultech-protocols/default.nix
+++ b/pkgs/development/python-modules/siobrultech-protocols/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "siobrultech-protocols";
+  version = "0.5.0";
+
+  disabled = pythonOlder "3.8";
+
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "sdwilsh";
+    repo = "siobrultech-protocols";
+    rev = "v${version}";
+    hash = "sha256-bpWOfdwNHJXfKcANSu69YgXsxsfUhaH63/fXF6H+MNg=";
+  };
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+    pyyaml
+  ];
+
+  pythonImportsCheck = [
+    "siobrultech_protocols.gem.api"
+    "siobrultech_protocols.gem.protocol"
+  ];
+
+  meta = {
+    description = "A Sans-I/O Python client library for Brultech Devices";
+    homepage = "https://github.com/sdwilsh/siobrultech-protocols";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1026,7 +1026,8 @@
       greeclimate
     ];
     "greeneye_monitor" = ps: with ps; [
-    ]; # missing inputs: greeneye_monitor
+      greeneye-monitor
+    ];
     "greenwave" = ps: with ps; [
     ]; # missing inputs: greenwavereality
     "group" = ps: with ps; [
@@ -3370,6 +3371,7 @@
     "gpslogger"
     "graphite"
     "gree"
+    "greeneye_monitor"
     "group"
     "growatt_server"
     "guardian"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3700,6 +3700,8 @@ in {
 
   green = callPackage ../development/python-modules/green { };
 
+  greeneye-monitor = callPackage ../development/python-modules/greeneye-monitor { };
+
   greenlet = callPackage ../development/python-modules/greenlet { };
 
   grequests = callPackage ../development/python-modules/grequests { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9557,6 +9557,8 @@ in {
 
   signify = callPackage ../development/python-modules/signify { };
 
+  siobrultech-protocols = callPackage ../development/python-modules/siobrultech-protocols { };
+
   siosocks = callPackage ../development/python-modules/siosocks { };
 
   sip = callPackage ../development/python-modules/sip { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
