### PR TITLE
bind: remove broken configure flags

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -1,9 +1,8 @@
 { config, stdenv, lib, fetchurl, fetchpatch
 , perl, pkg-config
 , libcap, libtool, libxml2, openssl, libuv, nghttp2, jemalloc
-, enableGSSAPI ? true, libkrb5
 , enablePython ? false, python3
-, enableSeccomp ? false, libseccomp
+, enableGSSAPI ? true, libkrb5
 , buildPackages, nixosTests
 }:
 
@@ -25,7 +24,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl pkg-config ];
   buildInputs = [ libtool libxml2 openssl libuv nghttp2 jemalloc ]
     ++ lib.optional stdenv.isLinux libcap
-    ++ lib.optional enableSeccomp libseccomp
     ++ lib.optional enableGSSAPI libkrb5
     ++ lib.optional enablePython (python3.withPackages (ps: with ps; [ ply ]));
 
@@ -33,25 +31,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--localstatedir=/var"
-    "--with-libtool"
-    (if enablePython then "--with-python" else "--without-python")
-    "--without-atf"
-    "--without-dlopen"
-    "--without-docbook-xsl"
-    "--without-idn"
-    "--without-idnlib"
     "--without-lmdb"
-    "--without-libjson"
-    "--without-pkcs11"
-    "--without-purify"
-    "--with-randomdev=/dev/random"
-    "--with-ecdsa"
-    "--with-gost"
-    "--without-eddsa"
-    "--with-aes"
-  ] ++ lib.optional stdenv.isLinux "--with-libcap=${libcap.dev}"
-    ++ lib.optional enableSeccomp "--enable-seccomp"
-    ++ lib.optional enableGSSAPI "--with-gssapi=${libkrb5.dev}/bin/krb5-config"
+  ] ++ lib.optional enableGSSAPI "--with-gssapi=${libkrb5.dev}/bin/krb5-config"
     ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "BUILD_CC=$(CC_FOR_BUILD)";
 
   postInstall = ''


### PR DESCRIPTION
###### Description of changes
```
configure: WARNING: unrecognized options: --without-atf, --without-docbook-xsl, --without-idn, --without-idnlib, --with-randomdev, --with-ecdsa, --with-gost, --without-eddsa, --with-aes, --with-libcap
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
