### PR TITLE
cloudflared: isn't broken after all

### DIFF
--- a/pkgs/applications/networking/cloudflared/default.nix
+++ b/pkgs/applications/networking/cloudflared/default.nix
@@ -29,7 +29,6 @@ buildGoModule rec {
   doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "CloudFlare Tunnel daemon (and DNS-over-HTTPS client)";
     homepage    = "https://www.cloudflare.com/products/tunnel";
     license     = licenses.asl20;


### PR DESCRIPTION
###### Description of changes

mark cloudflared not broken
was marked in https://github.com/NixOS/nixpkgs/pull/173671

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

https://hydra.nixos.org/build/177962726/ failed during tests. Rebuilt, tests ran fine on both arm64 and amd64 host.