### PR TITLE
graphite-cursors: init at 2021-11-26

### DIFF
--- a/pkgs/data/icons/graphite-cursors/default.nix
+++ b/pkgs/data/icons/graphite-cursors/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, makeFontsConf
+, inkscape, xcursorgen, bc }:
+
+stdenv.mkDerivation rec {
+  pname = "graphite-cursors";
+  version = "2021-11-26";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Kopl2NweYrq9rhw+0EUMhY/pfGo4g387927TZAhI5/A=";
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  # Complains about not being able to find the fontconfig config file otherwise
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  buildInputs = [
+    inkscape
+    xcursorgen
+    bc
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    for variant in dark dark-nord light light-nord; do
+    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/data/fonts/emojione/default.nix#L16
+      HOME="$NIX_BUILD_ROOT" ./build.sh
+    done
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -dm 0755 $out/share/icons
+    cp -pr dist-dark $out/share/icons/graphite-cursors
+    cp -pr dist-dark-nord $out/share/icons/graphite-cursors-nord
+    cp -pr dist-light $out/share/icons/graphite-cursors-light
+    cp -pr dist-light-nord $out/share/icons/graphite-cursors-light-nord
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Graphite cursors theme for linux desktops";
+    homepage = "https://github.com/vinceliuice/Graphite-cursors";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thehedgeh0g ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24766,6 +24766,8 @@ with pkgs;
 
   go-font = callPackage ../data/fonts/go-font { };
 
+  graphite-cursors = callPackage ../data/icons/graphite-cursors { };
+
   graphite-gtk-theme = callPackage ../data/themes/graphite-gtk-theme { };
 
   graphite-kde-theme = callPackage ../data/themes/graphite-kde-theme { };


### PR DESCRIPTION
###### Description of changes
Fixes #175928.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
