### PR TITLE
gcolor2: pull patch pending upstream inclusion for -fno-common toolch…

### DIFF
--- a/pkgs/applications/graphics/gcolor2/default.nix
+++ b/pkgs/applications/graphics/gcolor2/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, gtk2, perlPackages, pkg-config } :
+{lib, stdenv, fetchurl, fetchpatch, gtk2, perlPackages, pkg-config } :
 
 let version = "0.4"; in
 stdenv.mkDerivation {
@@ -16,9 +16,18 @@ stdenv.mkDerivation {
   '';
 
   # from https://github.com/PhantomX/slackbuilds/tree/master/gcolor2/patches
-  patches = if stdenv.hostPlatform.system == "x86_64-linux" then
+  patches = (if stdenv.hostPlatform.system == "x86_64-linux" then
         [ ./gcolor2-amd64.patch ] else
-        [ ];
+        [ ])
+   ++ [
+     # Pull patch pending upstream inclusion for -fno-common toolchains:
+     #   https://sourceforge.net/p/gcolor2/patches/8/
+     (fetchpatch {
+       name = "fno-common.patch";
+       url = "https://sourceforge.net/p/gcolor2/patches/8/attachment/0001-gcolor2-fix-build-on-gcc-10-fno-common.patch";
+       sha256 = "0187zc8as9g3d6mpm3isg87jfpryj0hajb4inwvii8gxrzbi5l5f";
+     })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gtk2 ]


### PR DESCRIPTION
…ains

Without the change build on upstream gcc-10 fails as:

    ld: callbacks.o:src/callbacks.h:44: multiple definition of `gcolor2'; main.o:src/callbacks.h:44: first defined here
    ld: callbacks.o:src/callbacks.h:46: multiple definition of `colorvalue'; main.o:src/callbacks.h:46: first defined here
    ld: callbacks.o:src/callbacks.h:45: multiple definition of `menu'; main.o:src/callbacks.h:45: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
