### PR TITLE
microsoft-edge: 100.0.1185.44 -> 102.0.1245.44

### DIFF
--- a/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
@@ -30,6 +30,7 @@
 , at-spi2-core
 , libuuid
 , systemd
+, wayland
 }:
 
 let
@@ -76,7 +77,7 @@ stdenv.mkDerivation rec {
         xorg.libXcomposite xorg.libXdamage xorg.libXext
         xorg.libXfixes xorg.libXrandr libxkbcommon
         gtk3 pango cairo gdk-pixbuf mesa
-        alsa-lib at-spi2-core xorg.libxshmfence systemd
+        alsa-lib at-spi2-core xorg.libxshmfence systemd wayland
       ];
       naclHelper = lib.makeLibraryPath [
         glib nspr atk libdrm xorg.libxcb mesa xorg.libX11

--- a/pkgs/applications/networking/browsers/microsoft-edge/default.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/default.nix
@@ -1,20 +1,20 @@
 {
   beta = import ./browser.nix {
     channel = "beta";
-    version = "101.0.1210.19";
+    version = "103.0.1264.21";
     revision = "1";
-    sha256 = "sha256:1kgc19ryw69xiqppz90d6sa45g99hzkh7x5yk9d3xlh1gc1xn54p";
+    sha256 = "sha256:1336i0hy7xnla0pi4vahaxshhmivi1zljhaxyg63352bc7w9j64f";
   };
   dev = import ./browser.nix {
     channel = "dev";
-    version = "102.0.1227.0";
+    version = "104.0.1287.1";
     revision = "1";
-    sha256 = "sha256:0dnyandri7yg7c9812pnsxqszxyqcssxf87yskjg2vw95hawf11x";
+    sha256 = "sha256:10h360vfsfql42i6mpdvf8d0219506ipbk3hdpwl0jhlsphmhw61";
   };
   stable = import ./browser.nix {
     channel = "stable";
-    version = "100.0.1185.44";
+    version = "102.0.1245.44";
     revision = "1";
-    sha256 = "sha256:0zv1zyijh620xz36a6nmhv7rbv4ln5f245hyh0w1sngynsl1rz89";
+    sha256 = "sha256:10r12xlkcnag5jdmnwpqsbkjx1ih1027l573vxmcxmvpmj6y4373";
   };
 }


### PR DESCRIPTION
###### Description of changes

- Version updates:
  - Update `microsoft-edge` to `102.0.1245.44`.
  - Update `microsoft-edge-beta` to `103.0.1264.21`.
  - Update `microsoft-edge-dev` to `104.0.1287.1`.
- Add `wayland` dependency to allow opening Edge by `https://github.com/kuwii/nixpkgs/archive/dev/microsoft-edge.tar.gz`, which does not work before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).