### PR TITLE
python3Packages.skytemple-dtef: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/development/python-modules/skytemple-dtef/default.nix
+++ b/pkgs/development/python-modules/skytemple-dtef/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "skytemple-dtef";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "0l2b66z5ngyas3ijbzwz2wizw46kz47f8jr729pzbg4wbqbqjihr";
+    sha256 = "QL+nLmjz0wCED2RjidIDK0tB6mAPnoaSJWpyLFu0pP4=";
   };
 
   propagatedBuildInputs = [ skytemple-files ];
@@ -20,6 +20,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/SkyTemple/skytemple-dtef";
     description = "A format for standardized rule-based tilesets with 256 adjacency combinations";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ xfix ];
+    maintainers = with maintainers; [ xfix marius851000 ];
   };
 }

--- a/pkgs/development/python-modules/skytemple-dtef/default.nix
+++ b/pkgs/development/python-modules/skytemple-dtef/default.nix
@@ -1,25 +1,43 @@
-{ lib, buildPythonPackage, fetchFromGitHub, skytemple-files }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, pytestCheckHook
+, pythonOlder
+, skytemple-files
+}:
 
 buildPythonPackage rec {
   pname = "skytemple-dtef";
   version = "1.1.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "QL+nLmjz0wCED2RjidIDK0tB6mAPnoaSJWpyLFu0pP4=";
+    hash = "sha256-QL+nLmjz0wCED2RjidIDK0tB6mAPnoaSJWpyLFu0pP4=";
   };
 
-  propagatedBuildInputs = [ skytemple-files ];
+  propagatedBuildInputs = [
+    pillow
+    skytemple-files
+  ];
 
-  doCheck = false; # there are no tests
-  pythonImportsCheck = [ "skytemple_dtef" ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "skytemple_dtef"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/SkyTemple/skytemple-dtef";
     description = "A format for standardized rule-based tilesets with 256 adjacency combinations";
+    homepage = "https://github.com/SkyTemple/skytemple-dtef";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ xfix marius851000 ];
+    maintainers = with maintainers; [ marius851000 xfix ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
