### PR TITLE
mwprocapture: fix compile on new GCC and new linux kernel

### DIFF
--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 
+  patches = [ ./pci.patch ];
+
+  NIX_CFLAGS_COMPILE="-Wno-error=implicit-fallthrough";
+
   postInstall = ''
     cd ../
     mkdir -p $out/bin

--- a/pkgs/os-specific/linux/mwprocapture/pci.patch
+++ b/pkgs/os-specific/linux/mwprocapture/pci.patch
@@ -1,0 +1,20 @@
+diff --git a/src/sources/avstream/capture.c b/src/sources/avstream/capture.c
+index f5d256d..a104f62 100644
+--- a/src/sources/avstream/capture.c
++++ b/src/sources/avstream/capture.c
+@@ -288,12 +288,12 @@ static int xi_cap_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+     }
+ 
+     if ((sizeof(dma_addr_t) > 4) &&
+-            !pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
++            !dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
+         xi_debug(1, "dma 64 OK!\n");
+     } else {
+         xi_debug(1, "dma 64 not OK!\n");
+-        if ((pci_set_dma_mask(pdev, DMA_BIT_MASK(64)) < 0) &&
+-                (pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) < 0) {
++        if ((dma_set_mask(&pdev->dev, DMA_BIT_MASK(64)) < 0) &&
++                (dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) < 0) {
+             xi_debug(0, "DMA configuration failed\n");
+             goto disable_pci;
+         }


### PR DESCRIPTION
###### Description of changes

I couldn't upgrade to NixOS 22.05 due to this broken driver, so this PR fixes mwprocapture to build on NixOS 22.05.

Namely:
* replaces references to deprecated `pci_set_dma_mask` with `dma_set_mask` so it builds on Linux 5.15.
* add `-Wno-error=implicit-fallthrough` so it builds on whatever new version of GCC nixpkgs was switched to (it warns on implicit fallthrough which breaks the build).

I have provided pci.patch to Magewall (the vendor) so maybe they will release a new drvier version that includes the change, but we should probably not wait on that.

@pwetzel @MP2E 
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
