### PR TITLE
zfs-unstable: 2.1.4 -> unstable-2022-05-17

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -17,6 +17,7 @@
 
 # for determining the latest compatible linuxPackages
 , linuxPackages_5_17 ? pkgs.linuxKernel.packages.linux_5_17
+, linuxPackages_5_18 ? pkgs.linuxKernel.packages.linux_5_18
 }:
 
 let
@@ -227,17 +228,17 @@ in {
 
   zfsUnstable = common {
     # check the release notes for compatible kernels
-    kernelCompatible = kernel.kernelOlder "5.18";
-    latestCompatibleLinuxPackages = linuxPackages_5_17;
+    kernelCompatible = kernel.kernelOlder "5.19";
+    latestCompatibleLinuxPackages = linuxPackages_5_18;
 
     # this package should point to a version / git revision compatible with the latest kernel release
     # IMPORTANT: Always use a tagged release candidate or commits from the
     # zfs-<version>-staging branch, because this is tested by the OpenZFS
     # maintainers.
-    version = "2.1.4";
-    # rev = "0000000000000000000000000000000000000000";
+    version = "unstable-2022-05-17";
+    rev = "05147319b0821f61fcff743e20605e191d523906";
 
-    sha256 = "sha256-pHz1N2j+d9p1xleEBwwrmK9mN5gEyM69Suy0dsrkZT4=";
+    sha256 = "sha256-ZdUhmVswb2wKs55If6Z5hK6MiSdkjWde1WSe60AJalI=";
 
     isUnstable = true;
   };


### PR DESCRIPTION
###### Description of changes

This specific ref has been tested by our fellow Arch users since 6 days ago: https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=zfs-dkms&id=5795e0cebad4374cdcadf26355d62da80727c016

I'm not sure if I'm allowed to do this, I only did it because I saw the comment over "rev".

Of course, I'm still testing this, and it's probably better to wait for a stable version, but in nixpkgs-unstable time never stops.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
