### PR TITLE
wallutils: use buildGoModule

### DIFF
--- a/pkgs/tools/graphics/wallutils/default.nix
+++ b/pkgs/tools/graphics/wallutils/default.nix
@@ -1,9 +1,17 @@
-{ buildGoPackage, fetchFromGitHub, lib
+{ buildGoModule
+, fetchFromGitHub
+, lib
 , pkg-config
-, wayland, libX11, xbitmaps, libXcursor, libXmu, libXpm, libheif
+, wayland
+, libX11
+, xbitmaps
+, libXcursor
+, libXmu
+, libXpm
+, libheif
 }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "wallutils";
   version = "5.10.0";
 
@@ -14,7 +22,7 @@ buildGoPackage rec {
     sha256 = "1phlkpy8kg4ai2xmachpbbxvl8fga9hqqbad2a2121yl60709l1k";
   };
 
-  goPackagePath = "github.com/xyproto/wallutils";
+  vendorSha256 = null;
 
   patches = [ ./lscollection-Add-NixOS-paths-to-DefaultWallpaperDirectories.patch ];
 
@@ -26,9 +34,14 @@ buildGoPackage rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ wayland libX11 xbitmaps libXcursor libXmu libXpm libheif ];
 
+  ldflags = [ "-s" "-w" ];
+
+  # Disable tests require desktop environment
+  doCheck = false;
+
   meta = with lib; {
     description = "Utilities for handling monitors, resolutions, and (timed) wallpapers";
-    inherit (src.meta) homepage;
+    homepage = https://github.com/xyproto/wallutils;
     license = licenses.mit;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
