### PR TITLE
acme-client: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/networking/acme-client/default.nix
+++ b/pkgs/tools/networking/acme-client/default.nix
@@ -1,31 +1,39 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
 , libbsd
 , libressl
 , pkg-config
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "acme-client";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchurl {
-    url = "https://data.wolfsden.cz/sources/acme-client-${version}.tar.xz";
-    sha256 = "sha256-fRSYwQmyV0WapjUJNG0UGO/tUDNTGUraj/BWq/a1QTo=";
+    url = "https://data.wolfsden.cz/sources/acme-client-${version}.tar.gz";
+    hash = "sha256-rIeWZSOT+nPzLf2mDtOkN/wmCGffG4H6PCQb2Vxbxxk=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libbsd libressl ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildInputs = [
+    libbsd
+    libressl
+  ];
 
-  meta = {
-    homepage = "https://sr.ht/~graywolf/acme-client-portable/";
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
     description = "Secure ACME/Let's Encrypt client";
+    homepage = "https://sr.ht/~graywolf/acme-client-portable/";
     platforms = platforms.unix;
     license = licenses.isc;
     maintainers = with maintainers; [ pmahoney ];
   };
 }
+


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 1.3.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
