### PR TITLE
new-lg4ff: init at 0.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7964,6 +7964,12 @@
     githubId = 19036;
     name = "Matthew Bauer";
   };
+  matthiasbenaets = {
+    email = "matthias.benaets@gmail.com";
+    github = "MatthiasBenaets";
+    githubId = 89214559;
+    name = "Matthias Benaets";
+  };
   matthiasbeyer = {
     email = "mail@beyermatthias.de";
     matrix = "@musicmatze:beyermatthi.as";

--- a/nixos/modules/hardware/new-lg4ff.nix
+++ b/nixos/modules/hardware/new-lg4ff.nix
@@ -1,0 +1,28 @@
+{ pkgs, lib, config, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.new-lg4ff;
+in {
+  options.hardware.new-lg4ff = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables improved Linux module drivers for Logitech driving wheels.
+        This will replace the existing in-kernel hid-logitech modules.
+        Works most notably on the Logitech G25, G27, G29 and Driving Force (GT).
+      '';
+    };
+  };
+
+  config = {
+    boot = {
+      extraModulePackages = [ pkgs.new-lg4ff ];
+      kernelModules = [ "hid-logitech-new" ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ matthiasbenaets ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -66,6 +66,7 @@
   ./hardware/network/ath-user-regd.nix
   ./hardware/network/b43.nix
   ./hardware/network/intel-2200bg.nix
+  ./hardware/new-lg4ff.nix
   ./hardware/nitrokey.nix
   ./hardware/opengl.nix
   ./hardware/openrazer.nix

--- a/pkgs/os-specific/linux/new-lg4ff/default.nix
+++ b/pkgs/os-specific/linux/new-lg4ff/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, kernel, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "new-lg4ff";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "berarma";
+    repo = "new-lg4ff";
+    rev = "${version}";
+    sha256 = "+05xDpNI4m6wTS+YPgA0fP4iM10nMOZOtCrdQxpevBU=";
+  };
+
+  preBuild = ''
+    substituteInPlace Makefile --replace "modules_install" "INSTALL_MOD_PATH=$out modules_install"
+    sed -i '/depmod/d' Makefile
+    sed -i "10i\\\trmmod hid-logitech 2> /dev/null || true" Makefile
+    sed -i "11i\\\trmmod hid-logitech-new 2> /dev/null || true" Makefile
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KVERSION=${kernel.modDirVersion}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  meta = with lib; {
+    description = "Experimental Logitech force feedback module for Linux";
+    homepage = "https://github.com/berarma/new-lg4ff";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ matthiasbenaets ];
+    platforms = platforms.linux;
+    broken = stdenv.isAarch64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23057,6 +23057,10 @@ with pkgs;
     stdenv = gcc11Stdenv;
   };
 
+  new-lg4ff = callPackage ../os-specific/linux/new-lg4ff {
+    inherit (linuxPackages) kernel;
+  };
+
   nmon = callPackage ../os-specific/linux/nmon { };
 
   hwdata = callPackage ../os-specific/linux/hwdata { };


### PR DESCRIPTION
###### Description of changes

Experimental Logitech force feedback module for Linux.
Improved driver for Logitech driving wheels.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
