### PR TITLE
linux-kernel config: disable DEBUG_INFO_REDUCED

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -41,6 +41,9 @@ let
         (whenBetween "5.2" "5.18" yes)
       ];
       DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT = whenAtLeast "5.18" yes;
+      # Reduced debug info conflict with BTF and have been enabled in
+      # aarch64 defconfig since 5.13
+      DEBUG_INFO_REDUCED        = whenAtLeast "5.13" (option no);
       # Disabled on 32-bit platforms, fails to build on 5.15+ with `Failed to parse base BTF 'vmlinux': -22`
       DEBUG_INFO_BTF            = whenAtLeast "5.2" (option (if stdenv.hostPlatform.is32bit && (versionAtLeast version "5.15") then no else yes));
       BPF_LSM                   = whenAtLeast "5.7" (option yes);


### PR DESCRIPTION
###### Description of changes

Linux's aarch64 defconfig has been updated in 5.13 to enable "reduced" debug infos (upstream commit [ed938a4bfc58](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ed938a4bfc58cd86eddcb4b1c9d582a435ffcf7b) ("arm64: defconfig: Use DEBUG_INFO_REDUCED"), but that commits locks DEBUG_INFO_BTF as noticed in #175467

This disables it back which should fix bpftrace usage of BTF not working on newer kernels.


Note I don't have the resources to rebuild, so didn't check. I'll try to trigger a nixosTests.bpf run on ofborg with this to validate.
 
###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @Mic92 