### PR TITLE
snowflake: 2.0.1 -> 2.2.0

### DIFF
--- a/pkgs/tools/networking/snowflake/default.nix
+++ b/pkgs/tools/networking/snowflake/default.nix
@@ -2,15 +2,15 @@
 
 buildGoModule rec {
   pname = "snowflake";
-  version = "2.0.1";
+  version = "2.2.0";
 
   src = fetchgit {
     url = "https://git.torproject.org/pluggable-transports/${pname}";
     rev = "v${version}";
-    hash = "sha256-ULkqsh0DeFI1GsaVaHGSjoEY38EktvDVC52Sx6cQLOE=";
+    sha256 = "0iazamrfixv6yxc5m49adm97biq93pn6hwwpbh8yq558hrc6bh70";
   };
 
-  vendorSha256 = "D5A19UHL1WEE1ODT80jKT+PJ5CTXPjc9Eg6v2Nfm4aw=";
+  vendorSha256 = "1v7cpg3kny0vqmdbgcc7i61wi5gx5wvrv0hmjykjrqgrvyq764c1";
 
   meta = with lib; {
     description = "System to defeat internet censorship";


### PR DESCRIPTION
###### Description of changes
[Changelog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/raw/ae5a71e6e58e664311e3a12f9adb48ed439df4a5/ChangeLog)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
