### PR TITLE
buildkite-test-collector-rust: init at version `0.1.0`

### DIFF
--- a/pkgs/development/tools/continuous-integration/buildkite-test-collector-rust/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-test-collector-rust/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, stdenv
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "buildkite-test-collector-rust";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "buildkite";
+    repo = "test-collector-rust";
+    rev = "v${version}";
+    sha256 = "sha256-rY/+AwxO0+xcnRj0A8TRhCUJQ0ecosybI6It1mDOdQM=";
+  };
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  cargoSha256 = "sha256-+3OwifInUAEn3IRbebg+eXEcHDNLkN169tNAUr7L8os=";
+
+  meta = with lib; {
+    description = "Rust adapter for Buildkite Test Analytics";
+    homepage = "https://buildkite.com/test-analytics";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ jfroche ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15086,6 +15086,10 @@ with pkgs;
 
   buildkite-cli = callPackage ../development/tools/continuous-integration/buildkite-cli { };
 
+  buildkite-test-collector-rust  = callPackage ../development/tools/continuous-integration/buildkite-test-collector-rust {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   bump = callPackage ../development/tools/github/bump { };
 
   libbpf = callPackage ../os-specific/linux/libbpf { };


### PR DESCRIPTION
###### Description of changes

Add package to enable new [buildkite test analytics](https://buildkite.com/test-analytics)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).