### PR TITLE
nanotts: init at 2021-2-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12209,6 +12209,12 @@
     githubId = 48666;
     name = "Matthew \"strager\" Glazar";
   };
+  strikerlulu = {
+    email = "strikerlulu7@gmail.com";
+    github = "strikerlulu";
+    githubId = 38893265;
+    name = "StrikerLulu";
+  };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";

--- a/pkgs/tools/audio/nanotts/default.nix
+++ b/pkgs/tools/audio/nanotts/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, popt, alsaLib }:
+
+stdenv.mkDerivation {
+  pname = "nano-tts";
+  version = "unstable-2021-02-22";
+
+  src = fetchFromGitHub {
+    repo = "nanotts";
+    owner = "gmn";
+    rev = "d8b91f3d9d524c30f6fe8098ea7a0a638c889cf9";
+    sha256 = "sha256-bFu3U50zc90iQeWkqOsCipkueJUZI3cW5342jjYSnGI=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ autoconf automake libtool ];
+  buildInputs = [ popt alsaLib ];
+
+  patchPhase = ''
+    substituteInPlace "src/main.cpp" --replace "/usr/share/pico/lang" "$out/share/lang"
+    echo "" > update_build_version.sh
+  '';
+
+  installPhase = ''
+    install -Dm755 -t $out/bin nanotts
+    install -Dm644 -t $out/share/lang $src/lang/*
+  '';
+
+  meta = {
+    description = "Speech synthesizer commandline utility that improves pico2wave, included with SVOX PicoTTS";
+    homepage = "https://github.com/gmn/nanotts";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.strikerlulu ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19731,6 +19731,8 @@ with pkgs;
 
   nanovna-saver = libsForQt5.callPackage ../applications/science/electronics/nanovna-saver { };
 
+  nanotts = callPackage ../tools/audio/nanotts { };
+
   ncnn = callPackage ../development/libraries/ncnn { };
 
   ndpi = callPackage ../development/libraries/ndpi { };


### PR DESCRIPTION
Add [nanotts](https://github.com/gmn/nanotts) which is an Improved SVOX PicoTTS speech synthesizer
using it is easy as `echo "testing" | nanotts -p` just like **espeak**
also add myself to maintainers

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
