### PR TITLE
tree: 1.8.0 -> 2.0.2

### DIFF
--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -1,44 +1,39 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromGitLab }:
 
 let
   # These settings are found in the Makefile, but there seems to be no
   # way to select one ore the other setting other than editing the file
   # manually, so we have to duplicate the know how here.
   systemFlags = lib.optionalString stdenv.isDarwin ''
-    CFLAGS="-O2 -Wall -fomit-frame-pointer"
+    CFLAGS="-O2 -Wall -fomit-frame-pointer -no-cpp-precomp"
     LDFLAGS=
-    EXTRA_OBJS=strverscmp.o
   '' + lib.optionalString stdenv.isCygwin ''
-    CFLAGS="-O2 -Wall -fomit-frame-pointer -DCYGWIN"
+    CFLAGS="-O2 -Wall -fomit-frame-pointer"
     LDFLAGS=-s
     TREE_DEST=tree.exe
-    EXTRA_OBJS=strverscmp.o
   '' + lib.optionalString (stdenv.isFreeBSD || stdenv.isOpenBSD) ''
     CFLAGS="-O2 -Wall -fomit-frame-pointer"
     LDFLAGS=-s
-    EXTRA_OBJS=strverscmp.o
   ''; # use linux flags by default
 in
 stdenv.mkDerivation rec {
   pname = "tree";
-  version = "1.8.0";
+  version = "2.0.2";
 
-  src = fetchurl {
-    url = "http://mama.indstate.edu/users/ice/tree/src/tree-${version}.tgz";
-    sha256 = "1hmpz6k0mr6salv0nprvm1g0rdjva1kx03bdf1scw8a38d5mspbi";
+  src = fetchFromGitLab {
+    owner = "OldManProgrammer";
+    repo = "unix-tree";
+    rev = version;
+    sha256 = "sha256-ex4fD8dZJGplL3oMaSokMBn6PRJ8/s83CnWQaAjBcao=";
   };
 
   preConfigure = ''
-    sed -i Makefile -e 's|^OBJS=|OBJS=$(EXTRA_OBJS) |'
-    makeFlagsArray+=(
-      ${systemFlags}
-      "CC=$CC"
-    )
+    makeFlagsArray+=(${systemFlags})
   '';
 
   makeFlags = [
-    "prefix=${placeholder "out"}"
-    "MANDIR=${placeholder "out"}/share/man/man1"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "PREFIX=${placeholder "out"}"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
