### PR TITLE
portaudio: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , alsa-lib
 , pkg-config
+, binutils
 , AudioUnit
 , AudioToolbox
 , CoreAudio
@@ -18,6 +19,8 @@ stdenv.mkDerivation rec {
     sha256 = "1vrdrd42jsnffh6rq8ap2c6fr4g9fcld89z649fs06bwqx1bzvs7";
   };
 
+  strictDeps = true;
+  depsBuildBuild = [ binutils ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optional (!stdenv.isDarwin) alsa-lib;
 


### PR DESCRIPTION
This doesn't _feel_ right, but it *does* compile :).

I tried some other things like updating the configure.in file and running autoreconf, but that was causing issues with the cpp bindings and went down a rabbit hole. This seems to be good enough for now.

Also (tried to) cross-compiled these derivations, which seem to have a dependency on portaudio (based on grepping):

- [x] pcaudiolib
- [x] libopenmpt
- [x] dsd
- [x] librespot
- [ ] espeak (build failure, unrelated: > src/espeak-ng: line 117: /build/source/src/.libs/lt-espeak-ng: cannot execute binary file: Exec format error)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
