### PR TITLE
contour: 0.1.1 -> 0.3.1.200

### DIFF
--- a/pkgs/applications/terminal-emulators/contour/default.nix
+++ b/pkgs/applications/terminal-emulators/contour/default.nix
@@ -1,30 +1,99 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake, pkg-config, freetype, libGL, pcre, nixosTests }:
+{ lib
+, stdenv
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, pkg-config
+, freetype
+, fontconfig
+, libGL
+, pcre
+, boost
+, catch2
+, fmt
+, microsoft_gsl
+, range-v3
+, libyamlcpp
+, ncurses
+, file
+, darwin
+, nixosTests
+}:
 
-mkDerivation rec {
-  pname = "contour";
-  version = "0.1.1";
-
-  src = fetchFromGitHub {
-    owner = "christianparpart";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-P7t+M75ZWjFcGWngcbaurdit6e+pb0ILljimhYqW0NI=";
-    fetchSubmodules = true;
+let
+  # Commits refs come from https://github.com/contour-terminal/contour/blob/master/scripts/install-deps.sh
+  libunicode-src = fetchFromGitHub {
+    owner = "contour-terminal";
+    repo = "libunicode";
+    rev = "c2369b6380df1197476b08d3e2d0e96b6446f776";
+    sha256 = "sha256-kq7GpFCkrJG7F9/YEGz3gMTgYzhp/QB8D5b9wwMaLvQ=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  termbench-pro-src = fetchFromGitHub {
+    owner = "contour-terminal";
+    repo = "termbench-pro";
+    rev = "cd571e3cebb7c00de9168126b28852f32fb204ed";
+    sha256 = "sha256-dNtOmBu63LFYfiGjXf34C2tiG8pMmsFT4yK3nBnK9WI=";
+  };
+in
+mkDerivation rec {
+  pname = "contour";
+  version = "0.3.1.200";
 
-  buildInputs = [ freetype libGL pcre ];
+  src = fetchFromGitHub {
+    owner = "contour-terminal";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-TpxVC0GFZD3jGISnDWHKEetgVVpznm5k/Vc2dwVfSG4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ncurses
+    file
+  ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+    libGL
+    pcre
+    boost
+    catch2
+    fmt
+    microsoft_gsl
+    range-v3
+    libyamlcpp
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.libs.utmp ];
+
+  preConfigure = ''
+    mkdir -p _deps/sources
+
+    cat > _deps/sources/CMakeLists.txt <<EOF
+    macro(ContourThirdParties_Embed_libunicode)
+        add_subdirectory(\''${ContourThirdParties_SRCDIR}/libunicode EXCLUDE_FROM_ALL)
+    endmacro()
+    macro(ContourThirdParties_Embed_termbench_pro)
+        add_subdirectory(\''${ContourThirdParties_SRCDIR}/termbench_pro EXCLUDE_FROM_ALL)
+    endmacro()
+    EOF
+
+    ln -s ${libunicode-src} _deps/sources/libunicode
+    ln -s ${termbench-pro-src} _deps/sources/termbench_pro
+
+    # Don't fix Darwin app bundle
+    sed -i '/fixup_bundle/d' src/contour/CMakeLists.txt
+  '';
 
   passthru.tests.test = nixosTests.terminal-emulators.contour;
 
   meta = with lib; {
     description = "Modern C++ Terminal Emulator";
-    homepage = "https://github.com/christianparpart/contour";
-    changelog = "https://github.com/christianparpart/contour/blob/HEAD/Changelog.md";
+    homepage = "https://github.com/contour-terminal/contour";
+    changelog = "https://github.com/contour-terminal/contour/raw/v${version}/Changelog.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ fortuneteller2k ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/contour.x86_64-darwin
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1516,7 +1516,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit CoreGraphics CoreServices CoreText Foundation OpenGL;
   };
 
-  contour = libsForQt5.callPackage ../applications/terminal-emulators/contour { };
+  contour = libsForQt5.callPackage ../applications/terminal-emulators/contour { fmt = fmt_8; };
 
   cool-retro-term = libsForQt5.callPackage ../applications/terminal-emulators/cool-retro-term { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
