### PR TITLE
authy: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/applications/misc/authy/default.nix
+++ b/pkgs/applications/misc/authy/default.nix
@@ -1,31 +1,10 @@
-{ alsa-lib
-, at-spi2-atk
-, at-spi2-core
-, atk
-, autoPatchelfHook
-, cairo
-, cups
-, dbus
+{ autoPatchelfHook
 , electron
-, expat
 , fetchurl
-, gdk-pixbuf
-, glib
-, gtk3
 , lib
-, libappindicator-gtk3
-, libdbusmenu-gtk3
-, libdrm
-, libuuid
 , makeWrapper
-, mesa
-, nspr
-, nss
-, pango
 , squashfsTools
 , stdenv
-, systemd
-, xorg
 }:
 
 stdenv.mkDerivation rec {
@@ -33,42 +12,6 @@ stdenv.mkDerivation rec {
   # curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/authy?channel=stable' | jq '.download_url,.version'
   version = "2.2.0";
   rev = "10";
-
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    gdk-pixbuf
-    glib
-    gtk3
-    libappindicator-gtk3
-    libdbusmenu-gtk3
-    libdrm
-    libuuid
-    mesa # for libgbm
-    nspr
-    nss
-    pango
-    stdenv.cc.cc
-    systemd
-    xorg.libX11
-    xorg.libXScrnSaver
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXtst
-    xorg.libxcb
-  ];
 
   src = fetchurl {
     url = "https://api.snapcraft.io/api/v1/snaps/download/H8ZpNgIoPyvmkgxOWw5MSzsXK1wRZiHn_${rev}.snap";

--- a/pkgs/applications/misc/authy/default.nix
+++ b/pkgs/applications/misc/authy/default.nix
@@ -94,25 +94,16 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/
+    mkdir -p $out/bin $out/share/applications $out/share/pixmaps/apps
 
-    cp -r ./* $out/
-    rm -R ./*
-
-    # The snap package has the `ffmpeg.so` file which is copied over with other .so files
-    mv $out/*.so $out/lib/
+    # Copy only what is needed
+    cp -r resources* $out/
+    cp -r locales* $out/
+    cp meta/gui/authy.desktop $out/share/applications/
+    cp meta/gui/icon.png $out/share/pixmaps/authy.png
 
     # Replace icon name in Desktop file
-    sed -i 's|''${SNAP}/meta/gui/icon.png|authy|g' "$out/meta/gui/authy.desktop"
-
-    # Move the desktop file, icon, binary to their appropriate locations
-    mkdir -p $out/bin $out/share/applications $out/share/pixmaps/apps
-    cp $out/meta/gui/authy.desktop $out/share/applications/
-    cp $out/meta/gui/icon.png $out/share/pixmaps/authy.png
-    cp $out/${pname} $out/bin/${pname}
-
-    # Cleanup
-    rm -r $out/{data-dir,gnome-platform,meta,scripts,usr,*.sh,*.so}
+    sed -i 's|''${SNAP}/meta/gui/icon.png|authy|g' "$out/share/applications/authy.desktop"
 
     runHook postInstall
   '';

--- a/pkgs/applications/misc/authy/default.nix
+++ b/pkgs/applications/misc/authy/default.nix
@@ -6,7 +6,7 @@
 , cairo
 , cups
 , dbus
-, electron_9
+, electron
 , expat
 , fetchurl
 , gdk-pixbuf
@@ -15,8 +15,10 @@
 , lib
 , libappindicator-gtk3
 , libdbusmenu-gtk3
+, libdrm
 , libuuid
 , makeWrapper
+, mesa
 , nspr
 , nss
 , pango
@@ -26,16 +28,11 @@
 , xorg
 }:
 
-let
-  # Currently only works with electron 9
-  electron = electron_9;
-in
-
 stdenv.mkDerivation rec {
   pname = "authy";
   # curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/authy?channel=stable' | jq '.download_url,.version'
-  version = "2.1.0";
-  rev = "9";
+  version = "2.2.0";
+  rev = "10";
 
   buildInputs = [
     alsa-lib
@@ -51,7 +48,9 @@ stdenv.mkDerivation rec {
     gtk3
     libappindicator-gtk3
     libdbusmenu-gtk3
+    libdrm
     libuuid
+    mesa # for libgbm
     nspr
     nss
     pango
@@ -73,7 +72,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://api.snapcraft.io/api/v1/snaps/download/H8ZpNgIoPyvmkgxOWw5MSzsXK1wRZiHn_${rev}.snap";
-    sha256 = "sha256-RxjxOYrbneVctyTJTMvoN/UdREohaZWb1kTdEeI6mUU=";
+    sha256 = "sha256-sB9/fVV/qp+DfjxpvzIUHsLkeEu35i2rEv1/JYMytG8=";
   };
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper squashfsTools ];


### PR DESCRIPTION
###### Description of changes

A new version is available and it doesn't seem to require the old (insecure) `electron_9` package anymore.
Also, the resulting output is rather big and it seems that some stuff is not actually needed?
Maybe instead of copying everything and deleting some stuff there should just be a minimal list of items to be copied to `$out`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
