### PR TITLE
n8n: 0.177.0 → 0.179.0

### DIFF
--- a/pkgs/applications/networking/n8n/node-packages.nix
+++ b/pkgs/applications/networking/n8n/node-packages.nix
@@ -13,15 +13,6 @@ let
         sha512 = "TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==";
       };
     };
-    "@azure/core-asynciterator-polyfill-1.0.2" = {
-      name = "_at_azure_slash_core-asynciterator-polyfill";
-      packageName = "@azure/core-asynciterator-polyfill";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.2.tgz";
-        sha512 = "3rkP4LnnlWawl0LZptJOdXNrT/fHp2eQMadoasa6afspXdpGrtPZuAQc2PD0cpgyuoXtUWyC3tv7xfntjGS5Dw==";
-      };
-    };
     "@azure/core-auth-1.3.2" = {
       name = "_at_azure_slash_core-auth";
       packageName = "@azure/core-auth";
@@ -49,13 +40,13 @@ let
         sha512 = "e1I2v2CZM0mQo8+RSix0x091Av493e4bnT22ds2fcQGslTHzM2oTbswkB65nP4iEpCxBrFxOSDPKExmTmjCVtQ==";
       };
     };
-    "@azure/core-paging-1.2.1" = {
+    "@azure/core-paging-1.3.0" = {
       name = "_at_azure_slash_core-paging";
       packageName = "@azure/core-paging";
-      version = "1.2.1";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.2.1.tgz";
-        sha512 = "UtH5iMlYsvg+nQYIl4UHlvvSrsBjOlRF4fs0j7mxd3rWdAStrKYrh2durOpHs5C9yZbVhsVDaisoyaf/lL1EVA==";
+        url = "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.3.0.tgz";
+        sha512 = "H6Tg9eBm0brHqLy0OSAGzxIh1t4UL8eZVrSUMJ60Ra9cwq2pOskFqVpz2pYoHDsBY1jZ4V/P8LRGb5D5pmC6rg==";
       };
     };
     "@azure/core-tracing-1.0.0-preview.13" = {
@@ -112,13 +103,13 @@ let
         sha512 = "FBEPKGnvtQJS8V8Tg1P9obgmVD9AodrIfwtwhBpsjenClhFyugMp3HPJY0tF7rInUB/CivKBCbnQKrUnKxqxzw==";
       };
     };
-    "@babel/runtime-7.17.9" = {
+    "@babel/runtime-7.18.3" = {
       name = "_at_babel_slash_runtime";
       packageName = "@babel/runtime";
-      version = "7.17.9";
+      version = "7.18.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz";
-        sha512 = "lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==";
+        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz";
+        sha512 = "38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==";
       };
     };
     "@colors/colors-1.5.0" = {
@@ -526,13 +517,13 @@ let
         sha512 = "cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==";
       };
     };
-    "@types/node-17.0.33" = {
+    "@types/node-17.0.36" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "17.0.33";
+      version = "17.0.36";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-17.0.33.tgz";
-        sha512 = "miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==";
+        url = "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz";
+        sha512 = "V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==";
       };
     };
     "@types/node-fetch-2.6.1" = {
@@ -598,13 +589,13 @@ let
         sha512 = "nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==";
       };
     };
-    "@types/snowflake-sdk-1.6.4" = {
+    "@types/snowflake-sdk-1.6.6" = {
       name = "_at_types_slash_snowflake-sdk";
       packageName = "@types/snowflake-sdk";
-      version = "1.6.4";
+      version = "1.6.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/snowflake-sdk/-/snowflake-sdk-1.6.4.tgz";
-        sha512 = "v3QjPbvd2dhyI5fPU5whxgUjhf9O19acIGiL65aUPCnkLIla5Z0ZqOiP3Jw5eyghunZHWohKfvtV+UdesCi29g==";
+        url = "https://registry.npmjs.org/@types/snowflake-sdk/-/snowflake-sdk-1.6.6.tgz";
+        sha512 = "oGdzQJONiv5UxaSsrIS49IvdcQRoPt6HTqIM8c0JTCIqEwGrsuqBq317PdLntM9SVc8BcDOYeAZTNdlISSSzwQ==";
       };
     };
     "@types/tough-cookie-2.3.8" = {
@@ -877,6 +868,15 @@ let
         sha512 = "HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==";
       };
     };
+    "array.prototype.reduce-1.0.4" = {
+      name = "array.prototype.reduce";
+      packageName = "array.prototype.reduce";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.4.tgz";
+        sha512 = "WnM+AjG/DvLRLo4DDl+r+SvCzYtD2Jd9oeBYMcEaI7t3fFrHY9M53/wdLcTvmZNQ70IU6Htj0emFkZ5TS+lrdw==";
+      };
+    };
     "asn1-0.2.6" = {
       name = "asn1";
       packageName = "asn1";
@@ -985,13 +985,13 @@ let
         sha512 = "z4oo33lmnvvNRqfUe3YjDGGpqu/L2+wXBIhMtwq6oqZ+exOUAkQYM6zd2VWKF7AIlajOF8ZZuPFfryTG9iLC/w==";
       };
     };
-    "aws-sdk-2.1135.0" = {
+    "aws-sdk-2.1145.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.1135.0";
+      version = "2.1145.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1135.0.tgz";
-        sha512 = "bl9n4QgrEh52hmQ+Jo76BgJXM/p+PwfVZvImEQHFeel/33H/PDLcTJquEw5bzxM1HRNI24iH+FNPwyWLMrttTw==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1145.0.tgz";
+        sha512 = "bjZJGFxHJadnp2kbg1etKw7ID1QmmKk1ivML0Xtt6S6GnGSfX8zVuLMkJZaxPMjlyZ6xeilGwzk2F9igxBCPCQ==";
       };
     };
     "aws-sign2-0.7.0" = {
@@ -1019,6 +1019,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz";
         sha512 = "ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==";
+      };
+    };
+    "axios-0.27.2" = {
+      name = "axios";
+      packageName = "axios";
+      version = "0.27.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz";
+        sha512 = "t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==";
       };
     };
     "axios-retry-3.2.5" = {
@@ -1129,13 +1138,13 @@ let
         sha512 = "rA2CrUl1+6yKrn+XgLs8Hdy18OER1UW146nM+ixzhQXDY+Bd3ySkyIJGwF2a4I45JwbvF1mDL/nWkqBwpOcdBA==";
       };
     };
