### PR TITLE
lm4tools: init at 0.1.3

### DIFF
--- a/pkgs/development/embedded/lm4tools/default.nix
+++ b/pkgs/development/embedded/lm4tools/default.nix
@@ -105,5 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers  = with lib.maintainers; [ rrbutani ];
     mainProgram  = "lm4flash";
     platforms    = with lib.platforms; unix ++ windows;
+    badPlatforms = with lib.systems.inspect; [
+      # `libusb1` doesn't appear to produce DLLs; we get runtime errors when
+      # not linking statically.
+      { isStatic = false; parsed = patterns.isWindows; }
+    ];
   };
 })

--- a/pkgs/development/embedded/lm4tools/default.nix
+++ b/pkgs/development/embedded/lm4tools/default.nix
@@ -28,6 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
     # When cross compiling `pkg-config` may have a prefix; we want to get its
     # name/path from `$PKG_CONFIG`.
     ./use-pkg-config-env-var.patch
+    # Build with `-O2`:
+    ./use-release-config-for-build.patch
+    # Have the `Makefile`s pass `pkg-config` the right flags when doing a
+    # static build.
+    #
+    # See the comment on `configurePhase` below.
+    ./pkg-config-static-build-support.patch
   ] ++ lib.optionals stdenv.hostPlatform.isWindows [
     # The minGW toolchain appends a `.exe` if it's not present which confuses
     # `install`.
@@ -35,6 +42,27 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals (!buildLmicdiusb) [
     ./disable-lmicdiusb-build.patch
   ];
+
+  # We want to communicate to the `Makefile`s whether or not we are doing a
+  # static build so that it can pass `--static` to `pkg-config` if we are.
+  # If the `Makefile` does not do this, it will not include "private"
+  # dependencies from `libusb1` (some macOS frameworks) and the build will
+  # fail.
+  #
+  # There doesn't seem to be a canonical way to tell if the stdenv is
+  # configured to make static binaries. The `makeStatic` stdenv adapters,
+  # for example, do not set `stdenv.hostPlatform.isStatic` and add different
+  # flags for macOS/Linux/etc.
+  # See: https://github.com/NixOS/nixpkgs/blob/0c4d65b21efd3ae2fcdec54492cbaa6542352eb9/pkgs/stdenv/adapters.nix#L56-L135
+  #
+  # So, we look for the `--enable-static` configure flag as an indicator
+  # that we're linking statically (even though the `makeStaticDarwin` adapter
+  # in isolation does *not* add this configure flag):
+  configurePhase = ''
+    if [[ "$configureFlags" =~ "--enable-static" ]]; then
+      makeFlagsArray+=(STATIC_BUILD=1)
+    fi
+  '';
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libusb1 ]

--- a/pkgs/development/embedded/lm4tools/default.nix
+++ b/pkgs/development/embedded/lm4tools/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, libusb1
+, darwin
+, testers
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lm4tools";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "utzig";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    sha256 = "ZjuCH/XjQEgg6KHAvb95/BkAy+C2OdbtBb/i6K30+uo=";
+  };
+
+  patches = [
+    # We don't want the Makefile to assume `libusb` lives in
+    # /usr/local/lib.
+    ./macOS-use-pkg-config.patch
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libusb1 ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      AppKit Carbon IOKit
+    ]);
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  # `lmicdiusb` has no help text so we don't check that it can run.
+  doCheck = true;
+  passthru.tests = {
+    lm4flash = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "${finalAttrs.finalPackage.meta.mainProgram} -V";
+    };
+  };
+
+  meta = with lib; rec {
+    description  = "Tools for TI Stellaris boards";
+    longDescription = ''
+      Tools to enable multi-platform development on the TI Stellaris
+      Launchpad boards (lm4f) and TI Tiva C boards (tm4c).
+
+      Includes `lm4flash` and `lmicdiusb`.
+    '';
+    homepage     = "https://github.com/utzig/lm4tools";
+    downloadPage = "${homepage}/releases/tag/v${finalAttrs.version}";
+    changelog    = downloadPage;
+    license      = with licenses; [ gpl2Plus bsd3 ];
+    maintainers  = with lib.maintainers; [ rrbutani ];
+    mainProgram  = "lm4flash";
+    platforms    = with lib.platforms; unix ++ windows;
+  };
+})

--- a/pkgs/development/embedded/lm4tools/disable-lmicdiusb-build.patch
+++ b/pkgs/development/embedded/lm4tools/disable-lmicdiusb-build.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 25544fe..52c4c24 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,5 @@
+ all:
+-	@${MAKE} -C lmicdiusb all
+ 	@${MAKE} -C lm4flash all
+ 
+ install: all
+-	@${MAKE} -C lmicdiusb install
+ 	@${MAKE} -C lm4flash install

