### PR TITLE
astral: init at 5.7.1

### DIFF
--- a/pkgs/applications/science/biology/astral/default.nix
+++ b/pkgs/applications/science/biology/astral/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, jdk8
+, makeWrapper
+, jre8
+, zip
+}:
+let
+  jdk = jdk8;
+  jre = jre8;
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "astral";
+  version = "5.7.1";
+
+  src = fetchFromGitHub {
+    owner = "smirarab";
+    repo = "ASTRAL";
+    rev = "v${version}";
+    sha256 = "043w2z6gbrisqirdid022f4b8jps1pp5syi344krv2bis1gjq5sn";
+  };
+
+  nativeBuildInputs = [ jdk makeWrapper jre zip ];
+
+  buildPhase = ''
+    patchShebangs ./make.sh
+    ./make.sh
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    java -jar astral.${version}.jar -i main/test_data/song_primates.424.gene.tre
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/lib
+    mkdir -p $out/bin
+    mv astral.${version}.jar $out/share/
+    mv lib/*.jar $out/share/lib
+    mv Astral.${version}.zip $out/share/
+    cp -a  main/test_data $out/share/
+    makeWrapper ${jre}/bin/java $out/bin/astral \
+        --add-flags "-jar $out/share/astral.${version}.jar"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/smirarab/ASTRAL";
+    description = "Tool for estimating an unrooted species tree given a set of unrooted gene trees";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bzizou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32715,6 +32715,8 @@ with pkgs;
 
   aragorn = callPackage ../applications/science/biology/aragorn { };
 
+  astral = callPackage ../applications/science/biology/astral { };
+
   archimedes = callPackage ../applications/science/electronics/archimedes {
     stdenv = gcc6Stdenv;
   };


### PR DESCRIPTION
###### Description of changes

New package into biology applications.

Tested with embedded test data, on a NixOS host and a Debian host using Nix:

```
bzizou@f-dahu:~/git/nixpkgs$ astral -i ~/.nix-profile/share/test_data/song_primates.424.gene.tre 

================== ASTRAL ===================== 

This is ASTRAL version 5.7.1
Gene trees are treated as unrooted
424 trees read from /home/bzizou/.nix-profile/share/test_data/song_primates.424.gene.tre
All output trees will be *arbitrarily* rooted at Marmoset

======== Running the main analysis
Number of taxa: 14 (14 species)
Taxa: [Marmoset, Orangutan, Human, Chimpanzee, Gorilla, Macaque, Galago, Mouse_Lemur, Tree_Shrew, Rat, Tarsier, Rabbit, Horse, Sloth]
Taxon occupancy: {Human=424, Rat=424, Tarsier=424, Galago=424, Rabbit=424, Macaque=424, Sloth=424, Marmoset=424, Tree_Shrew=424, Chimpanzee=424, Mouse_Lemur=424, Horse=424, Orangutan=424, Gorilla=424}
Number of gene trees: 424
0 trees have missing taxa
Calculating quartet distance matrix (for completion of X)
Species tree distances calculated ...
Building set of clusters (X) from gene trees 
------------------------------
gradient0: 339
Number of Clusters after addition by distance: 339
calculating extra bipartitions to be added at level 1 ...
Adding to X using resolutions of greedy consensus ...
Limit for sigma of degrees:400
polytomy size limit : 3
discarded polytomies:  [3]
Threshold 0.0:
Threshold 0.01:
Threshold 0.02:
Threshold 0.05:
Threshold 0.1:
Threshold 0.2:
Threshold 0.3333333333333333:
polytomy of size 3; rounds with additions with at least 5 support: 0; clusters: 339
max k is :0
Number of Clusters after addition by greedy: 339
gradient0 in heuristiic: 339
partitions formed in 0.285 secs
Dynamic Programming starting after 0.285 secs
Using tree-based weight calculation.
Using polytree-based weight calculation.
Polytree max score: 424424
Polytree building time: 0.083 seconds.
Number of quartet trees in the gene trees: 424424
Size of largest cluster: 14
Greedy score: 389226
estimationFactor: 1.090430752313566
Sub-optimal score: 389226
Total Number of elements weighted: 452
Normalized score (portion of input quartet trees satisfied before correcting for multiple individuals): 0.9182656965675834
Optimization score: 389734
Optimal tree inferred in 0.473 secs.
(Gorilla,((Human,Chimpanzee),(Orangutan,(Macaque,(Marmoset,(Tarsier,((Galago,Mouse_Lemur),((Horse,Sloth),(Tree_Shrew,(Rat,Rabbit))))))))));
Final quartet score is: 389734
Final normalized quartet score is: 0.9182656965675834
(Marmoset,((Tarsier,((Galago,Mouse_Lemur)1:2.4018020540034675,((Horse,Sloth)1:2.6056351956741435,(Tree_Shrew,(Rat,Rabbit)1:0.8024369743576611)0.92:0.08540838439417373)1:1.9852014529353605)1:0.655284855661726)1:4.260329699696363,(Macaque,(Orangutan,((Human,Chimpanzee)1:0.6408490436022495,Gorilla)1:2.3251916476229617)1:2.5898315305010144)1:2.7005416959060815));
(Marmoset,((Tarsier,((Galago,Mouse_Lemur)1:2.4018020540034675,((Horse,Sloth)1:2.6056351956741435,(Tree_Shrew,(Rat,Rabbit)1:0.8024369743576611)0.92:0.08540838439417373)1:1.9852014529353605)1:0.655284855661726)1:4.260329699696363,(Macaque,(Orangutan,((Human,Chimpanzee)1:0.6408490436022495,Gorilla)1:2.3251916476229617)1:2.5898315305010144)1:2.7005416959060815):0.0); 
Weight calculation took 0.043253397 secs
ASTRAL finished in 0.689 secs
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
