### PR TITLE
python310Packages.ua-parser: run tests

### DIFF
--- a/pkgs/development/python-modules/ua-parser/default.nix
+++ b/pkgs/development/python-modules/ua-parser/default.nix
@@ -1,20 +1,44 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyyaml
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "ua-parser";
   version = "0.10.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0csh307zfz666kkk5idrw3crj1x8q8vsqgwqil0r1n1hs4p7ica7";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "ua-parser";
+    repo = "uap-python";
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-kaTAfUtHj2vH7i7eIU61efuB4/XVHoc/z6o3ny+sgrQ=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace '"pyyaml"' ""
+  patches = [
+    ./dont-fetch-submodule.patch
+  ];
+
+  nativeBuildInputs = [
+    pyyaml
+  ];
+
+  preBuild = ''
+    mkdir -p build/lib/ua_parser
   '';
 
-  doCheck = false; # requires files from uap-core
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # import from $out
+    rm ua_parser/__init__.py
+  '';
 
   pythonImportsCheck = [ "ua_parser" ];
 

--- a/pkgs/development/python-modules/ua-parser/dont-fetch-submodule.patch
+++ b/pkgs/development/python-modules/ua-parser/dont-fetch-submodule.patch
@@ -1,0 +1,17 @@
+diff --git a/setup.py b/setup.py
+index a976eee..6919795 100644
+--- a/setup.py
++++ b/setup.py
+@@ -64,12 +64,6 @@ class build_regexes(Command):
+ 
+     def run(self):
+         work_path = self.work_path
+-        if not os.path.exists(os.path.join(work_path, ".git")):
+-            return
+-
+-        log.info("initializing git submodules")
+-        check_output(["git", "submodule", "init"], cwd=work_path)
+-        check_output(["git", "submodule", "update"], cwd=work_path)
+ 
+         yaml_src = os.path.join(work_path, "uap-core", "regexes.yaml")
+         if not os.path.exists(yaml_src):


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
