### PR TITLE
metamorphose2: 0.9.0 -> 0.10.0 & revert drop

### DIFF
--- a/pkgs/applications/misc/metamorphose2/default.nix
+++ b/pkgs/applications/misc/metamorphose2/default.nix
@@ -1,41 +1,42 @@
-{ lib, stdenv, fetchgit, makeWrapper, gettext
-, python27, python2Packages
+{ lib, stdenv, fetchFromGitHub, makeWrapper, gettext
+, python3
 }:
 
 stdenv.mkDerivation {
   pname = "metamorphose2";
-  version = "0.9.0beta";
+  version = "0.10.0beta";
 
   # exif-py vendored via submodule
-  # mutagen vendored via copy
-  src = fetchgit {
-    url = "https://github.com/metamorphose/metamorphose2.git";
-    #rev = "refs/tags/v2.${version}"; #for when wxPython3 support is released
-    rev = "d2bdd6a86340b9668e93b35a6a568894c9909d68";
-    sha256 = "0ivcb3c8hidrff0ivl4dnwa2p3ihpqjdbvdig8dhg9mm5phdbabn";
+  src = fetchFromGitHub {
+    owner = "timinaust";
+    repo = "metamorphose2";
+    rev = "ba0666dd02e4f3f58c1dadc309e7ec1cc13fe851";
+    sha256 = "0w9l1vyyswdhdwrmi71g23qyslvhg1xym4ksifd42vwf9dxy55qp";
+    fetchSubmodules = true;
   };
 
   postPatch = ''
+    rm -rf ./src/mutagen
     substituteInPlace messages/Makefile \
       --replace "\$(shell which msgfmt)" "${gettext}/bin/msgfmt"
   '';
 
   postInstall = ''
     rm $out/bin/metamorphose2
-    makeWrapper ${python27}/bin/python $out/bin/metamorphose2 \
+    makeWrapper ${python3.interpreter} $out/bin/metamorphose2 \
       --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out") \
       --add-flags "-O $out/share/metamorphose2/metamorphose2.py -w=3"
   '';
 
-  buildInput = [ gettext python27 ];
+  buildInput = [ gettext python3 ];
   nativeBuildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ python2Packages.wxPython python2Packages.pillow ];
+  propagatedBuildInputs = with python3.pkgs; [ mutagen wxPython_4_1 pillow six ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
     description = "a graphical mass renaming program for files and folders";
-    homepage    = "https://github.com/metamorphose/metamorphose2";
+    homepage    = "https://github.com/timinaust/metamorphose2";
     license     = with licenses; gpl3Plus;
     maintainers = with maintainers; [ ramkromberg ];
     platforms   = with platforms; linux;

--- a/pkgs/applications/misc/metamorphose2/default.nix
+++ b/pkgs/applications/misc/metamorphose2/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchgit, makeWrapper, gettext
+, python27, python2Packages
+}:
+
+stdenv.mkDerivation {
+  pname = "metamorphose2";
+  version = "0.9.0beta";
+
+  # exif-py vendored via submodule
+  # mutagen vendored via copy
+  src = fetchgit {
+    url = "https://github.com/metamorphose/metamorphose2.git";
+    #rev = "refs/tags/v2.${version}"; #for when wxPython3 support is released
+    rev = "d2bdd6a86340b9668e93b35a6a568894c9909d68";
+    sha256 = "0ivcb3c8hidrff0ivl4dnwa2p3ihpqjdbvdig8dhg9mm5phdbabn";
+  };
+
+  postPatch = ''
+    substituteInPlace messages/Makefile \
+      --replace "\$(shell which msgfmt)" "${gettext}/bin/msgfmt"
+  '';
+
+  postInstall = ''
+    rm $out/bin/metamorphose2
+    makeWrapper ${python27}/bin/python $out/bin/metamorphose2 \
+      --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out") \
+      --add-flags "-O $out/share/metamorphose2/metamorphose2.py -w=3"
+  '';
+
+  buildInput = [ gettext python27 ];
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python2Packages.wxPython python2Packages.pillow ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "a graphical mass renaming program for files and folders";
+    homepage    = "https://github.com/metamorphose/metamorphose2";
+    license     = with licenses; gpl3Plus;
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms   = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -820,7 +820,6 @@ mapAliases ({
   mercurial_4 = throw "mercurial_4 has been removed as it's unmaintained"; # Added 2021-10-18
   mesos = throw "mesos has been removed from nixpkgs, as it's unmaintained"; # Added 2020-08-15
   mess = mame; # Added 2019-10-30
-  metamorphose2 = throw "metamorphose2 has been removed from nixpkgs, as it was stuck on python2"; # Added 2022-01-12
   mididings = throw "mididings has been removed from nixpkgs as it doesn't support recent python3 versions and its upstream stopped maintaining it"; # Added 2022-01-12
   midoriWrapper = throw "'midoriWrapper' has been renamed to/replaced by 'midori'"; # Converted to throw 2022-02-22
   mime-types = mailcap; # Added 2022-01-21

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8284,6 +8284,8 @@ with pkgs;
 
   mencal = callPackage ../applications/misc/mencal { } ;
 
+  metamorphose2 = callPackage ../applications/misc/metamorphose2 { };
+
   metar = callPackage ../applications/misc/metar { };
 
   mfcuk = callPackage ../tools/security/mfcuk { };


### PR DESCRIPTION
###### Description of changes

a new fork replaced python2 with python3 so reverted the drop and updated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
