### PR TITLE
python3Packages.pomegranate: 0.13.5 -> 0.14.8

### DIFF
--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -15,27 +15,15 @@
 
 buildPythonPackage rec {
   pname = "pomegranate";
-  version = "0.13.5";
+  version = "0.14.8";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "jmschrei";
-    rev = "v${version}";
-    sha256 = "1hbxchp3daykkf1fa79a9mh34p78bygqcf1nv4qwkql3gw0pd6l7";
+    # no tags for recent versions: https://github.com/jmschrei/pomegranate/issues/974
+    rev = "0652e955c400bc56df5661db3298a06854c7cce8";
+    sha256 = "16g49nl2bgnh6nh7bd21s393zbksdvgp9l13ww2diwhplj6hlly3";
   };
-
-  patches = lib.optionals (lib.versionOlder version "13.6") [
-    # Fix compatibility with recent joblib release, will be part of the next
-    # pomegranate release after 0.13.5
-    (fetchpatch {
-      url = "https://github.com/jmschrei/pomegranate/commit/42d14bebc44ffd4a778b2a6430aa845591b7c3b7.patch";
-      sha256 = "0f9cx0fj9xkr3hch7jyrn76zjypilh5bqw734caaw6g2m49lvbff";
-    })
-  ] ++ [
-    # Likely an upstream test bug and not a real problem:
-    #   https://github.com/jmschrei/pomegranate/issues/939
-    ./disable-failed-on-nextworkx-2.6.patch
-  ] ;
 
   propagatedBuildInputs = [ numpy scipy cython networkx joblib pyyaml ];
 


### PR DESCRIPTION
###### Description of changes

ZHF: #172160

Builds on darwin where we were previously having test failures.

`cnvkit` already broken: https://hydra.nixos.org/eval/1764251?filter=cnvkit&compare=1764191&full=

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
