### PR TITLE
cc-wrapper: Allow user to override -target for clang

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -1,0 +1,11 @@
+needsTarget=true
+
+for p in "${params[@]}"; do
+    case "$p" in
+    -target | --target=*) needsTarget=false ;;
+    esac
+done
+
+if $needsTarget; then
+    extraBefore+=(-target @defaultTarget@)
+fi

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -29,7 +29,6 @@ cc1=0
 cxxInclude=1
 cxxLibrary=1
 cInclude=1
-needsTarget=@needsTarget@
 
 expandResponseParams "$@"
 linkType=$(checkLinkType "${params[@]}")
@@ -47,7 +46,6 @@ while (( "$n" < "$nParams" )); do
         -nostdinc) cInclude=0 cxxInclude=0 ;;
         -nostdinc++) cxxInclude=0 ;;
         -nostdlib) cxxLibrary=0 ;;
-        -target|--target=*) needsTarget=0;;
         -x)
             case "$p2" in
                 *-header) dontLink=1 ;;
@@ -161,8 +159,8 @@ if [ "$dontLink" != 1 ]; then
     export NIX_LINK_TYPE_@suffixSalt@=$linkType
 fi
 
-if [ $needsTarget == 1 ]; then
-    extraAfter+=(-target @defaultTarget@)
+if [[ -e @out@/nix-support/add-local-cc-cflags-before.sh ]]; then
+    source @out@/nix-support/add-local-cflags-before.sh
 fi
 
 # As a very special hack, if the arguments are just `-v', then don't

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -29,6 +29,7 @@ cc1=0
 cxxInclude=1
 cxxLibrary=1
 cInclude=1
+needsTarget=@needsTarget@
 
 expandResponseParams "$@"
 linkType=$(checkLinkType "${params[@]}")
@@ -46,6 +47,7 @@ while (( "$n" < "$nParams" )); do
         -nostdinc) cInclude=0 cxxInclude=0 ;;
         -nostdinc++) cxxInclude=0 ;;
         -nostdlib) cxxLibrary=0 ;;
+        -target|--target=*) needsTarget=0;;
         -x)
             case "$p2" in
                 *-header) dontLink=1 ;;
@@ -157,6 +159,10 @@ if [ "$dontLink" != 1 ]; then
         fi
     done
     export NIX_LINK_TYPE_@suffixSalt@=$linkType
+fi
+
+if [ $needsTarget == 1 ]; then
+    extraAfter+=(-target @defaultTarget@)
 fi
 
 # As a very special hack, if the arguments are just `-v', then don't

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -38,36 +38,23 @@ nParams=${#params[@]}
 while (( "$n" < "$nParams" )); do
     p=${params[n]}
     p2=${params[n+1]:-} # handle `p` being last one
-    if [ "$p" = -c ]; then
-        dontLink=1
-    elif [ "$p" = -S ]; then
-        dontLink=1
-    elif [ "$p" = -E ]; then
-        dontLink=1
-    elif [ "$p" = -E ]; then
-        dontLink=1
-    elif [ "$p" = -M ]; then
-        dontLink=1
-    elif [ "$p" = -MM ]; then
-        dontLink=1
-    elif [[ "$p" = -x && "$p2" = *-header ]]; then
-        dontLink=1
-    elif [[ "$p" = -x && "$p2" = c++* && "$isCxx" = 0 ]]; then
-        isCxx=1
-    elif [ "$p" = -nostdlib ]; then
-        cxxLibrary=0
-    elif [ "$p" = -nostdinc ]; then
-        cInclude=0
-        cxxInclude=0
-    elif [ "$p" = -nostdinc++ ]; then
-        cxxInclude=0
-    elif [[ "$p" != -?* ]]; then
-        # A dash alone signifies standard input; it is not a flag
-        nonFlagArgs=1
-    elif [ "$p" = -cc1 ]; then
-        cc1=1
-    fi
     n+=1
+
+    case "$p" in
+        -[cSEM] | -MM) dontLink=1 ;;
+        -cc1) cc1=1 ;;
+        -nostdinc) cInclude=0 cxxInclude=0 ;;
+        -nostdinc++) cxxInclude=0 ;;
+        -nostdlib) cxxLibrary=0 ;;
+        -x)
+            case "$p2" in
+                *-header) dontLink=1 ;;
+                c++*) isCxx=1 ;;
+            esac
+            ;;
+        -?*) ;;
+        *) nonFlagArgs=1 ;; # Includes a solitary dash (`-`) which signifies standard input; it is not a flag
+    esac
 done
 
 # If we pass a flag like -Wl, then gcc will call the linker unless it
@@ -81,29 +68,31 @@ fi
 
 # Optionally filter out paths not refering to the store.
 if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "$NIX_STORE" ]]; then
