### PR TITLE
terraform-providers: allow go version override in mkProvider

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -19,10 +19,11 @@ let
      , vendorSha256 ? throw "vendorSha256 missing: please use `buildGoModule`" /* added 2022/01 */
      , deleteVendor ? false
      , proxyVendor ? false
+     , mkProviderGoModule ? buildGoModule
      , # Looks like "registry.terraform.io/vancluever/acme"
        provider-source-address
      }@attrs:
-      buildGoModule {
+      mkProviderGoModule {
         pname = repo;
         inherit vendorSha256 version deleteVendor proxyVendor;
         subPackages = [ "." ];


### PR DESCRIPTION
Providers sometimes require other go version than the default go version
coming with `buildGoModule`.