### PR TITLE
cubiomes-viewer: 2.1.1 -> 2.2.2

### DIFF
--- a/pkgs/applications/misc/cubiomes-viewer/default.nix
+++ b/pkgs/applications/misc/cubiomes-viewer/default.nix
@@ -3,22 +3,27 @@
 , fetchFromGitHub
 , qtbase
 , qmake
+, qttools
 , wrapQtAppsHook
-, copyDesktopItems
-, makeDesktopItem
 }:
 
 stdenv.mkDerivation rec {
   pname = "cubiomes-viewer";
-  version = "2.1.1";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "Cubitect";
     repo = pname;
     rev = version;
-    sha256 = "sha256-cIA6W82XEeW0k9WNygZ/KVFZE31QThpkV4OazVEvmtw=";
+    sha256 = "sha256-jwYmgA2JtWpEbuuFPwGdKKaSZ2uAs3t7CCCeu6eD9nI=";
     fetchSubmodules = true;
   };
+
+  postPatch = ''
+    substituteInPlace cubiomes-viewer.pro \
+      --replace '$$[QT_INSTALL_BINS]/lupdate' lupdate \
+      --replace '$$[QT_INSTALL_BINS]/lrelease' lrelease
+  '';
 
   buildInputs = [
     qtbase
@@ -26,18 +31,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     qmake
+    qttools
     wrapQtAppsHook
-    copyDesktopItems
   ];
-
-  desktopItems = [ (makeDesktopItem {
-    name = pname;
-    desktopName = "Cubiomes Viewer";
-    exec = pname;
-    icon = pname;
-    categories = [ "Game" ];
-    comment = meta.description;
-  }) ];
 
   preBuild = ''
     # QMAKE_PRE_LINK is not executed (I dont know why)
@@ -50,8 +46,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp cubiomes-viewer $out/bin
 
-    mkdir -p $out/share/pixmaps
-    cp rc/icons/map.png $out/share/pixmaps/cubiomes-viewer.png
+    mkdir -p $out/share/{pixmaps,applications}
+    cp rc/icons/map.png $out/share/pixmaps/com.github.cubitect.cubiomes-viewer.png
+    cp etc/com.github.cubitect.cubiomes-viewer.desktop $out/share/applications
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/Cubitect/cubiomes-viewer/compare/2.1.1...2.2.2

In this update, a desktop file was added. Also, it now requires lupdate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
