### PR TITLE
vvvvvv: init at 2.3.6

### DIFF
--- a/pkgs/development/libraries/tinyxml-2/default.nix
+++ b/pkgs/development/libraries/tinyxml-2/default.nix
@@ -2,16 +2,24 @@
 
 stdenv.mkDerivation rec {
   pname = "tinyxml-2";
-  version = "6.0.0";
+  version = "9.0.0";
 
   src = fetchFromGitHub {
     repo = "tinyxml2";
     owner = "leethomason";
     rev = version;
-    sha256 = "031fmhpah449h3rkyamzzdpzccrrfrvjb4qn6vx2vjm47jwc54qv";
+    sha256 = "sha256-AQQOctXi7sWIH/VOeSUClX6hlm1raEQUOp+VoPjLM14=";
   };
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
+    # (setting it to an absolute path causes include files to go to $out/$out/include,
+    #  because the absolute path is interpreted with root at $out).
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
 
   meta = {
     description = "A simple, small, efficient, C++ XML parser";

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, cmake
+, makeWrapper
+, copyDesktopItems
+, makeDesktopItem
+, physfs
+, SDL2
+, SDL2_mixer
+, tinyxml-2
+, utf8cpp
+, Foundation
+, IOKit
+, makeAndPlay ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vvvvvv";
+  version = "2.3.6";
+
+  src = fetchFromGitHub {
+    owner = "TerryCavanagh";
+    repo = "VVVVVV";
+    rev = version;
+    sha256 = "sha256-sLNO4vkmlirsqJmCV9YWpyNnIiigU1KMls7rOgWgSmQ=";
+  };
+  sourceRoot = "source/desktop_version";
+  dataZip = fetchurl {
+    url = "https://thelettervsixtim.es/makeandplay/data.zip";
+    name = "data.zip";
+    sha256 = "sha256-x2eAlZT2Ry2p9WE252ZX44ZA1YQWSkYRIlCsYpPswOo=";
+    meta.license = lib.licenses.unfree;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    physfs
+    SDL2
+    SDL2_mixer
+    tinyxml-2
+    utf8cpp
+  ] ++ lib.optionals stdenv.isDarwin [ Foundation IOKit ];
+
+  # Help CMake find SDL_mixer.h
+  NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2_mixer}/include/SDL2";
+
+  cmakeFlags = [ "-DBUNDLE_DEPENDENCIES=OFF" ] ++ lib.optional makeAndPlay "-DMAKEANDPLAY=ON";
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "VVVVVV";
+      desktopName = "VVVVVV";
+      comment = meta.description;
+      exec = pname;
+      icon = "VVVVVV";
+      terminal = false;
+      categories = [ "Game" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 VVVVVV $out/bin/${pname}
+    install -Dm644 "$src/desktop_version/icon.ico" "$out/share/pixmaps/VVVVVV.png"
+
+    wrapProgram $out/bin/${pname} --add-flags "-assets ${dataZip}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A retro-styled platform game" + lib.optionalString makeAndPlay " (redistributable, without original levels)";
+    longDescription = ''
+      VVVVVV is a platform game all about exploring one simple mechanical
+      idea - what if you reversed gravity instead of jumping?
+    '' + lib.optionalString makeAndPlay ''
+      (Redistributable version, doesn't include the original levels.)
+    '';
+    homepage = "https://thelettervsixtim.es";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ martfont ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35304,6 +35304,10 @@ with pkgs;
     libpng = libpng12;
   };
 
+  vvvvvv = callPackage ../games/vvvvvv {
+    inherit (darwin.apple_sdk.frameworks) Foundation IOKit;
+  };
+
   wargus = callPackage ../games/wargus { };
 
   warmux = callPackage ../games/warmux { };


### PR DESCRIPTION
###### Description of changes

Adds VVVVVV, closing #77519 and superseding #79068.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Also updated tinyxml-2.
Didn't test Darwin at all. If no one can test it, I'll remove it.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
