### PR TITLE
nixos/doc: improve install instructions

### DIFF
--- a/doc/build-aux/pandoc-filters/docbook-writer/html-elements.lua
+++ b/doc/build-aux/pandoc-filters/docbook-writer/html-elements.lua
@@ -1,0 +1,11 @@
+--[[
+Converts some HTML elements commonly used in Markdown to corresponding DocBook elements.
+]]
+
+function RawInline(elem)
+  if elem.format == 'html' and elem.text == '<kbd>' then
+    return pandoc.RawInline('docbook', '<keycap>')
+  elseif elem.format == 'html' and elem.text == '</kbd>' then
+    return pandoc.RawInline('docbook', '</keycap>')
+  end
+end

--- a/nixos/doc/manual/from_md/installation/installing-usb.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-usb.section.xml
@@ -1,35 +1,135 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-booting-from-usb">
-  <title>Booting from a USB Drive</title>
+  <title>Booting from a USB flash drive</title>
   <para>
-    For systems without CD drive, the NixOS live CD can be booted from a
-    USB stick. You can use the <literal>dd</literal> utility to write
-    the image: <literal>dd if=path-to-image of=/dev/sdX</literal>. Be
-    careful about specifying the correct drive; you can use the
-    <literal>lsblk</literal> command to get a list of block devices.
+    The image has to be written verbatim to the USB flash drive for it
+    to be bootable on UEFI and BIOS systems. Here are the recommended
+    tools to do that.
   </para>
-  <note>
-    <title>On macOS</title>
+  <section xml:id="sec-booting-from-usb-graphical">
+    <title>Creating bootable USB flash drive with a graphical
+    tool</title>
+    <para>
+      Etcher is a popular and user-friendly tool. It works on Linux,
+      Windows and macOS.
+    </para>
+    <para>
+      Download it from
+      <link xlink:href="https://www.balena.io/etcher/">balena.io</link>,
+      start the program, select the downloaded NixOS ISO, then select
+      the USB flash drive and flash it.
+    </para>
+    <warning>
+      <para>
+        Etcher reports errors and usage statistics by default, which can
+        be disabled in the settings.
+      </para>
+    </warning>
+    <para>
+      An alternative is
+      <link xlink:href="https://bztsrc.gitlab.io/usbimager">USBImager</link>,
+      which is very simple and does not connect to the internet.
+      Download the version with write-only (wo) interface for your
+      system. Start the program, select the image, select the USB flash
+      drive and click <quote>Write</quote>.
+    </para>
+  </section>
+  <section xml:id="sec-booting-from-usb-linux">
+    <title>Creating bootable USB flash drive from a Terminal on
+    Linux</title>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          Plug in the USB flash drive.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Find the corresponding device with <literal>lsblk</literal>.
+          You can distinguish them by their size.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Make sure all partitions on the device are properly unmounted.
+          Replace <literal>sdX</literal> with your device (e.g.
+          <literal>sdb</literal>).
+        </para>
+      </listitem>
+    </orderedlist>
     <programlisting>
-$ diskutil list
-[..]
-/dev/diskN (external, physical):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER
-[..]
-$ diskutil unmountDisk diskN
-Unmount of all volumes on diskN was successful
-$ sudo dd if=nix.iso of=/dev/rdiskN bs=1M
+sudo umount /dev/sdX*
+</programlisting>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem override="4">
+        <para>
+          Then use the <literal>dd</literal> utility to write the image
+          to the USB flash drive.
+        </para>
+      </listitem>
+    </orderedlist>
+    <programlisting>
+sudo dd if=&lt;path-to-image&gt; of=/dev/sdX bs=4M conv=fsync
+</programlisting>
+  </section>
+  <section xml:id="sec-booting-from-usb-macos">
+    <title>Creating bootable USB flash drive from a Terminal on
+    macOS</title>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          Plug in the USB flash drive.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Find the corresponding device with
+          <literal>diskutil list</literal>. You can distinguish them by
+          their size.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Make sure all partitions on the device are properly unmounted.
+          Replace <literal>diskX</literal> with your device (e.g.
+          <literal>disk1</literal>).
+        </para>
+      </listitem>
+    </orderedlist>
+    <programlisting>
+diskutil unmountDisk diskX
+</programlisting>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem override="4">
+        <para>
+          Then use the <literal>dd</literal> utility to write the image
+          to the USB flash drive.
+        </para>
+      </listitem>
+    </orderedlist>
+    <programlisting>
+sudo dd if=&lt;path-to-image&gt; of=/dev/rdiskX bs=4m
 </programlisting>
     <para>
-      Using the 'raw' <literal>rdiskN</literal> device instead of
-      <literal>diskN</literal> completes in minutes instead of hours.
       After <literal>dd</literal> completes, a GUI dialog &quot;The disk
       you inserted was not readable by this computer&quot; will pop up,
       which can be ignored.
     </para>
-  </note>
-  <para>
-    The <literal>dd</literal> utility will write the image verbatim to
-    the drive, making it the recommended option for both UEFI and
-    non-UEFI installations.
-  </para>
+    <note>
+      <para>
+        Using the 'raw' <literal>rdiskX</literal> device instead of
+        <literal>diskX</literal> with dd completes in minutes instead of
+        hours.
+      </para>
+    </note>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem override="5">
+        <para>
+          Eject the disk when it is finished.
+        </para>
+      </listitem>
+    </orderedlist>
+    <programlisting>
+diskutil eject /dev/diskX
+</programlisting>
+  </section>
 </section>

--- a/nixos/doc/manual/from_md/installation/installing.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/installing.chapter.xml
@@ -1,26 +1,212 @@
 <chapter xmlns="http://docbook.org/ns/docbook"  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="sec-installation">
   <title>Installing NixOS</title>
   <section xml:id="sec-installation-booting">
