### PR TITLE
pkgs/shells/fish: Fix completion file generator

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -147,6 +147,16 @@ let
       sha256 = "sha256-tvI7OEOwTbawqQ/qH28NDkDMAntKcyCYIAhj8oZKlOo=";
     };
 
+    patches = [
+      # merged https://github.com/fish-shell/fish-shell/pull/8978
+      # "create_manpage_completions.py: Do not overstrip commands with dots"
+      (fetchpatch {
+        name = "fix-cmdname-completeion-generator.patch";
+        url = "https://github.com/fish-shell/fish-shell/commit/32d646a5483844e9b1fae4b73f252a34ec0d4c76.patch";
+        sha256 = "sha256-51hqgPHQ7oQbl1i3SfqvGsbkYMe2Jh+sEwCRu2kiv1U=";
+      })
+    ];
+
     # Fix FHS paths in tests
     postPatch = ''
       # src/fish_tests.cpp


### PR DESCRIPTION
Cherry-pick upstream commit to ensure that completions for commands
like mkfs.xfs(8) end up in mkfs.xfs.fish by fixing over-eager stripping
of file extensions.

All mkfs.*(8) (and fsck.*(8), etc.) programs would yield mkfs.fish files
with unique `complete -c mkfs ...` lines using the same command.

Thus completing `mkfs` in fish would for example yield XFS specific
suggestions, given "xfsprogs" was installed **and** won over other
packages.

Noticed through build logs:
```
building '/nix/store/5fz5jgkd2ycx5fk3lb30my2hr2br639f-system_fish-completions.drv'...
warning: collision between `/nix/store/1z01j2pma0l005w3qg6slndn0rp136s8-dosfstools-4.2_fish-completions/mkfs.fish' and `/nix/store/jxxgrng41l6qakg45fksk1qpil976vgi-xfsprogs-5.16.0_fish-completions/mkfs.fish'
```

@cole-h
