### PR TITLE
treewide: update git.kernel.org/cgit homepage URLs

### DIFF
--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Device Tree Compiler";
-    homepage = "https://git.kernel.org/cgit/utils/dtc/dtc.git";
+    homepage = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git";
     license = licenses.gpl2Plus; # dtc itself is GPLv2, libfdt is dual GPL/BSD
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/analysis/sparse/default.nix
+++ b/pkgs/development/tools/analysis/sparse/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Semantic parser for C";
-    homepage    = "https://git.kernel.org/cgit/devel/sparse/sparse.git/";
+    homepage    = "https://git.kernel.org/pub/scm/devel/sparse/sparse.git/";
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ thoughtpolice jkarlson ];

--- a/pkgs/development/tools/misc/pahole/default.nix
+++ b/pkgs/development/tools/misc/pahole/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-D__LIB=lib" "-DLIBBPF_EMBEDDED=OFF" ];
 
   meta = with lib; {
-    homepage = "https://git.kernel.org/cgit/devel/pahole/pahole.git/";
+    homepage = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git/";
     description = "Pahole and other DWARF utils";
     license = licenses.gpl2Only;
 

--- a/pkgs/os-specific/linux/broadcom-sta/i686-build-failure.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/i686-build-failure.patch
@@ -1,5 +1,5 @@
-https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=fe47ae6e1a5005b2e82f7eab57b5c3820453293a
-https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=4ea1636b04dbd66536fa387bae2eea463efc705b
+https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=fe47ae6e1a5005b2e82f7eab57b5c3820453293a
+https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=4ea1636b04dbd66536fa387bae2eea463efc705b
 
 diff -ru a/src/shared/linux_osl.c b/src/shared/linux_osl.c
 --- a/src/shared/linux_osl.c	2015-09-19 01:47:15.000000000 +0300

--- a/pkgs/os-specific/linux/broadcom-sta/linux-4.7.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-4.7.patch
@@ -2,12 +2,12 @@ Since Linux 4.7, the enum ieee80211_band is no longer used
 
 This shall cause no problem's since both enums ieee80211_band
 and nl80211_band were added in the same commit:
-https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=13ae75b103e07304a34ab40c9136e9f53e06475c
+https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=13ae75b103e07304a34ab40c9136e9f53e06475c
 
 This patch refactors the references of IEEE80211_BAND_* to NL80211_BAND_*
 
 Reference:
-https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=57fbcce37be7c1d2622b56587c10ade00e96afa3
+https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=57fbcce37be7c1d2622b56587c10ade00e96afa3
 
 --- a/src/wl/sys/wl_cfg80211_hybrid.c	2016-06-13 11:57:36.159340297 -0500
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c	2016-06-13 11:58:18.442323435 -0500

--- a/pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/4.11.patch
+++ b/pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/4.11.patch
@@ -428,7 +428,7 @@ index 000000000000..1ed7032d4472
 +solution, and details the disagreements and arguments.  The latest
 +version of this document can be found at the following URL.
 +
-+ https://git.kernel.org/cgit/linux/kernel/git/tj/cgroup.git/tree/Documentation/cgroup-v2-cpu.txt?h=cgroup-v2-cpu
++ https://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git/tree/Documentation/cgroup-v2-cpu.txt?h=cgroup-v2-cpu
 +
 +This document was posted to the linux-kernel and cgroup mailing lists.
 +Unfortunately, no consensus was reached as of Oct, 2016.  The thread
@@ -759,7 +759,7 @@ index 000000000000..1ed7032d4472
 +     Re: [PATCHSET RFC cgroup/for-4.6] cgroup, sched: implement resource group and PRIO_RGRP
 +     Peter Zijlstra <peterz@infradead.org>
 +
-+[5]  https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/cgroup-v2.txt
++[5]  https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/cgroup-v2.txt
 +     Control Group v2
 +     Tejun Heo <tj@kernel.org>
 +

--- a/pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/4.9.patch
+++ b/pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/4.9.patch
@@ -428,7 +428,7 @@ index 000000000000..1ed7032d4472
 +solution, and details the disagreements and arguments.  The latest
 +version of this document can be found at the following URL.
 +
-+ https://git.kernel.org/cgit/linux/kernel/git/tj/cgroup.git/tree/Documentation/cgroup-v2-cpu.txt?h=cgroup-v2-cpu
++ https://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git/tree/Documentation/cgroup-v2-cpu.txt?h=cgroup-v2-cpu
 +
 +This document was posted to the linux-kernel and cgroup mailing lists.
 +Unfortunately, no consensus was reached as of Oct, 2016.  The thread
@@ -759,7 +759,7 @@ index 000000000000..1ed7032d4472
 +     Re: [PATCHSET RFC cgroup/for-4.6] cgroup, sched: implement resource group and PRIO_RGRP
 +     Peter Zijlstra <peterz@infradead.org>
 +
-+[5]  https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/cgroup-v2.txt
++[5]  https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/cgroup-v2.txt
 +     Control Group v2
 +     Tejun Heo <tj@kernel.org>
 +

--- a/pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+++ b/pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
@@ -18,4 +18,4 @@ $ ver=4.7
 $ git log --reverse --patch v$ver..remotes/tc-cgroup/cgroup-v2-cpu-v$ver > ../nixpkgs/pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/$ver.patch
 ```
 
-[1]: https://git.kernel.org/cgit/linux/kernel/git/tj/cgroup.git/tree/Documentation/cgroup-v2-cpu.txt?h=cgroup-v2-cpu
+[1]: https://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git/tree/Documentation/cgroup-v2-cpu.txt?h=cgroup-v2-cpu

--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = [ ./f2fs-tools-cross-fix.patch ];
 
   meta = with lib; {
-    homepage = "http://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git/";
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/";
     description = "Userland tools for the f2fs filesystem";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/tools/security/efitools/default.nix
+++ b/pkgs/tools/security/efitools/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Tools for manipulating UEFI secure boot platforms";
-    homepage = "https://git.kernel.org/cgit/linux/kernel/git/jejb/efitools.git";
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git";
     license = licenses.gpl2;
     maintainers = [ maintainers.grahamc ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
These are now redirects, and no longer git clone-able despite looking
like git repo URLs.  I've updated them to the new locations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
