### PR TITLE
k0sctl: 0.12.6 -> 0.13.0

### DIFF
--- a/pkgs/applications/networking/cluster/k0sctl/default.nix
+++ b/pkgs/applications/networking/cluster/k0sctl/default.nix
@@ -7,23 +7,16 @@
 
 buildGoModule rec {
   pname = "k0sctl";
-  version = "0.12.6";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "k0sproject";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-TkkMO6xBHY5t5Rpd0ieSDXMrnQ+Xdq+65Rk93ZkYcUs=";
+    sha256 = "sha256-A50PbZTgv0EfL5aqTiTEOdfRXUgKGzTsRIiMgXItkxI=";
   };
 
-  vendorSha256 = "sha256-nTAuvHcsJiW0XYX5GM1SL8cnOhwdrj6iw8tuAkEWNzQ=";
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/k0sproject/${pname}/commit/22c694ab0335a1e6146d0d3f939ef79d2c005a3d.patch";
-      sha256 = "sha256-Ftq/vbQd5ArdHboDt6NdyuqpFalHVnsQBdpmyDG/t5Q=";
-    })
-  ];
+  vendorSha256 = "sha256-2i6SoixE5RitRuJpOU4LdzN9JY/76c3mjsbsXlQp854=";
 
   ldflags = [
     "-s"

--- a/pkgs/applications/networking/cluster/k0sctl/default.nix
+++ b/pkgs/applications/networking/cluster/k0sctl/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, fetchpatch
 , installShellFiles
 }:
 


### PR DESCRIPTION
###### Description of changes

https://github.com/k0sproject/k0sctl/releases/tag/v0.13.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


```
❯ nix-build -A k0sctl
/nix/store/zdcwsik1sgckb9awzqzrq0r50ygh7sdy-k0sctl-0.13.0

❯ /nix/store/zdcwsik1sgckb9awzqzrq0r50ygh7sdy-k0sctl-0.13.0/bin/k0sctl version
version: 0.13.0
commit: HEAD
```