### PR TITLE
Fix regression in xfce alias 

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -207,10 +207,11 @@ lib.makeScope pkgs.newScope (self: with self; {
   xfce4_power_manager_gtk3 = throw "xfce.xfce4_power_manager_gtk3 has been removed, use xfce.xfce4-power-manager instead"; # added 2022-05-24
   gtk = throw "xfce.gtk has been removed, use gtk2 instead"; # added 2022-05-24
   gtksourceview = throw "xfce.gtksourceview has been removed, use gtksourceview instead"; # added 2022-05-24
-  dconf = throw "xfce.dconf has been removed, use dconf instead"; # added 2022-05-24
-  vte = throw "xfce.vte has been removed, use vte instead"; # added 2022-05-24
 
   xinitrc = xfce4-session.xinitrc; # added 2019-11-04
 
   thunar-bare = thunar.override { thunarPlugins = []; };  # added 2019-11-04
+
+  # added 2019-11-30
+  inherit (pkgs) dconf vte;
 })


### PR DESCRIPTION
###### Description of changes

Currently, `xfce.catfish` and `xfce.xfce4-terminal` fail to build on current master (6e514cffb59684ec3170c590830249f3a5e1f503) due to a regression in a cleanup from PR #174277. This re-adds the `vte` and `dconf` config lines again.

Fixes #174880

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (tested with `xfce.catfish`)
  - [x] aarch64-linux (tested with `xfce.catfish`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
