### PR TITLE
texlab: remove unused dylib of human_name

### DIFF
--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -30,6 +30,13 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     installManPage texlab.1
+
+    # Remove generated dylib of human_name dependency. TexLab statically
+    # links to the generated rlib and doesn't reference the dylib. I
+    # couldn't find any way to prevent building this by passing cargo flags.
+    # See https://github.com/djudd/human-name/blob/master/Cargo.toml#L43
+    rm "$out/lib/libhuman_name${stdenv.hostPlatform.extensions.sharedLibrary}"
+    rmdir "$out/lib"
   '';
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
###### Description of changes

We don't need the `dylib` build of `human_name`, only the `rlib` build. It only adds to the closure size by referencing `rustc`.

- https://github.com/djudd/human-name/blob/master/Cargo.toml#L43

```
> nix-store --query --tree /nix/store/8qki9p7x164wn78l857f0dx0a7xvl5i7-texlab-4.0.0
/nix/store/8qki9p7x164wn78l857f0dx0a7xvl5i7-texlab-4.0.0
└───/nix/store/fz33c1mfi2krpg1lwzizfw28kj705yg0-glibc-2.34-210
    ├───/nix/store/kas3xyzrwq7fpriy1v2gyvhi0bgv7zav-libidn2-2.3.2
    │   ├───/nix/store/16y41vgaiwpsrm784b2743682r8r0bb6-libunistring-1.0
    │   │   └───/nix/store/16y41vgaiwpsrm784b2743682r8r0bb6-libunistring-1.0 [...]
    │   └───/nix/store/kas3xyzrwq7fpriy1v2gyvhi0bgv7zav-libidn2-2.3.2 [...]
    └───/nix/store/fz33c1mfi2krpg1lwzizfw28kj705yg0-glibc-2.34-210 [...]
```

Fixes #95568

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).