### PR TITLE
telegram-cli: pull patch pending upstream inclusion for -fno-common t…

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jansson, lib, libconfig, libevent, libgcrypt, lua, lua53Packages
+{ stdenv, fetchFromGitHub, fetchpatch, jansson, lib, libconfig, libevent, libgcrypt, lua, lua53Packages
 , makeWrapper, openssl, pkg-config, python3, readline, zlib
 }:
 
@@ -13,6 +13,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wYBPr2b8IOycO9y/CNyGjnRsyGyYl3oiXYtTzwTurVA=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Pull patch pending upstream upstream inclusion for -fno-common toolchains:
+    #   https://github.com/kenorb-contrib/tg/pull/61
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/kenorb-contrib/tg/commit/aad2e644fffa16066b227741d54de31bddb04ff8.patch";
+      sha256 = "sha256-LAa5J4BVj3QCiDSs+p2bynDroMSIqCeexQvrgaDl6OE=";
+    })
+  ];
 
   buildInputs = [
     jansson


### PR DESCRIPTION
…oolchain support

Without the change builds fails on upstream gcc-10 as:

    ld: objs/loop.o:/build/tg/loop.c:77: multiple definition of
      `verbosity'; objs/main.o:/build/tg/main.c:93: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
