### PR TITLE
Simplify `mkDerivation`

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -70,9 +70,7 @@ let
           makeDerivationExtensible mkDerivationSimple (self: attrs // f self attrs))
       attrs;
 
-in
-
-makeOverlayable (overrideAttrs:
+  mkDerivationSimple = overrideAttrs:
 
 
 # `mkDerivation` wraps the builtin `derivation` function to
@@ -485,6 +483,7 @@ lib.extendDerivation
    # should be made available to Nix expressions using the
    # derivation (e.g., in assertions).
    passthru)
-  (derivation derivationArg)
+  (derivation derivationArg);
 
-)
+in
+  makeOverlayable mkDerivationSimple

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -10,12 +10,6 @@ let
     inherit (stdenv) hostPlatform;
   };
 
-  makeOverlayable = mkDerivationSimple:
-    fnOrAttrs:
-      if builtins.isFunction fnOrAttrs
-      then makeDerivationExtensible mkDerivationSimple fnOrAttrs
-      else makeDerivationExtensibleConst mkDerivationSimple fnOrAttrs;
-
   # Based off lib.makeExtensible, with modifications:
   makeDerivationExtensible = mkDerivationSimple: rattrs:
     let
@@ -486,4 +480,7 @@ lib.extendDerivation
   (derivation derivationArg);
 
 in
-  makeOverlayable mkDerivationSimple
+  fnOrAttrs:
+    if builtins.isFunction fnOrAttrs
+    then makeDerivationExtensible mkDerivationSimple fnOrAttrs
+    else makeDerivationExtensibleConst mkDerivationSimple fnOrAttrs

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -11,7 +11,7 @@ let
   };
 
   # Based off lib.makeExtensible, with modifications:
-  makeDerivationExtensible = mkDerivationSimple: rattrs:
+  makeDerivationExtensible = rattrs:
     let
       # NOTE: The following is a hint that will be printed by the Nix cli when
       # encountering an infinite recursion. It must not be formatted into
@@ -42,14 +42,14 @@ let
                     f0 self super
                   else x;
             in
-              makeDerivationExtensible mkDerivationSimple
+              makeDerivationExtensible
                 (self: let super = rattrs self; in super // f self super))
           args;
     in finalPackage;
 
   # makeDerivationExtensibleConst == makeDerivationExtensible (_: attrs),
   # but pre-evaluated for a slight improvement in performance.
-  makeDerivationExtensibleConst = mkDerivationSimple: attrs:
+  makeDerivationExtensibleConst = attrs:
     mkDerivationSimple
       (f0:
         let
@@ -61,7 +61,7 @@ let
                 f0 self super
               else x;
         in
-          makeDerivationExtensible mkDerivationSimple (self: attrs // f self attrs))
+          makeDerivationExtensible (self: attrs // f self attrs))
       attrs;
 
   mkDerivationSimple = overrideAttrs:
@@ -482,5 +482,5 @@ lib.extendDerivation
 in
   fnOrAttrs:
     if builtins.isFunction fnOrAttrs
-    then makeDerivationExtensible mkDerivationSimple fnOrAttrs
-    else makeDerivationExtensibleConst mkDerivationSimple fnOrAttrs
+    then makeDerivationExtensible fnOrAttrs
+    else makeDerivationExtensibleConst fnOrAttrs


### PR DESCRIPTION
###### Description of changes

A simplification that I've held off in #119942 to keep the diff small without messing up the formatting. This "messes up" the formatting, but makes troubleshooting a tiny bit easier as it is simpler.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
