### PR TITLE
nushell: 0.62.0 -> 0.63.0

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -14,20 +14,22 @@
 , nghttp2
 , libgit2
 , withExtraFeatures ? true
+, testers
+, nushell
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nushell";
-  version = "0.62.0";
+  version = "0.63.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-fEwsoAbrV4fSreyB4+xcN8PGDlkLyaK+ptwgZrsBuLk=";
+    sha256 = "sha256-4thvUSOSvH/bv0aW7hGGQMvtXdS+yDfZzPRLZmPZQMQ=";
   };
 
-  cargoSha256 = "sha256-C4Eynvk3ogIl/RDwyA28hYKlkHA2eMYSCyIvAbp+NQo=";
+  cargoSha256 = "sha256-ALUp6sPcmnJy/A078umyKg8KBv23P0vv8mwoO9OU+DQ=";
 
   nativeBuildInputs = [ pkg-config ]
     ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ python3 ];
@@ -74,5 +76,8 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     shellPath = "/bin/nu";
+    tests.version = testers.testVersion {
+      package = nushell;
+    };
   };
 }

--- a/pkgs/shells/nushell/use-system-zstd-lib.diff
+++ b/pkgs/shells/nushell/use-system-zstd-lib.diff
@@ -1,8 +1,8 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 4261c06..6d6e537 100644
+index 6cebf66d..b6e40cd9 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2166,6 +2166,7 @@ dependencies = [
+@@ -2443,6 +2443,7 @@ dependencies = [
   "rstest",
   "serial_test",
   "tempfile",
@@ -10,23 +10,23 @@ index 4261c06..6d6e537 100644
  ]
  
  [[package]]
-@@ -4962,4 +4963,5 @@ checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+@@ -5365,4 +5366,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
  dependencies = [
   "cc",
   "libc",
 + "pkg-config",
  ]
 diff --git a/Cargo.toml b/Cargo.toml
-index e214da1..b78919a 100644
+index 0791d462..d520d9ae 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -67,6 +69,9 @@ hamcrest2 = "0.3.0"
- rstest = "0.12.0"
- itertools = "0.10.3"
+@@ -58,6 +58,9 @@ rayon = "1.5.1"
+ reedline = { version = "0.6.0", features = ["bashisms"]}
+ is_executable = "1.0.1"
  
 +# Specify that the indirect dependency ztsd-sys should pick up the system zstd C library
-+zstd-sys = { version = "1", features = [ "pkg-config" ] }
++zstd-sys = { version = "2", features = [ "pkg-config" ] }
 +
- [target.'cfg(windows)'.build-dependencies]
- embed-resource = "1"
- 
+ [dev-dependencies]
+ nu-test-support = { path="./crates/nu-test-support", version = "0.63.0"  }
+ tempfile = "3.2.0"


### PR DESCRIPTION
###### Description of changes

https://www.nushell.sh/blog/2022-05-24-nushell_0_63.html

Overlays and hooks seem to be the most impactful changes as someone who doesn't daily-drive.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
