### PR TITLE
petrifoo: pull patch pending upstream inclusion for -fno-common toolc…

### DIFF
--- a/pkgs/applications/audio/petrifoo/default.nix
+++ b/pkgs/applications/audio/petrifoo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, alsa-lib, cmake, gtk2, libjack2, libgnomecanvas
+{ lib, stdenv, fetchurl, fetchpatch, alsa-lib, cmake, gtk2, libjack2, libgnomecanvas
 , libpthreadstubs, libsamplerate, libsndfile, libtool, libxml2
 , pkg-config, openssl }:
 
@@ -10,6 +10,16 @@ stdenv.mkDerivation  rec {
     url =  "mirror://sourceforge/petri-foo/${pname}-${version}.tar.bz2";
     sha256 = "0b25iicgn8c42487fdw32ycfrll1pm2zjgy5djvgw6mfcaa4gizh";
   };
+
+  patches = [
+    # Pull patch pending upstream inclusion for -fno-common toollchain support:
+    #  https://github.com/petri-foo/Petri-Foo/pull/43
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/petri-foo/Petri-Foo/commit/6a3256c9b619b1fed18ad15063f110e8d91aa6fe.patch";
+      sha256 = "05yc4g22iwnd054jmvihrl461yr0cxnghslfrbhan6bac6fcvlal";
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 


### PR DESCRIPTION
…hain support

Without the change build fails on upstream gcc-10 as:

    ld: CMakeFiles/petri-foo.dir/voicetab.c.o:(.bss+0x0): multiple definition of
      `recent_manager'; CMakeFiles/petri-foo.dir/audio-settings.c.o:(.bss+0x0): first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
