### PR TITLE
lib/modules: Allow options in `_module.args`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -157,7 +157,9 @@ rec {
             # support for that, in turn it's lazy in its values. This means e.g.
             # a `_module.args.pkgs = import (fetchTarball { ... }) {}` won't
             # start a download when `pkgs` wasn't evaluated.
-            type = types.lazyAttrsOf types.raw;
+            type = types.submodule {
+              freeformType = types.lazyAttrsOf types.raw;
+            };
             # Only render documentation once at the root of the option tree,
             # not for all individual submodules.
             # Allow merging option decls to make this internal regardless.

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -252,6 +252,8 @@ checkConfigOutput '/freeform-submodules.nix"$' config.fooDeclarations.0 ./freefo
 # freeformTypes can get merged using `types.type`, including submodules
 checkConfigOutput '^10$' config.free.xxx.foo ./freeform-submodules.nix
 checkConfigOutput '^10$' config.free.yyy.bar ./freeform-submodules.nix
+# _module.args (https://github.com/NixOS/nixpkgs/issues/53458#issuecomment-1144640686)
+checkConfigOutput '^\[ "one" "two" \]$' config.result ./issue-53458-module-args-freeformType.nix
 
 ## types.anything
 # Check that attribute sets are merged recursively

--- a/lib/tests/modules/issue-53458-module-args-freeformType.nix
+++ b/lib/tests/modules/issue-53458-module-args-freeformType.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+# test framework doesn't do eval deeply for us, so here we go
+let ds = x: lib.deepSeq x x;
+in
+{
+  imports = [
+    ({
+      options._module.args.canMerge = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+      };
+    })
+    ({ _module.args.canMerge.a = "one"; })
+    ({ _module.args.canMerge.b = "two"; })
+    ({ canMerge, ... }: {
+      options.result = lib.mkOption {
+        default = ds (lib.attrValues canMerge);
+      };
+    })
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Allow types to be set for individual module arguments.

https://github.com/NixOS/nixpkgs/issues/53458#issuecomment-1144640686

The alternative is for module authors to define non-`_module.args` options that merge, and assign them to `_module.args` only once.

TODO

- [ ] check ofborg performance report

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
