### PR TITLE
bookletimposer: add new package

### DIFF
--- a/pkgs/applications/office/bookletimposer/configdir.patch
+++ b/pkgs/applications/office/bookletimposer/configdir.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/bookletimposer/config.py b/lib/bookletimposer/config.py
+index 8f107a4..d4d335d 100644
+--- a/lib/bookletimposer/config.py
++++ b/lib/bookletimposer/config.py
+@@ -45,14 +41,7 @@ def debug(msg):
+ 
+ 
+ def get_sharedir():
+-    if debug_enabled and os.path.exists(os.path.join("/", "usr", "local",
+-                                                     "share",
+-                                                     "bookletimposer")):
+-        return os.path.join("/", "usr", "local", "share")
+-    elif os.path.exists(os.path.join("/", "usr", "share", "bookletimposer")):
+-        return os.path.join("/", "usr", "share")
+-    else:
+-        return ""
++    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "share"))
+ 
+ 
+ def get_datadir():

--- a/pkgs/applications/office/bookletimposer/default.nix
+++ b/pkgs/applications/office/bookletimposer/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, fetchFromGitLab
+, python3
+, intltool
+, pandoc
+, gobject-introspection
+, wrapGAppsHook
+, gtk3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "bookletimposer";
+  version = "0.3.1";
+
+  src = fetchFromGitLab {
+    domain = "git.codecoop.org";
+    owner = "kjo";
+    repo = "bookletimposer";
+    rev = version;
+    sha256 = "sha256-AEpvsFBJfyqLucC0l4AN/nA2+aYBR50BEgAcNDJBSqg=";
+  };
+
+  patches = [
+    ./i18n.patch
+    ./configdir.patch
+  ];
+
+  nativeBuildInputs = [ intltool pandoc wrapGAppsHook ];
+
+  buildInputs = [ gobject-introspection ];
+
+  propagatedBuildInputs = [
+     gtk3
+     (python3.withPackages (ps: with ps; [ distutils_extra pypdf2 pygobject3 ]))
+  ];
+
+  meta = {
+    homepage = "https://kjo.herbesfolles.org/bookletimposer/";
+    description = "A utility to achieve some basic imposition on PDF documents, especially designed to work on booklets";
+    platforms = lib.platforms.linux;
+    license = "GPL-3.0-or-later";
+    maintainers = with lib.maintainers; [ afontain ];
+  };
+}

--- a/pkgs/applications/office/bookletimposer/i18n.patch
+++ b/pkgs/applications/office/bookletimposer/i18n.patch
@@ -1,0 +1,19 @@
+--- a/setup.cfg	2022-06-04 17:10:10.477581502 +0200
++++ b/setup.cfg	2022-06-04 17:10:15.185594382 +0200
+@@ -1,6 +1,3 @@
+ [build]
+ icons=False
+ help=True
+-
+-[build_i18n]
+-domain=bookletimposer
+--- a/setup.py	2022-06-04 17:25:18.020872735 +0200
++++ b/setup.py	2022-06-04 17:25:23.075884898 +0200
+@@ -115,7 +115,6 @@ It allows:
+       requires = ['gtk', 'PyPDF2'],
+       cmdclass = { "build" :            build_extra.build_extra,
+                    "build_uiheaders" :  build_uiheaders,
+-                   "build_i18n" :       build_i18n.build_i18n,
+                    "build_help" :       build_help.build_help,
+                    "build_icons" :      build_icons.build_icons,
+                    "build_man" :        build_man,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25588,6 +25588,8 @@ with pkgs;
 
   bookworm = callPackage ../applications/office/bookworm { };
 
+  bookletimposer = callPackage ../applications/office/bookletimposer { };
+
   boops = callPackage ../applications/audio/boops { };
 
   ChowCentaur  = callPackage ../applications/audio/ChowCentaur { };


### PR DESCRIPTION
###### BookletImposer: new package

This is a pdf manipulation tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested basic functionality of all binary files for 22.05 (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

