### PR TITLE
llvmPackages/libllvm: disable failing tests on armv7l

### DIFF
--- a/pkgs/development/compilers/llvm/14/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/14/llvm/default.nix
@@ -89,6 +89,9 @@ in stdenv.mkDerivation (rec {
     rm test/DebugInfo/X86/convert-inlined.ll
     rm test/DebugInfo/X86/convert-linked.ll
     rm test/tools/dsymutil/X86/op-convert.test
+    rm test/tools/gold/X86/split-dwarf.ll
+    rm test/tools/llvm-dwarfdump/X86/prettyprint_types.s
+    rm test/tools/llvm-dwarfdump/X86/simplified-template-names.s
   '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
     # Seems to require certain floating point hardware (NEON?)
     rm test/ExecutionEngine/frem.ll


### PR DESCRIPTION
###### Description of changes

This change fixes llvm native build on armv7l. It's a no-op on other platforms and could be merged to master.
```
llvm> 100% [===========================================================(B](B ETA: 00:00:00
llvm> ********************
llvm> Failed Tests (3):
llvm>   LLVM :: tools/gold/X86/split-dwarf.ll
llvm>   LLVM :: tools/llvm-dwarfdump/X86/prettyprint_types.s
llvm>   LLVM :: tools/llvm-dwarfdump/X86/simplified-template-names.s
llvm> Testing Time: 1961.31s
llvm>   Skipped          :     9
llvm>   Unsupported      :  1320
llvm>   Passed           : 45476
llvm>   Expectedly Failed:   160
llvm>   Failed           :     3
llvm> 1 warning(s) in tests
llvm> make[3]: *** [CMakeFiles/check-all.dir/build.make:71: CMakeFiles/check-all] Error 1
llvm> make[3]: Leaving directory '/build/llvm-src-14.0.1/llvm/build'
llvm> make[2]: *** [CMakeFiles/Makefile2:8894: CMakeFiles/check-all.dir/all] Error 2
llvm> make[2]: Leaving directory '/build/llvm-src-14.0.1/llvm/build'
llvm> make[1]: *** [CMakeFiles/Makefile2:8901: CMakeFiles/check-all.dir/rule] Error 2
llvm> make[1]: Leaving directory '/build/llvm-src-14.0.1/llvm/build'
llvm> make: *** [Makefile:228: check-all] Error 2
```
Related: https://github.com/NixOS/nixpkgs/pull/128139

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] armv7l-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
