### PR TITLE
lexicon: 3.9.4 -> 3.11.2

### DIFF
--- a/pkgs/development/python-modules/softlayer-zeep/default.nix
+++ b/pkgs/development/python-modules/softlayer-zeep/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, attrs
+, cached-property
+, isodate
+, lxml
+, platformdirs
+, requests
+, requests-toolbelt
+, requests-file
+, pytz
+, freezegun
+, pretend
+, pytest-httpx
+, pytest-asyncio
+, pytestCheckHook
+, requests-mock
+}:
+
+buildPythonPackage rec {
+  pname = "softlayer-zeep";
+  version = "5.0.0";
+
+  disabled = pythonOlder "3.6";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ff690c115eecaececa437bfe81430e9fdb49690e6465397c9dc77eb56b681e23";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    cached-property
+    isodate
+    lxml
+    platformdirs
+    requests
+    requests-toolbelt
+    requests-file
+    pytz
+  ];
+
+  checkInputs = [
+    freezegun
+    pretend
+    pytest-httpx
+    pytest-asyncio
+    pytestCheckHook
+    requests-mock
+  ];
+
+  preCheck = ''
+    export HOME=$TEMP
+  '';
+
+  pythonImportsCheck = [ "zeep" ];
+
+  meta = {
+    description = "A modern/fast Python SOAP client based on lxml / requests";
+    homepage = "https://github.com/softlayer/softlayer-zeep";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/softlayer/default.nix
+++ b/pkgs/development/python-modules/softlayer/default.nix
@@ -3,54 +3,65 @@
 , buildPythonPackage
 , click
 , fetchFromGitHub
-, mock
+, prettytable
 , prompt-toolkit
-, ptable
 , pygments
 , pytestCheckHook
 , pythonOlder
 , requests
-, sphinx
-, testtools
+, rich
+, softlayer-zeep
 , tkinter
 , urllib3
 }:
 
 buildPythonPackage rec {
   pname = "softlayer";
-  version = "5.9.9";
-  disabled = pythonOlder "3.5";
+  version = "unstable-2022-05-31";
+  disabled = pythonOlder "3.6";
+
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "softlayer-python";
-    rev = "v${version}";
-    sha256 = "sha256-LskPz5KXOi7olb3+DUP9uEFESQeo6ec/ZLx9B/w6Ni0=";
+    rev = "dae2ec73563a740c4670cc0718fd4b90c6d42eed";
+    hash = "sha256-JfdCm+Q40Nrt73R9w9bNMoUMrhDPP6Do0Lj1tXaznpw=";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "==" ">="
+  '';
 
   propagatedBuildInputs = [
     click
+    prettytable
     prompt-toolkit
-    ptable
     pygments
     requests
+    rich
     urllib3
   ];
 
   checkInputs = [
-    mock
     pytestCheckHook
-    sphinx
-    testtools
+    softlayer-zeep
     tkinter
+  ];
+
+  disabledTestPaths = [
+    # requires network access
+    "tests/transports/soap_tests.py"
   ];
 
   pythonImportsCheck = [ "SoftLayer" ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = stdenv.isDarwin;
     description = "Python libraries that assist in calling the SoftLayer API";
     homepage = "https://github.com/softlayer/softlayer-python";
+    changelog = "https://github.com/softlayer/softlayer-python/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -7,15 +7,20 @@ with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "lexicon";
-  version = "3.9.4";
+  version = "3.11.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-TySgIxBEl2RolndAkEN4vCIDKaI48vrh2ocd+CTn7Ow=";
+    hash = "sha256-z0GaA1O0ctP280QvhdzW7Cxonidz9dOnP6N4RJ+tqfw=";
   };
+
+  postPatch = ''
+    substituteInPlace lexicon/tests/providers/test_oci.py \
+      --replace "os.remove(KEY_FILE)" 'os.system(f"rm -f {KEY_FILE}")'
+  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -26,16 +31,13 @@ buildPythonApplication rec {
     boto3
     cryptography
     dnspython
-    future
+    importlib-metadata
     localzone
     oci
-    pynamecheap
     pyyaml
     requests
     softlayer
     tldextract
-    transip
-    xmltodict
     zeep
   ];
 
@@ -46,9 +48,15 @@ buildPythonApplication rec {
     vcrpy
   ];
 
+  preCheck = ''
+    export HOME=$TEMP
+  '';
+
   disabledTestPaths = [
     # Tests require network access
     "lexicon/tests/providers/test_auto.py"
+    # some problem with VCR.py
+    "lexicon/tests/providers/test_namecheap.py"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9789,6 +9789,8 @@ in {
 
   softlayer = callPackage ../development/python-modules/softlayer { };
 
+  softlayer-zeep = callPackage ../development/python-modules/softlayer-zeep { };
+
   solaredge = callPackage ../development/python-modules/solaredge { };
 
   solax = callPackage ../development/python-modules/solax { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

We could actually move lexicon to `pythonPackages` as dns-lexicon since it's also a Python library: https://github.com/AnalogJ/lexicon#id1

@blitz @flyfloh You should step up and maintain softlayer as well as softlayer-zeep.