### PR TITLE
noisetorch: 0.11.5 -> 0.12.0

### DIFF
--- a/pkgs/applications/audio/noisetorch/default.nix
+++ b/pkgs/applications/audio/noisetorch/default.nix
@@ -2,20 +2,20 @@
 
 buildGoModule rec {
   pname = "NoiseTorch";
-  version = "0.11.5";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lawl";
+    owner = "noisetorch";
     repo = "NoiseTorch";
-    rev = version;
-    sha256 = "sha256-j/6XB3vA5LvTuCxmeB0HONqEDzYg210AWW/h3nCGOD8=";
+    rev = "v${version}";
+    sha256 = "sha256-Y/rMoR74qeN5zr5ekq7Abpx2iTWf7dJimXfknPACWK8=";
   };
 
   vendorSha256 = null;
 
   doCheck = false;
 
-  ldflags = [ "-X main.version=${version}"  "-X main.distribution=nix" ];
+  ldflags = [ "-X main.version=${version}" "-X main.distribution=nix" ];
 
   subPackages = [ "." ];
 
@@ -34,9 +34,10 @@ buildGoModule rec {
 
   meta = with lib; {
     insecure = true;
-    knownVulnerabilities = [ "https://github.com/lawl/NoiseTorch/releases/tag/0.11.6" ];
+    knownVulnerabilities =
+      lib.optional (lib.versionOlder version "0.12") "https://github.com/noisetorch/NoiseTorch/releases/tag/v0.12.0";
     description = "Virtual microphone device with noise supression for PulseAudio";
-    homepage = "https://github.com/lawl/NoiseTorch";
+    homepage = "https://github.com/noisetorch/NoiseTorch";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ panaeon lom ];


### PR DESCRIPTION
###### Description of changes

This upgrades noisetorch to 0.12.0, and updates its' `meta.knownVulnerabilities` to point to older versions, now the new maintainers have [conducted an audit](https://github.com/noisetorch/NoiseTorch/releases/tag/v0.12.0).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Tested on Arch Linux by building with `nix-build` and running.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
