### PR TITLE
xannotate: pull patch pending upstream inclusion for -fno-common tool…

### DIFF
--- a/pkgs/tools/X11/xannotate/default.nix
+++ b/pkgs/tools/X11/xannotate/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchFromBitbucket, libX11}:
+{lib, stdenv, fetchFromBitbucket, fetchpatch, libX11}:
 stdenv.mkDerivation rec {
   pname = "xannotate";
   version = "20150301";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     sha256 = "02jy19if0rnbxvs6b0l5mi9ifvdj2qmv0pv278v9kfs0kvir68ik";
   };
 
+  patches = [
+    # Pull patch pending upstream inclusion for -gno-common tollchains:
+    #   https://github.com/blais/xannotate/pull/1
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/blais/xannotate/commit/ee637e2dee103d0e654865c2202ea1b3af2a20d6.patch";
+      sha256 = "1lw22d5qs1bwp53l332yl3yypfvwrbi750wp7yv90nfn3ia0xhni";
+    })
+  ];
+
   buildInputs = [ libX11 ];
 
   meta = {
@@ -17,6 +27,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus ;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;
-    homepage = "https://bitbucket.org/blais/xannotate";
+    homepage = "https://github.com/blais/xannotate";
   };
 }


### PR DESCRIPTION
…chain support

Without the change build fails against upstream gcc-10 as:

    ld: process.o:/build/source/src/process.h:26: multiple definition of
      `child'; backend.o:/build/source/src/process.h:26: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
