### PR TITLE
treewide: set `sourceProvenance` for packages containing downloaded jars

### DIFF
--- a/pkgs/applications/audio/jmusicbot/default.nix
+++ b/pkgs/applications/audio/jmusicbot/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Discord music bot that's easy to set up and run yourself";
     homepage = "https://github.com/jagrosh/MusicBot";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ SuperSandro2000 ];
     platforms = platforms.all;

--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -94,6 +94,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A decentralized bitcoin exchange network";
     homepage = "https://bisq.network";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ juaningan emmanuelrosa ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/blockchains/ergo/default.nix
+++ b/pkgs/applications/blockchains/ergo/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open protocol that implements modern scientific ideas in the blockchain area";
     homepage = "https://ergoplatform.org/en/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.cc0;
     platforms = platforms.all;
     maintainers = with maintainers; [ mmahut ];

--- a/pkgs/applications/blockchains/tessera/default.nix
+++ b/pkgs/applications/blockchains/tessera/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Enterprise Implementation of Quorum's transaction manager";
     homepage = "https://github.com/jpmorganchase/tessera";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ mmahut ];
   };

--- a/pkgs/applications/editors/bluej/default.nix
+++ b/pkgs/applications/editors/bluej/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple integrated development environment for Java";
     homepage = "https://www.bluej.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2ClasspathPlus;
     maintainers = with maintainers; [ chvp ];
     platforms = platforms.unix;

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -108,6 +108,7 @@ rec {
     meta = with lib; {
       homepage = "https://github.com/tobiasmelcher/EclipseAceJump";
       description = "Provides fast jumps to text based on initial letter";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.mit;
       platforms = platforms.all;
     };
@@ -130,6 +131,7 @@ rec {
     meta = with lib; {
       homepage = "https://mihai-nita.net/java/#ePluginAEC";
       description = "Adds support for ANSI escape sequences in the Eclipse console";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
       platforms = platforms.all;
     };
@@ -152,6 +154,7 @@ rec {
     meta = with lib; {
       description = "A powerful parser generator for processing structured text or binary files";
       homepage = "https://www.antlr.org/";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.bsd3;
       platforms = platforms.all;
     };
@@ -174,6 +177,7 @@ rec {
     meta = with lib; {
       description = "A powerful parser generator for processing structured text or binary files";
       homepage = "https://www.antlr.org/";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.bsd3;
       platforms = platforms.all;
     };
@@ -196,6 +200,7 @@ rec {
     meta = with lib; {
       homepage = "http://andrei.gmxhome.de/anyedit/";
       description = "Adds new tools to the context menu of text-based editors";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -218,6 +223,7 @@ rec {
     meta = with lib; {
       homepage = "https://github.com/cypher256/eclipse-encoding-plugin";
       description = "Show file encoding and line ending for the active editor in the eclipse status bar";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -240,6 +246,7 @@ rec {
     meta = with lib; {
       homepage = "http://andrei.gmxhome.de/bytecode/";
       description = "Shows disassembled bytecode of current java editor or class file";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.bsd2;
       platforms = platforms.all;
     };
@@ -259,6 +266,7 @@ rec {
     meta = with lib; {
       homepage = "https://eclipse.org/cdt/";
       description = "C/C++ development tooling";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
       maintainers = [ maintainers.bjornfor ];
@@ -278,6 +286,7 @@ rec {
     meta = with lib; {
       homepage = "https://eclipse-cs.sourceforge.net/";
       description = "Checkstyle integration into the Eclipse IDE";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.lgpl21;
       platforms = platforms.all;
     };
@@ -301,6 +310,7 @@ rec {
     meta = with lib; {
       homepage = "http://eclipsecolorthemes.org/";
       description = "Plugin to switch color themes conveniently and without side effects";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -333,6 +343,7 @@ rec {
     meta = with lib; {
       homepage = "http://www2.cs.tum.edu/projects/cup/eclipse.php";
       description = "IDE for developing CUP based parsers";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       platforms = platforms.all;
       maintainers = [ maintainers.romildo ];
     };
@@ -358,6 +369,7 @@ rec {
     meta = with lib; {
       homepage = "https://www.drools.org/";
       description = "Drools is a Business Rules Management System (BRMS) solution";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
     };
   };
@@ -375,6 +387,7 @@ rec {
     meta = with lib; {
       homepage = "https://www.eclemma.org/";
       description = "EclEmma is a free Java code coverage tool for Eclipse";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -397,6 +410,7 @@ rec {
     meta = with lib; {
       homepage = "http://findbugs.sourceforge.net/";
       description = "Plugin that uses static analysis to look for bugs in Java code";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -415,6 +429,7 @@ rec {
     meta = with lib; {
       homepage = "https://github.com/ddekany/jbosstools-freemarker";
       description = "Plugin that provides an editor for Apache FreeMarker files";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
     };
   };
 
@@ -431,6 +446,7 @@ rec {
     meta = with lib; {
       homepage = "http://gnuarmeclipse.livius.net/";
       description = "GNU ARM Eclipse Plug-ins";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
       maintainers = [ maintainers.bjornfor ];
@@ -469,6 +485,7 @@ rec {
     meta = with lib; {
       description = "Adds support for JSON files to Eclipse";
       homepage = "https://github.com/boothen/Json-Eclipse-Plugin";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -491,6 +508,7 @@ rec {
     meta = with lib; {
       homepage = "https://github.com/angelozerr/jdt-codemining";
       description = "Provides JDT Java CodeMining";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -516,6 +534,7 @@ rec {
     meta = with lib; {
       homepage = "https://github.com/RustDT";
       description = "Rust development tooling";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -533,6 +552,7 @@ rec {
     meta = with lib; {
       homepage = "http://scala-ide.org/";
       description = "The Scala IDE for Eclipse";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.bsd3;
       platforms = platforms.all;
     };
@@ -551,6 +571,7 @@ rec {
     meta = with lib; {
       homepage = "https://spotbugs.github.io/";
       description = "Plugin that uses static analysis to look for bugs in Java code";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.lgpl21;
       platforms = platforms.all;
     };
@@ -573,6 +594,7 @@ rec {
     meta = with lib; {
       homepage = "https://testng.org/doc/";
       description = "Eclipse plugin for the TestNG testing framework";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
       platforms = platforms.all;
     };
@@ -594,6 +616,7 @@ rec {
     meta = with lib; {
       homepage = "https://github.com/vrapper/vrapper";
       description = "A wrapper to provide a Vim-like input scheme for moving around and editing text";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.gpl3;
       platforms = platforms.all;
       maintainers = [ maintainers.stumoss ];
@@ -617,6 +640,7 @@ rec {
     meta = with lib; {
       homepage = "https://github.com/oyse/yedit";
       description = "A YAML editor plugin for Eclipse";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.epl10;
       platforms = platforms.all;
     };
@@ -634,6 +658,7 @@ rec {
     meta = with lib; {
       homepage = "https://www.eclipse.org/gef/zest/";
       description = "The Eclipse Visualization Toolkit";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       platforms = platforms.all;
       maintainers = [ maintainers.romildo ];
     };
@@ -656,6 +681,7 @@ rec {
     meta = with lib; {
       homepage = "https://ant.apache.org/ivy/ivyde/index.html";
       description = "A plugin which integrates Apache Ivy's dependency management";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
       platforms = platforms.all;
       maintainers = [ maintainers.r3dl3g ];
@@ -683,6 +709,7 @@ rec {
         Apache IvyDE Resolve Visualizer is an optional dependency of Apache IvyDE since
         it requires additional plugins to be installed (Zest).
       '';
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
       platforms = platforms.all;
       maintainers = [ maintainers.r3dl3g ];
@@ -706,6 +733,7 @@ rec {
     meta = with lib; {
       homepage = "https://ant.apache.org/ivy/index.html";
       description = "A popular dependency manager focusing on flexibility and simplicity";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
       platforms = platforms.all;
       maintainers = [ maintainers.r3dl3g ];
@@ -729,6 +757,7 @@ rec {
     meta = with lib; {
       homepage = "https://ant.apache.org/ivy/ivyde/index.html";
       description = "Ant Tasks integrated into Eclipse's Ant runtime";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
       platforms = platforms.all;
       maintainers = [ maintainers.r3dl3g ];

--- a/pkgs/applications/editors/greenfoot/default.nix
+++ b/pkgs/applications/editors/greenfoot/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple integrated development environment for Java";
     homepage = "https://www.greenfoot.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2ClasspathPlus;
     maintainers = [ maintainers.chvp ];
     platforms = platforms.unix;

--- a/pkgs/applications/editors/jedit/default.nix
+++ b/pkgs/applications/editors/jedit/default.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Mature programmer's text editor (Java based)";
     homepage = "http://www.jedit.org";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/applications/editors/jupyter-kernels/clojupyter/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/clojupyter/default.nix
@@ -25,6 +25,7 @@ let
   meta = with lib; {
     description = "A Jupyter kernel for Clojure";
     homepage = "https://github.com/clojupyter/clojupyter";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];  # deps from maven
     license = licenses.mit;
     maintainers = with maintainers; [ thomasjm ];
     platforms = jre.meta.platforms;

--- a/pkgs/applications/editors/music/tuxguitar/default.nix
+++ b/pkgs/applications/editors/music/tuxguitar/default.nix
@@ -38,6 +38,7 @@ in stdenv.mkDerivation rec {
       in Java-SWT. It can open GuitarPro, PowerTab and TablEdit files.
     '';
     homepage = "http://www.tuxguitar.com.ar/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl2;
     maintainers = [ maintainers.ardumont ];
     platforms = platforms.linux;

--- a/pkgs/applications/emulators/ccemux/default.nix
+++ b/pkgs/applications/emulators/ccemux/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A modular ComputerCraft emulator";
     homepage = "https://github.com/CCEmuX/CCEmuX";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ CrazedProgrammer ];
   };

--- a/pkgs/applications/finance/irpf/default.nix
+++ b/pkgs/applications/finance/irpf/default.nix
@@ -68,6 +68,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://www.gov.br/receitafederal/pt-br";
     license = licenses.unfree;
     platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ atila ];
   };
 }

--- a/pkgs/applications/graphics/alchemy/default.nix
+++ b/pkgs/applications/graphics/alchemy/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
       an expanded range of ideas and possibilities in a serendipitous way.
     '';
     homepage = "http://al.chemy.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.marcweber ];
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/fiji/default.nix
+++ b/pkgs/applications/graphics/fiji/default.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation rec {
     homepage = "https://imagej.net/software/fiji/";
     description = "batteries-included distribution of ImageJ2, bundling a lot of plugins which facilitate scientific image analysis";
     platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = with lib.licenses; [ gpl2Plus gpl3Plus bsd2 publicDomain ];
     maintainers = with maintainers; [ zane ];
   };

--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -74,6 +74,7 @@ in stdenv.mkDerivation rec {
       inspired by NIH Image for the Macintosh.
       It runs on any computer with a Java 1.4 or later virtual machine.
     '';
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.publicDomain;
     platforms = platforms.unix;
     maintainers = with maintainers; [ yuriaisaka ];

--- a/pkgs/applications/graphics/swingsane/default.nix
+++ b/pkgs/applications/graphics/swingsane/default.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
       crop, etc), PDF and PNG output.
     '';
     homepage = "http://swingsane.com/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = platforms.all;
   };

--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     homepage = "https://www.yworks.com/products/yed";
     description = "A powerful desktop application that can be used to quickly and effectively generate high-quality diagrams";
     platforms = jre.meta.platforms;

--- a/pkgs/applications/graphics/zgrviewer/default.nix
+++ b/pkgs/applications/graphics/zgrviewer/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     # Quicker to unpack locally than load Hydra
     hydraPlatforms = [];
     maintainers = with lib.maintainers; [raskin];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.lgpl21Plus;
     description = "GraphViz graph viewer/navigator";
     platforms = with lib.platforms; unix;

--- a/pkgs/applications/misc/HentaiAtHome/default.nix
+++ b/pkgs/applications/misc/HentaiAtHome/default.nix
@@ -31,6 +31,7 @@ buildGraalvmNativeImage rec {
     homepage = "https://ehwiki.org/wiki/Hentai@Home";
     description =
       "Hentai@Home is an open-source P2P gallery distribution system which reduces the load on the E-Hentai Galleries";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = with maintainers; [ terrorjack ];
   };

--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -31,6 +31,7 @@ EOF
   meta = with lib; {
     homepage = "https://github.com/ebzzry/emem";
     description = "A trivial Markdown to HTML converter";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     maintainers = [ maintainers.ebzzry ];
     platforms = platforms.unix;

--- a/pkgs/applications/misc/gpsprune/default.nix
+++ b/pkgs/applications/misc/gpsprune/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Application for viewing, editing and converting GPS coordinate data";
     homepage = "https://activityworkshop.net/software/gpsprune/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ rycee ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ vlaci ];
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/applications/misc/josm/default.nix
+++ b/pkgs/applications/misc/josm/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
     description = "An extensible editor for OpenStreetMap";
     homepage = "https://josm.openstreetmap.de/";
     changelog = "https://josm.openstreetmap.de/wiki/Changelog";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ rycee sikmir ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/jquake/default.nix
+++ b/pkgs/applications/misc/jquake/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
     downloadPage = "https://jquake.net/?down";
     changelog = "https://jquake.net/?docu";
     maintainers = with maintainers; [ nessdoor ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/keystore-explorer/default.nix
+++ b/pkgs/applications/misc/keystore-explorer/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Open source GUI replacement for the Java command-line utilities keytool and jarsigner";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.numinit ];
     platforms = lib.platforms.unix;

--- a/pkgs/applications/misc/mkgmap/default.nix
+++ b/pkgs/applications/misc/mkgmap/default.nix
@@ -76,6 +76,10 @@ stdenv.mkDerivation rec {
     description = "Create maps for Garmin GPS devices from OpenStreetMap (OSM) data";
     homepage = "https://www.mkgmap.org.uk/";
     downloadPage = "https://www.mkgmap.org.uk/download/mkgmap.html";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/mkgmap/splitter/default.nix
+++ b/pkgs/applications/misc/mkgmap/splitter/default.nix
@@ -72,6 +72,10 @@ stdenv.mkDerivation rec {
     description = "Utility for splitting OpenStreetMap maps into tiles";
     homepage = "https://www.mkgmap.org.uk/";
     downloadPage = "https://www.mkgmap.org.uk/download/splitter.html";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/omegat.nix
+++ b/pkgs/applications/misc/omegat.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
       translation leveraging into updated projects.
     '';
     homepage = "http://www.omegat.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ t184256 ];
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/misc/tabula-java/default.nix
+++ b/pkgs/applications/misc/tabula-java/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
       programmatically extract tables from PDFs.
     '';
     homepage = "https://tabula.technology/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = [ maintainers.jakewaksbaum ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/tabula/default.nix
+++ b/pkgs/applications/misc/tabula/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
       Microsoft Excel spreadsheet using a simple, easy-to-use interface.
     '';
     homepage = "https://tabula.technology/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = [ maintainers.dpaetzel ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -47,6 +47,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Electronic TV Program Guide";
     homepage = "https://www.tvbrowser.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jfrankenau ];

--- a/pkgs/applications/misc/vue/default.nix
+++ b/pkgs/applications/misc/vue/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     description = "Visual Understanding Environment - mind mapping software";
     maintainers = with lib.maintainers; [ raskin ];
     platforms = with lib.platforms; linux;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.free; # Apache License fork, actually
   };
 }

--- a/pkgs/applications/misc/xmind/default.nix
+++ b/pkgs/applications/misc/xmind/default.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation rec {
       and save to Evernote.
     '';
     homepage = "https://www.xmind.net/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ michalrus ];

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -57,6 +57,7 @@ let
         description = "Web Debugging Proxy";
         homepage = "https://www.charlesproxy.com/";
         maintainers = with maintainers; [ kalbasit ];
+        sourceProvenance = with sourceTypes; [ binaryBytecode ];
         license = licenses.unfree;
         platforms = platforms.unix;
       };

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -65,6 +65,7 @@ let
         homepage = "https://hadoop.apache.org/";
         description = "Framework for distributed processing of large data sets across clusters of computers";
         license = licenses.asl20;
+        sourceProvenance = with sourceTypes; [ binaryBytecode ];
 
         longDescription = ''
           The Apache Hadoop software library is a framework that allows for

--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -64,6 +64,7 @@ let
       meta = {
         description = "Apache Spark is a fast and general engine for large-scale data processing";
         homepage = "https://spark.apache.org/";
+        sourceProvenance = with sourceTypes; [ binaryBytecode ];
         license = lib.licenses.asl20;
         platforms = lib.platforms.all;
         maintainers = with maintainers; [ thoughtpolice offline kamilchm illustris ];

--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://jitsi.org/";
     description = "Open Source Video Calls and Chat";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = teams.jitsi.members;

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -103,6 +103,10 @@ in stdenv.mkDerivation rec {
       clients.
     '';
     homepage = "https://signald.org";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ expipiplus1 ma27 ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];

--- a/pkgs/applications/networking/jnetmap/default.nix
+++ b/pkgs/applications/networking/jnetmap/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Graphical network monitoring and documentation tool";
     homepage = "http://www.rakudave.ch/jnetmap/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;
     # Upstream supports macOS and Windows too.
     platforms = platforms.linux;

--- a/pkgs/applications/networking/mailreaders/msgviewer/default.nix
+++ b/pkgs/applications/networking/mailreaders/msgviewer/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Viewer for .msg files (MS Outlook)";
     homepage    = "https://www.washington.edu/alpine/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license     = licenses.asl20;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.all;

--- a/pkgs/applications/networking/p2p/freenet/default.nix
+++ b/pkgs/applications/networking/p2p/freenet/default.nix
@@ -73,6 +73,7 @@ in stdenv.mkDerivation {
   meta = {
     description = "Decentralised and censorship-resistant network";
     homepage = "https://freenetproject.org/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
     platforms = with lib.platforms; linux;

--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -87,6 +87,10 @@ in stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://www.frostwire.com/";
     description = "BitTorrent Client and Cloud File Downloader";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl2;
     maintainers = with maintainers; [ gavin ];
     platforms = [ "x86_64-darwin" "x86_64-linux" "i686-linux" ];

--- a/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
+++ b/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.frostwire.com/";
     description = "BitTorrent Client and Cloud File Downloader";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ gavin ];
     platforms = [ "x86_64-linux"];

--- a/pkgs/applications/networking/soapui/default.nix
+++ b/pkgs/applications/networking/soapui/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "The Most Advanced REST & SOAP Testing Tool in the World";
     homepage = "https://www.soapui.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = "SoapUI End User License Agreement";
     maintainers = with maintainers; [ gerschtli ];
     platforms = platforms.all;

--- a/pkgs/applications/office/atlassian-cli/default.nix
+++ b/pkgs/applications/office/atlassian-cli/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
     description = "An integrated family of CLI’s for various Atlassian applications";
     homepage = "https://bobswift.atlassian.net/wiki/spaces/ACLI/overview";
     license = licenses.unfreeRedistributable;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ twey ];
     inherit (jre.meta) platforms;
   };

--- a/pkgs/applications/office/ib/controller/default.nix
+++ b/pkgs/applications/office/ib/controller/default.nix
@@ -156,6 +156,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Automation Controller for the Trader Work Station of Interactive Brokers";
     homepage = "https://github.com/ib-controller/ib-controller";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = [ maintainers.tstrobel ];
     platforms = platforms.linux;

--- a/pkgs/applications/office/ib/tws/default.nix
+++ b/pkgs/applications/office/ib/tws/default.nix
@@ -89,6 +89,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Trader Work Station of Interactive Brokers";
     homepage = "https://www.interactivebrokers.com";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     maintainers = [ maintainers.tstrobel ];
     platforms = platforms.linux;

--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -69,6 +69,10 @@ stdenv.mkDerivation rec {
       Runtime Environment for plugins like Hibiscus (HBCI Online Banking),
       SynTAX (accounting) and JVerein (club management).
     '';
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ flokli r3dl3g ];

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -584,6 +584,8 @@ in
   meta = with lib; {
     description = "Comprehensive, professional-quality productivity suite, a variant of openoffice.org";
     homepage = "https://libreoffice.org/";
+    # at least one jar in dependencies
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl3;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;

--- a/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
+++ b/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   meta = with lib;{
     homepage = "https://www.astrolabeproject.com";
     description = "A Java-based tool for generating EPS files for constructing astrolabes and related tools";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = [ ];
     mainProgram = "AstrolabeGenerator";

--- a/pkgs/applications/science/astronomy/gprojector/default.nix
+++ b/pkgs/applications/science/astronomy/gprojector/default.nix
@@ -44,6 +44,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "G.Projector transforms an input map image into any of about 200 global and regional map projections";
     homepage = "https://www.giss.nasa.gov/tools/gprojector/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ alyaeanyx ];
     license = lib.licenses.unfree;
     inherit (jre.meta) platforms;

--- a/pkgs/applications/science/biology/astral/default.nix
+++ b/pkgs/applications/science/biology/astral/default.nix
@@ -50,6 +50,10 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/smirarab/ASTRAL";
     description = "Tool for estimating an unrooted species tree given a set of unrooted gene trees";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.asl20;
     maintainers = with maintainers; [ bzizou ];
   };

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2;
     platforms = platforms.all;
     homepage = "https://www.openmicroscopy.org/bio-formats/";

--- a/pkgs/applications/science/biology/macse/default.nix
+++ b/pkgs/applications/science/biology/macse/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Multiple alignment of coding sequences";
     homepage = "https://bioweb.supagro.inra.fr/macse/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2;
     maintainers = [ maintainers.bzizou ];
     platforms = platforms.all;

--- a/pkgs/applications/science/biology/picard-tools/default.nix
+++ b/pkgs/applications/science/biology/picard-tools/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     description = "Tools for high-throughput sequencing (HTS) data and formats such as SAM/BAM/CRAM and VCF";
     license = licenses.mit;
     homepage = "https://broadinstitute.github.io/picard/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ jbedo ];
     mainProgram = "picard";
     platforms = platforms.all;

--- a/pkgs/applications/science/biology/snpeff/default.nix
+++ b/pkgs/applications/science/biology/snpeff/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     description = "Genetic variant annotation and effect prediction toolbox";
     license = licenses.lgpl3;
     homepage = "http://snpeff.sourceforge.net/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ jbedo ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/science/biology/varscan/default.nix
+++ b/pkgs/applications/science/biology/varscan/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     # University School of Medicine.
     license = licenses.unfree;
     homepage = "https://github.com/dkoboldt/varscan";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ jbedo ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/science/chemistry/jmol/default.nix
+++ b/pkgs/applications/science/chemistry/jmol/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
      description = "A Java 3D viewer for chemical structures";
      homepage = "https://sourceforge.net/projects/jmol";
+     sourceProvenance = with sourceTypes; [ binaryBytecode ];
      license = licenses.lgpl2;
      platforms = platforms.all;
      maintainers = with maintainers; [ mounium ] ++ teams.sage.members;

--- a/pkgs/applications/science/electronics/diylc/default.nix
+++ b/pkgs/applications/science/electronics/diylc/default.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "https://bancika.github.io/diy-layout-creator/";
     changelog = "https://github.com/bancika/diy-layout-creator/releases";
     license = licenses.gpl3Plus;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/applications/science/logic/leo3/binary.nix
+++ b/pkgs/applications/science/logic/leo3/binary.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An automated theorem prover for classical higher-order logic with choice";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd3;
     maintainers = [maintainers.raskin];
     platforms = platforms.linux;

--- a/pkgs/applications/science/logic/logisim-evolution/default.nix
+++ b/pkgs/applications/science/logic/logisim-evolution/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/logisim-evolution/logisim-evolution";
     description = "Digital logic designer and simulator";
     maintainers = with maintainers; [ emilytrau ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };

--- a/pkgs/applications/science/logic/logisim/default.nix
+++ b/pkgs/applications/science/logic/logisim/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.cburch.com/logisim/";
     description = "Educational tool for designing and simulating digital logic circuits";
     maintainers = with maintainers; [ emilytrau ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };

--- a/pkgs/applications/science/logic/tlaplus/default.nix
+++ b/pkgs/applications/science/logic/tlaplus/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "An algorithm specification language with model checking tools";
     homepage    = "http://lamport.azurewebsites.net/tla/tla.html";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.mit;
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ florentc thoughtpolice ];

--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Optimization solver for mathematical programming";
     homepage = "https://www.gurobi.com";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ jfrankenau ];

--- a/pkgs/applications/science/misc/gephi/default.nix
+++ b/pkgs/applications/science/misc/gephi/default.nix
@@ -58,6 +58,10 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "A platform for visualizing and manipulating large graphs";
     homepage = "https://gephi.org";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl3;
     maintainers = [ maintainers.taeer ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/science/misc/netlogo/default.nix
+++ b/pkgs/applications/science/misc/netlogo/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
       many tens of thousands of students, teachers and researchers worldwide.
     '';
     homepage = "https://ccl.northwestern.edu/netlogo/index.shtml";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2;
     maintainers = [ maintainers.dpaetzel ];
     platforms = platforms.linux;

--- a/pkgs/applications/science/physics/quantomatic/default.nix
+++ b/pkgs/applications/science/physics/quantomatic/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     description = "A piece of software for reasoning about monoidal theories; in particular, quantum information processing";
     license = licenses.gpl3;
     homepage = "https://quantomatic.github.io/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ nickhu ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/science/programming/groove/default.nix
+++ b/pkgs/applications/science/programming/groove/default.nix
@@ -48,6 +48,7 @@ in stdenv.mkDerivation rec {
     description = "GRaphs for Object-Oriented VErification";
     homepage = "http://groove.cs.utwente.nl/";
     license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     platforms = platforms.all;
     maintainers = with maintainers; [ jfrankenau ];
   };

--- a/pkgs/applications/science/programming/jflap/default.nix
+++ b/pkgs/applications/science/programming/jflap/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     description = "GUI tool for experimenting with formal languages topics";
     homepage = "https://www.jflap.org/";
     license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = [ maintainers.grnnja ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/science/programming/plm/default.nix
+++ b/pkgs/applications/science/programming/plm/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     description = "Free cross-platform programming exerciser";
     homepage = "http://people.irisa.fr/Martin.Quinson/Teaching/PLM/";
     license = licenses.gpl3;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = [ ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/applications/version-management/gerrit/default.nix
+++ b/pkgs/applications/version-management/gerrit/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gerritcodereview.com/index.md";
     license = licenses.asl20;
     description = "A web based code review and repository management for the git version control system";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ flokli jammerful zimbatm ];
     platforms = platforms.unix;
   };

--- a/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
       it's faster (10-720x), simpler (dedicated to just removing things), and
       beautiful (can use Scala instead of bash to script customizations).
     '';
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = [ maintainers.changlinli ];
     mainProgram = "bfg";

--- a/pkgs/applications/video/filebot/default.nix
+++ b/pkgs/applications/video/filebot/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://filebot.net";
     changelog = "https://www.filebot.net/forums/viewforum.php?f=7";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ gleber felschr ];
     platforms = platforms.linux;

--- a/pkgs/applications/video/mediathekview/default.nix
+++ b/pkgs/applications/video/mediathekview/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Offers access to the Mediathek of different tv stations (ARD, ZDF, Arte, etc.)";
     homepage = "https://mediathekview.de/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ moredread ];
     platforms = platforms.all;

--- a/pkgs/development/compilers/aspectj/default.nix
+++ b/pkgs/development/compilers/aspectj/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.eclipse.org/aspectj/";
     description = "A seamless aspect-oriented extension to the Java programming language";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     platforms = lib.platforms.unix;
     license = lib.licenses.epl10;
   };

--- a/pkgs/development/compilers/closure/default.nix
+++ b/pkgs/development/compilers/closure/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A tool for making JavaScript download and run faster";
     homepage = "https://developers.google.com/closure/compiler/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = platforms.all;
   };

--- a/pkgs/development/compilers/javacard-devkit/default.nix
+++ b/pkgs/development/compilers/javacard-devkit/default.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
       For more details, please refer to the documentation by Oracle
     '';
     homepage = "https://www.oracle.com/technetwork/java/embedded/javacard/overview/index.html";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.ekleog ];
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/development/compilers/lingua-franca/default.nix
+++ b/pkgs/development/compilers/lingua-franca/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
       embedded code to distributed cloud and edge applications.
     '';
     homepage = "https://github.com/lf-lang/lingua-franca";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ revol-xut ];

--- a/pkgs/development/compilers/mozart/binary.nix
+++ b/pkgs/development/compilers/mozart/binary.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation {
       interfaces. Mozart implements the Oz language and provides both
       expressive power and advanced functionality.
     '';
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     platforms = attrNames binaries;
     hydraPlatforms = [];

--- a/pkgs/development/embedded/arduino/arduino-core/default.nix
+++ b/pkgs/development/embedded/arduino/arduino-core/default.nix
@@ -244,6 +244,7 @@ stdenv.mkDerivation rec {
     description = "Open-source electronics prototyping platform";
     homepage = "https://www.arduino.cc/";
     license = if withTeensyduino then licenses.unfreeRedistributable else licenses.gpl2;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ antono auntie robberer bjornfor bergey ];
   };

--- a/pkgs/development/embedded/stm32/stm32cubemx/default.nix
+++ b/pkgs/development/embedded/stm32/stm32cubemx/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation rec {
       step-by-step process.
     '';
     homepage = "https://www.st.com/en/development-tools/stm32cubemx.html";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ wucke13 ];
     platforms = platforms.all;

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -66,6 +66,7 @@ buildGraalvmNativeImage rec {
     '';
     homepage = "https://github.com/babashka/babashka";
     changelog = "https://github.com/babashka/babashka/blob/v${version}/CHANGELOG.md";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     maintainers = with maintainers; [
       bandresen

--- a/pkgs/development/interpreters/clojure/clooj.nix
+++ b/pkgs/development/interpreters/clojure/clooj.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A lightweight IDE for Clojure";
     homepage = "https://github.com/arthuredelstein/clooj";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
   };

--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A Lisp dialect for the JVM";
     homepage = "https://clojure.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     longDescription = ''
       Clojure is a dynamic programming language that targets the Java

--- a/pkgs/development/interpreters/jython/default.nix
+++ b/pkgs/development/interpreters/jython/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Python interpreter written in Java";
     homepage = "https://jython.org/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.psfl;
     platforms = jre.meta.platforms;
   };

--- a/pkgs/development/interpreters/rascal/default.nix
+++ b/pkgs/development/interpreters/rascal/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://www.rascal-mpl.org/";
     description = "Command-line REPL for the Rascal metaprogramming language";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.epl10;
     maintainers = [ lib.maintainers.eelco ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/java-modules/m2install.nix
+++ b/pkgs/development/java-modules/m2install.nix
@@ -1,5 +1,12 @@
-{ stdenv, fetchurl }:
-{ version, artifactId, groupId, sha512, type ? "jar", suffix ? "" }:
+{ lib, stdenv, fetchurl }:
+{ version
+, artifactId
+, groupId
+, sha512
+, type ? "jar"
+, suffix ? ""
+, sourceProvenance ? (if type == "jar" then [ lib.sourceTypes.binaryBytecode ] else [])
+}:
 
 let
   m2Path = "${builtins.replaceStrings ["."] ["/"] groupId}/${artifactId}/${version}";
@@ -18,4 +25,6 @@ in stdenv.mkDerivation {
     mkdir -p $out/m2/$m2Path
     cp $src $out/m2/$m2Path/$m2File
   '';
+
+  meta.sourceProvenance = sourceProvenance;
 }

--- a/pkgs/development/libraries/apache-activemq/default.nix
+++ b/pkgs/development/libraries/apache-activemq/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://activemq.apache.org/";
     description = "Messaging and Integration Patterns server written in Java";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/java/commons/bcel/default.nix
+++ b/pkgs/development/libraries/java/commons/bcel/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage    = "https://commons.apache.org/proper/commons-bcel/";
     description = "Gives users a convenient way to analyze, create, and manipulate (binary) Java class files";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ copumpkin ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;

--- a/pkgs/development/libraries/java/commons/bsf/default.nix
+++ b/pkgs/development/libraries/java/commons/bsf/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Interface to scripting languages, including JSR-223";
     homepage = "https://commons.apache.org/proper/commons-bsf/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/java/commons/compress/default.nix
+++ b/pkgs/development/libraries/java/commons/compress/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://commons.apache.org/proper/commons-compress";
     description = "Allows manipulation of ar, cpio, Unix dump, tar, zip, gzip, XZ, Pack200, bzip2, 7z, arj, lzma, snappy, DEFLATE and Z files";
     maintainers = with lib.maintainers; [ copumpkin ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/development/libraries/java/commons/daemon/default.nix
+++ b/pkgs/development/libraries/java/commons/daemon/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://commons.apache.org/proper/commons-daemon";
     description = "Apache Commons Daemon software is a set of utilities and Java support classes for running Java applications as server processes.";
     maintainers = with lib.maintainers; [ rsynnest ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/development/libraries/java/commons/fileupload/default.nix
+++ b/pkgs/development/libraries/java/commons/fileupload/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://commons.apache.org/proper/commons-fileupload";
     description = "Makes it easy to add robust, high-performance, file upload capability to your servlets and web applications";
     maintainers = with lib.maintainers; [ copumpkin ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/development/libraries/java/commons/io/default.nix
+++ b/pkgs/development/libraries/java/commons/io/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://commons.apache.org/proper/commons-io";
     description = "A library of utilities to assist with developing IO functionality";
     maintainers = with lib.maintainers; [ copumpkin ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/development/libraries/java/commons/lang/default.nix
+++ b/pkgs/development/libraries/java/commons/lang/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://commons.apache.org/proper/commons-lang";
     description = "Provides additional methods to manipulate standard Java library classes";
     maintainers = with lib.maintainers; [ copumpkin ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/development/libraries/java/commons/logging/default.nix
+++ b/pkgs/development/libraries/java/commons/logging/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Wrapper around a variety of logging API implementations";
     homepage = "https://commons.apache.org/proper/commons-logging";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/java/commons/math/default.nix
+++ b/pkgs/development/libraries/java/commons/math/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://commons.apache.org/proper/commons-math/";
     description = "A library of lightweight, self-contained mathematics and statistics components";
     maintainers = with lib.maintainers; [ copumpkin ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/development/libraries/java/hsqldb/default.nix
+++ b/pkgs/development/libraries/java/hsqldb/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://hsqldb.org";
     description = "A relational, embedable database management system written in Java and a set of related tools";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     platforms = platforms.unix;
     license = licenses.bsd3;
   };

--- a/pkgs/development/libraries/java/lombok/default.nix
+++ b/pkgs/development/libraries/java/lombok/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A library that can write a lot of boilerplate for your Java project";
     platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.mit;
     homepage = "https://projectlombok.org/";
     maintainers = [ lib.maintainers.CrystalGamma ];

--- a/pkgs/development/libraries/java/mockobjects/default.nix
+++ b/pkgs/development/libraries/java/mockobjects/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Generic unit testing framework and methodology for testing any kind of code";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     platforms = platforms.unix;
     license = licenses.asl20;
   };

--- a/pkgs/development/libraries/java/saxon/default.nix
+++ b/pkgs/development/libraries/java/saxon/default.nix
@@ -29,6 +29,7 @@ let
       meta = with lib; {
         inherit description license;
         homepage = "http://saxon.sourceforge.net/";
+        sourceProvenance = with sourceTypes; [ binaryBytecode ];
         maintainers = with maintainers; [ rvl ];
         platforms = platforms.all;
       };

--- a/pkgs/development/libraries/java/smack/default.nix
+++ b/pkgs/development/libraries/java/smack/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A XMPP (Jabber) client library for instant messaging and presence";
     homepage = "http://www.igniterealtime.org/projects/smack/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     platforms = lib.platforms.unix;
     license = lib.licenses.asl20;
   };

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -125,6 +125,7 @@ stdenv.mkDerivation {
       OCCI, Pro*C, ODBC or JDBC). This package includes the sqlplus
       command line SQL client.
     '';
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ flokli ];

--- a/pkgs/development/libraries/rabbitmq-java-client/default.nix
+++ b/pkgs/development/libraries/rabbitmq-java-client/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "RabbitMQ Java client library which allows Java code to interface to AMQP servers";
     homepage = "https://www.rabbitmq.com/java-client.html";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = with licenses; [ mpl11 gpl2 ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/misc/avr8-burn-omat/default.nix
+++ b/pkgs/development/misc/avr8-burn-omat/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "GUI tool for avrdude";
     homepage = "http://avr8-burn-o-mat.aaabbb.de/avr8_burn_o_mat_avrdude_gui_en.html";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3;
     platforms = platforms.all;
   };

--- a/pkgs/development/tools/alloy/default.nix
+++ b/pkgs/development/tools/alloy/default.nix
@@ -47,6 +47,7 @@ let generic = { version, sha256 }:
       '';
       homepage = "http://alloytools.org/";
       downloadPage = "http://alloytools.org/download.html";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.mit;
       platforms = platforms.unix;
       maintainers = with maintainers; [ notbandali ];

--- a/pkgs/development/tools/analysis/checkstyle/default.nix
+++ b/pkgs/development/tools/analysis/checkstyle/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
       Conventions, but is highly configurable.
     '';
     homepage = "http://checkstyle.sourceforge.net/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21;
     maintainers = with maintainers; [ pSub ];
     platforms = jre.meta.platforms;

--- a/pkgs/development/tools/analysis/emma/default.nix
+++ b/pkgs/development/tools/analysis/emma/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://emma.sourceforge.net/";
     description = "A code coverage tool for Java";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     platforms = lib.platforms.unix;
     license = lib.licenses.cpl10;
   };

--- a/pkgs/development/tools/analysis/findbugs/default.nix
+++ b/pkgs/development/tools/analysis/findbugs/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "http://findbugs.sourceforge.net/";
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; unix;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl3;
   };
 }

--- a/pkgs/development/tools/analysis/randoop/default.nix
+++ b/pkgs/development/tools/analysis/randoop/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Automatic test generation for Java";
     homepage = "https://randoop.github.io/randoop/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.linux;

--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A tool for reverse engineering Android apk files";
     homepage    = "https://ibotpeaches.github.io/Apktool/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license     = licenses.asl20;
     maintainers = with maintainers; [ offline ];
     platforms   = with platforms; unix;

--- a/pkgs/development/tools/avro-tools/default.nix
+++ b/pkgs/development/tools/avro-tools/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage    = "https://avro.apache.org/";
     description = "Avro command-line tools and utilities";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ];
   };

--- a/pkgs/development/tools/build-managers/apache-ant/1.9.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/1.9.nix
@@ -103,6 +103,7 @@ stdenv.mkDerivation rec {
       by an object that implements a particular Task interface.
     '';
 
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.eelco ];
     platforms = lib.platforms.all;

--- a/pkgs/development/tools/build-managers/apache-ant/default.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/default.nix
@@ -103,6 +103,7 @@ stdenv.mkDerivation rec {
       by an object that implements a particular Task interface.
     '';
 
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.eelco ];
     platforms = lib.platforms.all;

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -164,6 +164,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.asl20;
     maintainers = lib.teams.bazel.members;
     inherit platforms;

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -197,6 +197,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.asl20;
     maintainers = lib.teams.bazel.members;
     inherit platforms;

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -156,6 +156,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.asl20;
     maintainers = lib.teams.bazel.members;
     inherit platforms;

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -86,6 +86,7 @@ rec {
         homepage = "https://www.gradle.org/";
         changelog = "https://docs.gradle.org/${version}/release-notes.html";
         downloadPage = "https://gradle.org/next-steps/?version=${version}";
+        sourceProvenance = with sourceTypes; [ binaryBytecode ];
         license = licenses.asl20;
         platforms = if (supportedPlatforms != null) then supportedPlatforms else platforms.unix;
         maintainers = with maintainers; [ lorenzleutgeb liff ];

--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://leiningen.org/";
     description = "Project automation for Clojure";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.epl10;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ thiagokokada ];

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -17,6 +17,7 @@ buildGraalvmNativeImage rec {
   meta = with lib; {
     description = "A linter for Clojure code that sparks joy";
     homepage = "https://github.com/clj-kondo/clj-kondo";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     changelog = "https://github.com/clj-kondo/clj-kondo/blob/v${version}/CHANGELOG.md";
     maintainers = with maintainers; [ jlesquembre bandresen thiagokokada ];

--- a/pkgs/development/tools/continuous-integration/jenkins/default.nix
+++ b/pkgs/development/tools/continuous-integration/jenkins/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An extendable open source continuous integration server";
     homepage = "https://jenkins-ci.org";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ coconnor fpletz earldouglas nequissimus ];
     mainProgram = "jenkins-cli";

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
     description = "Version Control for your database";
     homepage = "https://www.liquibase.org/";
     changelog = "https://raw.githubusercontent.com/liquibase/liquibase/v${version}/changelog.txt";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
     platforms = with platforms; unix;

--- a/pkgs/development/tools/database/schemaspy/default.nix
+++ b/pkgs/development/tools/database/schemaspy/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://schemaspy.org";
     description = "Document your database simply and easily";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ jraygauthier ];
   };

--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Universal SQL Client";
     homepage = "http://squirrel-sql.sourceforge.net/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ khumba ];

--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec{
       This package is only the Community Edition of the Flyway command-line tool.
     '';
     homepage = "https://flywaydb.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = [ maintainers.cmcdragonkai ];

--- a/pkgs/development/tools/galen/default.nix
+++ b/pkgs/development/tools/galen/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://galenframework.com";
     description = "Automated layout testing for websites";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation rec {
       If you run NixOS, it can be enabled with `services.pcscd.enable = true;`.
     '';
     homepage = "https://github.com/martinpaljak/GlobalPlatformPro";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = with licenses; [ lgpl3 ];
     maintainers = with maintainers; [ ekleog ];
     mainProgram = "gp";

--- a/pkgs/development/tools/google-java-format/default.nix
+++ b/pkgs/development/tools/google-java-format/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
       A program that reformats Java source code to comply with Google Java Style.
     '';
     homepage = "https://github.com/google/google-java-format";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers.emptyflask ];
     platforms = platforms.all;

--- a/pkgs/development/tools/java/cfr/default.nix
+++ b/pkgs/development/tools/java/cfr/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
       entirely in Java 6.
     '';
     homepage = "http://www.benf.org/other/cfr/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     platforms = platforms.all;
   };

--- a/pkgs/development/tools/java/jhiccup/default.nix
+++ b/pkgs/development/tools/java/jhiccup/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Measure JVM application stalls and GC pauses";
     homepage    = "https://www.azul.com/jhiccup/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.cc0;
     platforms   = lib.platforms.linux;
     maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/development/tools/jdt-language-server/default.nix
+++ b/pkgs/development/tools/jdt-language-server/default.nix
@@ -96,6 +96,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/eclipse/eclipse.jdt.ls";
     description = "Java language server";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl20;
     maintainers = with maintainers; [ matt-snider ];
   };

--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -29,6 +29,7 @@ buildGraalvmNativeImage rec {
   meta = with lib; {
     description = "CLI to transform between JSON, EDN and Transit, powered with a minimal query language";
     homepage = "https://github.com/borkdude/jet";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     maintainers = with maintainers; [ ericdallo ];
   };

--- a/pkgs/development/tools/jpexs/default.nix
+++ b/pkgs/development/tools/jpexs/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
       texts or fonts.
     '';
     homepage = "https://github.com/jindrapetrik/jpexs-decompiler";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     platforms = jdk8.meta.platforms;
     maintainers = [ ];

--- a/pkgs/development/tools/mars-mips/default.nix
+++ b/pkgs/development/tools/mars-mips/default.nix
@@ -42,6 +42,7 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     description = "An IDE for programming in MIPS assembly language intended for educational-level use";
     homepage = "https://courses.missouristate.edu/KenVollmar/MARS/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ emilytrau ];
     platforms = platforms.all;

--- a/pkgs/development/tools/misc/bonnmotion/default.nix
+++ b/pkgs/development/tools/misc/bonnmotion/default.nix
@@ -44,6 +44,10 @@ stdenv.mkDerivation rec {
       COOJA, MiXiM, and ONE.
     '';
     homepage = "https://sys.cs.uos.de/bonnmotion/";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependency jars
+    ];
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ oxzi ];
   };

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -58,6 +58,7 @@ buildGraalvmNativeImage rec {
   meta = with lib; {
     description = "Language Server Protocol (LSP) for Clojure";
     homepage = "https://github.com/clojure-lsp/clojure-lsp";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ ericdallo babariviere ];
   };

--- a/pkgs/development/tools/misc/polylith/default.nix
+++ b/pkgs/development/tools/misc/polylith/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A tool used to develop Polylith based architectures in Clojure";
     homepage = "https://github.com/polyfy/polylith";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     maintainers = with maintainers; [ ericdallo jlesquembre ];
     platforms = jdk.meta.platforms;

--- a/pkgs/development/tools/nailgun/default.nix
+++ b/pkgs/development/tools/nailgun/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Client, protocol, and server for running Java programs from the command line without incurring the JVM startup overhead";
     homepage = "http://www.martiansoftware.com/nailgun/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ volth ];

--- a/pkgs/development/tools/parsing/antlr/3.4.nix
+++ b/pkgs/development/tools/parsing/antlr/3.4.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
       walk parse trees.
     '';
     homepage = "https://www.antlr.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/development/tools/parsing/antlr/3.5.nix
+++ b/pkgs/development/tools/parsing/antlr/3.5.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
       walk parse trees.
     '';
     homepage = "https://www.antlr.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = [ lib.maintainers.farlion ];

--- a/pkgs/development/tools/parsing/antlr/4.8.nix
+++ b/pkgs/development/tools/parsing/antlr/4.8.nix
@@ -81,6 +81,7 @@ let
         walk parse trees.
       '';
       homepage = "https://www.antlr.org/";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.bsd3;
       platforms = platforms.unix;
     };

--- a/pkgs/development/tools/parsing/antlr/4.9.nix
+++ b/pkgs/development/tools/parsing/antlr/4.9.nix
@@ -80,6 +80,7 @@ let
         walk parse trees.
       '';
       homepage = "https://www.antlr.org/";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.bsd3;
       platforms = platforms.unix;
     };

--- a/pkgs/development/tools/repository-managers/nexus/default.nix
+++ b/pkgs/development/tools/repository-managers/nexus/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Repository manager for binary software components";
     homepage = "http://www.sonatype.org/nexus";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     platforms = platforms.all;
     maintainers = with maintainers; [ aespinosa ironpinguin zaninime ];

--- a/pkgs/development/tools/scenebuilder/default.nix
+++ b/pkgs/development/tools/scenebuilder/default.nix
@@ -109,6 +109,10 @@ in stdenv.mkDerivation rec {
     broken = stdenv.isDarwin;
     description = "A visual, drag'n'drop, layout tool for designing JavaFX application user interfaces.";
     homepage = "https://gluonhq.com/products/scene-builder/";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.bsd3;
     maintainers = with maintainers; [ wirew0rm ];
     platforms = platforms.all;

--- a/pkgs/development/tools/scenic-view/default.nix
+++ b/pkgs/development/tools/scenic-view/default.nix
@@ -104,6 +104,10 @@ in stdenv.mkDerivation rec {
       This lets you find bugs and get things pixel perfect without having to do the compile-check-compile dance.
     '';
     homepage = "https://github.com/JonathanGiles/scenic-view/";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ wirew0rm ];
     platforms = platforms.all;

--- a/pkgs/development/tools/selenium/htmlunit-driver/default.nix
+++ b/pkgs/development/tools/selenium/htmlunit-driver/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     description = "A WebDriver server for running Selenium tests on the HtmlUnit headless browser";
     maintainers = with maintainers; [ coconnor offline ];
     platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/development/tools/selenium/selendroid/default.nix
+++ b/pkgs/development/tools/selenium/selendroid/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
     description = "Test automation for native or hybrid Android apps and the mobile web";
     maintainers = with maintainers; [ offline ];
     platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -33,6 +33,7 @@ in stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.seleniumhq.org/";
     description = "Selenium Server for remote WebDriver";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ coconnor offline ];
     mainProgram = "selenium-server";

--- a/pkgs/development/tools/sourcetrail/java.nix
+++ b/pkgs/development/tools/sourcetrail/java.nix
@@ -1,4 +1,4 @@
-{ pkgs, javaPackages }:
+{ lib, pkgs, javaPackages }:
 
 let
   javaIndexer = javaPackages.mavenbuild {
@@ -17,6 +17,7 @@ let
 
     meta = {
       description = "Java indexer for Sourcetrail";
+      sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     };
   };
 in

--- a/pkgs/development/tools/spring-boot-cli/default.nix
+++ b/pkgs/development/tools/spring-boot-cli/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
       a command line tool that runs “spring scripts”.
     '';
     homepage = "https://spring.io/projects/spring-boot";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ moaxcp ];

--- a/pkgs/development/tools/yuicompressor/default.nix
+++ b/pkgs/development/tools/yuicompressor/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A JavaScript and CSS minifier";
     homepage = "http://yui.github.io/yuicompressor/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd3;
     maintainers = with maintainers; [ jwiegley ];
     platforms = platforms.all;

--- a/pkgs/games/cgoban/default.nix
+++ b/pkgs/games/cgoban/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Client for the KGS Go Server";
     homepage = "https://www.gokgs.com/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.free;
     maintainers = with maintainers; [ savannidgerinel ];
     platforms = adoptopenjdk-jre-bin.meta.platforms;

--- a/pkgs/games/domination/default.nix
+++ b/pkgs/games/domination/default.nix
@@ -97,6 +97,10 @@ in stdenv.mkDerivation {
       It includes a map editor, a simple map format, multiplayer network play,
       single player, hotseat, 5 user interfaces and many more features.
     '';
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.gpl3;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;

--- a/pkgs/games/dwarf-fortress/legends-browser/default.nix
+++ b/pkgs/games/dwarf-fortress/legends-browser/default.nix
@@ -29,6 +29,7 @@ buildEnv {
   meta = with lib; {
     description = "A multi-platform, open source, java-based legends viewer for dwarf fortress";
     maintainers = with maintainers; [ Baughn ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     platforms = platforms.all;
     homepage = "https://github.com/robertjanetzko/LegendsBrowser";

--- a/pkgs/games/gcs/default.nix
+++ b/pkgs/games/gcs/default.nix
@@ -70,6 +70,10 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A stand-alone, interactive, character sheet editor for the GURPS 4th Edition roleplaying game system";
     homepage = "https://gurpscharactersheet.com/";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.mpl20;
     platforms = platforms.all;
     maintainers = with maintainers; [];

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -199,6 +199,10 @@ stdenv.mkDerivation rec {
     homepage = "https://mindustrygame.github.io/";
     downloadPage = "https://github.com/Anuken/Mindustry/releases";
     description = "A sandbox tower defense game";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ fgaz petabyteboy ];
     platforms = platforms.x86_64;

--- a/pkgs/games/minecraft-servers/derivation.nix
+++ b/pkgs/games/minecraft-servers/derivation.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Minecraft Server";
     homepage = "https://minecraft.net";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfreeRedistributable;
     platforms = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice tomberek costrouc jyooru ];

--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -29,6 +29,7 @@ in stdenv.mkDerivation {
   meta = {
     description = "High-performance Minecraft Server";
     homepage    = "https://papermc.io/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license     = lib.licenses.gpl3Only;
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ aaronjanse neonfuz ];

--- a/pkgs/games/purpur/default.nix
+++ b/pkgs/games/purpur/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
       gameplay features, and performance built on top of Airplane.
     '';
     homepage = "https://purpurmc.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ jyooru ];

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open source Old School RuneScape client";
     homepage = "https://runelite.net/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd2;
     maintainers = with maintainers; [ kmeakin ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -80,6 +80,10 @@ in stdenv.mkDerivation rec {
     homepage = "https://shatteredpixel.com/";
     downloadPage = "https://github.com/00-Evan/shattered-pixel-dungeon/releases";
     description = "Traditional roguelike game with pixel-art graphics and simple interface";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open-world single-player space-combat, roleplaying, exploration, and economic game";
     homepage = "https://fractalsoftworks.com";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ bbigras ];
   };

--- a/pkgs/games/tr-patcher/default.nix
+++ b/pkgs/games/tr-patcher/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Allow to update dependancies of the Tamriel-Data mod for morrowind";
     homepage = "https://gitlab.com/bmwinger/tr-patcher";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = [ maintainers.marius851000 ];
     platforms = platforms.linux;

--- a/pkgs/games/unciv/default.nix
+++ b/pkgs/games/unciv/default.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
     description = "An open-source Android/Desktop remake of Civ V";
     homepage = "https://github.com/yairm210/Unciv";
     maintainers = with maintainers; [ tex ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mpl20;
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/games/vassal/default.nix
+++ b/pkgs/games/vassal/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
       description = "A free, open-source boardgame engine";
       homepage = "https://vassalengine.org/";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.lgpl21Only;
       maintainers = with maintainers; [ tvestelind ];
       platforms = platforms.unix;

--- a/pkgs/games/xmage/default.nix
+++ b/pkgs/games/xmage/default.nix
@@ -32,6 +32,7 @@ EOS
 
   meta = with lib; {
     description = "Magic Another Game Engine";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer ];
     homepage = "http://xmage.de/";

--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -57,6 +57,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Display and control Android devices over USB or TCP/IP";
     homepage = "https://github.com/Genymobile/scrcpy";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # server
+    ];
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ deltaevo lukeadams msfjarvis ];

--- a/pkgs/servers/atlassian/bamboo.nix
+++ b/pkgs/servers/atlassian/bamboo.nix
@@ -31,6 +31,7 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     description = "Bamboo Data Center is a continuous delivery server.";
     homepage = "https://www.atlassian.com/software/bamboo";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = with licenses; [ unfree ];
     maintainers = with maintainers; [ techknowlogick ];
   };

--- a/pkgs/servers/atlassian/confluence.nix
+++ b/pkgs/servers/atlassian/confluence.nix
@@ -43,6 +43,7 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     description = "Team collaboration software written in Java and mainly used in corporate environments";
     homepage = "https://www.atlassian.com/software/confluence";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ fpletz globin willibutz ciil techknowlogick ];
   };

--- a/pkgs/servers/computing/storm/default.nix
+++ b/pkgs/servers/computing/storm/default.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://storm.apache.org/";
     description = "Distributed realtime computation system";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ edwtjo vizanto ];
     platforms = with platforms; unix;

--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -28,6 +28,7 @@ let
     meta = with lib; {
       homepage = "https://github.com/softwaremill/elasticmq";
       description = "Message queueing system with Java, Scala and Amazon SQS-compatible interfaces";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.asl20;
       platforms = platforms.unix;
       maintainers = with maintainers; [ peterromfeldhk ];

--- a/pkgs/servers/exhibitor/default.nix
+++ b/pkgs/servers/exhibitor/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "ZooKeeper co-process for instance monitoring, backup/recovery, cleanup and visualization";
     homepage = "https://github.com/soabase/exhibitor";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     mainProgram = "startExhibitor.sh";
     platforms = platforms.unix;

--- a/pkgs/servers/felix/default.nix
+++ b/pkgs/servers/felix/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An OSGi gateway";
     homepage = "https://felix.apache.org";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers.sander ];
   };

--- a/pkgs/servers/h2/default.nix
+++ b/pkgs/servers/h2/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "The Java SQL database";
     homepage = "http://www.h2database.com/html/main.html";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mpl20;
     platforms = lib.platforms.linux;
     maintainers = with maintainers; [ mahe ];

--- a/pkgs/servers/http/jboss/default.nix
+++ b/pkgs/servers/http/jboss/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.jboss.org/";
     description = "Open Source J2EE application server";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21;
     maintainers = [ maintainers.sander ];
     platforms = platforms.unix;

--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     description = "A Web server and javax.servlet container";
     homepage = "https://www.eclipse.org/jetty/";
     platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = with licenses; [ asl20 epl10 ];
     maintainers = with maintainers; [ emmanuelrosa ];
   };

--- a/pkgs/servers/http/tomcat/axis2/default.nix
+++ b/pkgs/servers/http/tomcat/axis2/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Web Services / SOAP / WSDL engine, the successor to the widely used Apache Axis SOAP stack";
     platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
   };
 }

--- a/pkgs/servers/jetbrains/youtrack.nix
+++ b/pkgs/servers/jetbrains/youtrack.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Issue tracking and project management tool for developers";
     maintainers = teams.serokell.members;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     # https://www.jetbrains.com/youtrack/buy/license.html
     license = licenses.unfree;
   };

--- a/pkgs/servers/jibri/default.nix
+++ b/pkgs/servers/jibri/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
       supported on a single jibri.
     '';
     homepage = "https://github.com/jitsi/jibri";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = teams.jitsi.members;
     platforms = platforms.linux;

--- a/pkgs/servers/keycloak/default.nix
+++ b/pkgs/servers/keycloak/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.keycloak.org/";
     description = "Identity and access management for modern applications and services";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = jre.meta.platforms;
     maintainers = with maintainers; [ ngerstle talyz ];

--- a/pkgs/servers/keycloak/keycloak-metrics-spi/default.nix
+++ b/pkgs/servers/keycloak/keycloak-metrics-spi/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/aerogear/keycloak-metrics-spi";
     description = "Keycloak Service Provider that adds a metrics endpoint";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.apsl20;
     maintainers = with maintainers; [ benley ];
   };

--- a/pkgs/servers/keycloak/scim-for-keycloak/default.nix
+++ b/pkgs/servers/keycloak/scim-for-keycloak/default.nix
@@ -30,6 +30,10 @@ javaPackages.mavenfod rec {
   meta = with lib; {
     homepage = "https://github.com/Captain-P-Goldfish/scim-for-keycloak";
     description = "A third party module that extends Keycloak with SCIM functionality";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # dependencies
+    ];
     license = licenses.bsd3;
     maintainers = with maintainers; [ mkg20001 ];
   };

--- a/pkgs/servers/ma1sd/default.nix
+++ b/pkgs/servers/ma1sd/default.nix
@@ -64,6 +64,10 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "a federated matrix identity server; fork of mxisd";
     homepage = "https://github.com/ma1uta/ma1sd";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ mguentner ];
     platforms = platforms.all;

--- a/pkgs/servers/metabase/default.nix
+++ b/pkgs/servers/metabase/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "The easy, open source way for everyone in your company to ask questions and learn from data";
     homepage    = "https://metabase.com";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license     = licenses.agpl3Only;
     platforms   = platforms.all;
     maintainers = with maintainers; [ schneefux thoughtpolice mmahut ];

--- a/pkgs/servers/misc/airsonic/default.nix
+++ b/pkgs/servers/misc/airsonic/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Personal media streamer";
     homepage = "https://airsonic.github.io";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3;
     platforms = platforms.all;
     maintainers = with maintainers; [ disassembler ];

--- a/pkgs/servers/monitoring/prometheus/jmx-httpserver.nix
+++ b/pkgs/servers/monitoring/prometheus/jmx-httpserver.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/prometheus/jmx_exporter";
     description = "A process for exposing JMX Beans via HTTP for Prometheus consumption";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers.offline ];
     platforms = platforms.unix;

--- a/pkgs/servers/monitoring/riemann/default.nix
+++ b/pkgs/servers/monitoring/riemann/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://riemann.io/";
     description = "A network monitoring system";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     platforms = platforms.all;
     maintainers = [];

--- a/pkgs/servers/monitoring/seyren/default.nix
+++ b/pkgs/servers/monitoring/seyren/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An alerting dashboard for Graphite";
     homepage = "https://github.com/scobal/seyren";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers.offline ];
     platforms = platforms.all;

--- a/pkgs/servers/monitoring/zipkin/default.nix
+++ b/pkgs/servers/monitoring/zipkin/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Zipkin distributed tracing system";
     homepage = "https://zipkin.io/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = [ maintainers.hectorj ];

--- a/pkgs/servers/nosql/riak/2.2.0.nix
+++ b/pkgs/servers/nosql/riak/2.2.0.nix
@@ -96,6 +96,10 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ cstrahan mdaiter ];
     description = "Dynamo inspired NoSQL DB by Basho";
     platforms   = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # dependencies
+    ];
     license     = licenses.asl20;
     knownVulnerabilities = [ "CVE-2017-3163 - see https://github.com/NixOS/nixpkgs/issues/33876" ];
   };

--- a/pkgs/servers/sql/mssql/jdbc/default.nix
+++ b/pkgs/servers/sql/mssql/jdbc/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/servers/sql/sqlite/jdbc/default.nix
+++ b/pkgs/servers/sql/sqlite/jdbc/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/xerial/sqlite-jdbc";
     description = "Library for accessing and creating SQLite database files in Java";
     license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ jraygauthier ];
   };

--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -35,6 +35,7 @@ let
     meta = with lib; {
       homepage = "http://www.ubnt.com/";
       description = "Controller for Ubiquiti UniFi access points";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.unfree;
       platforms = platforms.unix;
       maintainers = with maintainers; [ erictapen globin patryk27 pennae ];

--- a/pkgs/tools/backup/android-backup-extractor/default.nix
+++ b/pkgs/tools/backup/android-backup-extractor/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Utility to extract and repack Android backups created with adb backup";
     homepage = "https://github.com/nelenkov/android-backup-extractor";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ prusnak ];
   };

--- a/pkgs/tools/games/minecraft/amidst/default.nix
+++ b/pkgs/tools/games/minecraft/amidst/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/toolbox4minecraft/amidst";
     description = "Advanced Minecraft Interface and Data/Structure Tracking";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Only;
     maintainers = [ maintainers.ivar ];
     platforms = platforms.linux;

--- a/pkgs/tools/games/minecraft/fabric-installer/default.nix
+++ b/pkgs/tools/games/minecraft/fabric-installer/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://fabricmc.net/";
     description = "A lightweight, experimental modding toolchain for Minecraft";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers.ivar ];
     platforms = platforms.unix;

--- a/pkgs/tools/games/minecraft/optifine/generic.nix
+++ b/pkgs/tools/games/minecraft/optifine/generic.nix
@@ -30,6 +30,7 @@ runCommand "optifine-${mcVersion}" {
       It allows Minecraft to run faster and look better with full support for HD textures and many configuration options.
       This is for version ${mcVersion} of Minecraft.
     '';
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     maintainers = [ maintainers.ivar ];
     platforms = platforms.unix;

--- a/pkgs/tools/graphics/agi/default.nix
+++ b/pkgs/tools/graphics/agi/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/google/agi/";
     description = "Android GPU Inspector";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.ivar ];

--- a/pkgs/tools/graphics/briss/default.nix
+++ b/pkgs/tools/graphics/briss/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://sourceforge.net/projects/briss/";
     description = "Java application for cropping PDF files";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/tools/graphics/ditaa/default.nix
+++ b/pkgs/tools/graphics/ditaa/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Convert ascii art diagrams into proper bitmap graphics";
     homepage = "https://github.com/stathissideris/ditaa";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl3;
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/tools/graphics/welkin/default.nix
+++ b/pkgs/tools/graphics/welkin/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
       raskin
     ];
     hydraPlatforms = [];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.free;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/tools/graphics/zxing/default.nix
+++ b/pkgs/tools/graphics/zxing/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   '';
   meta = {
     description = "1D and 2D code reading library";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;

--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open source log management solution";
     homepage    = "https://www.graylog.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license     = licenses.gpl3;
     maintainers = [ maintainers.fadenb ];
     mainProgram = "graylogctl";

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -19,6 +19,7 @@ let
       meta = a.meta // {
         platforms = graylog.meta.platforms;
         maintainers = (a.meta.maintainers or []) ++ [ maintainers.fadenb ];
+        sourceProvenance = with sourceTypes; [ binaryBytecode ];
       };
     });
 in {

--- a/pkgs/tools/misc/ili2c/default.nix
+++ b/pkgs/tools/misc/ili2c/default.nix
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
       Checks the syntactical correctness of an INTERLIS data model.
     '';
     homepage = "https://www.interlis.ch/downloads/ili2c";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.das-g ];
     platforms = platforms.linux;

--- a/pkgs/tools/misc/jdiskreport/default.nix
+++ b/pkgs/tools/misc/jdiskreport/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.jgoodies.com/freeware/jdiskreport/";
     description = "A graphical utility to visualize disk usage";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfreeRedistributable; #TODO freedist, libs under BSD-3
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ kylesferrazza ];

--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A web application to generate UML diagrams on-the-fly.";
     homepage = "https://plantuml.com/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ truh ];

--- a/pkgs/tools/misc/plantuml/default.nix
+++ b/pkgs/tools/misc/plantuml/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Draw UML diagrams using a simple and human readable text description";
     homepage = "http://plantuml.sourceforge.net/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     # "plantuml -license" says GPLv3 or later
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ bjornfor Mogria ];

--- a/pkgs/tools/misc/procyon/default.nix
+++ b/pkgs/tools/misc/procyon/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Procyon is a suite of Java metaprogramming tools including a Java decompiler";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     homepage = "https://github.com/mstrobel/procyon/";
     license = licenses.asl20;
     maintainers = with maintainers; [ SuperSandro2000 ];

--- a/pkgs/tools/misc/smc/default.nix
+++ b/pkgs/tools/misc/smc/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
       SMC can also generate GraphViz state diagrams from the input file.
     '';
     homepage = "http://smc.sourceforge.net/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mpl11;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/tools/misc/umlet/default.nix
+++ b/pkgs/tools/misc/umlet/default.nix
@@ -46,6 +46,7 @@ in stdenv.mkDerivation rec {
       Linux.
     '';
     homepage = "https://www.umlet.com";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = with maintainers; [ oxzi ];
     platforms = platforms.all;

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://portswigger.net/burp/";
     downloadPage = "https://portswigger.net/burp/freedownload";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     platforms = jdk11.meta.platforms;
     hydraPlatforms = [];

--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Applications and router for I2P, anonymity over the Internet";
     homepage = "https://geti2p.net";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ joelmo ];

--- a/pkgs/tools/networking/openapi-generator-cli/default.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/default.nix
@@ -31,6 +31,7 @@ let this = stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/OpenAPITools/openapi-generator";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers.shou ];
   };

--- a/pkgs/tools/networking/swagger-codegen/default.nix
+++ b/pkgs/tools/networking/swagger-codegen/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/swagger-api/swagger-codegen";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers.jraygauthier ];
   };

--- a/pkgs/tools/networking/swagger-codegen3/default.nix
+++ b/pkgs/tools/networking/swagger-codegen3/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/swagger-api/swagger-codegen/tree/3.0.0";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = [ maintainers._1000101 ];
   };