--- a/pkgs/development/embedded/lm4tools/macOS-use-pkg-config.patch
+++ b/pkgs/development/embedded/lm4tools/macOS-use-pkg-config.patch
@@ -1,0 +1,31 @@
+diff --git a/lmicdiusb/Makefile b/lmicdiusb/Makefile
+index 8810d45..c5d5689 100644
+--- a/lmicdiusb/Makefile
++++ b/lmicdiusb/Makefile
+@@ -37,9 +37,6 @@
+ #//
+ #//*****************************************************************************
+ ifeq ($(shell uname),Darwin)
+-	LIBUSB_CFLAGS := -I/usr/local/include/libusb-1.0
+-	LIBUSB_LIBDIR := /usr/local/lib
+-	LIBUSB_LIBS := -lusb-1.0
+ 	LDFLAGS += -framework AppKit -framework Carbon -framework IOKit
+ endif
+ 
+@@ -49,11 +46,9 @@ ifeq ($(shell uname),FreeBSD)
+ 	LIBUSB_LIBS := -lusb
+ endif
+ 
+-ifeq ($(shell uname),Linux)
+ 	LIBUSB_CFLAGS ?= $(shell pkg-config --cflags libusb-1.0)
+ 	LIBUSB_LIBDIR ?= $(shell pkg-config --variable=libdir libusb-1.0)
+ 	LIBUSB_LIBS ?= $(shell pkg-config --libs-only-l libusb-1.0)
+-endif
+ 
+ VPATH += $(LIBUSB_LIBDIR)
+ 
+@@ -78,4 +73,3 @@ endif
+ 
+ clean:
+ 	rm -rf lmicdi lmicdi.o socket.o gdb.o
+-

--- a/pkgs/development/embedded/lm4tools/pkg-config-static-build-support.patch
+++ b/pkgs/development/embedded/lm4tools/pkg-config-static-build-support.patch
@@ -1,0 +1,51 @@
+diff --git a/lm4flash/Makefile b/lm4flash/Makefile
+index 0a85b35..1f6beef 100644
+--- a/lm4flash/Makefile
++++ b/lm4flash/Makefile
+@@ -2,13 +2,16 @@ EXE := lm4flash
+
+ CC ?= gcc
+ PKG_CONFIG ?= pkg-config
++ifdef STATIC_BUILD
++	PKG_CONFIG_FLAGS += --static
++endif
+ CFLAGS += -Wall
+
+ ifeq ($(shell uname),FreeBSD)
+ LDFLAGS += -lusb
+ else
+-CFLAGS += $(shell $(PKG_CONFIG) --cflags libusb-1.0)
+-LDFLAGS += $(shell $(PKG_CONFIG) --libs libusb-1.0)
++CFLAGS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --cflags libusb-1.0)
++LDFLAGS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs libusb-1.0)
+ endif
+
+ ifeq ($(shell uname),Darwin)
+diff --git a/lmicdiusb/Makefile b/lmicdiusb/Makefile
+index 088973c..4db4ee4 100644
+--- a/lmicdiusb/Makefile
++++ b/lmicdiusb/Makefile
+@@ -37,6 +37,9 @@
+ #//
+ #//*****************************************************************************
+ PKG_CONFIG ?= pkg-config
++ifdef STATIC_BUILD
++	PKG_CONFIG_FLAGS += --static
++endif
+
+ ifeq ($(shell uname),Darwin)
+ 	LDFLAGS += -framework AppKit -framework IOKit -framework Security
+@@ -48,11 +51,11 @@ ifeq ($(shell uname),FreeBSD)
+ 	LIBUSB_LIBS := -lusb
+ endif
+
+-	LIBUSB_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags libusb-1.0)
+-	LIBUSB_LIBDIR ?= $(shell $(PKG_CONFIG) --variable=libdir libusb-1.0)
++	LIBUSB_CFLAGS ?= $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --cflags libusb-1.0)
++	LIBUSB_LIBDIR ?= $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --variable=libdir libusb-1.0)
+	LIBUSB_LIBS ?= $(shell $(PKG_CONFIG) --libs-only-l libusb-1.0)
+
+ VPATH += $(LIBUSB_LIBDIR)
+
+-LDFLAGS += -L$(LIBUSB_LIBDIR) -g
++LDFLAGS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs libusb-1.0) -g