-    "bintrees-1.0.1" = {
+    "bintrees-1.0.2" = {
       name = "bintrees";
       packageName = "bintrees";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz";
-        sha512 = "tbaUB1QpTIj4cKY8c1rvNAvEQXA+ekzHmbe4jzNfW3QWsF9GnnP/BRWyl6/qqS53heoYJ93naaFcm/jooONH8g==";
+        url = "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz";
+        sha512 = "VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==";
       };
     };
     "bitsyntax-0.1.0" = {
@@ -1630,7 +1639,7 @@ let
       version = "1.1.3";
       src = fetchurl {
         url = "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz";
-        sha1 = "a7d0558bd89c42f795dd42328f740831ca53bc25";
+        sha512 = "72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==";
       };
     };
     "color-name-1.1.4" = {
@@ -1666,7 +1675,7 @@ let
       version = "1.1.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz";
-        sha1 = "f8889030685c7c4ff9e2a559f5077eb76a816f96";
+        sha512 = "/pyV40IrsdulWv+wFPmERh9k/mjsPZ64yUMDmWrtj/k1nmgrzzIENWKdaVKyBbvFdQWqkcaRxr+polCo3VMe7A==";
       };
     };
     "colorspace-1.1.4" = {
@@ -1705,13 +1714,13 @@ let
         sha512 = "P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==";
       };
     };
-    "commander-9.2.0" = {
+    "commander-9.3.0" = {
       name = "commander";
       packageName = "commander";
-      version = "9.2.0";
+      version = "9.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz";
-        sha512 = "e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==";
+        url = "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz";
+        sha512 = "hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==";
       };
     };
     "commist-1.1.0" = {
@@ -1729,7 +1738,7 @@ let
       version = "1.2.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz";
-        sha1 = "8a47901700238e4fc32269771230226f24b415a9";
+        sha512 = "Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==";
       };
     };
     "compressible-2.0.18" = {
@@ -1756,7 +1765,7 @@ let
       version = "0.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz";
-        sha1 = "d8a96bd77fd68df7793a73036a3ba0d5405d477b";
+        sha512 = "/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==";
       };
     };
     "concat-stream-2.0.0" = {
@@ -1783,7 +1792,7 @@ let
       version = "1.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz";
-        sha1 = "3d7cf4464db6446ea644bf4b39507f9851008e8e";
+        sha512 = "ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==";
       };
     };
     "constant-case-3.0.4" = {
@@ -1855,7 +1864,7 @@ let
       version = "1.0.6";
       src = fetchurl {
         url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz";
-        sha1 = "e303a882b342cc3ee8ca513a79999734dab3ae2c";
+        sha512 = "QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==";
       };
     };
     "core-js-2.6.12" = {
@@ -1867,13 +1876,13 @@ let
         sha512 = "Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==";
       };
     };
-    "core-js-3.22.5" = {
+    "core-js-3.22.7" = {
       name = "core-js";
       packageName = "core-js";
-      version = "3.22.5";
+      version = "3.22.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz";
-        sha512 = "VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==";
+        url = "https://registry.npmjs.org/core-js/-/core-js-3.22.7.tgz";
+        sha512 = "Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg==";
       };
     };
     "core-util-is-1.0.2" = {
@@ -1882,7 +1891,7 @@ let
       version = "1.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz";
-        sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
+        sha512 = "3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==";
       };
     };
     "crc-32-1.2.2" = {
@@ -1918,7 +1927,7 @@ let
       version = "4.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz";
-        sha1 = "7b9247621c23adfdd3856004a823cbe397424d41";
+        sha512 = "yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==";
       };
     };
     "crypt-0.0.2" = {
@@ -1927,7 +1936,7 @@ let
       version = "0.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz";
-        sha1 = "88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b";
+        sha512 = "mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==";
       };
     };
     "crypto-js-4.1.1" = {
@@ -1972,7 +1981,7 @@ let
       version = "0.0.10";
       src = fetchurl {
         url = "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz";
-        sha1 = "c6d2672632a2e5c83e013e6864a42ce8defd20ae";
+        sha512 = "FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==";
       };
     };
     "dashdash-1.14.1" = {
@@ -1981,7 +1990,7 @@ let
       version = "1.14.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz";
-        sha1 = "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0";
+        sha512 = "jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==";
       };
     };
     "date-utils-1.2.21" = {
@@ -1990,7 +1999,7 @@ let
       version = "1.2.21";
       src = fetchurl {
         url = "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz";
-        sha1 = "61fb16cdc1274b3c9acaaffe9fc69df8720a2b64";
+        sha512 = "wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA==";
       };
     };
     "debug-2.6.9" = {
@@ -2035,7 +2044,7 @@ let
       version = "1.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz";
-        sha1 = "aa24ffb9ac3df9a2351837cfb2d279360cd78492";
+        sha512 = "syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==";
       };
     };
     "deepmerge-1.5.2" = {
@@ -2071,7 +2080,7 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
-        sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
+        sha512 = "ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==";
       };
     };
     "delegates-1.0.0" = {
@@ -2080,7 +2089,7 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz";
-        sha1 = "84c6e159b81904fdca59a0ef44cd870d31250f9a";
+        sha512 = "bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==";
       };
     };
     "denque-1.5.1" = {
@@ -2143,7 +2152,7 @@ let
       version = "0.2.4";
       src = fetchurl {
         url = "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz";
-        sha1 = "b5e30361a6db023176d562892db85940a718f47e";
+        sha512 = "9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==";
       };
     };
     "dir-glob-3.0.1" = {
@@ -2161,7 +2170,7 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz";
-        sha1 = "e38331f0844bba49b9a9cb71c771585aab1bc65a";
+        sha512 = "c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==";
       };
     };
     "dom-serializer-1.4.1" = {
@@ -2224,7 +2233,7 @@ let
       version = "0.6.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz";
-        sha1 = "d813ccdac8d39d8ad526775514a13dda664d6b4b";
+        sha512 = "KRJa47iBEK0y6ZtgCgy2ykuvMT8c9gj3ua9Dv7vCkclFJJeH2FjhGY2xO5qBoWGahsjCGMlk4Cq9wJYeWxuYhQ==";
       };
     };
     "duplexify-3.7.1" = {
@@ -2242,7 +2251,7 @@ let
       version = "0.1.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz";
-        sha1 = "3a83a904e54353287874c564b7549386849a98c9";
+        sha512 = "eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==";
       };
     };
     "ecdsa-sig-formatter-1.0.11" = {
@@ -2260,7 +2269,7 @@ let
       version = "1.1.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz";
-        sha1 = "590c61156b0ae2f4f0255732a158b266bc56b21d";
+        sha512 = "WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==";
       };
     };
     "element-ui-2.15.8" = {
@@ -2287,7 +2296,7 @@ let
       version = "1.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz";
-        sha1 = "965f6513d2c2d1c5f4652b64a2e3396467fc2f93";
+        sha512 = "nnzgVSpB35qKrUN8358SjO1bYAmxoThECTWw9s3J0x5G8A9hokKHVDFzBjVpCoSryo6MhN8woVyascN5jheaNA==";
       };
     };
     "enabled-2.0.0" = {
@@ -2305,7 +2314,7 @@ let
       version = "1.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz";
-        sha1 = "ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59";
+        sha512 = "TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==";
       };
     };
     "encoding-japanese-2.0.0" = {
@@ -2353,13 +2362,22 @@ let
         sha512 = "2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==";
       };
     };
