### PR TITLE
Build offline documentation of python3.pkgs.pydantic

### DIFF
--- a/pkgs/development/python-modules/mdx-truly-sane-lists/default.nix
+++ b/pkgs/development/python-modules/mdx-truly-sane-lists/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, markdown
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "mdx_truly_sane_lists";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "radude";
+    repo = "mdx_truly_sane_lists";
+    rev = version;
+    sha256 = "1h8403ch016cwdy5zklzp7c6xrdyyhl4z07h97qzbafrbq07jyss";
+  };
+
+  propagatedBuildInputs = [ markdown ];
+
+  pythonImportsCheck = [ "mdx_truly_sane_lists" ];
+
+  checkPhase = ''
+    ${python.interpreter} mdx_truly_sane_lists/tests.py
+  '';
+
+  meta = with lib; {
+    description = "Extension for Python-Markdown that makes lists truly sane.";
+    longDescription = ''
+      Features custom indents for nested lists and fix for messy linebreaks and
+      paragraphs between lists.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocs-exclude/default.nix
+++ b/pkgs/development/python-modules/mkdocs-exclude/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, callPackage
+, buildPythonPackage
+, fetchFromGitHub
+, mkdocs
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-exclude";
+  version = "1.0.2";
+
+  # Repository has only 3 commits and no tags. Each of these commits has
+  # version of 1.0.0, 1.0.1 and 1.0.2 in setup.py, though.
+  src = fetchFromGitHub {
+    owner = "apenwarr";
+    repo = "mkdocs-exclude";
+    rev = "fdd67d2685ff706de126e99daeaaaf3f6f7cf3ae";
+    sha256 = "1phhl79xf4xq8w2sb2w5zm4bahcr33gsbxkz7dl1dws4qhcbxrfd";
+  };
+
+  propagatedBuildInputs = [ mkdocs ];
+
+  # Attempt to import "mkdocs_exclude" module in stand-alone mode fails:
+  #
+  #    module 'mkdocs.config' has no attribute 'config_options'
+  #
+  # It works fine when actually used to build documentation of "pydantic",
+  # though. This package has no tests.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A mkdocs plugin to exclude files from input using globs or regexes.";
+    homepage = "https://github.com/apenwarr/mkdocs-exclude";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -9,11 +9,23 @@
 , python-dotenv
 , pythonOlder
 , typing-extensions
+# dependencies for building documentation.
+, ansi2html
+, markdown-include
+, mkdocs
+, mkdocs-exclude
+, mkdocs-material
+, mdx-truly-sane-lists
+, sqlalchemy
+, ujson
+, orjson
+, hypothesis
 }:
 
 buildPythonPackage rec {
   pname = "pydantic";
   version = "1.9.0";
+  outputs = [ "out" "doc" ];
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
@@ -23,8 +35,24 @@ buildPythonPackage rec {
     sha256 = "sha256-C4WP8tiMRFmkDkQRrvP3yOSM2zN8pHJmX9cdANIckpM=";
   };
 
+  postPatch = ''
+    sed -i '/flake8/ d' Makefile
+  '';
+
   nativeBuildInputs = [
     cython
+
+    # dependencies for building documentation
+    ansi2html
+    markdown-include
+    mdx-truly-sane-lists
+    mkdocs
+    mkdocs-exclude
+    mkdocs-material
+    sqlalchemy
+    ujson
+    orjson
+    hypothesis
   ];
 
   propagatedBuildInputs = [
@@ -41,6 +69,18 @@ buildPythonPackage rec {
 
   preCheck = ''
     export HOME=$(mktemp -d)
+  '';
+
+  # Must include current directory into PYTHONPATH, since documentation
+  # building process expects "import pydantic" to work.
+  preBuild = ''
+    PYTHONPATH=$PWD:$PYTHONPATH make docs
+  '';
+
+  # Layout documentation in same way as "sphinxHook" does.
+  postInstall = ''
+    mkdir -p $out/share/doc/$name
+    mv ./site $out/share/doc/$name/html
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5372,6 +5372,7 @@ in {
 
   mkdocs = callPackage ../development/python-modules/mkdocs { };
   mkdocs-drawio-exporter = callPackage ../development/python-modules/mkdocs-drawio-exporter { };
+  mkdocs-exclude = callPackage ../development/python-modules/mkdocs-exclude { };
   mkdocs-macros = callPackage ../development/python-modules/mkdocs-macros { };
   mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
   mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5239,6 +5239,8 @@ in {
 
   md-toc = callPackage ../development/python-modules/md-toc { };
 
+  mdx-truly-sane-lists = callPackage ../development/python-modules/mdx-truly-sane-lists { };
+
   md2gemini = callPackage ../development/python-modules/md2gemini { };
 
   mdformat = callPackage ../development/python-modules/mdformat { };


### PR DESCRIPTION
Introduce `doc` output for `python3.pkgs.pydantic` and install html documentation into it.
Building html documentation required some python modules not present in nixpkgs, so I packaged them too.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
