### PR TITLE
hugo: broken = stdenv.isDarwin -> stdenv.isDarwin && stdenv.isx86_64

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = stdenv.isDarwin && stdenv.isx86_64;
     description = "A fast and modern static website engine";
     homepage = "https://gohugo.io";
     license = licenses.asl20;


### PR DESCRIPTION
###### Description of changes
In [37c633f](https://github.com/polynomialspace/nixpkgs/commit/37c633f7ae518456af1f3064bd5c386e2de92c37), several packages were marked broken on stdenv.Darwin, some of which seem to be broken specifically due to the older SDK used for x86_64-darwin. This is one of those packages, and in this case specifically, go1.17 [dropped support for 10.12](https://go.dev/doc/go1.17#ports) last year.
  
 Related: [NixOS#169478](https://github.com/NixOS/nixpkgs/issues/169478), [NixOS#101229](https://github.com/NixOS/nixpkgs/issues/101229), #173671
  
 ###### Things done
 * Built on platform(s)
    
   * [ ]  x86_64-linux
   * [ ]  aarch64-linux
   * [ ]  x86_64-darwin
   * [x]  aarch64-darwin
 * [x]  Tested basic functionality of all binary files (usually in `./result/bin/`)
