### PR TITLE
Revert "cln: fix build on darwin"

### DIFF
--- a/pkgs/development/libraries/cln/default.nix
+++ b/pkgs/development/libraries/cln/default.nix
@@ -1,14 +1,10 @@
-{ lib, stdenv, fetchurl, fetchgit, gmp }:
+{ lib, stdenv, fetchurl, gmp }:
 
 stdenv.mkDerivation rec {
   pname = "cln";
   version = "1.3.6";
 
-  src = if stdenv.isDarwin then fetchgit {
-    url = "git://www.ginac.de/cln.git";
-    rev = "cln_${builtins.replaceStrings [ "." ] [ "-" ] version}";
-    sha256 = "sha256-P32F4TIDhE2Dwzydq8iFK6ch3kICJcXeeXHs5PBQG88=";
-  } else fetchurl {
+  src = fetchurl {
     url = "${meta.homepage}${pname}-${version}.tar.bz2";
     sha256 = "0jlq9l4hphk7qqlgqj9ihjp4m3rwjbhk6q4v00lsbgbri07574pl";
   };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#172921

Self quoting here...

> Propose we revert this because it doesn't _actually_ fix the problem and breaks darwin x86_64. This approach produces an empty output because it can't find any `Makefile` because autoconf/automake hasn't been run on the source. I'm also not sure what difference pulling the source from git would make.
> 
> Interestingly, the author has made several commits to master in the last few days related to ARM assembly, so it's possible some combination of those applied as patches might help things. Could also look to see if there were a way to disable ARM assembly, because reading the commit messages it looks rather like a work in progress.

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
