### PR TITLE
nitter: 2022-05-13 -> 2022-06-04

### DIFF
--- a/pkgs/servers/nitter/default.nix
+++ b/pkgs/servers/nitter/default.nix
@@ -1,31 +1,36 @@
-{ lib, nimPackages, nixosTests, fetchFromGitHub, libsass }:
+{ lib
+, fetchFromGitHub
+, nimPackages
+, nixosTests
+}:
 
 nimPackages.buildNimPackage rec {
   pname = "nitter";
-  version = "unstable-2022-05-13";
-  nimBinOnly = true;
+  version = "unstable-2022-06-04";
 
   src = fetchFromGitHub {
     owner = "zedeus";
     repo = "nitter";
-    rev = "683c052036b268028f0ecae020a1519bc586516d";
-    sha256 = "179z66jlwbdarrgvpdh8aqy2ihkiakd22wqydrfgpsgr59ma8fgl";
+    rev = "138826fb4fbdec73fc6fee2e025fda88f7f2fb49";
+    hash = "sha256-fdzVfzmEFIej6Kb/K9MQyvbN8aN3hO7RetHL53cD59k=";
   };
 
   buildInputs = with nimPackages; [
-    jester
-    karax
-    sass
-    nimcrypto
-    markdown
-    packedjson
-    supersnappy
-    redpool
-    redis
-    zippy
     flatty
+    jester
     jsony
+    karax
+    markdown
+    nimcrypto
+    packedjson
+    redis
+    redpool
+    sass
+    supersnappy
+    zippy
   ];
+
+  nimBinOnly = true;
 
   postBuild = ''
     nim c --hint[Processing]:off -r tools/gencss
@@ -37,13 +42,13 @@ nimPackages.buildNimPackage rec {
     cp -r public $out/share/nitter/public
   '';
 
-  passthru.tests = { inherit (nixosTests) nitter; };
-
   meta = with lib; {
-    description = "Alternative Twitter front-end";
     homepage = "https://github.com/zedeus/nitter";
-    maintainers = with maintainers; [ erdnaxe ];
+    description = "Alternative Twitter front-end";
     license = licenses.agpl3Only;
+    maintainers = with maintainers; [ erdnaxe ];
     mainProgram = "nitter";
   };
+
+  passthru.tests = { inherit (nixosTests) nitter; };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/176216

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
