### PR TITLE
python310Packages.pyramid_chameleon: fix compatibility with pyramid 2

### DIFF
--- a/pkgs/development/python-modules/pyramid_chameleon/default.nix
+++ b/pkgs/development/python-modules/pyramid_chameleon/default.nix
@@ -1,29 +1,49 @@
 { lib
 , buildPythonPackage
-, fetchPypi
 , chameleon
+, fetchpatch
+, fetchPypi
 , pyramid
-, zope_interface
+, pytestCheckHook
 , setuptools
+, zope_interface
 }:
 
 buildPythonPackage rec {
-  pname = "pyramid_chameleon";
+  pname = "pyramid-chameleon";
   version = "0.3";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "d176792a50eb015d7865b44bd9b24a7bd0489fa9a5cebbd17b9e05048cef9017";
+    pname = "pyramid_chameleon";
+    inherit version;
+    sha256 = "sha256-0XZ5KlDrAV14ZbRL2bJKe9BIn6mlzrvRe54FBIzvkBc=";
   };
 
   patches = [
     # https://github.com/Pylons/pyramid_chameleon/pull/25
     ./test-renderers-pyramid-import.patch
+    # Compatibility with pyramid 2, https://github.com/Pylons/pyramid_chameleon/pull/34
+    (fetchpatch {
+      name = "support-later-limiter.patch";
+      url = "https://github.com/Pylons/pyramid_chameleon/commit/36348bf4c01f52c3461e7ba4d20b1edfc54dba50.patch";
+      sha256 = "sha256-cPS7JhcS8nkBS1T0OdZke25jvWHT0qkPFjyPUDKHBGU=";
+    })
   ];
 
-  propagatedBuildInputs = [ chameleon pyramid zope_interface setuptools ];
+  propagatedBuildInputs = [
+    chameleon
+    pyramid
+    setuptools
+    zope_interface
+  ];
 
-  pythonImportsCheck = [ "pyramid_chameleon" ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyramid_chameleon"
+  ];
 
   meta = with lib; {
     description = "Chameleon template compiler for pyramid";


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/178211193)

ZHF: #172160

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
