### PR TITLE
borgbackup: need either pyfuse3 or llfuse

### DIFF
--- a/pkgs/development/python-modules/llfuse/default.nix
+++ b/pkgs/development/python-modules/llfuse/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "llfuse";
-  version = "1.4.1";
+  version = "1.4.2";
 
   disabled = pythonOlder "3.5";
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "python-llfuse";
     repo = "python-llfuse";
     rev = "release-${version}";
-    sha256 = "1dcpdg6cpkmdbyg66fgrylj7dp9zqzg5bf23y6m6673ykgxlv480";
+    hash = "sha256-TnZnv439fLvg0WM96yx0dPSSz8Mrae6GDC9LiLFrgQ8=";
   };
 
   nativeBuildInputs = [ cython pkg-config ];

--- a/pkgs/development/python-modules/pyfuse3/default.nix
+++ b/pkgs/development/python-modules/pyfuse3/default.nix
@@ -1,21 +1,44 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, pkg-config, fuse3, trio, pytestCheckHook, pytest-trio, which, pythonAtLeast }:
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, cython
+, pkg-config
+, fuse3
+, trio
+, python
+, pytestCheckHook
+, pytest-trio
+, which
+}:
 
 buildPythonPackage rec {
   pname = "pyfuse3";
   version = "3.2.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "22d146dac59a8429115e9a93317975ea54b35e0278044a94d3fac5b4ad5f7e33";
+  disabled = pythonOlder "3.5";
+
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "libfuse";
+    repo = "pyfuse3";
+    rev = "release-${version}";
+    hash = "sha256-JGbp2bSI/Rvyys1xMd2o34KlqqBsV6B9LhuuNopayYA=";
   };
 
-  disabled = pythonAtLeast "3.10";
-
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    cython
+    pkg-config
+  ];
 
   buildInputs = [ fuse3 ];
 
   propagatedBuildInputs = [ trio ];
+
+  preBuild = ''
+    ${python.pythonForBuild.interpreter} setup.py build_cython
+  '';
 
   checkInputs = [
     pytestCheckHook
@@ -27,10 +50,15 @@ buildPythonPackage rec {
   # Checks if a /usr/bin directory exists, can't work on NixOS
   disabledTests = [ "test_listdir" ];
 
+  pythonImportsCheck = [
+    "pyfuse3"
+    "pyfuse3_asyncio"
+  ];
+
   meta = with lib; {
     description = "Python 3 bindings for libfuse 3 with async I/O support";
     homepage = "https://github.com/libfuse/pyfuse3";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ nyanloutre ];
+    maintainers = with maintainers; [ nyanloutre dotlambda ];
   };
 }

--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -44,11 +44,9 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     cython
-    llfuse
     msgpack
     packaging
-  ] ++ lib.optionals (!stdenv.isDarwin) [
-    pyfuse3
+    (if stdenv.isLinux then pyfuse3 else llfuse)
   ];
 
   preConfigure = ''

--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -27,6 +27,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = with python3.pkgs; [
+    cython
     setuptools-scm
     # For building documentation:
     sphinx
@@ -43,7 +44,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    cython
     msgpack
     packaging
     (if stdenv.isLinux then pyfuse3 else llfuse)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
@alyssais I tried to keep cross compilation working but couldn't test it.