### PR TITLE
gbl: fix aarch64-darwin build

### DIFF
--- a/pkgs/tools/archivers/gbl/default.nix
+++ b/pkgs/tools/archivers/gbl/default.nix
@@ -22,15 +22,20 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoPatches = [
-    # Upstream does not include Cargo.lock, even though this is recommended for applications.
-    # This patch adds it. https://github.com/dac-gmbh/gbl/pull/62
+    # update ring to fix building on Mac M1
+    # https://github.com/dac-gmbh/gbl/pull/64
     (fetchpatch {
-      url = "https://github.com/raboof/gbl/commit/99078da334c6e1ffd8189c691bbc711281fae5cc.patch";
-      sha256 = "sha256-sAKkn4//8P87ZJ6NTHm2NUJH1sAFFwfrybv2QtQ3nnM=";
+      url = "https://github.com/raboof/gbl/commit/17e154d66932af59abe8677309792606b7f64c7d.patch";
+      sha256 = "sha256-5Itoi86Q+9FzSTtnggODKPwwYPp5BpIVgR2vYMLHBts=";
+    })
+    # Upstream does not include Cargo.lock, even though this is recommended for applications.
+    (fetchpatch {
+      url = "https://github.com/raboof/gbl/commit/9423d36ee3168bca8db7a7cb65611dc7ddc2daf0.patch";
+      sha256 = "sha256-zwHXgUVkAYiQs/AT/pINnZoECoXzh+9astWMYENGTL8=";
     })
   ];
 
-  cargoSha256 = "sha256-RUZ6wswRtV8chq3+bY9LTRf6IYMbZ9/GPl2X5UcF7d8=";
+  cargoSha256 = "sha256-CeGLSseKUe2XudRqZm5Y7o7ZLDtDBg/MFunOGqxFZGM=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
@@ -44,10 +49,8 @@ rustPlatform.buildRustPackage rec {
       Utility to read, create and manipulate `.gbl` firmware update
       files targeting the Silicon Labs Gecko Bootloader.
     '';
-    homepage = "https://github.com/dac-gmbh/gbl";
+    homepage = "https://github.com/jonas-schievink/gbl";
     license = licenses.mit;
     maintainers = [ maintainers.raboof ];
-    # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
###### Description of changes

Compilation failed due to an old transitive dependency on 'ring',
https://github.com/briansmith/ring/issues/1063.

fixes #175087

#zhfff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->