### PR TITLE
xkcd-font: fix build

### DIFF
--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -15,14 +15,16 @@ in fetchFromGitHub {
 
     install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
     install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
-    for f in *; do
-      [[ "$f" == share ]] && continue
-      rm -rf "$f"
+    for f in * .*; do
+      case "$f" in
+        share|.|..) ;;
+        *) rm -rf "$f" ;;
+      esac
     done
 
     popd
   '';
-  sha256 = "sha256-oBDP4LG8csjvzSk1+EcPH6hcp44dWtPzVFSifzBq8lU=";
+  sha256 = "sha256-ITsJPs+ZXwUWYe2AmwyVZib8RV7bpiWHOUD8qEZRHHY=";
 
   meta = with lib; {
     description = "The xkcd font";

--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -15,6 +15,8 @@ in fetchFromGitHub {
 
     install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
     install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
+
+    # remove unrelated files
     for f in * .*; do
       case "$f" in
         share|.|..) ;;

--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -11,11 +11,18 @@ in fetchFromGitHub {
   rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
 
   postFetch = ''
-    tar xf $downloadedFile --strip=1
+    pushd $out
+
     install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
     install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
+    for f in *; do
+      [[ "$f" == share ]] && continue
+      rm -rf "$f"
+    done
+
+    popd
   '';
-  sha256 = "0xhwa53aiz20763jb9nvbr2zq9k6jl69p07dc4b0apwrrwz0jfr1";
+  sha256 = "sha256-oBDP4LG8csjvzSk1+EcPH6hcp44dWtPzVFSifzBq8lU=";
 
   meta = with lib; {
     description = "The xkcd font";


### PR DESCRIPTION
###### Description of changes

ZHF: #172160
ping @NixOS/nixos-release-managers

The current package tries to override the `postFetch` phase in `fetchzip`, but that no longer works after #173430.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
