### PR TITLE
ocamlPackages.srt: 0.1.1 -> 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/srt/default.nix
+++ b/pkgs/development/ocaml-modules/srt/default.nix
@@ -6,25 +6,22 @@
 
 buildDunePackage rec {
   pname = "srt";
-  version = "0.1.1";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-srt";
     rev = "v${version}";
-    sha256 = "0xh89w4j7lljvpy2n08x6m9kw88f82snmzf23kp0gw637sjnrj6f";
+    sha256 = "sha256-rnM50IzeiKOrpFf79jTHp+fXn0tdx+vrLuD3kzqLh5g=";
   };
-
-  useDune2 = true;
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ posix-socket srt ];
 
-  meta = {
+  meta = with lib; {
     description = "OCaml bindings for the libsrt library";
     license = lib.licenses.gpl2Only;
     inherit (src.meta) homepage;
-    maintainers = [ lib.maintainers.vbgl ];
+    maintainers = with maintainers; [ vbgl dandellion ];
   };
-
 }

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, makeWrapper, fetchurl, which, pkg-config
 , fetchFromGitLab
+, fetchFromGitHub
 , ocamlPackages
 , libao, portaudio, alsa-lib, libpulseaudio, libjack2
 , libsamplerate, libmad, taglib, lame, libogg
@@ -24,7 +25,8 @@ in
 
 # Liquidsoap 1.4.2 is not compatible with menhir ≥ 20220210
 # Locally override menhir to an earlier version
-let menhirLib = ocamlPackages.menhirLib.overrideAttrs (o: rec {
+let
+  menhirLib = ocamlPackages.menhirLib.overrideAttrs (o: rec {
     version = "20211128";
     src = fetchFromGitLab {
       domain = "gitlab.inria.fr";
@@ -41,6 +43,15 @@ let menhirLib = ocamlPackages.menhirLib.overrideAttrs (o: rec {
     inherit menhirLib menhirSdk;
   };
 
+  srt = ocamlPackages.srt.overrideAttrs (old: rec {
+    version = "0.1.1";
+    src = fetchFromGitHub {
+      owner = "savonet";
+      repo = "ocaml-srt";
+      rev = "v${version}";
+      sha256 = "0xh89w4j7lljvpy2n08x6m9kw88f82snmzf23kp0gw637sjnrj6f";
+    };
+  });
 in
 
 stdenv.mkDerivation {
@@ -82,7 +93,7 @@ stdenv.mkDerivation {
       ocamlPackages.xmlm ocamlPackages.ocaml_pcre
       ocamlPackages.camomile
       ocamlPackages.fdkaac
-      ocamlPackages.srt ocamlPackages.sedlex menhir menhirLib
+      srt ocamlPackages.sedlex menhir menhirLib
     ];
 
   hardeningDisable = [ "format" "fortify" ];


### PR DESCRIPTION
###### Description of changes

Part of splitting out https://github.com/NixOS/nixpkgs/pull/140777 for easier review

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
