### PR TITLE
libbpf: Use kernel sources instead of mirror

### DIFF
--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
 
   passthru.tests = { inherit (nixosTests) bpf; };
 
+  postPatch = ''
+    substituteInPlace scripts/bpf_*.py \
+        --replace "/usr/bin/python3" "${python3}/bin/python3" \
+        --replace "/usr/bin/env python3" "${python3}/bin/python3"
+  '';
+
   preConfigure = ''
     cd tools/lib/bpf
   '';

--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Common eBPF ELF object loading operations.";
-    homepage = "https://github.com/libbpf/libbpf";
+    homepage = "https://kernel.org/doc/html/latest/bpf/libbpf/index.html";
     license = with licenses; [ lgpl21 /* or */ bsd2 ];
     maintainers = with maintainers; [ thoughtpolice vcunat saschagrunert martinetd ];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15100,7 +15100,7 @@ with pkgs;
 
   bump = callPackage ../development/tools/github/bump { };
 
-  libbpf = callPackage ../os-specific/linux/libbpf { };
+  libbpf = linuxPackages.libbpf;
 
   bpftools = callPackage ../os-specific/linux/bpftools { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15100,7 +15100,7 @@ with pkgs;
 
   bump = callPackage ../development/tools/github/bump { };
 
-  libbpf = linuxPackages.libbpf;
+  libbpf = linuxPackages_latest.libbpf;
 
   bpftools = callPackage ../os-specific/linux/bpftools { };
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -402,6 +402,8 @@ in {
 
     kvmfr = callPackage ../os-specific/linux/kvmfr { };
 
+    libbpf = callPackage ../os-specific/linux/libbpf { };
+
     mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
 
     mwprocapture = callPackage ../os-specific/linux/mwprocapture { };


### PR DESCRIPTION
So that the bpf library used with the linux kernel will be compatible.

This also avoids the error caused by installing linux headers taken
from the github mirror (which might not have been the same as the
installed kernel!).

Particularly since systemd depends on libbpf, I would like to see CI
run successfully before this gets any serious attention.

###### Description of changes

Change the source of `libbpf` from the github mirror to the kernel sources. Make `libbpf` a `linuxPackage`, and make the top-level definition refer to `linuxPackages.libbpf`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
