### PR TITLE
unvanquished: fix sdl event overflow

### DIFF
--- a/pkgs/games/unvanquished/default.nix
+++ b/pkgs/games/unvanquished/default.nix
@@ -98,6 +98,8 @@ in stdenv.mkDerivation rec {
     chmod +w -R daemon/external_deps/linux64-${binary-deps-version}/
   '';
 
+  patches = [ ./fix-sdl-event-overflow.patch ];
+
   nativeBuildInputs = [ cmake unvanquished-binary-deps copyDesktopItems ];
   buildInputs = [
     gmp

--- a/pkgs/games/unvanquished/fix-sdl-event-overflow.patch
+++ b/pkgs/games/unvanquished/fix-sdl-event-overflow.patch
@@ -1,0 +1,27 @@
+From 3a978c485f2a7e02c0bc5aeed2c7c4378026cb33 Mon Sep 17 00:00:00 2001
+From: Sam Lantinga <slouken@libsdl.org>
+Date: Fri, 22 Apr 2022 23:34:10 -0700
+Subject: [PATCH] Only center the mouse if we get a mouse event with relative
+ motion
+
+For more information, see the discussion in https://github.com/libsdl-org/SDL/issues/5569
+
+Fixes https://github.com/DaemonEngine/Daemon/issues/600
+---
+ src/engine/sys/sdl_input.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/engine/sys/sdl_input.cpp b/src/engine/sys/sdl_input.cpp
+index 3da0fd3c8..5361cb550 100644
+--- a/daemon/src/engine/sys/sdl_input.cpp
++++ b/daemon/src/engine/sys/sdl_input.cpp
+@@ -1083,7 +1083,7 @@ static void IN_ProcessEvents( bool dropInput )
+ 					{
+ 						Com_QueueEvent( Util::make_unique<Sys::MouseEvent>(e.motion.xrel, e.motion.yrel) );
+ #if defined( __linux__ ) || defined( __BSD__ )
+-						if ( !in_nograb->integer )
++						if ( !in_nograb->integer && ( e.motion.xrel || e.motion.yrel ) )
+ 						{
+ 							// work around X window managers and edge-based workspace flipping
+ 							// - without this, we get LeaveNotify, no mouse button events, EnterNotify;
+


### PR DESCRIPTION
###### Description of changes

This backports https://github.com/DaemonEngine/Daemon/pull/624

See https://github.com/DaemonEngine/Daemon/issues/600 for the corresponding issue

**This is a PR for 22.05 only, and not nixos-unstable**. This is because no fix is known for the SDL version nixos-unstable ships, SDL2.0.22. This patch actually worsen the situation with SDL2.0.22.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (the only supported platform)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).