### PR TITLE
buildRubyGem: fix bundix cross

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -18,7 +18,7 @@
 # Normal gem packages can be used outside of bundler; a binstub is created in
 # $out/bin.
 
-{ lib, fetchurl, fetchgit, makeWrapper, gitMinimal, darwin
+{ lib, fetchurl, fetchgit, makeWrapper, gitMinimal, libobjc
 , ruby, bundler
 } @ defs:
 
@@ -96,7 +96,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
 
   buildInputs = [
     ruby
-  ] ++ lib.optionals stdenv.isDarwin [ darwin.libobjc ]
+  ] ++ lib.optionals stdenv.isDarwin [ libobjc ]
     ++ buildInputs;
 
   #name = builtins.trace (attrs.name or "no attr.name" ) "${namePrefix}${gemName}-${version}";

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -35,6 +35,7 @@ lib.makeOverridable (
 , namePrefix ? (let
     rubyName = builtins.parseDrvName ruby.name;
   in "${rubyName.name}${rubyName.version}-")
+, nativeBuildInputs ? []
 , buildInputs ? []
 , meta ? {}
 , patches ? []
@@ -87,11 +88,15 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
   inherit dontStrip;
   inherit type;
 
-  buildInputs = [
+  nativeBuildInputs = [
     ruby makeWrapper
   ] ++ lib.optionals (type == "git") [ gitMinimal ]
     ++ lib.optionals (type != "gem") [ bundler ]
-    ++ lib.optional stdenv.isDarwin darwin.libobjc
+    ++ nativeBuildInputs;
+
+  buildInputs = [
+    ruby
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.libobjc ]
     ++ buildInputs;
 
   #name = builtins.trace (attrs.name or "no attr.name" ) "${namePrefix}${gemName}-${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14584,7 +14584,9 @@ with pkgs;
 
   inherit (ocamlPackages) reason;
 
-  buildRubyGem = callPackage ../development/ruby-modules/gem { };
+  buildRubyGem = callPackage ../development/ruby-modules/gem {
+    inherit (darwin) libobjc;
+  };
   defaultGemConfig = callPackage ../development/ruby-modules/gem-config {
     inherit (darwin) DarwinTools cctools;
     inherit (darwin.apple_sdk.frameworks) CoreServices;


### PR DESCRIPTION
allows building bundix but most ruby gems still fail with

```
++ gem install --local --force --http-proxy http://nodtd.invalid/ --ignore-dependencies --install-dir /nix/store/...-ruby-aarch64-unknown-linux-gnu2.7.6-nio4r-2.5.8-aarch64-unknown-linux-gnu/lib/ruby/gems/2.7.0
--build-root / --backtrace --no-env-shebang -N /nix/store/...-nio4r-2.5.8.gem --
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 8: require: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 9: require: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 10: require: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 12: required_version: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 14: unless: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 15: abort: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 16: end: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 18: args: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 20: begin: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 21: Gem::GemRunner.new.run: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 22: rescue: command not found
/nix/store/...-ruby-aarch64-unknown-linux-gnu-2.7.6/bin/gem: line 23: exit: e.exit_code: numeric argument required
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