-    <title>Booting the system</title>
+    <title>Booting from the install medium</title>
+    <para>
+      To begin the installation, you have to boot your computer from the
+      install drive.
+    </para>
+    <orderedlist numeration="arabic">
+      <listitem>
+        <para>
+          Plug in the install drive. Then turn on or restart your
+          computer.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Open the boot menu by pressing the appropriate key, which is
+          usually shown on the display on early boot. Select the USB
+          flash drive (the option usually contains the word
+          <quote>USB</quote>). If you choose the incorrect drive, your
+          computer will likely continue to boot as normal. In that case
+          restart your computer and pick a different drive.
+        </para>
+        <note>
+          <para>
+            The key to open the boot menu is different across computer
+            brands and even models. It can be <keycap>F12</keycap>, but
+            also <keycap>F1</keycap>, <keycap>F9</keycap>,
+            <keycap>F10</keycap>, <keycap>Enter</keycap>,
+            <keycap>Del</keycap>, <keycap>Esc</keycap> or another
+            function key. If you are unsure and don’t see it on the
+            early boot screen, you can search online for your computers
+            brand, model followed by <quote>boot from usb</quote>. The
+            computer might not even have that feature, so you have to go
+            into the BIOS/UEFI settings to change the boot order. Again,
+            search online for details about your specific computer
+            model.
+          </para>
+          <para>
+            For Apple computers with Intel processors press and hold the
+            <keycap>⌥</keycap> (Option or Alt) key until you see the
+            boot menu. On Apple silicon press and hold the power button.
+          </para>
+        </note>
+        <note>
+          <para>
+            If your computer supports both BIOS and UEFI boot, choose
+            the UEFI option.
+          </para>
+        </note>
+        <note>
+          <para>
+            If you use a CD for the installation, the computer will
+            probably boot from it automatically. If not, choose the
+            option containing the word <quote>CD</quote> from the boot
+            menu.
+          </para>
+        </note>
+      </listitem>
+      <listitem>
+        <para>
+          Shortly after selecting the appropriate boot drive, you should
+          be presented with a menu with different installer options.
+          Leave the default and wait (or press <keycap>Enter</keycap> to
+          speed up).
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The graphical images will start their corresponding desktop
+          environment and the graphical installer, which can take some
+          time. The minimal images will boot to a command line. You have
+          to follow the instructions in
+          <xref linkend="sec-installation-manual" /> there.
+        </para>
+      </listitem>
+    </orderedlist>
+  </section>
+  <section xml:id="sec-installation-graphical">
+    <title>Graphical Installation</title>
+    <para>
+      The graphical installer is recommended for desktop users and will
+      guide you through the installation.
+    </para>
+    <orderedlist numeration="arabic">
+      <listitem>
+        <para>
+          In the <quote>Welcome</quote> screen, you can select the
+          language of the Installer and the installed system.
+        </para>
+        <tip>
+          <para>
+            Leaving the language as <quote>American English</quote> will
+            make it easier to search for error messages in a search
+            engine or to report an issue.
+          </para>
+        </tip>
+      </listitem>
+      <listitem>
+        <para>
+          Next you should choose your location to have the timezone set
+          correctly. You can actually click on the map!
+        </para>
+        <note>
+          <para>
+            The installer will use an online service to guess your
+            location based on your public IP address.
+          </para>
+        </note>
+      </listitem>
+      <listitem>
+        <para>
+          Then you can select the keyboard layout. The default keyboard
+          model should work well with most desktop keyboards. If you
+          have a special keyboard or notebook, your model might be in
+          the list. Select the language you are most comfortable typing
+          in.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          On the <quote>Users</quote> screen, you have to type in your
+          display name, login name and password. You can also enable an
+          option to automatically login to the desktop.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Then you have the option to choose a desktop environment. If
+          you want to create a custom setup with a window manager, you
+          can select <quote>No desktop</quote>.
+        </para>
+        <tip>
+          <para>
+            If you don’t have a favorite desktop and don’t know which
+            one to choose, you can stick to either GNOME or Plasma. They
+            have a quite different design, so you should choose
+            whichever you like better. They are both popular choices and
+            well tested on NixOS.
+          </para>
+        </tip>
+      </listitem>
+      <listitem>
+        <para>
+          You have the option to allow unfree software in the next
+          screen.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The easiest option in the <quote>Partitioning</quote> screen
+          is <quote>Erase disk</quote>, which will delete all data from
+          the selected disk and install the system on it. Also select
+          <quote>Swap (with Hibernation)</quote> in the dropdown below
+          it. You have the option to encrypt the whole disk with LUKS.
+        </para>
+        <note>
+          <para>
+            At the top left you see if the Installer was booted with
+            BIOS or UEFI. If you know your system supports UEFI and it
+            shows <quote>BIOS</quote>, reboot with the correct option.
+          </para>
+        </note>
+        <warning>
+          <para>
+            Make sure you have selected the correct disk at the top and
+            that no valuable data is still on the disk! It will be
+            deleted when formatting the disk.
+          </para>
+        </warning>
+      </listitem>
+      <listitem>
+        <para>
+          Check the choices you made in the <quote>Summary</quote> and
+          click <quote>Install</quote>.
+        </para>
+        <note>
+          <para>
+            The installation takes about 15 minutes. The time varies
+            based on the selected desktop environment, internet
+            connection speed and disk write speed.
+          </para>
+        </note>
+      </listitem>
+      <listitem>
+        <para>
+          When the install is complete, remove the USB flash drive and
+          reboot into your new system!
+        </para>
+      </listitem>
+    </orderedlist>
+  </section>
+  <section xml:id="sec-installation-manual">
+    <title>Manual Installation</title>
     <para>
       NixOS can be installed on BIOS or UEFI systems. The procedure for
-      a UEFI installation is by and large the same as a BIOS
-      installation. The differences are mentioned in the steps that
-      follow.
-    </para>
-    <para>
-      The installation media can be burned to a CD, or now more
-      commonly, <quote>burned</quote> to a USB drive (see
-      <xref linkend="sec-booting-from-usb" />).
-    </para>
-    <para>
-      The installation media contains a basic NixOS installation. When
-      it’s finished booting, it should have detected most of your
-      hardware.
+      a UEFI installation is broadly the same as for a BIOS
+      installation. The differences are mentioned in the following
+      steps.
     </para>
     <para>
       The NixOS manual is available by running
-      <literal>nixos-help</literal>.
+      <literal>nixos-help</literal> in the command line or from the
+      application menu in the desktop environment.
+    </para>
+    <para>
+      To have access to the command line on the graphical images, open
+      Terminal (GNOME) or Konsole (Plasma) from the application menu.
     </para>
     <para>
       You are logged-in automatically as <literal>nixos</literal>. The
@@ -31,11 +217,8 @@
 $ sudo -i
 </programlisting>
     <para>
