### PR TITLE
nixos/nextcloud: Fix broken config file

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -733,7 +733,7 @@ in {
               'trusted_domains' => ${writePhpArrary ([ cfg.hostName ] ++ c.extraTrustedDomains)},
               'trusted_proxies' => ${writePhpArrary (c.trustedProxies)},
               ${optionalString (c.defaultPhoneRegion != null) "'default_phone_region' => '${c.defaultPhoneRegion}',"}
-              ${optionalString (nextcloudGreaterOrEqualThan "23") "'profile.enabled' => ${boolToString cfg.globalProfiles}"}
+              ${optionalString (nextcloudGreaterOrEqualThan "23") "'profile.enabled' => ${boolToString cfg.globalProfiles},"}
               ${objectstoreConfig}
             ];
           '';


### PR DESCRIPTION
###### Description of changes
In following commit https://github.com/NixOS/nixpkgs/commit/9931c4a4072215569a80a8e31316ab35bc65c8a5 last line does not end with `,` and therefore if object store config is used it generates a broken config file.

Tested locally.
 
```
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: An unhandled exception has been thrown:
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: ParseError: syntax error, unexpected single-quoted string "objectstore", expecting "]" in /nix/store/3q
lk3c730dsf9gbp690h0nhxfy43jka1-nextcloud-config.php:39
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: Stack trace:
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: #0 /nix/store/jh50d9rx2p4b3qq752h0cxf2mp1ddvpd-nextcloud-24.0.1/lib/private/Config.php(71): OC\Config->
readData()
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: #1 /nix/store/jh50d9rx2p4b3qq752h0cxf2mp1ddvpd-nextcloud-24.0.1/lib/base.php(151): OC\Config->__constru
ct('/var/lib/nextcl...')
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: #2 /nix/store/jh50d9rx2p4b3qq752h0cxf2mp1ddvpd-nextcloud-24.0.1/lib/base.php(583): OC::initPaths()
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: #3 /nix/store/jh50d9rx2p4b3qq752h0cxf2mp1ddvpd-nextcloud-24.0.1/lib/base.php(1104): OC::init()
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: #4 /nix/store/jh50d9rx2p4b3qq752h0cxf2mp1ddvpd-nextcloud-24.0.1/console.php(48): require_once('/nix/sto
re/jh50...')
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: #5 /nix/store/jh50d9rx2p4b3qq752h0cxf2mp1ddvpd-nextcloud-24.0.1/occ(11): require_once('/nix/store/jh50.
..')
May 28 18:20:52 fravps01 nextcloud-setup-start[11518]: #6 {main}
May 28 18:20:52 fravps01 systemd[1]: nextcloud-setup.service: Main process exited, code=exited, status=1/FAILURE
May 28 18:20:52 fravps01 systemd[1]: nextcloud-setup.service: Failed with result 'exit-code'.
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
