### PR TITLE
ostinato: fix desktop file

### DIFF
--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -1,6 +1,7 @@
 { lib, mkDerivation, fetchFromGitHub, fetchurl, qmake, makeDesktopItem
 , qtbase, qtscript, protobuf, libpcap, wireshark, gzip, diffutils, gawk
 , libnl
+, copyDesktopItems
 }:
 
 mkDerivation rec {
@@ -21,31 +22,34 @@ mkDerivation rec {
 
   buildInputs = [ qtbase protobuf libpcap qtscript libnl ];
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    qmake
+  ];
 
   patches = [ ./drone_ini.patch ];
   prePatch = ''
     sed -i 's|/usr/include/libnl3|${libnl.dev}/include/libnl3|' server/drone.pro
   '';
 
-  desktopItem = makeDesktopItem {
+  desktopItems = lib.singleton (makeDesktopItem {
     name          = "ostinato";
     desktopName   = "Ostinato";
     genericName   = "Packet/Traffic Generator and Analyzer";
     comment       = "Network packet and traffic generator and analyzer with a friendly GUI";
     categories    = [ "Network" ];
     startupNotify = true;
-    exec          = "$out/bin/ostinato";
+    exec          = "@out@/bin/ostinato";
     icon          =  ostinatoIcon;
     extraConfig   = {
       "GenericName[it]" = "Generatore ed Analizzatore di pacchetti di rete";
       "Comment[it]"     = "Generatore ed Analizzatore di pacchetti di rete con interfaccia amichevole";
     };
-  };
+  });
 
-  postInstall = ''
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+  preFixup = ''
+    substituteInPlace $out/share/applications/ostinato.desktop \
+      --subst-var out
 
     cat > $out/bin/ostinato.ini <<EOF
     WiresharkPath=${wireshark}/bin/wireshark
@@ -62,8 +66,8 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "A packet traffic generator and analyzer";
-    homepage    = "https://ostinato.org";
-    license     = licenses.gpl3;
+    homepage    = "https://ostinato.org/";
+    license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ rick68 ];
     platforms   = with platforms; linux ++ darwin ++ cygwin;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
ZHF: #172160
cc @NixOS/nixos-release-managers 