### PR TITLE
gitlab: 15.0.0 -> 15.0.1

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "15.0.0",
-  "repo_hash": "sha256-+ZLHo35BhgWlopuwrVGiMvcWl8qUvHUV2kAEIXWazyY=",
+  "version": "15.0.1",
+  "repo_hash": "sha256-GMdR8drmnLR5KH/N0iyLmPi2sggeQX7PT2KP3QO5+/Y=",
   "yarn_hash": "1a8k3x3b9sirzicqkwmr10m27n593iljfh8awdc9700akbj155lr",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.0.0-ee",
+  "rev": "v15.0.1-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.0.0",
+    "GITALY_SERVER_VERSION": "15.0.1",
     "GITLAB_PAGES_VERSION": "1.58.0",
     "GITLAB_SHELL_VERSION": "14.3.0",
-    "GITLAB_WORKHORSE_VERSION": "15.0.0"
+    "GITLAB_WORKHORSE_VERSION": "15.0.1"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.0.0";
+  version = "15.0.1";
   package_version = "v14";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 in
@@ -24,7 +24,7 @@ buildGoModule {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "sha256-ib/gGkXo6W6LZ6j92oUMhJWdDYZRnA1p+tsOK6ewemk=";
+    sha256 = "sha256-pNVeXB2A8jYUVir6t8jz6ifBksWucZjUn6RIszXdwJY=";
   };
 
   vendorSha256 = "sha256-/tHKWo09ZV31TSIqlOk36V3y7gNikziUJHf+nS1gHEw=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.0.0";
+  version = "15.0.1";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
###### Description of changes
https://about.gitlab.com/releases/2022/06/01/critical-security-release-gitlab-15-0-1-released/

Fixes [CVE-2022-1680](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1680), [CVE-2022-1940](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1940), [CVE-2022-1948](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1948), [CVE-2022-1935](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1935), [CVE-2022-1936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1936), [CVE-2022-1944](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1944), [CVE-2022-1821](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1821), [CVE-2022-1783](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1783)

release-21.11 backport: #175842
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
