### PR TITLE
stdenv: support opt-in __structuredAttrs

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -990,6 +990,32 @@ Convenience function for `makeWrapper` that replaces `<\executable\>` with a wra
 
 If you will apply it multiple times, it will overwrite the wrapper file and you will end up with double wrapping, which should be avoided.
 
+### `prependToVar` \<variableName\> \<elements...\> {#fun-prependToVar}
+
+Prepend elements to a variable.
+
+Example:
+
+```shellSession
+$ configureFlags="--disable-static"
+$ prependToVar configureFlags --disable-dependency-tracking --enable-foo
+$ echo $configureFlags
+--disable-dependency-tracking --enable-foo --disable-static
+```
+
+### `appendToVar` \<variableName\> \<elements...\> {#fun-appendToVar}
+
+Append elements to a variable.
+
+Example:
+
+```shellSession
+$ configureFlags="--disable-static"
+$ appendToVar configureFlags --disable-dependency-tracking --enable-foo
+$ echo $configureFlags
+--disable-static --disable-dependency-tracking --enable-foo
+```
+
 ## Package setup hooks {#ssec-setup-hooks}
 
 Nix itself considers a build-time dependency as merely something that should previously be built and accessible at build time—packages themselves are on their own to perform any additional setup. In most cases, that is fine, and the downstream derivation can deal with its own dependencies. But for a few common tasks, that would result in almost every package doing the same sort of setup work—depending not on the package itself, but entirely on which dependencies were used.

