### PR TITLE
openmoji-black,openmoji-color: fix hanging builds

### DIFF
--- a/pkgs/data/fonts/openmoji/default.nix
+++ b/pkgs/data/fonts/openmoji/default.nix
@@ -1,7 +1,10 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , scfbuild
+, fontforge
+, libuninameslist
 , nodejs
 , nodePackages
 , python3Packages
@@ -13,6 +16,34 @@ let
     [ "color"              "black"              ]
     [ "OpenMoji-Color.ttf" "OpenMoji-Black.ttf" ]
     variant;
+
+  # With newer fontforge the build hangs, see
+  # https://github.com/NixOS/nixpkgs/issues/167869
+  # Patches etc taken from
+  # https://github.com/NixOS/nixpkgs/commit/69da642a5a9bb433138ba1b13c8d56fb5bb6ec05
+  fontforge-20201107 = fontforge.overrideAttrs (old: rec {
+    version = "20201107";
+    src = fetchFromGitHub {
+      owner = "fontforge";
+      repo = "fontforge";
+      rev = version;
+      sha256 = "sha256-Rl/5lbXaPgIndANaD0IakaDus6T53FjiBb45FIuGrvc=";
+    };
+    patches = [
+      (fetchpatch {
+        url = "https://salsa.debian.org/fonts-team/fontforge/raw/76bffe6ccf8ab20a0c81476a80a87ad245e2fd1c/debian/patches/0001-add-extra-cmake-install-rules.patch";
+        sha256 = "u3D9od2xLECNEHhZ+8dkuv9818tPkdP6y/Tvd9CADJg=";
+      })
+      (fetchpatch {
+        url = "https://github.com/fontforge/fontforge/commit/69e263b2aff29ad22f97f13935cfa97a1eabf207.patch";
+        sha256 = "06yyf90605aq6ppfiz83mqkdmnaq5418axp9jgsjyjq78b00xb29";
+      })
+    ];
+    buildInputs = old.buildInputs ++ [ libuninameslist ];
+  });
+  scfbuild-with-fontforge-20201107 = scfbuild.override (old: {
+    fontforge = fontforge-20201107;
+  });
 
 in stdenv.mkDerivation rec {
   pname = "openmoji";
@@ -26,7 +57,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    scfbuild
+    scfbuild-with-fontforge-20201107
     nodejs
     nodePackages.glob
     nodePackages.lodash


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/167869

ZHF: #172160
@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