-    "es-abstract-1.20.0" = {
+    "es-abstract-1.20.1" = {
       name = "es-abstract";
       packageName = "es-abstract";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz";
-        sha512 = "URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==";
+        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz";
+        sha512 = "WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==";
+      };
+    };
+    "es-array-method-boxes-properly-1.0.0" = {
+      name = "es-array-method-boxes-properly";
+      packageName = "es-array-method-boxes-properly";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz";
+        sha512 = "wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==";
       };
     };
     "es-to-primitive-1.2.1" = {
@@ -2377,7 +2395,7 @@ let
       version = "0.8.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz";
-        sha1 = "aba8d9e1943a895ac96837a62a39b3f55ecd94ab";
+        sha512 = "H19ompyhnKiBdjHR1DPHvf5RHgHPmJaY9JNzFGbMbPgdsUkvnUCN1Ke8J4Y0IMyTwFM2M9l4h2GoHwzwpSmXbA==";
       };
     };
     "escalade-3.1.1" = {
@@ -2395,7 +2413,7 @@ let
       version = "1.0.3";
       src = fetchurl {
         url = "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz";
-        sha1 = "0258eae4d3d0c0974de1c169188ef0051d1d1988";
+        sha512 = "NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==";
       };
     };
     "escape-string-regexp-1.0.5" = {
@@ -2404,7 +2422,7 @@ let
       version = "1.0.5";
       src = fetchurl {
         url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
-        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+        sha512 = "vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==";
       };
     };
     "escape-string-regexp-4.0.0" = {
@@ -2422,7 +2440,7 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz";
-        sha1 = "fbd65386980b30fbcd0e1305d4c3fb8614ef2119";
+        sha512 = "NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==";
       };
     };
     "esprima-4.0.1" = {
@@ -2440,7 +2458,7 @@ let
       version = "1.8.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz";
-        sha1 = "41ae2eeb65efa62268aebfea83ac7d79299b0887";
+        sha512 = "aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==";
       };
     };
     "event-target-shim-5.0.1" = {
@@ -2458,7 +2476,7 @@ let
       version = "1.1.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/events/-/events-1.1.1.tgz";
-        sha1 = "9ebdb7635ad099c70dcc4c2a1f5004288e8bd924";
+        sha512 = "kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==";
       };
     };
     "events-3.3.0" = {
@@ -2494,7 +2512,7 @@ let
       version = "2.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz";
-        sha1 = "97e801aa052df02454de46b02bf621642cdc8502";
+        sha512 = "A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==";
       };
     };
     "express-4.18.1" = {
@@ -2530,7 +2548,7 @@ let
       version = "1.3.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz";
-        sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
+        sha512 = "11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==";
       };
     };
     "fast-deep-equal-3.1.3" = {
@@ -2650,13 +2668,13 @@ let
         sha512 = "GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==";
       };
     };
