### PR TITLE
Introduce a type for options that contain the path to a secret file

### DIFF
--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -20,6 +20,23 @@ merging is handled.
     coerced to a string. Even if derivations can be considered as
     paths, the more specific `types.package` should be preferred.
 
+`types.secretFile`
+
+:   A string representing a filesystem path (starting with "/") to a file which
+    is supposed to remain secret.
+    Depending on how the module is implemented, setting an option of type
+    `types.path` to the literal value `/etc/secret_file` can make nix copy the
+    secret file at `nixos-rebuild` time to the store and thus make it world
+    readable. To avoid this behavior, it is enough to quote the path:
+    `"/etc/secret_file"`. This solution is simple, but it is easy to forget
+    about it. `types.secretFile` is design to prevent such mistakes.
+    Compared to `types.path`, this type adds further restrictions:
+    - only strings (as opposed to unquoted paths) are accepted as input.
+    - the string must not start by `/nix/store/`.
+    To bypass these restrictions you can pass the value to the function
+    `types.secretFile.makeWorldReadable`. This can be useful when writing NixOS
+    tests, as in this case the secret file is only an example value.
+
 `types.package`
 
 :   A top-level store path. This can be an attribute set pointing

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -39,6 +39,46 @@
       </varlistentry>
       <varlistentry>
         <term>
+          <literal>types.secretFile</literal>
+        </term>
+        <listitem>
+          <para>
+            A string representing a filesystem path (starting with
+            <quote>/</quote>) to a file which is supposed to remain
+            secret. Depending on how the module is implemented, setting
+            an option of type <literal>types.path</literal> to the
+            literal value <literal>/etc/secret_file</literal> can make
+            nix copy the secret file at <literal>nixos-rebuild</literal>
+            time to the store and thus make it world readable. To avoid
+            this behavior, it is enough to quote the path:
+            <literal>&quot;/etc/secret_file&quot;</literal>. This
+            solution is simple, but it is easy to forget about it.
+            <literal>types.secretFile</literal> is design to prevent
+            such mistakes. Compared to <literal>types.path</literal>,
+            this type adds further restrictions:
+          </para>
+          <itemizedlist spacing="compact">
+            <listitem>
+              <para>
+                only strings (as opposed to unquoted paths) are accepted
+                as input.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                the string must not start by
+                <literal>/nix/store/</literal>. To bypass these
+                restrictions you can pass the value to the function
+                <literal>types.secretFile.makeWorldReadable</literal>.
+                This can be useful when writing NixOS tests, as in this
+                case the secret file is only an example value.
+              </para>
+            </listitem>
+          </itemizedlist>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
           <literal>types.package</literal>
         </term>
         <listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -36,6 +36,36 @@
           PHP now defaults to PHP 8.1, updated from 8.0.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The NixOS module system now has a type
