### PR TITLE
lib/strings: add escapeSystemdArgs

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -97,6 +97,7 @@ let
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
       escapeShellArg escapeShellArgs isValidPosixName toShellVar toShellVars
       escapeRegex escapeXML replaceChars lowerChars
+      escapeSystemdArg escapeSystemdArgs
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
       getName getVersion

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -405,6 +405,26 @@ rec {
   */
   escapeRegex = escape (stringToCharacters "\\[{()^$?*+|.");
 
+  /* Escape argument as per systemd.syntax(7) to be safely used in systemd units.
+
+     Type: escapeSystemdArg :: string -> string
+
+     Example:
+       escapeSystemdArg "--regex=foo\.bar"
+       => "--regex=foo\\.bar"
+  */
+  escapeSystemdArg = escape ["\\"];
+
+  /* Escape all arguments as per systemd.syntax(7) to be safely used in systemd units.
+
+     Type: escapeSystemdArgs :: [string] -> string
+
+     Example:
+       escapeSystemdArg ["--regex" "foo\.bar"]
+       => "--regex foo\\.bar"
+  */
+  escapeSystemdArgs = concatMapStringsSep " " escapeSystemdArg;
+
   /* Quotes a string if it can't be used as an identifier directly.
 
      Type: string -> string


### PR DESCRIPTION
systemd.syntax(7) QUOTING describes systemd specific escape sequences
denoted by a backslash.

Considering cases where `ExecStart` contains words containing
backslashes, e.g. a program accepting regular expressions as arguments,
backslashes as part of the regular expression might be expanded by
systemd instead.

earlyoom(1)'s `--prefer REGEX` is a good example (over-simplified):
```
services.earlyoom.extraArgs = [
  "--prefer" (lib.escapeRegex ".electron-wrapped")
];
```

The regular expression is escaped:
```
$ systemctl cat earlyoom | grep ExecStart | cut -d= -f2
/nix/store/.../earlyoom ... --prefer \.electron-wrapped
```

But systemd still interpreted it:
```
$ journalctl -u earlyoom -p 4 -g escape -o cat
/etc/systemd/system/earlyoom.service:11: Ignoring unknown escape sequences: "\.electron-wrapped"
```

The process list confirms that systemd did not expand anything, though:
```
$ pgrep -a earlyoom
44634 /nix/store/.../earlyoom ... --prefer \.electron-wrapped
```

Provide `escapeSystemdArg` and `escapeSystemdArgs` to handle this with
self-describing code, in which it also becomes obvious that arguments
are not used in shell scripts (and thus subject to further rules) but
parsed by systemd instead -- a distinction which is practically never
made in configuration.nix(5), hence one must check themselves how to
handle arguments:
```
services.earlyoom.extraArgs = with lib.strings; [
  "--prefer" (escapeSystemdArg (escapeRegex ".electron-wrapped"))
];
```

```
$ systemctl cat earlyoom | grep ExecStart | cut -d= -f2
/nix/store/.../earlyoom ... --prefer \\.electron-wrapped
$ pgrep -a earlyoom
44697 /nix/store/.../earlyoom ... --prefer \.electron-wrapped
```