--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -110,6 +110,10 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Free client-side encryption for your cloud files";
     homepage = "https://cryptomator.org";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ bachp ];
     platforms = platforms.linux;

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -171,6 +171,10 @@ in stdenv.mkDerivation rec {
     description = "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";
     homepage = "https://ghidra-sre.org/";
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.asl20;
     maintainers = [ "roblabla" ];
   };

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -72,6 +72,7 @@ in stdenv.mkDerivation rec {
     description = "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";
     homepage = "https://github.com/NationalSecurityAgency/ghidra";
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ ck3d govanify mic92 ];
   };

--- a/pkgs/tools/security/ipscan/default.nix
+++ b/pkgs/tools/security/ipscan/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fast and friendly network scanner";
     homepage = "https://angryip.org";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kylesferrazza ];

--- a/pkgs/tools/security/jadx/default.nix
+++ b/pkgs/tools/security/jadx/default.nix
@@ -103,6 +103,10 @@ in stdenv.mkDerivation {
       Command line and GUI tools for produce Java source code from Android Dex
       and Apk files.
     '';
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ delroth ];

--- a/pkgs/tools/security/jd-gui/default.nix
+++ b/pkgs/tools/security/jd-gui/default.nix
@@ -102,6 +102,10 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fast Java Decompiler with powerful GUI";
     homepage    = "https://java-decompiler.github.io/";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license     = licenses.gpl3;
     platforms   = platforms.unix;
     maintainers = [ maintainers.thoughtpolice ];

