### PR TITLE
yubikey-agent: 0.1.5 -> unstable-2022-03-17

### DIFF
--- a/pkgs/tools/security/yubikey-agent/default.nix
+++ b/pkgs/tools/security/yubikey-agent/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "yubikey-agent";
-  version = "0.1.5";
 
+  version = "unstable-2022-03-17";
   src = fetchFromGitHub {
     owner = "FiloSottile";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "14s61jgcmpqh70jz0krrai8xg0xqhwmillxkij50vbsagpxjssk6";
+    repo = "yubikey-agent";
+    rev = "205a7ef2554625c7494038600d963123d6311873";
+    sha256 = "sha256-wJpN63KY5scmez6yYFsIr3JLEUB+YSl/XvoatIIeRI0=";
   };
 
   buildInputs =
@@ -21,7 +21,7 @@ buildGoModule rec {
     substituteInPlace main.go --replace 'notify-send' ${libnotify}/bin/notify-send
   '';
 
-  vendorSha256 = "1v4ccn7ysh8ax1nkf1v9fcgsdnz6zjyh6j6ivyljyfvma1lmcrmk";
+  vendorSha256 = "sha256-SnjbkDPVjAnCbM2nLqBsuaPZwOmvDTKiUbi/93BlWVQ=";
 
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

`yubikey-agent` is updated to a newer commit. It hasn't received an
official release in a while which is why the update is to an "unstable"
version.

Closes https://github.com/NixOS/nixpkgs/issues/145392

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've built the package using `nix-build` and have enabled the service via `services.yubikey-agent.enable = true;` and it worked. I was able to setup two yubikeys.