### PR TITLE
[22.05] treewide: mark more packages broken

### DIFF
--- a/pkgs/applications/audio/diopser/default.nix
+++ b/pkgs/applications/audio/diopser/default.nix
@@ -67,6 +67,7 @@ in  stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "A totally original phase rotation plugin";
     homepage = "https://github.com/robbert-vdh/diopser";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/audio/faustStk/default.nix
+++ b/pkgs/applications/audio/faustStk/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     done
   '';
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     description = "The physical modeling instruments included with faust, compiled as jack standalone and lv2 instruments";
     homepage = "https://ccrma.stanford.edu/~rmichon/faustSTK/";
     license = licenses.stk;

--- a/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = true;
     description = "A chorus algorithm that maintains constant and symmetric detuning depth (in cents), regardless of modulation rate. For jack and lv2";
     homepage = "https://github.com/magnetophon/constant-detune-chorus";
     license = lib.licenses.gpl3;

--- a/pkgs/applications/audio/miniaudicle/default.nix
+++ b/pkgs/applications/audio/miniaudicle/default.nix
@@ -48,12 +48,12 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "A light-weight integrated development environment for the ChucK digital audio programming language";
     homepage = "https://audicle.cs.princeton.edu/mini/";
     downloadPage = "https://audicle.cs.princeton.edu/mini/linux/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin; # not attempted
   };
 }

--- a/pkgs/applications/audio/muso/default.nix
+++ b/pkgs/applications/audio/muso/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "1hgdzyz005244f2mh97js9ga0a6s2hcd6iydz07f1hmhsh1j2bwy";
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = true;
     description = "An automatic music sorter (based on ID3 tags)";
     homepage = "https://github.com/quebin31/muso";
     license = with licenses; [ gpl3Plus ];

--- a/pkgs/applications/audio/myxer/default.nix
+++ b/pkgs/applications/audio/myxer/default.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     description = "A modern Volume Mixer for PulseAudio";
     homepage = "https://github.com/Aurailus/Myxer";
     license = licenses.gpl3Only;