--- a/pkgs/tools/security/open-ecard/default.nix
+++ b/pkgs/tools/security/open-ecard/default.nix
@@ -56,6 +56,7 @@ in stdenv.mkDerivation rec {
     description = "Client side implementation of the eCard-API-Framework (BSI
       TR-03112) and related international standards, such as ISO/IEC 24727";
     homepage = "https://www.openecard.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = with maintainers; [ sephalon ];
     platforms = platforms.linux;

--- a/pkgs/tools/system/sleuthkit/default.nix
+++ b/pkgs/tools/system/sleuthkit/default.nix
@@ -84,6 +84,10 @@ stdenv.mkDerivation rec {
     homepage = "https://www.sleuthkit.org/";
     maintainers = with maintainers; [ raskin gfrascadorio ];
     platforms = platforms.linux;
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # dependencies
+    ];
     license = licenses.ipl10;
   };
 }

--- a/pkgs/tools/text/crowdin-cli/default.nix
+++ b/pkgs/tools/text/crowdin-cli/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     mainProgram = "crowdin";
     homepage = "https://github.com/crowdin/crowdin-cli/";
     description = "A command-line client for the Crowdin API";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [ DamienCassou ];
   };

--- a/pkgs/tools/text/epubcheck/default.nix
+++ b/pkgs/tools/text/epubcheck/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/w3c/epubcheck";
     description = "Validation tool for EPUB";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = with licenses; [ asl20 bsd3 mpl10 w3c ];
     platforms = platforms.all;
     maintainers = with maintainers; [ eadwu ];