-      If you downloaded the graphical ISO image, you can run
-      <literal>systemctl start display-manager</literal> to start the
-      desktop environment. If you want to continue on the terminal, you
-      can use <literal>loadkeys</literal> to switch to your preferred
-      keyboard layout. (We even provide neo2 via
+      You can use <literal>loadkeys</literal> to switch to your
+      preferred keyboard layout. (We even provide neo2 via
       <literal>loadkeys de neo</literal>!)
     </para>
     <para>
@@ -49,8 +232,12 @@ $ sudo -i
       bootloader lists boot entries, select the serial console boot
       entry.
     </para>
-    <section xml:id="sec-installation-booting-networking">
+    <section xml:id="sec-installation-manual-networking">
       <title>Networking in the installer</title>
+      <para>
+        <anchor xml:id="sec-installation-booting-networking" />
+        <!-- legacy anchor -->
+      </para>
       <para>
         The boot process should have brought up networking (check
         <literal>ip a</literal>). Networking is necessary for the
@@ -130,179 +317,239 @@ OK
         able to login.
       </para>
     </section>
-  </section>
-  <section xml:id="sec-installation-partitioning">
-    <title>Partitioning and formatting</title>
-    <para>
-      The NixOS installer doesn’t do any partitioning or formatting, so
-      you need to do that yourself.
-    </para>
-    <para>
-      The NixOS installer ships with multiple partitioning tools. The
-      examples below use <literal>parted</literal>, but also provides
-      <literal>fdisk</literal>, <literal>gdisk</literal>,
-      <literal>cfdisk</literal>, and <literal>cgdisk</literal>.
-    </para>
-    <para>
-      The recommended partition scheme differs depending if the computer
-      uses <emphasis>Legacy Boot</emphasis> or
-      <emphasis>UEFI</emphasis>.
-    </para>
-    <section xml:id="sec-installation-partitioning-UEFI">
-      <title>UEFI (GPT)</title>
+    <section xml:id="sec-installation-manual-partitioning">
+      <title>Partitioning and formatting</title>
       <para>
-        Here's an example partition scheme for UEFI, using
-        <literal>/dev/sda</literal> as the device.
+        <anchor xml:id="sec-installation-partitioning" />
+        <!-- legacy anchor -->
       </para>
-      <note>
+      <para>
+        The NixOS installer doesn’t do any partitioning or formatting,
+        so you need to do that yourself.
+      </para>
+      <para>
+        The NixOS installer ships with multiple partitioning tools. The
+        examples below use <literal>parted</literal>, but also provides
+        <literal>fdisk</literal>, <literal>gdisk</literal>,
+        <literal>cfdisk</literal>, and <literal>cgdisk</literal>.
+      </para>
+      <para>
+        The recommended partition scheme differs depending if the
+        computer uses <emphasis>Legacy Boot</emphasis> or
+        <emphasis>UEFI</emphasis>.
+      </para>
+      <section xml:id="sec-installation-manual-partitioning-UEFI">
+        <title>UEFI (GPT)</title>
         <para>
-          You can safely ignore <literal>parted</literal>'s
-          informational message about needing to update /etc/fstab.
+          <anchor xml:id="sec-installation-partitioning-UEFI" />
+          <!-- legacy anchor -->
         </para>
-      </note>
-      <orderedlist numeration="arabic">
-        <listitem>
+        <para>
+          Here's an example partition scheme for UEFI, using
+          <literal>/dev/sda</literal> as the device.
+        </para>
+        <note>
           <para>
-            Create a <emphasis>GPT</emphasis> partition table.
+            You can safely ignore <literal>parted</literal>'s
+            informational message about needing to update /etc/fstab.
           </para>
-          <programlisting>
+        </note>
+        <orderedlist numeration="arabic">
+          <listitem>
+            <para>
+              Create a <emphasis>GPT</emphasis> partition table.
+            </para>
+            <programlisting>
 # parted /dev/sda -- mklabel gpt
 </programlisting>
-        </listitem>
-        <listitem>
-          <para>
-            Add the <emphasis>root</emphasis> partition. This will fill
-            the disk except for the end part, where the swap will live,
-            and the space left in front (512MiB) which will be used by
-            the boot partition.
-          </para>
-          <programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              Add the <emphasis>root</emphasis> partition. This will
+              fill the disk except for the end part, where the swap will
+              live, and the space left in front (512MiB) which will be
+              used by the boot partition.
+            </para>
+            <programlisting>
 # parted /dev/sda -- mkpart primary 512MB -8GB
 </programlisting>
-        </listitem>
-        <listitem>
-          <para>
-            Next, add a <emphasis>swap</emphasis> partition. The size
-            required will vary according to needs, here a 8GB one is
-            created.
-          </para>
-          <programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              Next, add a <emphasis>swap</emphasis> partition. The size
+              required will vary according to needs, here a 8GB one is
+              created.
+            </para>
+            <programlisting>
 # parted /dev/sda -- mkpart primary linux-swap -8GB 100%
 </programlisting>
-          <note>
+            <note>
+              <para>
+                The swap partition size rules are no different than for
+                other Linux distributions.
+              </para>
+            </note>
+          </listitem>
+          <listitem>
             <para>
-              The swap partition size rules are no different than for
-              other Linux distributions.
+              Finally, the <emphasis>boot</emphasis> partition. NixOS by
+              default uses the ESP (EFI system partition) as its
+              <emphasis>/boot</emphasis> partition. It uses the
+              initially reserved 512MiB at the start of the disk.
             </para>
-          </note>
-        </listitem>
-        <listitem>
-          <para>
-            Finally, the <emphasis>boot</emphasis> partition. NixOS by
-            default uses the ESP (EFI system partition) as its
-            <emphasis>/boot</emphasis> partition. It uses the initially
-            reserved 512MiB at the start of the disk.
-          </para>
-          <programlisting>
+            <programlisting>
 # parted /dev/sda -- mkpart ESP fat32 1MB 512MB
 # parted /dev/sda -- set 3 esp on
 </programlisting>
-        </listitem>
-      </orderedlist>
-      <para>
-        Once complete, you can follow with
-        <xref linkend="sec-installation-partitioning-formatting" />.
-      </para>
-    </section>
-    <section xml:id="sec-installation-partitioning-MBR">
-      <title>Legacy Boot (MBR)</title>
-      <para>
-        Here's an example partition scheme for Legacy Boot, using
-        <literal>/dev/sda</literal> as the device.
-      </para>
-      <note>
+          </listitem>
+        </orderedlist>
         <para>
-          You can safely ignore <literal>parted</literal>'s
-          informational message about needing to update /etc/fstab.
+          Once complete, you can follow with
+          <xref linkend="sec-installation-manual-partitioning-formatting" />.
         </para>
-      </note>
+      </section>
+      <section xml:id="sec-installation-manual-partitioning-MBR">
+        <title>Legacy Boot (MBR)</title>
+        <para>
+          <anchor xml:id="sec-installation-partitioning-MBR" />
+          <!-- legacy anchor -->
+        </para>
+        <para>
+          Here's an example partition scheme for Legacy Boot, using
+          <literal>/dev/sda</literal> as the device.
+        </para>
+        <note>
+          <para>
+            You can safely ignore <literal>parted</literal>'s
+            informational message about needing to update /etc/fstab.
+          </para>
+        </note>
+        <orderedlist numeration="arabic">
+          <listitem>
+            <para>
+              Create a <emphasis>MBR</emphasis> partition table.
+            </para>
+            <programlisting>
+# parted /dev/sda -- mklabel msdos
+</programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              Add the <emphasis>root</emphasis> partition. This will
+              fill the the disk except for the end part, where the swap
+              will live.
+            </para>
+            <programlisting>
+# parted /dev/sda -- mkpart primary 1MB -8GB
+</programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              Set the root partition’s boot flag to on. This allows the
+              disk to be booted from.
+            </para>
+            <programlisting>
+# parted /dev/sda -- set 1 boot on
+</programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              Finally, add a <emphasis>swap</emphasis> partition. The
+              size required will vary according to needs, here a 8GiB
+              one is created.
+            </para>
+            <programlisting>
+# parted /dev/sda -- mkpart primary linux-swap -8GB 100%
+</programlisting>
+            <note>
+              <para>
+                The swap partition size rules are no different than for
+                other Linux distributions.
+              </para>
+            </note>
+          </listitem>
+        </orderedlist>
+        <para>
+          Once complete, you can follow with
+          <xref linkend="sec-installation-manual-partitioning-formatting" />.
+        </para>
+      </section>
+      <section xml:id="sec-installation-manual-partitioning-formatting">
+        <title>Formatting</title>
+        <para>
+          <anchor xml:id="sec-installation-partitioning-formatting" />
+          <!-- legacy anchor -->
+        </para>
+        <para>
+          Use the following commands:
+        </para>
+        <itemizedlist>
+          <listitem>
+            <para>
+              For initialising Ext4 partitions:
+              <literal>mkfs.ext4</literal>. It is recommended that you
+              assign a unique symbolic label to the file system using
+              the option <literal>-L label</literal>, since this makes
+              the file system configuration independent from device
+              changes. For example:
+            </para>
+            <programlisting>
+# mkfs.ext4 -L nixos /dev/sda1
+</programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              For creating swap partitions: <literal>mkswap</literal>.
+              Again it’s recommended to assign a label to the swap
+              partition: <literal>-L label</literal>. For example:
+            </para>
+            <programlisting>
+# mkswap -L swap /dev/sda2
+</programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis role="strong">UEFI systems</emphasis>
+            </para>
+            <para>
+              For creating boot partitions: <literal>mkfs.fat</literal>.
+              Again it’s recommended to assign a label to the boot
+              partition: <literal>-n label</literal>. For example:
+            </para>
+            <programlisting>
+# mkfs.fat -F 32 -n boot /dev/sda3
+</programlisting>
+          </listitem>
+          <listitem>
+            <para>
+              For creating LVM volumes, the LVM commands, e.g.,
+              <literal>pvcreate</literal>, <literal>vgcreate</literal>,
+              and <literal>lvcreate</literal>.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              For creating software RAID devices, use
+              <literal>mdadm</literal>.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </section>
+    </section>
+    <section xml:id="sec-installation-manual-installing">
+      <title>Installing</title>
+      <para>
+        <anchor xml:id="sec-installation-installing" />
+        <!-- legacy anchor -->
+      </para>
       <orderedlist numeration="arabic">
         <listitem>
           <para>
-            Create a <emphasis>MBR</emphasis> partition table.
+            Mount the target file system on which NixOS should be
+            installed on <literal>/mnt</literal>, e.g.
           </para>
           <programlisting>
-# parted /dev/sda -- mklabel msdos
-</programlisting>
-        </listitem>
-        <listitem>
-          <para>
-            Add the <emphasis>root</emphasis> partition. This will fill
-            the the disk except for the end part, where the swap will
-            live.
-          </para>
-          <programlisting>
-# parted /dev/sda -- mkpart primary 1MB -8GB
-</programlisting>
-        </listitem>
-        <listitem>
-          <para>
-            Set the root partition’s boot flag to on. This allows the
-            disk to be booted from.
-          </para>
-          <programlisting>
-# parted /dev/sda -- set 1 boot on
-</programlisting>
-        </listitem>
-        <listitem>
-          <para>
-            Finally, add a <emphasis>swap</emphasis> partition. The size
-            required will vary according to needs, here a 8GiB one is
-            created.
-          </para>
-          <programlisting>
-# parted /dev/sda -- mkpart primary linux-swap -8GB 100%
-</programlisting>
-          <note>
-            <para>
-              The swap partition size rules are no different than for
-              other Linux distributions.
-            </para>
-          </note>
-        </listitem>
-      </orderedlist>
-      <para>
-        Once complete, you can follow with
-        <xref linkend="sec-installation-partitioning-formatting" />.
-      </para>
-    </section>
-    <section xml:id="sec-installation-partitioning-formatting">
-      <title>Formatting</title>
-      <para>
-        Use the following commands:
-      </para>
-      <itemizedlist>
-        <listitem>
-          <para>
-            For initialising Ext4 partitions:
-            <literal>mkfs.ext4</literal>. It is recommended that you
-            assign a unique symbolic label to the file system using the
-            option <literal>-L label</literal>, since this makes the
-            file system configuration independent from device changes.
-            For example:
-          </para>
-          <programlisting>
-# mkfs.ext4 -L nixos /dev/sda1
-</programlisting>
-        </listitem>
-        <listitem>
-          <para>
-            For creating swap partitions: <literal>mkswap</literal>.
-            Again it’s recommended to assign a label to the swap
-            partition: <literal>-L label</literal>. For example:
-          </para>
-          <programlisting>
-# mkswap -L swap /dev/sda2
+# mount /dev/disk/by-label/nixos /mnt
 </programlisting>
         </listitem>
         <listitem>
@@ -310,322 +557,287 @@ OK
             <emphasis role="strong">UEFI systems</emphasis>
           </para>
           <para>
-            For creating boot partitions: <literal>mkfs.fat</literal>.
-            Again it’s recommended to assign a label to the boot
-            partition: <literal>-n label</literal>. For example:
+            Mount the boot file system on <literal>/mnt/boot</literal>,
+            e.g.
           </para>
           <programlisting>
-# mkfs.fat -F 32 -n boot /dev/sda3
-</programlisting>
-        </listitem>
-        <listitem>
-          <para>
-            For creating LVM volumes, the LVM commands, e.g.,
-            <literal>pvcreate</literal>, <literal>vgcreate</literal>,
-            and <literal>lvcreate</literal>.
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            For creating software RAID devices, use
-            <literal>mdadm</literal>.
-          </para>
-        </listitem>
-      </itemizedlist>
-    </section>
-  </section>
-  <section xml:id="sec-installation-installing">
-    <title>Installing</title>
-    <orderedlist numeration="arabic">
-      <listitem>
-        <para>
-          Mount the target file system on which NixOS should be
-          installed on <literal>/mnt</literal>, e.g.
-        </para>
-        <programlisting>
-# mount /dev/disk/by-label/nixos /mnt
-</programlisting>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis role="strong">UEFI systems</emphasis>
-        </para>
-        <para>
-          Mount the boot file system on <literal>/mnt/boot</literal>,
-          e.g.
-        </para>
-        <programlisting>
 # mkdir -p /mnt/boot
 # mount /dev/disk/by-label/boot /mnt/boot
 </programlisting>
-      </listitem>
-      <listitem>
-        <para>
-          If your machine has a limited amount of memory, you may want
-          to activate swap devices now
-          (<literal>swapon device</literal>). The installer (or rather,
-          the build actions that it may spawn) may need quite a bit of
-          RAM, depending on your configuration.
-        </para>
-        <programlisting>
+        </listitem>
+        <listitem>
+          <para>
+            If your machine has a limited amount of memory, you may want
+            to activate swap devices now
+            (<literal>swapon device</literal>). The installer (or
+            rather, the build actions that it may spawn) may need quite
+            a bit of RAM, depending on your configuration.
+          </para>
+          <programlisting>
 # swapon /dev/sda2
 </programlisting>
-      </listitem>
-      <listitem>
-        <para>
-          You now need to create a file
-          <literal>/mnt/etc/nixos/configuration.nix</literal> that
-          specifies the intended configuration of the system. This is
-          because NixOS has a <emphasis>declarative</emphasis>
-          configuration model: you create or edit a description of the
-          desired configuration of your system, and then NixOS takes
-          care of making it happen. The syntax of the NixOS
-          configuration file is described in
-          <xref linkend="sec-configuration-syntax" />, while a list of
-          available configuration options appears in
-          <xref linkend="ch-options" />. A minimal example is shown in
-          <link linkend="ex-config">Example: NixOS Configuration</link>.
-        </para>
-        <para>
-          The command <literal>nixos-generate-config</literal> can
-          generate an initial configuration file for you:
-        </para>
-        <programlisting>
+        </listitem>
+        <listitem>
+          <para>
+            You now need to create a file
+            <literal>/mnt/etc/nixos/configuration.nix</literal> that
+            specifies the intended configuration of the system. This is
+            because NixOS has a <emphasis>declarative</emphasis>
+            configuration model: you create or edit a description of the
+            desired configuration of your system, and then NixOS takes
+            care of making it happen. The syntax of the NixOS
+            configuration file is described in
+            <xref linkend="sec-configuration-syntax" />, while a list of
+            available configuration options appears in
+            <xref linkend="ch-options" />. A minimal example is shown in
+            <link linkend="ex-config">Example: NixOS
+            Configuration</link>.
+          </para>
+          <para>
+            The command <literal>nixos-generate-config</literal> can
+            generate an initial configuration file for you:
+          </para>
+          <programlisting>
 # nixos-generate-config --root /mnt
 </programlisting>
-        <para>
-          You should then edit
-          <literal>/mnt/etc/nixos/configuration.nix</literal> to suit
-          your needs:
-        </para>
-        <programlisting>
+          <para>
+            You should then edit
+            <literal>/mnt/etc/nixos/configuration.nix</literal> to suit
+            your needs:
+          </para>
+          <programlisting>
 # nano /mnt/etc/nixos/configuration.nix
 </programlisting>
-        <para>
-          If you’re using the graphical ISO image, other editors may be
-          available (such as <literal>vim</literal>). If you have
-          network access, you can also install other editors – for
-          instance, you can install Emacs by running
-          <literal>nix-env -f '&lt;nixpkgs&gt;' -iA emacs</literal>.
-        </para>
-        <variablelist>
-          <varlistentry>
-            <term>
-              BIOS systems
-            </term>
-            <listitem>
-              <para>
-                You <emphasis>must</emphasis> set the option
-                <xref linkend="opt-boot.loader.grub.device" /> to
-                specify on which disk the GRUB boot loader is to be
-                installed. Without it, NixOS cannot boot.
-              </para>
-              <para>
-                If there are other operating systems running on the
-                machine before installing NixOS, the
-                <xref linkend="opt-boot.loader.grub.useOSProber" />
-                option can be set to <literal>true</literal> to
-                automatically add them to the grub menu.
-              </para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>
-              UEFI systems
-            </term>
-            <listitem>
-              <para>
-                You must select a boot-loader, either system-boot or
-                GRUB. The recommended option is systemd-boot: set the
-                option
-                <xref linkend="opt-boot.loader.systemd-boot.enable" />
-                to <literal>true</literal>.
-                <literal>nixos-generate-config</literal> should do this
-                automatically for new configurations when booted in UEFI
-                mode.
-              </para>
-              <para>
-                You may want to look at the options starting with
-                <link linkend="opt-boot.loader.efi.canTouchEfiVariables"><literal>boot.loader.efi</literal></link>
-                and
-                <link linkend="opt-boot.loader.systemd-boot.enable"><literal>boot.loader.systemd-boot</literal></link>
-                as well.
-              </para>
-              <para>
-                If you want to use GRUB, set
-                <xref linkend="opt-boot.loader.grub.device" /> to
-                <literal>nodev</literal> and
-                <xref linkend="opt-boot.loader.grub.efiSupport" /> to
-                <literal>true</literal>.
-              </para>
-              <para>
-                With system-boot, you should not need any special
-                configuration to detect other installed systems. With
-                GRUB, set
-                <xref linkend="opt-boot.loader.grub.useOSProber" /> to
-                <literal>true</literal>, but this will only detect
-                windows partitions, not other linux distributions. If
-                you dual boot another linux distribution, use
-                system-boot instead.
-              </para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-        <para>
-          If you need to configure networking for your machine the
-          configuration options are described in
-          <xref linkend="sec-networking" />. In particular, while wifi
-          is supported on the installation image, it is not enabled by
-          default in the configuration generated by
-          <literal>nixos-generate-config</literal>.
-        </para>
-        <para>
-          Another critical option is <literal>fileSystems</literal>,
-          specifying the file systems that need to be mounted by NixOS.
-          However, you typically don’t need to set it yourself, because
-          <literal>nixos-generate-config</literal> sets it automatically
-          in
-          <literal>/mnt/etc/nixos/hardware-configuration.nix</literal>
-          from your currently mounted file systems. (The configuration
-          file <literal>hardware-configuration.nix</literal> is included
-          from <literal>configuration.nix</literal> and will be
-          overwritten by future invocations of
-          <literal>nixos-generate-config</literal>; thus, you generally
-          should not modify it.) Additionally, you may want to look at
-          <link xlink:href="https://github.com/NixOS/nixos-hardware">Hardware
-          configuration for known-hardware</link> at this point or after
-          installation.
-        </para>
-        <note>
           <para>
-            Depending on your hardware configuration or type of file
-            system, you may need to set the option
-            <literal>boot.initrd.kernelModules</literal> to include the
-            kernel modules that are necessary for mounting the root file
-            system, otherwise the installed system will not be able to
-            boot. (If this happens, boot from the installation media
-            again, mount the target file system on
-            <literal>/mnt</literal>, fix
-            <literal>/mnt/etc/nixos/configuration.nix</literal> and
-            rerun <literal>nixos-install</literal>.) In most cases,
-            <literal>nixos-generate-config</literal> will figure out the
-            required modules.
+            If you’re using the graphical ISO image, other editors may
+            be available (such as <literal>vim</literal>). If you have
+            network access, you can also install other editors – for
+            instance, you can install Emacs by running
+            <literal>nix-env -f '&lt;nixpkgs&gt;' -iA emacs</literal>.
           </para>
-        </note>
-      </listitem>
-      <listitem>
-        <para>
-          Do the installation:
-        </para>
-        <programlisting>
+          <variablelist>
+            <varlistentry>
+              <term>
+                BIOS systems
+              </term>
+              <listitem>
+                <para>
+                  You <emphasis>must</emphasis> set the option
+                  <xref linkend="opt-boot.loader.grub.device" /> to
+                  specify on which disk the GRUB boot loader is to be
+                  installed. Without it, NixOS cannot boot.
+                </para>
+                <para>
+                  If there are other operating systems running on the
+                  machine before installing NixOS, the
+                  <xref linkend="opt-boot.loader.grub.useOSProber" />
+                  option can be set to <literal>true</literal> to
+                  automatically add them to the grub menu.
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                UEFI systems
+              </term>
+              <listitem>
+                <para>
+                  You must select a boot-loader, either system-boot or
+                  GRUB. The recommended option is systemd-boot: set the
+                  option
+                  <xref linkend="opt-boot.loader.systemd-boot.enable" />
+                  to <literal>true</literal>.
+                  <literal>nixos-generate-config</literal> should do
+                  this automatically for new configurations when booted
+                  in UEFI mode.
+                </para>
+                <para>
+                  You may want to look at the options starting with
+                  <link linkend="opt-boot.loader.efi.canTouchEfiVariables"><literal>boot.loader.efi</literal></link>
+                  and
+                  <link linkend="opt-boot.loader.systemd-boot.enable"><literal>boot.loader.systemd-boot</literal></link>
+                  as well.
+                </para>
+                <para>
+                  If you want to use GRUB, set
+                  <xref linkend="opt-boot.loader.grub.device" /> to
+                  <literal>nodev</literal> and
+                  <xref linkend="opt-boot.loader.grub.efiSupport" /> to
+                  <literal>true</literal>.
+                </para>
+                <para>
+                  With system-boot, you should not need any special
+                  configuration to detect other installed systems. With
+                  GRUB, set
+                  <xref linkend="opt-boot.loader.grub.useOSProber" /> to
+                  <literal>true</literal>, but this will only detect
+                  windows partitions, not other linux distributions. If
+                  you dual boot another linux distribution, use
+                  system-boot instead.
+                </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>
+            If you need to configure networking for your machine the
+            configuration options are described in
+            <xref linkend="sec-networking" />. In particular, while wifi
+            is supported on the installation image, it is not enabled by
+            default in the configuration generated by
+            <literal>nixos-generate-config</literal>.
+          </para>
+          <para>
+            Another critical option is <literal>fileSystems</literal>,
+            specifying the file systems that need to be mounted by
+            NixOS. However, you typically don’t need to set it yourself,
+            because <literal>nixos-generate-config</literal> sets it
+            automatically in
+            <literal>/mnt/etc/nixos/hardware-configuration.nix</literal>
+            from your currently mounted file systems. (The configuration
+            file <literal>hardware-configuration.nix</literal> is
+            included from <literal>configuration.nix</literal> and will
+            be overwritten by future invocations of
+            <literal>nixos-generate-config</literal>; thus, you
+            generally should not modify it.) Additionally, you may want
+            to look at
+            <link xlink:href="https://github.com/NixOS/nixos-hardware">Hardware
+            configuration for known-hardware</link> at this point or
+            after installation.
+          </para>
+          <note>
+            <para>
+              Depending on your hardware configuration or type of file
+              system, you may need to set the option
+              <literal>boot.initrd.kernelModules</literal> to include
+              the kernel modules that are necessary for mounting the
+              root file system, otherwise the installed system will not
+              be able to boot. (If this happens, boot from the
+              installation media again, mount the target file system on
+              <literal>/mnt</literal>, fix
+              <literal>/mnt/etc/nixos/configuration.nix</literal> and
+              rerun <literal>nixos-install</literal>.) In most cases,
+              <literal>nixos-generate-config</literal> will figure out
+              the required modules.
+            </para>
+          </note>
+        </listitem>
+        <listitem>
+          <para>
+            Do the installation:
+          </para>
+          <programlisting>
 # nixos-install
 </programlisting>
-        <para>
-          This will install your system based on the configuration you
-          provided. If anything fails due to a configuration problem or
-          any other issue (such as a network outage while downloading
-          binaries from the NixOS binary cache), you can re-run
-          <literal>nixos-install</literal> after fixing your
-          <literal>configuration.nix</literal>.
-        </para>
-        <para>
-          As the last step, <literal>nixos-install</literal> will ask
-          you to set the password for the <literal>root</literal> user,
-          e.g.
-        </para>
-        <programlisting>
+          <para>
+            This will install your system based on the configuration you
+            provided. If anything fails due to a configuration problem
+            or any other issue (such as a network outage while
+            downloading binaries from the NixOS binary cache), you can
+            re-run <literal>nixos-install</literal> after fixing your
+            <literal>configuration.nix</literal>.
+          </para>
+          <para>
+            As the last step, <literal>nixos-install</literal> will ask
+            you to set the password for the <literal>root</literal>
+            user, e.g.
+          </para>
+          <programlisting>
 setting root password...
 New password: ***
 Retype new password: ***
 </programlisting>
-        <note>
+          <note>
+            <para>
+              For unattended installations, it is possible to use
+              <literal>nixos-install --no-root-passwd</literal> in order
+              to disable the password prompt entirely.
+            </para>
+          </note>
+        </listitem>
+        <listitem>
           <para>
-            For unattended installations, it is possible to use
-            <literal>nixos-install --no-root-passwd</literal> in order
-            to disable the password prompt entirely.
+            If everything went well:
           </para>
-        </note>
-      </listitem>
-      <listitem>
-        <para>
-          If everything went well:
-        </para>
-        <programlisting>
+          <programlisting>
 # reboot
 </programlisting>
-      </listitem>
-      <listitem>
-        <para>
-          You should now be able to boot into the installed NixOS. The
-          GRUB boot menu shows a list of <emphasis>available
-          configurations</emphasis> (initially just one). Every time you
-          change the NixOS configuration (see
-          <link linkend="sec-changing-config">Changing
-          Configuration</link>), a new item is added to the menu. This
-          allows you to easily roll back to a previous configuration if
-          something goes wrong.
-        </para>
-        <para>
-          You should log in and change the <literal>root</literal>
-          password with <literal>passwd</literal>.
-        </para>
-        <para>
-          You’ll probably want to create some user accounts as well,
-          which can be done with <literal>useradd</literal>:
-        </para>
-        <programlisting>
+        </listitem>
+        <listitem>
+          <para>
+            You should now be able to boot into the installed NixOS. The
+            GRUB boot menu shows a list of <emphasis>available
+            configurations</emphasis> (initially just one). Every time
+            you change the NixOS configuration (see
+            <link linkend="sec-changing-config">Changing
+            Configuration</link>), a new item is added to the menu. This
+            allows you to easily roll back to a previous configuration
+            if something goes wrong.
+          </para>
+          <para>
+            You should log in and change the <literal>root</literal>
+            password with <literal>passwd</literal>.
+          </para>
+          <para>
+            You’ll probably want to create some user accounts as well,
+            which can be done with <literal>useradd</literal>:
+          </para>
+          <programlisting>
 $ useradd -c 'Eelco Dolstra' -m eelco
 $ passwd eelco
 </programlisting>
-        <para>
-          You may also want to install some software. This will be
-          covered in <xref linkend="sec-package-management" />.
-        </para>
-      </listitem>
-    </orderedlist>
-  </section>
-  <section xml:id="sec-installation-summary">
-    <title>Installation summary</title>
-    <para>
-      To summarise, <link linkend="ex-install-sequence">Example:
-      Commands for Installing NixOS on
-      <literal>/dev/sda</literal></link> shows a typical sequence of
-      commands for installing NixOS on an empty hard drive (here
-      <literal>/dev/sda</literal>). <link linkend="ex-config">Example:
-      NixOS Configuration</link> shows a corresponding configuration Nix
-      expression.
-    </para>
-    <anchor xml:id="ex-partition-scheme-MBR" />
-    <para>
-      <emphasis role="strong">Example: Example partition schemes for
-      NixOS on <literal>/dev/sda</literal> (MBR)</emphasis>
-    </para>
-    <programlisting>
+          <para>
+            You may also want to install some software. This will be
+            covered in <xref linkend="sec-package-management" />.
+          </para>
+        </listitem>
+      </orderedlist>
+    </section>
+    <section xml:id="sec-installation-manual-summary">
+      <title>Installation summary</title>
+      <para>
+        <anchor xml:id="sec-installation-summary" />
+        <!-- legacy anchor -->
+      </para>
+      <para>
+        To summarise, <link linkend="ex-install-sequence">Example:
+        Commands for Installing NixOS on
+        <literal>/dev/sda</literal></link> shows a typical sequence of
+        commands for installing NixOS on an empty hard drive (here
+        <literal>/dev/sda</literal>). <link linkend="ex-config">Example:
+        NixOS Configuration</link> shows a corresponding configuration
+        Nix expression.
+      </para>
+      <anchor xml:id="ex-partition-scheme-MBR" />
+      <para>
+        <emphasis role="strong">Example: Example partition schemes for
+        NixOS on <literal>/dev/sda</literal> (MBR)</emphasis>
+      </para>
+      <programlisting>
 # parted /dev/sda -- mklabel msdos
 # parted /dev/sda -- mkpart primary 1MiB -8GiB
 # parted /dev/sda -- mkpart primary linux-swap -8GiB 100%
 </programlisting>
-    <anchor xml:id="ex-partition-scheme-UEFI" />
-    <para>
-      <emphasis role="strong">Example: Example partition schemes for
-      NixOS on <literal>/dev/sda</literal> (UEFI)</emphasis>
-    </para>
-    <programlisting>
+      <anchor xml:id="ex-partition-scheme-UEFI" />
+      <para>
+        <emphasis role="strong">Example: Example partition schemes for
+        NixOS on <literal>/dev/sda</literal> (UEFI)</emphasis>
+      </para>
+      <programlisting>
 # parted /dev/sda -- mklabel gpt
 # parted /dev/sda -- mkpart primary 512MiB -8GiB
 # parted /dev/sda -- mkpart primary linux-swap -8GiB 100%
 # parted /dev/sda -- mkpart ESP fat32 1MiB 512MiB
 # parted /dev/sda -- set 3 esp on
 </programlisting>
-    <anchor xml:id="ex-install-sequence" />
-    <para>
-      <emphasis role="strong">Example: Commands for Installing NixOS on
-      <literal>/dev/sda</literal></emphasis>
-    </para>
-    <para>
-      With a partitioned disk.
-    </para>
-    <programlisting>
+      <anchor xml:id="ex-install-sequence" />
+      <para>
+        <emphasis role="strong">Example: Commands for Installing NixOS
+        on <literal>/dev/sda</literal></emphasis>
+      </para>
+      <para>
+        With a partitioned disk.
+      </para>
+      <programlisting>
 # mkfs.ext4 -L nixos /dev/sda1
 # mkswap -L swap /dev/sda2
 # swapon /dev/sda2
@@ -638,11 +850,11 @@ $ passwd eelco
 # nixos-install
 # reboot
 </programlisting>
-    <anchor xml:id="ex-config" />
-    <para>
-      <emphasis role="strong">Example: NixOS Configuration</emphasis>
-    </para>
-    <programlisting>
+      <anchor xml:id="ex-config" />
+      <para>
+        <emphasis role="strong">Example: NixOS Configuration</emphasis>
+      </para>
+      <programlisting>
 { config, pkgs, ... }: {
   imports = [
     # Include the results of the hardware scan.
@@ -661,6 +873,7 @@ $ passwd eelco
   services.sshd.enable = true;
 }
 </programlisting>
+    </section>
   </section>
   <section xml:id="sec-installation-additional-notes">
     <title>Additional installation notes</title>

--- a/nixos/doc/manual/from_md/installation/obtaining.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/obtaining.chapter.xml
@@ -2,16 +2,15 @@
   <title>Obtaining NixOS</title>
   <para>
     NixOS ISO images can be downloaded from the
-    <link xlink:href="https://nixos.org/nixos/download.html">NixOS
-    download page</link>. There are a number of installation options. If
-    you happen to have an optical drive and a spare CD, burning the
-    image to CD and booting from that is probably the easiest option.
-    Most people will need to prepare a USB stick to boot from.
-    <xref linkend="sec-booting-from-usb" /> describes the preferred
-    method to prepare a USB stick. A number of alternative methods are
-    presented in the
-    <link xlink:href="https://nixos.wiki/wiki/NixOS_Installation_Guide#Making_the_installation_media">NixOS
-    Wiki</link>.
+    <link xlink:href="https://nixos.org/download.html#nixos-iso">NixOS
+    download page</link>. Follow the instructions in
+    <xref linkend="sec-booting-from-usb" /> to create a bootable USB
+    flash drive.
+  </para>
+  <para>
+    If you have a very old system that can’t boot from USB, you can burn
+    the image to an empty CD. NixOS might not work very well on such
+    systems.
   </para>
   <para>
     As an alternative to installing NixOS yourself, you can get a
@@ -23,16 +22,16 @@
         Using virtual appliances in Open Virtualization Format (OVF)
         that can be imported into VirtualBox. These are available from
         the
-        <link xlink:href="https://nixos.org/nixos/download.html">NixOS
+        <link xlink:href="https://nixos.org/download.html#nixos-virtualbox">NixOS
         download page</link>.
       </para>
     </listitem>
     <listitem>
       <para>
-        Using AMIs for Amazon’s EC2. To find one for your region and
-        instance type, please refer to the
-        <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/ec2-amis.nix">list
-        of most recent AMIs</link>.
+        Using AMIs for Amazon’s EC2. To find one for your region, please
+        refer to the
+        <link xlink:href="https://nixos.org/download.html#nixos-amazon">download
+        page</link>.
       </para>
     </listitem>
     <listitem>

--- a/nixos/doc/manual/installation/installing-usb.section.md
+++ b/nixos/doc/manual/installation/installing-usb.section.md
@@ -1,31 +1,72 @@
-# Booting from a USB Drive {#sec-booting-from-usb}
+# Booting from a USB flash drive {#sec-booting-from-usb}
 
-For systems without CD drive, the NixOS live CD can be booted from a USB
-stick. You can use the `dd` utility to write the image:
-`dd if=path-to-image of=/dev/sdX`. Be careful about specifying the correct
-drive; you can use the `lsblk` command to get a list of block devices.
+The image has to be written verbatim to the USB flash drive for it to be
+bootable on UEFI and BIOS systems. Here are the recommended tools to do that.
 
-::: {.note}
-::: {.title}
-On macOS
+## Creating bootable USB flash drive with a graphical tool {#sec-booting-from-usb-graphical}
+
+Etcher is a popular and user-friendly tool. It works on Linux, Windows and macOS.
+
+Download it from [balena.io](https://www.balena.io/etcher/), start the program,
+select the downloaded NixOS ISO, then select the USB flash drive and flash it.
+
+::: {.warning}
+Etcher reports errors and usage statistics by default, which can be disabled in
+the settings.
 :::
 
-```ShellSession
-$ diskutil list
-[..]
-/dev/diskN (external, physical):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER
-[..]
-$ diskutil unmountDisk diskN
-Unmount of all volumes on diskN was successful
-$ sudo dd if=nix.iso of=/dev/rdiskN bs=1M
-```
+An alternative is [USBImager](https://bztsrc.gitlab.io/usbimager),
+which is very simple and does not connect to the internet. Download the version
+with write-only (wo) interface for your system. Start the program,
+select the image, select the USB flash drive and click "Write".
 
-Using the \'raw\' `rdiskN` device instead of `diskN` completes in
-minutes instead of hours. After `dd` completes, a GUI dialog \"The disk
-you inserted was not readable by this computer\" will pop up, which can
-be ignored.
-:::
+## Creating bootable USB flash drive from a Terminal on Linux {#sec-booting-from-usb-linux}
 
-The `dd` utility will write the image verbatim to the drive, making it
-the recommended option for both UEFI and non-UEFI installations.
+1. Plug in the USB flash drive.
+2. Find the corresponding device with `lsblk`. You can distinguish them by
+   their size.
+3. Make sure all partitions on the device are properly unmounted. Replace `sdX`
+   with your device (e.g. `sdb`).
+
+  ```ShellSession
+  sudo umount /dev/sdX*
+  ```
+
+4. Then use the `dd` utility to write the image to the USB flash drive.
+
+  ```ShellSession
+  sudo dd if=<path-to-image> of=/dev/sdX bs=4M conv=fsync
+  ```
+
+## Creating bootable USB flash drive from a Terminal on macOS {#sec-booting-from-usb-macos}
+
+1. Plug in the USB flash drive.
+2. Find the corresponding device with `diskutil list`. You can distinguish them
+   by their size.
+3. Make sure all partitions on the device are properly unmounted. Replace `diskX`
+   with your device (e.g. `disk1`).
+
+  ```ShellSession
+  diskutil unmountDisk diskX
+  ```
+
+4. Then use the `dd` utility to write the image to the USB flash drive.
+
+  ```ShellSession
+  sudo dd if=<path-to-image> of=/dev/rdiskX bs=4m
+  ```
+
+  After `dd` completes, a GUI dialog \"The disk
+  you inserted was not readable by this computer\" will pop up, which can
+  be ignored.
+
+  ::: {.note}
+  Using the \'raw\' `rdiskX` device instead of `diskX` with dd completes in
+  minutes instead of hours.
+  :::
+
+5. Eject the disk when it is finished.
+
+  ```ShellSession
+  diskutil eject /dev/diskX
+  ```

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -1,30 +1,143 @@
 # Installing NixOS {#sec-installation}
 
-## Booting the system {#sec-installation-booting}
+## Booting from the install medium {#sec-installation-booting}
+
+To begin the installation, you have to boot your computer from the install drive.
+
+1.   Plug in the install drive. Then turn on or restart your computer.
+
+2.   Open the boot menu by pressing the appropriate key, which is usually shown
+     on the display on early boot.
+     Select the USB flash drive (the option usually contains the word "USB").
+     If you choose the incorrect drive, your computer will likely continue to
+     boot as normal. In that case restart your computer and pick a
+     different drive.
+
+     ::: {.note}
+     The key to open the boot menu is different across computer brands and even
+     models. It can be <kbd>F12</kbd>, but also <kbd>F1</kbd>,
+     <kbd>F9</kbd>, <kbd>F10</kbd>, <kbd>Enter</kbd>, <kbd>Del</kbd>,
+     <kbd>Esc</kbd> or another function key. If you are unsure and don't see
+     it on the early boot screen, you can search online for your computers
+     brand, model followed by "boot from usb".
+     The computer might not even have that feature, so you have to go into the
+     BIOS/UEFI settings to change the boot order. Again, search online for
+     details about your specific computer model.
+
+     For Apple computers with Intel processors press and hold the <kbd>⌥</kbd>
+     (Option or Alt) key until you see the boot menu. On Apple silicon press
+     and hold the power button.
+     :::
+
+     ::: {.note}
+     If your computer supports both BIOS and UEFI boot, choose the UEFI option.
+     :::
+
+     ::: {.note}
+     If you use a CD for the installation, the computer will probably boot from
+     it automatically. If not, choose the option containing the word "CD" from
+     the boot menu.
+     :::
+
+3.   Shortly after selecting the appropriate boot drive, you should be
+     presented with a menu with different installer options. Leave the default
+     and wait (or press <kbd>Enter</kbd> to speed up).
+
+4.   The graphical images will start their corresponding desktop environment
+     and the graphical installer, which can take some time. The minimal images
+     will boot to a command line. You have to follow the instructions in
+     [](#sec-installation-manual) there.
+
+## Graphical Installation {#sec-installation-graphical}
+
+The graphical installer is recommended for desktop users and will guide you
+through the installation.
+
+1.   In the "Welcome" screen, you can select the language of the Installer and
+     the installed system.
+
+     ::: {.tip}
+     Leaving the language as "American English" will make it easier to search for
+     error messages in a search engine or to report an issue.
+     :::
+
+2.   Next you should choose your location to have the timezone set correctly.
+     You can actually click on the map!
+
+     ::: {.note}
+     The installer will use an online service to guess your location based on
+     your public IP address.
+     :::
+
+3.   Then you can select the keyboard layout. The default keyboard model should
+     work well with most desktop keyboards. If you have a special keyboard or
+     notebook, your model might be in the list. Select the language you are most
+     comfortable typing in.
+
+4.   On the "Users" screen, you have to type in your display name, login name
+     and password. You can also enable an option to automatically login to the
+     desktop.
+
+5.   Then you have the option to choose a desktop environment. If you want to
+     create a custom setup with a window manager, you can select "No desktop".
+
+     ::: {.tip}
+     If you don't have a favorite desktop and don't know which one to choose,
+     you can stick to either GNOME or Plasma. They have a quite different
+     design, so you should choose whichever you like better.
+     They are both popular choices and well tested on NixOS.
+     :::
+
+6.   You have the option to allow unfree software in the next screen.
+
+7.   The easiest option in the "Partitioning" screen is "Erase disk", which will
+     delete all data from the selected disk and install the system on it.
+     Also select "Swap (with Hibernation)" in the dropdown below it.
+     You have the option to encrypt the whole disk with LUKS.
+
+     ::: {.note}
+     At the top left you see if the Installer was booted with BIOS or UEFI. If
+     you know your system supports UEFI and it shows "BIOS", reboot with the
+     correct option.
+     :::
+
+     ::: {.warning}
+     Make sure you have selected the correct disk at the top and that no
+     valuable data is still on the disk! It will be deleted when
+     formatting the disk.
+     :::
+
+8.   Check the choices you made in the "Summary" and click "Install".
+
+     ::: {.note}
+     The installation takes about 15 minutes. The time varies based on the
+     selected desktop environment, internet connection speed and disk write speed.
+     :::
+
+9.  When the install is complete, remove the USB flash drive and
+    reboot into your new system!
+
+## Manual Installation {#sec-installation-manual}
 
 NixOS can be installed on BIOS or UEFI systems. The procedure for a UEFI
-installation is by and large the same as a BIOS installation. The
-differences are mentioned in the steps that follow.
+installation is broadly the same as for a BIOS installation. The differences
+are mentioned in the following steps.
 
-The installation media can be burned to a CD, or now more commonly,
-"burned" to a USB drive (see [](#sec-booting-from-usb)).
+The NixOS manual is available by running `nixos-help` in the command line
+or from the application menu in the desktop environment.
 
-The installation media contains a basic NixOS installation. When it's
-finished booting, it should have detected most of your hardware.
-
-The NixOS manual is available by running `nixos-help`.
+To have access to the command line on the graphical images, open
+Terminal (GNOME) or Konsole (Plasma) from the application menu.
 
 You are logged-in automatically as `nixos`. The `nixos` user account has
 an empty password so you can use `sudo` without a password:
+
 ```ShellSession
 $ sudo -i
 ```
 
-If you downloaded the graphical ISO image, you can run `systemctl
-start display-manager` to start the desktop environment. If you want
-to continue on the terminal, you can use `loadkeys` to switch to your
-preferred keyboard layout. (We even provide neo2 via `loadkeys de
-neo`!)
+You can use `loadkeys` to switch to your preferred keyboard layout.
+(We even provide neo2 via `loadkeys de neo`!)
 
 If the text is too small to be legible, try `setfont ter-v32n` to
 increase the font size.
@@ -33,7 +146,8 @@ To install over a serial port connect with `115200n8` (e.g.
 `picocom -b 115200 /dev/ttyUSB0`). When the bootloader lists boot
 entries, select the serial console boot entry.
 
-### Networking in the installer {#sec-installation-booting-networking}
+### Networking in the installer {#sec-installation-manual-networking}
+[]{#sec-installation-booting-networking} <!-- legacy anchor -->
 
 The boot process should have brought up networking (check `ip
 a`). Networking is necessary for the installer, since it will
@@ -100,7 +214,8 @@ placed by mounting the image on a different machine). Alternatively you
 must set a password for either `root` or `nixos` with `passwd` to be
 able to login.
 
-## Partitioning and formatting {#sec-installation-partitioning}
+### Partitioning and formatting {#sec-installation-manual-partitioning}
+[]{#sec-installation-partitioning} <!-- legacy anchor -->
 
 The NixOS installer doesn't do any partitioning or formatting, so you
 need to do that yourself.
@@ -112,7 +227,8 @@ below use `parted`, but also provides `fdisk`, `gdisk`, `cfdisk`, and
 The recommended partition scheme differs depending if the computer uses
 *Legacy Boot* or *UEFI*.
 
-### UEFI (GPT) {#sec-installation-partitioning-UEFI}
+#### UEFI (GPT) {#sec-installation-manual-partitioning-UEFI}
+[]{#sec-installation-partitioning-UEFI} <!-- legacy anchor -->
 
 Here\'s an example partition scheme for UEFI, using `/dev/sda` as the
 device.
@@ -158,9 +274,10 @@ update /etc/fstab.
     ```
 
 Once complete, you can follow with
-[](#sec-installation-partitioning-formatting).
+[](#sec-installation-manual-partitioning-formatting).
 
-### Legacy Boot (MBR) {#sec-installation-partitioning-MBR}
+#### Legacy Boot (MBR) {#sec-installation-manual-partitioning-MBR}
+[]{#sec-installation-partitioning-MBR} <!-- legacy anchor -->
 
 Here\'s an example partition scheme for Legacy Boot, using `/dev/sda` as
 the device.
@@ -202,9 +319,10 @@ update /etc/fstab.
     :::
 
 Once complete, you can follow with
-[](#sec-installation-partitioning-formatting).
+[](#sec-installation-manual-partitioning-formatting).
 
-### Formatting {#sec-installation-partitioning-formatting}
+#### Formatting {#sec-installation-manual-partitioning-formatting}
+[]{#sec-installation-partitioning-formatting} <!-- legacy anchor -->
 
 Use the following commands:
 
@@ -239,7 +357,8 @@ Use the following commands:
 
 -   For creating software RAID devices, use `mdadm`.
 
-## Installing {#sec-installation-installing}
+### Installing {#sec-installation-manual-installing}
+[]{#sec-installation-installing} <!-- legacy anchor -->
 
 1.  Mount the target file system on which NixOS should be installed on
     `/mnt`, e.g.
@@ -410,7 +529,8 @@ Use the following commands:
     You may also want to install some software. This will be covered in
     [](#sec-package-management).
 
-## Installation summary {#sec-installation-summary}
+### Installation summary {#sec-installation-manual-summary}
+[]{#sec-installation-summary} <!-- legacy anchor -->
 
 To summarise, [Example: Commands for Installing NixOS on `/dev/sda`](#ex-install-sequence)
 shows a typical sequence of commands for installing NixOS on an empty hard

--- a/nixos/doc/manual/installation/obtaining.chapter.md
+++ b/nixos/doc/manual/installation/obtaining.chapter.md
@@ -1,24 +1,21 @@
 # Obtaining NixOS {#sec-obtaining}
 
 NixOS ISO images can be downloaded from the [NixOS download
-page](https://nixos.org/nixos/download.html). There are a number of
-installation options. If you happen to have an optical drive and a spare
-CD, burning the image to CD and booting from that is probably the
-easiest option. Most people will need to prepare a USB stick to boot
-from. [](#sec-booting-from-usb) describes the preferred method to
-prepare a USB stick. A number of alternative methods are presented in
-the [NixOS Wiki](https://nixos.wiki/wiki/NixOS_Installation_Guide#Making_the_installation_media).
+page](https://nixos.org/download.html#nixos-iso). Follow the instructions in
+[](#sec-booting-from-usb) to create a bootable USB flash drive.
+
+If you have a very old system that can't boot from USB, you can burn the image
+to an empty CD. NixOS might not work very well on such systems.
 
 As an alternative to installing NixOS yourself, you can get a running
 NixOS system through several other means:
 
 -   Using virtual appliances in Open Virtualization Format (OVF) that
     can be imported into VirtualBox. These are available from the [NixOS
-    download page](https://nixos.org/nixos/download.html).
+    download page](https://nixos.org/download.html#nixos-virtualbox).
 
--   Using AMIs for Amazon's EC2. To find one for your region and
-    instance type, please refer to the [list of most recent
-    AMIs](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/ec2-amis.nix).
+-   Using AMIs for Amazon's EC2. To find one for your region, please refer
+    to the [download page](https://nixos.org/download.html#nixos-amazon).
 
 -   Using NixOps, the NixOS-based cloud deployment tool, which allows
     you to provision VirtualBox and EC2 NixOS instances from declarative

--- a/nixos/doc/manual/md-to-db.sh
+++ b/nixos/doc/manual/md-to-db.sh
@@ -19,6 +19,7 @@ pandoc_flags=(
   "--lua-filter=$DIR/../../../doc/build-aux/pandoc-filters/myst-reader/roles.lua"
   "--lua-filter=$DIR/../../../doc/build-aux/pandoc-filters/link-unix-man-references.lua"
   "--lua-filter=$DIR/../../../doc/build-aux/pandoc-filters/docbook-writer/rst-roles.lua"
+  "--lua-filter=$DIR/../../../doc/build-aux/pandoc-filters/docbook-writer/html-elements.lua"
   "--lua-filter=$DIR/../../../doc/build-aux/pandoc-filters/docbook-writer/labelless-link-is-xref.lua"
   -f "commonmark${pandoc_commonmark_enabled_extensions}+smart"
   -t docbook


### PR DESCRIPTION
###### Description of changes

- Update download URLs
- Replace "USB stick"/"USB Drive" with "USB flash drive" as that seem more correct
  https://en.wikipedia.org/wiki/USB_flash_drive
  https://elementary.io/docs/installation#choose-operating-system
- Don't mention CD as easiest option anymore,
  as all modern systems should be able to boot from USB,
  but many don't have a CD drive. Burning CDs is also usually wasteful as you
  can't burn them again.
- Remove link to NixOS Wiki (Making_the_installation_media) as it is not needed
- Add Etcher and USBImager as graphical tools to create install drive
- Make dd command consistent and use block size of 4 MB for faster flashing
- More consistent text
- Add instructions for "Booting from the install medium"
  Inspired by https://github.com/elementary/website/blob/9a91b0f4956b059db02122fbc738c4c067e033a7/docs/installation.md#booting-from-the-install-drive-booting-from-the-installation-medium-clear-float-2
- Add instructions for "Graphical Installation"
- Restructure headings and anchors for "Manual Installation"
- Adding legacy anchors for "Manual Installation" to not break links

---

I have tested booting from install drive created with Etcher, USBImager and dd on linux. It would be great if someone can test the other options (macOS and Windows).

I hope to get this into the release.

cc @dasJ 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
