### PR TITLE
vaapi-intel-hybrid: add -fcommon workaround

### DIFF
--- a/pkgs/development/libraries/vaapi-intel-hybrid/default.nix
+++ b/pkgs/development/libraries/vaapi-intel-hybrid/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "01org";
+    owner = "intel";
     repo = "intel-hybrid-driver";
     rev = version;
     sha256 = "sha256-uYX7RoU1XVzcC2ea3z/VBjmT47xmzK67Y4LaiFXyJZ8=";
@@ -24,6 +24,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmrt libdrm libva libX11 libGL wayland ];
 
   enableParallelBuilding = true;
+
+  # Workaround build failure on -fno-common toolchains like upstream gcc-10.
+  NIX_CFLAGS_COMPILE = "-fcommon";
 
   configureFlags = [
     "--enable-drm"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Workaround build failure on -fno-common toolchains, otherwise the build fails with linker errors:

>/nix/store/2b99rpx8zwdjjqkrvk7kqgn9mxhiidjy-binutils-2.38/bin/ld: .libs/hybrid_drv_video_la-media_drv_hw_g75.o:/build/source/src/media_drv_common.h:43: multiple definition of `ME_CURBE_INIT_DATA'; .libs/hybrid_drv_video_la-media_drv_common.o:/build/source/src/media_drv_common.c:135: first defined here
/nix/store/2b99rpx8zwdjjqkrvk7kqgn9mxhiidjy-binutils-2.38/bin/ld: .libs/hybrid_drv_video_la-media_drv_hw_g75.o:/build/source/src/media_drv_common.h:42: multiple definition of `SEARCH_PATH_TABLE'; .libs/hybrid_drv_video_la-media_drv_common.o:/build/source/src/media_drv_common.c:29: first defined here


See https://github.com/NixOS/nixpkgs/pull/110571 for additional context. @trofi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
