### PR TITLE
spectre-cli: init at unstable-2022-02-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3759,6 +3759,13 @@
     githubId = 11006031;
     name = "Leo Maroni";
   };
+  emmabastas = {
+    email = "emma.bastas@protonmail.com";
+    matrix = "@emmabastas:matrix.org";
+    github = "emmabastas";
+    githubId = 22533224;
+    name = "Emma Bastås";
+  };
   emmanuelrosa = {
     email = "emmanuelrosa@protonmail.com";
     matrix = "@emmanuelrosa:matrix.org";

--- a/pkgs/tools/security/spectre-cli/default.nix
+++ b/pkgs/tools/security/spectre-cli/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, libsodium
+, json_c
+, ncurses
+, libxml2
+, jq
+}:
+
+stdenv.mkDerivation rec {
+  pname = "spectre-cli";
+  version = "unstable-2022-02-05";
+
+  src = fetchFromGitLab {
+    owner = "spectre.app";
+    repo = "cli";
+    rev = "a5e7aab28f44b90e5bd1204126339a81f64942d2";
+    sha256 = "1hp4l1rhg7bzgx0hcai08rvcy6l9645sfngy2cr96l1bpypcld5i";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    libxml2
+    jq
+  ];
+
+  buildInputs = [
+    libsodium
+    json_c
+    ncurses
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SPECTRE_TESTS=ON"
+  ];
+
+  preConfigure = ''
+   echo "${version}" > VERSION
+
+    # The default buildPhase wants to create a ´build´ dir so we rename the build script to stop conflicts.
+    mv build build.sh
+  '';
+
+  # Some tests are expected to fail on ARM64
+  # See: https://gitlab.com/spectre.app/cli/-/issues/27#note_962950844
+  doCheck = !(stdenv.isLinux && stdenv.isAarch64);
+
+  checkPhase = ''
+    mv ../spectre-cli-tests ../spectre_tests.xml ./
+    patchShebangs spectre-cli-tests
+    export HOME=$(mktemp -d)
+
+    ./spectre-tests
+    ./spectre-cli-tests
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv spectre $out/bin
+  '';
+
+  meta = with lib; {
+    description = "A stateless cryptographic identity algorithm";
+    homepage = "https://spectre.app";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ emmabastas ];
+    mainProgram = "spectre";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1179,6 +1179,8 @@ with pkgs;
 
   sdlookup = callPackage ../tools/security/sdlookup { };
 
+  spectre-cli = callPackage ../tools/security/spectre-cli { };
+
   sx-go = callPackage ../tools/security/sx-go { };
 
   systeroid = callPackage ../tools/system/systeroid { };


### PR DESCRIPTION
###### Description of changes

A CLI wrapper for the "spectre algorithmn"
homepage: https://spectre.app/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
