### PR TITLE
phrase-cli: 2.4.4 -> 2.4.10

### DIFF
--- a/pkgs/tools/misc/phrase-cli/default.nix
+++ b/pkgs/tools/misc/phrase-cli/default.nix
@@ -2,16 +2,18 @@
 
 buildGoModule rec {
   pname = "phrase-cli";
-  version = "2.4.10";
+  version = "2.4.12";
 
   src = fetchFromGitHub {
     owner = "phrase";
     repo = "phrase-cli";
     rev = version;
-    sha256 = "sha256-dI11Y2sykEw1qsIpNJmzjyGbKcBw8rSx7etu7yE9peQ=";
+    sha256 = "sha256-+/hs6v3ereja2NtGApVBA3rTib5gAiGndbDg+FybWco=";
   };
 
-  vendorSha256 = "sha256-er8zQW1HT+xIi9l2AtI+LK2ijHUdBOyIYNzCsVx0a+Q=";
+  vendorSha256 = "sha256-Pt+F2ICuOQZBjMccK1qq/ueGOvnjDmAM5YLRINk2u/g=";
+
+  ldflags = [ "-X=github.com/phrase/phrase-cli/cmd.PHRASE_CLIENT_VERSION=${version}" ];
 
   postInstall = ''
     ln -s $out/bin/phrase-cli $out/bin/phrase

--- a/pkgs/tools/misc/phrase-cli/default.nix
+++ b/pkgs/tools/misc/phrase-cli/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "phrase-cli";
-  version = "2.4.4";
+  version = "2.4.10";
 
   src = fetchFromGitHub {
     owner = "phrase";
     repo = "phrase-cli";
     rev = version;
-    sha256 = "0xlfcj0jd6x4ynzg6d0p3wlmfq660w3zm13nzx04jfcjnks9sqvl";
+    sha256 = "sha256-dI11Y2sykEw1qsIpNJmzjyGbKcBw8rSx7etu7yE9peQ=";
   };
 
-  vendorSha256 = "1ablrs3prw011bpad8vn87y3c81q44mps873nhj278hlkz6im34g";
+  vendorSha256 = "sha256-er8zQW1HT+xIi9l2AtI+LK2ijHUdBOyIYNzCsVx0a+Q=";
 
   postInstall = ''
     ln -s $out/bin/phrase-cli $out/bin/phrase


### PR DESCRIPTION
###### Description of changes

bumped from 2.4.4 to 2.4.10 

changes between 2.4.4 and 2.4.10 can be seen [here](https://github.com/phrase/phrase-cli/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).