### PR TITLE
opensearch: init at 2.5.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -36,6 +36,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [imaginary](https://github.com/h2non/imaginary), a microservice for high-level image processing that Nextcloud can use to generate previews. Available as [services.imaginary](#opt-services.imaginary.enable).
 
+- [opensearch](https://opensearch.org), a search server alternative to Elasticsearch. Available as [services.opensearch](options.html#opt-services.opensearch.enable).
+
 - [goeland](https://github.com/slurdge/goeland), an alternative to rss2email written in golang with many filters. Available as [services.goeland](#opt-services.goeland.enable).
 
 - [atuin](https://github.com/ellie/atuin), a sync server for shell history. Available as [services.atuin](#opt-services.atuin.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1048,6 +1048,7 @@
   ./services/search/hound.nix
   ./services/search/kibana.nix
   ./services/search/meilisearch.nix
+  ./services/search/opensearch.nix
   ./services/search/solr.nix
   ./services/security/aesmd.nix
   ./services/security/certmgr.nix

--- a/nixos/modules/services/search/opensearch.nix
+++ b/nixos/modules/services/search/opensearch.nix
@@ -1,0 +1,210 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.opensearch;
+
+  settingsFormat = pkgs.formats.yaml {};
+
+  configDir = cfg.dataDir + "/config";
+
+  opensearchYml = settingsFormat.generate "opensearch.yml" cfg.settings;
+
+  loggingConfigFilename = "log4j2.properties";
+  loggingConfigFile = pkgs.writeTextFile {
+    name = loggingConfigFilename;
+    text = cfg.logging;
+  };
+in
+{
+
+  options.services.opensearch = {
+    enable = mkEnableOption (lib.mdDoc "Whether to enable OpenSearch.");
+
+    package = lib.mkPackageOptionMD pkgs "OpenSearch package to use." {
+      default = [ "opensearch" ];
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options."network.host" = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1";
+          description = lib.mdDoc ''
+            Which port this service should listen on.
+          '';
+        };
+
+        options."cluster.name" = lib.mkOption {
+          type = lib.types.str;
+          default = "opensearch";
+          description = lib.mdDoc ''
+            The name of the cluster.
+          '';
+        };
+
+        options."discovery.type" = lib.mkOption {
+          type = lib.types.str;
+          default = "single-node";
+          description = lib.mdDoc ''
+            The type of discovery to use.
+          '';
+        };
+
+        options."http.port" = lib.mkOption {
+          type = lib.types.port;
+          default = 9200;
+          description = lib.mdDoc ''
+            The port to listen on for HTTP traffic.
+          '';
+        };
+
+        options."transport.port" = lib.mkOption {
+          type = lib.types.port;
+          default = 9300;
+          description = lib.mdDoc ''
+            The port to listen on for transport traffic.
+          '';
+        };
+      };
+
+      default = {};
+
+      description = lib.mdDoc ''
+        OpenSearch configuration.
+      '';
+    };
+
+    logging = lib.mkOption {
+      description = lib.mdDoc "opensearch logging configuration.";
+
+      default = ''
+        logger.action.name = org.opensearch.action
+        logger.action.level = info
+
+        appender.console.type = Console
+        appender.console.name = console
+        appender.console.layout.type = PatternLayout
+        appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+        rootLogger.level = info
+        rootLogger.appenderRef.console.ref = console
+      '';
+      type = types.str;
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/opensearch";
+      description = lib.mdDoc ''
+        Data directory for opensearch.
+      '';
+    };
+
+    extraCmdLineOptions = lib.mkOption {
+      description = lib.mdDoc "Extra command line options for the opensearch launcher.";
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+    };
+
+    extraJavaOptions = lib.mkOption {
+      description = lib.mdDoc "Extra command line options for Java.";
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+      example = [ "-Djava.net.preferIPv4Stack=true" ];
+    };
+
+    restartIfChanged = lib.mkOption {
+      type = lib.types.bool;
+      description = lib.mdDoc ''
+        Automatically restart the service on config change.
+        This can be set to false to defer restarts on a server or cluster.
+        Please consider the security implications of inadvertently running an older version,
+        and the possibility of unexpected behavior caused by inconsistent versions across a cluster when disabling this option.
+      '';
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.opensearch = {
+      description = "OpenSearch Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = [ pkgs.inetutils ];
+      inherit (cfg) restartIfChanged;
+      environment = {
+        OPENSEARCH_HOME = cfg.dataDir;
+        OPENSEARCH_JAVA_OPTS = toString cfg.extraJavaOptions;
+        OPENSEARCH_PATH_CONF = configDir;
+      };
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/opensearch ${toString cfg.extraCmdLineOptions}";
+        User = "opensearch";
+        Group = "opensearch";
+        StateDirectory = cfg.dataDir;
+        StateDirectoryMode = "0700";
+        PermissionsStartOnly = true;
+        LimitNOFILE = "1024000";
+        Restart = "always";
+        TimeoutStartSec = "infinity";
+      };
+      preStart = optionalString (!config.boot.isContainer) ''
+        # Only set vm.max_map_count if lower than ES required minimum
+        # This avoids conflict if configured via boot.kernel.sysctl
+        if [ $(${pkgs.procps}/bin/sysctl -n vm.max_map_count) -lt 262144 ]; then
+          ${pkgs.procps}/bin/sysctl -w vm.max_map_count=262144
+        fi
+     '' + ''
+        mkdir -m 0700 -p ${cfg.dataDir}
+
+        # Install plugins
+        ln -sfT ${cfg.package}/lib ${cfg.dataDir}/lib
+        ln -sfT ${cfg.package}/modules ${cfg.dataDir}/modules
+
+        # opensearch needs to create the opensearch.keystore in the config directory
+        # so this directory needs to be writable.
+        mkdir -m 0700 -p ${configDir}
+
+        # Note that we copy config files from the nix store instead of symbolically linking them
+        # because otherwise X-Pack Security will raise the following exception:
+        # java.security.AccessControlException:
+        # access denied ("java.io.FilePermission" "/var/lib/opensearch/config/opensearch.yml" "read")
+
+        cp ${opensearchYml} ${configDir}/opensearch.yml
+        # Make sure the logging configuration for old opensearch versions is removed:
+        rm -f "${configDir}/logging.yml"
+        cp ${loggingConfigFile} ${configDir}/${loggingConfigFilename}
+        mkdir -p ${configDir}/scripts
+        cp ${cfg.package}/config/jvm.options ${configDir}/jvm.options
+        # redirect jvm logs to the data directory
+        mkdir -m 0700 -p ${cfg.dataDir}/logs
+        sed -e '#logs/gc.log#${cfg.dataDir}/logs/gc.log#' -i ${configDir}/jvm.options \
+
+        if [ "$(id -u)" = 0 ]; then chown -R opensearch:opensearch ${cfg.dataDir}; fi
+      '';
+      postStart = ''
+        # Make sure opensearch is up and running before dependents
+        # are started
+        while ! ${pkgs.curl}/bin/curl -sS -f http://${cfg.settings."network.host"}:${toString cfg.settings."http.port"} 2>/dev/null; do
+          sleep 1
+        done
+      '';
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    users = {
+      groups.opensearch = {};
+      users.opensearch = {
+        description = "OpenSearch daemon user";
+        home = cfg.dataDir;
+        group = "opensearch";
+        isSystemUser = true;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -490,6 +490,7 @@ in {
   ombi = handleTest ./ombi.nix {};
   openarena = handleTest ./openarena.nix {};
   openldap = handleTest ./openldap.nix {};
+  opensearch = handleTest ./opensearch.nix {};
   openresty-lua = handleTest ./openresty-lua.nix {};
   opensmtpd = handleTest ./opensmtpd.nix {};
   opensmtpd-rspamd = handleTest ./opensmtpd-rspamd.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -490,7 +490,7 @@ in {
   ombi = handleTest ./ombi.nix {};
   openarena = handleTest ./openarena.nix {};
   openldap = handleTest ./openldap.nix {};
-  opensearch = handleTest ./opensearch.nix {};
+  opensearch = discoverTests (import ./opensearch.nix);
   openresty-lua = handleTest ./openresty-lua.nix {};
   opensmtpd = handleTest ./opensmtpd.nix {};
   opensmtpd-rspamd = handleTest ./opensmtpd-rspamd.nix {};

--- a/nixos/tests/opensearch.nix
+++ b/nixos/tests/opensearch.nix
@@ -1,0 +1,19 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "opensearch";
+  meta.maintainers = with pkgs.lib.maintainers; [ shyim ];
+
+  nodes.machine = {
+    virtualisation.memorySize = 2048;
+    services.opensearch.enable = true;
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("opensearch.service")
+    machine.wait_for_open_port(9200)
+
+    machine.succeed(
+        "curl --fail localhost:9200"
+    )
+  '';
+})

--- a/nixos/tests/opensearch.nix
+++ b/nixos/tests/opensearch.nix
@@ -1,19 +1,52 @@
-import ./make-test-python.nix ({ pkgs, ... }: {
-  name = "opensearch";
-  meta.maintainers = with pkgs.lib.maintainers; [ shyim ];
+let
+  opensearchTest =
+    import ./make-test-python.nix (
+      { pkgs, lib, extraSettings ? {} }: {
+        name = "opensearch";
+        meta.maintainers = with pkgs.lib.maintainers; [ shyim ];
 
-  nodes.machine = {
-    virtualisation.memorySize = 2048;
-    services.opensearch.enable = true;
+        nodes.machine = lib.mkMerge [
+          {
+            virtualisation.memorySize = 2048;
+            services.opensearch.enable = true;
+          }
+          extraSettings
+        ];
+
+        testScript = ''
+          machine.start()
+          machine.wait_for_unit("opensearch.service")
+          machine.wait_for_open_port(9200)
+
+          machine.succeed(
+              "curl --fail localhost:9200"
+          )
+        '';
+      });
+in
+{
+  opensearch = opensearchTest {};
+  opensearchCustomPathAndUser = opensearchTest {
+    extraSettings = {
+      services.opensearch.dataDir = "/var/opensearch_test";
+      services.opensearch.user = "open_search";
+      services.opensearch.group = "open_search";
+      system.activationScripts.createDirectory = {
+        text = ''
+          mkdir -p "/var/opensearch_test"
+          chown open_search:open_search /var/opensearch_test
+          chmod 0700 /var/opensearch_test
+        '';
+        deps = [ "users" "groups" ];
+      };
+      users = {
+        groups.open_search = {};
+        users.open_search = {
+          description = "OpenSearch daemon user";
+          group = "open_search";
+          isSystemUser = true;
+        };
+      };
+    };
   };
-
-  testScript = ''
-    machine.start()
-    machine.wait_for_unit("opensearch.service")
-    machine.wait_for_open_port(9200)
-
-    machine.succeed(
-        "curl --fail localhost:9200"
-    )
-  '';
-})
+}

--- a/pkgs/servers/search/opensearch/default.nix
+++ b/pkgs/servers/search/opensearch/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, makeWrapper
+, jre_headless
+, util-linux
+, gnugrep
+, coreutils
+, autoPatchelfHook
+, zlib
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "opensearch";
+  version = "2.5.0";
+
+  src = fetchurl {
+    url = "https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/opensearch-${version}-linux-x64.tar.gz";
+    hash = "sha256-WPD5StVBb/hK+kP/1wkQQBKRQma/uaP+8ULeIFUBL1U=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre_headless util-linux ];
+  patches = [./opensearch-home-fix.patch ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -R bin config lib modules plugins $out
+
+    substituteInPlace $out/bin/opensearch \
+      --replace 'bin/opensearch-keystore' "$out/bin/opensearch-keystore"
+
+    wrapProgram $out/bin/opensearch \
+      --prefix PATH : "${lib.makeBinPath [ util-linux gnugrep coreutils ]}" \
+      --set JAVA_HOME "${jre_headless}"
+
+    wrapProgram $out/bin/opensearch-plugin --set JAVA_HOME "${jre_headless}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open Source, Distributed, RESTful Search Engine";
+    homepage = "https://github.com/opensearch-project/OpenSearch";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ shyim ];
+  };
+}

--- a/pkgs/servers/search/opensearch/default.nix
+++ b/pkgs/servers/search/opensearch/default.nix
@@ -42,7 +42,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.tests = { inherit (nixosTests) opensearch; };
+  passthru.tests = nixosTests.opensearch;
 
   meta = {
     description = "Open Source, Distributed, RESTful Search Engine";

--- a/pkgs/servers/search/opensearch/default.nix
+++ b/pkgs/servers/search/opensearch/default.nix
@@ -8,6 +8,7 @@
 , coreutils
 , autoPatchelfHook
 , zlib
+, nixosTests
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -40,6 +41,8 @@ stdenvNoCC.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = { inherit (nixosTests) opensearch; };
 
   meta = {
     description = "Open Source, Distributed, RESTful Search Engine";

--- a/pkgs/servers/search/opensearch/opensearch-home-fix.patch
+++ b/pkgs/servers/search/opensearch/opensearch-home-fix.patch
@@ -1,0 +1,26 @@
+diff -Naur a/bin/opensearch-env b/bin/opensearch-env
+--- a/bin/opensearch-env	2017-12-12 13:31:51.000000000 +0100
++++ b/bin/opensearch-env	2017-12-18 19:51:12.282809695 +0100
+@@ -19,18 +19,10 @@
+   fi
+ done
+ 
+-# determine OpenSearch home; to do this, we strip from the path until we find
+-# bin, and then strip bin (there is an assumption here that there is no nested
+-# directory under bin also named bin)
+-OPENSEARCH_HOME=`dirname "$SCRIPT"`
+-
+-# now make OPENSEARCH_HOME absolute
+-OPENSEARCH_HOME=`cd "$OPENSEARCH_HOME"; pwd`
+-
+-while [ "`basename "$OPENSEARCH_HOME"`" != "bin" ]; do
+-  OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
+-done
+-OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
++if [ -z "$OPENSEARCH_HOME" ]; then
++    echo "You must set the OPENSEARCH_HOME var" >&2
++    exit 1
++fi
+ 
+ # now set the classpath
+ OPENSEARCH_CLASSPATH="$OPENSEARCH_HOME/lib/*"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34812,6 +34812,8 @@ with pkgs;
 
   openrct2 = callPackage ../games/openrct2 { };
 
+  opensearch = callPackage ../servers/search/opensearch { };
+
   osu-lazer = callPackage ../games/osu-lazer { };
 
   osu-lazer-bin = callPackage ../games/osu-lazer/bin.nix { };


### PR DESCRIPTION
###### Description of changes

I maintain the PHP client for Opensearch and packaged it myself as I tested the newest release. Also relates to packaging request #151464

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


