### PR TITLE
python310Packages.webauthn: init at 1.5.2

### DIFF
--- a/pkgs/development/python-modules/webauthn/default.nix
+++ b/pkgs/development/python-modules/webauthn/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, asn1crypto
+, cbor2
+, pythonOlder
+, pydantic
+, pyopenssl
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "webauthn";
+  version = "1.5.2";
+  disabled = pythonOlder "3";
+
+  src = fetchFromGitHub {
+    owner = "duo-labs";
+    repo = "py_webauthn";
+    rev = "v${version}";
+    sha256 = "sha256-sjl65vx1VthVX6ED3lXXAcn2D5WzzGAINKBjCc10rcs=";
+  };
+
+  propagatedBuildInputs = [
+    asn1crypto
+    cbor2
+    pydantic
+    pyopenssl
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "webauthn" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/benoitc/gunicorn";
+    description = "gunicorn 'Green Unicorn' is a WSGI HTTP Server for UNIX, fast clients and sleepy applications";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/python-modules/webauthn/default.nix
+++ b/pkgs/development/python-modules/webauthn/default.nix
@@ -35,9 +35,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "webauthn" ];
 
   meta = with lib; {
-    homepage = "https://github.com/benoitc/gunicorn";
-    description = "gunicorn 'Green Unicorn' is a WSGI HTTP Server for UNIX, fast clients and sleepy applications";
-    license = licenses.mit;
+    homepage = "https://github.com/duo-labs/py_webauthn";
+    description = "Implementation of the WebAuthn API";
+    license = licenses.bsd3;
     maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11013,6 +11013,8 @@ in {
 
   webassets = callPackage ../development/python-modules/webassets { };
 
+  webauthn = callPackage ../development/python-modules/webauthn { };
+
   web = callPackage ../development/python-modules/web { };
 
   web-cache = callPackage ../development/python-modules/web-cache { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
