### PR TITLE
wireshark: 3.6.3 -> 3.6.5

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -11,7 +11,7 @@ assert withQt  -> qt5  != null;
 with lib;
 
 let
-  version = "3.6.3";
+  version = "3.6.5";
   variant = if withQt then "qt" else "cli";
 
 in stdenv.mkDerivation {
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "sha256-tgNkpMAGihCBGrP9B1ymwesOddRGACcbiKIO2Tou9jE=";
+    sha256 = "sha256-otdB1g/zUWE31LnzjNwH7uVKVuw2BG9MOv7mv7T26qE=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Description of changes
Changelogs:
 - https://www.wireshark.org/docs/relnotes/wireshark-3.6.4.html
 - https://www.wireshark.org/docs/relnotes/wireshark-3.6.5.html (only has a bug fix for windows)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (tested normal usage)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
# nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /root/.cache/nixpkgs-review/rev-086468ce4e09508eb2105d42be3b80cfc7cf4b37-2/nixpkgs dca832b5de38a0b4df24cef2e939de5b7ca9a2c4
Preparing worktree (detached HEAD dca832b5de3)
Updating files: 100% (30619/30619), done.
HEAD is now at dca832b5de3 buildah-unwrapped: 1.25.1 -> 1.26.1
$ nix-env --option system x86_64-linux -f /root/.cache/nixpkgs-review/rev-086468ce4e09508eb2105d42be3b80cfc7cf4b37-2/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff 086468ce4e09508eb2105d42be3b80cfc7cf4b37
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /root/.cache/nixpkgs-review/rev-086468ce4e09508eb2105d42be3b80cfc7cf4b37-2/nixpkgs -qaP --xml --out-path --show-trace --meta
11 packages updated:
compactor credslayer haka hfinger ostinato python3.10-pyshark python3.9-pyshark termshark wifite2 tshark (3.6.3 → 3.6.5) wireshark (3.6.3 → 3.6.5)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /root/.cache/nixpkgs-review/rev-086468ce4e09508eb2105d42be3b80cfc7cf4b37-2/build.nix
error: builder for '/nix/store/dnpmk5i9s1zylskaplg7vlnzq8wd1k0f-ostinato.desktop.drv' failed with exit code 1;
       last 1 log lines:
       > /nix/store/sbv3l3v7hha3xbyw9ac111s1h25wj3i5-ostinato.desktop/share/applications/ostinato.desktop: error: value "$out/bin/ostinato" for key "Exec" in group "Desktop Entry" contains a reserved character '$' outside of a quote
       For full logs, run 'nix log /nix/store/dnpmk5i9s1zylskaplg7vlnzq8wd1k0f-ostinato.desktop.drv'.
error: 1 dependencies of derivation '/nix/store/krkbqfh4cra5q76vnwwdvydg3242b6sn-ostinato-1.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/0d93igdpkgan9dll98lnh0rjrk1pb5vz-review-shell.drv' failed to build
1 package failed to build:
ostinato

10 packages built:
compactor credslayer haka hfinger python310Packages.pyshark python39Packages.pyshark termshark tshark wifite2 wireshark

$ nix-shell /root/.cache/nixpkgs-review/rev-086468ce4e09508eb2105d42be3b80cfc7cf4b37-2/shell.nix
error: Alias tshark is still in all-packages.nix
(use '--show-trace' to show detailed location information)
$ git worktree prune
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (tested wiresharks and tshark)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
cc @bjornfor @fpletz 
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