-    rest=()
+    kept=()
     nParams=${#params[@]}
     declare -i n=0
     while (( "$n" < "$nParams" )); do
         p=${params[n]}
         p2=${params[n+1]:-} # handle `p` being last one
-        if [ "${p:0:3}" = -L/ ] && badPath "${p:2}"; then
-            skip "${p:2}"
-        elif [ "$p" = -L ] && badPath "$p2"; then
-            n+=1; skip "$p2"
-        elif [ "${p:0:3}" = -I/ ] && badPath "${p:2}"; then
-            skip "${p:2}"
-        elif [ "$p" = -I ] && badPath "$p2"; then
-            n+=1; skip "$p2"
-        elif [ "$p" = -isystem ] && badPath "$p2"; then
-            n+=1; skip "$p2"
-        else
-            rest+=("$p")
-        fi
         n+=1
+
+        skipNext=false
+        path=""
+        case "$p" in
+            -[IL]/*) path=${p:2} ;;
+            -[IL] | -isystem) path=$p2 skipNext=true ;;
+        esac
+
+        if [[ -n $path ]] && badPath "$path"; then
+            skip "$path"
+            $skipNext && n+=1
+            continue
+        fi
+
+        kept+=("$p")
     done
     # Old bash empty array hack
-    params=(${rest+"${rest[@]}"})
+    params=(${kept+"${kept[@]}"})
 fi
 
 # Flirting with a layer violation here.
@@ -118,17 +107,17 @@ fi
 
 # Clear march/mtune=native -- they bring impurity.
 if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
-    rest=()
+    kept=()
     # Old bash empty array hack
     for p in ${params+"${params[@]}"}; do
         if [[ "$p" = -m*=native ]]; then
             skip "$p"
         else
-            rest+=("$p")
+            kept+=("$p")
         fi
     done
     # Old bash empty array hack
-    params=(${rest+"${rest[@]}"})
+    params=(${kept+"${kept[@]}"})
 fi
 
 if [[ "$isCxx" = 1 ]]; then

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -208,7 +208,6 @@ stdenv.mkDerivation {
     + ''
       export named_cc=${targetPrefix}cc
       export named_cxx=${targetPrefix}c++
-      export needsTarget=0
 
       if [ -e $ccPath/${targetPrefix}gcc ]; then
         wrap ${targetPrefix}gcc $wrapper $ccPath/${targetPrefix}gcc
@@ -216,8 +215,6 @@ stdenv.mkDerivation {
         export named_cc=${targetPrefix}gcc
         export named_cxx=${targetPrefix}g++
       elif [ -e $ccPath/clang ]; then
-        needsTarget=1
-        export defaultTarget=${targetPlatform.config}
         wrap ${targetPrefix}clang $wrapper $ccPath/clang
         ln -s ${targetPrefix}clang $out/bin/${targetPrefix}cc
         export named_cc=${targetPrefix}clang
@@ -228,8 +225,6 @@ stdenv.mkDerivation {
         wrap ${targetPrefix}g++ $wrapper $ccPath/${targetPrefix}g++
         ln -s ${targetPrefix}g++ $out/bin/${targetPrefix}c++
       elif [ -e $ccPath/clang++ ]; then
-        needsTarget=1
-        export defaultTarget=${targetPlatform.config}
         wrap ${targetPrefix}clang++ $wrapper $ccPath/clang++
         ln -s ${targetPrefix}clang++ $out/bin/${targetPrefix}c++
       fi
@@ -517,6 +512,15 @@ stdenv.mkDerivation {
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
+    ''
+
+    ##
+    ## General Clang support
+    ## Needs to go after ^ because the for loop eats \n and makes this file an invalid script
+    ##
+    + optionalString isClang ''
+      export defaultTarget=${targetPlatform.config}
+      substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
     ''
 
     ##

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -208,6 +208,7 @@ stdenv.mkDerivation {
     + ''
       export named_cc=${targetPrefix}cc
       export named_cxx=${targetPrefix}c++
+      export needsTarget=0
 
       if [ -e $ccPath/${targetPrefix}gcc ]; then
         wrap ${targetPrefix}gcc $wrapper $ccPath/${targetPrefix}gcc
@@ -215,6 +216,8 @@ stdenv.mkDerivation {
         export named_cc=${targetPrefix}gcc
         export named_cxx=${targetPrefix}g++
       elif [ -e $ccPath/clang ]; then
+        needsTarget=1
+        export defaultTarget=${targetPlatform.config}
         wrap ${targetPrefix}clang $wrapper $ccPath/clang
         ln -s ${targetPrefix}clang $out/bin/${targetPrefix}cc
         export named_cc=${targetPrefix}clang
@@ -225,6 +228,8 @@ stdenv.mkDerivation {
         wrap ${targetPrefix}g++ $wrapper $ccPath/${targetPrefix}g++
         ln -s ${targetPrefix}g++ $out/bin/${targetPrefix}c++
       elif [ -e $ccPath/clang++ ]; then
+        needsTarget=1
+        export defaultTarget=${targetPlatform.config}
         wrap ${targetPrefix}clang++ $wrapper $ccPath/clang++
         ln -s ${targetPrefix}clang++ $out/bin/${targetPrefix}c++
       fi
@@ -295,14 +300,6 @@ stdenv.mkDerivation {
       if [[ -f "$bintools/nix-support/dynamic-linker-m32" ]]; then
         ln -s "$bintools/nix-support/dynamic-linker-m32" "$out/nix-support"
       fi
-    ''
-
-    ##
-    ## General Clang support
-    ##
-    + optionalString isClang ''
-
-      echo "-target ${targetPlatform.config}" >> $out/nix-support/cc-cflags
     ''
 
     ##


### PR DESCRIPTION
###### Description of changes

Only sets -target in wrapped compiler if none is provided by the user. This is especially helpful for generating bpf objects.

Fixes #176128

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
