### PR TITLE
[WIP] Cura 5.0

### DIFF
--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -29,6 +29,12 @@ mkDerivation rec {
   cmakeFlags = [
     "-DURANIUM_DIR=${python3.pkgs.uranium.src}"
     "-DCURA_VERSION=${version}"
+    # The upstream code checks for an exact python version and errors out
+    # if we don't have that and do not pass `Python_VERSION` explicitly.
+    "-DPython_VERSION=${python3.pythonVersion}"
+    # Set install location to not be the global Python install dir
+    # (which is read-only in the nix store); see:
+    "-DPython_SITELIB_LOCAL=${placeholder "out"}/${python3.sitePackages}"
   ];
 
   makeWrapperArgs = [
@@ -52,7 +58,11 @@ mkDerivation rec {
 
   postFixup = ''
     wrapPythonPrograms
-    wrapQtApp $out/bin/cura
+
+    # find $out/bin
+    # exit 1
+
+    wrapQtApp $out/bin/cura_app.py
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -3,20 +3,20 @@
 
 mkDerivation rec {
   pname = "cura";
-  version = "4.12.1";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "Cura";
     rev = version;
-    sha256 = "sha256-QvX9o1nrYmY6zzPcxl+xD6JTMdphzT/is1SMYrISu4o=";
+    sha256 = "0r2f9izhf31dp3wqbl7zridr4c70mhzx0w7izzpikrdpgp6qg7f3";
   };
 
   materials = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "fdm_materials";
     rev = version;
-    sha256 = "0ykf14j4yx4cf12qw0d4bff9ixrx96m6wxqvi83sn721y7dsd2rs";
+    sha256 = "1hdan0sq2xknz3rzybmcfcalhh9z9m2gngw07bdbf0qggkc3hb0w";
   };
 
   buildInputs = [ qtbase qtquickcontrols2 qtgraphicaleffects ];

--- a/pkgs/applications/misc/curaengine/cmake/FindClipper.cmake
+++ b/pkgs/applications/misc/curaengine/cmake/FindClipper.cmake
@@ -1,0 +1,60 @@
+# Find Clipper library (http://www.angusj.com/delphi/clipper.php).
+# The following variables are set
+#
+# CLIPPER_FOUND
+# CLIPPER_INCLUDE_DIRS
+# CLIPPER_LIBRARIES
+#
+# It searches the environment variable $CLIPPER_PATH automatically.
+
+unset(CLIPPER_FOUND CACHE)
+unset(CLIPPER_INCLUDE_DIRS CACHE)
+unset(CLIPPER_LIBRARIES CACHE)
+unset(CLIPPER_LIBRARIES_RELEASE CACHE)
+unset(CLIPPER_LIBRARIES_DEBUG CACHE)
+
+if(CMAKE_BUILD_TYPE MATCHES "(Debug|DEBUG|debug)")
+    set(CLIPPER_BUILD_TYPE DEBUG)
+else()
+    set(CLIPPER_BUILD_TYPE RELEASE)
+endif()
+
+FIND_PATH(CLIPPER_INCLUDE_DIRS clipper.hpp
+    PATH_SUFFIXES polyclipping 
+    PATHS include/polyclipping ENV CLIPPER_PATH
+    )
+
+set(_deb_postfix "d")
+
+FIND_LIBRARY(CLIPPER_LIBRARIES_RELEASE polyclipping)
+FIND_LIBRARY(CLIPPER_LIBRARIES_DEBUG polyclipping${_deb_postfix})
+
+if(CLIPPER_LIBRARIES_${CLIPPER_BUILD_TYPE})
+    set(CLIPPER_LIBRARIES "${CLIPPER_LIBRARIES_${CLIPPER_BUILD_TYPE}}")
+else()
+    set(CLIPPER_LIBRARIES "${CLIPPER_LIBRARIES_RELEASE}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Clipper
+    "Clipper library cannot be found.  Consider set CLIPPER_PATH environment variable"
+    CLIPPER_INCLUDE_DIRS
+    CLIPPER_LIBRARIES)
+
+MARK_AS_ADVANCED(
+    CLIPPER_INCLUDE_DIRS
+    CLIPPER_LIBRARIES)
+
+if(CLIPPER_FOUND)
+    add_library(Clipper::Clipper UNKNOWN IMPORTED)
+    set_target_properties(Clipper::Clipper PROPERTIES IMPORTED_LOCATION ${CLIPPER_LIBRARIES})
+    set_target_properties(Clipper::Clipper PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CLIPPER_INCLUDE_DIRS})
+    if(CLIPPER_LIBRARIES_RELEASE AND CLIPPER_LIBRARIES_DEBUG)
+        set_target_properties(Clipper::Clipper PROPERTIES
+            IMPORTED_LOCATION_DEBUG          ${CLIPPER_LIBRARIES_DEBUG}
+            IMPORTED_LOCATION_RELWITHDEBINFO ${CLIPPER_LIBRARIES_RELEASE}
+            IMPORTED_LOCATION_RELEASE        ${CLIPPER_LIBRARIES_RELEASE}
+            IMPORTED_LOCATION_MINSIZEREL     ${CLIPPER_LIBRARIES_RELEASE}
+        )
+    endif()
+endif()

--- a/pkgs/applications/misc/curaengine/cmake/FindStb.cmake
+++ b/pkgs/applications/misc/curaengine/cmake/FindStb.cmake
@@ -1,0 +1,26 @@
+##  Finds the Stb utility library on your computer.
+#
+#   This script exports the following parameters for use if you find the Stb
+#   package:
+#   - Stb_FOUND: Whether Stb has been found on your computer.
+#   - Stb_INCLUDE_DIRS: The directory where the header files of Stb are located.
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_Stb QUIET Stb)
+
+find_path(Stb_INCLUDE_DIRS stb_image_resize.h #Search for something that is a little less prone to false positives than just stb.h.
+    HINTS ${PC_Stb_INCLUDEDIR} ${PC_Stb_INCLUDE_DIRS}
+    PATHS "$ENV{PROGRAMFILES}" "$ENV{PROGRAMW6432}" "/usr/include"
+    PATH_SUFFIXES include/stb stb include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Stb DEFAULT_MSG Stb_INCLUDE_DIRS)
+
+mark_as_advanced(Stb_INCLUDE_DIRS)
+
+if(Stb_FOUND)
+    message(STATUS "Found Stb installation at: ${Stb_INCLUDE_DIRS}")
+    add_library(Stb::Stb INTERFACE IMPORTED)
+    set_target_properties(Stb::Stb PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${Stb_INCLUDE_DIRS})
+endif()

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -2,27 +2,36 @@
 , lib
 , fetchFromGitHub
 , cmake