--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://languagetool.org";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ edwtjo ];
     platforms = jre.meta.platforms;

--- a/pkgs/tools/text/xml/basex/default.nix
+++ b/pkgs/tools/text/xml/basex/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation rec {
       modes, BaseX offers a client/server architecture.
     '';
     homepage = "https://basex.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd3;
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/tools/text/xml/jing-trang/default.nix
+++ b/pkgs/tools/text/xml/jing-trang/default.nix
@@ -46,6 +46,10 @@ stdenv.mkDerivation rec {
     # for downloads and call it the "project site".
     homepage = "https://www.thaiopensource.com/relaxng/trang.html";
     platforms = platforms.unix;
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -322,6 +322,9 @@ stdenv.mkDerivation rec {
       the backend output markups (which can be almost any type of SGML/XML
       markup) can be customized and extended by the user.
     '';
+    sourceProvenance = with sourceTypes; [
+      fromSource
+    ] ++ lib.optional _enableDitaaFilter binaryBytecode;
     homepage = "http://www.methods.co.nz/asciidoc/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -48,6 +48,10 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://xmlgraphics.apache.org/fop/";
     license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # source bundles dependencies as jars
+    ];
     platforms = platforms.all;
     maintainers = with maintainers; [ bjornfor ];
   };

--- a/pkgs/tools/typesetting/pdftk/default.nix
+++ b/pkgs/tools/typesetting/pdftk/default.nix
@@ -88,6 +88,10 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Command-line tool for working with PDFs";
     homepage = "https://gitlab.com/pdftk-java/pdftk";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ raskin averelld ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Description of changes

This is a broad and coarse sweep for packages I could easily identify as containing _downloaded_ jars in their outputs. It may well need further refinement from package maintainers. Some of these packages also contain binary native code, but I have not marked that in this PR - though I've made a note of these packages for the native-code-sweep.

Packages which build the main package but use binary dependencies have been marked as both `fromSource` _and_ `binaryBytecode` to differentiate them from packages which simply download the whole thing. The practical difference here is that the former packages _would_ be patchable if necessary, whereas the latter wouldn't.

Gradle-based builds are included as a separate commit as I wasn't quite so 100% sure where they were all gathering their `deps` from. It's oddly opaque.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
