### PR TITLE
ocamlPackages.menhir: 20211128 → 20220210

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, lib, which, ocamlPackages }:
+{ fetchFromGitHub, fetchpatch, lib, which, ocamlPackages }:
 
 let
   pname = "alt-ergo";
@@ -10,13 +10,11 @@ let
     rev = version;
     sha256 = "0hglj1p0753w2isds01h90knraxa42d2jghr35dpwf9g8a1sm9d3";
   };
-
-  useDune2 = true;
 in
 
 let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-lib";
-  inherit version src useDune2;
+  inherit version src;
   configureFlags = [ pname ];
   nativeBuildInputs = [ which ];
   buildInputs = with ocamlPackages; [ dune-configurator ];
@@ -25,7 +23,7 @@ let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
 
 let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-parsers";
-  inherit version src useDune2;
+  inherit version src;
   configureFlags = [ pname ];
   nativeBuildInputs = [ which ocamlPackages.menhir ];
   propagatedBuildInputs = [ alt-ergo-lib ] ++ (with ocamlPackages; [ camlzip psmt2-frontend ]);
@@ -33,7 +31,13 @@ let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
 
 ocamlPackages.buildDunePackage {
 
-  inherit pname version src useDune2;
+  inherit pname version src;
+
+  # Ensure compatibility with Menhir ≥ 20211215
+  patches = fetchpatch {
+    url = "https://github.com/OCamlPro/alt-ergo/commit/0f9c45af352657c3aec32fca63d11d44f5126df8.patch";
+    sha256 = "sha256:0zaj3xbk2s8k8jl0id3nrhdfq9mv0n378cbawwx3sziiizq7djbg";
+  };
 
   configureFlags = [ pname ];
 

--- a/pkgs/development/ocaml-modules/menhir/default.nix
+++ b/pkgs/development/ocaml-modules/menhir/default.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
 
   minimalOCamlVersion = "4.03";
 
-  inherit (menhirLib) version src useDune2;
+  inherit (menhirLib) version src;
 
   buildInputs = [ menhirLib menhirSdk ];
 

--- a/pkgs/development/ocaml-modules/menhir/lib.nix
+++ b/pkgs/development/ocaml-modules/menhir/lib.nix
@@ -2,17 +2,15 @@
 
 buildDunePackage rec {
   pname = "menhirLib";
-  version = "20211128";
+  version = "20220210";
 
   src = fetchFromGitLab {
     domain = "gitlab.inria.fr";
     owner = "fpottier";
     repo = "menhir";
     rev = version;
-    sha256 = "sha256-L/zfjPZfn9L7qqqqJGk3Ge52rvujOVPiL8jxfH5R60g=";
+    sha256 = "sha256:0f31isr3cyiishflz6qr4xc3gp9xwf32r3vxdvm5wnr2my1fnn1n";
   };
-
-  useDune2 = true;
 
   meta = with lib; {
     homepage = "http://pauillac.inria.fr/~fpottier/menhir/";

--- a/pkgs/development/ocaml-modules/menhir/sdk.nix
+++ b/pkgs/development/ocaml-modules/menhir/sdk.nix
@@ -5,7 +5,7 @@
 buildDunePackage rec {
   pname = "menhirSdk";
 
-  inherit (menhirLib) version src useDune2;
+  inherit (menhirLib) version src;
 
   meta = menhirLib.meta // {
     description = "Compile-time library for auxiliary tools related to Menhir";

--- a/pkgs/development/ocaml-modules/odate/default.nix
+++ b/pkgs/development/ocaml-modules/odate/default.nix
@@ -6,9 +6,7 @@ buildDunePackage rec {
   pname = "odate";
   version = "0.6";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.07";
 
   src = fetchFromGitHub {
     owner = "hhugo";
@@ -20,6 +18,11 @@ buildDunePackage rec {
   strictDeps = true;
 
   nativeBuildInputs = [ menhir ];
+
+  # Ensure compatibility of v0.6 with menhir ≥ 20220210
+  preBuild = ''
+    substituteInPlace dune-project --replace "(using menhir 1.0)" "(using menhir 2.0)"
+  '';
 
   meta = {
     description = "Date and duration in OCaml";

--- a/pkgs/development/ocaml-modules/toml/default.nix
+++ b/pkgs/development/ocaml-modules/toml/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage
+{ lib, fetchFromGitHub, fetchpatch, buildDunePackage
 , iso8601, menhir
 }:
 
@@ -11,6 +11,12 @@ buildDunePackage rec {
     repo = "to.ml";
     rev = version;
     sha256 = "sha256-VEZQTFPwAGShCBGbKUiNOIY1zA/JdTpXU0ZIGNWopnQ=";
+  };
+
+  # Ensure compatibility with menhir ≥ 20211215
+  patches = fetchpatch {
+    url = "https://github.com/ocaml-toml/To.ml/commit/41172b739dff43424a12f7c1f0f64939e3660648.patch";
+    sha256 = "sha256:1333xkmm9qp5m3pp4y5w17k6rvmb30v62qyra6rfk1km2v28hqqq";
   };
 
   nativeBuildInputs = [ menhir ];


### PR DESCRIPTION
###### Description of changes

Incompatible release. Fortunately, most clients have been updated.

I did not try to sort out `liquidsoap` as there is a pending update PR: #140777

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
