### PR TITLE
python310Packages.pysvn: 1.9.12 -> 1.9.18

### DIFF
--- a/pkgs/development/python-modules/pysvn/default.nix
+++ b/pkgs/development/python-modules/pysvn/default.nix
@@ -19,21 +19,21 @@
 
 buildPythonPackage rec {
   pname = "pysvn";
-  version = "1.9.12";
+  version = "1.9.18";
   format = "other";
 
   src = fetchurl {
     url = "https://pysvn.barrys-emacs.org/source_kits/${pname}-${version}.tar.gz";
-    sha256 = "sRPa4wNyjDmGdF1gTOgLS0pnrdyZwkkH4/9UCdh/R9Q=";
+    hash = "sha256-lUPsNumMYwZoiR1Gt/hqdLLoHOZybRxwvu9+eU1CY78=";
   };
+
+  patches = [
+    ./replace-python-first.patch
+  ];
 
   buildInputs = [ bash subversion apr aprutil expat neon openssl ]
     ++ lib.optionals stdenv.isLinux [ e2fsprogs ]
     ++ lib.optionals stdenv.isDarwin [ gcc ];
-
-  postPatch = ''
-    sed -i "117s|append(|insert(0, |" Tests/benchmark_diff.py
-  '';
 
   preConfigure = ''
     cd Source
@@ -47,11 +47,10 @@ buildPythonPackage rec {
       --apr-lib-dir=${apr.out}/lib \
       --svn-lib-dir=${subversion.out}/lib \
       --svn-bin-dir=${subversion.out}/bin
-  '' + (lib.optionalString (stdenv.isDarwin && !isPy3k) ''
-    sed -i -e 's|libpython2.7.dylib|lib/libpython2.7.dylib|' Makefile
-  '');
+  '';
 
-  checkInputs = [ glibcLocales  ];
+  checkInputs = [ glibcLocales ];
+
   checkPhase = ''
     runHook preCheck
 
@@ -60,10 +59,11 @@ buildPythonPackage rec {
     sed -i "s|/bin/bash|${bash}/bin/bash|" ../Tests/test-*.sh
     make -C ../Tests
 
-    ${python.interpreter} -c "import pysvn"
-
     runHook postCheck
   '';
+
+  # FIXME https://github.com/NixOS/nixpkgs/issues/175227
+  # pythonImportsCheck = [ "pysvn" ];
 
   installPhase = ''
     dest=$(toPythonPath $out)/pysvn
@@ -77,8 +77,9 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python bindings for Subversion";
-    homepage = "http://pysvn.tigris.org/";
+    homepage = "https://pysvn.sourceforge.io/";
     license = licenses.asl20;
+    maintainers = with maintainers; [ dotlambda ];
     # g++: command not found
     broken = stdenv.isDarwin;
   };

--- a/pkgs/development/python-modules/pysvn/replace-python-first.patch
+++ b/pkgs/development/python-modules/pysvn/replace-python-first.patch
@@ -1,0 +1,13 @@
+Index: Extension/Tests/benchmark_diff.py
+===================================================================
+--- Extension/Tests/benchmark_diff.py	(revision 2093)
++++ Extension/Tests/benchmark_diff.py	(working copy)
+@@ -115,7 +115,7 @@
+ 
+         if self.python:
+             python_re = LiteralCaseBlindSearch( self.python )
+-            self.replacement_list.append(
++            self.replacement_list.insert(0,
+                  (python_re,            '<PYTHON>') )
+ 
+         if self.svn_bin:


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
