### PR TITLE
python310Packages.wsgiproxy2: 0.4.2 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/webtest/default.nix
+++ b/pkgs/development/python-modules/webtest/default.nix
@@ -1,55 +1,54 @@
 { lib
+, beautifulsoup4
 , buildPythonPackage
 , fetchPypi
-, isPy27
-, webob
-, six
-, beautifulsoup4
-, waitress
-, pyquery
-, wsgiproxy2
 , pastedeploy
+, pyquery
 , pytestCheckHook
+, pythonOlder
+, six
+, waitress
+, webob
+, wsgiproxy2
 }:
 
 buildPythonPackage rec {
-  version = "3.0.0";
   pname = "webtest";
-  disabled = isPy27; # paste.deploy is not longer a valid import
+  version = "3.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     pname = "WebTest";
     inherit version;
-    sha256 = "54bd969725838d9861a9fa27f8d971f79d275d94ae255f5c501f53bb6d9929eb";
+    hash = "sha256-VL2WlyWDjZhhqfon+Nlx950nXZSuJV9cUB9Tu22ZKes=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "nose<1.3.0" "nose"
-  '';
-
   propagatedBuildInputs = [
-    webob
-    six
     beautifulsoup4
+    six
     waitress
+    webob
   ];
 
   checkInputs = [
-    pytestCheckHook
     pastedeploy
-    wsgiproxy2
     pyquery
+    pytestCheckHook
+    wsgiproxy2
   ];
 
-  # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;
 
-  pythonImportsCheck = [ "webtest" ];
+  pythonImportsCheck = [
+    "webtest"
+  ];
 
   meta = with lib; {
     description = "Helper to test WSGI applications";
-    homepage = "https://webtest.readthedocs.org/en/latest/";
+    homepage = "https://webtest.readthedocs.org/";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/wsgiproxy2/default.nix
+++ b/pkgs/development/python-modules/wsgiproxy2/default.nix
@@ -1,30 +1,39 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, six
+, fetchFromGitHub
 , webob
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname = "WSGIProxy2";
-  version = "0.4.2";
+  pname = "wsgiproxy2";
+  version = "0.5.1";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "13kf9bdxrc95y9vriaz0viry3ah11nz4rlrykcfvb8nlqpx3dcm4";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "gawel";
+    repo = "WSGIProxy2";
+    rev = version;
+    hash = "sha256-ouofw3cBQzBwSh3Pdtdl7KI2pg/T/z3qoh8zoeiKiSs=";
   };
 
-  propagatedBuildInputs = [ six webob ];
+  propagatedBuildInputs = [
+    webob
+  ];
 
-  # circular dep on webtest
+  # Circular dependency on webtest
   doCheck = false;
 
+  pythonImportsCheck = [
+    "wsgiproxy"
+  ];
+
   meta = with lib; {
-    homepage = "http://pythonpaste.org/wsgiproxy/";
     description = "HTTP proxying tools for WSGI apps";
+    homepage = "https://wsgiproxy2.readthedocs.io/";
     license = licenses.mit;
     maintainers = with maintainers; [ domenkozar ];
   };
-
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/gawel/WSGIProxy2/blob/master/CHANGES.rst#051-2021-08-26
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
