### PR TITLE
python3Packages.pep8-naming: 0.12.1 -> 0.13.0

### DIFF
--- a/pkgs/development/python-modules/pep8-naming/default.nix
+++ b/pkgs/development/python-modules/pep8-naming/default.nix
@@ -1,33 +1,21 @@
 { lib
 , fetchPypi
-, fetchpatch
 , buildPythonPackage
 , flake8
-, flake8-polyfill
 , python
 }:
 
 buildPythonPackage rec {
   pname = "pep8-naming";
-  version = "0.12.1";
+  version = "0.13.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-uyRVlHdX0WKqTK1V26TOApAFzRaS8omaIdUdhjDKeEE=";
+    sha256 = "sha256-nzjm3Phnoft61H9f9ywN2uVEps9k6592ALezwLtZgLU=";
   };
 
   propagatedBuildInputs = [
     flake8
-    flake8-polyfill
-  ];
-
-  patches = [
-    # Add missing option to get passing tests, https://github.com/PyCQA/pep8-naming/pull/181
-    (fetchpatch {
-      name = "add-missing-option.patch";
-      url = "https://github.com/PyCQA/pep8-naming/commit/03b8f36f6a8bb8bc79dfa5a71ad9be2a0bf8bbf5.patch";
-      sha256 = "1YTh84Yoj0MqFZoifM362563r1GuzaF+mMmdT/ckC7I=";
-    })
   ];
 
   checkPhase = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/PyCQA/pep8-naming/blob/0.13.0/CHANGELOG.rst#0130---2022-06-22
diff: https://github.com/PyCQA/pep8-naming/compare/0.12.1...0.13.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
