### PR TITLE
sm64ex-coop: init at 0.pre+date=2022-05-14

### DIFF
--- a/pkgs/games/sm64ex/default.nix
+++ b/pkgs/games/sm64ex/default.nix
@@ -1,71 +1,55 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, python3
-, pkg-config
-, audiofile
-, SDL2
-, hexdump
-, requireFile
-, compileFlags ? [ ]
-, region ? "us"
-, baseRom ? requireFile {
-    name = "baserom.${region}.z64";
-    message = ''
-      This nix expression requires that baserom.${region}.z64 is
-      already part of the store. To get this file you can dump your Super Mario 64 cartridge's contents
-      and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
-      Note that if you are not using a US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
-    '';
-    sha256 = {
-      "us" = "17ce077343c6133f8c9f2d6d6d9a4ab62c8cd2aa57c40aea1f490b4c8bb21d91";
-      "eu" = "c792e5ebcba34c8d98c0c44cf29747c8ee67e7b907fcc77887f9ff2523f80572";
-      "jp" = "9cf7a80db321b07a8d461fe536c02c87b7412433953891cdec9191bfad2db317";
-    }.${region};
-  }
+, callPackage
+, autoPatchelfHook
+, branch
 }:
 
-stdenv.mkDerivation rec {
-  pname = "sm64ex";
-  version = "unstable-2021-11-30";
+{
+  sm64ex = callPackage ./generic.nix {
+    pname = "sm64ex";
+    version = "0.pre+date=2021-11-30";
 
-  src = fetchFromGitHub {
-    owner = "sm64pc";
-    repo = "sm64ex";
-    rev = "db9a6345baa5acb41f9d77c480510442cab26025";
-    sha256 = "sha256-q7JWDvNeNrDpcKVtIGqB1k7I0FveYwrfqu7ZZK7T8F8=";
+    src = fetchFromGitHub {
+      owner = "sm64pc";
+      repo = "sm64ex";
+      rev = "db9a6345baa5acb41f9d77c480510442cab26025";
+      sha256 = "sha256-q7JWDvNeNrDpcKVtIGqB1k7I0FveYwrfqu7ZZK7T8F8=";
+    };
+
+    extraMeta = {
+      homepage = "https://github.com/sm64pc/sm64ex";
+      description = "Super Mario 64 port based off of decompilation";
+    };
   };
 
-  nativeBuildInputs = [ python3 pkg-config ];
-  buildInputs = [ audiofile SDL2 hexdump ];
+  sm64ex-coop = callPackage ./generic.nix {
+    pname = "sm64ex-coop";
+    version = "0.pre+date=2022-05-14";
 
-  makeFlags = [ "VERSION=${region}" ] ++ compileFlags
-    ++ lib.optionals stdenv.isDarwin [ "OSX_BUILD=1" ];
+    src = fetchFromGitHub {
+      owner = "djoslin0";
+      repo = "sm64ex-coop";
+      rev = "8200b175607fe2939f067d496627c202a15fe24c";
+      sha256 = "sha256-c1ZmMBtvYYcaJ/WxkZBVvNGVCeSXfm8NKe/BiAIJtks=";
+    };
 
-  inherit baseRom;
+    extraNativeBuildInputs = [
+      autoPatchelfHook
+    ];
 
-  preBuild = ''
-    patchShebangs extract_assets.py
-    cp $baseRom ./baserom.${region}.z64
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp build/${region}_pc/sm64.${region}.f3dex2e $out/bin/sm64ex
-  '';
-
-  enableParallelBuilding = true;
-
-  meta = with lib; {
-    homepage = "https://github.com/sm64pc/sm64ex";
-    description = "Super Mario 64 port based off of decompilation";
-    longDescription = ''
-      Super Mario 64 port based off of decompilation.
-      Note that you must supply a baserom yourself to extract assets from.
-      If you are not using an US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
-      If you would like to use patches sm64ex distributes as makeflags, add them to the "compileFlags" attribute.
+    postInstall = let
+      sharedLib = stdenv.hostPlatform.extensions.sharedLibrary;
+    in ''
+      mkdir -p $out/lib
+      cp $src/lib/bass/libbass{,_fx}${sharedLib} $out/lib
+      cp $src/lib/discordsdk/libdiscord_game_sdk${sharedLib} $out/lib
     '';
-    license = licenses.unfree;
-    maintainers = with maintainers; [ ivar ];
-    platforms = platforms.unix;
+
+    extraMeta = {
+      homepage = "https://github.com/djoslin0/sm64ex-coop";
+      description = "Super Mario 64 online co-op mod, forked from sm64ex";
+    };
   };
-}
+}.${branch}

--- a/pkgs/games/sm64ex/generic.nix
+++ b/pkgs/games/sm64ex/generic.nix
@@ -1,0 +1,83 @@
+{ pname
+, version
+, src
+, extraNativeBuildInputs ? [ ]
+, extraMeta ? {}
+, compileFlags ? [ ]
+, postInstall ? ""
+, region ? "us"
+
+, lib
+, stdenv
+, fetchFromGitHub
+, python3
+, pkg-config
+, audiofile
+, SDL2
+, hexdump
+, requireFile
+, baseRom ? requireFile {
+    name = "baserom.${region}.z64";
+    message = ''
+      This nix expression requires that baserom.${region}.z64 is
+      already part of the store. To get this file you can dump your Super Mario 64 cartridge's contents
+      and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
+      Note that if you are not using a US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
+    '';
+    sha256 = {
+      "us" = "17ce077343c6133f8c9f2d6d6d9a4ab62c8cd2aa57c40aea1f490b4c8bb21d91";
+      "eu" = "c792e5ebcba34c8d98c0c44cf29747c8ee67e7b907fcc77887f9ff2523f80572";
+      "jp" = "9cf7a80db321b07a8d461fe536c02c87b7412433953891cdec9191bfad2db317";
+    }.${region};
+  }
+}:
+
+stdenv.mkDerivation rec {
+  inherit pname version src postInstall;
+
+  nativeBuildInputs = [
+    python3
+    pkg-config
+    hexdump
+  ] ++ extraNativeBuildInputs;
+
+  buildInputs = [
+    audiofile
+    SDL2
+  ];
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "VERSION=${region}"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "OSX_BUILD=1"
+  ] ++ compileFlags;
+
+  preBuild = ''
+    patchShebangs extract_assets.py
+    ln -s ${baseRom} ./baserom.${region}.z64
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp build/${region}_pc/sm64.${region}.f3dex2e $out/bin/sm64ex
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    longDescription =
+      extraMeta.description or "Super Mario 64 port based off of decompilation" + "\n" + ''
+        Note that you must supply a baserom yourself to extract assets from.
+        If you are not using an US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
+        If you would like to use patches sm64ex distributes as makeflags, add them to the "compileFlags" attribute.
+      '';
+    mainProgram = "sm64ex";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ivar ];
+    platforms = platforms.unix;
+  } // extraMeta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31411,7 +31411,13 @@ with pkgs;
 
   runescape = callPackage ../games/runescape-launcher { };
 
-  sm64ex = callPackage ../games/sm64ex { };
+  sm64ex = callPackage ../games/sm64ex {
+    branch = "sm64ex";
+  };
+
+  sm64ex-coop = callPackage ../games/sm64ex {
+    branch = "sm64ex-coop";
+  };
 
   snipes = callPackage ../games/snipes { };
 


### PR DESCRIPTION
###### Description of changes
This adds [sm64ex-coop](https://github.com/djoslin0/sm64ex-coop), an Super Mario 64 online co-op mod, forked from sm64ex. I've tested this with a friend before, everything seems to work perfectly. It's very fun to experience this nostalgic game together with friends, id heavily recommand to give it a shot :)

It should also make packaging other forks of sm64pc way simpler, which I may work on in the future. There are a ton of [rom hacks](https://github.com/jesusyoshi54/sm64ex-alo/releases) for example which would be really cool to have in nixpkgs.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
