### PR TITLE
Fix issue #175196, infinite recursion in pkgs/config.nix

### DIFF
--- a/pkgs/test/config.nix
+++ b/pkgs/test/config.nix
@@ -1,0 +1,21 @@
+{ lib, ... }:
+lib.recurseIntoAttrs {
+
+  # https://github.com/NixOS/nixpkgs/issues/175196
+  allowPkgsInPermittedInsecurePackages =
+    let pkgs = import ../.. {
+          config = {
+            permittedInsecurePackages =
+              tempAllow pkgs.authy "2.1.0" [ "electron-9.4.4" ];
+          };
+        };
+        # Allow with forgetting
+        tempAllow = p: v: pa:
+          lib.optionals (lib.assertMsg (p.version == v) "${p.name} is no longer at version ${v}, consider removing the tempAllow") pa;
+        # For this test we don't _really_ care about the version though,
+        # only about evaluation strictness
+        tempAllowAlike = p: v: pa: builtins.seq v builtins.seq p.version pa;
+
+    in pkgs.hello;
+
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -22,6 +22,8 @@ with pkgs;
   cc-wrapper-libcxx-9 = callPackage ./cc-wrapper { stdenv = llvmPackages_9.libcxxStdenv; };
   stdenv-inputs = callPackage ./stdenv-inputs { };
 
+  config = callPackage ./config.nix { };
+
   haskell = callPackage ./haskell { };
 
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -128,7 +128,7 @@ let
 in {
 
   freeformType =
-    let t = lib.types.attrsOf lib.types.raw;
+    let t = lib.types.lazyAttrsOf lib.types.raw;
     in t // {
       merge = loc: defs:
         let r = t.merge loc defs;


### PR DESCRIPTION
###### Description of changes

pkgs/config.nix: Fix infinite recursion when freeform config is strict in pkgs
    
Closes https://github.com/NixOS/nixpkgs/issues/175196
    
The loop involved:
    
 - pkgs is strict in the config.nix freeformType's produced attrNames,
       as these are included in the config.
 - the attrNames were strict in all the direct attrValues, because of
       scanning for `mkIf`s.
    
 `lazyAttrsOf` removes proper `mkIf` support, which we don't need here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
