### PR TITLE
qdigidoc: Update to 4.2.11

### DIFF
--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -4,12 +4,12 @@
 
 mkDerivation rec {
   pname = "qdigidoc";
-  version = "4.2.9";
+  version = "4.2.11";
 
   src = fetchurl {
     url =
-      "https://github.com/open-eid/DigiDoc4-Client/releases/download/v${version}/qdigidoc4-${version}.tar.gz";
-    sha256 = "1rhd3mvj6ld16zgfscj81f1vhs2nvifsizky509l1av7dsjfbbzr";
+      "https://github.com/open-eid/DigiDoc4-Client/releases/download/v${version}/qdigidoc4_${version}.110-1804.tar.xz";
+    sha256 = "sha256-Sg6lFZeIJn3T/suDc5Z/kNqBf/sIV9c6EJJ0Nr0dwTM=";
   };
 
   tsl = fetchurl {


### PR DESCRIPTION
This release is still subject to double-free crashes in at least the
signature verification functionality, but debugging that requires an up
to date version (released two months ago), so here we go.

NB: Upstream released two source tarballs without further information,
qdigidoc4_r.2.11.110.orig.tar.xz contains sources without subdirectory,
qdigidoc4_r.2.11.110-1804.tar.xz contains a subdirectory with sources;
their difference is irrelevant for our build, so pick the one 1804 one:
```
$ diff -u -r qdigidoc4_r.2.11.110.orig/ qdigidoc4_r.2.11.110-1804/qdigidoc4/
Only in qdigidoc4_r.2.11.110.orig/cmake: .git
Only in qdigidoc4_r.2.11.110.orig/common: .git
Only in qdigidoc4_r.2.11.110.orig/common: .gitmodules
diff '--color=auto' -u -r qdigidoc4_r.2.11.110.orig/debian/changelog qdigidoc4_r.2.11.110-1804/qdigidoc4/debian/changelog
--- qdigidoc4_r.2.11.110.orig/debian/changelog	2022-01-28 13:44:35.000000000 +0200
+++ qdigidoc4_r.2.11.110-1804/qdigidoc4/debian/changelog	2022-01-28 13:44:38.000000000 +0200
@@ -1,3 +1,9 @@
+qdigidoc4 (4.2.11.110-1804) unstable; urgency=medium
+
+  * Release: 4.2.11.110.
+
+ -- RIA <info@ria.ee>  Fri, 28 Jan 2022 13:44:38 +0200
+
 qdigidoc4 (0.2.0.3) stable; urgency=low

   * Initial release
Only in qdigidoc4_r.2.11.110.orig/extensions/cmake: .git
Only in qdigidoc4_r.2.11.110.orig/extensions: .git
Only in qdigidoc4_r.2.11.110.orig/extensions: .gitmodules
```

```
$ git log --oneline v4.2.9..v4.2.11
2631e24 (tag: v4.2.11) Update translation (#1025)
76c671a Support Fedora (#997)
639cebe Update Qt to 5.12.2 (#1019)
cde7fb8 Add web-eid to diagnostics (#989)
faa8276 Add default option to sign button (#1001)
cb8262a Update OpenLDAP 2.6.0 (#996)
132de43 Workaround for Yaru theme on ubuntu 21.10 (#994)
58e4278 Improve safeFilename (#986)
1710f47 Fix coverity and cppcheck warnings (#992)
60af0bb Remove autofocus (#981)
5a9ff0a Use thread monitor event state (#845)
cdd95a5 Fix LDAP certificate validation (#980)
92f81ec Workaround SID/MID proxy unicode issues (#982)
92a5aaa Update version number and OpenSSL, OpenLDAP versions (#977)
5971e54 Update Xalan-C 1.12 (#976)
1f848cf Add more specific info for OpenSSLExceptions (#970)
0497b7f Set Select folder dialog button label and fix some translation warnings (#974)
e56e814 Workaround recent Qt changes to pass mousePressEvent (#978)
44f4a7e Update translations in russian for settings (#973)
25756eb Wait for upper level operations to avoid locked screen (#979)
232784e Don't set focus to fonds image (#967)
5cf2157 Change the view of expired and expiring certificates (#965)
b001274 Resolve a yellow background, when PIN is locked (#971)
4b20375 Fix the boolean value (#975)
1a41817 Resolve Ubuntu 21.04 warnings (#946)
301178b Set read-only permission for files in signed container (#962)
e028a30 Update OpenLDAP 2.5.5 (#963)
1fb5f6a Set accessible name to pin (#966)
18e6112 Handle libdigidocpp exception (#943)
a9efe0f Update translations (#961)
06e44a0 Fix Linux dark theme (#950)
a6ff428 Fix missed border of Accordion (#960)
a14476c Update list of components in Info view (#958)
8980270 Fix normalization of filenames (#952)
e4aac44 Shorten notifications display time (#948)
14606dc Use QSysInfo for OS version (#931)
b8716e7 Resolve a yellow background, when PIN is locked (#947)
0319c6b Don't allow searching for spaces during encryption (#929)
```

@flokli @mmahut @sowelisuwi
