### PR TITLE
python3Packages.osmnx: 1.1.2 → 1.2.0

### DIFF
--- a/pkgs/development/python-modules/Rtree/default.nix
+++ b/pkgs/development/python-modules/Rtree/default.nix
@@ -4,23 +4,25 @@
   fetchPypi,
   libspatialindex,
   numpy,
-  pytestCheckHook
+  pytestCheckHook,
+  pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "Rtree";
-  version = "0.9.7";
+  version = "1.0.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "be8772ca34699a9ad3fb4cfe2cfb6629854e453c10b3328039301bbfc128ca3e";
+    sha256 = "sha256-0Eg0ghITRrCTuaQlGNQPkhrfRFkVt66jB+smdoyDloI=";
   };
 
   buildInputs = [ libspatialindex ];
 
   patchPhase = ''
     substituteInPlace rtree/finder.py --replace \
-      "find_library('spatialindex_c')" "'${libspatialindex}/lib/libspatialindex_c${stdenv.hostPlatform.extensions.sharedLibrary}'"
+      'find_library("spatialindex_c")' '"${libspatialindex}/lib/libspatialindex_c${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';
 
   checkInputs = [

--- a/pkgs/development/python-modules/networkx/default.nix
+++ b/pkgs/development/python-modules/networkx/default.nix
@@ -2,26 +2,25 @@
 , buildPythonPackage
 , fetchPypi
 , nose
-, pytest
+, pytestCheckHook
 , decorator
 , setuptools
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "networkx";
   # upgrade may break sage, please test the sage build or ping @timokau on upgrade
-  version = "2.7.1";
+  version = "2.8.2";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-0RlLp1Pl7tB83s0dI8XNejx3IJm9jb0v6jZniM9N57o=";
+    sha256 = "sha256-rpnJsNNeW0pizxz+oB5bNjPY0C9KDq1paFtufeW4Xqs=";
   };
 
   propagatedBuildInputs = [ decorator setuptools ];
-  checkInputs = [ nose pytest];
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [ nose pytestCheckHook ];
 
   meta = {
     homepage = "https://networkx.github.io/";

--- a/pkgs/development/python-modules/osmnx/default.nix
+++ b/pkgs/development/python-modules/osmnx/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "osmnx";
-  version = "1.1.2";
-  disabled = pythonOlder "3.6";
+  version = "1.2.0";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner  = "gboeing";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "sha256-qrTAXZFm88elMrVjvGwfdNwTA/PRdCOHFqpcgoKVGNk=";
+    sha256 = "sha256-HfgMmPEiKstMXV0rtul8QLxB1FY32Ws7IEonBB+qZOc=";
   };
 
   propagatedBuildInputs = [ geopandas matplotlib networkx numpy pandas requests Rtree shapely folium scikit-learn scipy gdal rasterio ];


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/gboeing/osmnx/blob/main/CHANGELOG.md)

Requires:
* networkx>=2.8
* Rtree>=1.0

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
