### PR TITLE
vapoursynth: Add to pythonPackages

### DIFF
--- a/pkgs/development/python-modules/vapoursynth/default.nix
+++ b/pkgs/development/python-modules/vapoursynth/default.nix
@@ -1,0 +1,20 @@
+{ vapoursynth, cython, buildPythonPackage, python }:
+
+buildPythonPackage {
+  pname = "vapoursynth";
+
+  inherit (vapoursynth) src version;
+  nativeBuildInputs = [
+    cython
+  ];
+  buildInputs = [
+    vapoursynth
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s $src/test -p "*test.py"
+  '';
+
+  inherit (vapoursynth) meta;
+}
+

--- a/pkgs/development/python-modules/vapoursynth/default.nix
+++ b/pkgs/development/python-modules/vapoursynth/default.nix
@@ -3,10 +3,12 @@
 buildPythonPackage {
   pname = "vapoursynth";
 
-  inherit (vapoursynth) src version;
+  inherit (vapoursynth) version src;
+
   nativeBuildInputs = [
     cython
   ];
+
   buildInputs = [
     vapoursynth
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10882,6 +10882,10 @@ in {
 
   vallox-websocket-api = callPackage ../development/python-modules/vallox-websocket-api { };
 
+  vapoursynth = callPackage ../development/python-modules/vapoursynth {
+    inherit (pkgs) vapoursynth;
+  };
+
   variants = callPackage ../development/python-modules/variants { };
 
   varint = callPackage ../development/python-modules/varint { };


### PR DESCRIPTION
###### Description of changes

This allows it to be used in CI contexts.

Since both the python module and the frame-server itself are in the same repository,
the python module will take the source and version from the library.

This way only one package must be updated as they correspond to each other.

Otherwise a minimal flake.nix for a python library depending on vapoursynth looks like this:

```nix
{
  outputs = { self, nixpkgs }: 
    let
      pkgs = nixpkgs.legacyPackages.x86_64-linux;
      vapoursynthModule = pkgs.python310Packages.buildPythonPackage {
        pname = "vapoursynth";
        inherit (pkgs.vapoursynth) src version;
        buildInputs = [
          pkgs.python310Packages.cython
          pkgs.vapoursynth
        ];
      };
    in {
    devShells.x86_64-linux.default = pkgs.mkShell {
      buildInputs = [
        (pkgs.python310.withPackages (ps: [ vapoursynthModule ]))
      ];
    };
  };
}
```

The example code has not been tested but it should get the point across.

Since I am not sure if ofBorg manages to automatically ping the maintainers:
@rnhmjoj @sbruder @tadeokondrak 

Things I tested:
Importing vapoursynth using `nix-shell -I nixpkgs=. -p 'python310.withPackages(ps:[ps.vapoursynth])'` works as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
