### PR TITLE
usbimager: add variants

### DIFF
--- a/pkgs/tools/misc/usbimager/default.nix
+++ b/pkgs/tools/misc/usbimager/default.nix
@@ -1,15 +1,18 @@
 { lib, stdenv, fetchFromGitLab, pkg-config
-, withLibui ? true, gtk3
-, withUdisks ? stdenv.isLinux, udisks, glib
+, withLibui ? false, gtk3
+, withUdisks ? false, udisks, glib
+, withWriteOnly ? false
 , libX11 }:
 
 stdenv.mkDerivation rec {
-  pname = "usbimager";
+  pname = "usbimager"
+    + (if withLibui then "-gtk" else "-x11")
+    + (if withWriteOnly then "-wo" else "");
   version = "1.0.8";
 
   src = fetchFromGitLab {
     owner = "bztsrc";
-    repo = pname;
+    repo = "usbimager";
     rev = version;
     sha256 = "1j0g1anmdwc3pap3m4kfzqjfkn7q0vpmqniii2kcz7svs5h3ybga";
   };
@@ -17,9 +20,9 @@ stdenv.mkDerivation rec {
   sourceRoot = "source/src/";
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = lib.optionals withUdisks [ udisks glib ]
-    ++ lib.optional (!withLibui) libX11
-    ++ lib.optional withLibui gtk3;
+  buildInputs = lib.optionals (withUdisks && stdenv.isLinux) [ udisks glib ]
+    ++ lib.optional withLibui gtk3
+    ++ lib.optional (!withLibui) libX11;
     # libui is bundled with the source of usbimager as a compiled static libary
 
   postPatch = ''
@@ -33,10 +36,14 @@ stdenv.mkDerivation rec {
 
   makeFlags =  [ "PREFIX=$(out)" ]
     ++ lib.optional withLibui "USE_LIBUI=yes"
-    ++ lib.optional withUdisks "USE_UDISKS2=yes";
+    ++ lib.optional (!withLibui) "USE_X11=yes"
+    ++ lib.optional (withUdisks && stdenv.isLinux) "USE_UDISKS2=yes"
+    ++ lib.optional withWriteOnly "USE_WRONLY=yes";
 
   meta = with lib; {
-    description = "A very minimal GUI app that can write compressed disk images to USB drives";
+    description = "A very minimal GUI app that can write compressed disk images to USB drives"
+      + (if withLibui then " (GTK+" else " (X11")
+      + (if withWriteOnly then ", write-only interface)" else ")");
     homepage = "https://gitlab.com/bztsrc/usbimager";
     license = licenses.mit;
     maintainers = with maintainers; [ vdot0x23 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4726,7 +4726,12 @@ with pkgs;
 
   usbview = callPackage ../tools/misc/usbview { };
 
-  usbimager = callPackage ../tools/misc/usbimager { };
+  usbimager-x11 = callPackage ../tools/misc/usbimager { };
+  usbimager-x11-wo = callPackage ../tools/misc/usbimager { withWriteOnly = true; };
+  usbimager-gtk = callPackage ../tools/misc/usbimager { withLibui = true; withUdisks = true; };
+  usbimager-gtk-wo = callPackage ../tools/misc/usbimager { withLibui = true; withUdisks = true; withWriteOnly = true; };
+  usbimager = usbimager-x11;
+  usbimager-wo = usbimager-x11-wo;
 
   uwuify = callPackage ../tools/misc/uwuify { };
 


### PR DESCRIPTION
###### Description of changes

usbimager is now using X11 as it is more compatible
usbimager-wo uses X11 and provides a write-only interface
usbimager-gtk uses GTK+
usbimager-gtk-wo uses GTK+ and provides write-only interface

---

### Screenshots

usbimager-gtk

![Screenshot from 2022-05-28 10-54-10](https://user-images.githubusercontent.com/91113/170818415-7bd73f36-393f-4d53-830b-fe9291a24ca7.png)

usbimager-gtk-wo

![Screenshot from 2022-05-28 10-54-37](https://user-images.githubusercontent.com/91113/170818431-431a3187-c324-4a2d-8cd1-78994379d45a.png)

usbimager-x11

![Screenshot from 2022-05-28 10-55-03](https://user-images.githubusercontent.com/91113/170818441-aa4aa8c9-c4d7-449b-a82a-e0e4a11f81b9.png)

usbimager-x11-wo

fails to build: https://gist.github.com/davidak/582be1071937daefe7d58c1305d17093

Upstream issue: https://gitlab.com/bztsrc/usbimager/-/issues/89

```
nix build -f . usbimager-x11-wo
...
build flags: SHELL=/nix/store/0d3wgx8x6dxdb2cpnq105z23hah07z7l-bash-5.1-p16/bin/bash PREFIX=\$\(out\) USE_X11=yes USE_WRONLY=yes
...
gcc -DDISKS_TEST=0 -D_FILE_OFFSET_BITS=64 -D__USE_FILE_OFFSET64 -D__USE_LARGEFILE -Wall -Wextra -pedantic --std=c99 -O3 -fvisibility=hidden -I./zlib -I./bzip2 -I./xz -I./zstd -pthread -DUSE_WRONLY=1 -o disks_linux.o -c disks_linux.c
gcc -pthread -o usbimager lang.o stream.o main_libui.o disks_linux.o zlib/libz.a bzip2/libbz2.a xz/libxz.a zstd/libzstd.a libui/linux.a -lgtk-3 -lgdk-3 -lgobject-2.0 -lglib-2.0
/nix/store/2b99rpx8zwdjjqkrvk7kqgn9mxhiidjy-binutils-2.38/bin/ld: cannot find -lgtk-3: No such file or directory
/nix/store/2b99rpx8zwdjjqkrvk7kqgn9mxhiidjy-binutils-2.38/bin/ld: cannot find -lgdk-3: No such file or directory
/nix/store/2b99rpx8zwdjjqkrvk7kqgn9mxhiidjy-binutils-2.38/bin/ld: cannot find -lgobject-2.0: No such file or directory
/nix/store/2b99rpx8zwdjjqkrvk7kqgn9mxhiidjy-binutils-2.38/bin/ld: cannot find -lglib-2.0: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:173: usbimager] Error 1
```

(when i add gtk3 there too it builds, but has gtk not x11)

cc @vdot0x23

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
