### PR TITLE
qbittorrent: Wrap once, python is optional

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchFromGitHub, makeWrapper, pkg-config
+{ mkDerivation, lib, fetchFromGitHub, pkg-config
 , boost, libtorrent-rasterbar, qtbase, qttools, qtsvg
 , debugSupport ? false
 , guiSupport ? true, dbus ? null # GUI (disable to run headless)
@@ -24,7 +24,7 @@ mkDerivation rec {
   enableParallelBuilding = true;
 
   # NOTE: 2018-05-31: CMake is working but it is not officially supported
-  nativeBuildInputs = [ makeWrapper pkg-config ];
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ boost libtorrent-rasterbar qtbase qttools qtsvg ]
     ++ optional guiSupport dbus # D(esktop)-Bus depends on GUI support
@@ -40,11 +40,7 @@ mkDerivation rec {
     ++ optional (!webuiSupport) "--disable-webui"
     ++ optional debugSupport "--enable-debug";
 
-  postInstall = "wrapProgram $out/bin/${
-    if guiSupport
-    then "qbittorrent"
-    else "qbittorrent-nox"
-  } --prefix PATH : ${makeBinPath [ python3 ]}";
+  qtWrapperArgs = optional trackerSearch "--prefix PATH : ${makeBinPath [ python3 ]}";
 
   meta = {
     description = "Featureful free software BitTorrent client";


### PR DESCRIPTION
qbittorrent is wrapped twice which must be generally be avoided as it
breaks the program's basename, e.g. `argv[0]` ends up with
".qbittorrent-wrapped" rather than "qbittorrent" as basename.

This becomes relevant when matching for (exact) program names: pgrep(1),
earlyoom(1)'s `--avoid`, etc.

Furthermore, Python is only required by the (default enabled) tracker
search feature.

Since the "qbittorrent" ELF executable is wrapped automatically as a Qt
app, replace the unconditional `postInstall` hook with an optional
addition to `makeWrapperArgs` with is used by `wrapQtApp` eventually.

This merges two wrappers and thus fixes the basename.

@Anton-Latukha
