### PR TITLE
python3Packages.uvloop: unbreak on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -6,7 +6,7 @@
 , libuv
 , CoreServices
 , ApplicationServices
-# Check Inputs
+  # Check Inputs
 , aiohttp
 , psutil
 , pyopenssl
@@ -34,7 +34,6 @@ buildPythonPackage rec {
   checkInputs = [
     aiohttp
     pytestCheckHook
-    pyopenssl
     psutil
   ];
 
@@ -46,15 +45,18 @@ buildPythonPackage rec {
     "--assert=plain"
     "--strict"
     "--tb=native"
+    # Depend on pyopenssl
+    "--deselect tests/test_tcp.py::Test_UV_TCPSSL::test_flush_before_shutdown"
+    "--deselect tests/test_tcp.py::Test_UV_TCPSSL::test_renegotiation"
   ] ++ lib.optionals (stdenv.isAarch32 || stdenv.isAarch64) [
     # test gets stuck in epoll_pwait on hydras aarch64 builders
     # https://github.com/MagicStack/uvloop/issues/412
-    "--deselect" "tests/test_tcp.py::Test_AIO_TCPSSL::test_remote_shutdown_receives_trailing_data"
+    "--deselect tests/test_tcp.py::Test_AIO_TCPSSL::test_remote_shutdown_receives_trailing_data"
   ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     # Flaky test: https://github.com/MagicStack/uvloop/issues/412
-    "--deselect" "tests/test_tcp.py::Test_UV_TCPSSL::test_shutdown_timeout_handler_not_set"
+    "--deselect tests/test_tcp.py::Test_UV_TCPSSL::test_shutdown_timeout_handler_not_set"
     # Broken: https://github.com/NixOS/nixpkgs/issues/160904
-    "--deselect" "tests/test_context.py::Test_UV_Context::test_create_ssl_server_manual_connection_lost"
+    "--deselect tests/test_context.py::Test_UV_Context::test_create_ssl_server_manual_connection_lost"
   ];
 
   disabledTestPaths = [
@@ -66,7 +68,11 @@ buildPythonPackage rec {
     # Work around "OSError: AF_UNIX path too long"
     # https://github.com/MagicStack/uvloop/issues/463
     export TMPDIR="/tmp"
-   '' + ''
+    # pyopenssl is not well supported by upstream
+    # https://github.com/NixOS/nixpkgs/issues/175875
+    substituteInPlace tests/test_tcp.py \
+      --replace "from OpenSSL import SSL as openssl_ssl" ""
+  '' + ''
     # force using installed/compiled uvloop vs source by moving tests to temp dir
     export TEST_DIR=$(mktemp -d)
     cp -r tests $TEST_DIR


### PR DESCRIPTION
###### Description of changes

Disable tests that depend on pyopenssl which is [broken](https://github.com/NixOS/nixpkgs/issues/175875) on aarch64-darwin.

Disabled tests https://github.com/MagicStack/uvloop/blob/b0526cd50b99409a47fe4f803d8688200853de4b/tests/test_tcp.py#L14
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