+
+# Dependencies
+, clipper
 , libarcus
-, stb
 , protobuf
+, rapidjson
+, stb
 }:
 
 stdenv.mkDerivation rec {
   pname = "curaengine";
-  version = "4.13.1";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "CuraEngine";
-    rev = version;
-    sha256 = "sha256-dx0Q6cuA66lG4nwR7quW5Tvs9sdxjdV4gtpxXirI4nY=";
+    # TODO: Switch back to `rev = version;` on the next release that has this fix:
+    #       https://github.com/Ultimaker/CuraEngine/commit/bb9ad578abc949c474db7a0677a355ad379ae585#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL262
+    #       for https://github.com/Ultimaker/CuraEngine/issues/1650
+    rev = "41989f284a7350b9d70b0ae2d4e53b6a16adf9c9";
+    sha256 = "10kmv388mhgy4sl0jrb4x8ypm00176mxvzbf5b6z6639xzr98jnk";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
+    clipper
     libarcus
-    stb
     protobuf
+    rapidjson
+    stb
   ];
 
   cmakeFlags = [ "-DCURA_ENGINE_VERSION=${version}" ];

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libarcus, stb, protobuf }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, libarcus
+, stb
+, protobuf
+}:
 
 stdenv.mkDerivation rec {
   pname = "curaengine";
@@ -12,7 +19,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libarcus stb protobuf ];
+  buildInputs = [
+    libarcus
+    stb
+    protobuf
+  ];
 
   cmakeFlags = [ "-DCURA_ENGINE_VERSION=${version}" ];
 

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -1,40 +1,100 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchurl
+, runCommand
 , cmake
 
 # Dependencies
