### PR TITLE
btdu: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/tools/misc/btdu/default.nix
+++ b/pkgs/tools/misc/btdu/default.nix
@@ -1,23 +1,23 @@
 {stdenv, lib, fetchurl, dub, ncurses, ldc, zlib, removeReferencesTo }:
 
 let
-    _d_ae_ver              = "0.0.3100";
+    _d_ae_ver              = "0.0.3141";
     _d_btrfs_ver           = "0.0.12";
     _d_ncurses_ver         = "0.0.149";
     _d_emsi_containers_ver = "0.9.0";
 in
 stdenv.mkDerivation rec {
     pname = "btdu";
-    version = "0.3.1";
+    version = "0.4.0";
 
     srcs = [
       (fetchurl {
         url = "https://github.com/CyberShadow/${pname}/archive/v${version}.tar.gz";
-        sha256 = "760b2f0d28920a78b7967dd34c429125135688a3aefc57ab3a92d07bc3ef10cb";
+        sha256 = "1377d2ee14367deed6f0b17407a0de437450a4f381819265d98c38fbc05f792f";
       })
       (fetchurl {
         url = "https://github.com/CyberShadow/ae/archive/v${_d_ae_ver}.tar.gz";
-        sha256 = "86fa09ef6c1be4cbe8ad1c85729054e5d691b41ff57c7980d99937ec0f45b950";
+        sha256 = "5ae60c637050c11733da8a67735a43e16d6082d18b74ce64b04e24e42d8f5f5f";
       })
       (fetchurl {
         url = "https://github.com/CyberShadow/d-btrfs/archive/v${_d_btrfs_ver}.tar.gz";


### PR DESCRIPTION
###### Description of changes

Add [deletion](https://github.com/CyberShadow/btdu#deleting) (press d, then ShiftY to confirm)
Add --import, --export, [headless execution](https://github.com/CyberShadow/btdu#headless-mode), and stop conditions
Add --du to output du-compatible output
Improve explanation of ENOENT
Improve error message when given non-top-level subvolume paths
Try to find a TTY even when standard input/output are redirected

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
