### PR TITLE
python310Packages.nextcord: 2.0.0a10 -> 2.0.0b2

### DIFF
--- a/pkgs/development/python-modules/nextcord/default.nix
+++ b/pkgs/development/python-modules/nextcord/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "nextcord";
-  version = "2.0.0a10";
+  version = "2.0.0b2";
 
   format = "setuptools";
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "nextcord";
     repo = "nextcord";
     rev = version;
-    hash = "sha256-p99WJ4y2iJQTI3wHbh+jwJyLnE3aBXnHxrehDYYek/4=";
+    hash = "sha256-yp24eOmwdi5X2Y20jqq88CDFvmc6P5omOsSWFr2MWGI=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/nextcord/paths.patch
+++ b/pkgs/development/python-modules/nextcord/paths.patch
@@ -1,26 +1,71 @@
 diff --git a/nextcord/opus.py b/nextcord/opus.py
-index 97d437a3..755e1a5c 100644
+index 52e4ddbd..d8b8090b 100644
 --- a/nextcord/opus.py
 +++ b/nextcord/opus.py
-@@ -213,7 +213,7 @@ def _load_default() -> bool:
-             _filename = os.path.join(_basedir, 'bin', f'libopus-0.{_target}.dll')
+@@ -255,7 +255,7 @@ def _load_default() -> bool:
+             _filename = os.path.join(_basedir, "bin", f"libopus-0.{_target}.dll")
              _lib = libopus_loader(_filename)
          else:
--            _lib = libopus_loader(ctypes.util.find_library('opus'))
-+            _lib = libopus_loader('@libopus@')
-     except Exception:
-         _lib = None
+-            opus = ctypes.util.find_library("opus")
++            opus = ctypes.util.find_library("@opus@")
  
+             if opus is None:
+                 _lib = None
 diff --git a/nextcord/player.py b/nextcord/player.py
-index bedefc5a..34de0459 100644
+index 5d0674cc..fd1c20ef 100644
 --- a/nextcord/player.py
 +++ b/nextcord/player.py
-@@ -140,7 +140,7 @@ class FFmpegAudio(AudioSource):
-     .. versionadded:: 1.3
-     """
+@@ -148,7 +148,7 @@ class FFmpegAudio(AudioSource):
+         self,
+         source: Union[str, io.BufferedIOBase],
+         *,
+-        executable: str = "ffmpeg",
++        executable: str = "@ffmpeg@",
+         args: Any,
+         **subprocess_kwargs: Any,
+     ):
+@@ -275,7 +275,7 @@ class FFmpegPCMAudio(FFmpegAudio):
+         self,
+         source: Union[str, io.BufferedIOBase],
+         *,
+-        executable: str = "ffmpeg",
++        executable: str = "@ffmpeg@",
+         pipe: bool = False,
+         stderr: Optional[IO[str]] = None,
+         before_options: Optional[str] = None,
+@@ -378,7 +378,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+         *,
+         bitrate: int = 128,
+         codec: Optional[str] = None,
+-        executable: str = "ffmpeg",
++        executable: str = "@ffmpeg@",
+         pipe=False,
+         stderr=None,
+         before_options=None,
+@@ -532,7 +532,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+         """
  
--    def __init__(self, source: Union[str, io.BufferedIOBase], *, executable: str = 'ffmpeg', args: Any, **subprocess_kwargs: Any):
-+    def __init__(self, source: Union[str, io.BufferedIOBase], *, executable: str = '@ffmpeg@', args: Any, **subprocess_kwargs: Any):
-         piping = subprocess_kwargs.get('stdin') == subprocess.PIPE
-         if piping and isinstance(source, str):
-             raise TypeError("parameter conflict: 'source' parameter cannot be a string when piping to stdin")
+         method = method or "native"
+-        executable = executable or "ffmpeg"
++        executable = executable or "@ffmpeg@"
+         probefunc = fallback = None
+ 
+         if isinstance(method, str):
+@@ -577,7 +577,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+ 
+     @staticmethod
+     def _probe_codec_native(
+-        source, executable: str = "ffmpeg"
++        source, executable: str = "@ffmpeg@"
+     ) -> Tuple[Optional[str], Optional[int]]:
+         exe = executable[:2] + "probe" if executable in ("ffmpeg", "avconv") else executable
+         args = [
+@@ -606,7 +606,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+ 
+     @staticmethod
+     def _probe_codec_fallback(
+-        source, executable: str = "ffmpeg"
++        source, executable: str = "@ffmpeg@"
+     ) -> Tuple[Optional[str], Optional[int]]:
+         args = [executable, "-hide_banner", "-i", source]
+         proc = subprocess.Popen(


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
