### PR TITLE
[staging] openldap: Fix some issues by applying patches

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 
 # dependencies
 , cyrus_sasl
@@ -20,6 +21,39 @@ stdenv.mkDerivation rec {
     url = "https://www.openldap.org/software/download/OpenLDAP/openldap-release/${pname}-${version}.tgz";
     hash = "sha256-gdCTRSMutiSG7PWsrNLFbAxFtKbIwGZhLn9CGiOhz4c";
   };
+
+  patches = [
+    # ITS#9840 - ldif-filter: fix parallel build failure
+    (fetchpatch {
+      url = "https://github.com/openldap/openldap/commit/7d977f51e6dfa570a471d163b9e8255bdd3dc12f.patch";
+      hash = "sha256:1vid6pj2gmqywbghnd380x19ml241ldc1fyslb6br6q27zpgbdlp";
+    })
+    # ITS#9840 - libraries/Makefile.in: ignore the mkdir errors
+    (fetchpatch {
+      url = "https://github.com/openldap/openldap/commit/71f24015c312171c00ce94c9ff9b9c6664bdca8d.patch";
+      hash = "sha256:1a81vv6nkhgiadnj4g1wyzgzdp2zd151h0vkwvv9gzmqvhwcnc04";
+    })
+    # ITS#7165 back-mdb: check for stale readers on
+    (fetchpatch {
+      url = "https://github.com/openldap/openldap/commit/7e7f01c301db454e8c507999c77b55a1d97efc21.patch";
+      hash = "sha256:1fc2yck2gn3zlpfqjdn56ar206npi8cmb8yg5ny4lww0ygmyzdfz";
+    })
+    # ITS#9858 back-mdb: delay indexer task startup
+    (fetchpatch {
+      url = "https://github.com/openldap/openldap/commit/ac061c684cc79d64ab4089fe3020921a0064a307.patch";
+      hash = "sha256:01f0y50zlcj6n5mfkmb0di4p5vrlgn31zccx4a9k5m8vzxaqmw9d";
+    })
+    # ITS#9858 back-mdb: fix index reconfig
+    (fetchpatch {
+      url = "https://github.com/openldap/openldap/commit/c43c7a937cfb3a781f99b458b7ad71eb564a2bc2.patch";
+      hash = "sha256:02yh0c8cyx14iir5qhfam5shrg5d3115s2nv0pmqdj6najrqc5mm";
+    })
+    # ITS#9157: check for NULL ld
+    (fetchpatch {
+      url = "https://github.com/openldap/openldap/commit/6675535cd6ad01f9519ecd5d75061a74bdf095c7.patch";
+      hash = "sha256:0dali5ifcwba8400s065f0fizl9h44i0mzb06qgxhygff6yfrgif";
+    })
+  ];
 
   # TODO: separate "out" and "bin"
   outputs = [
@@ -59,7 +93,7 @@ stdenv.mkDerivation rec {
     "ac_cv_func_memcmp_working=yes"
   ] ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
-  makeFlags= [
+  makeFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
     "STRIP="  # Disable install stripping as it breaks cross-compiling. We strip binaries anyway in fixupPhase.
     "prefix=${placeholder "out"}"
@@ -116,6 +150,6 @@ stdenv.mkDerivation rec {
     description = "An open source implementation of the Lightweight Directory Access Protocol";
     license = licenses.openldap;
     maintainers = with maintainers; [ ajs124 das_j hexa ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

These patches are from the 2.6 support branch and will hence make it
into 2.6.3 at a later point. At this point however, I cannot use slapd
as a syncrepl slave because it segfaults on startup. This also fixes
parallel build.

Closes #175994
Closes #175626

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