+, boost178
 , clipper
 , libarcus
 , protobuf
 , rapidjson
 , stb
 }:
+let
+  # curaengine maintained its own `Findstb.cmake` in the past,
+  # but it was remove as part of their switch to `conan` in
+  #   https://github.com/Ultimaker/CuraEngine/commit/9f46b87fc9c85bfa46a678927f076644f6102e94
+  # We revive it here from the parent commit since it's unclear
+  # how nixpkgs's cmake should find it otherwise.
+  FindStbCmake = ./cmake/FindStb.cmake;
+  # FindStbCmake = fetchurl {
+  #   url = "https://raw.githubusercontent.com/Ultimaker/CuraEngine/ddbc941b28f1ec9442384185923e9e4f300461f2/cmake/Findstb.cmake";
+  #   sha256 = "176fhfp05khb7bl3zsk0msk18lx9fasxkd8vzlvxaxnfnw7g6r0k";
+  # };
+  FindStbCmakeDarknetROS = fetchurl {
+    url = "https://raw.githubusercontent.com/dustism/darknet_ros/20bdb7e83b42bf8f86595970cedc43928bf9028c/darknet_ros/cmake/Modules/FindStb.cmake";
+    sha256 = "0r6pfch73mrjzjj8063j59pkski6qaci100qv6lplf2iyyj78dd9";
+  };
 
