### PR TITLE
python310Packages.pyzmq: 22.3.0 -> 23.0.0

### DIFF
--- a/pkgs/development/python-modules/pysqueezebox/default.nix
+++ b/pkgs/development/python-modules/pysqueezebox/default.nix
@@ -1,22 +1,43 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder, aiohttp }:
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "pysqueezebox";
-  version = "0.5.5";
+  version = "0.6.0";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "93e6a3824b560d4ea2b2e5f0a67fdf3b309b6194fbf9927e44fc0d12c7fdc6c0";
+  src = fetchFromGitHub {
+    owner = "rajlaud";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-0ArKVRy4H0NWShlQMziKvbHp9OjpAkEKp4zrvpVlXOk=";
   };
 
   propagatedBuildInputs = [
     aiohttp
   ];
 
-  # No tests in the Pypi distribution
-  doCheck = false;
-  pythonImportsCheck = [ "pysqueezebox" ];
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pysqueezebox"
+  ];
+
+  disabledTestPaths = [
+    # Tests require network access
+    "tests/test_integration.py"
+  ];
 
   meta = with lib; {
     description = "Asynchronous library to control Logitech Media Server";
@@ -25,3 +46,4 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ nyanloutre ];
   };
 }
+

--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -1,46 +1,68 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchPypi
+, py
 , pytestCheckHook
+, python
+, pythonOlder
 , tornado
 , zeromq
-, py
-, python
 }:
 
 buildPythonPackage rec {
   pname = "pyzmq";
-  version = "22.3.0";
+  version = "23.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8eddc033e716f8c91c6a2112f0a8ebc5e00532b4a6ae1eb0ccc48e027f9c671c";
+    hash = "sha256-pF9cBHfRLfBe8uKSK0m3wK6dD0/5trsNZmVY3w7zcSI=";
   };
+
+  buildInputs = [
+    zeromq
+  ];
+
+  propagatedBuildInputs = [
+    py
+  ];
 
   checkInputs = [
     pytestCheckHook
     tornado
   ];
-  buildInputs = [ zeromq ];
-  propagatedBuildInputs = [ py ];
 
-  # failing tests
-  disabledTests = [
-    "test_socket" # hangs
-    "test_current"
-    "test_instance"
-    "test_callable_check"
-    "test_on_recv_basic"
-    "test_on_recv_wake"
-    "test_monitor" # https://github.com/zeromq/pyzmq/issues/1272
-    "test_cython"
-    "test_asyncio" # hangs
-    "test_mockable" # fails
+  pythonImportsCheck = [
+    "zmq"
   ];
 
   pytestFlagsArray = [
     "$out/${python.sitePackages}/zmq/tests/" # Folder with tests
   ];
 
+  disabledTests = [
+    # Tests hang
+    "test_socket"
+    "test_monitor"
+    # https://github.com/zeromq/pyzmq/issues/1272
+    "test_cython"
+    # Test fails
+    "test_mockable"
+    # Issues with the sandbox
+    "TestFutureSocket"
+    "TestIOLoop"
+    "TestPubLog"
+  ];
+
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "Python bindings for ØMQ";
+    homepage = "https://pyzmq.readthedocs.io/";
+    license = with licenses; [ bsd3 /* or */ lgpl3Only ];
+    maintainers = with maintainers; [ ];
+  };
 }


### PR DESCRIPTION
###### Description of changes
https://pyzmq.readthedocs.io/en/latest/changelog.html#id1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
