### PR TITLE
purescript: update script only considers full releases

### DIFF
--- a/pkgs/development/compilers/purescript/purescript/update.sh
+++ b/pkgs/development/compilers/purescript/purescript/update.sh
@@ -14,7 +14,7 @@ purescript_derivation_file="${script_dir}/default.nix"
 old_version="$(sed -En 's/.*\bversion = "(.*?)".*/\1/p' "$purescript_derivation_file")"
 
 # This is the latest release version of PureScript on GitHub.
-new_version=$(curl --silent "https://api.github.com/repos/purescript/purescript/releases" | jq '.[0].tag_name' --raw-output | sed -e 's/v//')
+new_version=$(curl --silent "https://api.github.com/repos/purescript/purescript/releases/latest" | jq '.tag_name' --raw-output | sed -e 's/v//')
 
 echo "Updating purescript from old version v${old_version} to new version v${new_version}."
 echo


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Make sure the purescript update script only considers full releases.  Before this change, the purescript update script would consider prereleases as valid releases.  This caused the r-ryantm bot to create PRs trying to update the purescript derivation in Nixpkgs to prerelease versions.

See https://github.com/NixOS/nixpkgs/pull/174485#issuecomment-1137291664 and https://discourse.purescript.org/t/purescript-continuous-prereleases/3006/2?u=cdepillabout for slightly more information.

To test this, it should be sufficient to just run `./pkgs/development/compilers/purescript/purescript/update.sh` and make sure nothing changes in the repo (at least until the next version of PureScript is released...).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
