### PR TITLE
release-alternatives.nix: fix eval

### DIFF
--- a/pkgs/top-level/release-alternatives.nix
+++ b/pkgs/top-level/release-alternatives.nix
@@ -9,7 +9,7 @@ let
   blasUsers = [
     # "julia_07" "julia_10" "julia_11" "julia_13" "octave" "octaveFull"
     "fflas-ffpack" "linbox" "R" "ipopt" "hpl" "rspamd" "octopus"
-    "sundials" "superlu" "suitesparse_5_3" "suitesparse_4_4"
+    "superlu" "suitesparse_5_3" "suitesparse_4_4"
     "suitesparse_4_2" "scs" "scalapack" "petsc" "cholmod-extra"
     "arpack" "qrupdate" "libcint" "iml" "globalarrays" "arrayfire" "armadillo"
     "xfitter" "lammps" "plink-ng" "quantum-espresso" "siesta"
@@ -33,10 +33,10 @@ let
     ["haskellPackages" "bindings-levmar"]
   ] ++ lib.optionals allowUnfree [ "magma" ];
   blas64Users = [
-    "rspamd" "suitesparse_5_3" "suitesparse_4_4"
+    "rspamd" "sundials" "suitesparse_5_3" "suitesparse_4_4"
     "suitesparse_4_2" "petsc" "cholmod-extra"
     "arpack" "qrupdate" "iml" "globalarrays" "arrayfire"
-    "xfitter" "lammps" "plink-ng" "quantum-espresso"
+    "lammps" "plink-ng" "quantum-espresso"
     "calculix" "csdp" "getdp" "jags"
     "lammps" "lammps-mpi"
     # ["ocamlPackages" "lacaml"]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
sundial requires ILP64, and xfitter requires !ILP64 through its
dependency on numpy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
