### PR TITLE
bpftrace: Pull tools into PATH

### DIFF
--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -62,8 +62,18 @@ stdenv.mkDerivation rec {
 
   # nuke the example/reference output .txt files, for the included tools,
   # stuffed inside $out. we don't need them at all.
+  # (see "Allow skipping examples" for a potential option
+  #  https://github.com/iovisor/bpftrace/pull/2256)
+  #
+  # Pull BPF scripts into $PATH (next to their bcc program equivalents), but do
+  # not move them to keep `${pkgs.bpftrace}/share/bpftrace/tools/...` working.
+  # (remove `chmod` once a new release "Add executable permission to tools"
+  #  https://github.com/iovisor/bpftrace/commit/77e524e6d276216ed6a6e1984cf204418db07c78)
   postInstall = ''
     rm -rf $out/share/bpftrace/tools/doc
+
+    ln -s $out/share/bpftrace/tools/*.bt $out/bin/
+    chmod +x $out/bin/*.bt
   '';
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
bpftrace: Pull tools into PATH
    
The *.bt(8) tools are meant to be used as standalone scripts,
their synopsis demonstrates this 

Especially under NixOS, calling them via their absoloute path
in interactive shells is a huge pain, however.
    
Symlink them next to bpftrace(8) itself so they end up in `PATH`
but do not move them to avoid breaking existing setups that expect
them under share/tools/.
    
This goes in line with our bcc as well as Debian's bpftrace package.

@rvl @thoughtpolice @martined
