### PR TITLE
betterlockscreen: wrap with dbus and dunst

### DIFF
--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -37,7 +37,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     cp betterlockscreen $out/bin/betterlockscreen
-    wrapProgram "$out/bin/betterlockscreen" --prefix PATH : "$out/bin:${lib.makeBinPath [ bc coreutils dbus dunst i3lock-color gawk gnugrep gnused imagemagick procps xdpyinfo xrandr xset ]}"
+    wrapProgram "$out/bin/betterlockscreen" \
+      --prefix PATH : "$out/bin:${lib.makeBinPath [ bc coreutils dbus dunst i3lock-color gawk gnugrep gnused imagemagick procps xdpyinfo xrandr xset ]}"
 
     runHook postInstall
   '';

--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -6,6 +6,8 @@
   # Dependencies (@see https://github.com/pavanjadhaw/betterlockscreen/blob/master/shell.nix)
 , bc
 , coreutils
+, dbus
+, dunst
 , i3lock-color
 , gawk
 , gnugrep
@@ -35,7 +37,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     cp betterlockscreen $out/bin/betterlockscreen
-    wrapProgram "$out/bin/betterlockscreen" --prefix PATH : "$out/bin:${lib.makeBinPath [ bc coreutils i3lock-color gawk gnugrep gnused imagemagick procps xdpyinfo xrandr xset ]}"
+    wrapProgram "$out/bin/betterlockscreen" --prefix PATH : "$out/bin:${lib.makeBinPath [ bc coreutils dbus dunst i3lock-color gawk gnugrep gnused imagemagick procps xdpyinfo xrandr xset ]}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

[The upstream script includes hooks to pause and unpause dunst][1], so this change wraps the executable with both dunst (for dunstctl) and dbus (else "Command dbus-send not found" errors)

I'm not super nix-literate, so I'm unsure if this is more ideally suited for something like `propagatedBuildInputs` for `dunst` or something but I can at least confirm that this makes the betterlockscreen hook work correctly on my x86_64-linux machine. :+1:

[1]: https://github.com/betterlockscreen/betterlockscreen/blob/e6c5530b7b563580fb40b123e00bba0a07d0bbb4/betterlockscreen#L96-L98


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~[22.11 Release Notes (or backporting 22.05 Release notes)]~(https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
  - ~[ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes~
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).