### PR TITLE
distrobox: 1.2.15 -> 1.3.0

### DIFF
--- a/pkgs/applications/virtualization/distrobox/default.nix
+++ b/pkgs/applications/virtualization/distrobox/default.nix
@@ -2,13 +2,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "distrobox";
-  version = "1.2.15";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "89luca89";
     repo = pname;
     rev = version;
-    sha256 = "sha256-9rivXnHyEE1MoGY+CwUeDStLGPVq+4FvwPjV7Nblk60=";
+    sha256 = "sha256-31SDi9B6Ug6lRDMgaMp6lwdSsmQ7ywEwjG1Ez/jXjBc=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
##### Description of changes

Bumping version to 1.3.0 as this is a quite big release, adding:

new tools and commands!
rootful containers support
new supported distros
improved integration with the host
many fixes and improvements

###### Full changelog

install: Stop calling git by @nathanchance in https://github.com/89luca89/distrobox/pull/261
all: use new default name for distrobox containers to avoid conflicts with toolbx
create/init: move some mounts inside init.
create: fix command suggestion after container creation
create: fix enter command suggestion for rootful use case
create: on newest podman keep-id is only supported in rootless mode, Fix https://github.com/89luca89/distrobox/issues/267
create: prompt to download latest image by default by @juhp in https://github.com/89luca89/distrobox/pull/289
create: update default image to Fedora-Toolbox 36
docs/usage: document 'stop' properly
docs: Add tutorial for fish in execute_commands_on_host.md by @thjderjktyrjkt in https://github.com/89luca89/distrobox/pull/257
docs: Couple of small docs & comments fixes by @dfaggioli in https://github.com/89luca89/distrobox/pull/273
docs: add entry on how to use qemu to use containers of different architectures
docs: change command count by @misobarisic in https://github.com/89luca89/distrobox/pull/265
docs: couple of small docs & comments fixes (https://github.com/89luca89/distrobox/pull/273)
docs: fix README command count typo by @misobarisic in https://github.com/89luca89/distrobox/pull/292
docs: signal a problem on OpenSUSE Leap 15.3 and 15.4 by @massimo-zaniboni in https://github.com/89luca89/distrobox/pull/285
docs: update commands for graphical sessions, Fix https://github.com/89luca89/distrobox/issues/276
distrobox-host-exec: new tool for host command execution by @dfaggioli in https://github.com/89luca89/distrobox/pull/283
distrobox: Error out on invalid options by @nathanchance in https://github.com/89luca89/distrobox/pull/255
distrobox: add support for rootful containers
enter: Fixed typo in bash option by @nogajun in https://github.com/89luca89/distrobox/pull/259
enter: do not use full path for default shell, let the container resolve it. Fix https://github.com/89luca89/distrobox/issues/251
enter: fix eval when variable is not found. https://github.com/89luca89/distrobox/issues/268
enter: fixup comment around --headless
enter: add support for --no-workdir/-nw. Fix https://github.com/89luca89/distrobox/issues/231
enter: improve fist-start logging and show user some progress
enter: improve logging steps by @89luca89 in https://github.com/89luca89/distrobox/pull/290
export: Fix distrobox-export --bin error handling by @michel-slm in https://github.com/89luca89/distrobox/pull/275
export: fix exporting of icons for hardcoded paths
export: fix usage in docker
export: remove redundant command check on app export, fix quoting for commands containing them. Fix https://github.com/89luca89/distrobox/issues/225
list: add -s/--size option to show container disk usage
init: Add AlmaLinux 9 to tested containers distros by @michel-slm in https://github.com/89luca89/distrobox/pull/280
init: Fix gentoo support by @nullpointerarray in https://github.com/89luca89/distrobox/pull/284
init: add more basic tools, unminimize apt-get/dnf/yum/pacman/zypper - install langs and docs
init: add pinentry to base package list by @89luca89 in https://github.com/89luca89/distrobox/pull/256
init: fix missing variables on some container images
init: mount home in canonical place for ostree systems. Fix https://github.com/89luca89/distrobox/issues/282
init: move host's theme, fonts, icons integration to /usr/local/share, freeing user's home. Fix https://github.com/89luca89/distrobox/issues/253
init: move some mountpoints as rw to avoid mount Unknown error 5005. by @89luca89 in https://github.com/89luca89/distrobox/pull/264
init: remove verbose for keepalive sync loop, or logs will fill on the long run.
init: Implement pre-initialization hooks by @michel-slm in https://github.com/89luca89/distrobox/pull/269
init: Some openSUSE improvement by @dfaggioli in https://github.com/89luca89/distrobox/pull/262
init: add support for microdnf, support ubi8 and ubi7 minimal. Fix https://github.com/89luca89/distrobox/issues/254
init: fix ash shell package detection, Fix https://github.com/89luca89/distrobox/issues/247
init: keep timezone, dns and hosts actively synced with host

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
