### PR TITLE
virtualbox: 6.1.30 -> 6.1.34

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -23,14 +23,14 @@ let
   buildType = "release";
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
   # change the hashes in extpack.nix and guest-additions/default.nix as well manually.
-  version = "6.1.30";
+  version = "6.1.34";
 in stdenv.mkDerivation {
   pname = "virtualbox";
   inherit version;
 
   src = fetchurl {
     url = "https://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "3c60a29375549ffc148aaebe859be91b27c19d6fa2deefde1373c4f6da8f18ef";
+    sha256 = "9c3ce1829432e5b8374f950698587038f45fb0492147dc200e59edb9bb75eb49";
   };
 
   outputs = [ "out" "modsrc" ];
@@ -97,6 +97,11 @@ in stdenv.mkDerivation {
     ./qtx11extras.patch
     # https://github.com/NixOS/nixpkgs/issues/123851
     ./fix-audio-driver-loading.patch
+    # NOTE: both patches below should be removed when updating to 6.1.35
+    # https://www.virtualbox.org/ticket/20914#comment:6
+    ./linux518.patch
+    # https://www.virtualbox.org/ticket/20904#comment:22
+    ./ffreestanding.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -12,7 +12,7 @@ fetchurl rec {
     # Manually sha256sum the extensionPack file, must be hex!
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
     # Checksums can also be found at https://www.virtualbox.org/download/hashes/${version}/SHA256SUMS
-    let value = "a5ee3e693a0470a77735556a77a09aa83bfc48181998b9b21b1af82ef1d11c2a";
+    let value = "d7856f0688b6d2ed1e8bff0b367efa952068b03fa5a3a29b46db08cfd5d9a810";
     in assert (builtins.stringLength value) == 64; value;
 
   meta = {

--- a/pkgs/applications/virtualization/virtualbox/ffreestanding.patch
+++ b/pkgs/applications/virtualization/virtualbox/ffreestanding.patch
@@ -1,0 +1,20 @@
+diff --git a/Config.kmk b/Config.kmk
+index 3df197404..4c6bd76bb 100644
+--- a/Config.kmk
++++ b/Config.kmk
+@@ -4503,11 +4504,14 @@ ifeq ($(VBOX_LDR_FMT),elf)
+ TEMPLATE_VBoxR0_TOOL                = $(VBOX_GCC_TOOL)
+ TEMPLATE_VBoxR0_CFLAGS              = -fno-pie -nostdinc -g $(VBOX_GCC_pipe) $(VBOX_GCC_WERR) $(VBOX_GCC_PEDANTIC_C) \
+ 	$(VBOX_GCC_Wno-variadic-macros) $(VBOX_GCC_R0_OPT) $(VBOX_GCC_R0_FP) -fno-strict-aliasing -fno-exceptions \
+-	$(VBOX_GCC_fno-stack-protector) -fno-common $(VBOX_GCC_fvisibility-hidden) -std=gnu99 $(VBOX_GCC_IPRT_FMT_CHECK)
++	$(VBOX_GCC_fno-stack-protector) -fno-common -ffreestanding $(VBOX_GCC_fvisibility-hidden) -std=gnu99 $(VBOX_GCC_IPRT_FMT_CHECK)
+ TEMPLATE_VBoxR0_CXXFLAGS            = -fno-pie -nostdinc -g $(VBOX_GCC_pipe) $(VBOX_GCC_WERR) $(VBOX_GCC_PEDANTIC_CXX) \
+ 	$(VBOX_GCC_Wno-variadic-macros) $(VBOX_GCC_R0_OPT) $(VBOX_GCC_R0_FP) -fno-strict-aliasing -fno-exceptions \
+ 	$(VBOX_GCC_fno-stack-protector) -fno-common $(VBOX_GCC_fvisibility-inlines-hidden) $(VBOX_GCC_fvisibility-hidden) \
+ 	-fno-rtti $(VBOX_GCC_IPRT_FMT_CHECK)
++ if $(VBOX_GCC_VERSION_CC) >= 40500 # 4.1.2 complains, 4.5.2 is okay, didn't check which version inbetween made it okay with g++.
++TEMPLATE_VBoxR0_CXXFLAGS           += -ffreestanding
++ endif
+ TEMPLATE_VBoxR0_CFLAGS.amd64        = -m64 -mno-red-zone -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fasynchronous-unwind-tables -ffreestanding
+ TEMPLATE_VBoxR0_CXXFLAGS.amd64      = -m64 -mno-red-zone -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fasynchronous-unwind-tables
+ TEMPLATE_VBoxR0_CXXFLAGS.freebsd    = -ffreestanding

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "d324d2d09d8dd00b1eb3ef3d80ab2e1726998421d13adc0d2a90e05d355aaa5c";
+    sha256 = "88f86fa0e6970b6a7c80d714b7a91a8c425ff8ef53a3e73fc80781191a87257b";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/applications/virtualization/virtualbox/linux518.patch
+++ b/pkgs/applications/virtualization/virtualbox/linux518.patch
@@ -1,0 +1,285 @@
+Index: include/VBox/sup.h
+===================================================================
+--- trunk/include/VBox/sup.h	(revision 151556)
++++ trunk/include/VBox/sup.h	(working copy)
+@@ -2142,6 +2142,26 @@
+  */
+ SUPR0DECL(uint32_t) SUPR0GetKernelFeatures(void);
+ 
++/**
++ * Notification from R0 VMM prior to loading the guest-FPU register state.
++ *
++ * @returns Whether the host-FPU register state has been saved by the host kernel.
++ * @param   fCtxHook    Whether thread-context hooks are enabled.
++ *
++ * @remarks Called with preemption disabled.
++ */
++SUPR0DECL(bool) SUPR0FpuBegin(bool fCtxHook);
++
++/**
++ * Notification from R0 VMM prior to saving the guest-FPU register state (and
++ * potentially restoring the host-FPU register state) in ring-0.
++ *
++ * @param   fCtxHook    Whether thread-context hooks are enabled.
++ *
++ * @remarks Called with preemption disabled.
++ */
++SUPR0DECL(void) SUPR0FpuEnd(bool fCtxHook);
++
+ /** @copydoc RTLogGetDefaultInstanceEx
+  * @remarks To allow overriding RTLogGetDefaultInstanceEx locally. */
+ SUPR0DECL(struct RTLOGGER *) SUPR0GetDefaultLogInstanceEx(uint32_t fFlagsAndGroup);
+Index: src/VBox/Additions/linux/sharedfolders/regops.c
+===================================================================
+--- trunk/src/VBox/Additions/linux/sharedfolders/regops.c	(revision 151556)
++++ trunk/src/VBox/Additions/linux/sharedfolders/regops.c	(working copy)
+@@ -3823,7 +3823,9 @@
+     .readpage       = vbsf_readpage,
+     .writepage      = vbsf_writepage,
+     /** @todo Need .writepages if we want msync performance...  */
+-#if RTLNX_VER_MIN(2,5,12)
++#if RTLNX_VER_MIN(5,18,0)
++    .dirty_folio = filemap_dirty_folio,
++#elif RTLNX_VER_MIN(2,5,12)
+     .set_page_dirty = __set_page_dirty_buffers,
+ #endif
+ #if RTLNX_VER_MIN(5,14,0)
+Index: src/VBox/Additions
+===================================================================
+--- trunk/src/VBox/Additions	(revision 151556)
++++ trunk/src/VBox/Additions	(working copy)
+
+Property changes on: src/VBox/Additions
+___________________________________________________________________
+Modified: svn:mergeinfo
+## -0,0 +0,1 ##
+   Merged /trunk/src/VBox/Additions:r150844
+Index: src/VBox/HostDrivers/Support/SUPDrv.cpp
+===================================================================
+--- trunk/src/VBox/HostDrivers/Support/SUPDrv.cpp	(revision 151556)
++++ trunk/src/VBox/HostDrivers/Support/SUPDrv.cpp	(working copy)
+@@ -98,6 +98,18 @@
+ # endif
+ #endif
+ 
++#if defined(RT_OS_LINUX) && !defined(__NO_FORTIFY) && defined(__OPTIMIZE__) && defined(CONFIG_FORTIFY_SOURCE)
++/* In Linux 5.18-rc1, memcpy became a wrapper which does fortify checks
++ * before triggering __underlying_memcpy() call. We do not pass these checks here,
++ * so bypass them for now.  */
++# if RTLNX_VER_MIN(5,18,0)
++#  define SUPDRV_MEMCPY __underlying_memcpy
++# else
++# define SUPDRV_MEMCPY  memcpy
++# endif
++#else
++# define SUPDRV_MEMCPY  memcpy
++#endif
+ 
+ /*
+  * Logging assignments:
+@@ -266,6 +278,8 @@
+     SUPEXP_STK_BACK(    2,  SUPR0ContFree),
+     SUPEXP_STK_BACK(    2,  SUPR0ChangeCR4),
+     SUPEXP_STK_BACK(    1,  SUPR0EnableVTx),
++    SUPEXP_STK_OKAY(    1,  SUPR0FpuBegin),
++    SUPEXP_STK_OKAY(    1,  SUPR0FpuEnd),
+     SUPEXP_STK_BACK(    0,  SUPR0SuspendVTxOnCpu),
+     SUPEXP_STK_BACK(    1,  SUPR0ResumeVTxOnCpu),
+     SUPEXP_STK_OKAY(    1,  SUPR0GetCurrentGdtRw),
+@@ -1742,7 +1756,7 @@
+ 
+             /* execute */
+             pReq->u.Out.cFunctions = RT_ELEMENTS(g_aFunctions);
+-            memcpy(&pReq->u.Out.aFunctions[0], g_aFunctions, sizeof(g_aFunctions));
++            SUPDRV_MEMCPY(&pReq->u.Out.aFunctions[0], g_aFunctions, sizeof(g_aFunctions));
+             pReq->Hdr.rc = VINF_SUCCESS;
+             return 0;
+         }
+Index: src/VBox/HostDrivers/Support/darwin/SUPDrv-darwin.cpp
+===================================================================
+--- trunk/src/VBox/HostDrivers/Support/darwin/SUPDrv-darwin.cpp	(revision 151556)
++++ trunk/src/VBox/HostDrivers/Support/darwin/SUPDrv-darwin.cpp	(working copy)
+@@ -2002,6 +2002,18 @@
+ }
+ 
+ 
++SUPR0DECL(bool) SUPR0FpuBegin(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++    return false;
++}
++
++
++SUPR0DECL(void) SUPR0FpuEnd(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++}
++
+ /*
+  *
+  * org_virtualbox_SupDrv
+Index: src/VBox/HostDrivers/Support/freebsd/SUPDrv-freebsd.c
+===================================================================
+--- trunk/src/VBox/HostDrivers/Support/freebsd/SUPDrv-freebsd.c	(revision 151556)
++++ trunk/src/VBox/HostDrivers/Support/freebsd/SUPDrv-freebsd.c	(working copy)
+@@ -640,3 +640,16 @@
+     return 0;
+ }
+ 
++
++SUPR0DECL(bool) SUPR0FpuBegin(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++    return false;
++}
++
++
++SUPR0DECL(void) SUPR0FpuEnd(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++}
++
+Index: src/VBox/HostDrivers/Support/linux/SUPDrv-linux.c
+===================================================================
+--- trunk/src/VBox/HostDrivers/Support/linux/SUPDrv-linux.c	(revision 151556)
++++ trunk/src/VBox/HostDrivers/Support/linux/SUPDrv-linux.c	(working copy)
+@@ -1454,6 +1454,31 @@
+ }
+ 
+ 
++SUPR0DECL(bool) SUPR0FpuBegin(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++#if RTLNX_VER_MIN(5,18,0)
++    kernel_fpu_begin();
++    /* if (fCtxHook) */
++        preempt_enable();  /* HACK ALERT! undo the implicit preempt_disable() in kernel_fpu_begin(). */
++    return true;
++#else
++    return false;
++#endif
++}
++
++
++SUPR0DECL(void) SUPR0FpuEnd(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++#if RTLNX_VER_MIN(5,18,0)
++    /* if (fCtxHook) */
++        preempt_disable();  /* HACK ALERT! undo the implicit preempt_enable() in SUPR0FpuBegin(). */
++    kernel_fpu_end();
++#endif
++}
++
++
+ int VBOXCALL    supdrvOSGetCurrentGdtRw(RTHCUINTPTR *pGdtRw)
+ {
+ #if RTLNX_VER_MIN(4,12,0)
+Index: src/VBox/HostDrivers/Support/os2/SUPDrv-os2.cpp
+===================================================================
+--- trunk/src/VBox/HostDrivers/Support/os2/SUPDrv-os2.cpp	(revision 151556)
++++ trunk/src/VBox/HostDrivers/Support/os2/SUPDrv-os2.cpp	(working copy)
+@@ -541,3 +541,16 @@
+     return 0;
+ }
+ 
++
++SUPR0DECL(bool) SUPR0FpuBegin(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++    return false;
++}
++
++
++SUPR0DECL(void) SUPR0FpuEnd(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++}
++
+Index: src/VBox/HostDrivers/Support/solaris/SUPDrv-solaris.c
+===================================================================
+--- trunk/src/VBox/HostDrivers/Support/solaris/SUPDrv-solaris.c	(revision 151556)
++++ trunk/src/VBox/HostDrivers/Support/solaris/SUPDrv-solaris.c	(working copy)
+@@ -1309,3 +1309,16 @@
+     return 0;
+ }
+ 
++
++SUPR0DECL(bool) SUPR0FpuBegin(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++    return false;
++}
++
++
++SUPR0DECL(void) SUPR0FpuEnd(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++}
++
+Index: src/VBox/HostDrivers/Support/win/SUPDrv-win.cpp
+===================================================================
+--- trunk/src/VBox/HostDrivers/Support/win/SUPDrv-win.cpp	(revision 151556)
++++ trunk/src/VBox/HostDrivers/Support/win/SUPDrv-win.cpp	(working copy)
+@@ -2704,6 +2704,19 @@
+ }
+ 
+ 
++SUPR0DECL(bool) SUPR0FpuBegin(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++    return false;
++}
++
++
++SUPR0DECL(void) SUPR0FpuEnd(bool fCtxHook)
++{
++    RT_NOREF(fCtxHook);
++}
++
++
+ SUPR0DECL(int) SUPR0IoCtlSetupForHandle(PSUPDRVSESSION pSession, intptr_t hHandle, uint32_t fFlags, PSUPR0IOCTLCTX *ppCtx)
+ {
+     /*
+Index: src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c
+===================================================================
+--- trunk/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c	(revision 151556)
++++ trunk/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c	(working copy)
+@@ -2311,7 +2311,13 @@
+                 vboxNetFltDumpPacket(pSG, true, "host", (fDst & INTNETTRUNKDIR_WIRE) ? 0 : 1);
+                 Log6(("vboxNetFltPortOsXmit: pBuf->cb dump:\n%.*Rhxd\n", sizeof(pBuf->cb), pBuf->cb));
+                 Log6(("vboxNetFltPortOsXmit: netif_rx_ni(%p)\n", pBuf));
++#if RTLNX_VER_MIN(5,18,0)
++                local_bh_disable();
++                err = netif_rx(pBuf);
++                local_bh_enable();
++#else
+                 err = netif_rx_ni(pBuf);
++#endif
+                 if (err)
+                     rc = RTErrConvertFromErrno(err);
+             }
+Index: src/VBox/VMM/VMMR0/CPUMR0.cpp
+===================================================================
+--- trunk/src/VBox/VMM/VMMR0/CPUMR0.cpp	(revision 151556)
++++ trunk/src/VBox/VMM/VMMR0/CPUMR0.cpp	(working copy)
+@@ -440,6 +440,9 @@
+     Assert(!(pVCpu->cpum.s.fUseFlags & CPUM_USED_FPU_GUEST));
+     Assert(!(pVCpu->cpum.s.fUseFlags & CPUM_SYNC_FPU_STATE));
+ 
++    /* Notify the support driver prior to loading the guest-FPU register state. */
++    SUPR0FpuBegin(false /* unused */);
++
+     if (!pVM->cpum.s.HostFeatures.fLeakyFxSR)
+     {
+         Assert(!(pVCpu->cpum.s.fUseFlags & CPUM_USED_MANUAL_XMM_RESTORE));
+@@ -484,6 +487,9 @@
+     Assert(ASMGetCR4() & X86_CR4_OSFXSR);
+     if (pVCpu->cpum.s.fUseFlags & (CPUM_USED_FPU_GUEST | CPUM_USED_FPU_HOST))
+     {
++        /* Notify the support driver prior to loading the host-FPU register state. */
++        SUPR0FpuEnd(false /* unused */);
++
+         fSavedGuest = RT_BOOL(pVCpu->cpum.s.fUseFlags & CPUM_USED_FPU_GUEST);
+         if (!(pVCpu->cpum.s.fUseFlags & CPUM_USED_MANUAL_XMM_RESTORE))
+             cpumR0SaveGuestRestoreHostFPUState(&pVCpu->cpum.s);

--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -19,6 +19,5 @@ stdenv.mkDerivation {
 
   meta = virtualbox.meta // {
     description = virtualbox.meta.description + " (kernel modules)";
-    broken = kernel.kernelAtLeast "5.18";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
