### PR TITLE
python3Packages.afdko: 3.8.1 -> 3.8.3; python3Packages.tqdm: 4.63 -> 4.64; antlr4_9: 4.9.2 -> 4.9.3

### DIFF
--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "afdko";
-  version = "3.8.1";
+  version = "3.8.3";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-BaSpw7TiBymCvoP0/z1zynWKQJH/PjbbGf85ZI9LOZw=";
+    sha256 = "0mplyla4zcai3qld7is7bl5wn2kzhp87w87yi13wpqnw06i6ij4b";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/afdko/use-dynamic-system-antlr4-runtime.patch
+++ b/pkgs/development/python-modules/afdko/use-dynamic-system-antlr4-runtime.patch
@@ -1,4 +1,4 @@
-commit 105daa26f09034af58eb13ac7c5c4ff5420c1724
+commit 1ccbf21a67da0fdbaad881a1f5c2a4df915e8c57
 Author: sternenseemann <sternenseemann@systemli.org>
 Date:   Tue Oct 5 18:16:10 2021 +0200
 
@@ -9,19 +9,17 @@ Date:   Tue Oct 5 18:16:10 2021 +0200
     called antlr4-runtime, not antlr4_static).
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d7f86fb6..c43c4456 100644
+index e9c8c08e..dc3a46da 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -36,13 +36,13 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
- # https://www.antlr.org/download/antlr4-cpp-runtime-4.9.2-source.zip
+@@ -36,11 +36,11 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ # https://www.antlr.org/download/antlr4-cpp-runtime-4.9.3-source.zip
  # set(ANTLR4_ZIP_REPOSITORY "/path_to_antlr4_archive/a4.zip")
  
 -add_definitions(-DANTLR4CPP_STATIC)
  set(ANTLR4_WITH_STATIC_CRT OFF)
- # Use slightly more recent commit than 4.9.2 to deal with utfcpp test
- # compilation problems
- # set(ANTLR4_TAG tags/4.9.2)
- set(ANTLR4_TAG 916f03366edf15bf8b50010b11d479c189bf9f96)
+ # 4.9.3 is the latest ANTLR4 version
+ set(ANTLR4_TAG tags/4.9.3)
 -include(ExternalAntlr4Cpp)
 +find_path(ANTLR4_HEADER antlr4-runtime.h PATH_SUFFIXES antlr4-runtime)
 +set(ANTLR4_INCLUDE_DIRS ${ANTLR4_HEADER})

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -14,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "tqdm";
-  version = "4.63.1";
+  version = "4.64.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-QjCkkRmkFsiMxH0NLTLV2Q8aKC1eSX1JgBlQcE5Jhj0=";
+    sha256 = "13a0spki37rdbx54nspcni3bpsp4d7p5ln570yipf1r01v9mbgj0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/parsing/antlr/4.9.nix
+++ b/pkgs/development/tools/parsing/antlr/4.9.nix
@@ -2,12 +2,12 @@
 , fetchpatch, fetchFromGitHub, cmake, ninja, pkg-config, libuuid, utf8cpp, darwin }:
 
 let
-  version = "4.9.2";
+  version = "4.9.3";
   source = fetchFromGitHub {
     owner = "antlr";
     repo = "antlr4";
     rev = version;
-    sha256 = "0rpqgl2y22iiyg42y8jyiy2g7x421yf0q16cf17j76iai6y0bm5p";
+    sha256 = "1af3cfqwk7lq1b5qsh1am0922fyhy7wmlpnrqdnvch3zzza9n1qm";
   };
 
   runtime = {
@@ -17,14 +17,6 @@ let
       src = source;
 
       outputs = [ "out" "dev" "doc" ];
-
-      patches = [
-        (fetchpatch {
-          name = "use-utfcpp-from-system.patch";
-          url = "https://github.com/antlr/antlr4/commit/5a808b470e1314b63b0a921178040ccabb357945.patch";
-          sha256 = "0nq7iajy9inllcspyqpxskfg3k5s1fwm7ph75i8lfc25rl35k1w7";
-        })
-      ];
 
       patchFlags = [ "-p3" ];
 
@@ -52,7 +44,7 @@ let
 
     src = fetchurl {
       url = "https://www.antlr.org/download/antlr-${version}-complete.jar";
-      sha256 = "1k9pw5gv2zhh06n1vys76kchlz4mz0vgv3iiba8w47b9fqa7n4dv";
+      sha256 = "0dnz2x54kigc58bxnynjhmr5iq49f938vj6p50gdir1xdna41kdg";
     };
 
     dontUnpack = true;


### PR DESCRIPTION
###### Description of changes

* antlr4 4.9.3 lets us drop a patch
* tqdm only has additions, so should be safe
* afdko >= 3.8.2 pins antlr4 4.9.3 and tqdm >= 4.64

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