-    "follow-redirects-1.15.0" = {
+    "follow-redirects-1.15.1" = {
       name = "follow-redirects";
       packageName = "follow-redirects";
-      version = "1.15.0";
+      version = "1.15.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz";
-        sha512 = "aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==";
+        url = "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz";
+        sha512 = "yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==";
       };
     };
     "for-each-0.3.3" = {
@@ -2674,7 +2692,7 @@ let
       version = "0.6.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz";
-        sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
+        sha512 = "j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==";
       };
     };
     "form-data-2.3.3" = {
@@ -2746,7 +2764,7 @@ let
       version = "0.5.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz";
-        sha1 = "3d8cadd90d976569fa835ab1f8e4b23a105605a7";
+        sha512 = "zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==";
       };
     };
     "fs-extra-8.1.0" = {
@@ -2773,7 +2791,7 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz";
-        sha1 = "1504ad2523158caa40db4a2787cb01411994ea4f";
+        sha512 = "OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==";
       };
     };
     "function-bind-1.1.1" = {
@@ -2890,7 +2908,7 @@ let
       version = "0.1.7";
       src = fetchurl {
         url = "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz";
-        sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
+        sha512 = "0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==";
       };
     };
     "glob-7.2.3" = {
@@ -2908,7 +2926,7 @@ let
       version = "3.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz";
-        sha1 = "9e6af6299d8d3bd2bd40430832bd113df906c5ae";
+        sha512 = "E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==";
       };
     };
     "glob-parent-5.1.2" = {
@@ -2926,7 +2944,7 @@ let
       version = "6.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz";
-        sha1 = "7045c99413b3eb94888d83ab46d0b404cc7bdde4";
+        sha512 = "uMbLGAP3S2aDOHUDfdoYcdIePUCfysbAd0IAoWVZbeGU/oNQ8asHVSshLDJUPWxfzj8zsCG7/XeHPHTtow0nsw==";
       };
     };
     "globby-11.1.0" = {
@@ -2944,7 +2962,7 @@ let
       version = "1.23.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz";
-        sha1 = "2edeeb958084d0f8ea7988e5d995b1c7dfc14777";
+        sha512 = "wYGVAa8/sh9ggF5qWoOs6eArcAgwEPkDNvf637jHRHkMUznvs7m/Q2vrc0KLN6B8px3nnRJqJcXK4mTK6lLFmg==";
       };
     };
     "google-timezones-json-1.0.2" = {
@@ -2980,7 +2998,7 @@ let
       version = "2.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz";
-        sha1 = "a94c2224ebcac04782a0d9035521f24735b7ec92";
+        sha512 = "Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==";
       };
     };
     "har-validator-5.1.5" = {
@@ -3007,7 +3025,7 @@ let
       version = "2.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
-        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
+        sha512 = "C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==";
       };
     };
     "has-bigints-1.0.2" = {
@@ -3061,7 +3079,7 @@ let
       version = "2.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz";
-        sha1 = "e0e6fe6a28cf51138855e086d1691e771de2a8b9";
+        sha512 = "8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==";
       };
     };
     "he-1.2.0" = {
@@ -3097,7 +3115,7 @@ let
       version = "1.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/help-me/-/help-me-1.1.0.tgz";
-        sha1 = "8f2d508d0600b4a456da2f086556e7e5c056a3c6";
+        sha512 = "P/IZ8yOMne3SCTHbVY429NZ67B/2bVQlcYGZh2iPPbdLrEQ/qY5aGChn0YTDmt7Sb4IKRI51fypItav+lNl76w==";
       };
     };
     "highlight.js-10.7.3" = {
@@ -3160,7 +3178,7 @@ let
       version = "1.2.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz";
-        sha1 = "9aecd925114772f3d95b65a60abb8f7c18fbace1";
+        sha512 = "CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==";
       };
     };
     "https-proxy-agent-5.0.1" = {
@@ -3241,7 +3259,7 @@ let
       version = "0.8.19";
       src = fetchurl {
         url = "https://registry.npmjs.org/imap/-/imap-0.8.19.tgz";
-        sha1 = "3678873934ab09cea6ba48741f284da2af59d8d5";
+        sha512 = "z5DxEA1uRnZG73UcPA4ES5NSCGnPuuouUx43OPX7KZx1yzq3N8/vx2mtXEShT5inxB3pRgnfG1hijfu7XN2YMw==";
       };
     };
     "imap-simple-4.3.0" = {
@@ -3268,7 +3286,7 @@ let
       version = "1.0.6";
       src = fetchurl {
         url = "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz";
-        sha1 = "49bd6331d7d02d0c09bc910a1075ba8165b56df9";
+        sha512 = "k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==";
       };
     };
     "inherits-2.0.4" = {
@@ -3313,7 +3331,7 @@ let
       version = "2.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz";
-        sha1 = "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9";
+        sha512 = "58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==";
       };
     };
     "ipaddr.js-1.9.1" = {
@@ -3412,7 +3430,7 @@ let
       version = "2.1.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz";
-        sha1 = "a88c02535791f02ed37c76a1b9ea9773c833f8c2";
+        sha512 = "SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==";
       };
     };
     "is-fullwidth-code-point-3.0.0" = {
@@ -3430,7 +3448,7 @@ let
       version = "3.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz";
-        sha1 = "7ba5ae24217804ac70707b96922567486cc3e84a";
+        sha512 = "UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==";
       };
     };
     "is-glob-4.0.3" = {
@@ -3457,7 +3475,7 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz";
-        sha1 = "6910bca5da8c95e784b5751b976cf5a10fee36d2";
+        sha512 = "czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==";
       };
     };
     "is-negative-zero-2.0.2" = {
@@ -3502,7 +3520,7 @@ let
       version = "1.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz";
-        sha1 = "31573761c057e33c2e91aab9e96da08cefbe76e5";
+        sha512 = "mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg==";
       };
     };
     "is-property-1.0.2" = {
@@ -3511,7 +3529,7 @@ let
       version = "1.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz";
-        sha1 = "57fe1c4e48474edd65b09911f26b1cd4095dda84";
+        sha512 = "Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==";
       };
     };
     "is-regex-1.1.4" = {
@@ -3583,7 +3601,7 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz";
-        sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
+        sha512 = "cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==";
       };
     };
     "is-unc-path-1.0.0" = {
@@ -3628,7 +3646,7 @@ let
       version = "0.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz";
-        sha1 = "8a18acfca9a8f4177e09abfc6038939b05d1eedf";
+        sha512 = "D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==";
       };
     };
     "isarray-1.0.0" = {
@@ -3637,16 +3655,16 @@ let
       version = "1.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz";
-        sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
+        sha512 = "VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==";
       };
     };
