### PR TITLE
nixos/nix-gc: Execute nix-collect-garbage directly

### DIFF
--- a/nixos/modules/services/misc/nix-gc.nix
+++ b/nixos/modules/services/misc/nix-gc.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, utils, ... }:
 
 with lib;
 
@@ -90,7 +90,9 @@ in
 
     systemd.services.nix-gc = lib.mkIf config.nix.enable {
       description = "Nix Garbage Collector";
-      serviceConfig.ExecStart = "${config.nix.package.out}/bin/nix-collect-garbage ${cfg.options}";
+      serviceConfig.ExecStart = utils.escapeSystemdExecArgs [
+        "${config.nix.package.out}/bin/nix-collect-garbage"
+      ] ++ cfg.options;
       startAt = optional cfg.automatic cfg.dates;
     };
 

--- a/nixos/modules/services/misc/nix-gc.nix
+++ b/nixos/modules/services/misc/nix-gc.nix
@@ -90,7 +90,7 @@ in
 
     systemd.services.nix-gc = lib.mkIf config.nix.enable {
       description = "Nix Garbage Collector";
-      script = "exec ${config.nix.package.out}/bin/nix-collect-garbage ${cfg.options}";
+      serviceConfig.ExecStart = "${config.nix.package.out}/bin/nix-collect-garbage ${cfg.options}";
       startAt = optional cfg.automatic cfg.dates;
     };
 


### PR DESCRIPTION
No need to wrap this simple invocation in shell code.

Noticed by inspecting `systemctl cat nix-gc` once.
