### PR TITLE
qt6.wrapQtAppsHook: remove dependencies: qtbase qtwayland

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -9,6 +9,7 @@
 , wrapQtAppsHook
 , extra-cmake-modules
 , qtbase
+, qtwayland
 , qtsvg
 , qtimageformats
 , qt5compat
@@ -112,6 +113,7 @@ env.mkDerivation rec {
 
   buildInputs = [
     qtbase
+    qtwayland
     qtsvg
     qtimageformats
     qt5compat

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -83,9 +83,8 @@ let
       qtwebsockets = callPackage ./modules/qtwebsockets.nix { };
       qtwebview = callPackage ./modules/qtwebview.nix { };
 
-      wrapQtAppsHook = makeSetupHook
-        {
-          deps = [ self.qtbase.dev self.qtwayland.dev makeWrapper ];
+      wrapQtAppsHook = makeSetupHook {
+          deps = [ makeWrapper ];
         } ./hooks/wrap-qt-apps-hook.sh;
     };
 

--- a/pkgs/games/cutemaze/default.nix
+++ b/pkgs/games/cutemaze/default.nix
@@ -4,6 +4,8 @@
 , cmake
 , qttools
 , wrapQtAppsHook
+, qtbase
+, qtwayland
 , qtsvg
 }:
 
@@ -22,7 +24,11 @@ stdenv.mkDerivation rec {
     wrapQtAppsHook
   ];
 
-  buildInputs = [ qtsvg ];
+  buildInputs = [
+    qtbase
+    qtwayland
+    qtsvg
+  ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications


### PR DESCRIPTION
###### Description of changes

fix #174828

make dependencies explicit to reduce closure size for cli apps

qt cli apps: `buildInputs = [ qtbase ];`

qt gui apps: `buildInputs = [ qtbase qtwayland ];`

qt wrappers like pyqt or pyside: ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
