### PR TITLE
curtail: init at 1.3.0

### DIFF
--- a/pkgs/applications/graphics/curtail/default.nix
+++ b/pkgs/applications/graphics/curtail/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, python3
+, fetchFromGitHub
+, wrapGAppsHook
+, appstream-glib
+, desktop-file-utils
+, gettext
+, gtk3
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, jpegoptim
+, libwebp
+, optipng
+, pngquant
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "curtail";
+  version = "1.3.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "Huluti";
+    repo = "Curtail";
+    rev = version;
+    sha256 = "sha256-tNk+KI+DEMR63zfcBpfPTxAFKzvGWvpa9erK9SAAtPc=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    appstream-glib
+    desktop-file-utils
+    gettext
+    gtk3
+    meson
+    ninja
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    appstream-glib
+    python3.pkgs.pygobject3
+    gobject-introspection
+    gettext
+  ];
+
+  # Currently still required for the gobject-introspection setup hook
+  strictDeps = false;
+
+  preInstall = ''
+    patchShebangs ../build-aux/meson/postinstall.py
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/curtail --prefix PATH : ${lib.makeBinPath [ jpegoptim libwebp optipng pngquant ]}
+  '';
+
+  meta = with lib; {
+    description = "Simple & useful image compressor";
+    homepage = "https://github.com/Huluti/Curtail";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ anselmschueler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25712,6 +25712,8 @@ with pkgs;
 
   curseradio = callPackage ../applications/audio/curseradio { };
 
+  curtail = callPackage ../applications/graphics/curtail { };
+
   cutecom = libsForQt5.callPackage ../tools/misc/cutecom { };
 
   cvs = callPackage ../applications/version-management/cvs { };


### PR DESCRIPTION
###### Description of changes

Adds Curtail, a simple GTK image compressor

This is a third pull request about this. Sorry, I mis-rebased before and the whole thing got bollocksed up. Please see #173520 for previous discussion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
