### PR TITLE
ocamlPackages.tar*: 1.1.0 -> 2.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/tar/default.nix
+++ b/pkgs/development/ocaml-modules/tar/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildDunePackage
+, camlp-streams
 , ppx_cstruct
 , cstruct
 , re
@@ -9,17 +10,18 @@
 
 buildDunePackage rec {
   pname = "tar";
-  version = "1.1.0";
+  version = "2.0.1";
   src = fetchFromGitHub {
     owner = "mirage";
     repo = "ocaml-tar";
     rev = "v${version}";
-    sha256 = "14k24vn3q5jl0iyrynb5vwg80670qsv12fsmc6cdgh4zwdpjh7zs";
+    sha256 = "1zr1ak164k1jm15xwqjf1iv77kdrrahak33wrxg7lifz9nnl0dms";
   };
 
   useDune2 = true;
 
   propagatedBuildInputs = [
+    camlp-streams
     ppx_cstruct
     cstruct
     re


### PR DESCRIPTION
###### Description of changes

[Changelog](https://github.com/mirage/ocaml-tar/blob/master/CHANGES.md#v201-2022-03-09)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).