### PR TITLE
_1password: fix hashes

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -14,10 +14,10 @@ let
   pname = "1password-cli";
   version = "2.3.1";
   sources = rec {
-    aarch64-linux = fetch "linux_arm64" "sha256-fKW2qSQkkC4GcnHcLLszX1pcqK67SaofVX017/cIkD0=" "zip";
-    i686-linux = fetch "linux_386" "sha256-TmQ3nWG12DTpAJaxbK+hnJak0RrFhhw6rJWfV7q8wb4=" "zip";
+    aarch64-linux = fetch "linux_arm64" "sha256-MikzcVqlhVSKzr1ttOCAg4p57sjsalSuwcqBhVUr5Ng=" "zip";
+    i686-linux = fetch "linux_386" "sha256-ElOhd3n38xAPtVePjQb8qMUCCAWqEfBKlX9Vuz5/Zns=" "zip";
     x86_64-linux = fetch "linux_amd64" "sha256-r8yl9dDiiIQBooePrq/dGw2RU9tJXmeblx+qk3qq5Ys=" "zip";
-    aarch64-darwin = fetch "apple_universal" "sha256-DD1j093SjnaPtkQ4XuU1zkRi6XPXtwnBxiqC6wZbV+w=" "pkg";
+    aarch64-darwin = fetch "apple_universal" "sha256-sXdYInNBOEW/zIEPjhKbFOMxZdrMlE8pOwhmXLUJgsk=" "pkg";
     x86_64-darwin = aarch64-darwin;
   };
   platforms = builtins.attrNames sources;


### PR DESCRIPTION

###### Description of changes
The latest version bump https://github.com/NixOS/nixpkgs/pull/174392 only updated the hash for x86_64-linux.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
