### PR TITLE
[Backport release-22.05] tracee: init at 0.7.0

### DIFF
--- a/pkgs/tools/security/tracee/bpf-core-clang-bpf.patch
+++ b/pkgs/tools/security/tracee/bpf-core-clang-bpf.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index d5cd754..db1c1d3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -411,7 +411,7 @@ $(OUTPUT_DIR)/tracee.bpf.core.o: \
+ 	$(TRACEE_EBPF_OBJ_CORE_HEADERS)
+ #
+ 	$(MAKE) $(OUTPUT_DIR)/tracee.bpf
+-	$(CMD_CLANG) \
++	$(CMD_CLANG_BPF) \
+ 		-D__TARGET_ARCH_$(LINUX_ARCH) \
+ 		-D__BPF_TRACING__ \
+ 		-DCORE \

--- a/pkgs/tools/security/tracee/default.nix
+++ b/pkgs/tools/security/tracee/default.nix
@@ -1,0 +1,113 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+
+, llvmPackages_13
+, pkg-config
+
+, zlib
+, libelf
+}:
+
+let
+  inherit (llvmPackages_13) clang;
+  clang-with-bpf =
+    (clang.overrideAttrs (o: { pname = o.pname + "-with-bpf"; })).override (o: {
+      extraBuildCommands = o.extraBuildCommands + ''
+        # make a separate wrapped clang we can target at bpf
+        cp $out/bin/clang $out/bin/clang-bpf
+        # extra flags to append after the cc-cflags
+        echo '-target bpf -fno-stack-protector' > $out/nix-support/cc-cflags-bpf
+        # use sed to attach the cc-cflags-bpf after cc-cflags
+        sed -i -E "s@^(extraAfter=\(\\$\NIX_CFLAGS_COMPILE_.*)(\))\$@\1 $(cat $out/nix-support/cc-cflags-bpf)\2@" $out/bin/clang-bpf
+      '';
+    });
+in
+buildGoModule rec {
+  pname = "tracee";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "aquasecurity";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Y++FWxADnj1W5S3VrAlJAnotFYb6biCPJ6dpQ0Nin8o=";
+    # Once libbpf hits 1.0 we will migrate to the nixpkgs libbpf rather than the
+    # pinned copy in submodules
+    fetchSubmodules = true;
+  };
+  vendorSha256 = "sha256-C2RExp67qax8+zJIgyMJ18sBtn/xEYj4tAvGCCpBssQ=";
+
+  patches = [
+    # bpf-core can't be compiled with wrapped clang since it forces the target
+    # we need to be able to replace it with another wrapped clang that has
+    # it's target as bpf
+    ./bpf-core-clang-bpf.patch
+    # add -s to ldflags for smaller binaries
+    ./disable-go-symbol-table.patch
+  ];
+
+
+  enableParallelBuilding = true;
+
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config clang-with-bpf ];
+  buildInputs = [ zlib libelf ];
+
+  makeFlags = [
+    "VERSION=v${version}"
+    "CMD_CLANG_BPF=clang-bpf"
+    # don't actually need git but the Makefile checks for it
+    "CMD_GIT=echo"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    make $makeFlags ''${enableParallelBuilding:+-j$NIX_BUILD_CORES -l$NIX_BUILD_CORES}
+    runHook postBuild
+  '';
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/tracee}
+
+    cp ./dist/tracee-ebpf $out/bin
+    cp ./dist/tracee-rules $out/bin
+
+    cp -r ./dist/rules $out/share/tracee/
+    cp -r ./cmd/tracee-rules/templates $out/share/tracee/
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/tracee-ebpf --help
+    $out/bin/tracee-ebpf --version | grep "v${version}"
+
+    $out/bin/tracee-rules --help
+
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://aquasecurity.github.io/tracee/latest/";
+    changelog = "https://github.com/aquasecurity/tracee/releases/tag/v${version}";
+    description = "Linux Runtime Security and Forensics using eBPF";
+    longDescription = ''
+      Tracee is a Runtime Security and forensics tool for Linux. It is using
+      Linux eBPF technology to trace your system and applications at runtime,
+      and analyze collected events to detect suspicious behavioral patterns. It
+      is delivered as a Docker image that monitors the OS and detects suspicious
+      behavior based on a pre-defined set of behavioral patterns.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/security/tracee/disable-go-symbol-table.patch
+++ b/pkgs/tools/security/tracee/disable-go-symbol-table.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile b/Makefile
+index d5cd754..0b74a79 100644
+--- a/Makefile
++++ b/Makefile
+@@ -471,7 +471,7 @@ ifeq ($(BTFHUB), 1)
+ endif
+ 	$(GO_ENV_EBPF) $(CMD_GO) build \
+ 		-tags $(GO_TAGS_EBPF) \
+-		-ldflags="-w \
++		-ldflags="-s -w \
+ 			-extldflags \"$(CGO_EXT_LDFLAGS_EBPF)\" \
+ 			-X main.version=\"$(VERSION)\" \
+ 			" \
+@@ -552,7 +552,7 @@ $(OUTPUT_DIR)/tracee-rules: \
+ #
+ 	$(GO_ENV_RULES) $(CMD_GO) build \
+ 		-tags $(GO_TAGS_RULES) \
+-		-ldflags="-w \
++		-ldflags="-s -w \
+ 			-extldflags \"$(CGO_EXT_LDFLAGS_RULES)\" \
+ 			" \
+ 		-v -o $@ \

