### PR TITLE
weylus: Add GST plugins to GST_PLUGIN_PATH, weylus: 0.11.4 -> unstable-2022-06-07

### DIFF
--- a/pkgs/applications/graphics/weylus/default.nix
+++ b/pkgs/applications/graphics/weylus/default.nix
@@ -25,13 +25,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "weylus";
-  version = "0.11.4";
+  version = "unstable-2022-06-07";
 
   src = fetchFromGitHub {
     owner = "H-M-H";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0gq2czxvahww97j4i3k18np29zl6wx85f8253wn3ibqrpfnklz6l";
+    rev = "b169a6be2bf3e8d105273d92f032cca5438de53a";
+    sha256 = "sha256-J9eVFIfmyBviVuT1MYKb5yoacbPqOAT3A8jahWv5qw8=";
   };
 
   buildInputs = [
@@ -71,7 +71,7 @@ rustPlatform.buildRustPackage rec {
     libtool
   ];
 
-  cargoSha256 = "1pigmch0sy9ipsafd83b8q54xwqjxdaif363n1q8n46arq4v81j0";
+  cargoSha256 = "sha256-R46RSRdtfqi1PRQ0MaSIIqtj+Pr3yikm6NeMwwu1CSw=";
 
   cargoBuildFlags = [ "--features=ffmpeg-system" ];
   cargoTestFlags = [ "--features=ffmpeg-system" ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Redos #145051 after #161052, and bumps to an unstable version for Wayland fixes. Tested working on Sway with an iPad Air on the other end. In xournal++ the Apple Pencil worked correctly with pressure sensitivity.

The Wayland-related fixes are a bit hard to cherry pick as patches, and I'm not sure whether we should bump to unstable or wait for an upstream release before merging. ~Note that this version is being shipped in [upstream's Docker image](https://hub.docker.com/layers/weylus_build/hhmhh/weylus_build/latest/images/sha256-cfe7bdc232c41366c8a9fc9887724a3c87f82880b0d63a2082b11d8004e1c891?context=explore).~

Ref: H-M-H/Weylus#155

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