-    "isbot-3.4.7" = {
+    "isbot-3.5.0" = {
       name = "isbot";
       packageName = "isbot";
-      version = "3.4.7";
+      version = "3.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/isbot/-/isbot-3.4.7.tgz";
-        sha512 = "huiRPlUf/je4GfR/pms78bOnUYRmwo2Dg/d9aRQCPXIIK3uX6u+iRFuTLsq969X40JcCunHrbS4SFlXIcEIoUw==";
+        url = "https://registry.npmjs.org/isbot/-/isbot-3.5.0.tgz";
+        sha512 = "QOFF7IE7hUdzo8pbhCubeiMzKdLZt+W/UwRZWwg+zghmnqXoMwh2V0bi5UT+oIvoD0IWCWjzAtp30ZrrRwJVCg==";
       };
     };
     "isexe-2.0.0" = {
@@ -3655,7 +3673,7 @@ let
       version = "2.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz";
-        sha1 = "e8fbf374dc556ff8947a10dcb0572d633f2cfa10";
+        sha512 = "RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==";
       };
     };
     "iso-639-1-2.1.13" = {
@@ -3673,7 +3691,7 @@ let
       version = "0.1.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz";
-        sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
+        sha512 = "Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==";
       };
     };
     "jmespath-0.16.0" = {
@@ -3691,7 +3709,7 @@ let
       version = "1.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz";
-        sha1 = "b8417b750661a392bee2c2537c68b2a9d4977cd5";
+        sha512 = "bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==";
       };
     };
     "js-yaml-3.14.1" = {
@@ -3718,7 +3736,7 @@ let
       version = "0.1.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz";
-        sha1 = "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513";
+        sha512 = "UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==";
       };
     };
     "json-diff-0.5.5" = {
@@ -3754,7 +3772,7 @@ let
       version = "1.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz";
-        sha1 = "9db7b59496ad3f3cfef30a75142d2d930ad72651";
+        sha512 = "Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==";
       };
     };
     "json-stringify-safe-5.0.1" = {
@@ -3763,7 +3781,7 @@ let
       version = "5.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
-        sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
+        sha512 = "ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==";
       };
     };
     "jsonfile-4.0.0" = {
@@ -3772,7 +3790,7 @@ let
       version = "4.0.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz";
-        sha1 = "8771aae0799b64076b76640fca058f9c10e33ecb";
+        sha512 = "m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==";
       };
     };
     "jsonwebtoken-8.5.1" = {
@@ -3853,7 +3871,7 @@ let
       version = "2.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz";
-        sha1 = "c2e7a9f772094dee9d34202ae8acce4687875580";
+        sha512 = "nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==";
       };
     };
     "libbase64-1.2.1" = {
@@ -3874,13 +3892,13 @@ let
         sha512 = "xOqorG21Va+3CjpFOfFTU7SWohHH2uIX9ZY4Byz6J+lvpfvc486tOAT/G9GfbrKtJ9O7NCX9o0aC2lxqbnZ9EA==";
       };
     };
-    "libphonenumber-js-1.9.53" = {
+    "libphonenumber-js-1.10.6" = {
       name = "libphonenumber-js";
       packageName = "libphonenumber-js";
-      version = "1.9.53";
+      version = "1.10.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.53.tgz";
-        sha512 = "3cuMrA2CY3TbKVC0wKye5dXYgxmVVi4g13gzotprQSguFHMqf0pIrMM2Z6ZtMsSWqvtIqi5TuQhGjMhxz0O9Mw==";
+        url = "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.6.tgz";
+        sha512 = "CIjT100/SmntsUjsLVs2t3ufeN4KdNXUxhD07tH153pdbaCWuAjv0jK/gPuywR3IImB/U/MQM+x9RfhMs5XZiA==";
       };
     };
     "libqp-1.1.0" = {
@@ -3889,7 +3907,7 @@ let
       version = "1.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz";
-        sha1 = "f5e6e06ad74b794fb5b5b66988bf728ef1dedbe8";
+        sha512 = "4Rgfa0hZpG++t1Vi2IiqXG9Ad1ig4QTmtuZF946QJP4bPqOYC78ixUXgz5TW/wE7lNaNKlplSYTxQ+fR2KZ0EA==";
       };
     };
     "limiter-1.1.5" = {
@@ -3943,7 +3961,7 @@ let
       version = "4.5.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz";
-        sha1 = "e23f3f9c4f8fbdde872529c1071857a086e5ccef";
+        sha512 = "H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==";
       };
     };
     "lodash.defaults-4.2.0" = {
@@ -3952,7 +3970,7 @@ let
       version = "4.2.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz";
-        sha1 = "d09178716ffea4dde9e5fb7b37f6f0802274580c";
+        sha512 = "qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==";
       };
     };
     "lodash.flatten-4.4.0" = {
@@ -3961,7 +3979,7 @@ let
       version = "4.4.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz";
-        sha1 = "f31c22225a9632d2bbf8e4addbef240aa765a61f";
+        sha512 = "C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==";
       };
     };
     "lodash.get-4.4.2" = {
@@ -3970,7 +3988,7 @@ let
       version = "4.4.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz";
-        sha1 = "2d177f652fa31e939b4438d5341499dfa3825e99";
+        sha512 = "z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==";
       };
     };
     "lodash.includes-4.3.0" = {
@@ -3979,7 +3997,7 @@ let
       version = "4.3.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz";
-        sha1 = "60bb98a87cb923c68ca1e51325483314849f553f";
+        sha512 = "W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==";
       };
     };
     "lodash.isarguments-3.1.0" = {
@@ -3988,7 +4006,7 @@ let
       version = "3.1.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz";
-        sha1 = "2f573d85c6a24289ff00663b491c1d338ff3458a";
+        sha512 = "chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==";
       };
     };
     "lodash.isboolean-3.0.3" = {
@@ -3997,7 +4015,7 @@ let
       version = "3.0.3";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz";
-        sha1 = "6c2e171db2a257cd96802fd43b01b20d5f5870f6";
+        sha512 = "Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==";
       };
     };
     "lodash.isequal-4.5.0" = {
@@ -4006,7 +4024,7 @@ let
       version = "4.5.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz";
-        sha1 = "415c4478f2bcc30120c22ce10ed3226f7d3e18e0";
+        sha512 = "pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==";
       };
     };
     "lodash.isinteger-4.0.4" = {
@@ -4015,7 +4033,7 @@ let
       version = "4.0.4";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz";
-        sha1 = "619c0af3d03f8b04c31f5882840b77b11cd68343";
+        sha512 = "DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==";
       };
     };
     "lodash.isnumber-3.0.3" = {
@@ -4024,7 +4042,7 @@ let
       version = "3.0.3";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz";
-        sha1 = "3ce76810c5928d03352301ac287317f11c0b1ffc";
+        sha512 = "QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==";
       };
     };
     "lodash.isplainobject-4.0.6" = {
@@ -4033,7 +4051,7 @@ let
       version = "4.0.6";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz";
-        sha1 = "7c526a52d89b45c45cc690b88163be0497f550cb";
+        sha512 = "oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==";
       };
     };
     "lodash.isstring-4.0.1" = {
@@ -4042,7 +4060,7 @@ let
       version = "4.0.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz";
-        sha1 = "d527dfb5456eca7cc9bb95d5daeaf88ba54a5451";
+        sha512 = "0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==";
       };
     };
     "lodash.merge-4.6.2" = {
@@ -4060,7 +4078,7 @@ let
       version = "4.1.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz";
-        sha1 = "0dd3971213c7c56df880977d504c88fb471a97ac";
+        sha512 = "Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==";
       };
     };
     "lodash.set-4.3.2" = {
@@ -4069,7 +4087,7 @@ let
       version = "4.3.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz";
-        sha1 = "d8757b1da807dde24816b0d6a84bea1a76230b23";
+        sha512 = "4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==";
       };
     };
     "lodash.throttle-4.1.1" = {
@@ -4078,7 +4096,7 @@ let
       version = "4.1.1";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz";
-        sha1 = "c23e91b710242ac70c37f1e1cda9274cc39bf2f4";
+        sha512 = "wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==";
       };
     };
     "lodash.uniqby-4.7.0" = {
@@ -4087,7 +4105,7 @@ let
       version = "4.7.0";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz";
-        sha1 = "d99c07a669e9e6d24e1362dfe266c67616af1302";
+        sha512 = "e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==";
       };
     };
     "lodash.unset-4.5.2" = {
@@ -4096,7 +4114,7 @@ let
       version = "4.5.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz";
-        sha1 = "370d1d3e85b72a7e1b0cdf2d272121306f23e4ed";
+        sha512 = "bwKX88k2JhCV9D1vtE8+naDKlLiGrSmf8zi/Y9ivFHwbmRfA8RxS/aVJ+sIht2XOwqoNr4xUPUkGZpc1sHFEKg==";
       };
     };
     "logform-2.4.0" = {
@@ -4141,7 +4159,7 @@ let
       version = "4.0.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz";
-        sha1 = "1d17679c069cda5d040991a09dbc2c0db377e55e";
+        sha512 = "uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==";
       };
     };
     "lru-cache-4.1.5" = {
@@ -4531,49 +4549,49 @@ let
         sha512 = "z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==";
       };
     };
