### PR TITLE
gnome-shell: backport fixes for the on-screen keyboard

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -104,6 +104,23 @@ stdenv.mkDerivation rec {
       url = "https://src.fedoraproject.org/rpms/gnome-shell/raw/9a647c460b651aaec0b8a21f046cc289c1999416/f/0001-gdm-Work-around-failing-fingerprint-auth.patch";
       sha256 = "pFvZli3TilUt6YwdZztpB8Xq7O60XfuWUuPMMVSpqLw=";
     })
+    # Backport Oo-screen keyboard fixes to GNOME 42
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/a3bfe0ab560ed214c888b79daca89975fed9604e.patch";
+      sha256 = "sha256-JNNiW+bWeUnlwfvcmE4l8O10ZMjv0oWKaJZ/1fTgIgE=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/da3d4e82e359e7aca63652c6d8e4f4ba2c71b722.patch";
+      sha256 = "sha256-WzPJrPFPYf/YTaPviVXfmcz1xvZqUYQegLh4Y4yAo64=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/1fa5c63307e03d806eacdcf14d31e63afc27af20.patch";
+      sha256 = "sha256-2PEkIYkzSahzB31pO1nT/kJNnHKCrtnUSJsw65tWzK0=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/9a0935305d76e7e7c5c9d659b71609d873cfecbb.patch";
+      sha256 = "sha256-zON6P8wYK0wGnb8XXJsEBGs5pTSClNoYBS7wQJM5jzw=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
These backports together fix the issue that the on-screen keyboard
cannot be activated in GNOME 42 and that it has broken rendering when
the screen is rotated. All of them have already been committed to
upstream gnome-shell, so should either land in GNOME 42.2 or at the very
least GNOME 43.

Fixes #172629

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
