### PR TITLE
partitionmanager: Wrap once

### DIFF
--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, fetchurl, lib, makeWrapper
-, extra-cmake-modules, kdoctools, wrapGAppsHook, wrapQtAppsHook
+{ mkDerivation, fetchurl, lib
+, extra-cmake-modules, kdoctools, wrapGAppsHook
 , kconfig, kcrash, kinit, kpmcore, polkit-qt
 , cryptsetup, lvm2, mdadm, smartmontools, systemdMinimal, util-linux
 , btrfs-progs, dosfstools, e2fsprogs, exfat, f2fs-tools, fatresize, hfsprogs
@@ -48,13 +48,16 @@ in mkDerivation rec {
     hash = "sha256-eChn3OkdLHC9pedDBBwszTeTj2l7ky2W79INqvjrkBo=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook wrapQtAppsHook makeWrapper ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
 
   propagatedBuildInputs = [ kconfig kcrash kinit kpmcore polkit-qt ];
 
-  postFixup = ''
-    wrapProgram $out/bin/partitionmanager \
+  dontWrapGApps = true;
+  preFixup = ''
+    qtWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
       --prefix PATH : "${runtimeDeps}"
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Merge both the GNOME and manual runtime `PATH` fixups into the automatic
Qt hook to end up with one wrapper containing all deduplicated variables
rather than three doing duplicate work and messing up `argv[0]`.

@peterhoeg @oxalica
