### PR TITLE
libidn2: hack to avoid referencing bootstrap tools

### DIFF
--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dpQM1Od46Ak1eanRlbJf/16Tbp3GJCBoUotDenZ2T5E=";
   };
 
+  # Beware: non-bootstrap libidn2 is overridden by ./hack.nix
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];
 
   patches = optional stdenv.isDarwin ./fix-error-darwin.patch;

--- a/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
+++ b/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, libidn2, libunistring, runCommandLocal, patchelf }:
+# Construct a copy of libidn2.* where all (transitive) libc references (in .bin)
+# get replaced by a new one, so that there's no reference to bootstrap tools.
+runCommandLocal
+  "${libidn2.pname}-${libidn2.version}"
+  {
+    outputs = [ "bin" "dev" "out" ];
+    passthru = {
+      inherit (libidn2) out info devdoc; # no need to touch these store paths
+    };
+  }
+  ''
+    cp -r '${libidn2.bin}' "$bin"
+    chmod +w "$bin"/bin/*
+    patchelf \
+      --set-interpreter '${stdenv.cc.bintools.dynamicLinker}' \
+      --set-rpath '${lib.concatMapStringsSep ":" (p: lib.getLib p + "/lib")
+                      [ stdenv.cc.libc libunistring libidn2 ]}' \
+      "$bin"/bin/*
+
+    cp -r '${libidn2.dev}' "$dev"
+    chmod +w "$dev"/nix-support/propagated-build-inputs
+    substituteInPlace "$dev"/nix-support/propagated-build-inputs \
+      --replace '${libidn2.bin}' "$bin"
+    substituteInPlace "$dev"/lib/pkgconfig/libidn2.pc \
+      --replace '${libidn2.dev}' "$dev"
+
+    ln -s '${libidn2.out}' "$out" # it's hard to be without any $out
+  ''
+

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -432,8 +432,16 @@ in
         inherit (prevStage)
           gzip bzip2 xz bash coreutils diffutils findutils gawk
           gnumake gnused gnutar gnugrep gnupatch patchelf
-          attr acl zlib pcre libunistring libidn2;
+          attr acl zlib pcre libunistring;
         ${localSystem.libc} = getLibc prevStage;
+
+        # Hack: avoid libidn2.{bin,dev} referencing bootstrap tools.  There's a logical cycle.
+        libidn2 = import ../../development/libraries/libidn2/no-bootstrap-reference.nix {
+          inherit lib;
+          inherit (prevStage) libidn2;
+          inherit (self) stdenv runCommandLocal patchelf libunistring;
+        };
+
       } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
         # Need to get rid of these when cross-compiling.
         inherit (prevStage) binutils binutils-unwrapped;


### PR DESCRIPTION
Due to bootstrap tools getting purged from closure of libidn2.dev,
a very large rebuild is caused.
- - -
Fixes https://github.com/NixOS/nixpkgs/issues/175693

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
