### PR TITLE
mle: 1.4.3 -> 1.5.0

### DIFF
--- a/pkgs/applications/editors/mle/default.nix
+++ b/pkgs/applications/editors/mle/default.nix
@@ -1,26 +1,53 @@
-{ lib, stdenv, fetchFromGitHub, termbox, pcre, uthash, lua5_3, makeWrapper, installShellFiles }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, pcre
+, uthash
+, lua5_4
+, makeWrapper
+, installShellFiles
+}:
 
 stdenv.mkDerivation rec {
   pname = "mle";
-  version = "1.4.3";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "adsr";
     repo = "mle";
     rev = "v${version}";
-    sha256 = "16dbwfdd6sqqn7jfaxd5wdy8y9ghbihnz6bgn3xhqcww8rj1sia1";
+    sha256 = "1nhd00lsx9v12zdmps92magz76c2d8zzln3lxvzl4ng73gbvq3n0";
   };
 
-  # Fix location of Lua 5.3 header and library
+  # Bug fixes found after v1.5.0 release
+  patches = [
+    (fetchpatch {
+      name = "skip_locale_dep_test.patch";
+      url = "https://github.com/adsr/mle/commit/e4dc4314b02a324701d9ae9873461d34cce041e5.patch";
+      sha256 = "sha256-j3Z/n+2LqB9vEkWzvRVSOrF6yE+hk6f0dvEsTQ74erw=";
+    })
+    (fetchpatch {
+      name = "fix_input_trail.patch";
+      url = "https://github.com/adsr/mle/commit/bc05ec0eee4143d824010c6688fce526550ed508.patch";
+      sha256 = "sha256-dM63EBDQfHLAqGZk3C5NtNAv23nCTxXVW8XpLkAeEyQ=";
+    })
+  ];
+
+  # Fix location of Lua 5.4 header and library
   postPatch = ''
-    substituteInPlace Makefile --replace "-llua5.3" "-llua";
-    substituteInPlace mle.h    --replace "<lua5.3/" "<";
+    substituteInPlace Makefile --replace "-llua5.4" "-llua";
+    substituteInPlace mle.h    --replace "<lua5.4/" "<";
     patchShebangs tests/*
   '';
 
+  # Use select(2) instead of poll(2) (poll is returning POLLINVAL on macOS)
+  # Enable compiler optimization
+  CFLAGS = "-DTB_OPT_SELECT -O2";
+
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
-  buildInputs = [ termbox pcre uthash lua5_3 ];
+  buildInputs = [ pcre uthash lua5_4 ];
 
   doCheck = true;
 
@@ -30,13 +57,8 @@ stdenv.mkDerivation rec {
     installManPage mle.1
   '';
 
-  postFixup = lib.optionalString stdenv.isDarwin ''
-    wrapProgram $out/bin/mle --prefix DYLD_LIBRARY_PATH : ${termbox}/lib
-  '';
-
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
-    description = "Small, flexible terminal-based text editor";
+    description = "Small, flexible, terminal-based text editor";
     homepage = "https://github.com/adsr/mle";
     license = licenses.asl20;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Description of changes

https://github.com/adsr/mle/compare/v1.4.3...v1.5.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
