### PR TITLE
swaynag-battery: init at version `0.2.0`

### DIFF
--- a/pkgs/applications/misc/swaynag-battery/default.nix
+++ b/pkgs/applications/misc/swaynag-battery/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "swaynag-battery";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "m00qek";
+    repo = "swaynag-battery";
+    rev = "v${version}";
+    hash = "sha256-7f9+4Fzw5B5ATuud4MJC3iyuNRTx6kwJ7/KsusGtQM8=";
+  };
+
+  vendorSha256 = "h9Zj3zmQ0Xpili5Pl6CXh1L0bb2uL1//B79I4/ron08=";
+
+  meta = with lib; {
+    homepage = "https://github.com/m00qek/swaynag-battery";
+    description = "Shows a message when your battery is discharging ";
+    maintainers = with maintainers; [ asbachb ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27205,6 +27205,8 @@ with pkgs;
 
   swaynotificationcenter = callPackage ../applications/misc/swaynotificationcenter { };
 
+  swaynag-battery = callPackage ../applications/misc/swaynag-battery {};
+
   tiramisu = callPackage ../applications/misc/tiramisu { };
 
   rootbar = callPackage ../applications/misc/rootbar {};


### PR DESCRIPTION
###### Description of changes
Shows a message on top of all displays (using [swaynag](https://github.com/swaywm/sway/tree/master/swaynag)) when battery is discharging and bellow an appointed threshold. Also, closes the message when a power supply is plugged in.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
 asbachb@nixos-t14s  ~/dev/src/nix/nixpkgs   new/174264  nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
this path will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/94qbmfs5nnqjsipspm8jbgm41zhfxqdy-nixpkgs-review-2.6.4
copying path '/nix/store/94qbmfs5nnqjsipspm8jbgm41zhfxqdy-nixpkgs-review-2.6.4' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   3aa72cc4711..cbd66894e60  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-dea2402b45b1c3da16100f31d863bb1eefbad76a/nixpkgs cbd66894e60294c14b20b34b4a00950cb224a897
Preparing worktree (detached HEAD cbd66894e60)
Updating files: 100% (30700/30700), done.
HEAD is now at cbd66894e60 Merge #175150: staging-next 2022-05-28
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-dea2402b45b1c3da16100f31d863bb1eefbad76a/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff dea2402b45b1c3da16100f31d863bb1eefbad76a
Auto-merging pkgs/top-level/all-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-dea2402b45b1c3da16100f31d863bb1eefbad76a/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package added:
swaynag-battery (init at 0.2.0)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/asbachb/.cache/nixpkgs-review/rev-dea2402b45b1c3da16100f31d863bb1eefbad76a/build.nix
1 package built:
swaynag-battery

$ nix-shell /home/asbachb/.cache/nixpkgs-review/rev-dea2402b45b1c3da16100f31d863bb1eefbad76a/shell.nix
these 7 paths will be fetched (2.14 MiB download, 12.76 MiB unpacked):
  /nix/store/6pkx11fz05v4m8jgx76y1q1ri6llpf3i-bash-interactive-5.1-p16-dev
  /nix/store/7ji068smnymqz2lg2fd42hjnjd5czbl6-ncurses-6.3-p20220507
  /nix/store/87g044p2zq221fvjzyrqyrkzxxayy1p9-readline-8.1p2
  /nix/store/cxj5773zkvps1v6qvd57fmxxwg957qza-bash-interactive-5.1-p16-info
  /nix/store/nn31pfpjs92mn34316k3kj2pzv23v029-bash-interactive-5.1-p16-doc
  /nix/store/pxfxgmas6iyqb6dq7d7d7kvv1vld4r89-bash-interactive-5.1-p16
  /nix/store/zij0phlssa5w4ablma69myzb95rpdvv0-bash-interactive-5.1-p16-man
copying path '/nix/store/nn31pfpjs92mn34316k3kj2pzv23v029-bash-interactive-5.1-p16-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/cxj5773zkvps1v6qvd57fmxxwg957qza-bash-interactive-5.1-p16-info' from 'https://cache.nixos.org'...
copying path '/nix/store/zij0phlssa5w4ablma69myzb95rpdvv0-bash-interactive-5.1-p16-man' from 'https://cache.nixos.org'...
copying path '/nix/store/7ji068smnymqz2lg2fd42hjnjd5czbl6-ncurses-6.3-p20220507' from 'https://cache.nixos.org'...
copying path '/nix/store/87g044p2zq221fvjzyrqyrkzxxayy1p9-readline-8.1p2' from 'https://cache.nixos.org'...
copying path '/nix/store/pxfxgmas6iyqb6dq7d7d7kvv1vld4r89-bash-interactive-5.1-p16' from 'https://cache.nixos.org'...
copying path '/nix/store/6pkx11fz05v4m8jgx76y1q1ri6llpf3i-bash-interactive-5.1-p16-dev' from 'https://cache.nixos.org'...

[nix-shell:~/.cache/nixpkgs-review/rev-dea2402b45b1c3da16100f31d863bb1eefbad76a]$
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
