### PR TITLE
xfce: explicitly uses pkgs.dconf and pkgs.vte

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -64,7 +64,9 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   #### APPLICATIONS
 
-  catfish = callPackage ./applications/catfish { };
+  catfish = callPackage ./applications/catfish {
+    inherit (pkgs) dconf; # remove this line when the dconf alias is removed
+  };
 
   gigolo = callPackage ./applications/gigolo { };
 
@@ -80,7 +82,9 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   xfce4-dict = callPackage ./applications/xfce4-dict { };
 
-  xfce4-terminal = callPackage ./applications/xfce4-terminal { };
+  xfce4-terminal = callPackage ./applications/xfce4-terminal {
+    inherit (pkgs) vte; # remove this line when the vte alias is removed
+  };
 
   xfce4-screensaver = callPackage ./applications/xfce4-screensaver { };
 


### PR DESCRIPTION

###### Description of changes

`xfce.dconf` and `xfce.vte` were aliases to `pkgs.dconf` and `pkgs.vte`. After redefining them to throw an error, it is needed to explicitly use `pkgs.dconf` and `pkgs.vte`.

Fixes https://github.com/NixOS/nixpkgs/issues/174880

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