--- a/pkgs/tools/security/tracee/skip-init-test.patch
+++ b/pkgs/tools/security/tracee/skip-init-test.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/integration/integration_test.go b/tests/integration/integration_test.go
+index 8601eb9..57088d2 100644
+--- a/tests/integration/integration_test.go
++++ b/tests/integration/integration_test.go
+@@ -149,6 +149,7 @@ func checkUidzero(t *testing.T, gotOutput *bytes.Buffer) {
+ 
+ // only capture pids of 1
+ func checkPidOne(t *testing.T, gotOutput *bytes.Buffer) {
++    t.Skip("Not compatible with systemd init")
+ 	_, _ = exec.Command("init", "q").CombinedOutput()
+ 
+ 	waitForTraceeOutput(gotOutput, time.Now())

--- a/pkgs/tools/security/tracee/skip-magic_write-test.patch
+++ b/pkgs/tools/security/tracee/skip-magic_write-test.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/integration/integration_test.go b/tests/integration/integration_test.go
+index 8601eb9..a8a3eed 100644
+--- a/tests/integration/integration_test.go
++++ b/tests/integration/integration_test.go
+@@ -75,6 +75,7 @@ func waitForTraceeOutput(gotOutput *bytes.Buffer, now time.Time) {
+ 
+ // small set of actions to trigger a magic write event
+ func checkMagicwrite(t *testing.T, gotOutput *bytes.Buffer) {
++    t.Skip()
+ 	// create a temp dir for testing
+ 	d, err := ioutil.TempDir("", "Test_MagicWrite-dir-*")
+ 	require.NoError(t, err)

--- a/pkgs/tools/security/tracee/test.nix
+++ b/pkgs/tools/security/tracee/test.nix
@@ -1,0 +1,41 @@
+{ pkgs ? import ../../../../. { } }:
+
+# manually run `nix-build ./pkgs/tools/security/tracee/test.nix` to test
+pkgs.nixosTest ({
+  name = "tracee-test";
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      environment.systemPackages = [
+        pkgs.tracee
+        # build the go integration tests as a binary
+        (pkgs.tracee.overrideAttrs (oa: {
+          pname = oa.pname + "-integration";
+          patches = oa.patches or [] ++ [
+            # skip test that runs `init -q` which is incompatible with systemd init
+            ./skip-init-test.patch
+            # skip magic_write test that currently fails
+            ./skip-magic_write-test.patch
+          ];
+          # just build the static lib we need for the go test binary
+          makeFlags = oa.makeFlags ++ [ "./dist/libbpf/libbpf.a" ];
+          postBuild = ''
+            # by default the tests are disabled and this is intended to be commented out
+            sed -i '/t.Skip("This test requires root privileges")/d' ./tests/integration/integration_test.go
+            CGO_CFLAGS="-I$PWD/dist/libbpf" CGO_LDFLAGS="-lelf -lz $PWD/dist/libbpf/libbpf.a" go test -tags ebpf,integration -c -o $GOPATH/tracee-integration ./tests/integration
+          '';
+          doCheck = false;
+          installPhase = ''
+            mkdir -p $out/bin
+            cp $GOPATH/tracee-integration $out/bin
+          '';
+          doInstallCheck = false;
+        }))
+      ];
+    };
+  };
+
+  testScript = ''
+    with subtest("run integration tests"):
+      print(machine.succeed('TRC_BIN="$(which tracee-ebpf)" tracee-integration -test.v -test.run "Test_Events"'))
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11014,6 +11014,8 @@ with pkgs;
 
   tracebox = callPackage ../tools/networking/tracebox { };
 
+  tracee = callPackage ../tools/security/tracee { };
+
   tracefilegen = callPackage ../development/tools/analysis/garcosim/tracefilegen { };
 
   tracefilesim = callPackage ../development/tools/analysis/garcosim/tracefilesim { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport tracee so it is in the stable release rather than waiting months for the next stable

I think this is how you backport :eyes: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