-    "n8n-core-0.117.0" = {
+    "n8n-core-0.119.0" = {
       name = "n8n-core";
       packageName = "n8n-core";
-      version = "0.117.0";
+      version = "0.119.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/n8n-core/-/n8n-core-0.117.0.tgz";
-        sha512 = "GEU8qBS/Gt+2FHNNb8txDkerzG7vlfDdeiy56lPF+oZJyEZzqgSJ8fNRUcv2b2kd5XjU9zTDcmjARclDC6SNmA==";
+        url = "https://registry.npmjs.org/n8n-core/-/n8n-core-0.119.0.tgz";
+        sha512 = "NdjFdQTIm8yn7UHV3DxA8xXceYBIWNGL58UVUfHws4BtxEO6EoAHmOpyIgTgE4FNmfna+/Bo2NNPruM9sG1UIw==";
       };
     };
-    "n8n-design-system-0.20.0" = {
+    "n8n-design-system-0.22.0" = {
       name = "n8n-design-system";
       packageName = "n8n-design-system";
-      version = "0.20.0";
+      version = "0.22.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/n8n-design-system/-/n8n-design-system-0.20.0.tgz";
-        sha512 = "uqcrm+fRtTd7A6+ai48GFcjpU4nIV+UmPld8p/8hoUpwCY265AojGaSKCWHzt8TceLCJXx5rlmLliE+v69d/sA==";
+        url = "https://registry.npmjs.org/n8n-design-system/-/n8n-design-system-0.22.0.tgz";
+        sha512 = "z6Vgtzvz0zxCVKGMym7sU5bgcaRhBSGaTT8ibJgblkQYNFRbSQjLjEki+Igc1SXSD8MopZoDRP9AkbMZRjJv/g==";
       };
     };
-    "n8n-editor-ui-0.143.0" = {
+    "n8n-editor-ui-0.145.0" = {
       name = "n8n-editor-ui";
       packageName = "n8n-editor-ui";
-      version = "0.143.0";
+      version = "0.145.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-0.143.0.tgz";
-        sha512 = "deb5c30jpLw4YKetmTeLNIyki7td2R24uVzsZ3BDGElybR+0DaJbMBRIZ6+bjq8IS750gaTeumKrH8ZBq9BSkg==";
+        url = "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-0.145.0.tgz";
+        sha512 = "+EMtb2yEvfmN8oSQBevrPEKssqX4jyblMRajixVsUn43XMXLt8N+94by2TsaEakWCqxFbOOq1MGBNX+0dSvNGA==";
       };
     };
-    "n8n-nodes-base-0.175.0" = {
+    "n8n-nodes-base-0.177.0" = {
       name = "n8n-nodes-base";
       packageName = "n8n-nodes-base";
-      version = "0.175.0";
+      version = "0.177.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-0.175.0.tgz";
-        sha512 = "KfyEbhK4T0sULZ75jcjU0U1IqXm/MNzL7GpRhBjDumDE1WRfpKSBdtYGFsHCbUEXroHnJjF2/L+ADJ9CV0g5MQ==";
+        url = "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-0.177.0.tgz";
+        sha512 = "Q+MBYjsqF/WdfGlMwlS6se9cJsuD3OHPVGI4GhBPlVPeb/L/WYga9V7jV5HKf/27HZD1uGxqL8O4Gkwerx9gFw==";
       };
     };
-    "n8n-workflow-0.99.0" = {
+    "n8n-workflow-0.101.0" = {
       name = "n8n-workflow";
       packageName = "n8n-workflow";
-      version = "0.99.0";
+      version = "0.101.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-0.99.0.tgz";
-        sha512 = "JVZQnncjVphY73jcPY2oW4fZ0WoKDDwC1Xzf509KAu362psOJ5Xrz4mAJwuj7Qv1H88UGhEOojvt/5gbRLi4zA==";
+        url = "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-0.101.0.tgz";
+        sha512 = "kl/ODNZcE/sDSWXlBj2QN304G+FLG7PZy9JNHX36/DrRDkxTjQ+KIRCIUR3lEfXLp1RGrcH2GJ5qt0WwV4bW9g==";
       };
     };
     "named-placeholders-1.1.2" = {
@@ -4774,13 +4792,13 @@ let
         sha512 = "AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==";
       };
     };
-    "nth-check-2.0.1" = {
+    "nth-check-2.1.1" = {
       name = "nth-check";
       packageName = "nth-check";
-      version = "2.0.1";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz";
-        sha512 = "it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==";
+        url = "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz";
+        sha512 = "lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==";
       };
     };
     "oauth-1.0a-2.2.6" = {
@@ -4810,13 +4828,13 @@ let
         sha1 = "2109adc7965887cfc05cbbd442cac8bfbb360863";
       };
     };
