### PR TITLE
ocamlPackages.alsa, ocamlPackages.gstreamer, ocamlPackages.portaudio, ocamlPackages.pulseaudio: init

### DIFF
--- a/pkgs/development/ocaml-modules/alsa/default.nix
+++ b/pkgs/development/ocaml-modules/alsa/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, alsa-lib }:
+
+buildDunePackage rec {
+  pname = "alsa";
+  version = "0.3.0";
+
+  minimalOCamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-alsa";
+    rev = version;
+    sha256 = "1qy22g73qc311rmv41w005rdlj5mfnn4yj1dx1jhqzr31zixl8hj";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ alsa-lib ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-alsa";
+    description = "OCaml interface for libasound2";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/gstreamer/default.nix
+++ b/pkgs/development/ocaml-modules/gstreamer/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, glib, gst_all_1 }:
+
+buildDunePackage rec {
+  pname = "gstreamer";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-gstreamer";
+    rev = "v${version}";
+    sha256 = "0y8xi1q0ld4hrk96bn6jfh9slyjrxmnlhm662ynacp3yzalp8jji";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ glib.dev gst_all_1.gstreamer.dev gst_all_1.gst-plugins-base ];
+
+  CFLAGS_COMPILE = [
+    "-I${glib.dev}/include/glib-2.0"
+    "-I${glib.out}/lib/glib-2.0/include"
+    "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0"
+    "-I${gst_all_1.gstreamer.dev}/include/gstreamer-1.0"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-gstreamer";
+    description = "Bindings for the GStreamer library which provides functions for playning and manipulating multimedia streams";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/portaudio/default.nix
+++ b/pkgs/development/ocaml-modules/portaudio/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, portaudio }:
+
+buildDunePackage rec {
+  pname = "portaudio";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-portaudio";
+    rev = "v${version}";
+    sha256 = "sha256-rMSE+ta7ughjjCnz4oho1D3VGaAsUlLtxizvxZT0/cQ=";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ portaudio ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-portaudio";
+    description = "Bindings for the portaudio library which provides high-level functions for using soundcards";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/pulseaudio/default.nix
+++ b/pkgs/development/ocaml-modules/pulseaudio/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, pulseaudio }:
+
+buildDunePackage rec {
+  pname = "pulseaudio";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-pulseaudio";
+    rev = "v${version}";
+    sha256 = "sha256-eG2HS5g3ycDftRDyXGBwPJE7VRnLXNUgcEgNfVm//ds=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ pulseaudio ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-pulseaudio";
+    description = "Bindings to Pulseaudio client library";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -482,6 +482,8 @@ let
       inherit (pkgs) gsl;
     };
 
+    gstreamer = callPackage ../development/ocaml-modules/gstreamer { };
+
     h2 = callPackage ../development/ocaml-modules/h2 { };
 
     hack_parallel = callPackage ../development/ocaml-modules/hack_parallel { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1209,6 +1209,10 @@ let
 
     pipebang = callPackage ../development/ocaml-modules/pipebang { };
 
+    portaudio = callPackage ../development/ocaml-modules/portaudio {
+      inherit (pkgs) portaudio;
+    };
+
     pprint = callPackage ../development/ocaml-modules/pprint { };
 
     ppx_blob = callPackage ../development/ocaml-modules/ppx_blob { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -24,6 +24,8 @@ let
 
     alcotest-mirage = callPackage ../development/ocaml-modules/alcotest/mirage.nix {};
 
+    alsa = callPackage ../development/ocaml-modules/alsa { };
+
     angstrom = callPackage ../development/ocaml-modules/angstrom { };
 
     angstrom-async = callPackage ../development/ocaml-modules/angstrom-async { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1135,6 +1135,10 @@ let
 
     ptime = callPackage ../development/ocaml-modules/ptime { };
 
+    pulseaudio = callPackage ../development/ocaml-modules/pulseaudio {
+      inherit (pkgs) pulseaudio;
+    };
+
     pure-splitmix = callPackage ../development/ocaml-modules/pure-splitmix { };
 
     resource-pooling = callPackage ../development/ocaml-modules/resource-pooling { };


### PR DESCRIPTION
###### Description of changes

Part of splitting out https://github.com/NixOS/nixpkgs/pull/140777 for easier review

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
