### PR TITLE
zynaddsubfx: pull upstream fix for -fno-common (mruby-zest)

### DIFF
--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , bison
 , git
 , python2
@@ -71,6 +72,14 @@ stdenv.mkDerivation rec {
   patches = [
     ./force-gcc-as-linker.patch
     ./system-libuv.patch
+
+    # Pull upstream fix for -fno-common toolchains:
+    #   https://github.com/mruby-zest/mruby-zest-build/issues/25
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/mruby-zest/mruby-zest-build/commit/4eb88250f22ee684acac95d4d1f114df504e37a7.patch";
+      sha256 = "0wg7qy1vg0mzcxagf35bv35dlr0q17pxjicigpf86yqppvgrzrsb";
+    })
   ];
 
   # Add missing dependencies of deps/mruby-dir-glob/mrbgem.rake


### PR DESCRIPTION
Without the change internal dependency mruby-zest fails to build on
-fno-common toolchain as:

    ld: libmruby.a(nvg_context.o):mruby-nanovg/src/nvg_context.c:217: multiple definition of
      `mrb_nvg_context_type'; libmruby.a(gem.o):mruby-widget-lib/src/gem.c:293: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
