### PR TITLE
nixos/systemd-boot: fix systemd-boot-builder refusing to update

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -204,21 +204,6 @@ def get_profiles() -> List[str]:
     else:
         return []
 
-def should_update(v_from: str, v_to: str) -> bool:
-    # see https://github.com/systemd/systemd/blob/main/src/boot/bootctl.c compare_product function
-
-    len_from = len(v_from)
-    len_to = len(v_to)
-
-    if len_from < len_to:
-        return False
-
-    if len_from > len_to:
-        return True
-
-    return v_from < v_to
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description='Update NixOS-related systemd-boot files')
     parser.add_argument('default_config', metavar='DEFAULT-CONFIG', help='The default NixOS config to boot')
@@ -276,7 +261,7 @@ def main() -> None:
         installed_version = installed_match.group(1)
         available_version = available_match.group(1)
 
-        if should_update(installed_version, available_version):
+        if installed_version < available_version:
             print("updating systemd-boot from %s to %s" % (installed_version, available_version))
             subprocess.check_call(["@systemd@/bin/bootctl", "--path=@efiSysMountPoint@", "update"])
         else:


### PR DESCRIPTION
Handling of the string length condition in should_update
was broken, as evident with the log message

> leaving systemd-boot 246 in place (250.4 is not newer)

when updating an old NixOS system.

Fixes a30de3b849bb29b4d2206e1a652707fba8ea18a4

Sorry, I goofed up following the code in `bootctl.c`