### PR TITLE
python310Packages.jsonrpc-base: 2.1.0 -> 2.1.1, python310Packages.jsonrpc-async: 2.1.0 -> 2.1.1, python310Packages.jsonrpc-websocket: 3.1.1 -> 3.1.4

### DIFF
--- a/pkgs/development/python-modules/jsonrpc-async/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-async/default.nix
@@ -2,7 +2,6 @@
 , aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , jsonrpc-base
 , pytest-aiohttp
 , pytestCheckHook
@@ -11,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "jsonrpc-async";
-  version = "2.1.0";
+  version = "2.1.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -20,7 +19,7 @@ buildPythonPackage rec {
     owner = "emlove";
     repo = pname;
     rev = version;
-    hash = "sha256-Lr8gvQR0Q46b/e1K/XyvqtJo18nBpHjlDdNq4vjCMyU=";
+    hash = "sha256-HhesXzxVjhWJkubiBi6sMoXi/zicqn99dqT5bilycS8=";
   };
 
   propagatedBuildInputs = [
@@ -31,15 +30,6 @@ buildPythonPackage rec {
   checkInputs = [
     pytest-aiohttp
     pytestCheckHook
-  ];
-
-  patches = [
-    # Fix tests with later pytest-aiohttp, https://github.com/emlove/jsonrpc-async/pull/9
-    (fetchpatch {
-      name = "support-later-pytest-aiohttp.patch";
-      url = "https://github.com/emlove/jsonrpc-async/commit/8b790f23af0d898df90460029d5ba3bcfb0423ed.patch";
-      sha256 = "sha256-rthHRF90hywMIbvIHo3Do/uzXKe+STPOoZIa80H4b/g=";
-    })
   ];
 
   pytestFlagsArray = [

--- a/pkgs/development/python-modules/jsonrpc-base/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-base/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "jsonrpc-base";
-  version = "2.1.0";
+  version = "2.1.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "emlove";
     repo = pname;
     rev = version;
-    hash = "sha256-fliyJmVmG1DgoePE92LKm/wknlgXgYq2mOzZMFAdqLE=";
+    hash = "sha256-C03m/zeLIFqsmEMSzt84LMOWAHUcpdEHhaa5hx2NsoQ=";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/jsonrpc-websocket/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-websocket/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "jsonrpc-websocket";
-  version = "3.1.1";
+  version = "3.1.4";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "emlove";
     repo = "jsonrpc-websocket";
     rev = version;
-    sha256 = "aAXY1OUsF83rGQ1sg1lDrbWmxWqJJ+ZnuvHR1Y+ZDs4=";
+    sha256 = "sha256-xSOITOVtsNMEDrq610l8LNipLdyMWzKOQDedQEGaNOQ=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes
- https://github.com/emlove/jsonrpc-base#changelog
- https://github.com/emlove/jsonrpc-async#changelog
- https://github.com/emlove/jsonrpc-websocket#changelog
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
