### PR TITLE
python310Packages.apipkg: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/apipkg/default.nix
+++ b/pkgs/development/python-modules/apipkg/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "apipkg";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a4be31cf8081e660d2cdea6edfb8a0f39f385866abdcfcfa45e5a0887345cb70";
+    sha256 = "sha256-zKNAIkFKE5duM6HjjWoJBWfve2jQNy+SPGmaj4wIivw=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/apipkg/default.nix
+++ b/pkgs/development/python-modules/apipkg/default.nix
@@ -1,41 +1,39 @@
-{ lib, buildPythonPackage, fetchPypi
-, pytest, setuptools-scm, isPy3k }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, setuptools-scm
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "apipkg";
   version = "2.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-zKNAIkFKE5duM6HjjWoJBWfve2jQNy+SPGmaj4wIivw=";
+    hash = "sha256-zKNAIkFKE5duM6HjjWoJBWfve2jQNy+SPGmaj4wIivw=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
-  checkInputs = [ pytest ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
-  # Fix pytest 4 support. See: https://github.com/pytest-dev/apipkg/issues/14
-  postPatch = ''
-    substituteInPlace "test_apipkg.py" \
-      --replace "py.test.ensuretemp('test_apipkg')" "py.path.local('test_apipkg')"
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  # Failing tests on Python 3
-  # https://github.com/pytest-dev/apipkg/issues/17
-  checkPhase = let
-    disabledTests = lib.optionals isPy3k [
-      "test_error_loading_one_element"
-      "test_aliasmodule_proxy_methods"
-      "test_eagerload_on_bython"
-    ];
-    testExpression = lib.optionalString (disabledTests != [])
-    "-k 'not ${lib.concatStringsSep " and not " disabledTests}'";
-  in ''
-    py.test ${testExpression}
-  '';
+  pythonImportsCheck = [
+    "apipkg"
+  ];
 
   meta = with lib; {
     description = "Namespace control and lazy-import mechanism";
     homepage = "https://github.com/pytest-dev/apipkg";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/pytest-dev/apipkg/releases/tag/v2.1.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