--- a/pkgs/applications/audio/non/default.nix
+++ b/pkgs/applications/audio/non/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation {
   ];
 
   meta = {
+    broken = stdenv.isx86_64;
     description = "Lightweight and lightning fast modular Digital Audio Workstation";
     homepage = "http://non.tuxfamily.org";
     license = lib.licenses.lgpl21;

--- a/pkgs/applications/audio/pianobooster/default.nix
+++ b/pkgs/applications/audio/pianobooster/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "A MIDI file player that teaches you how to play the piano";
     homepage = "https://github.com/captnfab/PianoBooster";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, python3, wrapGAppsHook, gettext, libsoup, gnome, gtk3, gdk-pixbuf, librsvg,
+{ stdenv, lib, fetchurl, python3, wrapGAppsHook, gettext, libsoup, gnome, gtk3, gdk-pixbuf, librsvg,
   tag ? "", xvfb-run, dbus, glibcLocales, glib, glib-networking, gobject-introspection, hicolor-icon-theme,
   gst_all_1, withGstPlugins ? true,
   xineBackend ? false, xine-lib,
@@ -63,6 +63,7 @@ python3.pkgs.buildPythonApplication rec {
   preFixup = lib.optionalString (kakasi != null) "gappsWrapperArgs+=(--prefix PATH : ${kakasi}/bin)";
 
   meta = with lib; {
+    broken = !withGstPlugins && stdenv.isx86_64;
     description = "GTK-based audio player written in Python, using the Mutagen tagging library";
     license = licenses.gpl2Plus;
 

--- a/pkgs/applications/blockchains/masari/default.nix
+++ b/pkgs/applications/blockchains/masari/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost miniupnpc openssl lmdb unbound readline ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "scalability-focused, untraceable, secure, and fungible cryptocurrency using the RingCT protocol";
     homepage = "https://www.getmasari.org/";
     license = licenses.bsd3;

--- a/pkgs/applications/blockchains/nano-wallet/default.nix
+++ b/pkgs/applications/blockchains/nano-wallet/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = stdenv.isx86_64;
     description = "Wallet for Nano cryptocurrency";
     homepage = "https://nano.org/en/wallet/";
     license = lib.licenses.bsd2;

--- a/pkgs/applications/blockchains/oxen/default.nix
+++ b/pkgs/applications/blockchains/oxen/default.nix
@@ -58,11 +58,11 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Private cryptocurrency based on Monero";
     homepage = "https://oxen.io/";
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = [ maintainers.viric ];
-    broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/oxen.x86_64-darwin
   };
 }

--- a/pkgs/applications/blockchains/particl-core/default.nix
+++ b/pkgs/applications/blockchains/particl-core/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = true;
     description = "Privacy-Focused Marketplace & Decentralized Application Platform";
     longDescription = ''
       An open source, decentralized privacy platform built for global person to person eCommerce.

--- a/pkgs/applications/blockchains/pivx/default.nix
+++ b/pkgs/applications/blockchains/pivx/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = true;
     description = "An open source crypto-currency focused on fast private transactions";
     longDescription = ''
       PIVX is an MIT licensed, open source, blockchain-based cryptocurrency with

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -202,7 +202,7 @@ in
     '';
 
     meta = with lib; {
-      broken = (stdenv.isLinux && stdenv.isAarch64);
+      broken = true;
       inherit description;
       homepage = "https://www.rstudio.com/";
       license = licenses.agpl3Only;

--- a/pkgs/applications/editors/textadept/11/default.nix
+++ b/pkgs/applications/editors/textadept/11/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "An extensible text editor based on Scintilla with Lua scripting. Version 11_beta";
     homepage = "http://foicica.com/textadept";
     license = licenses.mit;

--- a/pkgs/applications/graphics/djv/default.nix
+++ b/pkgs/applications/graphics/djv/default.nix
@@ -143,6 +143,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "A professional review software for VFX, animation, and film production";
     homepage = "https://darbyjohnston.github.io/DJV/";
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/fluxus/default.nix
+++ b/pkgs/applications/graphics/fluxus/default.nix
@@ -89,6 +89,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Livecoding environment for 3D graphics, sound, and games";
     license = licenses.gpl2;
     homepage = "http://www.pawfal.org/fluxus/";

--- a/pkgs/applications/misc/ericw-tools/default.nix
+++ b/pkgs/applications/misc/ericw-tools/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     homepage = "https://ericwa.github.io/ericw-tools/";
     description = "Map compile tools for Quake and Hexen 2";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/misc/gosmore/default.nix
+++ b/pkgs/applications/misc/gosmore/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   patchFlags = [ "-p1" "--binary" ]; # patch has dos style eol
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Open Street Map viewer";
     homepage = "https://sourceforge.net/projects/gosmore/";
     maintainers = with maintainers; [

--- a/pkgs/applications/misc/jigdo/default.nix
+++ b/pkgs/applications/misc/jigdo/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--without-libdb" ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Download utility that can fetch files from several sources simultaneously";
     homepage = "http://atterer.org/jigdo/";
     license = licenses.gpl2Only;

--- a/pkgs/applications/misc/ksmoothdock/default.nix
+++ b/pkgs/applications/misc/ksmoothdock/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , mkDerivation
 , fetchFromGitHub
 , fetchpatch
@@ -39,6 +40,7 @@ mkDerivation rec {
   cmakeDir = "../src";
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "A cool desktop panel for KDE Plasma 5";
     license = licenses.mit;
     homepage = "https://dangvd.github.io/ksmoothdock/";

--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -75,7 +75,7 @@ EOF
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     description = "Cross-platform open source Redis DB management tool";
     homepage = "https://redisdesktop.com/";
     license = licenses.gpl3Only;

--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     description = "A program to help prevent Repetitive Strain Injury";
     longDescription = ''
       Workrave is a program that assists in the recovery and prevention of

--- a/pkgs/applications/networking/ike/default.nix
+++ b/pkgs/applications/networking/ike/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     homepage = "https://www.shrew.net/software";
     description = "IPsec Client for FreeBSD, NetBSD and many Linux based operating systems";
     platforms = platforms.unix;

--- a/pkgs/applications/networking/p2p/retroshare/default.nix
+++ b/pkgs/applications/networking/p2p/retroshare/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, qmake, cmake, pkg-config, miniupnpc, bzip2
+{ stdenv, lib, mkDerivation, fetchFromGitHub, qmake, cmake, pkg-config, miniupnpc, bzip2
 , speex, libmicrohttpd, libxml2, libxslt, sqlcipher, rapidjson, libXScrnSaver
 , qtbase, qtx11extras, qtmultimedia, libgnome-keyring3
 }:
@@ -44,6 +44,7 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Decentralized peer to peer chat application.";
     homepage = "https://retroshare.cc/";
     license = licenses.gpl2Plus;

--- a/pkgs/applications/networking/taler/default.nix
+++ b/pkgs/applications/networking/taler/default.nix
@@ -14,7 +14,7 @@ let
       };
       enableParallelBuilding = true;
       meta = with lib; {
-        broken = (stdenv.isLinux && stdenv.isAarch64);
+        broken = true;
         description = "Anonymous, taxable payment system.";
         homepage = "https://taler.net/";
         license = licenses.agpl3Plus;

--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -82,7 +82,7 @@ mkDerivation rec {
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     description = "A mind-mapping application for KDE";
     license = licenses.mit;
     homepage = "https://waf.io/semantik.html";

--- a/pkgs/applications/radio/flwrap/default.nix
+++ b/pkgs/applications/radio/flwrap/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
+    broken = stdenv.isx86_64;
     description = "Digital modem file transfer program";
     homepage = "https://sourceforge.net/projects/fldigi/";
     license = lib.licenses.gpl3Plus;

--- a/pkgs/applications/radio/uhd/3.5.nix
+++ b/pkgs/applications/radio/uhd/3.5.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = true;
     description = "USRP Hardware Driver (for Software Defined Radio)";
     longDescription = ''
       The USRP Hardware Driver (UHD) software is the hardware driver for all

--- a/pkgs/applications/science/biology/strelka/default.nix
+++ b/pkgs/applications/science/biology/strelka/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Germline and small variant caller";
     license = licenses.gpl3;
     homepage = "https://github.com/Illumina/strelka";

--- a/pkgs/applications/science/chemistry/d-seams/default.nix
+++ b/pkgs/applications/science/chemistry/d-seams/default.nix
@@ -16,6 +16,7 @@ clangStdenv.mkDerivation rec {
   buildInputs = [ fmt rang libyamlcpp eigen catch2 boost gsl liblapack blas ];
 
   meta = with lib; {
+    broken = true;
     description =
       "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations";
     longDescription = ''

--- a/pkgs/applications/science/electronics/vhd2vl/default.nix
+++ b/pkgs/applications/science/electronics/vhd2vl/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "VHDL to Verilog converter";
     homepage = "https://github.com/ldoolitt/vhd2vl";
     license = licenses.gpl2Plus;

--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -129,6 +129,7 @@ clang_9.stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
+    broken = true;
     description = "A symbolic virtual machine built on top of LLVM";
     longDescription = ''
       KLEE is a symbolic virtual machine built on top of the LLVM compiler

--- a/pkgs/applications/science/math/cemu/default.nix
+++ b/pkgs/applications/science/math/cemu/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ luc65r ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
-    broken = stdenv.isDarwin;
+    broken = true;
   };
 }

--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -122,7 +122,8 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     # Newer cub is included with cudatoolkit now and it breaks the build.
     # https://github.com/Microsoft/CNTK/issues/3191
-    broken = cudaSupport;
+    #broken = cudaSupport;
+    broken = true;
     homepage = "https://github.com/Microsoft/CNTK";
     description = "An open source deep-learning toolkit";
     license = if onebitSGDSupport then licenses.unfreeRedistributable else licenses.mit;

--- a/pkgs/applications/science/math/getdp/default.nix
+++ b/pkgs/applications/science/math/getdp/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.optional mpiSupport "-DENABLE_MPI=1";
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "A General Environment for the Treatment of Discrete Problems";
     longDescription = ''
       GetDP is a free finite element solver using mixed elements to discretize

--- a/pkgs/applications/science/math/perseus/default.nix
+++ b/pkgs/applications/science/math/perseus/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
+    broken = stdenv.isx86_64;
     description = "The Persistent Homology Software";
     longDescription = ''
       Persistent homology - or simply, persistence - is an algebraic

--- a/pkgs/applications/science/misc/graphia/default.nix
+++ b/pkgs/applications/science/misc/graphia/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
+    broken = true;
     # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/graphia.x86_64-darwin
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "A visualisation tool for the creation and analysis of graphs.";
     homepage = "https://graphia.app";
     license = licenses.gpl3Only;

--- a/pkgs/applications/science/molecular-dynamics/dl-poly-classic/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/dl-poly-classic/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
+    broken = true;
     homepage = "https://www.ccp5.ac.uk/DL_POLY_C";
     description = "DL_POLY Classic is a general purpose molecular dynamics simulation package";
     license = licenses.bsdOriginal;

--- a/pkgs/applications/science/physics/crystfel/default.nix
+++ b/pkgs/applications/science/physics/crystfel/default.nix
@@ -207,6 +207,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = !withGui;
     description = "Data processing for serial crystallography";
     longDescription = ''
       CrystFEL is a suite of programs for processing (and simulating) Bragg diffraction data from "serial crystallography" experiments, often (but not always) performed using an X-ray Free-Electron Laser. Compared to rotation data, some of the particular characteristics of such data which call for a specialised software suite are:

--- a/pkgs/applications/terminal-emulators/contour/default.nix
+++ b/pkgs/applications/terminal-emulators/contour/default.nix
@@ -20,7 +20,7 @@ mkDerivation rec {
 
   meta = with lib; {
     # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/contour.x86_64-darwin
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = true;
     description = "Modern C++ Terminal Emulator";
     homepage = "https://github.com/christianparpart/contour";
     changelog = "https://github.com/christianparpart/contour/blob/HEAD/Changelog.md";

--- a/pkgs/applications/terminal-emulators/syncterm/default.nix
+++ b/pkgs/applications/terminal-emulators/syncterm/default.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
   runtimeDependencies = [ ncurses SDL2 ]; # Both of these are dlopen()'ed at runtime.
 
   meta = with lib; {
+    broken = true;
     # error: unsupported option '-fsanitize=safe-stack' for target 'x86_64-apple-darwin'
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     homepage = "https://syncterm.bbsdev.net/";
     description = "BBS terminal emulator";
     maintainers = with maintainers; [ embr ];

--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, which, qtbase, qtwebkit, qtscript, xlibsWrapper
+{ stdenv, lib, mkDerivation, fetchFromGitHub, which, qtbase, qtwebkit, qtscript, xlibsWrapper
 , libpulseaudio, fftwSinglePrec , lame, zlib, libGLU, libGL, alsa-lib, freetype
 , perl, pkg-config , libsamplerate, libbluray, lzo, libX11, libXv, libXrandr, libXvMC, libXinerama, libXxf86vm
 , libXmu , yasm, libuuid, taglib, libtool, autoconf, automake, file, exiv2, linuxHeaders
@@ -33,6 +33,7 @@ mkDerivation rec {
     [ "--dvb-path=${linuxHeaders}/include" ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     homepage = "https://www.mythtv.org/";
     description = "Open Source DVR";
     license = licenses.gpl2Plus;

--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -28,6 +28,7 @@ mkDerivation rec {
   ] ++ lib.optional stdenv.isDarwin CoreFoundation;
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Professional open-source NLE video editor";
     homepage = "https://www.olivevideoeditor.org/";
     downloadPage = "https://www.olivevideoeditor.org/download.php";

--- a/pkgs/applications/video/wxcam/default.nix
+++ b/pkgs/applications/video/wxcam/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "An open-source, wxGTK-based webcam app for Linux";
     longDescription = ''
     wxCam is a webcam application for linux. It supports video recording

--- a/pkgs/development/compilers/copper/default.nix
+++ b/pkgs/development/compilers/copper/default.nix
@@ -23,10 +23,10 @@ stdenv.mkDerivation rec {
     make BACKEND=elf64 install prefix=$out
   '';
   meta = with lib; {
+    broken = true;
     description = "Simple imperative language, statically typed with type inference and genericity";
     homepage = "https://tibleiz.net/copper/";
     license = licenses.bsd2;
     platforms = platforms.x86_64;
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = true;
     description = "Official reference compiler for the D language";
     homepage = "https://dlang.org/";
     # Everything is now Boost licensed, even the backend.

--- a/pkgs/development/compilers/gcl/2.6.13-pre.nix
+++ b/pkgs/development/compilers/gcl/2.6.13-pre.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "pic" "bindnow" ];
 
   meta = {
+    broken = stdenv.isx86_64;
     description = "GNU Common Lisp compiler working via GCC";
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -1,4 +1,5 @@
 { llvmPackages
+, stdenv
 , lib
 , fetchFromGitHub
 , cmake
@@ -56,6 +57,7 @@ llvmPackages.stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "C++ based language for image processing and computational photography";
     homepage = "https://halide-lang.org";
     license = licenses.mit;

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -112,6 +112,7 @@ let
     };
 
     meta = llvm_meta // {
+      broken = enablePolly;
       homepage = "https://clang.llvm.org/";
       description = "A C language family frontend for LLVM";
       longDescription = ''

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -272,6 +272,7 @@ in stdenv.mkDerivation (rec {
 
   requiredSystemFeatures = [ "big-parallel" ];
   meta = llvm_meta // {
+    broken = enablePolly;
     homepage = "https://llvm.org/";
     description = "A collection of modular and reusable compiler and toolchain technologies";
     longDescription = ''

--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation {
   doCheck = false;
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "MIT/GNU Scheme, a native code Scheme compiler";
 
     longDescription =

--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -80,6 +80,7 @@ in stdenv.mkDerivation rec {
   ];
 
   meta = {
+    broken = true;
     description = "An open source implementation of Oz 3";
     maintainers = [ lib.maintainers.layus ];
     license = lib.licenses.bsd2;

--- a/pkgs/development/compilers/mrustc/bootstrap.nix
+++ b/pkgs/development/compilers/mrustc/bootstrap.nix
@@ -138,6 +138,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     inherit (src.meta) homepage;
     description = "A minimal build of Rust";
     longDescription = ''

--- a/pkgs/development/compilers/obliv-c/default.nix
+++ b/pkgs/development/compilers/obliv-c/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = true;
     description = "A GCC wrapper that makes it easy to embed secure computation protocols inside regular C programs";
     license = lib.licenses.bsd3;
     maintainers = [lib.maintainers.raskin];

--- a/pkgs/development/embedded/xc3sprog/default.nix
+++ b/pkgs/development/embedded/xc3sprog/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libusb-compat-0_1 libftdi ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Command-line tools for programming FPGAs, microcontrollers and PROMs via JTAG";
     homepage = "http://xc3sprog.sourceforge.net/";
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/cxxtools/default.nix
+++ b/pkgs/development/libraries/cxxtools/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
+    broken = stdenv.isx86_64;
     homepage = "http://www.tntnet.org/cxxtools.html";
     description = "Comprehensive C++ class library for Unix and Linux";
     platforms = lib.platforms.linux ;

--- a/pkgs/development/libraries/gsmlib/default.nix
+++ b/pkgs/development/libraries/gsmlib/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [ autoreconfHook ];
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Library to access GSM mobile phones through GSM modems";
     homepage = "https://github.com/x-logLT/gsmlib";
     license = licenses.lgpl2;

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "C++ interface for GStreamer";
     homepage = "https://gstreamer.freedesktop.org/bindings/cplusplus.html";
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/hotpatch/default.nix
+++ b/pkgs/development/libraries/hotpatch/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Hot patching executables on Linux using .so file injection";
     homepage = src.meta.homepage;
     license = licenses.bsd3;

--- a/pkgs/development/libraries/iqueue/default.nix
+++ b/pkgs/development/libraries/iqueue/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libbsd microsoft_gsl ];
 
   meta = with lib; {
+    broken = true;
     homepage = "https://github.com/twosigma/iqueue";
     description = "Indexed queue";
     license = licenses.asl20;

--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   outputDoc = "dev";
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "C++ dynamic ndarray library, with Python exposure";
     homepage = "http://libdynd.org";
     license = licenses.bsd2;

--- a/pkgs/development/libraries/libpointmatcher/default.nix
+++ b/pkgs/development/libraries/libpointmatcher/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     inherit (src.meta) homepage;
     description = "An \"Iterative Closest Point\" library for 2-D/3-D mapping in robotic";
     license = licenses.bsd3;

--- a/pkgs/development/libraries/libportal/default.nix
+++ b/pkgs/development/libraries/libportal/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = (variant == "qt5");
     description = "Flatpak portal library";
     homepage = "https://github.com/flatpak/libportal";
     license = licenses.lgpl3Plus;

--- a/pkgs/development/libraries/loki/default.nix
+++ b/pkgs/development/libraries/loki/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "A C++ library of designs, containing flexible implementations of common design patterns and idioms";
     homepage = "http://loki-lib.sourceforge.net";
     license = licenses.mit;

--- a/pkgs/development/libraries/nanodbc/default.nix
+++ b/pkgs/development/libraries/nanodbc/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   '' else "";
 
   meta = with lib; {
+    broken = true;
     homepage = "https://github.com/nanodbc/nanodbc";
     changelog = "https://github.com/nanodbc/nanodbc/raw/v${version}/CHANGELOG.md";
     description = "Small C++ wrapper for the native C ODBC API";

--- a/pkgs/development/libraries/opae/default.nix
+++ b/pkgs/development/libraries/opae/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DBUILD_ASE=1" ];
 
   meta = with lib; {
+    broken = true;
     description = "Open Programmable Acceleration Engine SDK";
     homepage    = "https://01.org/opae";
     license     = licenses.bsd3;

--- a/pkgs/development/libraries/opendbx/default.nix
+++ b/pkgs/development/libraries/opendbx/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ readline libmysqlclient postgresql sqlite ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = stdenv.isx86_64;
     description = "Extremely lightweight but extensible database access library written in C";
     license = licenses.lgpl21;
     platforms = platforms.all;

--- a/pkgs/development/libraries/openimagedenoise/1_2_x.nix
+++ b/pkgs/development/libraries/openimagedenoise/1_2_x.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ tbb ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     homepage = "https://openimagedenoise.github.io";
     description = "High-Performance Denoising Library for Ray Tracing";
     license = licenses.asl20;

--- a/pkgs/development/libraries/openvino/default.nix
+++ b/pkgs/development/libraries/openvino/default.nix
@@ -119,6 +119,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "OpenVINO™ Toolkit repository";
     longDescription = ''
       This toolkit allows developers to deploy pre-trained deep learning models through a high-level C++ Inference Engine API integrated with application logic.
@@ -130,7 +131,6 @@ stdenv.mkDerivation rec {
     homepage = "https://docs.openvinotoolkit.org/";
     license = with licenses; [ asl20 ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin; # Cannot find macos sdk
     maintainers = with maintainers; [ tfmoraes ];
   };
 }

--- a/pkgs/development/libraries/pangomm/2.42.nix
+++ b/pkgs/development/libraries/pangomm/2.42.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = true;
     description = "C++ interface to the Pango text rendering library";
     homepage    = "https://www.pango.org/";
     license     = with licenses; [ lgpl2 lgpl21 ];

--- a/pkgs/development/libraries/partio/default.nix
+++ b/pkgs/development/libraries/partio/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "C++ (with python bindings) library for easily reading/writing/manipulating common animation particle formats such as PDB, BGEO, PTC";
     homepage = "https://www.disneyanimation.com/technology/partio.html";
     license = licenses.bsd3;

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -262,6 +262,9 @@ qtModule {
     # and qtwebengine 5.14+ requires at least SDK 10.14
     # (qtwebengine 5.12 is fine with SDK 10.12)
     # on aarch64-darwin we are already at MacOS SDK 11.0
-    broken = stdenv.isDarwin && stdenv.isx86_64 && (lib.versionAtLeast qtCompatVersion "5.14");
+    # libsForQt514.qt5.qtwebengine.x86_64-linux and related are broken
+    # qt515 and qt512 work fine
+    broken = (stdenv.isDarwin && stdenv.isx86_64 && (lib.versionAtLeast qtCompatVersion "5.14"))
+      || (stdenv.isx86_64 && (lib.versions.majorMinor qtCompatVersion == "5.14"));
   };
 }

--- a/pkgs/development/libraries/qtscriptgenerator/default.nix
+++ b/pkgs/development/libraries/qtscriptgenerator/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     description = "QtScript bindings generator";
     homepage = "https://code.qt.io/cgit/qt-labs/qtscriptgenerator.git/";
     inherit (qt4.meta) platforms;

--- a/pkgs/development/libraries/swiftshader/default.nix
+++ b/pkgs/development/libraries/swiftshader/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description =
       "A high-performance CPU-based implementation of the Vulkan, OpenGL ES, and Direct3D 9 graphics APIs";
     homepage = "https://opensource.google/projects/swiftshader";

--- a/pkgs/development/libraries/uri/default.nix
+++ b/pkgs/development/libraries/uri/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = stdenv.isx86_64;
     description = "C++ URI library";
     homepage = "https://cpp-netlib.org";
     license = lib.licenses.boost;

--- a/pkgs/development/libraries/webrtc-audio-processing/default.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     homepage = "http://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing";
     description = "A more Linux packaging friendly copy of the AudioProcessing module from the WebRTC project";
     license = licenses.bsd3;

--- a/pkgs/development/octave-modules/communications/default.nix
+++ b/pkgs/development/octave-modules/communications/default.nix
@@ -23,6 +23,7 @@ buildOctavePackage rec {
   ];
 
   meta = with lib; {
+    broken = true;
     homepage = "https://octave.sourceforge.io/communications/index.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ KarlJoad ];

--- a/pkgs/development/octave-modules/geometry/default.nix
+++ b/pkgs/development/octave-modules/geometry/default.nix
@@ -18,6 +18,7 @@ buildOctavePackage rec {
   ];
 
   meta = with lib; {
+    broken = true;
     homepage = "https://octave.sourceforge.io/geometry/index.html";
     license = with licenses; [ gpl3Plus boost ];
     maintainers = with maintainers; [ KarlJoad ];

--- a/pkgs/development/octave-modules/image/default.nix
+++ b/pkgs/development/octave-modules/image/default.nix
@@ -13,6 +13,7 @@ buildOctavePackage rec {
   };
 
   meta = with lib; {
+    broken = true;
     homepage = "https://octave.sourceforge.io/image/index.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ KarlJoad ];

--- a/pkgs/development/octave-modules/sparsersb/default.nix
+++ b/pkgs/development/octave-modules/sparsersb/default.nix
@@ -18,6 +18,7 @@ buildOctavePackage rec {
   ];
 
   meta = with lib; {
+    broken = true;
     homepage = "https://octave.sourceforge.io/sparsersb/index.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ KarlJoad ];

--- a/pkgs/development/python-modules/ifcopenshell/default.nix
+++ b/pkgs/development/python-modules/ifcopenshell/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = stdenv.isDarwin || stdenv.isx86_64;
     description = "Open source IFC library and geometry engine";
     homepage    = "http://ifcopenshell.org/";
     license     = licenses.lgpl3;

--- a/pkgs/development/tools/hobbes/default.nix
+++ b/pkgs/development/tools/hobbes/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
   checkTarget = "test";
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = true;
     description = "A language and an embedded JIT compiler";
     longDescription = ''
       Hobbes is a a language, embedded compiler, and runtime for efficient

--- a/pkgs/development/tools/rbspy/default.nix
+++ b/pkgs/development/tools/rbspy/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = true;
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = true;
     homepage = "https://rbspy.github.io/";
     description = ''
       A Sampling CPU Profiler for Ruby.

--- a/pkgs/development/tools/xqilla/default.nix
+++ b/pkgs/development/tools/xqilla/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-xerces=${xercesc}" ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "An XQuery and XPath 2 library and command line utility written in C++, implemented on top of the Xerces-C library";
     license     = licenses.asl20 ;
     maintainers = with maintainers; [ obadz ];

--- a/pkgs/games/dxx-rebirth/default.nix
+++ b/pkgs/games/dxx-rebirth/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Source Port of the Descent 1 and 2 engines";
     homepage = "https://www.dxx-rebirth.com/";
     license = licenses.gpl3;

--- a/pkgs/games/gscrabble/default.nix
+++ b/pkgs/games/gscrabble/default.nix
@@ -31,6 +31,7 @@ buildPythonApplication {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Golden Scrabble crossword puzzle game";
     homepage = "https://github.com/RaaH/gscrabble/";
     license = licenses.gpl2Plus;

--- a/pkgs/games/keeperrl/default.nix
+++ b/pkgs/games/keeperrl/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "A dungeon management rogue-like";
     homepage = "https://keeperrl.com/";
     license = licenses.gpl2;

--- a/pkgs/games/lincity/ng.nix
+++ b/pkgs/games/lincity/ng.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "City building game";
     license = licenses.gpl2;
     maintainers = with maintainers; [ raskin ];

--- a/pkgs/games/mars/default.nix
+++ b/pkgs/games/mars/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     chmod +x "$out/bin/mars"
   '';
   meta = with lib; {
+    broken = stdenv.isx86_64;
     homepage = "http://mars-game.sourceforge.net/";
     description = "A game about fighting with ships in a 2D space setting";
     license = licenses.gpl3Plus;

--- a/pkgs/games/npush/default.nix
+++ b/pkgs/games/npush/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = true;
     homepage = "http://npush.sourceforge.net/";
     description = "A Sokoban-like game";
     license = licenses.gpl2Plus;

--- a/pkgs/games/openclonk/default.nix
+++ b/pkgs/games/openclonk/default.nix
@@ -36,6 +36,7 @@ in stdenv.mkDerivation rec {
   cmakeBuildType = "RelWithDebInfo";
 
   meta = with lib; {
+    broken = true;
     description = "Free multiplayer action game in which you control clonks, small but witty and nimble humanoid beings";
     homepage = "https://www.openclonk.org";
     license = if enableSoundtrack then licenses.unfreeRedistributable else licenses.isc;

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     homepage = "https://springrts.com/";
     description = "A powerful real-time strategy (RTS) game engine";
     license = licenses.gpl2;

--- a/pkgs/games/stuntrally/default.nix
+++ b/pkgs/games/stuntrally/default.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
+    broken = true;
     description = "Stunt Rally game with Track Editor, based on VDrift and OGRE";
     homepage = "http://stuntrally.tuxfamily.org/";
     license = licenses.gpl3Plus;

--- a/pkgs/misc/urbit/default.nix
+++ b/pkgs/misc/urbit/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "An operating function";
     homepage = "https://urbit.org";
     license = licenses.mit;

--- a/pkgs/os-specific/linux/tiscamera/default.nix
+++ b/pkgs/os-specific/linux/tiscamera/default.nix
@@ -95,6 +95,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "The Linux sources and UVC firmwares for The Imaging Source cameras";
     homepage = "https://github.com/TheImagingSource/tiscamera";
     license = with licenses; [ asl20 ];

--- a/pkgs/servers/prayer/default.nix
+++ b/pkgs/servers/prayer/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "-lpam";
 
   meta = {
+    broken = true;
     homepage = "http://www-uxsup.csx.cam.ac.uk/~dpc22/prayer/";
     description = "Yet another Webmail interface for IMAP servers on Unix systems written in C";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/servers/rippled/validator-keys-tool.nix
+++ b/pkgs/servers/rippled/validator-keys-tool.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Generate master and ephemeral rippled validator keys";
     homepage = "https://github.com/ripple/validator-keys-tool";
     maintainers = with maintainers; [ offline rmcgibbo ];

--- a/pkgs/servers/sql/percona/5.6.x.nix
+++ b/pkgs/servers/sql/percona/5.6.x.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   passthru.mysqlVersion = "5.6";
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     homepage = "https://www.percona.com";
     description = "a free, fully compatible, enhanced, open source drop-in replacement for MySQL that provides superior performance, scalability and instrumentation";
     platforms = platforms.linux;

--- a/pkgs/tools/audio/isrcsubmit/default.nix
+++ b/pkgs/tools/audio/isrcsubmit/default.nix
@@ -14,8 +14,8 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [ musicbrainzngs discid ];
 
   meta = with lib; {
+    broken = true;
     # drutil is required on Darwin, which does not seem to be available in nixpkgs
-    broken = stdenv.isDarwin;
     description = "Script to submit ISRCs from disc to MusicBrainz";
     license = licenses.gpl3Plus;
     homepage = "http://jonnyjd.github.io/musicbrainz-isrcsubmit/";

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
   '' + extraPostInstall;
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Non-blocking backup tool for MySQL";
     homepage = "http://www.percona.com/software/percona-xtrabackup";
     license = licenses.lgpl2;

--- a/pkgs/tools/cd-dvd/mkcue/default.nix
+++ b/pkgs/tools/cd-dvd/mkcue/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
   postInstall = "chmod -v +w $out/bin/mkcue";
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Generates CUE sheets from a CD TOC";
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Manipulating CPC dsk images and files";
     homepage = "https://github.com/cpcsdk/idsk" ;
     license = licenses.mit;

--- a/pkgs/tools/graphics/pdftoipe/default.nix
+++ b/pkgs/tools/graphics/pdftoipe/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "A program that tries to convert arbitrary PDF documents to Ipe files";
     homepage = "https://github.com/otfried/ipe-tools";
     license = licenses.gpl3Plus;

--- a/pkgs/tools/graphics/yafaray-core/default.nix
+++ b/pkgs/tools/graphics/yafaray-core/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     ] ++ lib.optional withPython python3;
 
     meta = with lib; {
+      broken = true;
       description = "A free, open source raytracer";
       homepage = "http://www.yafaray.org";
       maintainers = with maintainers; [ hodapp ];

--- a/pkgs/tools/inputmethods/gebaar-libinput/default.nix
+++ b/pkgs/tools/inputmethods/gebaar-libinput/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libinput zlib ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "Gebaar, A Super Simple WM Independent Touchpad Gesture Daemon for libinput";
     homepage = "https://github.com/Coffee2CodeNL/gebaar-libinput";
     license = licenses.gpl3;

--- a/pkgs/tools/misc/gammy/default.nix
+++ b/pkgs/tools/misc/gammy/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
   buildInputs = [ libXxf86vm ];
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     description = "GUI tool for manual- of auto-adjusting of brightness/temperature";
     homepage = "https://github.com/Fushko/gammy";
     license = licenses.gpl3;

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -164,6 +164,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
+    broken = xenSupport;
     description = "GNU GRUB, the Grand Unified Boot Loader (2.x beta)";
 
     longDescription =

--- a/pkgs/tools/misc/grub4dos/default.nix
+++ b/pkgs/tools/misc/grub4dos/default.nix
@@ -34,6 +34,7 @@ in stdenv.mkDerivation {
   enableParallelBuilding = false;
 
   meta = with lib; {
+    broken = true;
     homepage = "http://grub4dos.chenall.net/";
     description = "GRUB for DOS is the dos extension of GRUB";
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/tools/misc/piston-cli/default.nix
+++ b/pkgs/tools/misc/piston-cli/default.nix
@@ -16,7 +16,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = true;
     description = "Piston api tool";
     homepage = "https://github.com/Shivansh-007/piston-cli";
     license = licenses.mit;

--- a/pkgs/tools/misc/sta/default.nix
+++ b/pkgs/tools/misc/sta/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {
+    broken = true;
     description = "Simple statistics from the command line interface (CLI), fast";
     longDescription = ''
       This is a lightweight, fast tool for calculating basic descriptive

--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = [ "-p tremor-cli" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = true;
     description = "Early stage event processing system for unstructured data with rich support for structural pattern matching, filtering and transformation";
     homepage = "https://www.tremor.rs/";
     license = licenses.asl20;

--- a/pkgs/tools/misc/xprite-editor/default.nix
+++ b/pkgs/tools/misc/xprite-editor/default.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = [ "--bin" "xprite-native" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = true;
     homepage = "https://github.com/rickyhan/xprite-editor";
     description = "Pixel art editor";
     license = licenses.gpl3;

--- a/pkgs/tools/networking/pdnsd/default.nix
+++ b/pkgs/tools/networking/pdnsd/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   CPPFLAGS = "-D__APPLE_USE_RFC_3542";
 
   meta = with lib; {
+    broken = true;
     description = "Permanent DNS caching";
     homepage = "http://members.home.nl/p.a.rombouts/pdnsd";
     license = licenses.gpl3Plus;

--- a/pkgs/tools/networking/snabb/default.nix
+++ b/pkgs/tools/networking/snabb/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   meta =  {
+    broken = true;
     homepage = "https://github.com/SnabbCo/snabbswitch";
     description = "Simple and fast packet networking toolkit";
     longDescription = ''

--- a/pkgs/tools/networking/tracebox/default.nix
+++ b/pkgs/tools/networking/tracebox/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isx86_64;
     homepage = "http://www.tracebox.org/";
     description = "A middlebox detection tool";
     license = lib.licenses.gpl2;

--- a/pkgs/tools/security/fprintd/tod.nix
+++ b/pkgs/tools/security/fprintd/tod.nix
@@ -18,4 +18,5 @@
       rev = "v${version}";
       sha256 = "sha256-rOTVThHOY/Q2IIu2RGiv26UE2V/JFfWWnfKZQfKl5Mg=";
     };
+    meta = oldAttrs.meta // { broken = true; };
   })

--- a/pkgs/tools/video/swfmill/default.nix
+++ b/pkgs/tools/video/swfmill/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxslt freetype libpng libxml2 ];
 
   meta = {
+    broken = stdenv.isx86_64;
     description = "An xml2swf and swf2xml processor with import functionalities";
     homepage = "http://swfmill.org";
     license = lib.licenses.gpl2;

--- a/pkgs/tools/virtualization/udocker/default.nix
+++ b/pkgs/tools/virtualization/udocker/default.nix
@@ -39,6 +39,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   meta = with lib; {
+    broken = true;
     description = "basic user tool to execute simple docker containers in user space without root privileges";
     homepage = "https://indigo-dc.gitbooks.io/udocker";
     license = licenses.asl20;


### PR DESCRIPTION
###### Description of changes

Mark some more packages broken. Now done with more care.

###### Things done

- [x] Manually checked on hydra if the build is broken in the latest release-22.05 eval: https://hydra.nixos.org/eval/1764429
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @dasJ 