### PR TITLE
ProtonVPN Updates

### DIFF
--- a/pkgs/applications/networking/protonvpn-cli/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonApplication rec {
   pname = "protonvpn-cli";
-  version = "3.11.1";
+  version = "3.12.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.5";
@@ -18,7 +18,7 @@ buildPythonApplication rec {
     owner = "protonvpn";
     repo = "linux-cli";
     rev = version;
-    sha256 = "sha256-u+POtUz7NoGS23aOmvDCZPUp2HW1xXGtfbZR88cWCBc=";
+    sha256 = "sha256-z0ewAqf8hjyExqBN8KBsDwJ+SA/pIBYZhKtXF9M65HE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonApplication rec {
   pname = "protonvpn-gui";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "linux-app";
-    rev = "refs/tags/${version}";
-    sha256 = "sha256-Od12qHiyXHu2JnjYV7amZz5xxL+eiWUVbcG5Tbcrr28=";
+    rev = version;
+    sha256 = "sha256-+YLrIhe7kzQHPRk/3D1r56ESS1BdDxP1PFeNIg/kGLw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "protonvpn-nm-lib";
-  version = "3.9.0";
+  version = "3.10.0";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = pname;
     rev = version;
-    sha256 = "sha256-yV3xeIyPc2DJj5DOa5PA1MHt00bjJ/Y9zZK77s/XRAA=";
+    sha256 = "sha256-WVIQ43J01BQzYhEPDHcoAmUvlsaDw0Z7yLQGajVdedU=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Major update of ProtonVPN components:
- `python3Packages.protonvpn-nm-lib`
- `protonvpn-cli` (Supersedes #174481)
- `protonvpn-gui` (Supersedes #174483)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
