### PR TITLE
python310Packages.drf-spectacular: init at 0.22.1

### DIFF
--- a/pkgs/development/python-modules/drf-spectacular/default.nix
+++ b/pkgs/development/python-modules/drf-spectacular/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, dj-rest-auth
+, django
+, django-allauth
+, django-filter
+, django-oauth-toolkit
+, django-polymorphic
+, django-rest-auth
+, django-rest-polymorphic
+, djangorestframework
+, djangorestframework-camel-case
+, djangorestframework-dataclasses
+, djangorestframework-recursive
+, djangorestframework-simplejwt
+, drf-jwt
+, drf-nested-routers
+, drf-spectacular-sidecar
+, inflection
+, jsonschema
+, psycopg2
+, pytest-django
+, pytestCheckHook
+, pyyaml
+, uritemplate
+}:
+
+buildPythonPackage rec {
+  pname = "drf-spectacular";
+  version = "0.22.1";
+
+  src = fetchFromGitHub {
+    owner = "tfranzel";
+    repo = "drf-spectacular";
+    rev = version;
+    sha256 = "sha256-SgzyIzgFBXsNHfY2OfCq0LhJyi/ZCOSA8QveKNduIBc=";
+  };
+
+  propagatedBuildInputs = [
+    django
+    djangorestframework
+    inflection
+    jsonschema
+    pyyaml
+    uritemplate
+  ];
+
+  checkInputs = [
+    dj-rest-auth
+    django-allauth
+    django-filter
+    django-oauth-toolkit
+    django-polymorphic
+    django-rest-auth
+    django-rest-polymorphic
+    djangorestframework-camel-case
+    djangorestframework-dataclasses
+    djangorestframework-recursive
+    djangorestframework-simplejwt
+    drf-jwt
+    drf-nested-routers
+    drf-spectacular-sidecar
+    psycopg2
+    pytest-django
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "drf_spectacular" ];
+
+  meta = with lib; {
+    description = "Sane and flexible OpenAPI 3 schema generation for Django REST framework";
+    homepage = "https://github.com/tfranzel/drf-spectacular";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2548,6 +2548,8 @@ in {
 
   drf-nested-routers = callPackage ../development/python-modules/drf-nested-routers { };
 
+  drf-spectacular = callPackage ../development/python-modules/drf-spectacular { };
+
   drf-spectacular-sidecar = callPackage ../development/python-modules/drf-spectacular-sidecar { };
 
   drf-yasg = callPackage ../development/python-modules/drf-yasg { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
