### PR TITLE
auditwheel: 4.0.0 -> 5.1.2

### DIFF
--- a/pkgs/tools/package-management/auditwheel/default.nix
+++ b/pkgs/tools/package-management/auditwheel/default.nix
@@ -8,13 +8,12 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "auditwheel";
-  version = "4.0.0";
-
-  disabled = python3.pkgs.pythonOlder "3.6";
+  version = "5.1.2";
+  format = "setuptools";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "03a079fe273f42336acdb5953ff5ce7578f93ca6a832b16c835fe337a1e2bd4a";
+    hash = "sha256-PuWDABSTHqhK9c0GXGN7ZhTvoD2biL2Pv8kk5+0B1ro=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -26,15 +25,17 @@ python3.pkgs.buildPythonApplication rec {
     setuptools
   ];
 
-  # integration tests require docker and networking
-  disabledTestPaths = [ "tests/integration" ];
-
   checkInputs = with python3.pkgs; [
     pretend
     pytestCheckHook
   ];
 
-  # ensure that there are no undeclared deps
+  # Integration tests require docker and networking
+  disabledTestPaths = [
+    "tests/integration"
+  ];
+
+  # Ensure that there are no undeclared deps
   postCheck = ''
     PATH= PYTHONPATH= $out/bin/auditwheel --version > /dev/null
   '';


### PR DESCRIPTION
###### Description of changes
https://github.com/pypa/auditwheel/releases
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