--- a/nixos/modules/services/networking/ircd-hybrid/builder.sh
+++ b/nixos/modules/services/networking/ircd-hybrid/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 doSub() {

--- a/nixos/modules/services/web-servers/jboss/builder.sh
+++ b/nixos/modules/services/web-servers/jboss/builder.sh
@@ -1,5 +1,6 @@
 set -e
 
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 mkdir -p $out/bin

--- a/pkgs/applications/misc/adobe-reader/builder.sh
+++ b/pkgs/applications/misc/adobe-reader/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 echo "unpacking $src..."

--- a/pkgs/applications/networking/cluster/nomad-autoscaler/default.nix
+++ b/pkgs/applications/networking/cluster/nomad-autoscaler/default.nix
@@ -45,7 +45,7 @@ let
       mv bin/nomad-autoscaler $bin/bin
       ln -s $bin/bin/nomad-autoscaler $out/bin/nomad-autoscaler
 
-      for d in $outputs; do
+      for d in $(getAllOutputNames); do
         mkdir -p ''${!d}/share
       done
       rmdir $bin/share

--- a/pkgs/applications/office/libreoffice/download-list-builder.sh
+++ b/pkgs/applications/office/libreoffice/download-list-builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 tar --extract --file=$src libreoffice-$version/download.lst -O > $out

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -55,9 +55,9 @@ let
   bintoolsVersion = lib.getVersion bintools;
   bintoolsName = lib.removePrefix targetPrefix (lib.getName bintools);
 
-  libc_bin = if libc == null then null else getBin libc;
-  libc_dev = if libc == null then null else getDev libc;
-  libc_lib = if libc == null then null else getLib libc;
+  libc_bin = if libc == null then "" else getBin libc;
+  libc_dev = if libc == null then "" else getDev libc;
+  libc_lib = if libc == null then "" else getLib libc;
   bintools_bin = if nativeTools then "" else getBin bintools;
   # The wrapper scripts use 'cat' and 'grep', so we may need coreutils.
   coreutils_bin = if nativeTools then "" else getBin coreutils;
@@ -102,8 +102,6 @@ stdenv.mkDerivation {
   version = if bintools == null then null else bintoolsVersion;
 
   preferLocalBuild = true;
-
-  inherit bintools_bin libc_bin libc_dev libc_lib;
 
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (bintools ? info) "info");
 
@@ -189,8 +187,6 @@ stdenv.mkDerivation {
 
   strictDeps = true;
   depsTargetTargetPropagated = extraPackages;
-
-  wrapperName = "BINTOOLS_WRAPPER";
 
   setupHooks = [
     ../setup-hooks/role.bash
@@ -368,7 +364,9 @@ stdenv.mkDerivation {
     expandResponseParams = "${expand-response-params}/bin/expand-response-params";
     shell = getBin shell + shell.shellPath or "";
     gnugrep_bin = if nativeTools then "" else gnugrep;
-    inherit dynamicLinker suffixSalt coreutils_bin;
+    wrapperName = "BINTOOLS_WRAPPER";
+    inherit dynamicLinker targetPrefix suffixSalt coreutils_bin;
+    inherit bintools_bin libc_bin libc_dev libc_lib;
   };
 
   meta =

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -103,15 +103,12 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  inherit bintools_bin libc_bin libc_dev libc_lib coreutils_bin;
-  shell = getBin shell + shell.shellPath or "";
-  gnugrep_bin = if nativeTools then "" else gnugrep;
-
-  inherit targetPrefix suffixSalt;
+  inherit bintools_bin libc_bin libc_dev libc_lib;
 
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (bintools ? info) "info");
 
   passthru = {
+    inherit targetPrefix suffixSalt;
     inherit bintools libc nativeTools nativeLibc nativePrefix;
 
     emacsBufferSetup = pkgs: ''
@@ -366,10 +363,13 @@ stdenv.mkDerivation {
     ##
     + extraBuildCommands;
 
-  inherit dynamicLinker;
-
-  # for substitution in utils.bash
-  expandResponseParams = "${expand-response-params}/bin/expand-response-params";
+  env = {
+    # for substitution in utils.bash
+    expandResponseParams = "${expand-response-params}/bin/expand-response-params";
+    shell = getBin shell + shell.shellPath or "";
+    gnugrep_bin = if nativeTools then "" else gnugrep;
+    inherit dynamicLinker suffixSalt coreutils_bin;
+  };
 
   meta =
     let bintools_ = if bintools != null then bintools else {}; in

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -68,7 +68,7 @@ let
   # The dynamic linker has different names on different platforms. This is a
   # shell glob that ought to match it.
   dynamicLinker =
-    /**/ if sharedLibraryLoader == null then null
+    /**/ if sharedLibraryLoader == null then ""
     else if targetPlatform.libc == "musl"             then "${sharedLibraryLoader}/lib/ld-musl-*"
     else if targetPlatform.libc == "uclibc"           then "${sharedLibraryLoader}/lib/ld*-uClibc.so.1"
     else if (targetPlatform.libc == "bionic" && targetPlatform.is32bit) then "/system/bin/linker"
@@ -87,7 +87,7 @@ let
     else if targetPlatform.isDarwin                   then "/usr/lib/dyld"
     else if targetPlatform.isFreeBSD                  then "/libexec/ld-elf.so.1"
     else if lib.hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1"
-    else null;
+    else "";
 
   expand-response-params =
     if buildPackages ? stdenv && buildPackages.stdenv.hasCC && buildPackages.stdenv.cc != "/dev/null"

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -42,9 +42,9 @@ let
   ccVersion = lib.getVersion cc;
   ccName = lib.removePrefix targetPrefix (lib.getName cc);
 
-  libc_bin = if libc == null then null else getBin libc;
-  libc_dev = if libc == null then null else getDev libc;
-  libc_lib = if libc == null then null else getLib libc;
+  libc_bin = if libc == null then "" else getBin libc;
+  libc_dev = if libc == null then "" else getDev libc;
+  libc_lib = if libc == null then "" else getLib libc;
   cc_solib = getLib cc
     + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
 
@@ -131,10 +131,6 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  inherit cc libc_bin libc_dev libc_lib;
-
-  inherit darwinPlatformForCC darwinMinVersion darwinMinVersionVariable;
-
   outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
 
   passthru = {
@@ -144,7 +140,7 @@ stdenv.mkDerivation {
     # Binutils, and Apple's "cctools"; "bintools" as an attempt to find an
     # unused middle-ground name that evokes both.
     inherit bintools;
-    inherit libc nativeTools nativeLibc nativePrefix isGNU isClang;
+    inherit cc libc nativeTools nativeLibc nativePrefix isGNU isClang;
 
     emacsBufferSetup = pkgs: ''
       ; We should handle propagation here too
@@ -267,8 +263,6 @@ stdenv.mkDerivation {
   strictDeps = true;
   propagatedBuildInputs = [ bintools ] ++ extraTools ++ optionals cc.langD or false [ zlib ];
   depsTargetTargetPropagated = optional (libcxx != null) libcxx ++ extraPackages;
-
-  wrapperName = "CC_WRAPPER";
 
   setupHooks = [
     ../setup-hooks/role.bash
@@ -541,7 +535,10 @@ stdenv.mkDerivation {
     expandResponseParams = "${expand-response-params}/bin/expand-response-params";
     shell = getBin shell + shell.shellPath or "";
     gnugrep_bin = if nativeTools then "" else gnugrep;
-    inherit suffixSalt coreutils_bin bintools;
+    wrapperName = "CC_WRAPPER";
+    inherit suffixSalt coreutils_bin bintools cc;
+    inherit libc_bin libc_dev libc_lib;
+    inherit darwinPlatformForCC darwinMinVersion darwinMinVersionVariable;
   };
 
   meta =

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -131,16 +131,14 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  inherit cc libc_bin libc_dev libc_lib bintools coreutils_bin;
-  shell = getBin shell + shell.shellPath or "";
-  gnugrep_bin = if nativeTools then "" else gnugrep;
+  inherit cc libc_bin libc_dev libc_lib;
 
-  inherit targetPrefix suffixSalt;
   inherit darwinPlatformForCC darwinMinVersion darwinMinVersionVariable;
 
   outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
 
   passthru = {
+    inherit targetPrefix suffixSalt;
     # "cc" is the generic name for a C compiler, but there is no one for package
     # providing the linker and related tools. The two we use now are GNU
     # Binutils, and Apple's "cctools"; "bintools" as an attempt to find an
@@ -538,8 +536,13 @@ stdenv.mkDerivation {
         nixSupport);
 
 
-  # for substitution in utils.bash
-  expandResponseParams = "${expand-response-params}/bin/expand-response-params";
+  env = {
+    # for substitution in utils.bash
+    expandResponseParams = "${expand-response-params}/bin/expand-response-params";
+    shell = getBin shell + shell.shellPath or "";
+    gnugrep_bin = if nativeTools then "" else gnugrep;
+    inherit suffixSalt coreutils_bin bintools;
+  };
 
   meta =
     let cc_ = if cc != null then cc else {}; in

--- a/pkgs/build-support/fetchbzr/builder.sh
+++ b/pkgs/build-support/fetchbzr/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source "$stdenv/setup"
 
 header "exporting \`$url' (revision $rev) into \`$out'"

--- a/pkgs/build-support/fetchcvs/builder.sh
+++ b/pkgs/build-support/fetchcvs/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 (echo "#!$SHELL"; \

--- a/pkgs/build-support/fetchdarcs/builder.sh
+++ b/pkgs/build-support/fetchdarcs/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 tagtext=""

--- a/pkgs/build-support/fetchdocker/fetchdocker-builder.sh
+++ b/pkgs/build-support/fetchdocker/fetchdocker-builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source "${stdenv}/setup"
 header "exporting ${repository}/${imageName} (tag: ${tag}) into ${out}"
 mkdir -p "${out}"
@@ -8,7 +9,7 @@ cat <<EOF > "${out}/compositeImage.sh"
 # Create a tar archive of a docker image's layers, docker image config
 # json, manifest.json, and repositories json; this streams directly to
 # stdout and is intended to be used in concert with docker load, i.e:
-# 
+#
 # ${out}/compositeImage.sh | docker load
 
 # The first character follow the 's' command for sed becomes the

--- a/pkgs/build-support/fetchfossil/builder.sh
+++ b/pkgs/build-support/fetchfossil/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 header "Cloning Fossil $url [$rev] into $out"
 

--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -2,6 +2,8 @@
 # - no revision specified and remote has a HEAD which is used
 # - revision specified and remote has a HEAD
 # - revision specified and remote without HEAD
+#
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 header "exporting $url (rev $rev) into $out"

--- a/pkgs/build-support/fetchhg/builder.sh
+++ b/pkgs/build-support/fetchhg/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 header "getting $url${rev:+ ($rev)} into $out"
 

--- a/pkgs/build-support/fetchipfs/builder.sh
+++ b/pkgs/build-support/fetchipfs/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 # Curl flags to handle redirects, not use EPSV, handle cookies for

--- a/pkgs/build-support/fetchmtn/builder.sh
+++ b/pkgs/build-support/fetchmtn/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 set -x

--- a/pkgs/build-support/fetchsvn/builder.sh
+++ b/pkgs/build-support/fetchsvn/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 header "exporting $url (r$rev) into $out"

--- a/pkgs/build-support/fetchsvnssh/builder.sh
+++ b/pkgs/build-support/fetchsvnssh/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 header "exporting $url (r$rev) into $out"

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 source $mirrorsFile

--- a/pkgs/build-support/nuke-references/default.nix
+++ b/pkgs/build-support/nuke-references/default.nix
@@ -32,8 +32,10 @@ stdenvNoCC.mkDerivation {
   '';
 
   # FIXME: get rid of perl dependency.
-  inherit perl;
-  inherit (builtins) storeDir;
-  shell = lib.getBin shell + (shell.shellPath or "");
-  signingUtils = if darwinCodeSign then signingUtils else null;
+  env = {
+    inherit perl;
+    inherit (builtins) storeDir;
+    shell = lib.getBin shell + (shell.shellPath or "");
+    signingUtils = if darwinCodeSign then signingUtils else "";
+  };
 }

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -36,13 +36,10 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
-
-  inherit targetPrefix suffixSalt baseBinName;
-
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (pkg-config ? doc) "doc");
 
   passthru = {
+    inherit targetPrefix suffixSalt;
     inherit pkg-config;
   };
 
@@ -83,8 +80,6 @@ stdenv.mkDerivation {
       ln -s ${pkg-config}/share $out/share
     '';
 
-  wrapperName = "PKG_CONFIG_WRAPPER";
-
   setupHooks = [
     ../setup-hooks/role.bash
     ./setup-hook.sh
@@ -119,6 +114,12 @@ stdenv.mkDerivation {
     ## Extra custom steps
     ##
     + extraBuildCommands;
+
+  env = {
+    shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
+    wrapperName = "PKG_CONFIG_WRAPPER";
+    inherit targetPrefix suffixSalt baseBinName;
+  };
 
   meta =
     let pkg-config_ = if pkg-config != null then pkg-config else {}; in

--- a/pkgs/build-support/release/nix-build.nix
+++ b/pkgs/build-support/release/nix-build.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation (
       echo "$system" > $out/nix-support/system
 
       if [ -z "${toString doingAnalysis}" ]; then
-          for i in $outputs; do
+          for i in $(getAllOutputNames); do
               if [ "$i" = out ]; then j=none; else j="$i"; fi
               mkdir -p ''${!i}/nix-support
               echo "nix-build $j ''${!i}" >> ''${!i}/nix-support/hydra-build-products

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -84,7 +84,7 @@ autoPatchelf() {
 # (Expressions don't expand in single quotes, use double quotes for that.)
 postFixupHooks+=('
     if [ -z "${dontAutoPatchelf-}" ]; then
-        autoPatchelf -- $(for output in $outputs; do
+        autoPatchelf -- $(for output in $(getAllOutputNames); do
             [ -e "${!output}" ] || continue
             echo "${!output}"
         done)

--- a/pkgs/build-support/setup-hooks/move-docs.sh
+++ b/pkgs/build-support/setup-hooks/move-docs.sh
@@ -5,10 +5,17 @@
 preFixupHooks+=(_moveToShare)
 
 _moveToShare() {
-    forceShare=${forceShare:=man doc info}
+    if [ -n "$__structuredAttrs" ]; then
+        if [ -z "${forceShare-}" ]; then
+            forceShare=( man doc info )
+        fi
+    else
+        forceShare=( ${forceShare:-man doc info} )
+    fi
+
     if [[ -z "$out" ]]; then return; fi
 
-    for d in $forceShare; do
+    for d in "${forceShare[@]}"; do
         if [ -d "$out/$d" ]; then
             if [ -d "$out/share/$d" ]; then
                 echo "both $d/ and share/$d/ exist!"
@@ -20,4 +27,3 @@ _moveToShare() {
         fi
     done
 }
-

--- a/pkgs/build-support/setup-hooks/patch-ppd-files/patch-ppd-hook.sh
+++ b/pkgs/build-support/setup-hooks/patch-ppd-files/patch-ppd-hook.sh
@@ -70,7 +70,7 @@ patchPpdFileCommands () {
     # * outputs of current build before buildInputs
     # * `/lib/cups/filter' before `/bin`
     # * add HOST_PATH at end, so we don't miss anything
-    for path in $outputs; do
+    for path in $(getAllOutputNames); do
         addToSearchPath cupspath "${!path}/lib/cups/filter"
         addToSearchPath cupspath "${!path}/bin"
     done

--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -12,11 +12,20 @@ _doStrip() {
     local -ra stripCmds=(STRIP STRIP_FOR_TARGET)
     local -ra ranlibCmds=(RANLIB RANLIB_FOR_TARGET)
 
+    # TODO(structured-attrs): This doesn't work correctly if one of
+    #   the items in strip*List or strip*Flags contains a space,
+    #   even with structured attrs enabled.  This is OK for now
+    #   because very few packages set any of these, and it doesn't
+    #   affect any of them.
+    #
+    #   After __structuredAttrs = true is universal, come back and
+    #   push arrays all the way through this logic.
+
     # Strip only host paths by default. Leave targets as is.
-    stripDebugList=${stripDebugList:-lib lib32 lib64 libexec bin sbin}
-    stripDebugListTarget=${stripDebugListTarget:-}
-    stripAllList=${stripAllList:-}
-    stripAllListTarget=${stripAllListTarget:-}
+    stripDebugList=${stripDebugList[*]:-lib lib32 lib64 libexec bin sbin}
+    stripDebugListTarget=${stripDebugListTarget[*]:-}
+    stripAllList=${stripAllList[*]:-}
+    stripAllListTarget=${stripAllListTarget[*]:-}
 
     local i
     for i in ${!stripCmds[@]}; do
@@ -30,8 +39,8 @@ _doStrip() {
         if [[ "${dontStrip-}" || "${flag-}" ]] || ! type -f "${stripCmd-}" 2>/dev/null
         then continue; fi
 
-        stripDirs "$stripCmd" "$ranlibCmd" "$debugDirList" "${stripDebugFlags:--S}"
-        stripDirs "$stripCmd" "$ranlibCmd" "$allDirList" "${stripAllFlags:--s}"
+        stripDirs "$stripCmd" "$ranlibCmd" "$debugDirList" "${stripDebugFlags[*]:--S}"
+        stripDirs "$stripCmd" "$ranlibCmd" "$allDirList" "${stripAllFlags[*]:--s}"
     done
 }
 

--- a/pkgs/build-support/setup-hooks/win-dll-link.sh
+++ b/pkgs/build-support/setup-hooks/win-dll-link.sh
@@ -15,7 +15,7 @@ _linkDLLs() {
     #   prefix $PATH by currently-built outputs
     local DLLPATH=""
     local outName
-    for outName in $outputs; do
+    for outName in $(getAllOutputNames); do
         addToSearchPath DLLPATH "${!outName}/bin"
     done
     DLLPATH="$DLLPATH:$PATH"

--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -35,7 +35,7 @@ echo "testBuildFailure: Original builder produced exit code: $r"
 # -----------------------------------------
 # Write the build log to the default output
 
-outs=( $outputs )
+outs=( $(getAllOutputNames) )
 defOut=${outs[0]}
 defOutPath=${!defOut}
 

--- a/pkgs/data/icons/catppuccin-cursors/default.nix
+++ b/pkgs/data/icons/catppuccin-cursors/default.nix
@@ -50,7 +50,7 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    for output in $outputs; do
+    for output in $(getAllOutputNames); do
       if [ "$output" != "out" ]; then
         local outputDir="''${!output}"
         local iconsDir="$outputDir"/share/icons

--- a/pkgs/data/icons/comixcursors/default.nix
+++ b/pkgs/data/icons/comixcursors/default.nix
@@ -52,7 +52,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   installPhase = ''
-    for outputName in $outputs ; do
+    for outputName in $(getAllOutputNames) ; do
       if [ $outputName != out ]; then
         local outputDir=''${!outputName};
         local iconsDir=$outputDir/share/icons

--- a/pkgs/desktops/gnome/core/gdm/default.nix
+++ b/pkgs/desktops/gnome/core/gdm/default.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation rec {
     # We use rsync to merge the directories.
     rsync --archive "${DESTDIR}/etc" "$out"
     rm --recursive "${DESTDIR}/etc"
-    for o in $outputs; do
+    for o in $(getAllOutputNames); do
         if [[ "$o" = "debug" ]]; then continue; fi
         rsync --archive "${DESTDIR}/''${!o}" "$(dirname "''${!o}")"
         rm --recursive "${DESTDIR}/''${!o}"

--- a/pkgs/desktops/gnustep/make/builder.sh
+++ b/pkgs/desktops/gnustep/make/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 preConfigure() {

--- a/pkgs/development/compilers/aspectj/builder.sh
+++ b/pkgs/development/compilers/aspectj/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 export JAVA_HOME=$jre

--- a/pkgs/development/compilers/chicken/4/fetchegg/builder.sh
+++ b/pkgs/development/compilers/chicken/4/fetchegg/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 header "exporting egg ${eggName} (version $version) into $out"

--- a/pkgs/development/compilers/chicken/5/fetchegg/builder.sh
+++ b/pkgs/development/compilers/chicken/5/fetchegg/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 header "exporting egg ${eggName} (version $version) into $out"

--- a/pkgs/development/compilers/fpc/binary-builder-darwin.sh
+++ b/pkgs/development/compilers/fpc/binary-builder-darwin.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 pkgdir=$(pwd)/pkg

--- a/pkgs/development/compilers/fpc/binary-builder.sh
+++ b/pkgs/development/compilers/fpc/binary-builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 tar xf $src

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 

--- a/pkgs/development/compilers/ios-cross-compile/9.2_builder.sh
+++ b/pkgs/development/compilers/ios-cross-compile/9.2_builder.sh
@@ -1,4 +1,5 @@
 # -*- shell-script -*-
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 function extract

--- a/pkgs/development/compilers/ocaml/builder.sh
+++ b/pkgs/development/compilers/ocaml/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 configureFlags="-prefix $out $configureFlags"

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -132,12 +132,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/12.nix
+++ b/pkgs/development/compilers/openjdk/12.nix
@@ -136,12 +136,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/13.nix
+++ b/pkgs/development/compilers/openjdk/13.nix
@@ -136,12 +136,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/14.nix
+++ b/pkgs/development/compilers/openjdk/14.nix
@@ -132,12 +132,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/15.nix
+++ b/pkgs/development/compilers/openjdk/15.nix
@@ -131,12 +131,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/16.nix
+++ b/pkgs/development/compilers/openjdk/16.nix
@@ -138,12 +138,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -149,12 +149,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/18.nix
+++ b/pkgs/development/compilers/openjdk/18.nix
@@ -140,12 +140,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/19.nix
+++ b/pkgs/development/compilers/openjdk/19.nix
@@ -140,12 +140,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -187,12 +187,12 @@ let
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
       # Add the local library paths to remove dependencies on the bootstrap
-      for output in $outputs; do
+      for output in $(getAllOutputNames); do
         if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -281,15 +281,17 @@ in with passthru; stdenv.mkDerivation {
     substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
   '';
 
-  CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
-  LDFLAGS = concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs);
-  LIBS = "${optionalString (!stdenv.isDarwin) "-lcrypt"}";
-  NIX_LDFLAGS = lib.optionalString (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) ({
-    "glibc" = "-lgcc_s";
-    "musl" = "-lgcc_eh";
-  }."${stdenv.hostPlatform.libc}" or "");
-  # Determinism: We fix the hashes of str, bytes and datetime objects.
-  PYTHONHASHSEED=0;
+  env = {
+    CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
+    LDFLAGS = concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs);
+    LIBS = "${optionalString (!stdenv.isDarwin) "-lcrypt"}";
+    NIX_LDFLAGS = lib.optionalString (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) ({
+      "glibc" = "-lgcc_s";
+      "musl" = "-lgcc_eh";
+    }."${stdenv.hostPlatform.libc}" or "");
+    # Determinism: We fix the hashes of str, bytes and datetime objects.
+    PYTHONHASHSEED=0;
+  };
 
   configureFlags = [
     "--without-ensurepip"

--- a/pkgs/development/interpreters/python/setup-hook.nix
+++ b/pkgs/development/interpreters/python/setup-hook.nix
@@ -6,7 +6,9 @@ let
   hook = ./setup-hook.sh;
 in runCommand "python-setup-hook.sh" {
   strictDeps = true;
-  inherit sitePackages;
+  env = {
+    inherit sitePackages;
+  };
 } ''
   cp ${hook} hook.sh
   substituteAllInPlace hook.sh

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -60,7 +60,9 @@ stdenv.mkDerivation rec {
     ../../../build-support/setup-hooks/role.bash
     ./gettext-setup-hook.sh
   ];
-  gettextNeedsLdflags = stdenv.hostPlatform.libc != "glibc" && !stdenv.hostPlatform.isMusl;
+  env = {
+    gettextNeedsLdflags = stdenv.hostPlatform.libc != "glibc" && !stdenv.hostPlatform.isMusl;
+  };
 
   enableParallelBuilding = true;
   enableParallelChecking = false; # fails sometimes

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -54,9 +54,6 @@ assert withGd -> gd != null && libpng != null;
 
 stdenv.mkDerivation ({
   version = version + patchSuffix;
-  linuxHeaders = if withLinuxHeaders then linuxHeaders else null;
-
-  inherit (stdenv) is64bit;
 
   enableParallelBuilding = true;
 
@@ -175,10 +172,14 @@ stdenv.mkDerivation ({
   nativeBuildInputs = [ bison python3Minimal ] ++ extraNativeBuildInputs;
   buildInputs = [ linuxHeaders ] ++ lib.optionals withGd [ gd libpng ] ++ extraBuildInputs;
 
-  # Needed to install share/zoneinfo/zone.tab.  Set to impure /bin/sh to
-  # prevent a retained dependency on the bootstrap tools in the stdenv-linux
-  # bootstrap.
-  BASH_SHELL = "/bin/sh";
+  env = {
+    linuxHeaders = if withLinuxHeaders then linuxHeaders else "";
+    inherit (stdenv) is64bit;
+    # Needed to install share/zoneinfo/zone.tab.  Set to impure /bin/sh to
+    # prevent a retained dependency on the bootstrap tools in the stdenv-linux
+    # bootstrap.
+    BASH_SHELL = "/bin/sh";
+  };
 
   # Used by libgcc, elf-header, and others to determine ABI
   passthru = { inherit version; minorRelease = version; };

--- a/pkgs/development/libraries/glibc/locales-builder.sh
+++ b/pkgs/development/libraries/glibc/locales-builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 # Glibc cannot have itself in its RPATH.
 export NIX_NO_SELF_RPATH=1
 

--- a/pkgs/development/libraries/gtk-sharp/builder.sh
+++ b/pkgs/development/libraries/gtk-sharp/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 genericBuild

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -167,7 +167,7 @@ stdenv.mkDerivation rec {
     rsync --archive "${DESTDIR}${system}"/* "$out"
     rm --recursive "${DESTDIR}${system}"/*
     rmdir --parents --ignore-fail-on-non-empty "${DESTDIR}${system}"
-    for o in $outputs; do
+    for o in $(getAllOutputNames); do
         rsync --archive "${DESTDIR}/''${!o}" "$(dirname "''${!o}")"
         rm --recursive "${DESTDIR}/''${!o}"
     done

--- a/pkgs/development/libraries/wtk/builder.sh
+++ b/pkgs/development/libraries/wtk/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 mkdir unzipped

--- a/pkgs/development/libraries/xapian/default.nix
+++ b/pkgs/development/libraries/xapian/default.nix
@@ -26,7 +26,7 @@ let
     nativeBuildInputs = [ autoreconfHook ];
 
     doCheck = true;
-    AUTOMATED_TESTING = true; # https://trac.xapian.org/changeset/8be35f5e1/git
+    env.AUTOMATED_TESTING = true; # https://trac.xapian.org/changeset/8be35f5e1/git
 
     patches = lib.optionals stdenv.isDarwin [ ./skip-flaky-darwin-test.patch ];
 

--- a/pkgs/development/nim-packages/fetch-nimble/builder.sh
+++ b/pkgs/development/nim-packages/fetch-nimble/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 export HOME=$NIX_BUILD_TOP
 

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -1,6 +1,4 @@
-if [ -f .attrs.sh ]; then
-    . .attrs.sh
-fi
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 PERL5LIB="$PERL5LIB${PERL5LIB:+:}$out/lib/perl5/site_perl"

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -1,3 +1,6 @@
+if [ -f .attrs.sh ]; then
+    . .attrs.sh
+fi
 source $stdenv/setup
 
 PERL5LIB="$PERL5LIB${PERL5LIB:+:}$out/lib/perl5/site_perl"

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -24,6 +24,8 @@
 # https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC
 , PERL_USE_UNSAFE_INC ? "1"
 
+, env ? {}
+
 , ...
 }@attrs:
 
@@ -43,10 +45,11 @@ lib.throwIf (attrs ? name) "buildPerlPackage: `name` (\"${attrs.name}\") is depr
     buildInputs = buildInputs ++ [ perl ];
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.mini or perl) ];
 
-    fullperl = buildPerl;
-
     inherit outputs src doCheck checkTarget enableParallelBuilding;
-    inherit PERL_AUTOINSTALL AUTOMATED_TESTING PERL_USE_UNSAFE_INC;
+    env = {
+      inherit PERL_AUTOINSTALL AUTOMATED_TESTING PERL_USE_UNSAFE_INC;
+      fullperl = buildPerl;
+    } // env;
 
     meta = defaultMeta // (attrs.meta or { });
   });

--- a/pkgs/development/tools/build-managers/apache-maven/builder.sh
+++ b/pkgs/development/tools/build-managers/apache-maven/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 unpackPhase

--- a/pkgs/development/tools/build-managers/boot/builder.sh
+++ b/pkgs/development/tools/build-managers/boot/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 boot_bin=$out/bin/boot

--- a/pkgs/development/tools/misc/automake/builder.sh
+++ b/pkgs/development/tools/misc/automake/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 # Wrap the given `aclocal' program, appending extra `-I' flags

--- a/pkgs/development/tools/parsing/antlr/builder.sh
+++ b/pkgs/development/tools/parsing/antlr/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 tar zxvf $src

--- a/pkgs/misc/cups/drivers/samsung/4.00.39/builder.sh
+++ b/pkgs/misc/cups/drivers/samsung/4.00.39/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 arch=$(uname -m)

--- a/pkgs/os-specific/darwin/signing-utils/auto-sign-hook.sh
+++ b/pkgs/os-specific/darwin/signing-utils/auto-sign-hook.sh
@@ -25,7 +25,7 @@ signDarwinBinariesIn() {
 signDarwinBinariesInAllOutputs() {
   local output
 
-  for output in $outputs; do
+  for output in $(getAllOutputNames); do
      signDarwinBinariesIn "${!output}"
   done
 }

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 unpackManually() {

--- a/pkgs/os-specific/linux/opengl/xorg-sys/builder.sh
+++ b/pkgs/os-specific/linux/opengl/xorg-sys/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 mkdir -p $out/lib

--- a/pkgs/servers/http/tomcat/axis2/builder.sh
+++ b/pkgs/servers/http/tomcat/axis2/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
 unzip $src

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   ];
 
   # needs to find a local perl module during build
-  PERL_USE_UNSAFE_INC = "1";
+  env.PERL_USE_UNSAFE_INC = "1";
 
   # TODO: tests are failing https://munin-monitoring.org/ticket/1390#comment:1
   # NOTE: important, test command always exits with 0, think of a way to abort the build once tests pass

--- a/pkgs/servers/x11/xorg/builder.sh
+++ b/pkgs/servers/x11/xorg/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 # This is the builder for all X.org components.
 source $stdenv/setup
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -262,11 +262,12 @@ rec {
           ln -s ${bootstrapTools}/bin/rewrite-tbd $out/bin
         '';
 
-        binutils-unwrapped = { name = "bootstrap-stage0-binutils"; outPath = bootstrapTools; };
+        binutils-unwrapped = bootstrapTools // {
+          name = "bootstrap-stage0-binutils";
+        };
 
-        cctools = {
+        cctools = bootstrapTools // {
           name = "bootstrap-stage0-cctools";
-          outPath = bootstrapTools;
           targetPrefix = "";
         };
 

--- a/pkgs/stdenv/generic/default-builder.sh
+++ b/pkgs/stdenv/generic/default-builder.sh
@@ -1,2 +1,6 @@
+if [ -f .attrs.sh ]; then
+    . .attrs.sh
+fi
+
 source $stdenv/setup
 genericBuild

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -156,7 +156,7 @@ let
 
 # Experimental.  For simple packages mostly just works,
 # but for anything complex, be prepared to debug if enabling.
-, __structuredAttrs ? false
+, __structuredAttrs ? config.structuredAttrsByDefault or false
 
 , env ? { }
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -488,8 +488,8 @@ else let
     assert lib.assertMsg (overlappingNames == [ ])
       "The ‘env’ attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping: ${lib.concatStringsSep ", " overlappingNames}";
     lib.mapAttrs
-      (n: v: assert lib.assertMsg (lib.isString v || lib.isBool v || lib.isInt v)
-        "The ‘env’ attribute set can only contain string, boolean or integer attributes. The ‘${n}’ attribute is of type ${builtins.typeOf v}."; v)
+      (n: v: assert lib.assertMsg (lib.isString v || lib.isBool v || lib.isInt v || lib.isDerivation v)
+        "The ‘env’ attribute set can only contain derivation, string, boolean or integer attributes. The ‘${n}’ attribute is of type ${builtins.typeOf v}."; v)
       env;
 
 in

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -154,6 +154,12 @@ let
   (! attrs ? outputHash) # Fixed-output drvs can't be content addressed too
   && config.contentAddressedByDefault
 
+# Experimental.  For simple packages mostly just works,
+# but for anything complex, be prepared to debug if enabling.
+, __structuredAttrs ? false
+
+, env ? { }
+
 , ... } @ attrs:
 
 let
@@ -259,13 +265,16 @@ else let
     lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or [])
       (lib.concatLists propagatedDependencies));
 
+  envIsExportable = lib.isAttrs env && !lib.isDerivation env;
+
   derivationArg =
     (removeAttrs attrs
-      ["meta" "passthru" "pos"
+      (["meta" "passthru" "pos"
        "checkInputs" "installCheckInputs"
        "__darwinAllowLocalNetworking"
        "__impureHostDeps" "__propagatedImpureHostDeps"
-       "sandboxProfile" "propagatedSandboxProfile"])
+       "sandboxProfile" "propagatedSandboxProfile"]
+       ++ lib.optionals envIsExportable [ "env" ]))
     // (lib.optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
       name =
         let
@@ -289,7 +298,7 @@ else let
           then attrs.name + hostSuffix
           else "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
         );
-    }) // {
+    }) // lib.optionalAttrs (envIsExportable && __structuredAttrs) { env = checkedEnv; } // {
       builder = attrs.realBuilder or stdenv.shell;
       args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
       inherit stdenv;
@@ -304,8 +313,7 @@ else let
 
       userHook = config.stdenv.userHook or null;
       __ignoreNulls = true;
-
-      inherit strictDeps;
+      inherit __structuredAttrs strictDeps;
 
       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
@@ -473,6 +481,17 @@ else let
                    else true);
     };
 
+  checkedEnv =
+    let
+      overlappingNames = lib.intersectLists (lib.attrNames env) (lib.attrNames derivationArg);
+    in
+    assert lib.assertMsg (overlappingNames == [ ])
+      "The ‘env’ attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping: ${lib.concatStringsSep ", " overlappingNames}";
+    lib.mapAttrs
+      (n: v: assert lib.assertMsg (lib.isString v || lib.isBool v || lib.isInt v)
+        "The ‘env’ attribute set can only contain string, boolean or integer attributes. The ‘${n}’ attribute is of type ${builtins.typeOf v}."; v)
+      env;
+
 in
 
 lib.extendDerivation
@@ -509,7 +528,7 @@ lib.extendDerivation
    # should be made available to Nix expressions using the
    # derivation (e.g., in assertions).
    passthru)
-  (derivation derivationArg);
+  (derivation (derivationArg // lib.optionalAttrs envIsExportable checkedEnv));
 
 in
   fnOrAttrs:

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -878,6 +878,10 @@ substituteInPlace() {
 }
 
 _allFlags() {
+    # export some local variables for the awk below
+    # so some substitutions such as name don't have to be in the env attrset
+    # when __structuredAttrs is enabled
+    export system pname name version
     for varName in $(awk 'BEGIN { for (v in ENVIRON) if (v ~ /^[a-z][a-zA-Z0-9_]*$/) print v }'); do
         if (( "${NIX_DEBUG:-0}" >= 1 )); then
             printf "@%s@ -> %q\n" "${varName}" "${!varName}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -27,6 +27,10 @@ if [ -n "$__structuredAttrs" ]; then
         # ex: out=/nix/store/...
         export "$outputName=${outputs[$outputName]}"
     done
+    # $NIX_ATTRS_JSON_FILE points to the wrong location in sandbox
+    # https://github.com/NixOS/nix/issues/6736
+    export NIX_ATTRS_JSON_FILE="$NIX_BUILD_TOP/.attrs.json"
+    export NIX_ATTRS_SH_FILE="$NIX_BUILD_TOP/.attrs.sh"
 else
     : ${outputs:=out}
 fi

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -249,7 +249,7 @@ in
         # Apparently iconv won't work with bootstrap glibc, but it will be used
         # with glibc built later where we keep *this* build of libunistring,
         # so we need to trick it into supporting libiconv.
-        am_cv_func_iconv_works = "yes";
+        env = attrs.env or {} // { am_cv_func_iconv_works = "yes"; };
       });
       libidn2 = super.libidn2.overrideAttrs (attrs: {
         postFixup = attrs.postFixup or "" + ''

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -21,6 +21,7 @@ with pkgs;
   cc-wrapper-clang-9 = callPackage ./cc-wrapper { stdenv = llvmPackages_9.stdenv; };
   cc-wrapper-libcxx-9 = callPackage ./cc-wrapper { stdenv = llvmPackages_9.libcxxStdenv; };
   stdenv-inputs = callPackage ./stdenv-inputs { };
+  stdenv = callPackage ./stdenv { };
 
   config = callPackage ./config.nix { };
 

--- a/pkgs/test/simple/builder.sh
+++ b/pkgs/test/simple/builder.sh
@@ -1,3 +1,4 @@
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 set -x
 
 export NIX_DEBUG=1

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -1,0 +1,107 @@
+# To run these tests:
+# nix-build -A tests.stdenv
+
+{ stdenv
+, pkgs
+, lib
+,
+}:
+
+let
+  # use a early stdenv so when hacking on stdenv this test can be run quickly
+  bootStdenv = stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv;
+  pkgsStructured = import pkgs.path { config = { structuredAttrsByDefault = true; }; inherit (stdenv.hostPlatform) system; };
+  bootStdenvStructuredAttrsByDefault = pkgsStructured.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv;
+in
+
+{
+  test-env-attrset = bootStdenv.mkDerivation {
+    name = "test-env-attrset";
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+    dontPatch = true;
+    dontFixup = true;
+    env = {
+      string = "testing-string";
+    };
+
+    installPhase = ''
+      declare -p string
+      echo "env.string = $string"
+      [[ $string == "testing-string" ]] || (echo "string was not testing-string" && false)
+      touch $out
+    '';
+  };
+
+  test-structured-env-attrset = bootStdenv.mkDerivation {
+    name = "test-structured-env-attrset";
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+    dontPatch = true;
+    dontFixup = true;
+    __structuredAttrs = true;
+    env = {
+      string = "testing-string";
+    };
+
+    installPhase = ''
+      declare -p string
+      echo "env.string = $string"
+      [[ $string == "testing-string" ]] || (echo "string was not testing-string" && false)
+      touch $out
+    '';
+  };
+
+  test-cc-wrapper-substitutions = bootStdenv.cc.overrideAttrs (previousAttrs: {
+    name = "test-cc-wrapper-substitutions";
+
+    postFixup = previousAttrs.postFixup + ''
+      declare -p wrapperName
+      echo "env.wrapperName = $wrapperName"
+      [[ $wrapperName == "CC_WRAPPER" ]] || (echo "wrapperName was not CC_WRAPPER" && false)
+      touch $out
+    '';
+  });
+
+  structuredAttrsByDefault = lib.recurseIntoAttrs {
+
+    test-cc-wrapper-substitutions = bootStdenvStructuredAttrsByDefault.cc.overrideAttrs (previousAttrs: {
+      name = "test-cc-wrapper-substitutions-structuredAttrsByDefault";
+
+      postFixup = previousAttrs.postFixup + ''
+        declare -p wrapperName
+        echo "env.wrapperName = $wrapperName"
+        [[ $wrapperName == "CC_WRAPPER" ]] || (echo "wrapperName was not CC_WRAPPER" && false)
+        declare -p suffixSalt
+        echo "env.suffixSalt = $suffixSalt"
+        [[ $suffixSalt == "${bootStdenvStructuredAttrsByDefault.cc.suffixSalt}" ]] || (echo "wrapperName was not ${bootStdenvStructuredAttrsByDefault.cc.suffixSalt}" && false)
+
+        grep -q "@out@" $out/bin/cc || echo "@out@ in $out/bin/cc was substituted"
+        grep -q "@suffixSalt@" $out/bin/cc && (echo "$out/bin/cc contains unsubstituted variables" && false)
+
+        touch $out
+      '';
+    });
+
+    test-structured-env-attrset = bootStdenvStructuredAttrsByDefault.mkDerivation {
+      name = "test-structured-env-attrset-structuredAttrsByDefault";
+      dontUnpack = true;
+      dontConfigure = true;
+      dontBuild = true;
+      dontPatch = true;
+      dontFixup = true;
+      env = {
+        string = "testing-string";
+      };
+
+      installPhase = ''
+        declare -p string
+        echo "env.string = $string"
+        [[ $string == "testing-string" ]] || (echo "string was not testing-string" && false)
+        touch $out
+      '';
+    };
+  };
+}

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -22,10 +22,10 @@ let
       postFixup = previousAttrs.postFixup + ''
         declare -p wrapperName
         echo "env.wrapperName = $wrapperName"
-        [[ $wrapperName == "CC_WRAPPER" ]] || (echo "wrapperName was not CC_WRAPPER" && false)
+        [[ $wrapperName == "CC_WRAPPER" ]] || (echo "'\$wrapperName' was not 'CC_WRAPPER'" && false)
         declare -p suffixSalt
         echo "env.suffixSalt = $suffixSalt"
-        [[ $suffixSalt == "${stdenv'.cc.suffixSalt}" ]] || (echo "wrapperName was not ${stdenv'.cc.suffixSalt}" && false)
+        [[ $suffixSalt == "${stdenv'.cc.suffixSalt}" ]] || (echo "'\$suffxSalt' was not '${stdenv'.cc.suffixSalt}'" && false)
 
         grep -q "@out@" $out/bin/cc || echo "@out@ in $out/bin/cc was substituted"
         grep -q "@suffixSalt@" $out/bin/cc && (echo "$out/bin/cc contains unsubstituted variables" && false)
@@ -46,7 +46,35 @@ let
         buildCommand = ''
           declare -p string
           echo "env.string = $string"
-          [[ $string == "testing-string" ]] || (echo "string was not testing-string" && false)
+          [[ $string == "testing-string" ]] || (echo "'\$string' was not 'testing-string'" && false)
+          touch $out
+        '';
+      } // extraAttrs);
+
+  testPrependAndAppendToVar = { name, stdenv', extraAttrs ? { } }:
+    stdenv'.mkDerivation
+      ({
+        inherit name;
+        env = {
+          string = "testing-string";
+        };
+
+        passAsFile = [ "buildCommand" ] ++ lib.optionals (extraAttrs ? extraTest) [ "extraTest" ];
+        # FIXME: with structuredAttrs string is converted to a indexed array
+        # should a/pToVar check if the passed variable is a array or a string?
+        # declare -x string="testing-string"
+        # declare -ax string=([0]="world" [1]="testing-string" [2]="hello")
+        buildCommand = ''
+          declare -p string
+          appendToVar string hello
+          # test that quoted strings work
+          prependToVar string "world"
+          declare -p string
+
+          [[ $string == "world testing-string hello" ]] || (echo "'\$string' was not 'world testing-string hello'" && false)
+
+          eval "$extraTest"
+
           touch $out
         '';
       } // extraAttrs);
@@ -56,13 +84,65 @@ in
 {
   test-env-attrset = testEnvAttrset { name = "test-env-attrset"; stdenv' = bootStdenv; };
 
-  test-structured-env-attrset = testEnvAttrset { name = "test-structured-env-attrset"; stdenv' = bootStdenv; extraAttrs = { __structuredAttrs = true; }; };
+  test-prepend-append-to-var = testPrependAndAppendToVar {
+    name = "test-prepend-append-to-var";
+    stdenv' = bootStdenv;
+  };
 
-  test-cc-wrapper-substitutions = ccWrapperSubstitutionsTest { name = "test-cc-wrapper-substitutions"; stdenv' = bootStdenv; };
+  test-structured-env-attrset = testEnvAttrset {
+    name = "test-structured-env-attrset";
+    stdenv' = bootStdenv;
+    extraAttrs = { __structuredAttrs = true; };
+  };
+
+  test-cc-wrapper-substitutions = ccWrapperSubstitutionsTest {
+    name = "test-cc-wrapper-substitutions";
+    stdenv' = bootStdenv;
+  };
 
   structuredAttrsByDefault = lib.recurseIntoAttrs {
-    test-cc-wrapper-substitutions = ccWrapperSubstitutionsTest { name = "test-cc-wrapper-substitutions-structuredAttrsByDefault"; stdenv' = bootStdenvStructuredAttrsByDefault; };
+    test-cc-wrapper-substitutions = ccWrapperSubstitutionsTest {
+      name = "test-cc-wrapper-substitutions-structuredAttrsByDefault";
+      stdenv' = bootStdenvStructuredAttrsByDefault;
+    };
 
-    test-structured-env-attrset = testEnvAttrset { name = "test-structured-env-attrset-structuredAttrsByDefault"; stdenv' = bootStdenvStructuredAttrsByDefault; };
+    test-structured-env-attrset = testEnvAttrset {
+      name = "test-structured-env-attrset-structuredAttrsByDefault";
+      stdenv' = bootStdenvStructuredAttrsByDefault;
+    };
+
+    test-prepend-append-to-var = testPrependAndAppendToVar {
+      name = "test-prepend-append-to-var-structuredAttrsByDefault";
+      stdenv' = bootStdenvStructuredAttrsByDefault;
+      extraAttrs = {
+        # will be a bash indexed array in attrs.sh
+        # declare -a list=('a' 'b' )
+        # and a json array in attrs.json
+        # "list":["a","b"]
+        list = [ "a" "b" ];
+        # will be a bash associative array(dictionary) in attrs.sh
+        # declare -A array=(['a']='1' ['b']='2' )
+        # and a json object in attrs.json
+        # {"array":{"a":"1","b":"2"}
+        array = { a = "1"; b = "2"; };
+        extraTest = ''
+          declare -p array
+          array+=(["c"]="3")
+          declare -p array
+
+          [[ "''${array[c]}" == "3" ]] || (echo "c element of '\$array' was not '3'" && false)
+
+          declare -p list
+          prependToVar list hello
+          # test that quoted strings work
+          appendToVar list "world"
+          declare -p list
+
+          [[ "''${list[0]}" == "hello" ]] || (echo "first element of '\$list' was not 'hello'" && false)
+          [[ "''${list[1]}" == "a" ]] || (echo "first element of '\$list' was not 'a'" && false)
+          [[ "''${list[-1]}" == "world" ]] || (echo "last element of '\$list' was not 'world'" && false)
+        '';
+      };
+    };
   };
 }

--- a/pkgs/tools/typesetting/lout/builder.sh
+++ b/pkgs/tools/typesetting/lout/builder.sh
@@ -1,6 +1,7 @@
 # Prepare a makefile specifying the appropriate output directories.
 #
 # Written by Ludovic Courtès <ludo@gnu.org>.
+if [ -e .attrs.sh ]; then source .attrs.sh; fi
 
 source "$stdenv/setup" || exit 1
 

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -247,7 +247,7 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
     "xetex"
   ];
   postInstall = ''
-    for output in $outputs; do
+    for output in $(getAllOutputNames); do
       mkdir -p "''${!output}/bin"
     done
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13933,9 +13933,11 @@ with pkgs;
 
   wrapNonDeterministicGcc = stdenv: ccWrapper:
     if ccWrapper.isGNU then ccWrapper.overrideAttrs(old: {
-      cc = old.cc.override {
-        reproducibleBuild = false;
-        profiledCompiler = with stdenv; (!isDarwin && hostPlatform.isx86);
+      env = old.env // {
+        cc = old.env.cc.override {
+          reproducibleBuild = false;
+          profiledCompiler = with stdenv; (!isDarwin && hostPlatform.isx86);
+        };
       };
     }) else ccWrapper;
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -47,6 +47,10 @@ let
       feature = "set `strictDeps` to true by default";
     };
 
+    structuredAttrsByDefault = mkMassRebuild {
+      feature = "set `__structuredAttrs` to true by default";
+    };
+
     enableParallelBuildingByDefault = mkMassRebuild {
       feature = "set `enableParallelBuilding` to true by default";
     };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23029,7 +23029,7 @@ let
 
     # For some crazy reason Makefile.PL doesn't generate a Makefile if
     # AUTOMATED_TESTING is set.
-    AUTOMATED_TESTING = false;
+    env.AUTOMATED_TESTING = false;
 
     # Makefile.PL looks for ncurses in Glibc's prefix.
     preConfigure =
@@ -27058,7 +27058,7 @@ let
         hash = "sha256-gxxY8549/ebS3QORjSs8IgdBs2aD05Tu+9Bn70gu7gQ=";
       })
     ];
-    AUTOMATED_TESTING = false;
+    env.AUTOMATED_TESTING = false;
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [ pkgs.xorg.libxcb pkgs.xorg.xcbproto pkgs.xorg.xcbutil pkgs.xorg.xcbutilwm ExtUtilsDepends ExtUtilsPkgConfig TestDeep TestException XSObjectMagic ];
     propagatedBuildInputs = [ DataDump MouseXNativeTraits XMLDescent XMLSimple ];


### PR DESCRIPTION
###### Description of changes
supersedes https://github.com/NixOS/nixpkgs/pull/85042
Read https://github.com/NixOS/nixpkgs/pull/72074
Built hello with structuredAttrs
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
