### PR TITLE
WIP: zxfer: init at 1.1.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9848,6 +9848,12 @@
     githubId = 6498458;
     name = "pebble kite";
   };
+  pbsds = {
+    name = "Peder Bergebakken Sundt";
+    email = "pbsds@hotmail.com";
+    github = "pbsds";
+    githubId = 140964;
+  };
   pcarrier = {
     email = "pc@rrier.ca";
     github = "pcarrier";

--- a/pkgs/tools/filesystems/zxfer/default.nix
+++ b/pkgs/tools/filesystems/zxfer/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, installShellFiles
+, coreutils
+, gnused
+, gawk
+, gnugrep
+, openssh
+, rsync
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zxfer";
+  version = "1.1.7";
+
+  src = fetchFromGitHub {
+    repo = "zxfer";
+    owner = "allanjude";
+    rev = "v${version}";
+    sha256 = "11SQJcD3GqPYBIgaycyKkc62/diVKPuuj2Or97j+NZY=";
+  };
+
+  nativeBuildInputs = [
+   installShellFiles
+  ];
+
+  buildInputs = [
+    coreutils
+    gawk
+    gnused
+    gnugrep
+    openssh
+    rsync
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp zxfer $out/bin/
+
+    installManPage zxfer.8
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/allanjude/zxfer";
+    description = "Transfer ZFS filesystems, snapshots, properties, files and directories";
+    longDescription = ''
+      Transfer a source zfs filesystem, directory or files to a destination, using
+      either zfs send/receive or rsync to do the heavy lifting.
+    '';
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11974,6 +11974,8 @@ with pkgs;
 
   zpool-auto-expand-partitions = callPackage ../tools/filesystems/zpool-auto-expand-partitions { };
 
+  zxfer = callPackage ../tools/filesystems/zxfer { };
+
   zile = callPackage ../applications/editors/zile { };
 
   zinnia = callPackage ../tools/inputmethods/zinnia { };


### PR DESCRIPTION
###### Description of changes

Adds the package zxfer.

**Project description**
A popular script in BSD-land for managing ZFS snapshot replication.
It allows the easy and reliable backup, restore or transfer of ZFS filesystems, either locally or remotely.

**Metadata**

* homepage URL: https://github.com/allanjude/zxfer
* source URL: https://github.com/allanjude/zxfer
* license: bsd-2clause
* platforms: unix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Not yet tested, as I do not have a linux box with ZFS, hence the draft status.

**Question:** should this depend on ZFS?