### PR TITLE
expressvpn: init at 3.25.0.13

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -71,6 +71,13 @@
           <link linkend="opt-services.persistent-evdev.enable">services.persistent-evdev</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://www.expressvpn.com">expressvpn</link>,
+          the CLI client for ExpressVPN. Available as
+          <link linkend="opt-services.expressvpn.enable">services.expressvpn</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -31,6 +31,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   Available as [services.infnoise](options.html#opt-services.infnoise.enable).
 - [persistent-evdev](https://github.com/aiberia/persistent-evdev), a daemon to add virtual proxy devices that mirror a physical input device but persist even if the underlying hardware is hot-plugged. Available as [services.persistent-evdev](#opt-services.persistent-evdev.enable).
 
+- [expressvpn](https://www.expressvpn.com), the CLI client for ExpressVPN. Available as [services.expressvpn](#opt-services.expressvpn.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-22.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -771,6 +771,7 @@
   ./services/networking/ergo.nix
   ./services/networking/ergochat.nix
   ./services/networking/eternal-terminal.nix
+  ./services/networking/expressvpn.nix
   ./services/networking/fakeroute.nix
   ./services/networking/ferm.nix
   ./services/networking/fireqos.nix

--- a/nixos/modules/services/networking/expressvpn.nix
+++ b/nixos/modules/services/networking/expressvpn.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+{
+  options.services.expressvpn.enable = mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Enable the ExpressVPN daemon.
+    '';
+  };
+
+  config = mkIf config.services.expressvpn.enable {
+    boot.kernelModules = [ "tun" ];
+
+    systemd.services.expressvpn = {
+      description = "ExpressVPN Daemon";
+      serviceConfig = {
+        ExecStart = "${pkgs.expressvpn}/bin/expressvpnd";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "network-online.target" ];
+    };
+  };
+
+  meta.maintainers = with maintainers; [ yureien ];
+}

--- a/pkgs/applications/networking/expressvpn/default.nix
+++ b/pkgs/applications/networking/expressvpn/default.nix
@@ -1,0 +1,98 @@
+{ autoPatchelfHook
+, buildFHSUserEnv
+, dpkg
+, fetchurl
+, inotify-tools
+, lib
+, stdenvNoCC
+, sysctl
+, writeScript
+}:
+
+let
+  pname = "expressvpn";
+  clientVersion = "3.25.0";
+  clientBuild = "13";
+  version = lib.strings.concatStringsSep "." [ clientVersion clientBuild ];
+
+  expressvpnBase = stdenvNoCC.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://www.expressvpn.works/clients/linux/expressvpn_${version}-1_amd64.deb";
+      hash = "sha256-lyDjG346FrgT7SZbsWET+Hexl9Un6mzMukfO2PwlInA=";
+    };
+
+    nativeBuildInputs = [ dpkg autoPatchelfHook ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    unpackPhase = ''
+      runHook preUnpack
+      dpkg --fsys-tarfile $src | tar --extract
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mv usr/ $out/
+      runHook postInstall
+    '';
+  };
+
+  expressvpndFHS = buildFHSUserEnv {
+    name = "expressvpnd";
+
+    # When connected, it directly creates/deletes resolv.conf to change the DNS entries.
+    # Since it's running in an FHS environment, it has no effect on actual resolv.conf.
+    # Hence, place a watcher that updates host resolv.conf when FHS resolv.conf changes.
+    runScript = writeScript "${pname}-wrapper" ''
+      cp /host/etc/resolv.conf /etc/resolv.conf;
+      while inotifywait /etc 2>/dev/null;
+      do
+        cp /etc/resolv.conf /host/etc/resolv.conf;
+      done &
+      expressvpnd --client-version ${clientVersion} --client-build ${clientBuild}
+    '';
+
+    # expressvpnd binary has hard-coded the path /sbin/sysctl hence below workaround.
+    extraBuildCommands = ''
+      chmod +w sbin
+      ln -s ${sysctl}/bin/sysctl sbin/sysctl
+    '';
+
+    # The expressvpnd binary also uses hard-coded paths to the other binaries and files
+    # it ships with, hence the FHS environment.
+
+    targetPkgs = pkgs: with pkgs; [
+      expressvpnBase
+      inotify-tools
+      iproute2
+    ];
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/share
+    ln -s ${expressvpnBase}/bin/expressvpn $out/bin
+    ln -s ${expressvpndFHS}/bin/expressvpnd $out/bin
+    ln -s ${expressvpnBase}/share/{bash-completion,doc,man} $out/share/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CLI client for ExpressVPN";
+    homepage = "https://www.expressvpn.com";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ yureien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -390,6 +390,8 @@ with pkgs;
 
   evans = callPackage ../development/tools/evans { };
 
+  expressvpn = callPackage ../applications/networking/expressvpn { };
+
   firefly-desktop = callPackage ../applications/misc/firefly-desktop { };
 
   frugal = callPackage ../development/tools/frugal { };


### PR DESCRIPTION
###### Description of changes

Added expressvpn, the CLI client for [ExpressVPN](https://www.expressvpn.com/).

~~Since the binary directly modifies /etc/resolv.conf (When connecting it moves the existing file to /etc/resolv.conf.expressvpn-orig and creates a new file, and when disconnecting, it reverts this), the functionality is currently broken as the daemon is running inside a FHS environment. IP is being leaked cause of DNS.~~

Fixed by running `inotifywait` and updating /host/etc/resolv.conf when /etc/resolv.conf changes.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
