### PR TITLE
qdigidoc: Wrap just once

### DIFF
--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchurl, cmake, gettext, makeWrapper
+{ lib, mkDerivation, fetchurl, cmake, gettext
 , pkg-config, libdigidocpp, opensc, openldap, openssl, pcsclite, qtbase
 , qttranslations, qtsvg }:
 
@@ -17,7 +17,7 @@ mkDerivation rec {
     sha256 = "1cikz36w9phgczcqnwk4k3mx3kk919wy2327jksmfa4cjfjq4a8d";
   };
 
-  nativeBuildInputs = [ cmake gettext makeWrapper pkg-config ];
+  nativeBuildInputs = [ cmake gettext pkg-config ];
 
   postPatch = ''
     substituteInPlace client/CMakeLists.txt \
@@ -35,10 +35,9 @@ mkDerivation rec {
     qttranslations
   ];
 
-  postInstall = ''
-    wrapProgram $out/bin/qdigidoc4 \
-      --prefix LD_LIBRARY_PATH : ${opensc}/lib/pkcs11/
-  '';
+  qtWrapperArgs = [
+      "--prefix LD_LIBRARY_PATH : ${opensc}/lib/pkcs11/"
+  ];
 
   meta = with lib; {
     description = "Qt-based UI for signing and verifying DigiDoc documents";


### PR DESCRIPTION
Merge `LD_LIBRARY_PATH` fixing into the automatic Qt wrapping hook.
Otherwise `argv[0]` ends up as ".qdigidoc4-wrapped" due extra wrapping.

@mmahut @yana