-    "object-inspect-1.12.0" = {
+    "object-inspect-1.12.2" = {
       name = "object-inspect";
       packageName = "object-inspect";
-      version = "1.12.0";
+      version = "1.12.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz";
-        sha512 = "Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==";
+        url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz";
+        sha512 = "z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==";
       };
     };
     "object-keys-1.1.1" = {
@@ -4837,13 +4855,13 @@ let
         sha512 = "ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==";
       };
     };
-    "object.getownpropertydescriptors-2.1.3" = {
+    "object.getownpropertydescriptors-2.1.4" = {
       name = "object.getownpropertydescriptors";
       packageName = "object.getownpropertydescriptors";
-      version = "2.1.3";
+      version = "2.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz";
-        sha512 = "VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==";
+        url = "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.4.tgz";
+        sha512 = "sccv3L/pMModT6dJAYF3fzGMVcb38ysQ0tEE6ixv2yXJDtEIPph268OlAdJj5/qZMZDq2g/jqvwppt36uS/uQQ==";
       };
     };
     "on-finished-2.4.1" = {
@@ -5368,13 +5386,13 @@ let
         sha512 = "epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==";
       };
     };
-    "postcss-8.4.13" = {
+    "postcss-8.4.14" = {
       name = "postcss";
       packageName = "postcss";
-      version = "8.4.13";
+      version = "8.4.14";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz";
-        sha512 = "jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==";
+        url = "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz";
+        sha512 = "E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==";
       };
     };
     "postgres-array-2.0.0" = {
@@ -6322,13 +6340,13 @@ let
         sha512 = "LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==";
       };
     };
-    "snowflake-sdk-1.6.9" = {
+    "snowflake-sdk-1.6.10" = {
       name = "snowflake-sdk";
       packageName = "snowflake-sdk";
-      version = "1.6.9";
+      version = "1.6.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snowflake-sdk/-/snowflake-sdk-1.6.9.tgz";
-        sha512 = "Rt16zh5t++mZH+CXUBq3sYUUaEQnEMKT86mFtzfgIUk8MnZFJ4qBOwdheSWYU7OI9QnLqLmy8nZN40o9CFgm5A==";
+        url = "https://registry.npmjs.org/snowflake-sdk/-/snowflake-sdk-1.6.10.tgz";
+        sha512 = "kguQQSGhmNqZfmN/yZNDaIaMMktTcrTYBjtyx+szJzV69b5F+5b77btpYp+bCFqao69otVM+IPUtb3sugvCVnQ==";
       };
     };
     "source-map-0.6.1" = {
@@ -6628,13 +6646,13 @@ let
         sha512 = "PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g==";
       };
     };
-    "tdigest-0.1.1" = {
+    "tdigest-0.1.2" = {
       name = "tdigest";
       packageName = "tdigest";
-      version = "0.1.1";
+      version = "0.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz";
-        sha1 = "2e3cb2c39ea449e55d1e6cd91117accca4588021";
+        url = "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz";
+        sha512 = "+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==";
       };
     };
     "tedious-6.7.1" = {
@@ -7393,13 +7411,13 @@ let
         sha1 = "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f";
       };
     };
-    "ws-7.5.7" = {
+    "ws-7.5.8" = {
       name = "ws";
       packageName = "ws";
-      version = "7.5.7";
+      version = "7.5.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz";
-        sha512 = "KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==";
+        url = "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz";
+        sha512 = "ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==";
       };
     };
     "xlsx-0.17.5" = {
@@ -7561,10 +7579,10 @@ in
   n8n = nodeEnv.buildNodePackage {
     name = "n8n";
     packageName = "n8n";
-    version = "0.177.0";
+    version = "0.179.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/n8n/-/n8n-0.177.0.tgz";
-      sha512 = "13x/zsHa64Dw/0BhjmlZEGvABJxkZeKTG0oKXzRf1Vq/zoctxofapx188ccJzYQ+tZnOHdX0arjf2baQDTNIGw==";
+      url = "https://registry.npmjs.org/n8n/-/n8n-0.179.0.tgz";
+      sha512 = "S6AtNNN3c5rWpPPs1iK23j9eeg2rF8RxuumKtE302ed6m3c0iEIMlZpVWFTJCfE+vi13drBUwffd89C2McVhUA==";
     };
     dependencies = [
       (sources."@azure/abort-controller-1.1.0" // {
@@ -7572,7 +7590,6 @@ in
           sources."tslib-2.4.0"
         ];
       })
-      sources."@azure/core-asynciterator-polyfill-1.0.2"
       (sources."@azure/core-auth-1.3.2" // {
         dependencies = [
           sources."tslib-2.4.0"
@@ -7589,7 +7606,7 @@ in
           sources."tslib-2.4.0"
         ];
       })
-      (sources."@azure/core-paging-1.2.1" // {
+      (sources."@azure/core-paging-1.3.0" // {
         dependencies = [
           sources."tslib-2.4.0"
         ];
@@ -7616,7 +7633,7 @@ in
           sources."tslib-2.4.0"
         ];
       })
