### PR TITLE
groestlcoin: 22.0 -> 23.0

### DIFF
--- a/pkgs/applications/blockchains/groestlcoin/default.nix
+++ b/pkgs/applications/blockchains/groestlcoin/default.nix
@@ -24,7 +24,7 @@
 }:
 
 let
-  version = "22.0";
+  version = "23.0";
   desktop = fetchurl {
     url = "https://raw.githubusercontent.com/Groestlcoin/packaging/${version}/debian/groestlcoin-qt.desktop";
     sha256 = "0mxwq4jvcip44a796iwz7n1ljkhl3a4p47z7qlsxcfxw3zmm0k0k";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     owner = "Groestlcoin";
     repo = "groestlcoin";
     rev = "v${version}";
-    sha256 = "104zzcigpk976iqyinjn6mw3l36zb1if7249iz44ds1zaxv3g1v1";
+    sha256 = "1ag7wpaw4zssx1g482kziqr95yl2vk9r332689s3093xv9i9pz4s";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ]


### PR DESCRIPTION
###### Description of changes
* new upstream release: https://github.com/Groestlcoin/groestlcoin/releases/tag/v23.0

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).