### PR TITLE
syncthingtray: 1.1.3 -> 1.1.20

### DIFF
--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -7,6 +7,8 @@
 , extra-cmake-modules
 , cpp-utilities
 , qtutilities
+, qtforkawesome
+, boost
 , cmake
 , kio
 , plasma-framework
@@ -19,17 +21,23 @@
 }:
 
 mkDerivation rec {
-  version = "1.1.3";
+  version = "1.1.20";
   pname = "syncthingtray";
 
   src = fetchFromGitHub {
     owner = "Martchus";
     repo = "syncthingtray";
     rev = "v${version}";
-    sha256 = "sha256-ovit2XSkxSjcbpqQUv8IzMqfsfItbtXLbx0/Vy0+J0Y=";
+    sha256 = "sha256-T0ddAROwVSh+IKGZZNDMC7YB2IfQZal2pAQ5ArirtjI=";
   };
 
-  buildInputs = [ qtbase cpp-utilities qtutilities ]
+  buildInputs = [
+    qtbase
+    cpp-utilities
+    qtutilities
+    boost
+    qtforkawesome
+  ]
     ++ lib.optionals webviewSupport [ qtwebengine ]
     ++ lib.optionals jsSupport [ qtdeclarative ]
     ++ lib.optionals kioPluginSupport [ kio ]

--- a/pkgs/development/libraries/qtforkawesome/default.nix
+++ b/pkgs/development/libraries/qtforkawesome/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cpp-utilities
+, qtutilities
+, qttools
+, qtbase
+, cmake
+, perl
+}:
+
+let
+  fork_awesome_release = fetchFromGitHub {
+    owner = "ForkAwesome";
+    repo = "Fork-Awesome";
+    rev = "1.2.0";
+    sha256 = "sha256-zG6/0dWjU7/y/oDZuSEv+54Mchng64LVyV8bluskYzc=";
+  };
+in stdenv.mkDerivation rec {
+  pname = "qtforkawesome";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "Martchus";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-J3F+ikz6gQqV+JsOX8EpMOWoTmI6UK5KndFALUo4oiU=";
+  };
+
+  buildInputs = [
+    qtbase
+    cpp-utilities
+    qtutilities
+  ];
+  nativeBuildInputs = [
+    cmake
+    qttools
+    perl
+    perl.pkgs.YAML
+  ];
+  cmakeFlags = [
+    "-DFORK_AWESOME_FONT_FILE=${fork_awesome_release}/fonts/forkawesome-webfont.woff2"
+    "-DFORK_AWESOME_ICON_DEFINITIONS=${fork_awesome_release}/src/icons/icons.yml"
+  ];
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/Martchus/qtforkawesome";
+    description = "Library that bundles ForkAwesome for use within Qt applications";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms   = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -195,6 +195,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   qtfeedback = callPackage ../development/libraries/qtfeedback { };
 
+  qtforkawesome = callPackage ../development/libraries/qtforkawesome { };
+
   qtutilities = callPackage ../development/libraries/qtutilities { };
 
   qtinstaller = callPackage ../development/libraries/qtinstaller { };


### PR DESCRIPTION
###### Motivation for this change

Close https://github.com/NixOS/nixpkgs/issues/174571 .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
