### PR TITLE
jellyfin: fix permissions on state directory

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -53,7 +53,10 @@ in
         User = cfg.user;
         Group = cfg.group;
         StateDirectory = "jellyfin";
+        StateDirectoryMode = "0700";
         CacheDirectory = "jellyfin";
+        CacheDirectoryMode = "0700";
+        UMask = "0077";
         ExecStart = "${cfg.package}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
         Restart = "on-failure";
 


### PR DESCRIPTION
Previously, all configuration and state data was accessible to all
users on the system running jellyfin. This included user passwords in
the Jellyfin database, as well as credentials for LDAP if configured.
The exact set of accessible data depends on system configuration.

Thanks to Sofie Finnes Øvrelid for reporting this issue.

Fixes: CVE-2022-32198

Co-Authored-By: Martin Weinelt <hexa@darmstadt.ccc.de>

cc module maintainer @minijackson 