### PR TITLE
grapejuice: 4.10.2 -> 5.1.1

### DIFF
--- a/pkgs/games/grapejuice/default.nix
+++ b/pkgs/games/grapejuice/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitLab
 , gobject-introspection
+, pciutils
 , python3Packages
 , gtk3
 , wrapGAppsHook
@@ -9,21 +10,21 @@
 , desktop-file-utils
 , xdg-utils
 , xdg-user-dirs
-, wine
+, gettext
 , winetricks
-, pciutils
+, wine
 , glxinfo
 }:
 
 python3Packages.buildPythonApplication rec  {
   pname = "grapejuice";
-  version = "4.10.2";
+  version = "5.1.1";
 
   src = fetchFromGitLab {
     owner = "BrinkerVII";
     repo = "grapejuice";
-    rev = "9a7cf806d35b4d53b3d3762339eba7d861b5043d";
-    sha256 = "sha256-cKZv9qPCnl7i4kb6PG8RYx3HNLcwgI4d2zkw899MA6E=";
+    rev = "v${version}";
+    sha256 = "sha256-31pxQtKw5sLGnnNdboF7AAIFqsan5pXKHIHtKq/ErRE=";
   };
 
   nativeBuildInputs = [
@@ -36,16 +37,19 @@ python3Packages.buildPythonApplication rec  {
 
   buildInputs = [
     cairo
+    gettext
   ];
 
   propagatedBuildInputs = with python3Packages; [
-    requests
-    pygobject3
-    dbus-python
-    packaging
     psutil
+    dbus-python
+    pygobject3
+    packaging
+    wheel
     setuptools
+    requests
     unidecode
+    click
   ];
 
   dontWrapGApps = true;
@@ -58,6 +62,7 @@ python3Packages.buildPythonApplication rec  {
   postPatch = ''
     substituteInPlace src/grapejuice_common/assets/desktop/grapejuice.desktop \
       --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
+      --replace \$GRAPEJUICE_GUI_EXECUTABLE "$out/bin/grapejuice-gui" \
       --replace \$GRAPEJUICE_ICON grapejuice
 
     substituteInPlace src/grapejuice_common/assets/desktop/roblox-player.desktop \
@@ -71,6 +76,12 @@ python3Packages.buildPythonApplication rec  {
     substituteInPlace src/grapejuice_common/assets/desktop/roblox-studio.desktop \
       --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
       --replace \$STUDIO_ICON "grapejuice-roblox-studio"
+
+    substituteInPlace src/grapejuice_common/paths.py \
+      --replace 'return local_share() / "locale"' 'return Path("${placeholder "out"}/share/locale")'
+
+    substituteInPlace src/grapejuice_common/features/settings.py \
+      --replace 'k_default_wine_home: "",' 'k_default_wine_home: "${wine}",'
   '';
 
   postInstall = ''
@@ -78,6 +89,23 @@ python3Packages.buildPythonApplication rec  {
     cp -r src/grapejuice_common/assets/desktop/* $out/share/applications/
     cp -r src/grapejuice_common/assets/icons $out/share/
     cp src/grapejuice_common/assets/mime_xml/*.xml $out/share/mime/packages/
+
+    # compile locales (*.po -> *.mo)
+    # from https://gitlab.com/brinkervii/grapejuice/-/blob/master/src/grapejuice_common/util/mo_util.py
+    LOCALE_DIR="$out/share/locale"
+    PO_DIR="src/grapejuice_common/assets/po"
+    LINGUAS_FILE="src/grapejuice_common/assets/po/LINGUAS"
+
+    for lang in $(<"$LINGUAS_FILE") # extract langs from LINGUAS_FILE
+    do
+      po_file="$PO_DIR/$lang.po"
+      mo_file_dir="$LOCALE_DIR/$lang/LC_MESSAGES"
+
+      mkdir -p $mo_file_dir
+
+      mo_file="$mo_file_dir/grapejuice.mo"
+      msgfmt $po_file -o $mo_file # msgfmt from gettext
+    done
   '';
 
   # No tests
@@ -87,9 +115,9 @@ python3Packages.buildPythonApplication rec  {
 
   meta = with lib; {
     homepage = "https://gitlab.com/brinkervii/grapejuice";
-    description = "A wine+Roblox management application";
+    description = "Simple Wine+Roblox management tool";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ artturin ];
+    maintainers = with maintainers; [ artturin helium ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Update grapejuice from 4.10.2 to 5.1.1
Required compiling of locales and adding `wine64` (grapejuice requires both `wine` and `wine64`) 

Edit: Using `wineWow` instead of `wine` and `wine64`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Grapejuice changelog: https://gitlab.com/brinkervii/grapejuice/-/releases/v5.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
