### PR TITLE
netdata: do not persist ./configure flags to decrease closure size

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -49,6 +49,10 @@ in stdenv.mkDerivation rec {
     # Therefore we put it into `/run/netdata`, which is owned
     # by netdata only.
     ./ipc-socket-in-run.patch
+
+    # Avoid build-only inputs in closure leaked by configure command:
+    #   https://github.com/NixOS/nixpkgs/issues/175693#issuecomment-1143344162
+    ./skip-CONFIGURE_COMMAND.patch
   ];
 
   NIX_CFLAGS_COMPILE = optionalString withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";

--- a/pkgs/tools/system/netdata/skip-CONFIGURE_COMMAND.patch
+++ b/pkgs/tools/system/netdata/skip-CONFIGURE_COMMAND.patch
@@ -1,0 +1,16 @@
+Shrink closure size by avoiding paths embedded from configure call.
+
+https://github.com/NixOS/nixpkgs/issues/175693
+--- a/daemon/buildinfo.c
++++ b/daemon/buildinfo.c
+@@ -248,7 +248,9 @@ void print_build_info(void) {
+     char *prebuilt_distro = NULL;
+     get_install_type(&install_type, &prebuilt_arch, &prebuilt_distro);
+ 
+-    printf("Configure options: %s\n", CONFIGURE_COMMAND);
++    // To minimize closure size do not persist configure options
++    // with build-time inputs.
++    printf("Configure options: REMOVED\n");
+ 
+     if (install_type == NULL) {
+         printf("Install type: unknown\n");


### PR DESCRIPTION
Before:

    $ nix path-info -r ./result | wc -l
    76
    $ nix path-info -Sh ./result
    ...-netdata-1.34.1       366.8M

After:

    $ nix path-info -r ./result | wc -l
    30
    $ nix path-info -Sh ./result
    ...-netdata-1.34.1       205.7M

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
