### PR TITLE
python3Packages.uamqp: use openssl on darwin-aarch64

### DIFF
--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -27,6 +27,19 @@ buildPythonPackage rec {
     ./darwin-azure-c-shared-utility-corefoundation.patch
   ];
 
+  postPatch = lib.optionalString (stdenv.isDarwin && !stdenv.isx86_64) ''
+    # force darwin aarch64 to use openssl instead of applessl, removing
+    # some quirks upstream thinks they need to use openssl on macos
+    sed -i \
+      -e '/^use_openssl =/cuse_openssl = True' \
+      -e 's/\bazssl\b/ssl/' \
+      -e 's/\bazcrypto\b/crypto/' \
+      setup.py
+    sed -i \
+      -e '/#define EVP_PKEY_id/d' \
+      src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/x509_openssl.c
+  '';
+
   nativeBuildInputs = [
     cmake
   ];


### PR DESCRIPTION
###### Description of changes
Azure's libraries aren't happy enough with our macos sdk on aarch64 to let us use applessl.

This is a bit of a hack, so I'd rather stick with applessl on x86_64, where we can get it to work. But I see this as a better situation for a platform where `uamqp` won't currently build at all.

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
