### PR TITLE
victor-mono: 1.5.2 -> 1.5.3

### DIFF
--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -1,10 +1,11 @@
 { lib, fetchzip }:
 
 let
-  version = "1.5.2";
+  version = "1.5.3";
 in
 fetchzip {
   name = "victor-mono-${version}";
+  stripRoot = false;
 
   # Upstream prefers we download from the website,
   # but we really insist on a more versioned resource.
@@ -17,11 +18,11 @@ fetchzip {
 
   postFetch = ''
     mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    cp --recursive $out/OTF $out/share/fonts/opentype
+    cp --recursive $out/TTF $out/share/fonts/truetype
   '';
 
-  sha256 = "sha256-cNDZh0P/enmoKL/6eHzkgl5ghtai2K9cTgWMVmm8GIA=";
+  sha256 = "sha256-vqsVD5GEzcBoYCCJU7b+ie/cHS2DarIBaGAZZEGSo+A=";
 
   meta = with lib; {
     description = "Free programming font with cursive italics and ligatures";


### PR DESCRIPTION
###### Description of changes

This PR updates the font Victor Mono to 1.5.3. Release notes here https://github.com/rubjo/victor-mono/releases/tag/v1.5.3

I had to do some modifications to the derivation because I couldn't build it if I just bumped the version number and the `sha256` field:
- the zip we download does not contain a single directory at the top level so I had to `stripRoot = false` (not sure why it worked with 1.5.2 because the zip structure is identical :man_shrugging:)
- I had a look at the `fetchzip` function in this repo and saw that it automatically unzips the file and then deletes it, so I replaced the double-unzip from the script with `cp` otherwise it would fails with a "file not found" error (again, this doesn't seem like a recent change in behaviour for `fetchzip` so I'm at a loss why the derivation for 1.5.2 was building before)

I wasn't sure against which branch to open this PR. The Contribution manual mentions starting branches from my current nixos channel (22.05) so I opened a PR back to `nixos-22.05`. 

Please let me know if I've done something wrong or opened this PR against the wrong branch :)

LE: after re-reading the manual I saw the note at the bottom about rebasing on top of `master` so I retargeted the PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
