### PR TITLE
Fix: make pyarrow buildable on darwin

### DIFF
--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -83,12 +83,19 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     # Requires loopback networking
     "--deselect=pyarrow/tests/test_ipc.py::test_socket_"
+    "--deselect=pyarrow/tests/test_flight.py::test_never_sends_data"
+    "--deselect=pyarrow/tests/test_flight.py::test_large_descriptor"
+    "--deselect=pyarrow/tests/test_flight.py::test_large_metadata_client"
+    "--deselect=pyarrow/tests/test_flight.py::test_none_action_side_effect"
   ];
 
   dontUseSetuptoolsCheck = true;
   preCheck = ''
     shopt -s extglob
     rm -r pyarrow/!(tests)
+  '' + lib.optionalString stdenv.isDarwin  ''
+    # OSError: [Errno 24] Too many open files
+    ulimit -n 1024
   '';
 
   pythonImportsCheck = [ "pyarrow" ] ++ map (module: "pyarrow.${module}") ([
@@ -104,7 +111,6 @@ buildPythonPackage rec {
   ] ++ lib.optionals (!stdenv.isDarwin) [ "plasma" ]);
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "A cross-language development platform for in-memory data";
     homepage = "https://arrow.apache.org/";
     license = licenses.asl20;


### PR DESCRIPTION

###### Description of changes

This change disables several tests that fail on darwin due to requiring
localhost networking. In addition, it bumps up the number of open file
descriptors to allow test_pandas.py/TestConvertMisc tests to pass.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
