### PR TITLE
doc/multiple-output: codify convention co-installable doc outputs

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -663,3 +663,9 @@ stdenv.mkDerivation {
   ...
 }
 ```
+
+### Building offline documentation {#ssec-building-offline-documentation}
+
+Packages _should_ build and install offline documentation from, e.g Sphinx or TexInfo sources, if they are availabe in upstream release.Packages _should_ use version control checkout (e.g git or subversion) instead of release archive if later is missing documentation (often happens with archives on PyPi). Packages _should_ build documentation in html format and install it into `doc` output if html format is available. Packages _may_ build and install documentation in additional formats (e.g text, pdf, epub) into extra outputs; additional formats _should not_ be installed into `doc` output. Documentation outputs of different versions of same application _should_ be all co-insta llable; installing documentation into `share/doc/$name` (not `share/doc/$pname`) is an easy way to achieve it.
+
+If upstream maintains documentation separately with independent release process or if documentation is maintained by party other than primary maintainer, it is _optional_ for packages download and build said documentation.


### PR DESCRIPTION
This change to NixPkgs manual is prompted by discussions that happened is
multiple pull requests about whether to install documentation into
`share/doc/$pname`(as it is usually done with conventional package managers) or
into `/share/doc/$name` that allows co-installing documentation of multiple
versions in single Nix profile.

Right now manual does not state policy about correct way to install
documentation.

I suggest codifying $name location, since it has clear usability advantage and,
as far as I can tell, no disadvantages at all (except paths being slightly
longer).

Should there be consensus on this approach, I volunteer to patch stdenv fixup
phase (or, alternatively, introduce another fixup hook for more gradual
migration) to do equivalent of following:

```
if [[ -e $doc/share/$pname ]] && ! [[ -e $doc/share/$name ]] ; then
	mv $doc/share/$pname $doc/share/$name
fi
```

Suggestions to wording are welcome.

https://github.com/NixOS/nixpkgs/pull/175349#discussion_r884366295
https://github.com/NixOS/nixpkgs/pull/173325#discussion_r874739676

