### PR TITLE
opensnitch-ui: fix events table and notifications

### DIFF
--- a/pkgs/development/python-modules/pyasn/default.nix
+++ b/pkgs/development/python-modules/pyasn/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, }:
+{ lib, buildPythonPackage, fetchPypi, fetchFromGitHub, python, }:
 
 buildPythonPackage rec {
   pname = "pyasn";
@@ -8,6 +8,18 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-6UK1SRY2Pse4tw6urs0OtOQe8bz0ojl7KabXFfzN+SU=";
   };
+
+  datasrc = fetchFromGitHub {
+    owner = "hadiasghari";
+    repo = "pyasn";
+    rev = "${version}";
+    sha256 = "sha256-R7Vi1Mn44Mg3HQLDk9O43MkXXwbLRr/jjVKSHJvgYj0";
+  };
+
+  postInstall = ''
+    install -dm755 $out/${python.sitePackages}/pyasn/data
+    cp $datasrc/data/* $out/${python.sitePackages}/pyasn/data
+  '';
 
   doCheck = false; # Tests require internet connection which wont work
 

--- a/pkgs/tools/networking/opensnitch/ui.nix
+++ b/pkgs/tools/networking/opensnitch/ui.nix
@@ -15,6 +15,11 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-8IfupmQb1romGEvv/xqFkYhp0gGoY4ZEllX6rZYIkqw=";
   };
 
+  postPatch = ''
+    substituteInPlace ui/opensnitch/utils.py \
+      --replace /usr/lib/python3/dist-packages/data ${python3Packages.pyasn}/${python3Packages.python.sitePackages}/pyasn/data
+  '';
+
   nativeBuildInputs = [
     python3Packages.pyqt5
     wrapQtAppsHook
@@ -32,7 +37,9 @@ python3Packages.buildPythonApplication rec {
 
   preBuild = ''
     make -C ../proto ../ui/opensnitch/ui_pb2.py
+    # sourced from ui/Makefile
     pyrcc5 -o opensnitch/resources_rc.py opensnitch/res/resources.qrc
+    sed -i 's/^import ui_pb2/from . import ui_pb2/' opensnitch/ui_pb2*
   '';
 
   preConfigure = ''
@@ -44,7 +51,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   postInstall = ''
-    mv $out/lib/python3.9/site-packages/usr/* $out/
+    mv $out/${python3Packages.python.sitePackages}/usr/* $out/
   '';
 
   dontWrapQtApps = true;


### PR DESCRIPTION
###### Description of changes

The events table (first tab) in opensnitch-ui stopped populating in 22.05 and allow/block notification failed to pop, leaving users scratching their heads wondering why the internet isn't working :D

The issue was traced back to bad imports. Upstream had this sorted in the Makefile: https://github.com/evilsocket/opensnitch/blob/master/ui/Makefile#L8
So I've done the same: https://github.com/RamKromberg/nixpkgs/blob/a82364af80ac25d4f0d7ef672203b760d582d987/pkgs/tools/networking/opensnitch/ui.nix#L41

Additionally, the IPASN data files were missing from the pyasn's pypy package so lookups weren't being performed. Arch copied them from the github package so I followed their example: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-pyasn

Otherwise, I also tweaked the site-package strings so they won't break over future version changes.

NOTE: Please backport to stable as opensnitch-ui is currently broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