--- a/pkgs/development/embedded/lm4tools/use-pkg-config-env-var.patch
+++ b/pkgs/development/embedded/lm4tools/use-pkg-config-env-var.patch
@@ -1,0 +1,47 @@
+diff --git a/lm4flash/Makefile b/lm4flash/Makefile
+index 20bd741..6822d6b 100644
+--- a/lm4flash/Makefile
++++ b/lm4flash/Makefile
+@@ -1,13 +1,14 @@
+ EXE := lm4flash
+ 
+ CC ?= gcc
++PKG_CONFIG ?= pkg-config
+ CFLAGS += -Wall
+ 
+ ifeq ($(shell uname),FreeBSD)
+ LDFLAGS += -lusb
+ else
+-CFLAGS += $(shell pkg-config --cflags libusb-1.0)
+-LDFLAGS += $(shell pkg-config --libs libusb-1.0)
++CFLAGS += $(shell $(PKG_CONFIG) --cflags libusb-1.0)
++LDFLAGS += $(shell $(PKG_CONFIG) --libs libusb-1.0)
+ endif
+ 
+ all: $(EXE)
+diff --git a/lmicdiusb/Makefile b/lmicdiusb/Makefile
+index c5d5689..11cdb89 100644
+--- a/lmicdiusb/Makefile
++++ b/lmicdiusb/Makefile
+@@ -36,6 +36,8 @@
+ #// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+ #//
+ #//*****************************************************************************
++PKG_CONFIG ?= pkg-config
++
+ ifeq ($(shell uname),Darwin)
+ 	LDFLAGS += -framework AppKit -framework Carbon -framework IOKit
+ endif
+@@ -46,9 +48,9 @@ ifeq ($(shell uname),FreeBSD)
+ 	LIBUSB_LIBS := -lusb
+ endif
+ 
+-	LIBUSB_CFLAGS ?= $(shell pkg-config --cflags libusb-1.0)
+-	LIBUSB_LIBDIR ?= $(shell pkg-config --variable=libdir libusb-1.0)
+-	LIBUSB_LIBS ?= $(shell pkg-config --libs-only-l libusb-1.0)
++	LIBUSB_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags libusb-1.0)
++	LIBUSB_LIBDIR ?= $(shell $(PKG_CONFIG) --variable=libdir libusb-1.0)
++	LIBUSB_LIBS ?= $(shell $(PKG_CONFIG) --libs-only-l libusb-1.0)
+ 
+ VPATH += $(LIBUSB_LIBDIR)
+ 

--- a/pkgs/development/embedded/lm4tools/use-release-config-for-build.patch
+++ b/pkgs/development/embedded/lm4tools/use-release-config-for-build.patch
@@ -1,0 +1,11 @@
+diff --git a/lm4flash/Makefile b/lm4flash/Makefile
+index 20bd741..c872783 100644
+--- a/lm4flash/Makefile
++++ b/lm4flash/Makefile
+@@ -12,5 +12,5 @@ endif
+
+-all: $(EXE)
++all: release
+
+ release: CFLAGS += -O2
+ release: $(EXE)

--- a/pkgs/development/embedded/lm4tools/windows-file-ext.patch
+++ b/pkgs/development/embedded/lm4tools/windows-file-ext.patch
@@ -1,0 +1,19 @@
+diff --git a/lm4flash/Makefile b/lm4flash/Makefile
+index 20bd741..df1beea 100644
+--- a/lm4flash/Makefile
++++ b/lm4flash/Makefile
+@@ -1,4 +1,4 @@
+-EXE := lm4flash
++EXE := lm4flash.exe
+ 
+ CC ?= gcc
+ CFLAGS += -Wall
+@@ -18,7 +18,7 @@ release: $(EXE)
+ debug: CFLAGS += -g -DDEBUG
+ debug: $(EXE)
+ 
+-$(EXE): $(EXE).c
++$(EXE): lm4flash.c
+ 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
+ 
+ install: $(EXE)

--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation rec {
     lib.optional enableUdev udev ++
     lib.optionals stdenv.isDarwin [ libobjc IOKit Security ];
 
+  # Not providing the deps dir breaks the build on Windows.
+  dontAddDisableDepTrack = if stdenv.hostPlatform.isWindows then true else null;
+
   dontDisableStatic = withStatic;
 
   configureFlags =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18877,6 +18877,8 @@ with pkgs;
 
   ls-lint = callPackage ../development/tools/ls-lint { };
 
+  lm4tools = callPackage ../development/embedded/lm4tools { };
+
   lsof = callPackage ../development/tools/misc/lsof { };
 
   ltrace = callPackage ../development/tools/misc/ltrace { };


### PR DESCRIPTION
###### Description of changes

Adds [`lm4tools`](https://github.com/utzig/lm4tools), a pair of tools for embedded development on the [TI Stellaris Launchpad](https://www.ti.com/tool/EK-LM4F120XL) and derivatives, as a package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
  - [ ] x86_64-linux `pkgsStatic`
  - [ ] aarch64-linux `pkgsStatic`
  - [ ] `pkgsCross.mingwW64`, static (from an `x86_64-linux` builder)
  - [ ] x86_64-darwin static (with `stdenvAdapters.makeStatic` as described [here](https://github.com/ut-utp/.github/wiki/lm4flash-Binaries))
  - [ ] aarch64-darwin static (with `stdenvAdapters.makeStatic` as described [here](https://github.com/ut-utp/.github/wiki/lm4flash-Binaries))
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`?
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
