### PR TITLE
libdwarf: 20181024 -> 20210528

### DIFF
--- a/pkgs/development/libraries/libdwarf/0.4.nix
+++ b/pkgs/development/libraries/libdwarf/0.4.nix
@@ -1,24 +1,7 @@
-{ lib, stdenv, fetchurl, zlib }:
-
-stdenv.mkDerivation rec {
-  pname = "libdwarf";
+{ callPackage, zlib }:
+callPackage ./common.nix rec {
   version = "0.4.0";
-
-  src = fetchurl {
-    url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
-    sha512 = "30e5c6c1fc95aa28a014007a45199160e1d9ba870b196d6f98e6dd21a349e9bb31bba1bd6817f8ef9a89303bed0562182a7d46fcbb36aedded76c2f1e0052e1e";
-  };
-
-  configureFlags = [ "--enable-shared" "--disable-nonshared" ];
-
+  url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
+  sha512 = "30e5c6c1fc95aa28a014007a45199160e1d9ba870b196d6f98e6dd21a349e9bb31bba1bd6817f8ef9a89303bed0562182a7d46fcbb36aedded76c2f1e0052e1e";
   buildInputs = [ zlib ];
-
-  outputs = [ "bin" "lib" "dev" "out" ];
-
-  meta = {
-    homepage = "https://github.com/davea42/libdwarf-code";
-    platforms = lib.platforms.unix;
-    license = lib.licenses.lgpl21Plus;
-    maintainers = [ lib.maintainers.atry ];
-  };
 }

--- a/pkgs/development/libraries/libdwarf/common.nix
+++ b/pkgs/development/libraries/libdwarf/common.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchurl, buildInputs, sha512, version, libelf, url }:
+
+stdenv.mkDerivation rec {
+  pname = "libdwarf";
+  inherit version;
+
+  src = fetchurl {
+    inherit url;
+    inherit sha512;
+  };
+
+  configureFlags = [ "--enable-shared" "--disable-nonshared" ];
+
+  inherit buildInputs;
+
+  outputs = [ "bin" "lib" "dev" "out" ];
+
+  meta = {
+    homepage = "https://github.com/davea42/libdwarf-code";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.atry ];
+  };
+}

--- a/pkgs/development/libraries/libdwarf/common.nix
+++ b/pkgs/development/libraries/libdwarf/common.nix
@@ -5,8 +5,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    inherit url;
-    inherit sha512;
+    inherit url sha512;
   };
 
   configureFlags = [ "--enable-shared" "--disable-nonshared" ];

--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -1,56 +1,7 @@
-{ lib, stdenv, fetchurl, libelf, zlib }:
-
-let
-  version = "20181024";
-  src = fetchurl {
-    url = "https://www.prevanders.net/libdwarf-${version}.tar.gz";
-    # Upstream displays this hash broken into three parts:
-    sha512 = "02f8024bb9959c91a1fe322459f7587a589d096595"
-           + "6d643921a173e6f9e0a184db7aef66f0fd2548d669"
-           + "5be7f9ee368f1cc8940cea4ddda01ff99d28bbf1fe58";
-  };
-  meta = {
-    homepage = "https://www.prevanders.net/dwarf.html";
-    platforms = lib.platforms.linux;
-    license = lib.licenses.lgpl21Plus;
-  };
-
-in rec {
-  libdwarf = stdenv.mkDerivation {
-    pname = "libdwarf";
-    inherit version;
-
-    configureFlags = [ "--enable-shared" "--disable-nonshared" ];
-
-    preConfigure = ''
-      cd libdwarf
-    '';
-    buildInputs = [ libelf zlib ];
-
-    installPhase = ''
-      mkdir -p $out/lib $out/include
-      cp libdwarf.so.1 $out/lib
-      ln -s libdwarf.so.1 $out/lib/libdwarf.so
-      cp libdwarf.h dwarf.h $out/include
-    '';
-
-    inherit meta src;
-  };
-
-  dwarfdump = stdenv.mkDerivation {
-    pname = "dwarfdump";
-    inherit version;
-
-    preConfigure = ''
-      cd dwarfdump
-    '';
-
-    buildInputs = [ libelf libdwarf ];
-
-    installPhase = ''
-      install -m755 -D dwarfdump $out/bin/dwarfdump
-    '';
-
-    inherit meta src;
-  };
+{ callPackage, zlib, libelf }:
+callPackage ./common.nix rec {
+  version = "20210528";
+  url = "https://www.prevanders.net/libdwarf-${version}.tar.gz";
+  sha512 = "e0f9c88554053ee6c1b1333960891189e7820c4a4ddc302b7e63754a4cdcfc2acb1b4b6083a722d1204a75e994fff3401ecc251b8c3b24090f8cb4046d90f870";
+  buildInputs = [ zlib libelf ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18439,8 +18439,8 @@ with pkgs;
   libdvdread = callPackage ../development/libraries/libdvdread { };
   libdvdread_4_9_9 = callPackage ../development/libraries/libdvdread/4.9.9.nix { };
 
-  inherit (callPackage ../development/libraries/libdwarf { })
-    libdwarf dwarfdump;
+  libdwarf = callPackage ../development/libraries/libdwarf { };
+  dwarfdump = libdwarf.bin;
   libdwarf_0_4 = callPackage ../development/libraries/libdwarf/0.4.nix { };
 
   libe57format = callPackage ../development/libraries/libe57format { };


### PR DESCRIPTION
###### Description of changes

Changelog: https://www.prevanders.net/dwarf.html#libdwarf-20210528

`dwarfdump` is kept for backward compatibility 

Note that the latest version libdwarf is 0.4.0, but we cannot make 0.4.0 default because it changed the include path and it would break all packages that depend on libdwarf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
