### PR TITLE
esshader: init at unstable-2020-08-09

### DIFF
--- a/pkgs/tools/graphics/esshader/default.nix
+++ b/pkgs/tools/graphics/esshader/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, pkg-config, libGL, glfw, soil, lib }:
+
+stdenv.mkDerivation {
+  pname = "esshader";
+  version = "unstable-2020-08-09";
+
+  src = fetchFromGitHub {
+    owner = "cmcsun";
+    repo = "esshader";
+    rev = "506eb02f3de52d3d1f4d81ac9ee145655216dee5";
+    sha256 = "sha256-euxJw7CqOwi6Ndzalps37kDr5oOIL3tZICCfmxsujfk=";
+  };
+
+  postPatch = ''
+    substituteInPlace config.mk \
+      --replace "-lGLESv2" "-lGL -lGLESv2"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    libGL glfw soil
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a esshader $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Offline ShaderToy-compatible GLSL shader viewer using OpenGL ES 2.0";
+    homepage = "https://github.com/cmcsun/esshader";
+    license = licenses.mit;
+    maintainers = with maintainers; [ astro ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5670,6 +5670,8 @@ with pkgs;
 
   escrotum = callPackage ../tools/graphics/escrotum { };
 
+  esshader = callPackage ../tools/graphics/esshader { };
+
   etcher = callPackage ../tools/misc/etcher {
     electron = electron_12;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Shadertoy.com is great. This smol program renders the demos somewhat faster compared to WebGL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
