### PR TITLE
keepassxc: Wrap once

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -87,6 +87,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ asciidoctor cmake wrapGAppsHook wrapQtAppsHook qttools pkg-config ];
 
+  dontWrapGApps = true;
+  postFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   buildInputs = [
     curl
     botan2


### PR DESCRIPTION
Using Qt *and* GTK means both wrapper hooks kick in, so avoid automatic
GTK wrapping and merge arguments into Qt ones as usual.

Duplicate wrapping must be avoided as it breaks the program's basename,
e.g. `argv[0]` ends up with ".keepassxc-wrapped" rather than
"keepassxc" as basename.

This fixes all three ELF executables (there is `-cli` and `-proxy`).

@jonafato @turlon
