### PR TITLE
emacs-mac: 27.2-8.3 -> 28.1-9.0

### DIFF
--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -5,10 +5,10 @@
 
 stdenv.mkDerivation rec {
   pname = "emacs";
-  version = "27.2";
+  version = "28.1";
 
   emacsName = "emacs-${version}";
-  macportVersion = "8.3";
+  macportVersion = "9.0";
   name = "emacs-mac-${version}-${macportVersion}";
 
   src = fetchurl {


### PR DESCRIPTION
###### Description of changes

Change log from https://bitbucket.org/mituharu/emacs-mac/commits/3ff676c2f98cb6c47fecb37f31a589a910dd3876:
```
* emacs-28.1-mac-9.0 (2022-04-06)
Based on Emacs 28.1.
Drop support for Mac OS X 10.6 - OS X 10.9.
Emoji composition handling is aligned with upstream.  You may find
some incompatibilities with the previous versions.

** Fixed bugs

*** Rotated SVG is clipped when dimension is specified by percentage.

*** Typing F10 on a full-screen frame causes hang on Monterey.
Reported by Brandon Bremen.
It no longer hangs, but still F10 does not activate the menu bar for a
full-screen frame on Monterey if the "Automatically hide and show the
menu bar in full screen" setting is checked (default).

*** When posix_spawn is used, emacs-gdb doesn't work properly.
Apply a fix for Bug#54667.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->



- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).