### PR TITLE
rss-glx: fix build

### DIFF
--- a/pkgs/misc/screensavers/rss-glx/cstddef.patch
+++ b/pkgs/misc/screensavers/rss-glx/cstddef.patch
@@ -1,0 +1,12 @@
+diff --git i/src/Implicit/impSurface.h w/src/Implicit/impSurface.h
+index 41fab81..027587f 100644
+--- i/src/Implicit/impSurface.h
++++ w/src/Implicit/impSurface.h
+@@ -25,6 +25,7 @@
+ #ifdef WIN32
+ 	#include <windows.h>
+ #endif
++#include <cstddef>
+ #include <vector>
+ #include <GL/gl.h>
+ 

--- a/pkgs/misc/screensavers/rss-glx/default.nix
+++ b/pkgs/misc/screensavers/rss-glx/default.nix
@@ -1,4 +1,16 @@
-{lib, stdenv, fetchurl, pkg-config, xlibsWrapper, libXext, libGLU, libGL, imagemagick6, libtiff, bzip2}:
+{ lib
+, stdenv
+, fetchurl
+, autoconf
+, pkg-config
+, xlibsWrapper
+, libXext
+, libGLU
+, libGL
+, imagemagick6
+, libtiff
+, bzip2
+}:
 
 stdenv.mkDerivation rec {
   version = "0.9.1";
@@ -9,8 +21,12 @@ stdenv.mkDerivation rec {
     sha256 = "1aikafjqrfmv23jnrrm5d56dg6injh4l67zjdxzdapv9chw7g3cg";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ autoconf pkg-config ];
   buildInputs = [ libGLU libGL xlibsWrapper imagemagick6 libtiff bzip2 ];
+
+  patches = [
+    ./cstddef.patch
+  ];
 
   NIX_CFLAGS_COMPILE = "-I${imagemagick6.dev}/include/ImageMagick";
   NIX_LDFLAGS= "-rpath ${libXext}/lib";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34562,7 +34562,7 @@ with pkgs;
     stdenv = gccStdenv;
   };
 
-  rss-glx = callPackage ../misc/screensavers/rss-glx { stdenv = gcc10StdenvCompat; };
+  rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
   run-scaled = callPackage ../tools/X11/run-scaled { };
 


### PR DESCRIPTION
###### Description of changes

Fix build https://hydra.nixos.org/build/178217710

ZHF: #172160

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
