### PR TITLE
gnome-firmware: 42.1 -> 42.2

### DIFF
--- a/pkgs/applications/misc/gnome-firmware/default.nix
+++ b/pkgs/applications/misc/gnome-firmware/default.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-firmware";
-  version = "42.1";
+  version = "42.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "gnome-firmware";
     rev = version;
-    sha256 = "9QZ98EElENWsME/jXoj9YJl2e+ipyLm0g4grQUwmnuE=";
+    sha256 = "L0R2lXU69I6NI7Srq5s+8N9261Ic8B7FVaaXNjz2Ll0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/gnome-firmware/default.nix
+++ b/pkgs/applications/misc/gnome-firmware/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, gitUpdater
 , appstream-glib
 , desktop-file-utils
 , fwupd
@@ -52,6 +53,11 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dconsolekit=false"
   ];
+
+  passthru.updateScript = gitUpdater {
+    inherit pname version;
+    ignoredVersions = "(alpha|beta|rc).*";
+  };
 
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/World/gnome-firmware";


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/World/gnome-firmware/-/compare/42.1...42.2

<ul>
          <li>Do not show the estimated time to completion</li>
          <li>Provide generic device fallbacks</li>
          <li>Show the about dialog in the menu</li>
          <li>Show translated device problems</li>
</ul>


Also add an update script, I set `ignoredVersions` since there is tags like [42.beta](https://gitlab.gnome.org/World/gnome-firmware/-/tree/42.beta)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
