### PR TITLE
nixos: remove effect-less nixpgks.initialSystem

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -50,11 +50,6 @@ let
       # they way through, but has the last priority behind everything else.
       nixpkgs.system = lib.mkDefault system;
 
-      # Stash the value of the `system` argument. When using `nesting.children`
-      # we want to have the same default value behavior (immediately above)
-      # without any interference from the user's configuration.
-      nixpkgs.initialSystem = system;
-
       _module.args.pkgs = lib.mkIf (pkgs_ != null) (lib.mkForce pkgs_);
     };
   };

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -67,6 +67,7 @@ in
   imports = [
     ./assertions.nix
     ./meta.nix
+    (mkRemovedOptionModule [ "nixpkgs" "initialSystem" ] "The NixOS options `nesting.clone` and `nesting.children` have been deleted, and replaced with named specialisation. Therefore `nixpgks.initialSystem` has no effect anymore.")
   ];
 
   options.nixpkgs = {
@@ -217,14 +218,6 @@ in
 
         Ignored when <code>nixpkgs.localSystem</code> is set.
         Ignored when <code>nixpkgs.pkgs</code> is set.
-      '';
-    };
-
-    initialSystem = mkOption {
-      type = types.str;
-      internal = true;
-      description = ''
-        Preserved value of <literal>system</literal> passed to <literal>eval-config.nix</literal>.
       '';
     };
   };


### PR DESCRIPTION
- initialSystem was keeping track of the evaluating system
- it had been used by `nesting.children`
- since, 20.09, `nesting.children` has been replaced with named
  specializations

It appears that this option was left over and not cleand up properly.
