### PR TITLE
warp: init at 0.1.2

### DIFF
--- a/pkgs/applications/networking/warp/default.nix
+++ b/pkgs/applications/networking/warp/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, appstream-glib
+, desktop-file-utils
+, itstool
+, meson
+, ninja
+, pkg-config
+, python3
+, rustPlatform
+, wrapGAppsHook
+, glib
+, gtk4
+, libadwaita
+}:
+
+stdenv.mkDerivation rec {
+  pname = "warp";
+  version = "0.1.2";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "warp";
+    rev = "v${version}";
+    hash = "sha256-6KWTjfrJr0QkiYHkwy4IKrzQuVUMHc1yILM7ixHBHSQ=";
+  };
+
+  postPatch = ''
+    patchShebangs build-aux
+  '';
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-Xy/tn5iUqwlmztmTmqUbISAk1xu9vkbMk4CvK4j2ttM=";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    itstool
+    meson
+    ninja
+    pkg-config
+    python3
+    wrapGAppsHook
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+  ];
+
+  meta = {
+    description = "Fast and secure file transfer";
+    homepage = "https://apps.gnome.org/app/app.drey.Warp";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dotlambda ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30450,6 +30450,8 @@ with pkgs;
 
   waon = callPackage ../applications/audio/waon { };
 
+  warp = callPackage ../applications/networking/warp { };
+
   w3m = callPackage ../applications/networking/browsers/w3m { };
 
   # Should always be the version with the most features


### PR DESCRIPTION
###### Description of changes
A GUI for magic-wormhole.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
The package is called [warp-share-files](https://aur.archlinux.org/packages/warp-share-files) in the AUR. Should we do the same?