### PR TITLE
tmux: 3.2a > 3.3, add me as maintainer

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -1,11 +1,12 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
 , autoreconfHook
-, pkg-config
 , bison
-, ncurses
 , libevent
+, ncurses
+, pkg-config
+, systemd
 , utf8proc
 }:
 
@@ -22,7 +23,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "tmux";
-  version = "3.2a";
+  version = "3.3";
 
   outputs = [ "out" "man" ];
 
@@ -30,16 +31,8 @@ stdenv.mkDerivation rec {
     owner = "tmux";
     repo = "tmux";
     rev = version;
-    sha256 = "0143ylfk7zsl3xmiasb768238gr582cfhsgv3p0h0f13bp8d6q09";
+    sha256 = "sha256-Sxj2vXkbbPNRrqJKeIYwI7xdBtwRbl6a6a3yZr7UWW0=";
   };
-
-  patches = [
-    # See https://github.com/tmux/tmux/pull/2755
-    (fetchpatch {
-      url = "https://github.com/tmux/tmux/commit/d0a2683120ec5a33163a14b0e1b39d208745968f.patch";
-      sha256 = "070knpncxfxi6k4q64jwi14ns5vm3606cf402h1c11cwnaa84n1g";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -50,12 +43,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ncurses
     libevent
-  ] ++ lib.optionals stdenv.isDarwin [ utf8proc ];
+  ] ++ lib.optionals stdenv.isLinux [ systemd ]
+  ++ lib.optionals stdenv.isDarwin [ utf8proc ];
 
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-  ] ++ lib.optionals stdenv.isDarwin [ "--enable-utf8proc" ];
+  ] ++ lib.optionals stdenv.isLinux [ "--enable-systemd" ]
+  ++ lib.optionals stdenv.isDarwin [ "--enable-utf8proc" ];
 
   enableParallelBuilding = true;
 
@@ -67,24 +62,21 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://tmux.github.io/";
     description = "Terminal multiplexer";
-
-    longDescription =
-      '' tmux is intended to be a modern, BSD-licensed alternative to programs such as GNU screen. Major features include:
-
-          * A powerful, consistent, well-documented and easily scriptable command interface.
-          * A window may be split horizontally and vertically into panes.
-          * Panes can be freely moved and resized, or arranged into preset layouts.
-          * Support for UTF-8 and 256-colour terminals.
-          * Copy and paste with multiple buffers.
-          * Interactive menus to select windows, sessions or clients.
-          * Change the current window by searching for text in the target.
-          * Terminal locking, manually or after a timeout.
-          * A clean, easily extended, BSD-licensed codebase, under active development.
-      '';
+    longDescription = ''
+      tmux is intended to be a modern, BSD-licensed alternative to programs such as GNU screen. Major features include:
+        * A powerful, consistent, well-documented and easily scriptable command interface.
+        * A window may be split horizontally and vertically into panes.
+        * Panes can be freely moved and resized, or arranged into preset layouts.
+        * Support for UTF-8 and 256-colour terminals.
+        * Copy and paste with multiple buffers.
+        * Interactive menus to select windows, sessions or clients.
+        * Change the current window by searching for text in the target.
+        * Terminal locking, manually or after a timeout.
+        * A clean, easily extended, BSD-licensed codebase, under active development.
+    '';
     changelog = "https://github.com/tmux/tmux/raw/${version}/CHANGES";
     license = lib.licenses.bsd3;
-
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ thammers fpletz ];
+    maintainers = with lib.maintainers; [ thammers fpletz SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