-      sources."@babel/runtime-7.17.9"
+      sources."@babel/runtime-7.18.3"
       sources."@colors/colors-1.5.0"
       (sources."@dabh/diagnostics-2.0.3" // {
         dependencies = [
@@ -7685,7 +7702,7 @@ in
       sources."@types/lodash-4.14.182"
       sources."@types/lossless-json-1.0.1"
       sources."@types/mime-1.3.2"
-      sources."@types/node-17.0.33"
+      sources."@types/node-17.0.36"
       (sources."@types/node-fetch-2.6.1" // {
         dependencies = [
           sources."form-data-3.0.1"
@@ -7697,7 +7714,7 @@ in
       sources."@types/range-parser-1.2.4"
       sources."@types/readable-stream-2.3.13"
       sources."@types/serve-static-1.13.10"
-      sources."@types/snowflake-sdk-1.6.4"
+      sources."@types/snowflake-sdk-1.6.6"
       sources."@types/tough-cookie-2.3.8"
       sources."@types/tunnel-0.0.3"
       sources."@xmldom/xmldom-0.7.5"
@@ -7738,6 +7755,7 @@ in
       sources."array-parallel-0.1.3"
       sources."array-series-0.1.5"
       sources."array-union-2.1.0"
+      sources."array.prototype.reduce-1.0.4"
       sources."asn1-0.2.6"
       sources."asn1.js-5.4.1"
       sources."asn1.js-rfc2560-5.0.1"
@@ -7753,7 +7771,7 @@ in
         ];
       })
       sources."avsc-5.7.4"
-      (sources."aws-sdk-2.1135.0" // {
+      (sources."aws-sdk-2.1145.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."events-1.1.1"
@@ -7789,7 +7807,7 @@ in
       sources."bignumber.js-2.4.0"
       sources."binary-extensions-2.2.0"
       sources."binascii-0.0.2"
-      sources."bintrees-1.0.1"
+      sources."bintrees-1.0.2"
       (sources."bitsyntax-0.1.0" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -7930,7 +7948,7 @@ in
       sources."cookie-0.4.1"
       sources."cookie-parser-1.4.6"
       sources."cookie-signature-1.0.6"
-      sources."core-js-3.22.5"
+      sources."core-js-3.22.7"
       sources."core-util-is-1.0.2"
       sources."crc-32-1.2.2"
       sources."cron-1.7.2"
@@ -7994,7 +8012,8 @@ in
       sources."entities-2.2.0"
       sources."env-variable-0.0.6"
       sources."err-code-2.0.3"
-      sources."es-abstract-1.20.0"
+      sources."es-abstract-1.20.1"
+      sources."es-array-method-boxes-properly-1.0.0"
       sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.8.2"
       sources."escalade-3.1.1"
@@ -8040,7 +8059,7 @@ in
       })
       sources."flatted-3.2.5"
       sources."fn.name-1.1.0"
-      sources."follow-redirects-1.15.0"
+      sources."follow-redirects-1.15.1"
       sources."for-each-0.3.3"
       sources."forever-agent-0.6.1"
       sources."form-data-4.0.0"
@@ -8165,7 +8184,7 @@ in
       sources."is-windows-1.0.2"
       sources."is-wsl-2.2.0"
       sources."isarray-0.0.1"
-      sources."isbot-3.4.7"
+      sources."isbot-3.5.0"
       sources."isexe-2.0.0"
       sources."iso-639-1-2.1.13"
       sources."isstream-0.1.2"
@@ -8198,7 +8217,7 @@ in
           sources."iconv-lite-0.6.3"
         ];
       })
-      sources."libphonenumber-js-1.9.53"
+      sources."libphonenumber-js-1.10.6"
       sources."libqp-1.1.0"
       sources."limiter-1.1.5"
       sources."linkify-it-4.0.0"
@@ -8310,15 +8329,15 @@ in
         ];
       })
       sources."mz-2.7.0"
-      sources."n8n-core-0.117.0"
-      sources."n8n-design-system-0.20.0"
-      sources."n8n-editor-ui-0.143.0"
-      (sources."n8n-nodes-base-0.175.0" // {
+      sources."n8n-core-0.119.0"
+      sources."n8n-design-system-0.22.0"
+      sources."n8n-editor-ui-0.145.0"
+      (sources."n8n-nodes-base-0.177.0" // {
         dependencies = [
           sources."iconv-lite-0.6.3"
         ];
       })
-      sources."n8n-workflow-0.99.0"
+      sources."n8n-workflow-0.101.0"
       (sources."named-placeholders-1.1.2" // {
         dependencies = [
           sources."lru-cache-4.1.5"
@@ -8352,14 +8371,14 @@ in
       sources."normalize-path-3.0.0"
       sources."normalize-wheel-1.0.1"
       sources."npmlog-5.0.1"
-      sources."nth-check-2.0.1"
+      sources."nth-check-2.1.1"
       sources."oauth-1.0a-2.2.6"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
-      sources."object-inspect-1.12.0"
+      sources."object-inspect-1.12.2"
       sources."object-keys-1.1.1"
       sources."object.assign-4.1.2"
-      sources."object.getownpropertydescriptors-2.1.3"
+      sources."object.getownpropertydescriptors-2.1.4"
       sources."on-finished-2.4.1"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -8447,7 +8466,7 @@ in
       sources."popsicle-transport-http-1.2.1"
       sources."popsicle-transport-xhr-2.0.0"
       sources."popsicle-user-agent-1.0.0"
-      sources."postcss-8.4.13"
+      sources."postcss-8.4.14"
       sources."postgres-array-2.0.0"
       sources."postgres-bytea-1.0.0"
       sources."postgres-date-1.0.7"
@@ -8576,7 +8595,7 @@ in
       sources."shell-escape-0.2.0"
       (sources."showdown-2.1.0" // {
         dependencies = [
-          sources."commander-9.2.0"
+          sources."commander-9.3.0"
         ];
       })
       sources."side-channel-1.0.4"
@@ -8590,8 +8609,9 @@ in
           sources."tslib-2.4.0"
         ];
       })
-      (sources."snowflake-sdk-1.6.9" // {
+      (sources."snowflake-sdk-1.6.10" // {
         dependencies = [
+          sources."axios-0.27.2"
           sources."debug-3.2.7"
           sources."tmp-0.2.1"
           sources."uuid-3.4.0"
@@ -8629,7 +8649,7 @@ in
       sources."supports-color-7.2.0"
       sources."tar-6.1.11"
       sources."tarn-1.1.5"
-      sources."tdigest-0.1.1"
+      sources."tdigest-0.1.2"
       (sources."tedious-6.7.1" // {
         dependencies = [
           sources."@types/node-12.20.52"
@@ -8761,7 +8781,7 @@ in
       sources."wordwrap-1.0.0"
       sources."wrap-ansi-6.2.0"
       sources."wrappy-1.0.2"
-      sources."ws-7.5.7"
+      sources."ws-7.5.8"
       sources."xlsx-0.17.5"
       sources."xml2js-0.4.23"
       sources."xmlbuilder-11.0.1"


### PR DESCRIPTION
###### Description of changes

Some more features, some more fixes.

https://github.com/n8n-io/n8n/blob/master/CHANGELOG.md#01790-2022-05-30

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
