### PR TITLE
gmad: unstable-2015-04-16 -> unstable-2020-02-24

### DIFF
--- a/pkgs/games/gmad/default.nix
+++ b/pkgs/games/gmad/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "gmad";
-  version = "unstable-2015-04-16";
+  version = "unstable-2020-02-24";
 
   meta = {
     description = "Garry's Mod Addon Creator and Extractor";
-    homepage = "https://github.com/garrynewman/gmad";
+    homepage = "https://github.com/Facepunch/gmad";
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.abigailbuccaneer ];
     platforms = lib.platforms.all;
   };
 
   src = fetchFromGitHub {
-    owner = "garrynewman";
+    owner = "Facepunch";
     repo = "gmad";
-    rev = "377f3458bf1ecb8a1a2217c2194773e3c2a2dea0";
-    sha256="0myi9njr100gxhxk1vrzr2sbij5kxl959sq0riiqgg01div338g0";
+    rev = "5236973a2fcbb3043bdd3d4529ce68b6d938ad93";
+    sha256="04an17nvnj38mpi0w005v41ib8ynb5qhgrdkmsda4hq7l1gn276s";
   };
 
   buildInputs = [ premake4 bootil ];


### PR DESCRIPTION
###### Description of changes
Just a bunch of minor bug fixes and I updated the github owner to Facepunch (the repo was a redirect at this point).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
