### PR TITLE
lirc: adapt to linux-headers-5.18

### DIFF
--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -10,11 +10,17 @@ stdenv.mkDerivation rec {
     sha256 = "1whlyifvvc7w04ahq07nnk1h18wc8j7c6wnvlb6mszravxh3qxcb";
   };
 
-  # Fix installation of Python bindings
-  patches = [ (fetchpatch {
-    url = "https://sourceforge.net/p/lirc/tickets/339/attachment/0001-Fix-Python-bindings.patch";
-    sha256 = "088a39x8c1qd81qwvbiqd6crb2lk777wmrs8rdh1ga06lglyvbly";
-  }) ];
+  patches = [
+    # Fix installation of Python bindings
+    (fetchpatch {
+      url = "https://sourceforge.net/p/lirc/tickets/339/attachment/0001-Fix-Python-bindings.patch";
+      sha256 = "088a39x8c1qd81qwvbiqd6crb2lk777wmrs8rdh1ga06lglyvbly";
+    })
+
+    # Add a workaround for linux-headers-5.18 until upstream adapts:
+    #   https://sourceforge.net/p/lirc/git/merge-requests/45/
+    ./linux-headers-5.18.patch
+  ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/development/libraries/lirc/linux-headers-5.18.patch
+++ b/pkgs/development/libraries/lirc/linux-headers-5.18.patch
@@ -1,0 +1,35 @@
+--- a/daemons/lircd.cpp
++++ b/daemons/lircd.cpp
+@@ -110,6 +110,17 @@ int clock_gettime(int clk_id, struct timespec *t){
+ #endif
+ #define WHITE_SPACE " \t"
+ 
++/* Defines removed in linux-headers-5.18:
++     https://sourceforge.net/p/lirc/git/merge-requests/45/
++ */
++#ifndef LIRC_CAN_SET_REC_FILTER
++#    define LIRC_CAN_SET_REC_FILTER 0x08000000
++#endif
++
++#ifndef LIRC_CAN_NOTIFY_DECODE
++#    define LIRC_CAN_NOTIFY_DECODE 0x01000000
++#endif
++
+ static const logchannel_t logchannel = LOG_APP;
+ 
+ /** How long we sleep while waiting for busy write sockets. */
+--- a/tools/lirc-lsplugins.cpp
++++ b/tools/lirc-lsplugins.cpp
+@@ -21,6 +21,12 @@
+ #include "config.h"
+ #include "lirc_private.h"
+ 
++/* Defines removed in linux-headers-5.18:
++     https://sourceforge.net/p/lirc/git/merge-requests/45/
++ */
++#ifndef LIRC_CAN_NOTIFY_DECODE
++#    define LIRC_CAN_NOTIFY_DECODE 0x01000000
++#endif
+ 
+ #define USAGE \
+ 	"\nSynopsis:\n" \


### PR DESCRIPTION
Without the change update to linux-header-5.18 causes build failure as:

    lircd.cpp: In function 'int setup_hardware()':
    lircd.cpp:492:49: error: 'LIRC_CAN_SET_REC_FILTER' was not declared in this scope; did you mean 'LIRC_CAN_SET_REC_CARRIER'?
      492 |                     || (curr_driver->features & LIRC_CAN_SET_REC_FILTER)) {
          |                                                 ^~~~~~~~~~~~~~~~~~~~~~~
          |                                                 LIRC_CAN_SET_REC_CARRIER

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
