### PR TITLE
edk2-uefi-shell: init at 202202

### DIFF
--- a/pkgs/tools/misc/edk2-uefi-shell/default.nix
+++ b/pkgs/tools/misc/edk2-uefi-shell/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, edk2
+, util-linux
+, nasm
+, python3
+}:
+edk2.mkDerivation "ShellPkg/ShellPkg.dsc" (finalAttrs: {
+  pname = "edk2-uefi-shell";
+  inherit (edk2) version;
+
+  nativeBuildInputs = [ util-linux nasm python3 ];
+  strictDeps = true;
+
+  # We only have a .efi file in $out which shouldn't be patched or stripped
+  dontPatchELF = true;
+  dontStrip = true;
+
+  # GUID hardcoded to match ShellPkg.dsc
+  installPhase = ''
+    runHook preInstall
+    install -D -m0644 Build/Shell/RELEASE*/*/Shell_EA4BB293-2D7F-4456-A681-1F22F42CD0BC.efi $out/shell.efi
+    runHook postInstall
+  '';
+
+  passthru.efi = "${finalAttrs.finalPackage}/shell.efi";
+
+  meta = {
+    inherit (edk2.meta) license platforms;
+    description = "UEFI Shell from Tianocore EFI development kit";
+    homepage = "https://github.com/tianocore/tianocore.github.io/wiki/ShellPkg";
+    maintainers = with lib.maintainers; [ LunNova ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6010,6 +6010,8 @@ with pkgs;
 
   edk2 = callPackage ../development/compilers/edk2 { };
 
+  edk2-uefi-shell = callPackage ../tools/misc/edk2-uefi-shell { };
+
   eff = callPackage ../development/interpreters/eff { };
 
   eflite = callPackage ../applications/audio/eflite {};


### PR DESCRIPTION
###### Description of changes

This builds ShellPkg.dsc from edk2, and outputs just the final `shell.efi` for use in whatever way you want eg copying it to your EFI partition.

https://github.com/tianocore/tianocore.github.io/wiki/ShellPkg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
