### PR TITLE
gforth: explicitly set lispdir

### DIFF
--- a/pkgs/development/compilers/gforth/default.nix
+++ b/pkgs/development/compilers/gforth/default.nix
@@ -5,6 +5,7 @@
 let
   swig = callPackage ./swig.nix { };
   bootForth = callPackage ./boot-forth.nix { };
+  lispDir = "${placeholder "out"}/share/emacs/site-lisp";
 in stdenv.mkDerivation rec {
 
   pname = "gforth";
@@ -26,11 +27,14 @@ in stdenv.mkDerivation rec {
 
   passthru = { inherit bootForth; };
 
-  configureFlags = lib.optional stdenv.isDarwin [ "--build=x86_64-apple-darwin" ];
+  configureFlags = [
+    "--with-lispdir=${lispDir}"
+  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    "--build=x86_64-apple-darwin"
+  ];
 
-  postInstall = ''
-    mkdir -p $out/share/emacs/site-lisp
-    cp gforth.el $out/share/emacs/site-lisp/
+  preConfigure = ''
+    mkdir -p ${lispDir}
   '';
 
   meta = {

--- a/pkgs/development/compilers/gforth/default.nix
+++ b/pkgs/development/compilers/gforth/default.nix
@@ -38,7 +38,6 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = {
-    broken = stdenv.isDarwin;
     description = "The Forth implementation of the GNU project";
     homepage = "https://github.com/forthy42/gforth";
     license = lib.licenses.gpl3;


### PR DESCRIPTION
###### Description of changes

Otherwise in situations where we don't have a working sandbox (darwin), if `/usr/share/emacs` happens to exist, the install
phase will try to put its lisp files there and fail due to permissions.

Fixes build on darwin.

ZHF: #172160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
