### PR TITLE
apacheHttpdPackages.mod_mbtiles: init at 2022-05-25

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_mbtiles/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_mbtiles/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, apacheHttpd, sqlite }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_mbtiles";
+  version = "unstable-2022-05-25";
+
+  src = fetchFromGitHub {
+    owner = "systemed";
+    repo = pname;
+    rev = "f9d12a9581820630dd923c3c90aa8dcdcf65cb87";
+    sha256 = "sha256-wOoLSNLgh0YXHUFn7WfUkQXpyWsgCrVZlMg55rvi9q4=";
+  };
+
+  buildInputs = [ apacheHttpd sqlite ];
+
+  buildPhase = ''
+    apxs -lsqlite3 -ca mod_mbtiles.c
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D .libs/mod_mbtiles.so -t $out/modules
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/systemed/mod_mbtiles";
+    description = "Serve tiles with Apache directly from an .mbtiles file";
+    license = licenses.free;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21573,6 +21573,8 @@ with pkgs;
 
     mod_itk = callPackage ../servers/http/apache-modules/mod_itk { };
 
+    mod_mbtiles = callPackage ../servers/http/apache-modules/mod_mbtiles { };
+
     php = pkgs.php.override { inherit apacheHttpd; };
 
     subversion = pkgs.subversion.override { httpServer = true; inherit apacheHttpd; };


### PR DESCRIPTION
###### Description of changes

> **mod_mbtiles** is an Apache module to serve tiles directly from an [.mbtiles](https://github.com/mapbox/mbtiles-spec) file using the familiar /tileset/z/x/y.ext path. Use it to serve your vector tiles made with [tilemaker](https://github.com/systemed/tilemaker)[1].
> 
> Serving directly from .mbtiles is fast, space-efficient and simple.

1) tilemaker #171829

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
