### PR TITLE
bcc: Split manuals into own output

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -77,6 +77,8 @@ python.pkgs.buildPythonApplication rec {
     wrapPythonProgramsIn "$out/share/bcc/tools" "$out $pythonPath"
   '';
 
+  outputs = [ "out" "man" ];
+
   passthru.tests = {
     bpf = nixosTests.bpf;
   };


### PR DESCRIPTION
This should avoid manual cache/database rebuilds whenever tools alone
change.

Our bpftrace does the same already.

@ragge @mic92 @thoughtpolice @martinetd
