### PR TITLE
gnote: new package

### DIFF
--- a/pkgs/applications/office/gnote/default.nix
+++ b/pkgs/applications/office/gnote/default.nix
@@ -1,4 +1,4 @@
-#{ stdenv, lib, meson }: 
+#{ stdenv, lib, meson }:
 with import <nixpkgs> {};
 stdenv.mkDerivation rec {
   pname = "gnote";

--- a/pkgs/applications/office/gnote/default.nix
+++ b/pkgs/applications/office/gnote/default.nix
@@ -1,0 +1,43 @@
+#{ stdenv, lib, meson }: 
+with import <nixpkgs> {};
+stdenv.mkDerivation rec {
+  pname = "gnote";
+  version = "42.0";
+
+  src = pkgs.fetchurl {
+    url = "https://gitlab.gnome.org/GNOME/gnote/-/archive/${version}/gnote-${version}.tar.gz";
+    sha256 = "1W1zGNwoM3ea2SCQwC7kpRSUS6n0sAY23Fiffny32k8=";
+  };
+
+  buildInputs = [
+    glib
+    gtkmm3
+    gtk3
+    gspell
+    libxml2
+    libxslt
+    libuuid
+    libsecret
+    desktop-file-utils
+  ];
+
+  nativeBuildInputs = [
+      pkg-config
+      meson
+      ninja
+      gettext
+      wrapGAppsHook
+      docbook_xsl
+      python3
+      itstool
+      yelp-tools
+    ];
+
+  meta = with lib; {
+    homepage = "https://wiki.gnome.org/Apps/Gnote";
+    description = "A note taking application";
+    maintainers = [ maintainers.notthemessiah ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes

> Gnote is a simple note-taking application for GNOME desktop environment. It allows you to capture your ideas, link them together using [WikiWiki](https://wiki.gnome.org/WikiWiki)-style links, group together in notebooks and some extra features for everyday use.
> Notes can be printed or exported as HTML documents.
> Gnote also supports synchronization, making it simple to use it on multiple devices.

C++ fork of Tomboy and integrated with modern GNOME.

homepage: https://wiki.gnome.org/Apps/Gnote

###### Things done

- Built and runs on x86_64-linux
- Tested functionality and it appears to work
