### PR TITLE
sysstat: Do not compress manual pages with xz(1)

### DIFF
--- a/pkgs/os-specific/linux/sysstat/default.nix
+++ b/pkgs/os-specific/linux/sysstat/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     export PATH_CHKCONFIG=/no-such-program
     export BZIP=${bzip2.bin}/bin/bzip2
     export SYSTEMCTL=systemctl
+    export COMPRESS_MANPG=n
   '';
 
   makeFlags = [ "SYSCONFIG_DIR=$(out)/etc" "IGNORE_FILE_ATTRIBUTES=y" "CHOWN=true" ];


### PR DESCRIPTION
sysstat compresses manual pages using the `ZIP` environment variable
unless `COMPRESS_MANPG` is set.

`ZIP` seems to default to xz(1) and is for more than just compressing
manuals.

At least with `documentation.man.mandoc.enable = true;` this renders
them unreadable:
```
$ man -w mpstat
man: outdated mandoc.db lacks mpstat(1) entry, run makewhatis /nix/store/lk0r6ibvkrvaq96gp8h4rqgrd2q0c8q5-system-path/share/man
/nix/store/lk0r6ibvkrvaq96gp8h4rqgrd2q0c8q5-system-path/share/man/man1/mpstat.1.xz

```
(followed by `PAGER` showing compressed mpstat.1.xz content.)

Disable manual page compression during build and thus defer it to Nix:
```
gzipping man pages under /nix/store/wl2dwl1lhs9g5w2d5dhr0pcskp78nz42-sysstat-12.4.5/share/man/
```

This also avoids potential runtime incompatibilites in sysstat
(I am not a `services.systat` user).

@eelco