+          <literal>secretFile</literal> for options which contain the
+          path to a file that should remain secret. This is to avoid
+          mistakes where one writes
+          <literal>services.miniflux.adminCredentialsFile = /etc/secret</literal>
+          instead of
+          <literal>services.miniflux.adminCredentialsFile = &quot;/etc/secret&quot;;</literal>
+          which makes nix copy <literal>/etc/secret</literal> to the
+          store where everyone could read it. A number of modules have
+          been converted to use it. This is a breaking change visible by
+          an error message like this:
+        </para>
+        <programlisting>
+error: A definition for option `services.miniflux.adminCredentialsFile' is not of type `quoted path to a secret file'. Definition values:
+     - In `nixos/lib/build-vms.nix': /etc/secret
+</programlisting>
+        <para>
+          To fix the issue you must assess whether leaking
+          <literal>/etc/secret</literal> to the store and thus all local
+          users is a problem. If it is the case, then add quotes:
+          <literal>services.miniflux.adminCredentialsFile = &quot;/etc/secrets&quot;</literal>.
+          If you notice this during upgrade, your secret probably has
+          already leaked and it may be a good time to change it. If
+          leaking this file is acceptable (for example in a NixOS test),
+          you can keep the old behavior like this:
+          <literal>services.miniflux.adminCredentialsFile = lib.types.secretFile.makeWorldReadable /etc/secret</literal>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.11-new-services">

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -19,6 +19,25 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - PHP now defaults to PHP 8.1, updated from 8.0.
 
+- The NixOS module system now has a type `secretFile` for options which contain
+  the path to a file that should remain secret. This is to avoid mistakes where
+  one writes `services.miniflux.adminCredentialsFile = /etc/secret` instead of
+  `services.miniflux.adminCredentialsFile = "/etc/secret";` which makes nix
+  copy `/etc/secret` to the store where everyone could read it. A number of
+  modules have been converted to use it. This is a breaking change visible by
+  an error message like this:
+  ```
+  error: A definition for option `services.miniflux.adminCredentialsFile' is not of type `quoted path to a secret file'. Definition values:
+       - In `nixos/lib/build-vms.nix': /etc/secret
+  ```
+  To fix the issue you must assess whether leaking `/etc/secret` to the store
+  and thus all local users is a problem. If it is the case, then add quotes:
+  `services.miniflux.adminCredentialsFile = "/etc/secrets"`. If you notice this
+  during upgrade, your secret probably has already leaked and it may be a good
+  time to change it. If leaking this file is acceptable (for example in a NixOS
+  test), you can keep the old behavior like this:
+  `services.miniflux.adminCredentialsFile = lib.types.secretFile.makeWorldReadable /etc/secret`.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Services {#sec-release-22.11-new-services}

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -554,7 +554,7 @@ let
       };
 
       credentialsFile = mkOption {
-        type = types.path;
+        type = types.secretFile;
         inherit (defaultAndText "credentialsFile" null) default defaultText;
         description = ''
           Path to an EnvironmentFile for the cert's service containing any required and

--- a/nixos/modules/services/networking/knot.nix
+++ b/nixos/modules/services/networking/knot.nix
@@ -48,7 +48,7 @@ in {
       };
 
       keyFiles = mkOption {
-        type = types.listOf types.path;
+        type = types.listOf types.secretFile;
         default = [];
         description = ''
           A list of files containing additional configuration

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -40,7 +40,7 @@ in
       };
 
       adminCredentialsFile = mkOption  {
-        type = types.path;
+        type = types.secretFile;
         description = ''
           File containing the ADMIN_USERNAME and
           ADMIN_PASSWORD (length >= 6) in the format of

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -18,12 +18,12 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: let
   dnsConfig = nodes: {
     dnsProvider = "exec";
     dnsPropagationCheck = false;
-    credentialsFile = pkgs.writeText "wildcard.env" ''
+    credentialsFile = lib.types.secretFile.makeWorldReadable (pkgs.writeText "wildcard.env" ''
       EXEC_PATH=${dnsScript nodes}
       EXEC_POLLING_INTERVAL=1
       EXEC_PROPAGATION_TIMEOUT=1
       EXEC_SEQUENCE_INTERVAL=1
-    '';
+    '');
   };
 
   documentRoot = pkgs.runCommand "docroot" {} ''

--- a/nixos/tests/knot.nix
+++ b/nixos/tests/knot.nix
@@ -29,12 +29,12 @@ let
     paths = [ exampleZone delegatedZone ];
   };
   # DO NOT USE pkgs.writeText IN PRODUCTION. This put secrets in the nix store!
-  tsigFile = pkgs.writeText "tsig.conf" ''
+  tsigFile = lib.types.secretFile.makeWorldReadable (pkgs.writeText "tsig.conf" ''
     key:
       - id: slave_key
         algorithm: hmac-sha256
         secret: zOYgOgnzx3TGe5J5I/0kxd7gTcxXhLYMEq3Ek3fY37s=
-  '';
+  '');
 in {
   name = "knot";
   meta = with pkgs.lib.maintainers; {

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -7,14 +7,14 @@ let
   defaultPort = 8080;
   defaultUsername = "admin";
   defaultPassword = "password";
-  adminCredentialsFile = pkgs.writeText "admin-credentials" ''
+  adminCredentialsFile = lib.types.secretFile.makeWorldReadable (pkgs.writeText "admin-credentials" ''
             ADMIN_USERNAME=${defaultUsername}
             ADMIN_PASSWORD=${defaultPassword}
-          '';
-  customAdminCredentialsFile = pkgs.writeText "admin-credentials" ''
+          '');
+  customAdminCredentialsFile = lib.types.secretFile.makeWorldReadable (pkgs.writeText "admin-credentials" ''
             ADMIN_USERNAME=${username}
             ADMIN_PASSWORD=${password}
-          '';
+          '');
 
 in
 with lib;


### PR DESCRIPTION
###### Description of changes

This should avoid mistakes like `passwordFile = /etc/secret;` where that path is unquoted so nix copies it to the nix store and makes it public.
I converted three modules to illustrate, but if this is merged we could add many others. It will be a breaking change but for security's sake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
