### PR TITLE
pyqt6: init

### DIFF
--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -1,0 +1,158 @@
+{ lib
+, buildPythonPackage
+, python
+, isPy27
+, fetchPypi
+, pkg-config
+, dbus
+, lndir
+, dbus-python
+, sip
+, pyqt6_sip
+, pyqt-builder
+, qt6Packages
+, symlinkJoin
+, makeWrapper
+, withConnectivity ? false
+, withMultimedia ? false
+, withWebSockets ? false
+, withLocation ? false
+}:
+let
+  # FIXME: qmake no longer supports splitting outputs into various paths
+  # It also doesn't like symlinks, so the only option for now is to simply
+  # copy all dependencies under a single directory.
+  qt6Libs = with qt6Packages;
+    (symlinkJoin {
+      name = "qt6-libs";
+      paths = lib.flatten (map (x: [x.out x.dev]) [
+        qtbase
+        qtdeclarative
+        qtsvg
+        qtwebchannel
+      ]
+        ++ lib.optional withConnectivity qtconnectivity
+        ++ lib.optional withMultimedia qtmultimedia
+        ++ lib.optional withWebSockets qtwebsockets
+        ++ lib.optional withLocation qtpositioning
+    );})
+    .overrideAttrs (o: {
+      buildCommand = builtins.concatStringsSep "\n" [
+        o.buildCommand
+        ''
+         ( TMPLINKS=$(mktemp -u)
+            trap "rm -rf $TMPLINKS" EXIT
+
+            mv $out $TMPLINKS
+
+            cp --reflink=auto -rL $TMPLINKS $out
+         )
+        ''
+      ];
+    });
+
+    out = placeholder "out";
+
+in buildPythonPackage rec {
+  pname = "PyQt6";
+  version = "6.3.1";
+  format = "pyproject";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-jMbiHbr3BH0fyJfjlszZcQoS8u+XZWPa1l8GAX0sl1c=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = with qt6Packages; [
+    pkg-config
+    lndir
+    sip
+    qt6Libs
+    makeWrapper
+  ];
+
+  buildInputs = with qt6Packages; [
+    dbus
+    qt6Libs
+    pyqt-builder
+  ];
+
+  propagatedBuildInputs = [
+    dbus-python
+    pyqt6_sip
+  ];
+
+  patches = [
+    # TODO: contribute upstream
+    ./pyqt6-fix-find-dbus-python.patch
+  ];
+
+  passthru = {
+    inherit sip pyqt6_sip;
+    multimediaEnabled = withMultimedia;
+    WebSocketsEnabled = withWebSockets;
+  };
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export PYTHONPATH=$PYTHONPATH:${out}/lib/${python.libPrefix}/site-packages
+
+    sip-build --no-make \
+     --confirm-license \
+     --build-dir=dist \
+     --target-dir=${out}/lib/${python.libPrefix}/site-packages \
+     --scripts-dir=${out}/bin \
+     --no-qml-plugin
+
+    runHook postConfigure
+  '';
+
+  # Checked using pythonImportsCheck
+  doCheck = false;
+
+  buildPhase = ''
+    cd dist
+    make -j "$NIX_BUILD_CORES"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    make install -j "$NIX_BUILD_CORES"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for i in ${out}/bin/*; do
+      wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
+    done
+  '';
+
+  pythonImportsCheck = [
+    "PyQt6"
+    "PyQt6.QtCore"
+    "PyQt6.QtQml"
+    "PyQt6.QtWidgets"
+    "PyQt6.QtGui"
+  ]
+    ++ lib.optional withWebSockets "PyQt6.QtWebSockets"
+    ++ lib.optional withMultimedia "PyQt6.QtMultimedia"
+    ++ lib.optional withConnectivity "PyQt6.QtConnectivity"
+    ++ lib.optional withLocation "PyQt6.QtPositioning";
+
+  meta = with lib; {
+    description = "Python bindings for Qt6";
+    homepage    = "https://riverbankcomputing.com/";
+    license     = licenses.gpl3Only;
+    platforms   = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ nrdxp ];
+  };
+}

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , python
+, pythonPackages
 , isPy27
 , fetchPypi
 , pkg-config
@@ -97,6 +98,10 @@ in buildPythonPackage rec {
     inherit sip pyqt6_sip;
     multimediaEnabled = withMultimedia;
     WebSocketsEnabled = withWebSockets;
+
+    pyqtwebengine = qt6Packages.callPackage ../pyqtwebengine/6.x.nix {
+      inherit pythonPackages qt6Libs;
+    };
   };
 
   configurePhase = ''

--- a/pkgs/development/python-modules/pyqt/pyqt6-fix-find-dbus-python.patch
+++ b/pkgs/development/python-modules/pyqt/pyqt6-fix-find-dbus-python.patch
@@ -1,0 +1,26 @@
+From 67e4baafcb63bb016044bd8304db0bf9afdff40a Mon Sep 17 00:00:00 2001
+From: Timothy DeHerrera <tim@nrdxp.dev>
+Date: Thu, 2 Jun 2022 19:03:51 -0600
+Subject: [PATCH] [PATCH] Fix building with Nix
+
+Find dbus-python with pkg-config
+---
+ project.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/project.py b/project.py
+index 71800c4..c4875c1 100644
+--- a/project.py
++++ b/project.py
+@@ -248,7 +248,7 @@ del find_qt
+         dbus_lib_dirs = []
+         dbus_libs = []
+ 
+-        args = ['pkg-config', '--cflags-only-I', '--libs dbus-1']
++        args = ['pkg-config', '--cflags-only-I', '--libs', 'dbus-1', 'dbus-python']
+ 
+         for line in self.read_command_pipe(args, fatal=False):
+             for flag in line.strip().split():
+-- 
+2.36.0
+

--- a/pkgs/development/python-modules/pyqt/sip6.nix
+++ b/pkgs/development/python-modules/pyqt/sip6.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pyqt6-sip";
+  version = "13.4.0";
+
+  src = fetchPypi {
+    pname = "PyQt6_sip";
+    inherit version;
+    sha256 = "sha256-bYej7lhy11EbdpV9aKMhCTUsrzt6QqAdnuIAMrNQ2Xk=";
+  };
+
+  # There is no test code and the check phase fails with:
+  # > error: could not create 'PyQt6/sip.cpython-39-x86_64-linux-gnu.so': No such file or directory
+  doCheck = false;
+  pythonImportsCheck = ["PyQt6.sip"];
+
+  meta = with lib; {
+    description = "Python bindings for Qt6";
+    homepage    = "https://www.riverbankcomputing.com/software/sip/";
+    license     = licenses.gpl3Only;
+    platforms   = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ nrdxp ];
+  };
+}

--- a/pkgs/development/python-modules/pyqtwebengine/6.x.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/6.x.nix
@@ -1,0 +1,71 @@
+{ lib, pythonPackages, pkg-config
+, qtbase, qtsvg, qtwebengine, python
+, wrapQtAppsHook, qt6Libs, qtpositioning
+}:
+
+let
+  inherit (pythonPackages) buildPythonPackage python isPy27 pyqt6 enum34 sip pyqt-builder;
+  qt6Libs' = qt6Libs.overrideAttrs (o:
+    {paths = o.paths ++ lib.flatten (map (x: [x.dev x.out])[
+      qtwebengine
+      qtpositioning
+    ]);}
+  );
+in buildPythonPackage rec {
+  pname = "PyQt6_WebEngine";
+  version = "6.3.1";
+  format = "pyproject";
+
+  disabled = isPy27;
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-w9H1UntLFfRBAtYXxZsddNmvUPghYp6TNfE99H3o8Ac=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt6}/${python.sitePackages}/PyQt6/bindings\"]"
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    pkg-config
+    sip
+    qt6Libs'
+    qtwebengine
+    pyqt-builder
+  ];
+
+  buildInputs = [
+    sip
+    qt6Libs'
+    qtwebengine
+  ];
+
+  propagatedBuildInputs = [ pyqt6 ];
+
+  dontWrapQtApps = true;
+
+  # Checked using pythonImportsCheck
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "PyQt6.QtWebEngineCore"
+    "PyQt6.QtWebEngineWidgets"
+  ];
+
+  enableParallelBuilding = true;
+
+  passthru = {
+    inherit wrapQtAppsHook;
+  };
+
+  meta = with lib; {
+    description = "Python bindings for Qt6";
+    homepage    = "http://www.riverbankcomputing.co.uk";
+    license     = licenses.gpl3;
+    platforms   = lib.lists.intersectLists qtwebengine.meta.platforms platforms.mesaPlatforms;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8119,7 +8119,11 @@ in {
 
   pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix { };
 
+  pyqt6 = callPackage ../development/python-modules/pyqt/6.x.nix { };
+
   pyqt5_sip = callPackage ../development/python-modules/pyqt/sip.nix { };
+
+  pyqt6_sip = callPackage ../development/python-modules/pyqt/sip6.nix { };
 
   pyqt5_with_qtmultimedia = self.pyqt5.override {
     withMultimedia = true;


### PR DESCRIPTION
###### Description of changes

Add a package for pyqt6 which I hope to eventually use to update the webengine backend of Qutebrowser in a follow up PR. 
It is not fully working as #17045 resurfaced and the fix isn't immediately obvious, opening as draft to get some feedback.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).