### PR TITLE
crackxls: pull patch pending upstream inclusion for -fno-common toolc…

### DIFF
--- a/pkgs/tools/security/crackxls/default.nix
+++ b/pkgs/tools/security/crackxls/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, autoconf, automake, openssl, libgsf, gmp }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, autoconf, automake, openssl, libgsf, gmp }:
 
 stdenv.mkDerivation rec {
 
@@ -12,8 +12,21 @@ stdenv.mkDerivation rec {
     sha256 = "0q5jl7hcds3f0rhly3iy4fhhbyh9cdrfaw7zdrazzf1wswwhyssz";
   };
 
+  patches = [
+    # Pull patch pending upstream inclusion for -fno-common support:
+    #   https://github.com/GavinSmith0123/crackxls2003/pull/3
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/GavinSmith0123/crackxls2003/commit/613d6c1844f76c7b67671aaa265375fed56c2a56.patch";
+      sha256 = "1pk67x67d9wji576mc57z5bzqlf9ygvn9m1z47w12mad7qmj9h1n";
+    })
+  ];
+
   nativeBuildInputs = [ pkg-config autoconf automake ];
   buildInputs = [ openssl libgsf gmp ];
+
+  # Avoid "-O5 -march=native"
+  makeFlags = [ "OPTIM_FLAGS=" ];
 
   installPhase =
   ''


### PR DESCRIPTION
…hains

Without the change build fails on upstream gcc-10 as:

  ld: decrypt.o:/build/crackxls2003/decrypt.c:50: multiple definition of
    `real_key'; crackxls2003.o:/build/crackxls2003/crackxls2003.c:64: first defined here

While at it dropped -O5 -march=native default optimization flags.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
