### PR TITLE
python310Packages.graphene: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/graphene-django/default.nix
+++ b/pkgs/development/python-modules/graphene-django/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, fetchpatch
 
 , graphene
 , graphql-core
@@ -32,6 +33,11 @@ buildPythonPackage rec {
 
   patches = [
     ./graphene-3_2_0.patch
+    (fetchpatch {
+      url = "https://github.com/graphql-python/graphene-django/commit/ca555293a4334c26cf9a390dd1e3d0bd4c819a17.patch";
+      excludes = [ "setup.py" ];
+      sha256 = "sha256-RxG1MRhmpBKnHhSg4SV+DjZ3uA0nl9oUeei56xjtUpw=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/graphene/default.nix
+++ b/pkgs/development/python-modules/graphene/default.nix
@@ -1,7 +1,6 @@
 { lib
 , aniso8601
 , buildPythonPackage
-, fetchpatch
 , fetchFromGitHub
 , graphql-core
 , graphql-relay
@@ -18,31 +17,17 @@
 
 buildPythonPackage rec {
   pname = "graphene";
-  version = "3.0.0";
+  version = "3.1.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "graphql-python";
     repo = "graphene";
     rev = "v${version}";
-    sha256 = "0qgp3nl6afyz6y27bw175hyqppx75pp1vqwl7nvlpwvgwyyc2mnl";
+    sha256 = "sha256-fKvaor9tOsJWXFMAH0/iDQi5NYJPec2sJevbQsKhQQ4=";
   };
-
-  patches = [
-    # Fix graphql-core 3.2.0 support
-    (fetchpatch {
-      # https://github.com/graphql-python/graphene/pull/1378
-      url = "https://github.com/graphql-python/graphene/commit/989970f89341ebb949962d13dcabca8a6ccddad4.patch";
-      hash = "sha256-qRxWTqv5XQN7uFjL2uv9NjTvSLi76/MyFSa4jpkb8to=";
-    })
-    (fetchpatch {
-      # https://github.com/graphql-python/graphene/pull/1417
-      url = "https://github.com/graphql-python/graphene/commit/4e0e18d1682b7759bdf16499c573f675c7fb51cb.patch";
-      hash = "sha256-icdTGDabJouQ3hVpcMkkeabNwdoDxdVVAboTOWFbO94=";
-    })
-  ];
 
   propagatedBuildInputs = [
     aniso8601
@@ -62,17 +47,6 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "--benchmark-disable"
-  ];
-
-  disabledTests = [
-    # Expects different Exeception classes, but receives none of them
-    # https://github.com/graphql-python/graphene/issues/1346
-    "test_unexpected_error"
-    # https://github.com/graphql-python/graphene/pull/1417#issuecomment-1102492138
-    "test_example_end_to_end"
-  ] ++ lib.optionals (pythonAtLeast "3.10") [
-    "test_objecttype_as_container_extra_args"
-    "test_objecttype_as_container_invalid_kwargs"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
