### PR TITLE
MoniqueMonosynth: init at 2022-05-02

### DIFF
--- a/pkgs/applications/audio/MoniqueMonosynth/default.nix
+++ b/pkgs/applications/audio/MoniqueMonosynth/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , cmake
+, ninja
 , pkg-config
 , alsa-lib
 , curl
@@ -39,7 +40,7 @@ stdenv.mkDerivation {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake ninja pkg-config ];
 
   buildInputs = [
     alsa-lib
@@ -67,18 +68,16 @@ stdenv.mkDerivation {
   patches = [ ./no-lto-no-werror.patch ];
 
   # JUCE dlopen's these at runtime, crashes without them
-  NIX_LDFLAGS = (toString [
+  NIX_LDFLAGS = [
     "-lX11"
     "-lXext"
     "-lXcursor"
     "-lXinerama"
     "-lXrandr"
-  ]);
+  ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/lib/vst3
-    mkdir -p $out/lib/lv2
+    mkdir -p $out/bin $out/lib/vst3 $out/lib/lv2
 
     cp -r MoniqueMonosynth_artefacts/Release/LV2/MoniqueMonosynth.lv2 $out/lib/lv2
     cp -r MoniqueMonosynth_artefacts/Release/VST3/MoniqueMonosynth.vst3 $out/lib/vst3
@@ -89,7 +88,6 @@ stdenv.mkDerivation {
     description = "A monophonic synth from Thomas Arndt";
     homepage = "https://github.com/surge-synthesizer/monique-monosynth";
     license = with licenses; [ gpl3Only mit ];
-    # Assumed to be the same as for Surge-XT
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ minijackson ];
   };

--- a/pkgs/applications/audio/MoniqueMonosynth/default.nix
+++ b/pkgs/applications/audio/MoniqueMonosynth/default.nix
@@ -1,0 +1,96 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, alsa-lib
+, curl
+, freetype
+, libjack2
+, libX11
+, libXcursor
+, libXext
+, libXinerama
+, libXrandr
+, lv2
+, pcre
+, util-linux
+, webkitgtk
+}:
+
+let
+  juce-lv2 = fetchFromGitHub {
+    owner = "lv2-porting-project";
+    repo = "JUCE";
+    rev = "5106d9d77b892c22afcb9379c13982f270429e2e";
+    hash = "sha256-bpZJ5NEDRfMtmx0RkKQFZWqS/SnYAFRhrDg9MSphh4c=";
+  };
+in
+stdenv.mkDerivation {
+  # Use TitleCase to align with the binary name
+  pname = "MoniqueMonosynth";
+  version = "2022-05-02";
+
+  src = fetchFromGitHub {
+    owner = "surge-synthesizer";
+    repo = "monique-monosynth";
+    rev = "ba94f7bf926908345a3f61eb91e43421df60dd1c";
+    hash = "sha256-6YRfF/UlqiXAmayfzGOLqq4ND/H4kPzWe4tVD0IXR4Y=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    alsa-lib
+    curl
+    freetype
+    libjack2
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+    lv2
+    pcre
+    util-linux
+    webkitgtk
+  ];
+
+  cmakeFlags = [
+    "-DJUCE_SUPPORTS_LV2=ON"
+    "-DMONIQUE_JUCE_PATH=${juce-lv2}"
+  ];
+
+  # LTO introduces "undefined references to ..." at link time
+  # -Werror produces errors with recent versions of GCC (and is discouraged)
+  patches = [ ./no-lto-no-werror.patch ];
+
+  # JUCE dlopen's these at runtime, crashes without them
+  NIX_LDFLAGS = (toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ]);
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/lib/vst3
+    mkdir -p $out/lib/lv2
+
+    cp -r MoniqueMonosynth_artefacts/Release/LV2/MoniqueMonosynth.lv2 $out/lib/lv2
+    cp -r MoniqueMonosynth_artefacts/Release/VST3/MoniqueMonosynth.vst3 $out/lib/vst3
+    cp -r MoniqueMonosynth_artefacts/Release/Standalone/MoniqueMonosynth $out/bin
+  '';
+
+  meta = with lib; {
+    description = "A monophonic synth from Thomas Arndt";
+    homepage = "https://github.com/surge-synthesizer/monique-monosynth";
+    license = with licenses; [ gpl3Only mit ];
+    # Assumed to be the same as for Surge-XT
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ minijackson ];
+  };
+}

--- a/pkgs/applications/audio/MoniqueMonosynth/no-lto-no-werror.patch
+++ b/pkgs/applications/audio/MoniqueMonosynth/no-lto-no-werror.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0781791e481..de0da6a5880 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -187,7 +187,6 @@ target_link_libraries(${PROJECT_NAME}
+     juce::juce_gui_extra
+   PUBLIC
+     juce::juce_recommended_config_flags
+-    juce::juce_recommended_lto_flags
+ 
+     monique::oddsound-mts
+     )
+@@ -210,7 +209,6 @@ if(APPLE)
+ elseif(UNIX)
+   message(STATUS "Turning off a legitimate compiler warning" )
+   target_compile_options(${PROJECT_NAME} PUBLIC
+-    -Werror
+     -Wno-deprecated-declarations
+     # -ftime-trace
+     )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28266,6 +28266,8 @@ with pkgs;
 
   mm-common = callPackage ../development/libraries/mm-common { };
 
+  MoniqueMonosynth = callPackage ../applications/audio/MoniqueMonosynth { };
+
   mpc-qt = libsForQt5.callPackage ../applications/video/mpc-qt { };
 
   mps-youtube = callPackage ../applications/misc/mps-youtube { };


### PR DESCRIPTION
###### Description of changes

A somewhat new synthesizer that recently became open source under the Surge synth project: https://github.com/surge-synthesizer/monique-monosynth

Note that the project doesn't have a stable release yet.

I don't have my whole setup on hand right now so I didn't check whether the vst(3)/lv2 plugins worked, but I'm putting it out there in case someone is interested.

Pinging Surge-XT maintainer in case they are interested (feel free to ignore if not, and sorry in advance): @magnetophon @orivej 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).