### PR TITLE
python310Packages.wfuzz: disable on unsupported Python releases

### DIFF
--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -1,30 +1,31 @@
-{ buildPythonPackage
+{ lib
+, stdenv
+, buildPythonPackage
 , chardet
 , colorama
 , fetchFromGitHub
-, future
-, isPy27
-, lib
-, mock
 , netaddr
 , pycurl
 , pyparsing
 , pytest
 , pytestCheckHook
+, pythonOlder
 , setuptools
 , six
-, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "wfuzz";
   version = "3.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "xmendez";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1izasczm2zwknwzxbfzqhlf4zp02jvb54ha1hfk4rlwiz0rr1kj4";
+    hash = "sha256-RM6QM/iR00ymg0FBUtaWAtxPHIX4u9U/t5N/UT/T6sc=";
   };
 
   propagatedBuildInputs = [
@@ -33,9 +34,6 @@ buildPythonPackage rec {
     six
     setuptools
     pyparsing
-  ] ++ lib.optionals isPy27 [
-    mock
-    future
   ] ++ lib.optionals stdenv.hostPlatform.isWindows [
     colorama
   ];
@@ -44,14 +42,21 @@ buildPythonPackage rec {
     netaddr
     pytest
     pytestCheckHook
-  ] ++ lib.optionals isPy27 [
-    mock
   ];
 
-  preCheck = "export HOME=$(mktemp -d)";
-  # The skipped tests are requiring a local web server
-  pytestFlagsArray = [ "tests/test_{moduleman,filterintro,reqresp,api,clparser}.py" ];
-  pythonImportsCheck = [ "wfuzz" ];
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTestPaths = [
+    # The tests are requiring a local web server
+    "tests/test_acceptance.py"
+    "tests/acceptance/test_saved_filter.py"
+  ];
+
+  pythonImportsCheck = [
+    "wfuzz"
+  ];
 
   meta = with lib; {
     description = "Web content fuzzer to facilitate web applications assessments";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
