### PR TITLE
cacert: use buildcatrust build with python3Minimal

### DIFF
--- a/pkgs/data/misc/mailcap/default.nix
+++ b/pkgs/data/misc/mailcap/default.nix
@@ -1,23 +1,25 @@
-{ lib, fetchzip }:
+{ lib, stdenv, fetchurl }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "mailcap";
   version = "2.1.53";
 
-in fetchzip {
-  name = "mailcap-${version}";
+  src = fetchurl {
+    url = "https://releases.pagure.org/mailcap/mailcap-${version}.tar.xz";
+    sha256 = "sha256-Xuou8XswSXe6PsuHr61DGfoEQPgl5Pb7puj6L/64h4U=";
+  };
 
-  url = "https://releases.pagure.org/mailcap/mailcap-${version}.tar.xz";
-  sha256 = "sha256-6JPj2tZgoTEZ8hNEi9ZZhElBNm9SRTSXifMmCicwiLo=";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    tar -xavf $downloadedFile --strip-components=1
     substituteInPlace mailcap --replace "/usr/bin/" ""
-    gzip mailcap.5
     sh generate-nginx-mimetypes.sh < mime.types > nginx-mime.types
 
     install -D -m0644 nginx-mime.types $out/etc/nginx/mime.types
     install -D -m0644 -t $out/etc mailcap mime.types
-    install -D -m0644 -t $out/share/man/man5 mailcap.5.gz
+    install -D -m0644 -t $out/share/man/man5 mailcap.5
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24120,7 +24120,10 @@ with pkgs;
 
   brise = callPackage ../data/misc/brise { };
 
-  cacert = callPackage ../data/misc/cacert { };
+  cacert = callPackage ../data/misc/cacert {
+    # avoid an infinite recursion through mailcap
+    buildcatrust = with python3Minimal.pkgs; toPythonApplication buildcatrust;
+  };
 
   caladea = callPackage ../data/fonts/caladea {};
 


### PR DESCRIPTION
to avoid inifinite recursion with mailcap

Co-authored-by: Artturi <Artturin@artturin.com>

Closes #176286

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
