### PR TITLE
python310Packages.pyunifiprotect: init at 3.7.0, python310Packages.unifi-discovery: init at 1.1.3

### DIFF
--- a/pkgs/development/python-modules/aioshutil/default.nix
+++ b/pkgs/development/python-modules/aioshutil/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "aioshutil";
+  version = "1.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "kumaraditya303";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-CQIzNu1NrGDOh2uVif/EzB5C5t/Y/h9oT56Gp6jrOPQ=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace " --cov aioshutil --cov-report xml" ""
+  '';
+
+  pythonImportsCheck = [
+    "aioshutil"
+  ];
+
+  meta = with lib; {
+    description = "Asynchronous version of function of shutil module";
+    homepage = "https://github.com/kumaraditya303/aioshutil";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pyunifiprotect/default.nix
+++ b/pkgs/development/python-modules/pyunifiprotect/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, aiohttp
+, aioshutil
+, buildPythonPackage
+, fetchFromGitHub
+, packaging
+, pillow
+, poetry-core
+, pydantic
+, pyjwt
+, pytest-aiohttp
+, pytest-asyncio
+, pytest-benchmark
+, pytest-timeout
+, pytest-xdist
+, pytestCheckHook
+, python-dotenv
+, pythonOlder
+, pytz
+, typer
+}:
+
+buildPythonPackage rec {
+  pname = "pyunifiprotect";
+  version = "3.7.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "briis";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-0adbUKTkbgA4pKrIVFGowD4Wf8brjfkLpfCT/+Mw6vs=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    aioshutil
+    packaging
+    pillow
+    pydantic
+    pyjwt
+    python-dotenv
+    pytz
+    typer
+  ];
+
+  checkInputs = [
+    pytest-aiohttp
+    pytest-asyncio
+    pytest-benchmark
+    pytest-timeout
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # https://github.com/briis/pyunifiprotect/pull/176
+    substituteInPlace setup.cfg \
+      --replace "asyncio" "aiohttp"
+    substituteInPlace pyproject.toml \
+      --replace "--cov=pyunifiprotect --cov-append" ""
+  '';
+
+  pythonImportsCheck = [
+    "pyunifiprotect"
+  ];
+
+  pytestFlagsArray = [
+    "--benchmark-disable"
+  ];
+
+  disabledTests = [
+    # Tests require ffprobe
+    "test_get_camera_video"
+  ];
+
+  meta = with lib; {
+    description = "Library for interacting with the Unifi Protect API";
+    homepage = "https://github.com/briis/pyunifiprotect";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/unifi-discovery/default.nix
+++ b/pkgs/development/python-modules/unifi-discovery/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, aiohttp
+, aioresponses
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pyroute2
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "unifi-discovery";
+  version = "1.1.3";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-++5Rg3cCyH4h6zzEXbsQM5tRnUsnV3RCzuOctcjA/x4=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    pyroute2
+  ];
+
+  checkInputs = [
+    aioresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "--cov=unifi_discovery --cov-report=term-missing:skip-covered" ""
+  '';
+
+  pythonImportsCheck = [
+    "unifi_discovery"
+  ];
+
+  meta = with lib; {
+    description = "Module to discover Unifi devices";
+    homepage = "https://github.com/bdraco/unifi-discovery";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2876,7 +2876,9 @@
     ];
     "unifiprotect" = ps: with ps; [
       aiohttp-cors
-    ]; # missing inputs: pyunifiprotect unifi-discovery
+      pyunifiprotect
+      unifi-discovery
+    ];
     "universal" = ps: with ps; [
     ];
     "upb" = ps: with ps; [
@@ -3779,6 +3781,7 @@
     "ukraine_alarm"
     "unifi"
     "unifi_direct"
+    "unifiprotect"
     "universal"
     "upb"
     "upcloud"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10780,6 +10780,8 @@ in {
 
   unifi = callPackage ../development/python-modules/unifi { };
 
+  unifi-discovery = callPackage ../development/python-modules/unifi-discovery { };
+
   unify = callPackage ../development/python-modules/unify { };
 
   unifiled = callPackage ../development/python-modules/unifiled { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8761,6 +8761,8 @@ in {
 
   pyunifi = callPackage ../development/python-modules/pyunifi { };
 
+  pyunifiprotect = callPackage ../development/python-modules/pyunifiprotect { };
+
   pyupdate = callPackage ../development/python-modules/pyupdate { };
 
   pyupgrade = callPackage ../development/python-modules/pyupgrade { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -403,6 +403,8 @@ in {
 
   aioshelly = callPackage ../development/python-modules/aioshelly { };
 
+  aioshutil = callPackage ../development/python-modules/aioshutil { };
+
   aiosignal = callPackage ../development/python-modules/aiosignal { };
 
   aioslimproto = callPackage ../development/python-modules/aioslimproto { };


### PR DESCRIPTION
###### Description of changes
- Library for interacting with the Unifi Protect AP: https://github.com/briis/pyunifiprotect
- Module to discover Unifi devices: https://github.com/bdraco/unifi-discovery

Those are home Assistant dependencies.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
