### PR TITLE
python3Packages.wandb: hardcode git path

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -32,6 +32,7 @@
 , setproctitle
 , setuptools
 , shortuuid
+, substituteAll
 , tqdm
 }:
 
@@ -48,6 +49,13 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-ZY7nTj93piTEeHhW+H+nQ+ws2dDmmY6u3p7uz296PbA=";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./hardcode-git-path.patch;
+      git = "${lib.getBin git}/bin/git";
+    })
+  ];
 
   # setuptools is necessary since pkg_resources is required at runtime.
   propagatedBuildInputs = [
@@ -66,16 +74,6 @@ buildPythonPackage rec {
     setuptools
     shortuuid
   ];
-
-  # wandb expects git to be in PATH. See https://gist.github.com/samuela/57aeee710e41ab2bf361b7ed8fbbeabf
-  # for the error message, and an example usage here: https://github.com/wandb/client/blob/d5f655b7ca7e3eac2f3a67a84bc5c2a664a31baf/wandb/sdk/internal/meta.py#L128.
-  # See https://github.com/NixOS/nixpkgs/pull/164176#discussion_r828801621 as to
-  # why we don't put it in propagatedBuildInputs. Note that this is difficult to
-  # test offline due to https://github.com/wandb/client/issues/3519.
-  postInstall = ''
-    mkdir -p $out/bin
-    ln -s ${git}/bin/git $out/bin/git
-  '';
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/wandb/hardcode-git-path.patch
+++ b/pkgs/development/python-modules/wandb/hardcode-git-path.patch
@@ -1,0 +1,83 @@
+diff --git a/functional_tests/kfp/wandb_probe.py b/functional_tests/kfp/wandb_probe.py
+index 82fadfe1..25c1454c 100644
+--- a/functional_tests/kfp/wandb_probe.py
++++ b/functional_tests/kfp/wandb_probe.py
+@@ -5,7 +5,7 @@ import subprocess
+ def wandb_probe_package():
+     if not os.environ.get("WB_PROBE_PACKAGE"):
+         return
+-    s, o = subprocess.getstatusoutput("git rev-parse HEAD")
++    s, o = subprocess.getstatusoutput("@git@ rev-parse HEAD")
+     if s:
+         return
+     wandb_local = f"git+https://github.com/wandb/client.git@{o}#egg=wandb"
+diff --git a/wandb/cli/cli.py b/wandb/cli/cli.py
+index 5767e61c..56009fec 100644
+--- a/wandb/cli/cli.py
++++ b/wandb/cli/cli.py
+@@ -1745,7 +1745,7 @@ def restore(ctx, run, no_git, branch, project, entity):
+     commit, json_config, patch_content, metadata = api.run_config(
+         project, run=run, entity=entity
+     )
+-    repo = metadata.get("git", {}).get("repo")
++    repo = metadata.get("@git@", {}).get("repo")
+     image = metadata.get("docker")
+     restore_message = (
+         """`wandb restore` needs to be run from the same git repository as the original run.
+@@ -1764,7 +1764,7 @@ Run `git clone %s` and restore from there or pass the --no-git flag."""
+ 
+     if commit and api.git.enabled:
+         wandb.termlog(f"Fetching origin and finding commit: {commit}")
+-        subprocess.check_call(["git", "fetch", "--all"])
++        subprocess.check_call(["@git@", "fetch", "--all"])
+         try:
+             api.git.repo.commit(commit)
+         except ValueError:
+@@ -1818,7 +1818,7 @@ Run `git clone %s` and restore from there or pass the --no-git flag."""
+             # --reject is necessary or else this fails any time a binary file
+             # occurs in the diff
+             exit_code = subprocess.call(
+-                ["git", "apply", "--reject", patch_rel_path], cwd=root
++                ["@git@", "apply", "--reject", patch_rel_path], cwd=root
+             )
+             if exit_code == 0:
+                 wandb.termlog("Applied patch")
+diff --git a/wandb/sdk/internal/internal_api.py b/wandb/sdk/internal/internal_api.py
+index 612220b9..b761bfbd 100644
+--- a/wandb/sdk/internal/internal_api.py
++++ b/wandb/sdk/internal/internal_api.py
+@@ -660,7 +660,7 @@ class Api:
+         )
+         patch = BytesIO()
+         if self.git.dirty:
+-            self.git.repo.git.execute(["git", "diff"], output_stream=patch)
++            self.git.repo.git.execute(["@git@", "diff"], output_stream=patch)
+             patch.seek(0)
+         cwd = "."
+         if self.git.enabled:
+diff --git a/wandb/sdk/internal/meta.py b/wandb/sdk/internal/meta.py
+index 6c53f750..c385951a 100644
+--- a/wandb/sdk/internal/meta.py
++++ b/wandb/sdk/internal/meta.py
+@@ -125,7 +125,7 @@ class Meta:
+         logger.debug("save patches")
+         try:
+             root = self._git.root
+-            diff_args = ["git", "diff"]
++            diff_args = ["@git@", "diff"]
+             if self._git.has_submodule_diff:
+                 diff_args.append("--submodule=diff")
+ 
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py
+index 614df9f5..38db460b 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py
+@@ -67,7 +67,7 @@ def get_git_changeset():
+     repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+     try:
+         git_log = subprocess.Popen(
+-            'git log --pretty=format:%ct --quiet -1 HEAD',
++            '@git@ log --pretty=format:%ct --quiet -1 HEAD',
+             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+             shell=True, cwd=repo_dir, universal_newlines=True,
+         )


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
