### PR TITLE
jansson: 2.13.1 -> 2.14

### DIFF
--- a/pkgs/development/libraries/jansson/default.nix
+++ b/pkgs/development/libraries/jansson/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/akheron/jansson/raw/v${version}/CHANGES";
     license = licenses.mit;
     platforms = platforms.all;
+    maintainers = [ maintainers.marsam ];
   };
 }

--- a/pkgs/development/libraries/jansson/default.nix
+++ b/pkgs/development/libraries/jansson/default.nix
@@ -1,17 +1,22 @@
-{lib, stdenv, fetchurl}:
+{ lib, stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "jansson";
-  version = "2.13.1";
+  version = "2.14";
 
-  src = fetchurl {
-    url = "https://digip.org/jansson/releases/${pname}-${version}.tar.gz";
-    sha256 = "0ks7gbs0j8p4dmmi2sq129mxy5gfg0z6220i1jk020mi2zd7gwzl";
+  src = fetchFromGitHub {
+    owner = "akheron";
+    repo = "jansson";
+    rev = "v${version}";
+    sha256 = "sha256-FQgy2+g3AyRVJeniqPQj0KNeHgPdza2pmEIXqSyYry4=";
   };
 
+  nativeBuildInputs = [ cmake ];
+
   meta = with lib; {
-    homepage = "http://www.digip.org/jansson/";
+    homepage = "https://github.com/akheron/jansson";
     description = "C library for encoding, decoding and manipulating JSON data";
+    changelog = "https://github.com/akheron/jansson/raw/v${version}/CHANGES";
     license = licenses.mit;
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/akheron/jansson/raw/v2.14/CHANGES
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
