### PR TITLE
symbolic-preview: 0.0.2 -> 0.0.3

### DIFF
--- a/pkgs/applications/graphics/symbolic-preview/default.nix
+++ b/pkgs/applications/graphics/symbolic-preview/default.nix
@@ -1,25 +1,21 @@
-{ lib, stdenv, fetchurl, wrapGAppsHook
-, cargo, desktop-file-utils, meson, ninja, pkg-config, python3, rustc
-, gdk-pixbuf, glib, gtk3, libhandy, libxml2
+{ lib, stdenv, fetchurl, wrapGAppsHook4
+, cargo, desktop-file-utils, meson, ninja, pkg-config, rustc
+, glib, gtk4, libadwaita, libxml2
 }:
 
 stdenv.mkDerivation rec {
   pname = "symbolic-preview";
-  version = "0.0.2";
+  version = "0.0.3";
 
   src = fetchurl {
-    url = "https://gitlab.gnome.org/World/design/symbolic-preview/uploads/91fd27bb70553c8d6c3ad2a35446ff6e/symbolic-preview-${version}.tar.xz";
-    sha256 = "1v8l10ppwbjkrq7nvb0wqc3pid6pd8dqpki3jhmjjkmbd7rpdpkq";
+    url = "https://gitlab.gnome.org/World/design/symbolic-preview/uploads/df71a2eee9ea0c90b3d146e7286fec42/symbolic-preview-${version}.tar.xz";
+    sha256 = "08g2sbdb1x5z26mi68nmciq6xwv0chvxw6anj1qdfh7npsg0dm4c";
   };
 
   nativeBuildInputs = [
-    cargo desktop-file-utils meson ninja pkg-config python3 rustc wrapGAppsHook
+    cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook4
   ];
-  buildInputs = [ gdk-pixbuf glib gtk3 libhandy libxml2 ];
-
-  postPatch = ''
-    patchShebangs build-aux/meson_post_install.py
-  '';
+  buildInputs = [ glib gtk4 libadwaita libxml2 ];
 
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/World/design/symbolic-preview";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29825,9 +29825,7 @@ with pkgs;
 
   sylpheed = callPackage ../applications/networking/mailreaders/sylpheed { };
 
-  symbolic-preview = callPackage ../applications/graphics/symbolic-preview {
-    libhandy = libhandy_0;
-  };
+  symbolic-preview = callPackage ../applications/graphics/symbolic-preview { };
 
   symlinks = callPackage ../tools/system/symlinks { };
 


### PR DESCRIPTION
- https://gitlab.gnome.org/World/design/symbolic-preview/-/compare/0.0.2...0.0.3
- [Change log](https://gitlab.gnome.org/World/design/symbolic-preview/-/blob/0.0.3/data/org.gnome.design.SymbolicPreview.metainfo.xml.in.in#L34-L40)


<img src="https://user-images.githubusercontent.com/20080233/172012007-863cbb5a-47dd-4c23-9e21-fad6993d95d9.png" width=50%>



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
