### PR TITLE
ntfs3g: 2021.8.22 -> 2022.5.17

### DIFF
--- a/pkgs/tools/filesystems/ntfs-3g/autoconf-sbin-helpers.patch
+++ b/pkgs/tools/filesystems/ntfs-3g/autoconf-sbin-helpers.patch
@@ -1,0 +1,98 @@
+diff --git a/configure.ac b/configure.ac
+index 9aa25bd5..c7c0437b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -185,6 +185,30 @@ AC_ARG_ENABLE(
+ 	]
+ )
+ 
++AC_ARG_WITH(
++	[mount-helper],
++	[AS_HELP_STRING([--with-mount-helper=BIN],[use the specified binary as mount helper @<:@default=/sbin/mount@:>@])],
++	[mount_helper="$withval"],
++	[mount_helper="/sbin/mount"]
++)
++AC_DEFINE_UNQUOTED([MOUNT_HELPER], ["$mount_helper"], [Binary used as mount helper.])
++
++AC_ARG_WITH(
++	[umount-helper],
++	[AS_HELP_STRING([--with-umount-helper=BIN],[use the specified binary as umount helper @<:@default=/sbin/umount@:>@])],
++	[umount_helper="$withval"],
++	[umount_helper="/sbin/umount"]
++)
++AC_DEFINE_UNQUOTED([UMOUNT_HELPER], ["$umount_helper"], [Binary used as umount helper.])
++
++AC_ARG_WITH(
++	[modprobe-helper],
++	[AS_HELP_STRING([--with-modprobe-helper=BIN],[use the specified binary as modprobe helper @<:@default=/sbin/modprobe@:>@])],
++	[modprobe_helper="$withval"],
++	[modprobe_helper="/sbin/modprobe"]
++)
++AC_DEFINE_UNQUOTED([MODPROBE_HELPER], ["$modprobe_helper"], [Binary used as modprobe helper.])
++
+ # pthread_rwlock_t requires _GNU_SOURCE
+ AC_GNU_SOURCE
+ 
+diff --git a/libfuse-lite/mount_util.c b/libfuse-lite/mount_util.c
+index 8b317224..ee75ace6 100644
+--- a/libfuse-lite/mount_util.c
++++ b/libfuse-lite/mount_util.c
+@@ -89,10 +89,10 @@ int fuse_mnt_add_mount(const char *progname, const char *fsname,
+             exit(1);
+         }
+         rmdir(tmp);
+-        execle("/sbin/mount", "/sbin/mount", "-F", type, "-o", opts,
++        execle(MOUNT_HELPER, MOUNT_HELPER, "-F", type, "-o", opts,
+               fsname, mnt, NULL, &env);
+-        fprintf(stderr, "%s: failed to execute /sbin/mount: %s\n", progname,
+-                strerror(errno));
++        fprintf(stderr, "%s: failed to execute %s: %s\n", progname,
++                MOUNT_HELPER, strerror(errno));
+         exit(1);
+     }
+     res = waitpid(res, &status, 0);
+@@ -126,14 +126,14 @@ int fuse_mnt_umount(const char *progname, const char *mnt, int lazy)
+ 
+         setuid(geteuid());
+         if (lazy) {
+-            execle("/sbin/umount", "/sbin/umount", mnt,
++            execle(UMOUNT_HELPER, UMOUNT_HELPER, mnt,
+                    NULL, &env);
+         } else {
+-            execle("/sbin/umount", "/sbin/umount", "-f", mnt,
++            execle(UMOUNT_HELPER, UMOUNT_HELPER, "-f", mnt,
+                    NULL, &env);
+         }
+-        fprintf(stderr, "%s: failed to execute /sbin/umount: %s\n", progname,
+-                strerror(errno));
++        fprintf(stderr, "%s: failed to execute %s: %s\n", progname,
++                UMOUNT_HELPER, strerror(errno));
+         exit(1);
+     }
+     res = waitpid(res, &status, 0);
+diff --git a/src/lowntfs-3g.c b/src/lowntfs-3g.c
+index 9330500c..dd18a93f 100644
+--- a/src/lowntfs-3g.c
++++ b/src/lowntfs-3g.c
+@@ -4463,7 +4463,7 @@ static fuse_fstype load_fuse_module(void)
+ 	int i;
+ 	struct stat st;
+ 	pid_t pid;
+-	const char *cmd = "/sbin/modprobe";
++	const char *cmd = MODPROBE_HELPER;
+ 	char *env = (char*)NULL;
+ 	struct timespec req = { 0, 100000000 };   /* 100 msec */
+ 	fuse_fstype fstype;
+diff --git a/src/ntfs-3g.c b/src/ntfs-3g.c
+index d8227e71..f5d77252 100644
+--- a/src/ntfs-3g.c
++++ b/src/ntfs-3g.c
+@@ -4171,7 +4171,7 @@ static fuse_fstype load_fuse_module(void)
+ 	int i;
+ 	struct stat st;
+ 	pid_t pid;
+-	const char *cmd = "/sbin/modprobe";
++	const char *cmd = MODPROBE_HELPER;
+ 	char *env = (char*)NULL;
+ 	struct timespec req = { 0, 100000000 };   /* 100 msec */
+ 	fuse_fstype fstype;

--- a/pkgs/tools/filesystems/ntfs-3g/consistent-sbindir-usage.patch
+++ b/pkgs/tools/filesystems/ntfs-3g/consistent-sbindir-usage.patch
@@ -1,0 +1,48 @@
+diff --git a/ntfsprogs/Makefile.am b/ntfsprogs/Makefile.am
+index 08228322..a390d8c7 100644
+--- a/ntfsprogs/Makefile.am
++++ b/ntfsprogs/Makefile.am
+@@ -165,7 +165,7 @@ extras:	libs $(EXTRA_PROGRAMS)
+ 
+ if ENABLE_MOUNT_HELPER
+ install-exec-hook:
+-	$(INSTALL) -d $(DESTDIR)/$(sbindir)
++	$(INSTALL) -d $(DESTDIR)$(sbindir)
+ 	$(LN_S) -f $(sbindir)/mkntfs $(DESTDIR)$(sbindir)/mkfs.ntfs
+ 
+ install-data-hook:
+@@ -173,7 +173,7 @@ install-data-hook:
+ 	$(LN_S) -f mkntfs.8 $(DESTDIR)$(man8dir)/mkfs.ntfs.8
+ 
+ uninstall-local:
+-	$(RM) -f $(DESTDIR)/sbin/mkfs.ntfs
++	$(RM) -f $(DESTDIR)$(sbindir)/mkfs.ntfs
+ 	$(RM) -f $(DESTDIR)$(man8dir)/mkfs.ntfs.8
+ endif
+ 
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 8d984083..ea407067 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -66,9 +66,9 @@ endif
+ 
+ if ENABLE_MOUNT_HELPER
+ install-exec-local:	install-rootbinPROGRAMS
+-	$(MKDIR_P) "$(DESTDIR)/sbin"
+-	$(LN_S) -f "$(rootbindir)/ntfs-3g" "$(DESTDIR)/sbin/mount.ntfs-3g"
+-	$(LN_S) -f "$(rootbindir)/lowntfs-3g" "$(DESTDIR)/sbin/mount.lowntfs-3g"
++	$(MKDIR_P) "$(DESTDIR)$(rootsbindir)"
++	$(LN_S) -f "$(rootbindir)/ntfs-3g" "$(DESTDIR)$(rootsbindir)/mount.ntfs-3g"
++	$(LN_S) -f "$(rootbindir)/lowntfs-3g" "$(DESTDIR)$(rootsbindir)/mount.lowntfs-3g"
+ 
+ install-data-local:	install-man8
+ 	$(LN_S) -f ntfs-3g.8 "$(DESTDIR)$(man8dir)/mount.ntfs-3g.8"
+@@ -76,7 +76,7 @@ install-data-local:	install-man8
+ 
+ uninstall-local:
+ 	$(RM) -f "$(DESTDIR)$(man8dir)/mount.ntfs-3g.8"
+-	$(RM) -f "$(DESTDIR)/sbin/mount.ntfs-3g" "$(DESTDIR)/sbin/mount.lowntfs-3g"
++	$(RM) -f "$(DESTDIR)$(rootsbindir)/mount.ntfs-3g" "$(DESTDIR)$(rootsbindir)/mount.lowntfs-3g"
+ endif
+ 
+ endif # ENABLE_NTFS_3G

--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -1,30 +1,34 @@
-{ lib, stdenv, fetchurl, pkg-config, mount, libuuid
-, macfuse-stubs, DiskArbitration
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
+, gettext, mount, libuuid, kmod, macfuse-stubs, DiskArbitration
 , crypto ? false, libgcrypt, gnutls
 }:
 
 stdenv.mkDerivation rec {
   pname = "ntfs3g";
-  version = "2021.8.22";
+  version = "2022.5.17";
 
   outputs = [ "out" "dev" "man" "doc" ];
 
-  buildInputs = [ libuuid ] ++ lib.optionals crypto [ gnutls libgcrypt ]
-    ++ lib.optionals stdenv.isDarwin [ macfuse-stubs DiskArbitration ];
-  nativeBuildInputs = [ pkg-config ];
-
-  src = fetchurl {
-    url = "https://tuxera.com/opensource/ntfs-3g_ntfsprogs-${version}.tgz";
-    sha256 = "55b883aa05d94b2ec746ef3966cb41e66bed6db99f22ddd41d1b8b94bb202efb";
+  src = fetchFromGitHub {
+    owner = "tuxera";
+    repo = "ntfs-3g";
+    rev = version;
+    sha256 = "sha256-xh8cMNIHeJ1rtk5zwOsmcxeedgZ3+MSiWn2UC7y+gtQ=";
   };
 
-  patchPhase = ''
-    substituteInPlace src/Makefile.in --replace /sbin '@sbindir@'
-    substituteInPlace ntfsprogs/Makefile.in --replace /sbin '@sbindir@'
-    substituteInPlace libfuse-lite/mount_util.c \
-      --replace /bin/mount ${mount}/bin/mount \
-      --replace /bin/umount ${mount}/bin/umount
-  '';
+  buildInputs = [ gettext libuuid ]
+    ++ lib.optionals crypto [ gnutls libgcrypt ]
+    ++ lib.optionals stdenv.isDarwin [ macfuse-stubs DiskArbitration ];
+
+  # Note: libgcrypt is listed here non-optionally because its m4 macros are
+  # being used in ntfs-3g's configure.ac.
+  nativeBuildInputs = [ autoreconfHook libgcrypt pkg-config ];
+
+  patches = [
+    # https://github.com/tuxera/ntfs-3g/pull/39
+    ./autoconf-sbin-helpers.patch
+    ./consistent-sbindir-usage.patch
+  ];
 
   configureFlags = [
     "--disable-ldconfig"
@@ -34,6 +38,9 @@ stdenv.mkDerivation rec {
     "--enable-xattr-mappings"
     "--${if crypto then "enable" else "disable"}-crypto"
     "--enable-extras"
+    "--with-mount-helper=${mount}/bin/mount"
+    "--with-umount-helper=${mount}/bin/umount"
+    "--with-modprobe-helper=${kmod}/bin/modprobe"
   ];
 
   postInstall =
@@ -41,6 +48,8 @@ stdenv.mkDerivation rec {
       # Prefer ntfs-3g over the ntfs driver in the kernel.
       ln -sv mount.ntfs-3g $out/sbin/mount.ntfs
     '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://github.com/tuxera/ntfs-3g";


### PR DESCRIPTION
###### Description of changes

Moderate severity: GHSA-xchm-ph5h-hw4x
High severity: GHSA-6mv4-4v73-xw58

This is unfortunately more complex than a simple version bump because
upstream has not released a dist tarball for this release. This commit
switches to using the github source and running autoreconf ourselves.

Along the way, stop randomly patching sources and Makefiles and instead
switch to upstreamable alternatives. The two (small) build system
patches have been sent upstream, see tuxera/ntfs-3g#39.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).