### PR TITLE
ossia-score: init at 3.1.11

### DIFF
--- a/pkgs/applications/audio/ossia-score/default.nix
+++ b/pkgs/applications/audio/ossia-score/default.nix
@@ -1,0 +1,123 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, ninja
+, pkg-config
+, qttools
+, wrapQtAppsHook
+, alsa-lib
+, boost182
+# , faust
+, ffmpeg
+, fftw
+, flac
+, lame
+, libjack2
+, libopus
+, libsndfile
+, libvorbis
+, lilv
+, lv2
+, mpg123
+, pipewire
+, portaudio
+, portmidi
+, qtbase
+, qtdeclarative
+, qtscxml
+, qtserialport
+, qtshadertools
+, qtsvg
+, qtwayland
+, qtwebsockets
+, suil
+}:
+
+# TODO: figure out LLVM jit
+# assert lib.versionAtLeast llvm.version "13";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ossia-score";
+  version = "3.1.12";
+
+  src = fetchFromGitHub {
+    owner = "ossia";
+    repo = "score";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-SLovwDt+TORJI00sRhizdLhIEm/2U7K3tt0EwBLyx4I=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ninja pkg-config qttools wrapQtAppsHook ];
+
+  # TODO: figure out if we want avahi / bluez / speex / SDL2 (needed for joystick support) by default
+  # what about leapmotion?
+  buildInputs = [
+    alsa-lib
+    boost182
+    # faust
+    ffmpeg
+    fftw
+    flac
+    lame
+    libjack2
+    libopus
+    libsndfile
+    libvorbis
+    lilv
+    lv2
+    mpg123
+    pipewire
+    portaudio
+    portmidi
+    qtbase
+    qtdeclarative
+    qtserialport
+    qtscxml
+    qtshadertools
+    qtsvg
+    qtwayland
+    qtwebsockets
+    suil
+  ];
+
+  cmakeFlags = [
+    "-Wno-dev"
+
+    "-DSCORE_DEPLOYMENT_BUILD=1"
+    "-DSCORE_STATIC_PLUGINS=1"
+    "-DSCORE_FHS_BUILD=1"
+    "-DCMAKE_UNITY_BUILD=1"
+    "-DCMAKE_SKIP_RPATH=ON"
+
+    "-DLilv_INCLUDE_DIR=${lilv.dev}/include/lilv-0"
+    "-DLilv_LIBRARY=${lilv}/lib/liblilv-0.so"
+
+    "-DSuil_INCLUDE_DIR=${suil}/include/suil-0"
+    "-DSuil_LIBRARY=${suil}/lib/libsuil-0.so"
+  ];
+
+  # Ossia dlopen's these at runtime, refuses to start without them
+  env.NIX_LDFLAGS = toString [
+    "-llilv-0"
+    "-lsuil-0"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCOMPONENT=OssiaScore -P cmake_install.cmake
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://ossia.io/score/about.html";
+    description = "A sequencer for audio-visual artists, designed to enable the creation of interactive shows, museum installations, intermedia digital artworks, interactive music and more in an intuitive user interface";
+    # TODO: this should work for darwin too
+    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ minijackson ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11791,6 +11791,10 @@ with pkgs;
 
   osslsigncode = callPackage ../development/tools/osslsigncode { };
 
+  ossia-score = qt6.callPackage ../applications/audio/ossia-score {
+    # inherit (llvmPackages_14) libclang llvm;
+  };
+
   ostree = callPackage ../tools/misc/ostree { };
 
   ostree-rs-ext = callPackage ../tools/misc/ostree-rs-ext { };


### PR DESCRIPTION
###### Description of changes

A really cool application for audio / video / etc.: https://ossia.io/score/about.html

I don't have my whole setup on hand right now so I didn't do extensive checks with using vst(3)/lv2 plugins, but I'm putting it out there in case someone is interested.

Pinging the previously maintainer of `i-score`, the ancestor of ossia-score (sorry if you are not interested): @magnetophon 

On a side note, I'd be really down to create an "audio-production" nixpkgs workgroup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
