### PR TITLE
linux_zen: 5.17.7-zen1 -> 5.18.0-zen1

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -2,7 +2,7 @@
 
 let
   # having the full version string here makes it easier to update
-  modDirVersion = "5.17.7-zen1";
+  modDirVersion = "5.18.0-zen1";
   parts = lib.splitString "-" modDirVersion;
   version = lib.elemAt parts 0;
   suffix = lib.elemAt parts 1;
@@ -20,7 +20,7 @@ buildLinux (args // {
     owner = "zen-kernel";
     repo = "zen-kernel";
     inherit rev;
-    sha256 = "sha256-sjXe+L9ZTtHDPLFY5d7Ui0NU0s7fw0qLfXIDnRxpKvE=";
+    sha256 = "sha256-A0QrY1REbRODnHtmyNqVaiLhDgYCECevfHZCxtoQ9kU=";
   };
 
   structuredExtraConfig = with lib.kernel; {

--- a/pkgs/os-specific/linux/kernel/update-zen.sh
+++ b/pkgs/os-specific/linux/kernel/update-zen.sh
@@ -7,6 +7,8 @@ old=$(nix-instantiate --eval -A linuxPackages_zen.kernel.modDirVersion "$nixpkgs
 old="${old%\"}"
 old="${old#\"}"
 new=$(curl https://github.com/zen-kernel/zen-kernel/releases.atom | grep -m1 -o -E '[0-9.]+-zen[0-9]+')
+# add ".0" patch to modDirVersion when minor only
+new=$(echo "$new" | sed -E 's/^([0-9]+)\.([0-9]+)-(\w+)$/\1.\2.0-\3/')
 if [[ "$new" == "$old" ]]; then
     echo "already up-to-date"
     exit 0


### PR DESCRIPTION
###### Description of changes
Bump zen kernel to [v5.18, released in 24 May 2022](https://github.com/zen-kernel/zen-kernel/releases/tag/v5.18-zen1).
Also fixes update script for `.0` patch versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
