### PR TITLE
libtiff: 4.3.0 -> 4.4.0

### DIFF
--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -15,8 +15,13 @@ stdenv.mkDerivation {
   sourceRoot = "svn-r1900/FreeImage/trunk";
 
   # Ensure that the bundled libraries are not used at all
-  prePatch = "rm -rf Source/Lib* Source/OpenEXR Source/ZLib";
-  patches = [ ./unbundle.diff ./libtiff-4.4.0.diff ];
+  prePatch = ''
+    rm -rf Source/Lib* Source/OpenEXR Source/ZLib
+  '';
+  patches = [
+    ./unbundle.diff
+    ./libtiff-4.4.0.diff
+  ];
 
   postPatch = ''
     # To support cross compilation, use the correct `pkg-config`.

--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   # Ensure that the bundled libraries are not used at all
   prePatch = "rm -rf Source/Lib* Source/OpenEXR Source/ZLib";
-  patches = [ ./unbundle.diff ];
+  patches = [ ./unbundle.diff ./libtiff-4.4.0.diff ];
 
   postPatch = ''
     # To support cross compilation, use the correct `pkg-config`.

--- a/pkgs/development/libraries/freeimage/libtiff-4.4.0.diff
+++ b/pkgs/development/libraries/freeimage/libtiff-4.4.0.diff
@@ -1,0 +1,15 @@
+Fix build with libtiff 4.4.0 by not using a private libtiff API.
+Patch by Kurt Schwehr: https://sourceforge.net/p/freeimage/discussion/36109/thread/2018fdc6e7/
+
+diff -ru a/Source/Metadata/XTIFF.cpp b/Source/Metadata/XTIFF.cpp
+--- a/Source/Metadata/XTIFF.cpp
++++ b/Source/Metadata/XTIFF.cpp
+@@ -749,7 +749,7 @@
+ 				continue;
+ 			}
+ 			// type of storage may differ (e.g. rationnal array vs float array type)
+-			if((unsigned)_TIFFDataSize(tif_tag_type) != FreeImage_TagDataWidth(tag_type)) {
++			if((unsigned)TIFFFieldSetGetSize(fld) != FreeImage_TagDataWidth(tag_type)) {
+ 				// skip tag or _TIFFmemcpy will fail
+ 				continue;
+ 			}

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -25,11 +25,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libtiff";
-  version = "4.3.0";
+  version = "4.4.0";
 
   src = fetchurl {
     url = "https://download.osgeo.org/libtiff/tiff-${version}.tar.gz";
-    sha256 = "1j3snghqjbhwmnm5vz3dr1zm68dj15mgbx1wqld7vkl7n2nfaihf";
+    sha256 = "1vdbk3sc497c58kxmp02irl6nqkfm9rjs3br7g59m59qfnrj6wli";
   };
 
   patches = [
@@ -38,61 +38,6 @@ stdenv.mkDerivation rec {
     # libc++abi 11 has an `#include <version>`, this picks up files name
     # `version` in the project's include paths
     ./rename-version.patch
-    (fetchpatch {
-      name = "CVE-2022-22844.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/03047a26952a82daaa0792957ce211e0aa51bc64.patch";
-      sha256 = "0cfih55f5qpc84mvlwsffik80bgz6drkflkhrdyqq8m84jw3mbwb";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0561.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/eecb0712f4c3a5b449f70c57988260a667ddbdef.patch";
-      sha256 = "0m57fdxyvhhr9cc260lvkkn2g4zr4n4v9nricc6lf9h6diagd7mk";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0562.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/561599c99f987dc32ae110370cfdd7df7975586b.patch";
-      sha256 = "0ycirjjc1vigj03kwjb92n6jszsl9p17ccw5hry7lli9gxyyr0an";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0891.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/46dc8fcd4d38c3b6f35ab28e532aee80e6f609d6.patch";
-      sha256 = "1zn2pgsmbrjx3g2bpdggvwwbp6i348mikwlx4ws482h2379vmyj1";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0865.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/5e18004500cda10d9074bdb6166b054e95b659ed.patch";
-      sha256 = "131b9ial6avl2agwk31wp2jkrx59955f4r0dikx1jdaywqb7zhd1";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0924.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/408976c44ef0aad975e0d1b6c6dc80d60f9dc665.patch";
-      sha256 = "1aqaynp74ijxr3rizvbyz23ncs71pbbcw5src1zv46473sy55s8p";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0907.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/f2b656e2e64adde07a6cffd5c8e96bd81a850fea.patch";
-      sha256 = "0nsplq671qx0f35qww9mx27raqp3nvslz8iv7f3hxdgldylmh2vs";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0909.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/f8d0f9aa1ba04c9ae3bfe869a18141a8b8117ad7.patch";
-      sha256 = "1plhk6ildl16bp0k3wvzfd4a97hqfqfbbn7vjinsaasf4v0x3q5j";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0908.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/a95b799f65064e4ba2e2dfc206808f86faf93e85.patch";
-      sha256 = "0i61kkjaixdn2p933lpma9s6i0772vhxjxxcwyqagw96lmszrcm7";
-    })
-    (fetchpatch {
-      name = "CVE-2022-1354.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/87f580f39011109b3bb5f6eca13fac543a542798.patch";
-      sha256 = "0171c662xiv3295x4wsq6qq0v90js51j54vsl7wm043kjkrp1fsb";
-    })
-    (fetchpatch {
-      name = "CVE-2022-1355.patch";
-      url = "https://gitlab.com/libtiff/libtiff/-/commit/c1ae29f9ebacd29b7c3e0c7db671af7db3584bc2.patch";
-      sha256 = "1y75c72s41pl39d5zr5pmkiyfrancllv8fbl10zvc67pg3qjq4v8";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchpatch
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
@@ -21,6 +22,14 @@ import ./generic.nix (rec {
     inherit version;
     sha256 = "f401ed2bbb155e1ade150ccc63db1a4f6c1909d3d378f7d1235a44e90d75fb97";
   };
+
+  patches = [
+    # Fix failing test with libtiff 4.4.0
+    (fetchpatch {
+      url = "https://github.com/python-pillow/Pillow/commit/40a918d274182b7d7c063d7797fb77d967982c4a.patch";
+      sha256 = "sha256-f8m3Xt3V3pHggK1JEc2tnPmrTVPFjfV4YJqwE1KM1pA=";
+    })
+  ];
 
   passthru.tests = {
     inherit imageio matplotlib pilkit pydicom reportlab;

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -2,6 +2,7 @@
 , version
 , disabled
 , src
+, patches ? []
 , meta
 , passthru ? {}
 , ...
@@ -10,7 +11,7 @@
 with args;
 
 buildPythonPackage rec {
-  inherit pname version src meta passthru;
+  inherit pname version src meta passthru patches;
 
   # Disable imagefont tests, because they don't work well with infinality:
   # https://github.com/python-pillow/Pillow/issues/1259


### PR DESCRIPTION
###### Description of changes

New upstream release: http://www.simplesystems.org/libtiff/v4.4.0.html

Removed all CVE patches, since they reference commits in the [history of the v4.4.0 tag](https://gitlab.com/libtiff/libtiff/-/commits/v4.4.0/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - **PENDING: libtiff.passthru.tests**
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
