### PR TITLE
sundials: 5.7.0 -> 6.2.0

### DIFF
--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -12,16 +12,19 @@
 
 stdenv.mkDerivation rec {
   pname = "sundials";
-  version = "5.7.0";
+  version = "6.2.0";
 
   outputs = [ "out" "examples" ];
 
   src = fetchurl {
     url = "https://github.com/LLNL/sundials/releases/download/v${version}/sundials-${version}.tar.gz";
-    hash = "sha256-SNp7qoFS3bIq7RsC2C0du0+/6iKs9nY0ARqgMDoQCkM=";
+    hash = "sha256-GV1Vk3cvxIP2Pwh5TXnkurMMLsWObOSw+2vMDgxI8x0=";
   };
 
-  nativeBuildInputs = [ cmake gfortran ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
 
   buildInputs = [
     python
@@ -32,9 +35,8 @@ stdenv.mkDerivation rec {
       blas
       lapack
     ])
-  # KLU support is based on Suitesparse.
-  # It is tested upstream according to the section 1.1.4 of
-  # [INSTALL_GUIDE.pdf](https://raw.githubusercontent.com/LLNL/sundials/master/INSTALL_GUIDE.pdf)
+  # KLU support is based on Suitesparse. It is tested upstream according to the
+  # section 1.1.4.2 of INSTALL_GUIDE.pdf found in the source tarball.
   ++ lib.optionals (kluSupport) [
     suitesparse
   ];
@@ -64,11 +66,13 @@ stdenv.mkDerivation rec {
   #
   # build error:
   #
-  # /private/tmp/nix-build-sundials-5.7.0.drv-0/ccD2dUtR.s:21:15: error: index must be an integer in range [-256, 255].
+  # /private/tmp/nix-build-sundials-6.2.0.drv-0/ccD2dUtR.s:21:15: error: index must be an integer in range [-256, 255].
   #         ldr     x0, [x0, ___stack_chk_guard];momd
   #                          ^
-  # /private/tmp/nix-build-sundials-5.7.0.drv-0/ccD2dUtR.s:46:15: error: index must be an integer in range [-256, 255].
+  # /private/tmp/nix-build-sundials-6.2.0.drv-0/ccD2dUtR.s:46:15: error: index must be an integer in range [-256, 255].
   #         ldr     x0, [x0, ___stack_chk_guard];momd
+  #
+  # See also a proposed solution: https://github.com/NixOS/nixpkgs/pull/151983
 
   hardeningDisable = lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "stackprotector" ];
 
@@ -77,7 +81,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Suite of nonlinear differential/algebraic equation solvers";
-    homepage    = "https://computation.llnl.gov/projects/sundials";
+    homepage    = "https://computing.llnl.gov/projects/sundials";
     platforms   = platforms.all;
     maintainers = with maintainers; [ idontgetoutmuch ];
     license     = licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
