### PR TITLE
bluewalker: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2323,6 +2323,12 @@
     githubId = 3956062;
     name = "Simon Lackerbauer";
   };
+  cimm = {
+    email = "8k9ft8m5gv@astil.be";
+    github = "cimm";
+    githubId = 68112;
+    name = "Simon";
+  };
   cirno-999 = {
     email = "reverene@protonmail.com";
     github = "cirno-999";

--- a/pkgs/tools/bluetooth/bluewalker/default.nix
+++ b/pkgs/tools/bluetooth/bluewalker/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitLab }:
+
+buildGoModule rec {
+  pname = "bluewalker";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    owner = "jtaimisto";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-spuJRiNiaBV4EsetUq8vUfR6ejUNZxLhVzS3AZZyrrQ=";
+  };
+
+  vendorSha256 = "189qs6vmx63vwsjmc4qgf1y8xjsi7x6l1f5c3kd8j8jnagl26z4h";
+
+  ldflags = [ # omit some things for a smaller binary
+    "-w" # omit the DWARF symbol table
+    "-s" # omit symbol table and debug info
+  ];
+
+  meta = with lib; {
+    description = "Simple command line Bluetooth LE scanner";
+    homepage = src.meta.homepage;
+    changelog = "https://gitlab.com/jtaimisto/${pname}/-/raw/master/CHANGELOG";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ cimm ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/bluetooth/bluewalker/default.nix
+++ b/pkgs/tools/bluetooth/bluewalker/default.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Simple command line Bluetooth LE scanner";
-    homepage = src.meta.homepage;
+    homepage = "https://gitlab.com/jtaimisto/bluewalker";
     changelog = "https://gitlab.com/jtaimisto/${pname}/-/raw/master/CHANGELOG";
     license = licenses.bsd2;
     maintainers = with maintainers; [ cimm ];

--- a/pkgs/tools/bluetooth/bluewalker/default.nix
+++ b/pkgs/tools/bluetooth/bluewalker/default.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Simple command line Bluetooth LE scanner";
     homepage = "https://gitlab.com/jtaimisto/bluewalker";
-    changelog = "https://gitlab.com/jtaimisto/${pname}/-/raw/master/CHANGELOG";
+    changelog = "https://gitlab.com/jtaimisto/bluewalker/-/tags/v${version}";
     license = licenses.bsd2;
     maintainers = with maintainers; [ cimm ];
     platforms = platforms.linux;

--- a/pkgs/tools/bluetooth/bluewalker/default.nix
+++ b/pkgs/tools/bluetooth/bluewalker/default.nix
@@ -13,9 +13,9 @@ buildGoModule rec {
 
   vendorSha256 = "189qs6vmx63vwsjmc4qgf1y8xjsi7x6l1f5c3kd8j8jnagl26z4h";
 
-  ldflags = [ # omit some things for a smaller binary
-    "-w" # omit the DWARF symbol table
-    "-s" # omit symbol table and debug info
+  ldflags = [
+    "-w"
+    "-s"
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2703,6 +2703,8 @@ with pkgs;
 
   bluemix-cli = callPackage ../tools/admin/bluemix-cli { };
 
+  bluewalker = callPackage ../tools/bluetooth/bluewalker { };
+
   blur-effect = callPackage ../tools/graphics/blur-effect { };
 
   bootiso = callPackage ../tools/cd-dvd/bootiso { };


### PR DESCRIPTION
###### Description of changes

I packaged [bluewalker](https://gitlab.com/jtaimisto/bluewalker), a command line Bluetooth LE scanner written in go since I would like to keep using it after migrating form Fedora. Might as well contribute it back to the main repository if anyone else wants to use it.

This is the first time I package a Nix application so maybe someone can tell me if I am missing something.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).