### PR TITLE
mono: fix build on Darwin

### DIFF
--- a/pkgs/development/compilers/mono/4.nix
+++ b/pkgs/development/compilers/mono/4.nix
@@ -1,9 +1,9 @@
-{ callPackage, Foundation, libobjc }:
+{ callPackage, Foundation, libobjc, stdenv, lib }:
 
 callPackage ./generic.nix ({
   inherit Foundation libobjc;
   version = "4.8.1.0";
   sha256 = "1vyvp2g28ihcgxgxr8nhzyzdmzicsh5djzk8dk1hj5p5f2k3ijqq";
   enableParallelBuilding = false; # #32386, https://hydra.nixos.org/build/65600645
-  extraPatches = [ ./mono4-glibc.patch ];
+  extraPatches = lib.optionals stdenv.isLinux [ ./mono4-glibc.patch ];
 })

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -76,7 +76,9 @@ stdenv.mkDerivation rec {
   inherit enableParallelBuilding;
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    # Per nixpkgs#151720 the build failures for aarch64-darwin are fixed upstream, but a
+    # stable release with the fix is not available yet.
+    broken = stdenv.isDarwin && stdenv.isAarch64 && lib.versionOlder version "6.12.0.129";
     homepage = "https://mono-project.com/";
     description = "Cross platform, open source .NET development framework";
     platforms = with platforms; darwin ++ linux;


### PR DESCRIPTION
###### Description of changes

This flags mono as broken on just aarch64-darwin. NixOS/nixpkgs#151720 notes that the problem preventing mono from building on aarch64-darwin is fixed upstream but not in a stable release, but I tried to keep the changes minimal. Once mono is updated to a suitable version, only older versions will remain flagged as broken.

I also fixed the build failure of `mono4`, which was due to applying a Linux-only patch unconditionally.

Sandbox is set to relaxed on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
