### PR TITLE
libnatspec: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/libnatspec/default.nix
+++ b/pkgs/development/libraries/libnatspec/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ popt ];
 
+  propagatedBuildInputs = [ libiconv ];
+
   meta = with lib; {
     broken = stdenv.isDarwin;
     homepage = "http://natspec.sourceforge.net/";
@@ -20,6 +22,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.lgpl21;
   };
-} // lib.optionalAttrs (!stdenv.isLinux) {
-  propagatedBuildInputs = [ libiconv ];
 }

--- a/pkgs/development/libraries/libnatspec/default.nix
+++ b/pkgs/development/libraries/libnatspec/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libiconv ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     homepage = "http://natspec.sourceforge.net/";
     description = "A library intended to smooth national specificities in using of programs";
     platforms = platforms.unix;


### PR DESCRIPTION
###### Description of changes
Broken in 3c12e95ad18367c92865bd13aef68c402fa76036 when parentheses were removed, changing the semantics.

Use a simpler, more common construction to avoid such mixups.

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
