### PR TITLE
tootle: pin to vala 0.54

### DIFF
--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , nix-update-script
 , fetchpatch
-, vala
+, vala_0_54
 , meson
 , ninja
 , pkg-config
@@ -44,6 +44,12 @@ stdenv.mkDerivation rec {
       url = "https://git.alpinelinux.org/aports/plain/community/tootle/0002-Use-reason_phrase-instead-of-get_phrase.patch?id=001bf1ce9695ddb0bbb58b44433d54207c15b0b5";
       sha256 = "sha256-rm5NFLeAL2ilXpioywgCR9ppoq+MD0MLyVaBmdzVkqU=";
     })
+    # Application: make app_entries private
+    # https://github.com/bleakgrey/tootle/pull/346
+    (fetchpatch {
+      url = "https://git.alpinelinux.org/aports/plain/community/tootle/0003-make-app-entries-private.patch?id=c973e68e3cba855f1601ef010afa9a14578b9499";
+      sha256 = "sha256-zwU0nxf/haBZl4tOYDmMzwug+HC6lLDT8/12Wt62+S4=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -51,7 +57,11 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    vala
+    # Does not build with Vala 0.56.1:
+    # ../src/Widgets/Status.vala:8.43-8.56: error: construct
+    # properties not supported for specified property type
+    # public API.NotificationType? kind { get; construct set; }
+    vala_0_54
     wrapGAppsHook
   ];
 
@@ -68,11 +78,6 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    # Fix build with vala 0.56
-    # https://github.com/bleakgrey/tootle/pull/346
-    substituteInPlace src/Application.vala \
-      --replace "public const GLib.ActionEntry[] app_entries" "private const GLib.ActionEntry[] app_entries"
-
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';


### PR DESCRIPTION
###### Description of changes

I gave up. While it builds with vala 0.56.0 it [breaks again with vala 0.56.1](https://hydra.nixos.org/build/178620404/nixlog/2), there is no upstream fix and I am also not sure how to fix this.

The relevant code does not exist on lastest master but lastest master is likely an unfinished GTK4 port so I don't really wish to use lastest master.

```
../src/Widgets/Status.vala:8.43-8.56: error: construct properties not supported for specified property type
    8 |         public API.NotificationType? kind { get; construct set; }
      |                                                  ^~~~~~~~~~~~~~  
```

https://github.com/bleakgrey/tootle/blob/1.0/src/Widgets/Status.vala#L8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
