### PR TITLE
selectdefaultapplication: init at unstable-2021-08-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9416,6 +9416,12 @@
     githubId = 20391;
     name = "Nahum Shalman";
   };
+  nsnelson = {
+    email = "noah.snelson@protonmail.com";
+    github = "peeley";
+    githubId = 30942198;
+    name = "Noah Snelson";
+  };
   nthorne = {
     email = "notrupertthorne@gmail.com";
     github = "nthorne";

--- a/pkgs/applications/misc/selectdefaultapplication/default.nix
+++ b/pkgs/applications/misc/selectdefaultapplication/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, qmake, qtbase, wrapQtAppsHook }:
+
+stdenv.mkDerivation {
+  pname = "selectdefaultapplication";
+  version = "unstable-2021-08-12";
+
+  src = fetchFromGitHub {
+    owner = "sandsmark";
+    repo = "selectdefaultapplication";
+    rev = "c752df6ba8caceeef54bcf6527f1bccc2ca8202a";
+    sha256 = "C/70xpt6RoQNIlAjSJhOCyheolK4Xp6RiSZmeqMP4fw=";
+  };
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+  buildInputs = [ qtbase ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp selectdefaultapplication $out/bin
+
+    install -Dm644 -t "$out/share/applications" selectdefaultapplication.desktop
+    install -Dm644 -t "$out/share/icons/hicolor/48x48/apps" selectdefaultapplication.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A very simple application that lets you define default applications on Linux in a sane way";
+    homepage = "https://github.com/sandsmark/selectdefaultapplication";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/selectdefaultapplication/default.nix
+++ b/pkgs/applications/misc/selectdefaultapplication/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "A very simple application that lets you define default applications on Linux in a sane way";
     homepage = "https://github.com/sandsmark/selectdefaultapplication";
+    maintainers = with maintainers; [ nsnelson ];
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10457,6 +10457,8 @@ with pkgs;
 
   seexpr = callPackage ../development/compilers/seexpr { };
 
+  selectdefaultapplication = libsForQt5.callPackage ../applications/misc/selectdefaultapplication { };
+
   semgrep = python3.pkgs.callPackage ../tools/security/semgrep { };
   semgrep-core = callPackage ../tools/security/semgrep/semgrep-core.nix { };
 


### PR DESCRIPTION
###### Description of changes

Creates the package definition for `selectdefaultapplication`, an application to select default applications for various file types on Linux systems.

Also adds myself (nsnelson) to the maintainer list and as the maintainer of `selectdefaultapplication`.

Closes #174133.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
