### PR TITLE
linuxPackages_hardkernel_latest.usbip: pull upstream fix for -fno-com…

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
@@ -1,4 +1,4 @@
-{ buildPackages, fetchFromGitHub, perl, buildLinux, libelf, util-linux, ... } @ args:
+{ buildPackages, fetchFromGitHub, fetchurl, perl, buildLinux, libelf, util-linux, kernelPatches ? [], ... } @ args:
 
 buildLinux (args // rec {
   version = "4.14.180-176";
@@ -15,6 +15,14 @@ buildLinux (args // rec {
     rev = version;
     sha256 = "0n7i7a2bkrm9p1wfr20h54cqm32fbjvwyn703r6zm1f6ivqhk43v";
   };
+
+  kernelPatches = args.kernelPatches ++ [{
+    name = "usbip-tools-fno-common";
+    patch = fetchurl {
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=d5efc2e6b98fe661dbd8dd0d5d5bfb961728e57a";
+      hash = "sha256-1CXYCV5zMLA4YdbCr8cO2N4CHEDzQChS9qbKYHPm3U4=";
+    };
+  }];
 
   defconfig = "odroidxu4_defconfig";
 

--- a/pkgs/os-specific/linux/usbip/default.nix
+++ b/pkgs/os-specific/linux/usbip/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, kernel, udev, autoconf, automake, libtool, hwdata, kernelOlder }:
+{ lib, stdenv, fetchpatch, kernel, udev, autoconf, automake, libtool, hwdata, kernelOlder }:
 
 stdenv.mkDerivation {
   name = "usbip-${kernel.name}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     ./fix-snprintf-truncation.patch
     # fixes build with gcc9
     ./fix-strncpy-truncation.patch
-  ];
+  ] ++ kernel.patches;
 
   nativeBuildInputs = [ autoconf automake libtool ];
   buildInputs = [ udev ];


### PR DESCRIPTION
…mon toolchains

Without the change builds fails on upstream -gcc-10 as:

    ld: tools/usb/usbip/libsrc/vhci_driver.c:18: multiple definition of
      `udev_context'; tools/usb/usbip/libsrc/usbip_host_common.c:38: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