+  FindClipperCmake = fetchurl {
+    url = "https://raw.githubusercontent.com/tamasmeszaros/libnest2d/11f1a8e8b7344008edc3fa0d4ff7b09253b153bb/cmake_modules/FindClipper.cmake";
+    sha256 = "12z1400a796j1i9brppvya1nd6bycxq5vkpcw43zpjgsisch004h";
+  };
+  # Make a directory that contains all of the extra `.cmake` files,
+  # so we can provide it with `-DCMAKE_MODULE_PATH`.
+  # Note that CMake is case sensitive on non-Windows for these file names!
+  ExtraFindCmakeDir = runCommand "curaengine-cmake-dir" {} ''
+    mkdir -p $out
+    # ln -s ${FindStbCmakeDarknetROS} $out/Findstb.cmake
+    ln -s ${FindStbCmake} $out/FindStb.cmake
+    ln -s ${FindClipperCmake} $out/FindClipper.cmake
+  '';
+
+  in
 stdenv.mkDerivation rec {
   pname = "curaengine";
   version = "5.0.0";
 
+  # src = fetchFromGitHub {
+  #   owner = "Ultimaker";
+  #   repo = "CuraEngine";
+  #   # TODO: This upstream commit is slightly after the 5.0.0 release.
+  #   #       Switch back to `rev = version;` on the next release that has this fix:
+  #   #       https://github.com/Ultimaker/CuraEngine/commit/bb9ad578abc949c474db7a0677a355ad379ae585#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL262
+  #   #       for https://github.com/Ultimaker/CuraEngine/issues/1650
+  #   rev = "41989f284a7350b9d70b0ae2d4e53b6a16adf9c9";
+  #   sha256 = "10kmv388mhgy4sl0jrb4x8ypm00176mxvzbf5b6z6639xzr98jnk";
+  # };
+  # src = lib.cleanSource /home/niklas/src/CuraEngine;
   src = fetchFromGitHub {
-    owner = "Ultimaker";
+    owner = "nh2";
     repo = "CuraEngine";
-    # TODO: Switch back to `rev = version;` on the next release that has this fix:
-    #       https://github.com/Ultimaker/CuraEngine/commit/bb9ad578abc949c474db7a0677a355ad379ae585#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL262
-    #       for https://github.com/Ultimaker/CuraEngine/issues/1650
-    rev = "41989f284a7350b9d70b0ae2d4e53b6a16adf9c9";
-    sha256 = "10kmv388mhgy4sl0jrb4x8ypm00176mxvzbf5b6z6639xzr98jnk";
+    rev = "9be6b828b4a42866e5c407b1da4012dd6ad1c84c";
+    sha256 = "sha256-W26XY0o4xJ8zWoikIlHy0R9Q9lsu85DRrf8dLxkgGZ8=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    boost178 # Change to `boost` once nixpkgs default boost is >= 1.78
+    rapidjson
+    stb
+  ];
   buildInputs = [
     clipper
     libarcus
     protobuf
-    rapidjson
-    stb
   ];
 
-  cmakeFlags = [ "-DCURA_ENGINE_VERSION=${version}" ];
+  cmakeFlags = [
+    "-DCURA_ENGINE_VERSION=${version}"
+    # "-Darcus_DIR=${lib.getLib libarcus}/lib/cmake/Arcus"
+    # "-DCMAKE_PREFIX_PATH=${lib.getDev libarcus}/lib/cmake/Arcus"
+    # "--log-level=DEBUG"
+    # "-Dclipper_DIR=${lib.getLib clipper}"
+    # "-Dclipper_INCLUDE_DIR=${lib.getDev clipper}/include"
+    # "-Dclipper_LIBRARIES=${lib.getLib clipper}/lib"
+
+    #
+    "-DCMAKE_MODULE_PATH=${ExtraFindCmakeDir}"
+
+    # "-DStb_DIR=${lib.getDev stb}/include/stb" # used by `FindStbCmakeDarknetROS` above
+    "-DPC_Stb_INCLUDEDIR=${lib.getDev stb}" # used by `FindStbCmake` above
+
+    "-DCMAKE_VERBOSE_MAKEFILE=1"
+  ];
 
   meta = with lib; {
     description = "A powerful, fast and robust engine for processing 3D models into 3D printing instruction";

--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -1,17 +1,17 @@
 { lib, buildPythonPackage, python, fetchFromGitHub
 , fetchpatch
-, cmake, sip_4, protobuf, pythonOlder }:
+, cmake, sip, protobuf, pythonOlder }:
 
 buildPythonPackage rec {
   pname = "libarcus";
-  version = "4.12.0";
+  version = "5.0.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "libArcus";
     rev = version;
-    sha256 = "sha256-X33ptwYj9YkVWqUDPP+Ic+hoIb+rwsLdQXvHLA9z+3w=";
+    sha256 = "0f871vx14hyjnqiqik36zmf7mi7dvzf08cqpryk8g1acj9mkh3ag";
   };
 
   patches = [
@@ -25,13 +25,19 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.4";
 
-  propagatedBuildInputs = [ sip_4 ];
+  propagatedBuildInputs = [ sip ];
   nativeBuildInputs = [ cmake ];
   buildInputs = [ protobuf ];
 
-  postPatch = ''
-    sed -i 's#''${Python3_SITEARCH}#${placeholder "out"}/${python.sitePackages}#' cmake/SIPMacros.cmake
-  '';
+  cmakeFlags = [
+    # The upstream code checks for an exact python version and errors out
+    # if we don't have that and do not pass `Python_VERSION` explicitly:
+    #     https://github.com/Ultimaker/libArcus/commit/f867664e46144fed9ae9c4f4e6a29192163fb884#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR31
+    "-DPython_VERSION=${python.pythonVersion}"
+    # Set install location to not be the global Python install dir
+    # (which is read-only in the nix store); see:
+    "-DPython_SITELIB_LOCAL=${placeholder "out"}/${python.sitePackages}"
+  ];
 
   meta = with lib; {
     description = "Communication library between internal components for Ultimaker software";

--- a/pkgs/development/python-modules/libsavitar/default.nix
+++ b/pkgs/development/python-modules/libsavitar/default.nix
@@ -1,24 +1,30 @@
-{ lib, buildPythonPackage, python, pythonOlder, fetchFromGitHub, cmake, sip_4 }:
+{ lib, buildPythonPackage, python, pythonOlder, fetchFromGitHub, cmake, sip }:
 
 buildPythonPackage rec {
   pname = "libsavitar";
-  version = "4.12.0";
+  version = "5.0.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "libSavitar";
     rev = version;
-    sha256 = "sha256-MAA1WtGED6lvU6N4BE6wwY1aYaFrCq/gkmQFz3VWqNA=";
+    sha256 = "05c0y2wmn094vnd3aymnwishf74l7pyal0fnwf4lhs6i2y59km38";
   };
-
-  postPatch = ''
-    sed -i 's#''${Python3_SITEARCH}#${placeholder "out"}/${python.sitePackages}#' cmake/SIPMacros.cmake
-  '';
 
   nativeBuildInputs = [ cmake ];
 
-  propagatedBuildInputs = [ sip_4 ];
+  propagatedBuildInputs = [ sip ];
+
+  cmakeFlags = [
+    # The upstream code checks for an exact python version and errors out
+    # if we don't have that and do not pass `Python_VERSION` explicitly:
+    #     https://github.com/Ultimaker/libSavitar/commit/a7ee88779574769e8c4cd82281f96d53fc4f742a#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR27
+    "-DPython_VERSION=${python.pythonVersion}"
+    # Set install location to not be the global Python install dir
+    # (which is read-only in the nix store); see:
+    "-DPython_SITELIB_LOCAL=${placeholder "out"}/${python.sitePackages}"
+  ];
 
   disabled = pythonOlder "3.4.0";
 

--- a/pkgs/development/python-modules/uranium/default.nix
+++ b/pkgs/development/python-modules/uranium/default.nix
@@ -2,7 +2,7 @@
 , pyqt5, numpy, scipy, shapely, libarcus, cryptography, doxygen, gettext, pythonOlder }:
 
 buildPythonPackage rec {
-  version = "4.12.0";
+  version = "5.0.0";
   pname = "uranium";
   format = "other";
 
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "Ultimaker";
     repo = "Uranium";
     rev = version;
-    sha256 = "sha256-SE9xqrloPXIRTJiiqUdRKFmb4c0OjmJK5CMn6VXMFmk=";
+    sha256 = "0y98psfi5d982v941mh2jj3ln5wdsybmbz36wmh4lvgr67bdmdbf";
   };
 
   disabled = pythonOlder "3.5.0";
@@ -20,12 +20,21 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cmake doxygen ];
 
   postPatch = ''
-    sed -i 's,/python''${PYTHON_VERSION_MAJOR}/dist-packages,/python''${PYTHON_VERSION_MAJOR}.''${PYTHON_VERSION_MINOR}/site-packages,g' CMakeLists.txt
     sed -i \
      -e "s,Resources.addSearchPath(os.path.join(os.path.abspath(os.path.dirname(__file__)).*,Resources.addSearchPath(\"$out/share/uranium/resources\")," \
      -e "s,self._plugin_registry.addPluginLocation(os.path.join(os.path.abspath(os.path.dirname(__file__)).*,self._plugin_registry.addPluginLocation(\"$out/lib/uranium/plugins\")," \
      UM/Application.py
   '';
+
+  cmakeFlags = [
+    # The upstream code checks for an exact python version and errors out
+    # if we don't have that and do not pass `Python_VERSION` explicitly:
+    #     https://github.com/Ultimaker/Uranium/commit/21409e7b0af35bd61b13167b655345db5f481423#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR16
+    "-DPython_VERSION=${python.pythonVersion}"
+    # Set install location to not be the global Python install dir
+    # (which is read-only in the nix store); see:
+    "-DPython_SITELIB_LOCAL=${placeholder "out"}/${python.sitePackages}"
+  ];
 
   meta = with lib; {
     description = "A Python framework for building Desktop applications";


### PR DESCRIPTION
###### Description of changes

https://ultimaker.com/learn/ultimaker-cura-5-0-stable-release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## TODO

* Get it to build
  * [x] Solve `The target name "clipper::clipper" is reserved or not valid for certain CMake features` https://github.com/NixOS/nixpkgs/issues/94555#issuecomment-1140307317
  * [x] Handle need for `Python_VERSION`
  * [x] Handle `libarcus` `No such file or directory` build failure:
    ```
    [ 75%] Linking CXX shared library libArcus.so
    [ 75%] Built target Arcus
    [ 87%] Building CXX object CMakeFiles/sip_pyArcus.dir/python/PythonMessage.cpp.o
    [100%] Linking CXX shared library pyArcus.so
    No such file or directory
    make[2]: *** [CMakeFiles/sip_pyArcus.dir/build.make:101: pyArcus.so] Error 1
    make[2]: *** Deleting file 'pyArcus.so'
    make[1]: *** [CMakeFiles/Makefile2:140: CMakeFiles/sip_pyArcus.dir/all] Error 2
    make: *** [Makefile:136: all] Error 2
    builder for '/nix/store/ign5qzsxyh3w7793y7hrp3ka2q1di6iy-python3.9-libarcus-5.0.0.drv' failed with exit code 2
    ```
    * `strace reveals:
      ```
      execve("/Scripts/sip-build", ["/Scripts/sip-build", "--pep484-pyi", "--no-protected-is-public"], 0x7fffffffc8a8 /* 93 vars */) = -1 ENOENT (No such file or directory)
      ```
      Seems to be https://github.com/Ultimaker/libArcus/issues/141
      * The solution here is to switch the nixpkgs dependency from `sip_4` to `sip`.
  * [x] Handle `libsavitar` `Permission denied` build failure:
    ```
    The project has been built.
    [100%] Built target sip_pySavitar
    Install the project...
    -- Install configuration: "Release"
    -- Installing: /nix/store/8hlxrxsabk802bxbshy9s6jh67fbrivp-python3.9-libsavitar-5.0.0/lib/libpugixml.a
    -- Installing: /nix/store/8hlxrxsabk802bxbshy9s6jh67fbrivp-python3.9-libsavitar-5.0.0/include/pugixml.hpp
    -- Installing: /nix/store/8hlxrxsabk802bxbshy9s6jh67fbrivp-python3.9-libsavitar-5.0.0/include/pugiconfig.hpp
    -- Installing: /nix/store/8hlxrxsabk802bxbshy9s6jh67fbrivp-python3.9-libsavitar-5.0.0/lib/cmake/pugixml/pugixml-config.cmake
    -- Installing: /nix/store/8hlxrxsabk802bxbshy9s6jh67fbrivp-python3.9-libsavitar-5.0.0/lib/cmake/pugixml/pugixml-config-release.cmake
    -- Installing: /nix/store/01kia41csjia67pry1rv828i9pvnnqfq-python3-3.9.12/lib/python3.9/site-packages/pySavitar.so
    CMake Error at cmake_install.cmake:65 (file):
      file INSTALL cannot copy file "/build/source/build/pySavitar.so" to
      "/nix/store/01kia41csjia67pry1rv828i9pvnnqfq-python3-3.9.12/lib/python3.9/site-packages/pySavitar.so":
      Permission denied.
    ```
   * That was the `sed` of `Python3_SITEARCH` against `cmake/SIPMacros.cmake` which no longer exists. Fixed the same way as the following point.
    * That's https://github.com/Ultimaker/libSavitar/commit/2e38a9d6bbf425616cb9686f93361d836a3d6128#diff-eac21c2947270bfb405e58165e66168f27710254d57932af6888b6af2ec9ea03L58
      * Can be solved using `Python_SITELIB_LOCAL`: https://github.com/Ultimaker/libSavitar/blob/c66d04c00ecb9f014e0bd696732518781276bd3e/CMakeLists.txt#L107-L108
  * [x] Get `curaengine` to build
    * Requires various patches because upstreams switch to `conan` seems to generate CMake targets that are not available without conan.
  * [ ] Get `cura` to build
  * [x] Package `PyQt6` required by `cura` at runtime