### PR TITLE
[Backport release-21.11] logrotate: fix CVE-2022-1348

### DIFF
--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -14,6 +14,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-OJOV++rtN9ry+l0c0eanpu/Pwu8cOHfyEaDWp3FZjkw=";
   };
 
+  patches = [
+    # Fix CVE-2022-1348 by backporting two upstream commits
+    # - 1f76a381e2caa0603ae3dbc51ed0f1aa0d6658b9 and
+    # - addbd293242b0b78aa54f054e6c1d249451f137d
+    # in a custom patch, as cherry-picking directly failed.
+    ./fix-cve-2022-1348.diff
+  ];
+
   # Logrotate wants to access the 'mail' program; to be done.
   configureFlags = [
     "--with-compress-command=${gzip}/bin/gzip"

--- a/pkgs/tools/system/logrotate/fix-cve-2022-1348.diff
+++ b/pkgs/tools/system/logrotate/fix-cve-2022-1348.diff
@@ -1,0 +1,69 @@
+diff --git a/logrotate.c b/logrotate.c
+index d7a1c19..45b985a 100644
+--- a/logrotate.c
++++ b/logrotate.c
+@@ -2514,6 +2514,7 @@ static int writeState(const char *stateFilename)
+     struct tm now;
+     time_t now_time, last_time;
+     char *prevCtx;
++    int force_mode = 0;
+ 
+     localtime_r(&nowSecs, &now);
+ 
+@@ -2581,7 +2582,13 @@ static int writeState(const char *stateFilename)
+ 
+     close(fdcurr);
+ 
+-    fdsave = createOutputFile(tmpFilename, O_RDWR | O_CREAT | O_TRUNC, &sb, prev_acl, 0);
++    if (sb.st_mode & (mode_t)S_IROTH) {
++        /* drop world-readable flag to prevent others from locking */
++        sb.st_mode &= ~(mode_t)S_IROTH;
++        force_mode = 1;
++    }
++
++    fdsave = createOutputFile(tmpFilename, O_RDWR | O_CREAT | O_TRUNC, &sb, prev_acl, force_mode);
+ #ifdef WITH_ACL
+     if (prev_acl) {
+         acl_free(prev_acl);
+@@ -2915,14 +2922,16 @@ static int readState(const char *stateFilename)
+ static int lockState(const char *stateFilename, int skip_state_lock)
+ {
+     int lockFd = open(stateFilename, O_RDWR | O_CLOEXEC);
++    struct stat sb;
++
+     if (lockFd == -1) {
+         if (errno == ENOENT) {
+             message(MESS_DEBUG, "Creating stub state file: %s\n",
+                     stateFilename);
+ 
+-            /* create a stub state file with mode 0644 */
++            /* create a stub state file with mode 0640 */
+             lockFd = open(stateFilename, O_CREAT | O_EXCL | O_WRONLY,
+-                          S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
++                          S_IWUSR | S_IRUSR | S_IRGRP);
+             if (lockFd == -1) {
+                 message(MESS_ERROR, "error creating stub state file %s: %s\n",
+                         stateFilename, strerror(errno));
+@@ -2942,6 +2951,22 @@ static int lockState(const char *stateFilename, int skip_state_lock)
+         return 0;
+     }
+ 
++    if (fstat(lockFd, &sb) == -1) {
++        message(MESS_ERROR, "error stat()ing state file %s: %s\n",
++                stateFilename, strerror(errno));
++        close(lockFd);
++        return 1;
++    }
++
++    if (sb.st_mode & S_IROTH) {
++        message(MESS_ERROR, "state file %s is world-readable and thus can"
++                " be locked from other unprivileged users."
++                " Skipping lock acquisition...\n",
++                stateFilename);
++        close(lockFd);
++        return 0;
++    }
++
+     if (flock(lockFd, LOCK_EX | LOCK_NB) == -1) {
+         if (errno == EWOULDBLOCK) {
+             message(MESS_ERROR, "state file %s is already locked\n"


### PR DESCRIPTION
###### Description of changes
Fixes CVE-2022-1348.

Manual backport of #174565.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
