### PR TITLE
doc/builders/images/dockertools: improve shadowSetup example

### DIFF
--- a/doc/builders/images/dockertools.section.md
+++ b/doc/builders/images/dockertools.section.md
@@ -302,7 +302,7 @@ buildImage {
 
   runAsRoot = ''
     #!${pkgs.runtimeShell}
-    ${shadowSetup}
+    ${pkgs.dockerTools.shadowSetup}
     groupadd -r redis
     useradd -r -g redis redis
     mkdir /data


### PR DESCRIPTION
The example snippet will fail with this error as it is not self contained and
assumes `shadowSetup` was given:

    $ nix-build docker-image.nix
    error: undefined variable 'shadowSetup' at docker-image.nix:20:7

Instead use the full reference to `shadowSetup` in the example so it will work
as stated.