### PR TITLE
nfs4-acl-tools: init at 0.3.7

### DIFF
--- a/nixos/tests/nfs/kerberos.nix
+++ b/nixos/tests/nfs/kerberos.nix
@@ -47,6 +47,8 @@ in
               options = [ "nfsvers=4" "sec=krb5p" "noauto" ];
             };
           };
+
+        environment.systemPackages = [ pkgs.nfs4-acl-tools ];
       };
 
     server = { lib, ...}:
@@ -129,5 +131,11 @@ in
           ids = client.succeed("stat -c '%U %G' /data/alice").split()
           expected = ["alice", "users"]
           assert ids == expected, f"ids incorrect: got {ids} expected {expected}"
+
+      with subtest("ACL tools are working"):
+          client.succeed("su alice -c 'nfs4_getfacl /data/alice'")
+          client.succeed("su alice -c 'ls /data/alice'")
+          client.succeed("su alice -c 'nfs4_setfacl -a D::alice@nfs.test:r /data/alice'")
+          client.fail("su alice -c 'ls /data/alice'")
     '';
 })

--- a/pkgs/tools/filesystems/nfs4-acl-tools/default.nix
+++ b/pkgs/tools/filesystems/nfs4-acl-tools/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchgit, stdenv, autoreconfHook269, gnumake, libtool, attr }:
+
+stdenv.mkDerivation rec {
+  pname = "nfs4-acl-tools";
+  version = "0.3.7";
+
+  src = fetchgit {
+    url = "git://git.linux-nfs.org/projects/bfields/nfs4-acl-tools.git";
+    rev = "${pname}-${version}";
+    sha256 = "McDRqKSFMy2iDUJReqRNr+4uSEd6o5D0e9r3qVXrCVM=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook269 ];
+  MAKE = "${gnumake}/bin/make";
+  LIBTOOL = "${libtool}/bin/libtool";
+
+  buildInputs = [ attr.dev ];
+
+  meta = with lib; {
+    description = "Linux NFSv4 ACL tools (provides nfs4_getfacl, nfs4_setfacl and nfs4_editfacl)";
+
+    # University of Michigan license
+    # http://git.linux-nfs.org/?p=bfields/nfs4-acl-tools.git;a=blob_plain;f=COPYING;hb=HEAD
+    # I couldn't find a canonical URL to add it the Nixpkgs list of licenses
+
+    homepage = "http://git.linux-nfs.org/?p=bfields/nfs4-acl-tools.git;a=summary";
+    maintainers =  with maintainers; [ danth ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8637,6 +8637,8 @@ with pkgs;
 
   nfs-ganesha = callPackage ../servers/nfs-ganesha { };
 
+  nfs4-acl-tools = callPackage ../tools/filesystems/nfs4-acl-tools { };
+
   ngrep = callPackage ../tools/networking/ngrep { };
 
   neuron-notes = haskell.lib.compose.justStaticExecutables (haskell.lib.compose.generateOptparseApplicativeCompletion "neuron" haskellPackages.neuron);


### PR DESCRIPTION
###### Description of changes

Adds [NFSv4 ACL tools](http://git.linux-nfs.org/?p=bfields/nfs4-acl-tools.git;a=summary) and a corresponding NixOS test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
