### PR TITLE
lispPackages: update to Quicklisp 2022-02-20

### DIFF
--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -8,7 +8,7 @@ let lispPackages = rec {
 
   quicklisp = buildLispPackage rec {
     baseName = "quicklisp";
-    version = "2021-02-13";
+    version = "2022-02-20";
 
     buildSystems = [];
 
@@ -25,8 +25,8 @@ let lispPackages = rec {
       quicklispdist = pkgs.fetchurl {
         # Will usually be replaced with a fresh version anyway, but needs to be
         # a valid distinfo.txt
-        url = "http://beta.quicklisp.org/dist/quicklisp/2021-12-09/distinfo.txt";
-        sha256 = "sha256:0gc4cv73nl7xkfwvmkmfhfx6yqf876nfm2v24v6fky9n24sh4y6w";
+        url = "http://beta.quicklisp.org/dist/quicklisp/2022-02-20/distinfo.txt";
+        sha256 = "sha256:07gq5kgsss2s9wdqn9z4krhs4kaf1gp9xnk4zd8csk5p7zmcd2dd";
       };
       buildPhase = "true; ";
       postInstall = ''

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
@@ -2,15 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "alexandria";
-  version = "20211209-git";
+  version = "20220220-git";
+
+  parasites = [ "alexandria/tests" ];
 
   description = "Alexandria is a collection of portable public domain utilities.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/alexandria/2021-12-09/alexandria-20211209-git.tgz";
-    sha256 = "13xyajg5n3ad3x2hrmzni1w87b0wc41wn7manbvc3dc5n55afxk0";
+    url = "http://beta.quicklisp.org/archive/alexandria/2022-02-20/alexandria-20220220-git.tgz";
+    sha256 = "1i2hw3v97xy8x4v6bd2md6ydyk1x6lh4hv3lqm5y861v0q182mlj";
   };
 
   packageName = "alexandria";
@@ -20,8 +22,8 @@ rec {
 }
 /* (SYSTEM alexandria DESCRIPTION
     Alexandria is a collection of portable public domain utilities. SHA256
-    13xyajg5n3ad3x2hrmzni1w87b0wc41wn7manbvc3dc5n55afxk0 URL
-    http://beta.quicklisp.org/archive/alexandria/2021-12-09/alexandria-20211209-git.tgz
-    MD5 4f578a956567ea0d6c99c2babd1752f3 NAME alexandria FILENAME alexandria
-    DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS (alexandria-tests)
-    PARASITES NIL) */
+    1i2hw3v97xy8x4v6bd2md6ydyk1x6lh4hv3lqm5y861v0q182mlj URL
+    http://beta.quicklisp.org/archive/alexandria/2022-02-20/alexandria-20220220-git.tgz
+    MD5 33d42a3f39fa9487215d768a65f6c254 NAME alexandria FILENAME alexandria
+    DEPS NIL DEPENDENCIES NIL VERSION 20220220-git SIBLINGS NIL PARASITES
+    (alexandria/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "anaphora";
-  version = "20211209-git";
+  version = "20220220-git";
 
   parasites = [ "anaphora/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/anaphora/2021-12-09/anaphora-20211209-git.tgz";
-    sha256 = "1pi166qwf3zwswhgq8c4r84rl5d6lnn0rkb3cdf5afyxmminsadg";
+    url = "http://beta.quicklisp.org/archive/anaphora/2022-02-20/anaphora-20220220-git.tgz";
+    sha256 = "0jjf46m2jab7qnkw2s9hn91lvb2d1a9h4z78d34z68zklag4y4gp";
   };
 
   packageName = "anaphora";
@@ -21,8 +21,8 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM anaphora DESCRIPTION The Anaphoric Macro Package from Hell SHA256
-    1pi166qwf3zwswhgq8c4r84rl5d6lnn0rkb3cdf5afyxmminsadg URL
-    http://beta.quicklisp.org/archive/anaphora/2021-12-09/anaphora-20211209-git.tgz
-    MD5 81827cd43d29293e967916bb11c4df88 NAME anaphora FILENAME anaphora DEPS
-    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20211209-git SIBLINGS NIL
+    0jjf46m2jab7qnkw2s9hn91lvb2d1a9h4z78d34z68zklag4y4gp URL
+    http://beta.quicklisp.org/archive/anaphora/2022-02-20/anaphora-20220220-git.tgz
+    MD5 f773589c518c8fd4d1be7baf2ff757a3 NAME anaphora FILENAME anaphora DEPS
+    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20220220-git SIBLINGS NIL
     PARASITES (anaphora/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/arnesi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/arnesi.nix
@@ -4,11 +4,11 @@ rec {
   baseName = "arnesi";
   version = "20170403-git";
 
-  parasites = [ "arnesi/cl-ppcre-extras" "arnesi/slime-extras" ];
+  parasites = [ "arnesi/cl-ppcre-extras" ];
 
   description = "A bag-of-tools utilities library used to aid in implementing the bese.it toolkit";
 
-  deps = [ args."alexandria" args."cl-ppcre" args."closer-mop" args."collectors" args."iterate" args."swank" args."symbol-munger" ];
+  deps = [ args."alexandria" args."cl-ppcre" args."closer-mop" args."collectors" args."iterate" args."symbol-munger" ];
 
   src = fetchurl {
     url = "http://beta.quicklisp.org/archive/arnesi/2017-04-03/arnesi-20170403-git.tgz";
@@ -28,8 +28,7 @@ rec {
     ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME closer-mop FILENAME closer-mop)
      (NAME collectors FILENAME collectors) (NAME iterate FILENAME iterate)
-     (NAME swank FILENAME swank) (NAME symbol-munger FILENAME symbol-munger))
+     (NAME symbol-munger FILENAME symbol-munger))
     DEPENDENCIES
-    (alexandria cl-ppcre closer-mop collectors iterate swank symbol-munger)
-    VERSION 20170403-git SIBLINGS NIL PARASITES
-    (arnesi/cl-ppcre-extras arnesi/slime-extras)) */
+    (alexandria cl-ppcre closer-mop collectors iterate symbol-munger) VERSION
+    20170403-git SIBLINGS NIL PARASITES (arnesi/cl-ppcre-extras)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/array-operations.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/array-operations.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "array-operations";
-  version = "20210411-git";
+  version = "20220220-git";
 
   parasites = [ "array-operations/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."anaphora" args."clunit2" args."let-plus" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/array-operations/2021-04-11/array-operations-20210411-git.tgz";
-    sha256 = "0l6wxd3a1xdcmcsc93prq8ymainfsy15imiwnaik1i9g94fcbjz8";
+    url = "http://beta.quicklisp.org/archive/array-operations/2022-02-20/array-operations-20220220-git.tgz";
+    sha256 = "0c326nl5hssx9ffh1wi0xqk9ii68djzfaw6vr9npygx4da9lssrl";
   };
 
   packageName = "array-operations";
@@ -22,11 +22,11 @@ rec {
 }
 /* (SYSTEM array-operations DESCRIPTION
     Simple array operations library for Common Lisp. SHA256
-    0l6wxd3a1xdcmcsc93prq8ymainfsy15imiwnaik1i9g94fcbjz8 URL
-    http://beta.quicklisp.org/archive/array-operations/2021-04-11/array-operations-20210411-git.tgz
-    MD5 902c6034c006bc6ca88ef59e7ff2b1aa NAME array-operations FILENAME
+    0c326nl5hssx9ffh1wi0xqk9ii68djzfaw6vr9npygx4da9lssrl URL
+    http://beta.quicklisp.org/archive/array-operations/2022-02-20/array-operations-20220220-git.tgz
+    MD5 9bdd752321c39e98699bc07800b582e7 NAME array-operations FILENAME
     array-operations DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
      (NAME clunit2 FILENAME clunit2) (NAME let-plus FILENAME let-plus))
-    DEPENDENCIES (alexandria anaphora clunit2 let-plus) VERSION 20210411-git
+    DEPENDENCIES (alexandria anaphora clunit2 let-plus) VERSION 20220220-git
     SIBLINGS NIL PARASITES (array-operations/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/chipz.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/chipz.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "chipz";
-  version = "20210807-git";
+  version = "20220220-git";
 
   description = "A library for decompressing deflate, zlib, and gzip data";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/chipz/2021-08-07/chipz-20210807-git.tgz";
-    sha256 = "0g7xhh4yq9azjq7gnszaq2kbxima2q30apb3rrglc1ign973hr8x";
+    url = "http://beta.quicklisp.org/archive/chipz/2022-02-20/chipz-20220220-git.tgz";
+    sha256 = "1j3hraigg0qnxdl7ib2licpzg62sr4a6v6iszwindmxm9icrdn1s";
   };
 
   packageName = "chipz";
@@ -20,7 +20,7 @@ rec {
 }
 /* (SYSTEM chipz DESCRIPTION
     A library for decompressing deflate, zlib, and gzip data SHA256
-    0g7xhh4yq9azjq7gnszaq2kbxima2q30apb3rrglc1ign973hr8x URL
-    http://beta.quicklisp.org/archive/chipz/2021-08-07/chipz-20210807-git.tgz
-    MD5 11438e3bc60c39294c337cb232ae8040 NAME chipz FILENAME chipz DEPS NIL
-    DEPENDENCIES NIL VERSION 20210807-git SIBLINGS NIL PARASITES NIL) */
+    1j3hraigg0qnxdl7ib2licpzg62sr4a6v6iszwindmxm9icrdn1s URL
+    http://beta.quicklisp.org/archive/chipz/2022-02-20/chipz-20220220-git.tgz
+    MD5 b14d05a5a12c3e5cf4bf50e98c679fd7 NAME chipz FILENAME chipz DEPS NIL
+    DEPENDENCIES NIL VERSION 20220220-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fad.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-fad";
-  version = "20210124-git";
+  version = "20220220-git";
 
-  parasites = [ "cl-fad-test" ];
+  parasites = [ "cl-fad/test" ];
 
   description = "Portable pathname library";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-ppcre" args."unit-test" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-fad/2021-01-24/cl-fad-20210124-git.tgz";
-    sha256 = "17vkvkwg4wpyny5x2nsazgpip5nxxahsjngaxjyrj5z15d4lkrm0";
+    url = "http://beta.quicklisp.org/archive/cl-fad/2022-02-20/cl-fad-20220220-git.tgz";
+    sha256 = "09229w4rr2lg4y8244w5170i1znmc2svbn6n8s39ndhdnw0akyli";
   };
 
   packageName = "cl-fad";
@@ -21,11 +21,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-fad DESCRIPTION Portable pathname library SHA256
-    17vkvkwg4wpyny5x2nsazgpip5nxxahsjngaxjyrj5z15d4lkrm0 URL
-    http://beta.quicklisp.org/archive/cl-fad/2021-01-24/cl-fad-20210124-git.tgz
-    MD5 aa8705a0dd8ca1b43d8c76a177efdf74 NAME cl-fad FILENAME cl-fad DEPS
+    09229w4rr2lg4y8244w5170i1znmc2svbn6n8s39ndhdnw0akyli URL
+    http://beta.quicklisp.org/archive/cl-fad/2022-02-20/cl-fad-20220220-git.tgz
+    MD5 5caa98f5badf1d84ae385a3937ee2e01 NAME cl-fad FILENAME cl-fad DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-ppcre FILENAME cl-ppcre) (NAME unit-test FILENAME unit-test))
     DEPENDENCIES (alexandria bordeaux-threads cl-ppcre unit-test) VERSION
-    20210124-git SIBLINGS NIL PARASITES (cl-fad-test)) */
+    20220220-git SIBLINGS NIL PARASITES (cl-fad/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-form-types.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-form-types.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-form-types";
-  version = "20211209-git";
+  version = "20211230-git";
 
   parasites = [ "cl-form-types/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."closer-mop" args."collectors" args."fiveam" args."introspect-environment" args."iterate" args."optima" args."parse-declarations-1_dot_0" args."symbol-munger" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-form-types/2021-12-09/cl-form-types-20211209-git.tgz";
-    sha256 = "1w1918a9rjw9dp5qpwq3mf0p4yyd2xladnd6sz4zk645y7wxd08i";
+    url = "http://beta.quicklisp.org/archive/cl-form-types/2021-12-30/cl-form-types-20211230-git.tgz";
+    sha256 = "1valmc2mph4yi432l39i0d72bl7m34igvfrv0z83pgnl6yg78zrr";
   };
 
   packageName = "cl-form-types";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM cl-form-types DESCRIPTION
     Library for determining types of Common Lisp forms. SHA256
-    1w1918a9rjw9dp5qpwq3mf0p4yyd2xladnd6sz4zk645y7wxd08i URL
-    http://beta.quicklisp.org/archive/cl-form-types/2021-12-09/cl-form-types-20211209-git.tgz
-    MD5 2c128061c2e8a97b70fbf8939708d53e NAME cl-form-types FILENAME
+    1valmc2mph4yi432l39i0d72bl7m34igvfrv0z83pgnl6yg78zrr URL
+    http://beta.quicklisp.org/archive/cl-form-types/2021-12-30/cl-form-types-20211230-git.tgz
+    MD5 5516b165131493e7ee85de0bed38a921 NAME cl-form-types FILENAME
     cl-form-types DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -39,4 +39,4 @@ rec {
     (agutil alexandria anaphora arrows cl-environments closer-mop collectors
      fiveam introspect-environment iterate optima parse-declarations-1.0
      symbol-munger)
-    VERSION 20211209-git SIBLINGS NIL PARASITES (cl-form-types/test)) */
+    VERSION 20211230-git SIBLINGS NIL PARASITES (cl-form-types/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-isaac.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-isaac.nix
@@ -1,0 +1,26 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "cl-isaac";
+  version = "20150804-git";
+
+  description = "Optimized Common Lisp version of Bob Jenkins' ISAAC-32 and ISAAC-64 algorithms, fast cryptographic random number generators.";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cl-isaac/2015-08-04/cl-isaac-20150804-git.tgz";
+    sha256 = "0z5h5v3q1xi83cvyi1a6v2dr0yfx5cmj1l9lzcsxv5szf58zwkya";
+  };
+
+  packageName = "cl-isaac";
+
+  asdFilesToKeep = ["cl-isaac.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-isaac DESCRIPTION
+    Optimized Common Lisp version of Bob Jenkins' ISAAC-32 and ISAAC-64 algorithms, fast cryptographic random number generators.
+    SHA256 0z5h5v3q1xi83cvyi1a6v2dr0yfx5cmj1l9lzcsxv5szf58zwkya URL
+    http://beta.quicklisp.org/archive/cl-isaac/2015-08-04/cl-isaac-20150804-git.tgz
+    MD5 03beb7c110fa638fa32c4afcb5a9d604 NAME cl-isaac FILENAME cl-isaac DEPS
+    NIL DEPENDENCIES NIL VERSION 20150804-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-json.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-json.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-json";
-  version = "20141217-git";
+  version = "20220220-git";
 
   parasites = [ "cl-json.test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-json/2014-12-17/cl-json-20141217-git.tgz";
-    sha256 = "00cfppyi6njsbpv1x03jcv4zwplg0q1138174l3wjkvi3gsql17g";
+    url = "http://beta.quicklisp.org/archive/cl-json/2022-02-20/cl-json-20220220-git.tgz";
+    sha256 = "106w8afxyl02hl3zci2wxryrvdapjw3fmjwn6bxwbzl0nnz557k7";
   };
 
   packageName = "cl-json";
@@ -22,8 +22,8 @@ rec {
 }
 /* (SYSTEM cl-json DESCRIPTION
     JSON in Lisp. JSON (JavaScript Object Notation) is a lightweight data-interchange format.
-    SHA256 00cfppyi6njsbpv1x03jcv4zwplg0q1138174l3wjkvi3gsql17g URL
-    http://beta.quicklisp.org/archive/cl-json/2014-12-17/cl-json-20141217-git.tgz
-    MD5 9d873fa462b93c76d90642d8e3fb4881 NAME cl-json FILENAME cl-json DEPS
-    ((NAME fiveam FILENAME fiveam)) DEPENDENCIES (fiveam) VERSION 20141217-git
+    SHA256 106w8afxyl02hl3zci2wxryrvdapjw3fmjwn6bxwbzl0nnz557k7 URL
+    http://beta.quicklisp.org/archive/cl-json/2022-02-20/cl-json-20220220-git.tgz
+    MD5 8781f6947923afb0bd7b3ec328b815a3 NAME cl-json FILENAME cl-json DEPS
+    ((NAME fiveam FILENAME fiveam)) DEPENDENCIES (fiveam) VERSION 20220220-git
     SIBLINGS NIL PARASITES (cl-json.test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-pdf";
-  version = "20211020-git";
+  version = "20220220-git";
 
   description = "Common Lisp PDF Generation Library";
 
   deps = [ args."iterate" args."uiop" args."zpb-ttf" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-pdf/2021-10-20/cl-pdf-20211020-git.tgz";
-    sha256 = "0wyh7iv86sqzdn5xj5crrip8iri5a64qzc6cczgbj1gkv65i28bk";
+    url = "http://beta.quicklisp.org/archive/cl-pdf/2022-02-20/cl-pdf-20220220-git.tgz";
+    sha256 = "0a0d3jdvrcjxjwajkfr6iz8xmbk6yri7zcnv5gjnldpn0f4iv1l0";
   };
 
   packageName = "cl-pdf";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-pdf DESCRIPTION Common Lisp PDF Generation Library SHA256
-    0wyh7iv86sqzdn5xj5crrip8iri5a64qzc6cczgbj1gkv65i28bk URL
-    http://beta.quicklisp.org/archive/cl-pdf/2021-10-20/cl-pdf-20211020-git.tgz
-    MD5 c8a9cfd5d65eae217bd55d786d31dca9 NAME cl-pdf FILENAME cl-pdf DEPS
+    0a0d3jdvrcjxjwajkfr6iz8xmbk6yri7zcnv5gjnldpn0f4iv1l0 URL
+    http://beta.quicklisp.org/archive/cl-pdf/2022-02-20/cl-pdf-20220220-git.tgz
+    MD5 e613e178e3a3a879037f441841ca5aa4 NAME cl-pdf FILENAME cl-pdf DEPS
     ((NAME iterate FILENAME iterate) (NAME uiop FILENAME uiop)
      (NAME zpb-ttf FILENAME zpb-ttf))
-    DEPENDENCIES (iterate uiop zpb-ttf) VERSION 20211020-git SIBLINGS
+    DEPENDENCIES (iterate uiop zpb-ttf) VERSION 20220220-git SIBLINGS
     (cl-pdf-parser) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-postgres";
-  version = "postmodern-20211209-git";
+  version = "postmodern-20220220-git";
 
   parasites = [ "cl-postgres/simple-date-tests" "cl-postgres/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-ppcre" args."fiveam" args."ironclad" args."md5" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
-    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz";
+    sha256 = "17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5";
   };
 
   packageName = "cl-postgres";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-postgres DESCRIPTION Low-level client library for PostgreSQL
-    SHA256 1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
-    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME cl-postgres FILENAME cl-postgres
+    SHA256 17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5 URL
+    http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz
+    MD5 d30fbcddd0b858445622f4f04676561e NAME cl-postgres FILENAME cl-postgres
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -37,5 +37,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-base64 cl-ppcre fiveam ironclad md5
      simple-date simple-date/postgres-glue split-sequence uax-15 uiop usocket)
-    VERSION postmodern-20211209-git SIBLINGS (postmodern s-sql simple-date)
+    VERSION postmodern-20220220-git SIBLINGS (postmodern s-sql simple-date)
     PARASITES (cl-postgres/simple-date-tests cl-postgres/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-template.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-template.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-ppcre-template";
-  version = "cl-unification-20200925-git";
+  version = "cl-unification-20211230-git";
 
   description = "A system used to conditionally load the CL-PPCRE Template.
 
@@ -13,8 +13,8 @@ REGULAR-EXPRESSION-TEMPLATE.";
   deps = [ args."cl-ppcre" args."cl-unification" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz";
-    sha256 = "05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais";
+    url = "http://beta.quicklisp.org/archive/cl-unification/2021-12-30/cl-unification-20211230-git.tgz";
+    sha256 = "1gf961ihdmn8k805r5bg4kj802nazz9gxs462isibkxjjc7sjlsl";
   };
 
   packageName = "cl-ppcre-template";
@@ -28,12 +28,12 @@ REGULAR-EXPRESSION-TEMPLATE.";
 This system is not required and it is handled only if CL-PPCRE is
 available.  If it is, then the library provides the
 REGULAR-EXPRESSION-TEMPLATE.
-    SHA256 05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais URL
-    http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz
-    MD5 90588d566c2e12dac3530b65384a87ab NAME cl-ppcre-template FILENAME
+    SHA256 1gf961ihdmn8k805r5bg4kj802nazz9gxs462isibkxjjc7sjlsl URL
+    http://beta.quicklisp.org/archive/cl-unification/2021-12-30/cl-unification-20211230-git.tgz
+    MD5 7be56c62289bb8db07a8caaea4102ac4 NAME cl-ppcre-template FILENAME
     cl-ppcre-template DEPS
     ((NAME cl-ppcre FILENAME cl-ppcre)
      (NAME cl-unification FILENAME cl-unification))
-    DEPENDENCIES (cl-ppcre cl-unification) VERSION cl-unification-20200925-git
+    DEPENDENCIES (cl-ppcre cl-unification) VERSION cl-unification-20211230-git
     SIBLINGS (cl-unification-lib cl-unification-test cl-unification) PARASITES
     NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-unicode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-unicode.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-ppcre-unicode";
-  version = "cl-ppcre-20190521-git";
+  version = "cl-ppcre-20220220-git";
 
-  parasites = [ "cl-ppcre-unicode-test" ];
+  parasites = [ "cl-ppcre-unicode/test" ];
 
   description = "Perl-compatible regular expression library (Unicode)";
 
-  deps = [ args."cl-ppcre" args."cl-ppcre-test" args."cl-unicode" args."flexi-streams" ];
+  deps = [ args."cl-ppcre" args."cl-ppcre_slash_test" args."cl-unicode" args."flexi-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz";
-    sha256 = "0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx";
+    url = "http://beta.quicklisp.org/archive/cl-ppcre/2022-02-20/cl-ppcre-20220220-git.tgz";
+    sha256 = "14s56h7l0w1r65qsh060kijqg6hzkpfma9qxd6h6l6qq0db69vxv";
   };
 
   packageName = "cl-ppcre-unicode";
@@ -22,13 +22,13 @@ rec {
 }
 /* (SYSTEM cl-ppcre-unicode DESCRIPTION
     Perl-compatible regular expression library (Unicode) SHA256
-    0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx URL
-    http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz
-    MD5 a980b75c1b386b49bcb28107991eb4ec NAME cl-ppcre-unicode FILENAME
+    14s56h7l0w1r65qsh060kijqg6hzkpfma9qxd6h6l6qq0db69vxv URL
+    http://beta.quicklisp.org/archive/cl-ppcre/2022-02-20/cl-ppcre-20220220-git.tgz
+    MD5 dfc08fa8887d446fb0d7f243c1b4e757 NAME cl-ppcre-unicode FILENAME
     cl-ppcre-unicode DEPS
     ((NAME cl-ppcre FILENAME cl-ppcre)
-     (NAME cl-ppcre-test FILENAME cl-ppcre-test)
+     (NAME cl-ppcre/test FILENAME cl-ppcre_slash_test)
      (NAME cl-unicode FILENAME cl-unicode)
      (NAME flexi-streams FILENAME flexi-streams))
-    DEPENDENCIES (cl-ppcre cl-ppcre-test cl-unicode flexi-streams) VERSION
-    cl-ppcre-20190521-git SIBLINGS (cl-ppcre) PARASITES (cl-ppcre-unicode-test)) */
+    DEPENDENCIES (cl-ppcre cl-ppcre/test cl-unicode flexi-streams) VERSION
+    cl-ppcre-20220220-git SIBLINGS (cl-ppcre) PARASITES (cl-ppcre-unicode/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-ppcre";
-  version = "20190521-git";
+  version = "20220220-git";
 
-  parasites = [ "cl-ppcre-test" ];
+  parasites = [ "cl-ppcre/test" ];
 
   description = "Perl-compatible regular expression library";
 
   deps = [ args."flexi-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz";
-    sha256 = "0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx";
+    url = "http://beta.quicklisp.org/archive/cl-ppcre/2022-02-20/cl-ppcre-20220220-git.tgz";
+    sha256 = "14s56h7l0w1r65qsh060kijqg6hzkpfma9qxd6h6l6qq0db69vxv";
   };
 
   packageName = "cl-ppcre";
@@ -21,8 +21,8 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-ppcre DESCRIPTION Perl-compatible regular expression library
-    SHA256 0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx URL
-    http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz
-    MD5 a980b75c1b386b49bcb28107991eb4ec NAME cl-ppcre FILENAME cl-ppcre DEPS
+    SHA256 14s56h7l0w1r65qsh060kijqg6hzkpfma9qxd6h6l6qq0db69vxv URL
+    http://beta.quicklisp.org/archive/cl-ppcre/2022-02-20/cl-ppcre-20220220-git.tgz
+    MD5 dfc08fa8887d446fb0d7f243c1b4e757 NAME cl-ppcre FILENAME cl-ppcre DEPS
     ((NAME flexi-streams FILENAME flexi-streams)) DEPENDENCIES (flexi-streams)
-    VERSION 20190521-git SIBLINGS (cl-ppcre-unicode) PARASITES (cl-ppcre-test)) */
+    VERSION 20220220-git SIBLINGS (cl-ppcre-unicode) PARASITES (cl-ppcre/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unification.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unification.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-unification";
-  version = "20200925-git";
+  version = "20211230-git";
 
   description = "The CL-UNIFICATION system.
 
@@ -11,8 +11,8 @@ The system contains the definitions for the 'unification' machinery.";
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz";
-    sha256 = "05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais";
+    url = "http://beta.quicklisp.org/archive/cl-unification/2021-12-30/cl-unification-20211230-git.tgz";
+    sha256 = "1gf961ihdmn8k805r5bg4kj802nazz9gxs462isibkxjjc7sjlsl";
   };
 
   packageName = "cl-unification";
@@ -23,8 +23,8 @@ The system contains the definitions for the 'unification' machinery.";
 /* (SYSTEM cl-unification DESCRIPTION The CL-UNIFICATION system.
 
 The system contains the definitions for the 'unification' machinery.
-    SHA256 05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais URL
-    http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz
-    MD5 90588d566c2e12dac3530b65384a87ab NAME cl-unification FILENAME
-    cl-unification DEPS NIL DEPENDENCIES NIL VERSION 20200925-git SIBLINGS
+    SHA256 1gf961ihdmn8k805r5bg4kj802nazz9gxs462isibkxjjc7sjlsl URL
+    http://beta.quicklisp.org/archive/cl-unification/2021-12-30/cl-unification-20211230-git.tgz
+    MD5 7be56c62289bb8db07a8caaea4102ac4 NAME cl-unification FILENAME
+    cl-unification DEPS NIL DEPENDENCIES NIL VERSION 20211230-git SIBLINGS
     (cl-unification-lib cl-unification-test cl-ppcre-template) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-webkit2";
-  version = "cl-webkit-20211209-git";
+  version = "cl-webkit-20220220-git";
 
   description = "An FFI binding to WebKit2GTK+";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-12-09/cl-webkit-20211209-git.tgz";
-    sha256 = "1lpzp9rb011zbl8j2jpqhal38slyqq1p6cxxjk51h6mdq7x7z1a0";
+    url = "http://beta.quicklisp.org/archive/cl-webkit/2022-02-20/cl-webkit-20220220-git.tgz";
+    sha256 = "0s650lsbf75h4kpbvrny9kw9xr0q5bkihyca0kd3gmj3qgqr3ccz";
   };
 
   packageName = "cl-webkit2";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-webkit2 DESCRIPTION An FFI binding to WebKit2GTK+ SHA256
-    1lpzp9rb011zbl8j2jpqhal38slyqq1p6cxxjk51h6mdq7x7z1a0 URL
-    http://beta.quicklisp.org/archive/cl-webkit/2021-12-09/cl-webkit-20211209-git.tgz
-    MD5 cf710088281b691a91aa29566f50f83a NAME cl-webkit2 FILENAME cl-webkit2
+    0s650lsbf75h4kpbvrny9kw9xr0q5bkihyca0kd3gmj3qgqr3ccz URL
+    http://beta.quicklisp.org/archive/cl-webkit/2022-02-20/cl-webkit-20220220-git.tgz
+    MD5 e95433dc2744393b1ca07a7b3d047bf4 NAME cl-webkit2 FILENAME cl-webkit2
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -41,4 +41,4 @@ rec {
      cl-cffi-gtk-gdk cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
      cl-cffi-gtk-gobject cl-cffi-gtk-pango closer-mop iterate trivial-features
      trivial-garbage)
-    VERSION cl-webkit-20211209-git SIBLINGS NIL PARASITES NIL) */
+    VERSION cl-webkit-20220220-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl_plus_ssl";
-  version = "cl+ssl-20211209-git";
+  version = "cl+ssl-20220220-git";
 
   parasites = [ "cl+ssl/config" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-12-09/cl+ssl-20211209-git.tgz";
-    sha256 = "1m1dx4jfqpd2jdica7safq3fig31xyn96a0yslvszbhkyn22r0nb";
+    url = "http://beta.quicklisp.org/archive/cl+ssl/2022-02-20/cl+ssl-20220220-git.tgz";
+    sha256 = "1105kk87326s2ladpaz4axzfay4lg3nksxh7sxdla2vwj4nh7pmy";
   };
 
   packageName = "cl+ssl";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl+ssl DESCRIPTION Common Lisp interface to OpenSSL. SHA256
-    1m1dx4jfqpd2jdica7safq3fig31xyn96a0yslvszbhkyn22r0nb URL
-    http://beta.quicklisp.org/archive/cl+ssl/2021-12-09/cl+ssl-20211209-git.tgz
-    MD5 900134876fea38710e6535420ec60864 NAME cl+ssl FILENAME cl_plus_ssl DEPS
+    1105kk87326s2ladpaz4axzfay4lg3nksxh7sxdla2vwj4nh7pmy URL
+    http://beta.quicklisp.org/archive/cl+ssl/2022-02-20/cl+ssl-20220220-git.tgz
+    MD5 1b24cc75930e7018419ed6660b7cc537 NAME cl+ssl FILENAME cl_plus_ssl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME flexi-streams FILENAME flexi-streams)
@@ -35,5 +35,5 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi flexi-streams split-sequence
      trivial-features trivial-garbage trivial-gray-streams uiop usocket)
-    VERSION cl+ssl-20211209-git SIBLINGS (cl+ssl.test) PARASITES
+    VERSION cl+ssl-20220220-git SIBLINGS (cl+ssl.test) PARASITES
     (cl+ssl/config)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack-socket";
-  version = "clack-20211209-git";
+  version = "clack-20220220-git";
 
   description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz";
-    sha256 = "1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd";
+    url = "http://beta.quicklisp.org/archive/clack/2022-02-20/clack-20220220-git.tgz";
+    sha256 = "1fk7apnm69hchib0gx1ipmgala53wjgwhfdwafgyl58wikhzsphf";
   };
 
   packageName = "clack-socket";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-socket DESCRIPTION System lacks description SHA256
-    1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd URL
-    http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz
-    MD5 c223a854a79b257e0489e185abe48e16 NAME clack-socket FILENAME
-    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20211209-git SIBLINGS
+    1fk7apnm69hchib0gx1ipmgala53wjgwhfdwafgyl58wikhzsphf URL
+    http://beta.quicklisp.org/archive/clack/2022-02-20/clack-20220220-git.tgz
+    MD5 a74eeeebb582f3b711088254b6e256f5 NAME clack-socket FILENAME
+    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20220220-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-test clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack";
-  version = "20211209-git";
+  version = "20220220-git";
 
   description = "Web application environment for Common Lisp";
 
-  deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."split-sequence" args."uiop" args."usocket" ];
+  deps = [ args."alexandria" args."bordeaux-threads" args."cl-isaac" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."split-sequence" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz";
-    sha256 = "1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd";
+    url = "http://beta.quicklisp.org/archive/clack/2022-02-20/clack-20220220-git.tgz";
+    sha256 = "1fk7apnm69hchib0gx1ipmgala53wjgwhfdwafgyl58wikhzsphf";
   };
 
   packageName = "clack";
@@ -19,21 +19,21 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack DESCRIPTION Web application environment for Common Lisp SHA256
-    1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd URL
-    http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz
-    MD5 c223a854a79b257e0489e185abe48e16 NAME clack FILENAME clack DEPS
+    1fk7apnm69hchib0gx1ipmgala53wjgwhfdwafgyl58wikhzsphf URL
+    http://beta.quicklisp.org/archive/clack/2022-02-20/clack-20220220-git.tgz
+    MD5 a74eeeebb582f3b711088254b6e256f5 NAME clack FILENAME clack DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
-     (NAME ironclad FILENAME ironclad) (NAME lack FILENAME lack)
+     (NAME cl-isaac FILENAME cl-isaac) (NAME lack FILENAME lack)
      (NAME lack-component FILENAME lack-component)
      (NAME lack-middleware-backtrace FILENAME lack-middleware-backtrace)
      (NAME lack-util FILENAME lack-util)
      (NAME split-sequence FILENAME split-sequence) (NAME uiop FILENAME uiop)
      (NAME usocket FILENAME usocket))
     DEPENDENCIES
-    (alexandria bordeaux-threads ironclad lack lack-component
+    (alexandria bordeaux-threads cl-isaac lack lack-component
      lack-middleware-backtrace lack-util split-sequence uiop usocket)
-    VERSION 20211209-git SIBLINGS
+    VERSION 20220220-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-test t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "closer-mop";
-  version = "20211209-git";
+  version = "20220220-git";
 
   description = "Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/closer-mop/2021-12-09/closer-mop-20211209-git.tgz";
-    sha256 = "1zrjsibbph8dz8k0qjawp9c22094rag3aasd4r761m2r482xf5zl";
+    url = "http://beta.quicklisp.org/archive/closer-mop/2022-02-20/closer-mop-20220220-git.tgz";
+    sha256 = "090scah4xj4ca9h8n9mblzkv6452qjby0x5ss9prhixpi3j47wx1";
   };
 
   packageName = "closer-mop";
@@ -20,7 +20,7 @@ rec {
 }
 /* (SYSTEM closer-mop DESCRIPTION
     Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.
-    SHA256 1zrjsibbph8dz8k0qjawp9c22094rag3aasd4r761m2r482xf5zl URL
-    http://beta.quicklisp.org/archive/closer-mop/2021-12-09/closer-mop-20211209-git.tgz
-    MD5 0b2a02f6b6a57b5b707df5e1d51950cd NAME closer-mop FILENAME closer-mop
-    DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS NIL PARASITES NIL) */
+    SHA256 090scah4xj4ca9h8n9mblzkv6452qjby0x5ss9prhixpi3j47wx1 URL
+    http://beta.quicklisp.org/archive/closer-mop/2022-02-20/closer-mop-20220220-git.tgz
+    MD5 51cf41fa1369e7a969d0e6ea05b38355 NAME closer-mop FILENAME closer-mop
+    DEPS NIL DEPENDENCIES NIL VERSION 20220220-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/collectors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/collectors.nix
@@ -2,9 +2,9 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "collectors";
-  version = "20161204-git";
+  version = "20220220-git";
 
-  parasites = [ "collectors-test" ];
+  parasites = [ "collectors/test" ];
 
   description = "A library providing various collector type macros
    pulled from arnesi into its own library and stripped of dependencies";
@@ -12,8 +12,8 @@ rec {
   deps = [ args."alexandria" args."closer-mop" args."iterate" args."lisp-unit2" args."symbol-munger" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/collectors/2016-12-04/collectors-20161204-git.tgz";
-    sha256 = "0cf2y2yxraqs9v54gbj8hhp7s522gz8qfwwc5hvlhl2s7540b2zf";
+    url = "http://beta.quicklisp.org/archive/collectors/2022-02-20/collectors-20220220-git.tgz";
+    sha256 = "04i7f2qmrnan78535a8d0h50lx77h6jjf6ijdjrj0dis9cyb92ny";
   };
 
   packageName = "collectors";
@@ -24,13 +24,13 @@ rec {
 /* (SYSTEM collectors DESCRIPTION
     A library providing various collector type macros
    pulled from arnesi into its own library and stripped of dependencies
-    SHA256 0cf2y2yxraqs9v54gbj8hhp7s522gz8qfwwc5hvlhl2s7540b2zf URL
-    http://beta.quicklisp.org/archive/collectors/2016-12-04/collectors-20161204-git.tgz
-    MD5 59c8c885a8e512d4f09e73d3e0c97b1f NAME collectors FILENAME collectors
+    SHA256 04i7f2qmrnan78535a8d0h50lx77h6jjf6ijdjrj0dis9cyb92ny URL
+    http://beta.quicklisp.org/archive/collectors/2022-02-20/collectors-20220220-git.tgz
+    MD5 429ba50dd0a45e5a6e093a13b2d23d0e NAME collectors FILENAME collectors
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
      (NAME lisp-unit2 FILENAME lisp-unit2)
      (NAME symbol-munger FILENAME symbol-munger))
     DEPENDENCIES (alexandria closer-mop iterate lisp-unit2 symbol-munger)
-    VERSION 20161204-git SIBLINGS NIL PARASITES (collectors-test)) */
+    VERSION 20220220-git SIBLINGS NIL PARASITES (collectors/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/contextl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/contextl.nix
@@ -1,0 +1,28 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "contextl";
+  version = "20211230-git";
+
+  description = "ContextL is a CLOS extension for Context-oriented Programming (COP).";
+
+  deps = [ args."closer-mop" args."lw-compat" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/contextl/2021-12-30/contextl-20211230-git.tgz";
+    sha256 = "1pp7phm5s412a7v9a0f80bq0x96n83v15cx0icxpb40g9kvqfvrd";
+  };
+
+  packageName = "contextl";
+
+  asdFilesToKeep = ["contextl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM contextl DESCRIPTION
+    ContextL is a CLOS extension for Context-oriented Programming (COP). SHA256
+    1pp7phm5s412a7v9a0f80bq0x96n83v15cx0icxpb40g9kvqfvrd URL
+    http://beta.quicklisp.org/archive/contextl/2021-12-30/contextl-20211230-git.tgz
+    MD5 0c7093716e2772f90635bcd3c4d23dc0 NAME contextl FILENAME contextl DEPS
+    ((NAME closer-mop FILENAME closer-mop) (NAME lw-compat FILENAME lw-compat))
+    DEPENDENCIES (closer-mop lw-compat) VERSION 20211230-git SIBLINGS
+    (dynamic-wind) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dexador";
-  version = "20211209-git";
+  version = "20220220-git";
 
   description = "Yet another HTTP client for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-cookie" args."cl-ppcre" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."local-time" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."uiop" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/dexador/2021-12-09/dexador-20211209-git.tgz";
-    sha256 = "0cknpgz9cbqnaa0wafs7nfqlis8cikfxi11gd5r9md8zm0iw3gi7";
+    url = "http://beta.quicklisp.org/archive/dexador/2022-02-20/dexador-20220220-git.tgz";
+    sha256 = "10zpg5s36kc7n93h5409fqz2n6w75flhrd35n2yw8g8p6baxwvmm";
   };
 
   packageName = "dexador";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dexador DESCRIPTION Yet another HTTP client for Common Lisp SHA256
-    0cknpgz9cbqnaa0wafs7nfqlis8cikfxi11gd5r9md8zm0iw3gi7 URL
-    http://beta.quicklisp.org/archive/dexador/2021-12-09/dexador-20211209-git.tgz
-    MD5 211593b3d20b0be78f8c525a9a1f5cfb NAME dexador FILENAME dexador DEPS
+    10zpg5s36kc7n93h5409fqz2n6w75flhrd35n2yw8g8p6baxwvmm URL
+    http://beta.quicklisp.org/archive/dexador/2022-02-20/dexador-20220220-git.tgz
+    MD5 a8eb6c4ada563f23ce889259ebd005cf NAME dexador FILENAME dexador DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -48,4 +48,4 @@ rec {
      flexi-streams local-time proc-parse quri smart-buffer split-sequence
      static-vectors trivial-features trivial-garbage trivial-gray-streams
      trivial-mimes uiop usocket xsubseq)
-    VERSION 20211209-git SIBLINGS (dexador-test) PARASITES NIL) */
+    VERSION 20220220-git SIBLINGS (dexador-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "djula";
-  version = "20211209-git";
+  version = "20220220-git";
 
   description = "An implementation of Django templates for Common Lisp.";
 
   deps = [ args."access" args."alexandria" args."anaphora" args."arnesi" args."babel" args."cl-annot" args."cl-interpol" args."cl-locale" args."cl-ppcre" args."cl-slice" args."cl-syntax" args."cl-syntax-annot" args."cl-unicode" args."closer-mop" args."collectors" args."flexi-streams" args."gettext" args."iterate" args."let-plus" args."local-time" args."named-readtables" args."parser-combinators" args."split-sequence" args."symbol-munger" args."trivial-backtrace" args."trivial-features" args."trivial-gray-streams" args."trivial-types" args."yacc" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/djula/2021-12-09/djula-20211209-git.tgz";
-    sha256 = "0csr3c12wf1qcwwfabgz9rvkramj74l15cwj8c01pmcraly8cya7";
+    url = "http://beta.quicklisp.org/archive/djula/2022-02-20/djula-20220220-git.tgz";
+    sha256 = "0ni5l8c1916ga6zh3l0c0vihh7r0vzncfvm5s4p9vimnvv53ghrl";
   };
 
   packageName = "djula";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM djula DESCRIPTION
     An implementation of Django templates for Common Lisp. SHA256
-    0csr3c12wf1qcwwfabgz9rvkramj74l15cwj8c01pmcraly8cya7 URL
-    http://beta.quicklisp.org/archive/djula/2021-12-09/djula-20211209-git.tgz
-    MD5 f7cb3581b5eb40c8609e90cdf87a2a06 NAME djula FILENAME djula DEPS
+    0ni5l8c1916ga6zh3l0c0vihh7r0vzncfvm5s4p9vimnvv53ghrl URL
+    http://beta.quicklisp.org/archive/djula/2022-02-20/djula-20220220-git.tgz
+    MD5 c18f5f10bb21f476870e6ae06c950c76 NAME djula FILENAME djula DEPS
     ((NAME access FILENAME access) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arnesi FILENAME arnesi)
      (NAME babel FILENAME babel) (NAME cl-annot FILENAME cl-annot)
@@ -51,4 +51,4 @@ rec {
      named-readtables parser-combinators split-sequence symbol-munger
      trivial-backtrace trivial-features trivial-gray-streams trivial-types
      yacc)
-    VERSION 20211209-git SIBLINGS (djula-demo djula-test) PARASITES NIL) */
+    VERSION 20220220-git SIBLINGS (djula-demo djula-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "esrap";
-  version = "20211020-git";
+  version = "20220220-git";
 
   parasites = [ "esrap/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."fiveam" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/esrap/2021-10-20/esrap-20211020-git.tgz";
-    sha256 = "06cqvalqsid82an8c4acbf13y65gw8nb4pckm8gv8fknvh4k1x7h";
+    url = "http://beta.quicklisp.org/archive/esrap/2022-02-20/esrap-20220220-git.tgz";
+    sha256 = "136wly0wfpvl974lh05k5k0xi61xi1p3afd62dqxvjkw64pi29m3";
   };
 
   packageName = "esrap";
@@ -22,11 +22,11 @@ rec {
 }
 /* (SYSTEM esrap DESCRIPTION
     A Packrat / Parsing Grammar / TDPL parser for Common Lisp. SHA256
-    06cqvalqsid82an8c4acbf13y65gw8nb4pckm8gv8fknvh4k1x7h URL
-    http://beta.quicklisp.org/archive/esrap/2021-10-20/esrap-20211020-git.tgz
-    MD5 9657755b3fe896c1252dc7fdd22320b7 NAME esrap FILENAME esrap DEPS
+    136wly0wfpvl974lh05k5k0xi61xi1p3afd62dqxvjkw64pi29m3 URL
+    http://beta.quicklisp.org/archive/esrap/2022-02-20/esrap-20220220-git.tgz
+    MD5 da6912f125df3fee0175e7cfd6a9ed8d NAME esrap FILENAME esrap DEPS
     ((NAME alexandria FILENAME alexandria) (NAME fiveam FILENAME fiveam)
      (NAME trivial-with-current-source-form FILENAME
       trivial-with-current-source-form))
     DEPENDENCIES (alexandria fiveam trivial-with-current-source-form) VERSION
-    20211020-git SIBLINGS NIL PARASITES (esrap/tests)) */
+    20220220-git SIBLINGS NIL PARASITES (esrap/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiveam.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiveam.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "fiveam";
-  version = "20211209-git";
+  version = "20220220-git";
 
   parasites = [ "fiveam/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."net_dot_didierverna_dot_asdf-flv" args."trivial-backtrace" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/fiveam/2021-12-09/fiveam-20211209-git.tgz";
-    sha256 = "0kyyr2dlgpzkn2cw9i4fwyip1d1la4cbv8l4b8jz31f5c1p76ab7";
+    url = "http://beta.quicklisp.org/archive/fiveam/2022-02-20/fiveam-20220220-git.tgz";
+    sha256 = "0saj55a1kj1dg11f2fgc7dlq8pm40rx8kbsvbn6q4705l1f3an34";
   };
 
   packageName = "fiveam";
@@ -21,11 +21,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM fiveam DESCRIPTION A simple regression testing framework SHA256
-    0kyyr2dlgpzkn2cw9i4fwyip1d1la4cbv8l4b8jz31f5c1p76ab7 URL
-    http://beta.quicklisp.org/archive/fiveam/2021-12-09/fiveam-20211209-git.tgz
-    MD5 10d6a5a19f47ed94cbd9edf1d4c20933 NAME fiveam FILENAME fiveam DEPS
+    0saj55a1kj1dg11f2fgc7dlq8pm40rx8kbsvbn6q4705l1f3an34 URL
+    http://beta.quicklisp.org/archive/fiveam/2022-02-20/fiveam-20220220-git.tgz
+    MD5 9de18cdc08bc1104e46af99f05697e16 NAME fiveam FILENAME fiveam DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME net.didierverna.asdf-flv FILENAME net_dot_didierverna_dot_asdf-flv)
      (NAME trivial-backtrace FILENAME trivial-backtrace))
     DEPENDENCIES (alexandria net.didierverna.asdf-flv trivial-backtrace)
-    VERSION 20211209-git SIBLINGS NIL PARASITES (fiveam/test)) */
+    VERSION 20220220-git SIBLINGS NIL PARASITES (fiveam/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/flexi-streams.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/flexi-streams.nix
@@ -2,17 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "flexi-streams";
-  version = "20210807-git";
-
-  parasites = [ "flexi-streams-test" ];
+  version = "20220220-git";
 
   description = "Flexible bivalent streams for Common Lisp";
 
   deps = [ args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/flexi-streams/2021-08-07/flexi-streams-20210807-git.tgz";
-    sha256 = "1g2cvz0bjigr6lw3gigdwcm1x1w0pcyr3ainnix9wyp1kxc2n2rw";
+    url = "http://beta.quicklisp.org/archive/flexi-streams/2022-02-20/flexi-streams-20220220-git.tgz";
+    sha256 = "01p7rzldys6nll0mdn33y0036nn490xing1nnl795y42slz58yd1";
   };
 
   packageName = "flexi-streams";
@@ -21,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM flexi-streams DESCRIPTION Flexible bivalent streams for Common Lisp
-    SHA256 1g2cvz0bjigr6lw3gigdwcm1x1w0pcyr3ainnix9wyp1kxc2n2rw URL
-    http://beta.quicklisp.org/archive/flexi-streams/2021-08-07/flexi-streams-20210807-git.tgz
-    MD5 6c026daab0766c11f5aee9cc3df3394e NAME flexi-streams FILENAME
+    SHA256 01p7rzldys6nll0mdn33y0036nn490xing1nnl795y42slz58yd1 URL
+    http://beta.quicklisp.org/archive/flexi-streams/2022-02-20/flexi-streams-20220220-git.tgz
+    MD5 eb1f06b71bb83512d730bb47225a45cb NAME flexi-streams FILENAME
     flexi-streams DEPS
     ((NAME trivial-gray-streams FILENAME trivial-gray-streams)) DEPENDENCIES
-    (trivial-gray-streams) VERSION 20210807-git SIBLINGS NIL PARASITES
-    (flexi-streams-test)) */
+    (trivial-gray-streams) VERSION 20220220-git SIBLINGS (flexi-streams-test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_asdf.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hu_dot_dwim_dot_asdf";
-  version = "20200925-darcs";
+  version = "stable-git";
 
   description = "Various ASDF extensions such as attached test and documentation system, explicit development support, etc.";
 
   deps = [ args."asdf" args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.asdf/2020-09-25/hu.dwim.asdf-20200925-darcs.tgz";
-    sha256 = "1812gk65x8yy8s817zhzga52zvdlagws4sw6a8f6zk7yaaa6br8h";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.asdf/2021-12-30/hu.dwim.asdf-stable-git.tgz";
+    sha256 = "0na57b7qdy2i05s2ycq1gffxn98havsw9ia1nsr99fw7jngg1skv";
   };
 
   packageName = "hu.dwim.asdf";
@@ -20,10 +20,10 @@ rec {
 }
 /* (SYSTEM hu.dwim.asdf DESCRIPTION
     Various ASDF extensions such as attached test and documentation system, explicit development support, etc.
-    SHA256 1812gk65x8yy8s817zhzga52zvdlagws4sw6a8f6zk7yaaa6br8h URL
-    http://beta.quicklisp.org/archive/hu.dwim.asdf/2020-09-25/hu.dwim.asdf-20200925-darcs.tgz
-    MD5 feec747077117dd9850db77ed1919c21 NAME hu.dwim.asdf FILENAME
+    SHA256 0na57b7qdy2i05s2ycq1gffxn98havsw9ia1nsr99fw7jngg1skv URL
+    http://beta.quicklisp.org/archive/hu.dwim.asdf/2021-12-30/hu.dwim.asdf-stable-git.tgz
+    MD5 20251cb11ed1d151dc7194a010e196a9 NAME hu.dwim.asdf FILENAME
     hu_dot_dwim_dot_asdf DEPS
     ((NAME asdf FILENAME asdf) (NAME uiop FILENAME uiop)) DEPENDENCIES
-    (asdf uiop) VERSION 20200925-darcs SIBLINGS (hu.dwim.asdf.documentation)
+    (asdf uiop) VERSION stable-git SIBLINGS (hu.dwim.asdf.documentation)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def.nix
@@ -2,15 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hu_dot_dwim_dot_def";
-  version = "20201016-darcs";
+  version = "stable-git";
+
+  parasites = [ "hu.dwim.def/namespace" ];
 
   description = "General purpose, homogenous, extensible definer macro.";
 
-  deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."iterate" args."metabang-bind" ];
+  deps = [ args."alexandria" args."anaphora" args."bordeaux-threads" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_util" args."iterate" args."metabang-bind" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz";
-    sha256 = "0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz";
+    sha256 = "1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz";
   };
 
   packageName = "hu.dwim.def";
@@ -20,17 +22,21 @@ rec {
 }
 /* (SYSTEM hu.dwim.def DESCRIPTION
     General purpose, homogenous, extensible definer macro. SHA256
-    0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj URL
-    http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz
-    MD5 c4d7469472f57cd700d8319e35dd5f32 NAME hu.dwim.def FILENAME
+    1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz URL
+    http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz
+    MD5 701fd28dce4536e91607fe5d2e1e8164 NAME hu.dwim.def FILENAME
     hu_dot_dwim_dot_def DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.util FILENAME hu_dot_dwim_dot_util)
      (NAME iterate FILENAME iterate)
-     (NAME metabang-bind FILENAME metabang-bind))
-    DEPENDENCIES (alexandria anaphora hu.dwim.asdf iterate metabang-bind)
-    VERSION 20201016-darcs SIBLINGS
+     (NAME metabang-bind FILENAME metabang-bind)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria anaphora bordeaux-threads hu.dwim.asdf hu.dwim.util iterate
+     metabang-bind trivial-garbage)
+    VERSION stable-git SIBLINGS
     (hu.dwim.def+cl-l10n hu.dwim.def+contextl hu.dwim.def+hu.dwim.common
-     hu.dwim.def+hu.dwim.delico hu.dwim.def+swank hu.dwim.def.documentation
-     hu.dwim.def.namespace hu.dwim.def.test)
-    PARASITES NIL) */
+     hu.dwim.def+hu.dwim.delico hu.dwim.def+swank)
+    PARASITES (hu.dwim.def/namespace)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_contextl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_contextl.nix
@@ -1,0 +1,38 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_def_plus_contextl";
+  version = "hu.dwim.def-stable-git";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."anaphora" args."closer-mop" args."contextl" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."iterate" args."lw-compat" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz";
+    sha256 = "1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz";
+  };
+
+  packageName = "hu.dwim.def+contextl";
+
+  asdFilesToKeep = ["hu.dwim.def+contextl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.def+contextl DESCRIPTION System lacks description SHA256
+    1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz URL
+    http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz
+    MD5 701fd28dce4536e91607fe5d2e1e8164 NAME hu.dwim.def+contextl FILENAME
+    hu_dot_dwim_dot_def_plus_contextl DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME closer-mop FILENAME closer-mop) (NAME contextl FILENAME contextl)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME iterate FILENAME iterate) (NAME lw-compat FILENAME lw-compat)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES
+    (alexandria anaphora closer-mop contextl hu.dwim.asdf hu.dwim.def iterate
+     lw-compat metabang-bind)
+    VERSION hu.dwim.def-stable-git SIBLINGS
+    (hu.dwim.def+cl-l10n hu.dwim.def+hu.dwim.common hu.dwim.def+hu.dwim.delico
+     hu.dwim.def+swank hu.dwim.def)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common.nix
@@ -1,0 +1,40 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common";
+  version = "hu.dwim.def-stable-git";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."anaphora" args."closer-mop" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_common-lisp" args."hu_dot_dwim_dot_def" args."iterate" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz";
+    sha256 = "1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz";
+  };
+
+  packageName = "hu.dwim.def+hu.dwim.common";
+
+  asdFilesToKeep = ["hu.dwim.def+hu.dwim.common.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.def+hu.dwim.common DESCRIPTION System lacks description
+    SHA256 1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz URL
+    http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz
+    MD5 701fd28dce4536e91607fe5d2e1e8164 NAME hu.dwim.def+hu.dwim.common
+    FILENAME hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)
+     (NAME hu.dwim.common-lisp FILENAME hu_dot_dwim_dot_common-lisp)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES
+    (alexandria anaphora closer-mop hu.dwim.asdf hu.dwim.common
+     hu.dwim.common-lisp hu.dwim.def iterate metabang-bind)
+    VERSION hu.dwim.def-stable-git SIBLINGS
+    (hu.dwim.def+cl-l10n hu.dwim.def+contextl hu.dwim.def+hu.dwim.delico
+     hu.dwim.def+swank hu.dwim.def)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_swank.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hu_dot_dwim_dot_def_plus_swank";
-  version = "hu.dwim.def-20201016-darcs";
+  version = "hu.dwim.def-stable-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."iterate" args."metabang-bind" args."swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz";
-    sha256 = "0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz";
+    sha256 = "1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz";
   };
 
   packageName = "hu.dwim.def+swank";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM hu.dwim.def+swank DESCRIPTION System lacks description SHA256
-    0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj URL
-    http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz
-    MD5 c4d7469472f57cd700d8319e35dd5f32 NAME hu.dwim.def+swank FILENAME
+    1jmm9g2zacx3c6pd9v5ff1x5fzp9srz5844x0qpxj3bz9jfk2sgz URL
+    http://beta.quicklisp.org/archive/hu.dwim.def/2021-12-30/hu.dwim.def-stable-git.tgz
+    MD5 701fd28dce4536e91607fe5d2e1e8164 NAME hu.dwim.def+swank FILENAME
     hu_dot_dwim_dot_def_plus_swank DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
      (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
@@ -30,8 +30,7 @@ rec {
      (NAME metabang-bind FILENAME metabang-bind) (NAME swank FILENAME swank))
     DEPENDENCIES
     (alexandria anaphora hu.dwim.asdf hu.dwim.def iterate metabang-bind swank)
-    VERSION hu.dwim.def-20201016-darcs SIBLINGS
+    VERSION hu.dwim.def-stable-git SIBLINGS
     (hu.dwim.def+cl-l10n hu.dwim.def+contextl hu.dwim.def+hu.dwim.common
-     hu.dwim.def+hu.dwim.delico hu.dwim.def hu.dwim.def.documentation
-     hu.dwim.def.namespace hu.dwim.def.test)
+     hu.dwim.def+hu.dwim.delico hu.dwim.def)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
@@ -11,8 +11,8 @@ rec {
   deps = [ args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-09/hu.dwim.defclass-star-stable-git.tgz";
-    sha256 = "0draahmhi5mmrj9aqabqdaipqcb9adxqdypjbdiawg55dw36g0cy";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz";
+    sha256 = "13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj";
   };
 
   packageName = "hu.dwim.defclass-star";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM hu.dwim.defclass-star DESCRIPTION
     Simplify class like definitions with defclass* and friends. SHA256
-    0draahmhi5mmrj9aqabqdaipqcb9adxqdypjbdiawg55dw36g0cy URL
-    http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-09/hu.dwim.defclass-star-stable-git.tgz
-    MD5 e35fa9767089eb2fb03befaec18d5081 NAME hu.dwim.defclass-star FILENAME
+    13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj URL
+    http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz
+    MD5 4ea430dc53b6fdca3de78bb18ec04d31 NAME hu.dwim.defclass-star FILENAME
     hu_dot_dwim_dot_defclass-star DEPS
     ((NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
      (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_contextl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_contextl.nix
@@ -1,0 +1,36 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_defclass-star_plus_contextl";
+  version = "hu.dwim.defclass-star-stable-git";
+
+  description = "System lacks description";
+
+  deps = [ args."closer-mop" args."contextl" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_defclass-star" args."lw-compat" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz";
+    sha256 = "13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj";
+  };
+
+  packageName = "hu.dwim.defclass-star+contextl";
+
+  asdFilesToKeep = ["hu.dwim.defclass-star+contextl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.defclass-star+contextl DESCRIPTION System lacks description
+    SHA256 13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj URL
+    http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz
+    MD5 4ea430dc53b6fdca3de78bb18ec04d31 NAME hu.dwim.defclass-star+contextl
+    FILENAME hu_dot_dwim_dot_defclass-star_plus_contextl DEPS
+    ((NAME closer-mop FILENAME closer-mop) (NAME contextl FILENAME contextl)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.defclass-star FILENAME hu_dot_dwim_dot_defclass-star)
+     (NAME lw-compat FILENAME lw-compat))
+    DEPENDENCIES
+    (closer-mop contextl hu.dwim.asdf hu.dwim.defclass-star lw-compat) VERSION
+    hu.dwim.defclass-star-stable-git SIBLINGS
+    (hu.dwim.defclass-star+hu.dwim.def+contextl
+     hu.dwim.defclass-star+hu.dwim.def hu.dwim.defclass-star+swank
+     hu.dwim.defclass-star)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def.nix
@@ -1,0 +1,39 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def";
+  version = "hu.dwim.defclass-star-stable-git";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_defclass-star" args."iterate" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz";
+    sha256 = "13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj";
+  };
+
+  packageName = "hu.dwim.defclass-star+hu.dwim.def";
+
+  asdFilesToKeep = ["hu.dwim.defclass-star+hu.dwim.def.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.defclass-star+hu.dwim.def DESCRIPTION
+    System lacks description SHA256
+    13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj URL
+    http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz
+    MD5 4ea430dc53b6fdca3de78bb18ec04d31 NAME hu.dwim.defclass-star+hu.dwim.def
+    FILENAME hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.defclass-star FILENAME hu_dot_dwim_dot_defclass-star)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES
+    (alexandria anaphora hu.dwim.asdf hu.dwim.def hu.dwim.defclass-star iterate
+     metabang-bind)
+    VERSION hu.dwim.defclass-star-stable-git SIBLINGS
+    (hu.dwim.defclass-star+contextl hu.dwim.defclass-star+hu.dwim.def+contextl
+     hu.dwim.defclass-star+swank hu.dwim.defclass-star)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl.nix
@@ -1,0 +1,46 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl";
+  version = "hu.dwim.defclass-star-stable-git";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."anaphora" args."closer-mop" args."contextl" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_defclass-star" args."hu_dot_dwim_dot_defclass-star_plus_contextl" args."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" args."iterate" args."lw-compat" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz";
+    sha256 = "13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj";
+  };
+
+  packageName = "hu.dwim.defclass-star+hu.dwim.def+contextl";
+
+  asdFilesToKeep = ["hu.dwim.defclass-star+hu.dwim.def+contextl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.defclass-star+hu.dwim.def+contextl DESCRIPTION
+    System lacks description SHA256
+    13isdvccyf383p0s5s63a3dh7j7jr7dvl2ywbaprv6c1gpx7fbdj URL
+    http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-30/hu.dwim.defclass-star-stable-git.tgz
+    MD5 4ea430dc53b6fdca3de78bb18ec04d31 NAME
+    hu.dwim.defclass-star+hu.dwim.def+contextl FILENAME
+    hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME closer-mop FILENAME closer-mop) (NAME contextl FILENAME contextl)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.defclass-star FILENAME hu_dot_dwim_dot_defclass-star)
+     (NAME hu.dwim.defclass-star+contextl FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_contextl)
+     (NAME hu.dwim.defclass-star+hu.dwim.def FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def)
+     (NAME iterate FILENAME iterate) (NAME lw-compat FILENAME lw-compat)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES
+    (alexandria anaphora closer-mop contextl hu.dwim.asdf hu.dwim.def
+     hu.dwim.defclass-star hu.dwim.defclass-star+contextl
+     hu.dwim.defclass-star+hu.dwim.def iterate lw-compat metabang-bind)
+    VERSION hu.dwim.defclass-star-stable-git SIBLINGS
+    (hu.dwim.defclass-star+contextl hu.dwim.defclass-star+hu.dwim.def
+     hu.dwim.defclass-star+swank hu.dwim.defclass-star)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_logger.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_logger.nix
@@ -1,0 +1,54 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_logger";
+  version = "stable-git";
+
+  description = "Generic purpose logger utility.";
+
+  deps = [ args."alexandria" args."anaphora" args."bordeaux-threads" args."closer-mop" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_common-lisp" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_def_slash_namespace" args."hu_dot_dwim_dot_defclass-star" args."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_syntax-sugar" args."hu_dot_dwim_dot_util" args."hu_dot_dwim_dot_util_slash_threads" args."iterate" args."local-time" args."metabang-bind" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.logger/2021-12-30/hu.dwim.logger-stable-git.tgz";
+    sha256 = "02dziwaayz1c9544ybp9sxr1ijk4vx6ixgiblnlr3vxn4lpwkjs6";
+  };
+
+  packageName = "hu.dwim.logger";
+
+  asdFilesToKeep = ["hu.dwim.logger.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.logger DESCRIPTION Generic purpose logger utility. SHA256
+    02dziwaayz1c9544ybp9sxr1ijk4vx6ixgiblnlr3vxn4lpwkjs6 URL
+    http://beta.quicklisp.org/archive/hu.dwim.logger/2021-12-30/hu.dwim.logger-stable-git.tgz
+    MD5 8ad8efcd986ced0f2098bd8ab513efc8 NAME hu.dwim.logger FILENAME
+    hu_dot_dwim_dot_logger DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)
+     (NAME hu.dwim.common-lisp FILENAME hu_dot_dwim_dot_common-lisp)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.def+hu.dwim.common FILENAME
+      hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common)
+     (NAME hu.dwim.def/namespace FILENAME hu_dot_dwim_dot_def_slash_namespace)
+     (NAME hu.dwim.defclass-star FILENAME hu_dot_dwim_dot_defclass-star)
+     (NAME hu.dwim.defclass-star+hu.dwim.def FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def)
+     (NAME hu.dwim.syntax-sugar FILENAME hu_dot_dwim_dot_syntax-sugar)
+     (NAME hu.dwim.util FILENAME hu_dot_dwim_dot_util)
+     (NAME hu.dwim.util/threads FILENAME hu_dot_dwim_dot_util_slash_threads)
+     (NAME iterate FILENAME iterate) (NAME local-time FILENAME local-time)
+     (NAME metabang-bind FILENAME metabang-bind)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria anaphora bordeaux-threads closer-mop hu.dwim.asdf
+     hu.dwim.common hu.dwim.common-lisp hu.dwim.def hu.dwim.def+hu.dwim.common
+     hu.dwim.def/namespace hu.dwim.defclass-star
+     hu.dwim.defclass-star+hu.dwim.def hu.dwim.syntax-sugar hu.dwim.util
+     hu.dwim.util/threads iterate local-time metabang-bind trivial-garbage)
+    VERSION stable-git SIBLINGS
+    (hu.dwim.logger+iolib hu.dwim.logger+swank hu.dwim.logger.documentation
+     hu.dwim.logger.test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_partial-eval.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_partial-eval.nix
@@ -1,0 +1,62 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_partial-eval";
+  version = "20171130-darcs";
+
+  description = "Extensible partial evaluator.";
+
+  deps = [ args."alexandria" args."anaphora" args."bordeaux-threads" args."closer-mop" args."contextl" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_common-lisp" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_def_plus_contextl" args."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_defclass-star" args."hu_dot_dwim_dot_defclass-star_plus_contextl" args."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl" args."hu_dot_dwim_dot_logger" args."hu_dot_dwim_dot_syntax-sugar" args."hu_dot_dwim_dot_util" args."hu_dot_dwim_dot_util_slash_source" args."hu_dot_dwim_dot_walker" args."iterate" args."local-time" args."lw-compat" args."metabang-bind" args."swank" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.partial-eval/2017-11-30/hu.dwim.partial-eval-20171130-darcs.tgz";
+    sha256 = "1fw1lgxdif55viqrdqj4p5d936wipflavlk6cs2aj9hssm14nvqh";
+  };
+
+  packageName = "hu.dwim.partial-eval";
+
+  asdFilesToKeep = ["hu.dwim.partial-eval.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.partial-eval DESCRIPTION Extensible partial evaluator.
+    SHA256 1fw1lgxdif55viqrdqj4p5d936wipflavlk6cs2aj9hssm14nvqh URL
+    http://beta.quicklisp.org/archive/hu.dwim.partial-eval/2017-11-30/hu.dwim.partial-eval-20171130-darcs.tgz
+    MD5 78c498a3ba353e0a62e15df49a459078 NAME hu.dwim.partial-eval FILENAME
+    hu_dot_dwim_dot_partial-eval DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME closer-mop FILENAME closer-mop) (NAME contextl FILENAME contextl)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)
+     (NAME hu.dwim.common-lisp FILENAME hu_dot_dwim_dot_common-lisp)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.def+contextl FILENAME hu_dot_dwim_dot_def_plus_contextl)
+     (NAME hu.dwim.def+hu.dwim.common FILENAME
+      hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common)
+     (NAME hu.dwim.defclass-star FILENAME hu_dot_dwim_dot_defclass-star)
+     (NAME hu.dwim.defclass-star+contextl FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_contextl)
+     (NAME hu.dwim.defclass-star+hu.dwim.def FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def)
+     (NAME hu.dwim.defclass-star+hu.dwim.def+contextl FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl)
+     (NAME hu.dwim.logger FILENAME hu_dot_dwim_dot_logger)
+     (NAME hu.dwim.syntax-sugar FILENAME hu_dot_dwim_dot_syntax-sugar)
+     (NAME hu.dwim.util FILENAME hu_dot_dwim_dot_util)
+     (NAME hu.dwim.util/source FILENAME hu_dot_dwim_dot_util_slash_source)
+     (NAME hu.dwim.walker FILENAME hu_dot_dwim_dot_walker)
+     (NAME iterate FILENAME iterate) (NAME local-time FILENAME local-time)
+     (NAME lw-compat FILENAME lw-compat)
+     (NAME metabang-bind FILENAME metabang-bind) (NAME swank FILENAME swank)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria anaphora bordeaux-threads closer-mop contextl hu.dwim.asdf
+     hu.dwim.common hu.dwim.common-lisp hu.dwim.def hu.dwim.def+contextl
+     hu.dwim.def+hu.dwim.common hu.dwim.defclass-star
+     hu.dwim.defclass-star+contextl hu.dwim.defclass-star+hu.dwim.def
+     hu.dwim.defclass-star+hu.dwim.def+contextl hu.dwim.logger
+     hu.dwim.syntax-sugar hu.dwim.util hu.dwim.util/source hu.dwim.walker
+     iterate local-time lw-compat metabang-bind swank trivial-garbage)
+    VERSION 20171130-darcs SIBLINGS
+    (hu.dwim.partial-eval.documentation hu.dwim.partial-eval.test) PARASITES
+    NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hu_dot_dwim_dot_stefil";
-  version = "20200218-darcs";
+  version = "stable-git";
 
   parasites = [ "hu.dwim.stefil/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
-    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz";
+    sha256 = "0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12";
   };
 
   packageName = "hu.dwim.stefil";
@@ -21,11 +21,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM hu.dwim.stefil DESCRIPTION A Simple Test Framework In Lisp. SHA256
-    16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf URL
-    http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz
-    MD5 3e87e0973f8373e342b75b13c802cc53 NAME hu.dwim.stefil FILENAME
+    0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12 URL
+    http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz
+    MD5 5340af8dbdd9035275cbf12861b5b2d4 NAME hu.dwim.stefil FILENAME
     hu_dot_dwim_dot_stefil DEPS ((NAME alexandria FILENAME alexandria))
-    DEPENDENCIES (alexandria) VERSION 20200218-darcs SIBLINGS
+    DEPENDENCIES (alexandria) VERSION stable-git SIBLINGS
     (hu.dwim.stefil+hu.dwim.def+swank hu.dwim.stefil+hu.dwim.def
      hu.dwim.stefil+swank)
     PARASITES (hu.dwim.stefil/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def";
-  version = "hu.dwim.stefil-20200218-darcs";
+  version = "hu.dwim.stefil-stable-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_stefil" args."iterate" args."metabang-bind" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
-    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz";
+    sha256 = "0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12";
   };
 
   packageName = "hu.dwim.stefil+hu.dwim.def";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM hu.dwim.stefil+hu.dwim.def DESCRIPTION System lacks description
-    SHA256 16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf URL
-    http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz
-    MD5 3e87e0973f8373e342b75b13c802cc53 NAME hu.dwim.stefil+hu.dwim.def
+    SHA256 0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12 URL
+    http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz
+    MD5 5340af8dbdd9035275cbf12861b5b2d4 NAME hu.dwim.stefil+hu.dwim.def
     FILENAME hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
      (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
@@ -32,6 +32,6 @@ rec {
     DEPENDENCIES
     (alexandria anaphora hu.dwim.asdf hu.dwim.def hu.dwim.stefil iterate
      metabang-bind)
-    VERSION hu.dwim.stefil-20200218-darcs SIBLINGS
+    VERSION hu.dwim.stefil-stable-git SIBLINGS
     (hu.dwim.stefil+hu.dwim.def+swank hu.dwim.stefil+swank hu.dwim.stefil)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank";
-  version = "hu.dwim.stefil-20200218-darcs";
+  version = "hu.dwim.stefil-stable-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_def_plus_swank" args."hu_dot_dwim_dot_stefil" args."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_stefil_plus_swank" args."iterate" args."metabang-bind" args."swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
-    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz";
+    sha256 = "0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12";
   };
 
   packageName = "hu.dwim.stefil+hu.dwim.def+swank";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM hu.dwim.stefil+hu.dwim.def+swank DESCRIPTION
     System lacks description SHA256
-    16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf URL
-    http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz
-    MD5 3e87e0973f8373e342b75b13c802cc53 NAME hu.dwim.stefil+hu.dwim.def+swank
+    0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12 URL
+    http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz
+    MD5 5340af8dbdd9035275cbf12861b5b2d4 NAME hu.dwim.stefil+hu.dwim.def+swank
     FILENAME hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
      (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
@@ -38,6 +38,6 @@ rec {
     (alexandria anaphora hu.dwim.asdf hu.dwim.def hu.dwim.def+swank
      hu.dwim.stefil hu.dwim.stefil+hu.dwim.def hu.dwim.stefil+swank iterate
      metabang-bind swank)
-    VERSION hu.dwim.stefil-20200218-darcs SIBLINGS
+    VERSION hu.dwim.stefil-stable-git SIBLINGS
     (hu.dwim.stefil+hu.dwim.def hu.dwim.stefil+swank hu.dwim.stefil) PARASITES
     NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_swank.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hu_dot_dwim_dot_stefil_plus_swank";
-  version = "hu.dwim.stefil-20200218-darcs";
+  version = "hu.dwim.stefil-stable-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_stefil" args."swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
-    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz";
+    sha256 = "0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12";
   };
 
   packageName = "hu.dwim.stefil+swank";
@@ -19,16 +19,16 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM hu.dwim.stefil+swank DESCRIPTION System lacks description SHA256
-    16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf URL
-    http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz
-    MD5 3e87e0973f8373e342b75b13c802cc53 NAME hu.dwim.stefil+swank FILENAME
+    0lvrpl08vkqfhj81za9zj8qyqrc1qzg6xk2jwv0hadacsaxjka12 URL
+    http://beta.quicklisp.org/archive/hu.dwim.stefil/2021-12-30/hu.dwim.stefil-stable-git.tgz
+    MD5 5340af8dbdd9035275cbf12861b5b2d4 NAME hu.dwim.stefil+swank FILENAME
     hu_dot_dwim_dot_stefil_plus_swank DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
      (NAME hu.dwim.stefil FILENAME hu_dot_dwim_dot_stefil)
      (NAME swank FILENAME swank))
     DEPENDENCIES (alexandria hu.dwim.asdf hu.dwim.stefil swank) VERSION
-    hu.dwim.stefil-20200218-darcs SIBLINGS
+    hu.dwim.stefil-stable-git SIBLINGS
     (hu.dwim.stefil+hu.dwim.def+swank hu.dwim.stefil+hu.dwim.def
      hu.dwim.stefil)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_syntax-sugar.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_syntax-sugar.nix
@@ -1,0 +1,41 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_syntax-sugar";
+  version = "20161204-darcs";
+
+  parasites = [ "hu.dwim.syntax-sugar/lambda-with-bang-args" ];
+
+  description = "Various syntax extensions.";
+
+  deps = [ args."alexandria" args."anaphora" args."closer-mop" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_common-lisp" args."hu_dot_dwim_dot_walker" args."iterate" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.syntax-sugar/2016-12-04/hu.dwim.syntax-sugar-20161204-darcs.tgz";
+    sha256 = "1ywzqp73aqvb9ah7g8vj2a29rfbdc0mba9amwjvnrgb29yxv7bsk";
+  };
+
+  packageName = "hu.dwim.syntax-sugar";
+
+  asdFilesToKeep = ["hu.dwim.syntax-sugar.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.syntax-sugar DESCRIPTION Various syntax extensions. SHA256
+    1ywzqp73aqvb9ah7g8vj2a29rfbdc0mba9amwjvnrgb29yxv7bsk URL
+    http://beta.quicklisp.org/archive/hu.dwim.syntax-sugar/2016-12-04/hu.dwim.syntax-sugar-20161204-darcs.tgz
+    MD5 c155225d3a2b9a329adfcb705b915a91 NAME hu.dwim.syntax-sugar FILENAME
+    hu_dot_dwim_dot_syntax-sugar DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)
+     (NAME hu.dwim.common-lisp FILENAME hu_dot_dwim_dot_common-lisp)
+     (NAME hu.dwim.walker FILENAME hu_dot_dwim_dot_walker)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES
+    (alexandria anaphora closer-mop hu.dwim.asdf hu.dwim.common
+     hu.dwim.common-lisp hu.dwim.walker iterate metabang-bind)
+    VERSION 20161204-darcs SIBLINGS
+    (hu.dwim.syntax-sugar.documentation hu.dwim.syntax-sugar.test) PARASITES
+    (hu.dwim.syntax-sugar/lambda-with-bang-args)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_util.nix
@@ -1,0 +1,60 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_util";
+  version = "stable-git";
+
+  parasites = [ "hu.dwim.util/authorization" "hu.dwim.util/command-line" "hu.dwim.util/error-handling" "hu.dwim.util/error-handling+swank" "hu.dwim.util/finite-state-machine" "hu.dwim.util/flexml" ];
+
+  description = "Various utilities, this is the most basic system that only introduce a small number of external dependencies.";
+
+  deps = [ args."alexandria" args."anaphora" args."cl-ppcre" args."closer-mop" args."command-line-arguments" args."cxml" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_common-lisp" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_def_slash_namespace" args."hu_dot_dwim_dot_defclass-star" args."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_logger" args."hu_dot_dwim_dot_partial-eval" args."hu_dot_dwim_dot_syntax-sugar" args."hu_dot_dwim_dot_walker" args."iterate" args."metabang-bind" args."swank" args."uiop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.util/2021-12-30/hu.dwim.util-stable-git.tgz";
+    sha256 = "1nm0q9cyhkwy4w0867ayiz4wn98mm6hzl9ifp1a5p8k458d37y2s";
+  };
+
+  packageName = "hu.dwim.util";
+
+  asdFilesToKeep = ["hu.dwim.util.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.util DESCRIPTION
+    Various utilities, this is the most basic system that only introduce a small number of external dependencies.
+    SHA256 1nm0q9cyhkwy4w0867ayiz4wn98mm6hzl9ifp1a5p8k458d37y2s URL
+    http://beta.quicklisp.org/archive/hu.dwim.util/2021-12-30/hu.dwim.util-stable-git.tgz
+    MD5 62ee64d5aa5cfd150f5f471cd976427f NAME hu.dwim.util FILENAME
+    hu_dot_dwim_dot_util DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME cl-ppcre FILENAME cl-ppcre) (NAME closer-mop FILENAME closer-mop)
+     (NAME command-line-arguments FILENAME command-line-arguments)
+     (NAME cxml FILENAME cxml)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)
+     (NAME hu.dwim.common-lisp FILENAME hu_dot_dwim_dot_common-lisp)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.def+hu.dwim.common FILENAME
+      hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common)
+     (NAME hu.dwim.def/namespace FILENAME hu_dot_dwim_dot_def_slash_namespace)
+     (NAME hu.dwim.defclass-star FILENAME hu_dot_dwim_dot_defclass-star)
+     (NAME hu.dwim.defclass-star+hu.dwim.def FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def)
+     (NAME hu.dwim.logger FILENAME hu_dot_dwim_dot_logger)
+     (NAME hu.dwim.partial-eval FILENAME hu_dot_dwim_dot_partial-eval)
+     (NAME hu.dwim.syntax-sugar FILENAME hu_dot_dwim_dot_syntax-sugar)
+     (NAME hu.dwim.walker FILENAME hu_dot_dwim_dot_walker)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind) (NAME swank FILENAME swank)
+     (NAME uiop FILENAME uiop))
+    DEPENDENCIES
+    (alexandria anaphora cl-ppcre closer-mop command-line-arguments cxml
+     hu.dwim.asdf hu.dwim.common hu.dwim.common-lisp hu.dwim.def
+     hu.dwim.def+hu.dwim.common hu.dwim.def/namespace hu.dwim.defclass-star
+     hu.dwim.defclass-star+hu.dwim.def hu.dwim.logger hu.dwim.partial-eval
+     hu.dwim.syntax-sugar hu.dwim.walker iterate metabang-bind swank uiop)
+    VERSION stable-git SIBLINGS
+    (hu.dwim.util+iolib hu.dwim.util.documentation hu.dwim.util.test) PARASITES
+    (hu.dwim.util/authorization hu.dwim.util/command-line
+     hu.dwim.util/error-handling hu.dwim.util/error-handling+swank
+     hu.dwim.util/finite-state-machine hu.dwim.util/flexml)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_walker.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_walker.nix
@@ -1,0 +1,59 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_walker";
+  version = "stable-git";
+
+  parasites = [ "hu.dwim.walker/test" ];
+
+  description = "Common Lisp form walker and unwalker (to and from CLOS instances).";
+
+  deps = [ args."alexandria" args."anaphora" args."closer-mop" args."contextl" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_common-lisp" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_def_plus_contextl" args."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_defclass-star" args."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_stefil_plus_swank" args."hu_dot_dwim_dot_syntax-sugar" args."hu_dot_dwim_dot_util" args."hu_dot_dwim_dot_util_slash_temporary-files" args."iolib_slash_os" args."iterate" args."lw-compat" args."metabang-bind" args."swank" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.walker/2021-02-28/hu.dwim.walker-stable-git.tgz";
+    sha256 = "02dy46dc422531bq2y7rd75c6j0fgidplgkcwyhp0a2dqrisywjz";
+  };
+
+  packageName = "hu.dwim.walker";
+
+  asdFilesToKeep = ["hu.dwim.walker.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.walker DESCRIPTION
+    Common Lisp form walker and unwalker (to and from CLOS instances). SHA256
+    02dy46dc422531bq2y7rd75c6j0fgidplgkcwyhp0a2dqrisywjz URL
+    http://beta.quicklisp.org/archive/hu.dwim.walker/2021-02-28/hu.dwim.walker-stable-git.tgz
+    MD5 27371190d8fd780827efca6e669b8915 NAME hu.dwim.walker FILENAME
+    hu_dot_dwim_dot_walker DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME closer-mop FILENAME closer-mop) (NAME contextl FILENAME contextl)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)
+     (NAME hu.dwim.common-lisp FILENAME hu_dot_dwim_dot_common-lisp)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.def+contextl FILENAME hu_dot_dwim_dot_def_plus_contextl)
+     (NAME hu.dwim.def+hu.dwim.common FILENAME
+      hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common)
+     (NAME hu.dwim.defclass-star FILENAME hu_dot_dwim_dot_defclass-star)
+     (NAME hu.dwim.defclass-star+hu.dwim.def FILENAME
+      hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def)
+     (NAME hu.dwim.stefil+hu.dwim.def FILENAME
+      hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def)
+     (NAME hu.dwim.stefil+swank FILENAME hu_dot_dwim_dot_stefil_plus_swank)
+     (NAME hu.dwim.syntax-sugar FILENAME hu_dot_dwim_dot_syntax-sugar)
+     (NAME hu.dwim.util FILENAME hu_dot_dwim_dot_util)
+     (NAME hu.dwim.util/temporary-files FILENAME
+      hu_dot_dwim_dot_util_slash_temporary-files)
+     (NAME iolib/os FILENAME iolib_slash_os) (NAME iterate FILENAME iterate)
+     (NAME lw-compat FILENAME lw-compat)
+     (NAME metabang-bind FILENAME metabang-bind) (NAME swank FILENAME swank))
+    DEPENDENCIES
+    (alexandria anaphora closer-mop contextl hu.dwim.asdf hu.dwim.common
+     hu.dwim.common-lisp hu.dwim.def hu.dwim.def+contextl
+     hu.dwim.def+hu.dwim.common hu.dwim.defclass-star
+     hu.dwim.defclass-star+hu.dwim.def hu.dwim.stefil+hu.dwim.def
+     hu.dwim.stefil+swank hu.dwim.syntax-sugar hu.dwim.util
+     hu.dwim.util/temporary-files iolib/os iterate lw-compat metabang-bind
+     swank)
+    VERSION stable-git SIBLINGS NIL PARASITES (hu.dwim.walker/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ieee-floats.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ieee-floats.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "ieee-floats";
-  version = "20170830-git";
+  version = "20220220-git";
 
-  parasites = [ "ieee-floats-tests" ];
+  parasites = [ "ieee-floats/tests" ];
 
   description = "Convert floating point values to IEEE 754 binary representation";
 
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/ieee-floats/2017-08-30/ieee-floats-20170830-git.tgz";
-    sha256 = "15c4q4w3cda82vqlpvdfrnah6ms6vxbjf4a0chd10daw72rwayqk";
+    url = "http://beta.quicklisp.org/archive/ieee-floats/2022-02-20/ieee-floats-20220220-git.tgz";
+    sha256 = "0iaigf6961cnwhsfh4hwgshkid57ba4mjjwsdbwh1a0yzmcd7mbd";
   };
 
   packageName = "ieee-floats";
@@ -22,8 +22,8 @@ rec {
 }
 /* (SYSTEM ieee-floats DESCRIPTION
     Convert floating point values to IEEE 754 binary representation SHA256
-    15c4q4w3cda82vqlpvdfrnah6ms6vxbjf4a0chd10daw72rwayqk URL
-    http://beta.quicklisp.org/archive/ieee-floats/2017-08-30/ieee-floats-20170830-git.tgz
-    MD5 3434b4d91224ca6a817ced9d83f14bb6 NAME ieee-floats FILENAME ieee-floats
+    0iaigf6961cnwhsfh4hwgshkid57ba4mjjwsdbwh1a0yzmcd7mbd URL
+    http://beta.quicklisp.org/archive/ieee-floats/2022-02-20/ieee-floats-20220220-git.tgz
+    MD5 91237afb503d64fc7164cf7776a203ba NAME ieee-floats FILENAME ieee-floats
     DEPS ((NAME fiveam FILENAME fiveam)) DEPENDENCIES (fiveam) VERSION
-    20170830-git SIBLINGS NIL PARASITES (ieee-floats-tests)) */
+    20220220-git SIBLINGS NIL PARASITES (ieee-floats/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/introspect-environment.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/introspect-environment.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "introspect-environment";
-  version = "20210807-git";
+  version = "20220220-git";
 
   description = "Small interface to portable but nonstandard introspection of CL environments.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/introspect-environment/2021-08-07/introspect-environment-20210807-git.tgz";
-    sha256 = "124rnbcjygw7wm07bpcibsqkvsqxhr8pq42p7phw39kmcp9hns4j";
+    url = "http://beta.quicklisp.org/archive/introspect-environment/2022-02-20/introspect-environment-20220220-git.tgz";
+    sha256 = "0d1cay632hq5sjpq6lvalwba707cipvrdj77iw1m1dm04rawbaqz";
   };
 
   packageName = "introspect-environment";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM introspect-environment DESCRIPTION
     Small interface to portable but nonstandard introspection of CL environments.
-    SHA256 124rnbcjygw7wm07bpcibsqkvsqxhr8pq42p7phw39kmcp9hns4j URL
-    http://beta.quicklisp.org/archive/introspect-environment/2021-08-07/introspect-environment-20210807-git.tgz
-    MD5 f9d4e1208146e9435c2ce1b82a87a209 NAME introspect-environment FILENAME
-    introspect-environment DEPS NIL DEPENDENCIES NIL VERSION 20210807-git
+    SHA256 0d1cay632hq5sjpq6lvalwba707cipvrdj77iw1m1dm04rawbaqz URL
+    http://beta.quicklisp.org/archive/introspect-environment/2022-02-20/introspect-environment-20220220-git.tgz
+    MD5 e2a9864b2f9792f31ad20b44ea25a58b NAME introspect-environment FILENAME
+    introspect-environment DEPS NIL DEPENDENCIES NIL VERSION 20220220-git
     SIBLINGS (introspect-environment-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "ironclad";
-  version = "v0.56";
+  version = "v0.57";
 
   parasites = [ "ironclad/aead/eax" "ironclad/aead/etm" "ironclad/aead/gcm" "ironclad/aeads" "ironclad/cipher/aes" "ironclad/cipher/arcfour" "ironclad/cipher/aria" "ironclad/cipher/blowfish" "ironclad/cipher/camellia" "ironclad/cipher/cast5" "ironclad/cipher/chacha" "ironclad/cipher/des" "ironclad/cipher/idea" "ironclad/cipher/kalyna" "ironclad/cipher/keystream" "ironclad/cipher/kuznyechik" "ironclad/cipher/misty1" "ironclad/cipher/rc2" "ironclad/cipher/rc5" "ironclad/cipher/rc6" "ironclad/cipher/salsa20" "ironclad/cipher/seed" "ironclad/cipher/serpent" "ironclad/cipher/sm4" "ironclad/cipher/sosemanuk" "ironclad/cipher/square" "ironclad/cipher/tea" "ironclad/cipher/threefish" "ironclad/cipher/twofish" "ironclad/cipher/xchacha" "ironclad/cipher/xor" "ironclad/cipher/xsalsa20" "ironclad/cipher/xtea" "ironclad/ciphers" "ironclad/core" "ironclad/digest/adler32" "ironclad/digest/blake2" "ironclad/digest/blake2s" "ironclad/digest/crc24" "ironclad/digest/crc32" "ironclad/digest/groestl" "ironclad/digest/jh" "ironclad/digest/kupyna" "ironclad/digest/md2" "ironclad/digest/md4" "ironclad/digest/md5" "ironclad/digest/ripemd-128" "ironclad/digest/ripemd-160" "ironclad/digest/sha1" "ironclad/digest/sha256" "ironclad/digest/sha3" "ironclad/digest/sha512" "ironclad/digest/skein" "ironclad/digest/sm3" "ironclad/digest/streebog" "ironclad/digest/tiger" "ironclad/digest/tree-hash" "ironclad/digest/whirlpool" "ironclad/digests" "ironclad/kdf/argon2" "ironclad/kdf/bcrypt" "ironclad/kdf/hmac" "ironclad/kdf/password-hash" "ironclad/kdf/pkcs5" "ironclad/kdf/scrypt" "ironclad/kdfs" "ironclad/mac/blake2-mac" "ironclad/mac/blake2s-mac" "ironclad/mac/cmac" "ironclad/mac/gmac" "ironclad/mac/hmac" "ironclad/mac/poly1305" "ironclad/mac/siphash" "ironclad/mac/skein-mac" "ironclad/macs" "ironclad/prng/fortuna" "ironclad/prngs" "ironclad/public-key/curve25519" "ironclad/public-key/curve448" "ironclad/public-key/dsa" "ironclad/public-key/ed25519" "ironclad/public-key/ed448" "ironclad/public-key/elgamal" "ironclad/public-key/rsa" "ironclad/public-key/secp256k1" "ironclad/public-key/secp256r1" "ironclad/public-key/secp384r1" "ironclad/public-key/secp521r1" "ironclad/public-keys" "ironclad/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."rt" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/ironclad/2021-10-20/ironclad-v0.56.tgz";
-    sha256 = "06jya7y8xlwak84akhp4qg9x6nyjrnnzqmzdigxc5a3c77mk3p6k";
+    url = "http://beta.quicklisp.org/archive/ironclad/2022-02-20/ironclad-v0.57.tgz";
+    sha256 = "1hp66ksf2gswiladyc7ql718hlp4rdqw21hrm6d0jfbki3b9y9h1";
   };
 
   packageName = "ironclad";
@@ -21,12 +21,12 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM ironclad DESCRIPTION System lacks description SHA256
-    06jya7y8xlwak84akhp4qg9x6nyjrnnzqmzdigxc5a3c77mk3p6k URL
-    http://beta.quicklisp.org/archive/ironclad/2021-10-20/ironclad-v0.56.tgz
-    MD5 3ea7bf7271864fd960d7e06a4e5aa9b7 NAME ironclad FILENAME ironclad DEPS
+    1hp66ksf2gswiladyc7ql718hlp4rdqw21hrm6d0jfbki3b9y9h1 URL
+    http://beta.quicklisp.org/archive/ironclad/2022-02-20/ironclad-v0.57.tgz
+    MD5 76e5e0edbe68b6cce88f6272bc11a09c NAME ironclad FILENAME ironclad DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads) (NAME rt FILENAME rt))
-    DEPENDENCIES (alexandria bordeaux-threads rt) VERSION v0.56 SIBLINGS
+    DEPENDENCIES (alexandria bordeaux-threads rt) VERSION v0.57 SIBLINGS
     (ironclad-text) PARASITES
     (ironclad/aead/eax ironclad/aead/etm ironclad/aead/gcm ironclad/aeads
      ironclad/cipher/aes ironclad/cipher/arcfour ironclad/cipher/aria

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-component";
-  version = "lack-20211209-git";
+  version = "lack-20220220-git";
 
   description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
-    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
+    url = "http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz";
+    sha256 = "122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1";
   };
 
   packageName = "lack-component";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-component DESCRIPTION System lacks description SHA256
-    0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
-    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
-    610b1aea0280193d6f125aa1317a2d79 NAME lack-component FILENAME
-    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20211209-git SIBLINGS
+    122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1 URL
+    http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz MD5
+    3dd95bf5e8ed28862b2390ee64dd33e5 NAME lack-component FILENAME
+    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20220220-git SIBLINGS
     (lack-app-directory lack-app-file lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
      lack-middleware-mount lack-middleware-session lack-middleware-static

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-middleware-backtrace";
-  version = "lack-20211209-git";
+  version = "lack-20220220-git";
 
   description = "System lacks description";
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
-    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
+    url = "http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz";
+    sha256 = "122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1";
   };
 
   packageName = "lack-middleware-backtrace";
@@ -19,11 +19,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-middleware-backtrace DESCRIPTION System lacks description
-    SHA256 0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
-    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
-    610b1aea0280193d6f125aa1317a2d79 NAME lack-middleware-backtrace FILENAME
+    SHA256 122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1 URL
+    http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz MD5
+    3dd95bf5e8ed28862b2390ee64dd33e5 NAME lack-middleware-backtrace FILENAME
     lack-middleware-backtrace DEPS ((NAME uiop FILENAME uiop)) DEPENDENCIES
-    (uiop) VERSION lack-20211209-git SIBLINGS
+    (uiop) VERSION lack-20220220-git SIBLINGS
     (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-csrf lack-middleware-mount
      lack-middleware-session lack-middleware-static lack-request lack-response

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-util";
-  version = "lack-20211209-git";
+  version = "lack-20220220-git";
 
   description = "System lacks description";
 
-  deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" ];
+  deps = [ args."cl-isaac" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
-    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
+    url = "http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz";
+    sha256 = "122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1";
   };
 
   packageName = "lack-util";
@@ -19,14 +19,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-util DESCRIPTION System lacks description SHA256
-    0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
-    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
-    610b1aea0280193d6f125aa1317a2d79 NAME lack-util FILENAME lack-util DEPS
-    ((NAME alexandria FILENAME alexandria)
-     (NAME bordeaux-threads FILENAME bordeaux-threads)
-     (NAME ironclad FILENAME ironclad))
-    DEPENDENCIES (alexandria bordeaux-threads ironclad) VERSION
-    lack-20211209-git SIBLINGS
+    122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1 URL
+    http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz MD5
+    3dd95bf5e8ed28862b2390ee64dd33e5 NAME lack-util FILENAME lack-util DEPS
+    ((NAME cl-isaac FILENAME cl-isaac)) DEPENDENCIES (cl-isaac) VERSION
+    lack-20220220-git SIBLINGS
     (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
      lack-middleware-mount lack-middleware-session lack-middleware-static

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack";
-  version = "20211209-git";
+  version = "20220220-git";
 
   description = "A minimal Clack";
 
-  deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack-component" args."lack-util" ];
+  deps = [ args."cl-isaac" args."lack-component" args."lack-util" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
-    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
+    url = "http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz";
+    sha256 = "122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1";
   };
 
   packageName = "lack";
@@ -19,17 +19,14 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack DESCRIPTION A minimal Clack SHA256
-    0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
-    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
-    610b1aea0280193d6f125aa1317a2d79 NAME lack FILENAME lack DEPS
-    ((NAME alexandria FILENAME alexandria)
-     (NAME bordeaux-threads FILENAME bordeaux-threads)
-     (NAME ironclad FILENAME ironclad)
+    122k2jknsgvca22g0jq1bd881d64b6fiaprbzsbf67gjaf2djmn1 URL
+    http://beta.quicklisp.org/archive/lack/2022-02-20/lack-20220220-git.tgz MD5
+    3dd95bf5e8ed28862b2390ee64dd33e5 NAME lack FILENAME lack DEPS
+    ((NAME cl-isaac FILENAME cl-isaac)
      (NAME lack-component FILENAME lack-component)
      (NAME lack-util FILENAME lack-util))
-    DEPENDENCIES
-    (alexandria bordeaux-threads ironclad lack-component lack-util) VERSION
-    20211209-git SIBLINGS
+    DEPENDENCIES (cl-isaac lack-component lack-util) VERSION 20220220-git
+    SIBLINGS
     (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
      lack-middleware-mount lack-middleware-session lack-middleware-static

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lambda-fiddle.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lambda-fiddle.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lambda-fiddle";
-  version = "20190710-git";
+  version = "20211020-git";
 
   description = "A collection of functions to process lambda-lists.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lambda-fiddle/2019-07-10/lambda-fiddle-20190710-git.tgz";
-    sha256 = "0v4qjpp9fq9rlxhr5f6mjs5f076xrjk19rl6qgp1ap1ykcrx8k4j";
+    url = "http://beta.quicklisp.org/archive/lambda-fiddle/2021-10-20/lambda-fiddle-20211020-git.tgz";
+    sha256 = "13v1dcwd40qavy1y6p9h10v4xvzq347fjqq8jbhbbpb337ch1syq";
   };
 
   packageName = "lambda-fiddle";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM lambda-fiddle DESCRIPTION
     A collection of functions to process lambda-lists. SHA256
-    0v4qjpp9fq9rlxhr5f6mjs5f076xrjk19rl6qgp1ap1ykcrx8k4j URL
-    http://beta.quicklisp.org/archive/lambda-fiddle/2019-07-10/lambda-fiddle-20190710-git.tgz
-    MD5 78f68f144ace9cb8f634ac14b3414e5e NAME lambda-fiddle FILENAME
-    lambda-fiddle DEPS NIL DEPENDENCIES NIL VERSION 20190710-git SIBLINGS NIL
+    13v1dcwd40qavy1y6p9h10v4xvzq347fjqq8jbhbbpb337ch1syq URL
+    http://beta.quicklisp.org/archive/lambda-fiddle/2021-10-20/lambda-fiddle-20211020-git.tgz
+    MD5 89c1c5a2066775e728e4b8051f67d932 NAME lambda-fiddle FILENAME
+    lambda-fiddle DEPS NIL DEPENDENCIES NIL VERSION 20211020-git SIBLINGS NIL
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/legit.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/legit.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "legit";
-  version = "20190710-git";
+  version = "20211020-git";
 
   description = "CL interface to the GIT binary.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-ppcre" args."documentation-utils" args."lambda-fiddle" args."simple-inferiors" args."trivial-indent" args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/legit/2019-07-10/legit-20190710-git.tgz";
-    sha256 = "0g7cn50qvivsn0w9yszqw2qh22jsj60067pmg5pvwsjm03xdl9s9";
+    url = "http://beta.quicklisp.org/archive/legit/2021-10-20/legit-20211020-git.tgz";
+    sha256 = "01a5l7haj3bg176iwxqzzkwx090l8qrl0ni9x64fdgg75dh2m43l";
   };
 
   packageName = "legit";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM legit DESCRIPTION CL interface to the GIT binary. SHA256
-    0g7cn50qvivsn0w9yszqw2qh22jsj60067pmg5pvwsjm03xdl9s9 URL
-    http://beta.quicklisp.org/archive/legit/2019-07-10/legit-20190710-git.tgz
-    MD5 9b380fc23d4bab086df8a0e4a598457a NAME legit FILENAME legit DEPS
+    01a5l7haj3bg176iwxqzzkwx090l8qrl0ni9x64fdgg75dh2m43l URL
+    http://beta.quicklisp.org/archive/legit/2021-10-20/legit-20211020-git.tgz
+    MD5 1d8531d126b10a1ed6bdec81179f9472 NAME legit FILENAME legit DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-ppcre FILENAME cl-ppcre)
@@ -32,4 +32,4 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-ppcre documentation-utils lambda-fiddle
      simple-inferiors trivial-indent uiop)
-    VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-binary.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-binary.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lisp-binary";
-  version = "20210411-git";
+  version = "20220220-git";
 
   description = "Declare binary formats as structs and then read and write them.";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."closer-mop" args."flexi-streams" args."iterate" args."moptilities" args."quasiquote-2_dot_0" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lisp-binary/2021-04-11/lisp-binary-20210411-git.tgz";
-    sha256 = "1sbapl8qla4xb8wcix9yxpijkbk1bpybhay7ncb3z2im7r2kzsnb";
+    url = "http://beta.quicklisp.org/archive/lisp-binary/2022-02-20/lisp-binary-20220220-git.tgz";
+    sha256 = "1fr4pj6c65ndhaixmby3xgr1nb6qpap9dn9gddvwxsl1jxks9cw3";
   };
 
   packageName = "lisp-binary";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM lisp-binary DESCRIPTION
     Declare binary formats as structs and then read and write them. SHA256
-    1sbapl8qla4xb8wcix9yxpijkbk1bpybhay7ncb3z2im7r2kzsnb URL
-    http://beta.quicklisp.org/archive/lisp-binary/2021-04-11/lisp-binary-20210411-git.tgz
-    MD5 29d85f01a1cb17742164bacae940d29c NAME lisp-binary FILENAME lisp-binary
+    1fr4pj6c65ndhaixmby3xgr1nb6qpap9dn9gddvwxsl1jxks9cw3 URL
+    http://beta.quicklisp.org/archive/lisp-binary/2022-02-20/lisp-binary-20220220-git.tgz
+    MD5 af14f9a7ce07b38f5c7af3666a9d5ac2 NAME lisp-binary FILENAME lisp-binary
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME closer-mop FILENAME closer-mop)
@@ -34,4 +34,4 @@ rec {
     DEPENDENCIES
     (alexandria babel cffi closer-mop flexi-streams iterate moptilities
      quasiquote-2.0 trivial-features trivial-gray-streams)
-    VERSION 20210411-git SIBLINGS (lisp-binary-test) PARASITES NIL) */
+    VERSION 20220220-git SIBLINGS (lisp-binary-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lw-compat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lw-compat.nix
@@ -1,0 +1,26 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "lw-compat";
+  version = "20160318-git";
+
+  description = "A few utility functions from the LispWorks library that are used in the Closer to MOP libraries.";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/lw-compat/2016-03-18/lw-compat-20160318-git.tgz";
+    sha256 = "10p5w6xga79z9nqcmp364ng76ik80ipy5m1cjgf6bah4ivrbn56q";
+  };
+
+  packageName = "lw-compat";
+
+  asdFilesToKeep = ["lw-compat.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM lw-compat DESCRIPTION
+    A few utility functions from the LispWorks library that are used in the Closer to MOP libraries.
+    SHA256 10p5w6xga79z9nqcmp364ng76ik80ipy5m1cjgf6bah4ivrbn56q URL
+    http://beta.quicklisp.org/archive/lw-compat/2016-03-18/lw-compat-20160318-git.tgz
+    MD5 024b8e63d13fb12dbcccaf18cf4f8dfa NAME lw-compat FILENAME lw-compat DEPS
+    NIL DEPENDENCIES NIL VERSION 20160318-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
@@ -2,18 +2,18 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "mgl-pax";
-  version = "20211209-git";
+  version = "20220220-git";
 
-  parasites = [ "mgl-pax/document" "mgl-pax/navigate" ];
+  parasites = [ "mgl-pax/navigate" ];
 
   description = "Exploratory programming tool and documentation
   generator.";
 
-  deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."colorize" args."md5" args."named-readtables" args."pythonic-string-reader" args."swank" ];
+  deps = [ args."alexandria" args."mgl-pax_dot_asdf" args."named-readtables" args."pythonic-string-reader" args."swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-12-09/mgl-pax-20211209-git.tgz";
-    sha256 = "19d47msc8240bldkc0fi60cpzsx1q9392dxhmqn28gn7998pdkgh";
+    url = "http://beta.quicklisp.org/archive/mgl-pax/2022-02-20/mgl-pax-20220220-git.tgz";
+    sha256 = "0wfdj8np8fflp51zqsby0fwhad675xk0nbw02w0xxp4sjya0hk5a";
   };
 
   packageName = "mgl-pax";
@@ -23,17 +23,14 @@ rec {
 }
 /* (SYSTEM mgl-pax DESCRIPTION Exploratory programming tool and documentation
   generator.
-    SHA256 19d47msc8240bldkc0fi60cpzsx1q9392dxhmqn28gn7998pdkgh URL
-    http://beta.quicklisp.org/archive/mgl-pax/2021-12-09/mgl-pax-20211209-git.tgz
-    MD5 605583bb2910e0fe2211c8152fe38e0e NAME mgl-pax FILENAME mgl-pax DEPS
-    ((NAME 3bmd FILENAME _3bmd)
-     (NAME 3bmd-ext-code-blocks FILENAME _3bmd-ext-code-blocks)
-     (NAME alexandria FILENAME alexandria) (NAME colorize FILENAME colorize)
-     (NAME md5 FILENAME md5) (NAME named-readtables FILENAME named-readtables)
+    SHA256 0wfdj8np8fflp51zqsby0fwhad675xk0nbw02w0xxp4sjya0hk5a URL
+    http://beta.quicklisp.org/archive/mgl-pax/2022-02-20/mgl-pax-20220220-git.tgz
+    MD5 51050b8c146333bd352e77d9ffee5475 NAME mgl-pax FILENAME mgl-pax DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME mgl-pax.asdf FILENAME mgl-pax_dot_asdf)
+     (NAME named-readtables FILENAME named-readtables)
      (NAME pythonic-string-reader FILENAME pythonic-string-reader)
      (NAME swank FILENAME swank))
     DEPENDENCIES
-    (3bmd 3bmd-ext-code-blocks alexandria colorize md5 named-readtables
-     pythonic-string-reader swank)
-    VERSION 20211209-git SIBLINGS NIL PARASITES
-    (mgl-pax/document mgl-pax/navigate)) */
+    (alexandria mgl-pax.asdf named-readtables pythonic-string-reader swank)
+    VERSION 20220220-git SIBLINGS (mgl-pax.asdf) PARASITES (mgl-pax/navigate)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax_dot_asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax_dot_asdf.nix
@@ -1,0 +1,26 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "mgl-pax_dot_asdf";
+  version = "mgl-pax-20220220-git";
+
+  description = "System lacks description";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/mgl-pax/2022-02-20/mgl-pax-20220220-git.tgz";
+    sha256 = "0wfdj8np8fflp51zqsby0fwhad675xk0nbw02w0xxp4sjya0hk5a";
+  };
+
+  packageName = "mgl-pax.asdf";
+
+  asdFilesToKeep = ["mgl-pax.asdf.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM mgl-pax.asdf DESCRIPTION System lacks description SHA256
+    0wfdj8np8fflp51zqsby0fwhad675xk0nbw02w0xxp4sjya0hk5a URL
+    http://beta.quicklisp.org/archive/mgl-pax/2022-02-20/mgl-pax-20220220-git.tgz
+    MD5 51050b8c146333bd352e77d9ffee5475 NAME mgl-pax.asdf FILENAME
+    mgl-pax_dot_asdf DEPS NIL DEPENDENCIES NIL VERSION mgl-pax-20220220-git
+    SIBLINGS (mgl-pax) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
@@ -2,18 +2,18 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "named-readtables";
-  version = "20211209-git";
+  version = "20220220-git";
 
   parasites = [ "named-readtables/test" ];
 
-  description = "Library that creates a namespace for named readtable
-  akin to the namespace of packages.";
+  description = "Library that creates a namespace for readtables akin
+  to the namespace of packages.";
 
-  deps = [ ];
+  deps = [ args."try" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/named-readtables/2021-12-09/named-readtables-20211209-git.tgz";
-    sha256 = "0mlxbs7r6ksjk9ilsgp756qp4jlgplr30kxdn7npq27wg0rpvz2n";
+    url = "http://beta.quicklisp.org/archive/named-readtables/2022-02-20/named-readtables-20220220-git.tgz";
+    sha256 = "1mhwm8flks3g38bbx33crw862mn80i98mqd6jc7hx8ka42zbr1dk";
   };
 
   packageName = "named-readtables";
@@ -22,10 +22,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM named-readtables DESCRIPTION
-    Library that creates a namespace for named readtable
-  akin to the namespace of packages.
-    SHA256 0mlxbs7r6ksjk9ilsgp756qp4jlgplr30kxdn7npq27wg0rpvz2n URL
-    http://beta.quicklisp.org/archive/named-readtables/2021-12-09/named-readtables-20211209-git.tgz
-    MD5 52def9392c93bb9c6da4b957549bcb0b NAME named-readtables FILENAME
-    named-readtables DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS
-    NIL PARASITES (named-readtables/test)) */
+    Library that creates a namespace for readtables akin
+  to the namespace of packages.
+    SHA256 1mhwm8flks3g38bbx33crw862mn80i98mqd6jc7hx8ka42zbr1dk URL
+    http://beta.quicklisp.org/archive/named-readtables/2022-02-20/named-readtables-20220220-git.tgz
+    MD5 3505b527d172099c5c7d0b4665081eec NAME named-readtables FILENAME
+    named-readtables DEPS ((NAME try FILENAME try)) DEPENDENCIES (try) VERSION
+    20220220-git SIBLINGS NIL PARASITES (named-readtables/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/nbd.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/nbd.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "nbd";
-  version = "20200925-git";
+  version = "20211020-git";
 
   parasites = [ "nbd/simple-in-memory" ];
 
   description = "Network Block Device server library.";
 
-  deps = [ args."bordeaux-threads" args."flexi-streams" args."lisp-binary" args."wild-package-inferred-system" ];
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."closer-mop" args."flexi-streams" args."iterate" args."lisp-binary" args."moptilities" args."quasiquote-2_dot_0" args."trivial-features" args."trivial-gray-streams" args."wild-package-inferred-system" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/nbd/2020-09-25/nbd-20200925-git.tgz";
-    sha256 = "1npq9a8l3mn67n22ywqm8wh6kr9xv9djla2yj2m535gkysrlvnky";
+    url = "http://beta.quicklisp.org/archive/nbd/2021-10-20/nbd-20211020-git.tgz";
+    sha256 = "1fmx5hnv2q3c4gj94vr1j7pfhh44zqgsjnxn1l5lpzkdc95hxd2y";
   };
 
   packageName = "nbd";
@@ -21,13 +21,21 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM nbd DESCRIPTION Network Block Device server library. SHA256
-    1npq9a8l3mn67n22ywqm8wh6kr9xv9djla2yj2m535gkysrlvnky URL
-    http://beta.quicklisp.org/archive/nbd/2020-09-25/nbd-20200925-git.tgz MD5
-    f32b7a508ac87c1e179c259b171dc837 NAME nbd FILENAME nbd DEPS
-    ((NAME bordeaux-threads FILENAME bordeaux-threads)
+    1fmx5hnv2q3c4gj94vr1j7pfhh44zqgsjnxn1l5lpzkdc95hxd2y URL
+    http://beta.quicklisp.org/archive/nbd/2021-10-20/nbd-20211020-git.tgz MD5
+    9f5755497817a667537f5bbcde153512 NAME nbd FILENAME nbd DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi) (NAME closer-mop FILENAME closer-mop)
      (NAME flexi-streams FILENAME flexi-streams)
-     (NAME lisp-binary FILENAME lisp-binary)
+     (NAME iterate FILENAME iterate) (NAME lisp-binary FILENAME lisp-binary)
+     (NAME moptilities FILENAME moptilities)
+     (NAME quasiquote-2.0 FILENAME quasiquote-2_dot_0)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams)
      (NAME wild-package-inferred-system FILENAME wild-package-inferred-system))
     DEPENDENCIES
-    (bordeaux-threads flexi-streams lisp-binary wild-package-inferred-system)
-    VERSION 20200925-git SIBLINGS NIL PARASITES (nbd/simple-in-memory)) */
+    (alexandria babel bordeaux-threads cffi closer-mop flexi-streams iterate
+     lisp-binary moptilities quasiquote-2.0 trivial-features
+     trivial-gray-streams wild-package-inferred-system)
+    VERSION 20211020-git SIBLINGS NIL PARASITES (nbd/simple-in-memory)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/numpy-file-format.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/numpy-file-format.nix
@@ -1,0 +1,33 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "numpy-file-format";
+  version = "20210124-git";
+
+  parasites = [ "numpy-file-format/tests" ];
+
+  description = "Read and write Numpy .npy and .npz files.";
+
+  deps = [ args."ieee-floats" args."trivial-features" args."uiop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/numpy-file-format/2021-01-24/numpy-file-format-20210124-git.tgz";
+    sha256 = "17iwihpf28f5q4hgz93vixrrq35ya4x5fmz3mdqhgpqkdhpf012h";
+  };
+
+  packageName = "numpy-file-format";
+
+  asdFilesToKeep = ["numpy-file-format.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM numpy-file-format DESCRIPTION
+    Read and write Numpy .npy and .npz files. SHA256
+    17iwihpf28f5q4hgz93vixrrq35ya4x5fmz3mdqhgpqkdhpf012h URL
+    http://beta.quicklisp.org/archive/numpy-file-format/2021-01-24/numpy-file-format-20210124-git.tgz
+    MD5 0d81ce1e67ed1323787eb0f3cd698113 NAME numpy-file-format FILENAME
+    numpy-file-format DEPS
+    ((NAME ieee-floats FILENAME ieee-floats)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME uiop FILENAME uiop))
+    DEPENDENCIES (ieee-floats trivial-features uiop) VERSION 20210124-git
+    SIBLINGS NIL PARASITES (numpy-file-format/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "osicat";
-  version = "20211209-git";
+  version = "20220220-git";
 
   parasites = [ "osicat/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."rt" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/osicat/2021-12-09/osicat-20211209-git.tgz";
-    sha256 = "0c85aapyvr2f5c3lvpfv3hfdghwmsqf40qgyk9hwjva8s9242pgl";
+    url = "http://beta.quicklisp.org/archive/osicat/2022-02-20/osicat-20220220-git.tgz";
+    sha256 = "1mq2kim5v5mah9qds56z370bim0gc1ymxq41xp0i553dwhcmchdq";
   };
 
   packageName = "osicat";
@@ -21,13 +21,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM osicat DESCRIPTION A lightweight operating system interface SHA256
-    0c85aapyvr2f5c3lvpfv3hfdghwmsqf40qgyk9hwjva8s9242pgl URL
-    http://beta.quicklisp.org/archive/osicat/2021-12-09/osicat-20211209-git.tgz
-    MD5 3581652999e0b16c6a1a8295585e7491 NAME osicat FILENAME osicat DEPS
+    1mq2kim5v5mah9qds56z370bim0gc1ymxq41xp0i553dwhcmchdq URL
+    http://beta.quicklisp.org/archive/osicat/2022-02-20/osicat-20220220-git.tgz
+    MD5 8013cfd6decb2e75e888fd4e7b703f73 NAME osicat FILENAME osicat DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
      (NAME cffi-toolchain FILENAME cffi-toolchain) (NAME rt FILENAME rt)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES
     (alexandria babel cffi cffi-grovel cffi-toolchain rt trivial-features)
-    VERSION 20211209-git SIBLINGS NIL PARASITES (osicat/tests)) */
+    VERSION 20220220-git SIBLINGS NIL PARASITES (osicat/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "postmodern";
-  version = "20211209-git";
+  version = "20220220-git";
 
   parasites = [ "postmodern/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_plus_local-time" args."cl-postgres_slash_tests" args."cl-ppcre" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."local-time" args."md5" args."s-sql" args."s-sql_slash_tests" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
-    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz";
+    sha256 = "17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5";
   };
 
   packageName = "postmodern";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM postmodern DESCRIPTION PostgreSQL programming API SHA256
-    1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
-    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME postmodern FILENAME postmodern
+    17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5 URL
+    http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz
+    MD5 d30fbcddd0b858445622f4f04676561e NAME postmodern FILENAME postmodern
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -46,5 +46,5 @@ rec {
      cl-postgres/tests cl-ppcre closer-mop fiveam global-vars ironclad
      local-time md5 s-sql s-sql/tests simple-date simple-date/postgres-glue
      split-sequence uax-15 uiop usocket)
-    VERSION 20211209-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
+    VERSION 20220220-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
     (postmodern/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/py4cl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/py4cl.nix
@@ -1,0 +1,32 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "py4cl";
+  version = "20210228-git";
+
+  description = "Call Python libraries from Common Lisp";
+
+  deps = [ args."cl-json" args."ieee-floats" args."numpy-file-format" args."trivial-features" args."trivial-garbage" args."uiop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/py4cl/2021-02-28/py4cl-20210228-git.tgz";
+    sha256 = "1cbfqwz742icyydgdc4l1yj63x046mi7j0gglavrd75d3fqnjky4";
+  };
+
+  packageName = "py4cl";
+
+  asdFilesToKeep = ["py4cl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM py4cl DESCRIPTION Call Python libraries from Common Lisp SHA256
+    1cbfqwz742icyydgdc4l1yj63x046mi7j0gglavrd75d3fqnjky4 URL
+    http://beta.quicklisp.org/archive/py4cl/2021-02-28/py4cl-20210228-git.tgz
+    MD5 63b115198c82ec3d925394c44221dfa7 NAME py4cl FILENAME py4cl DEPS
+    ((NAME cl-json FILENAME cl-json) (NAME ieee-floats FILENAME ieee-floats)
+     (NAME numpy-file-format FILENAME numpy-file-format)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage) (NAME uiop FILENAME uiop))
+    DEPENDENCIES
+    (cl-json ieee-floats numpy-file-format trivial-features trivial-garbage
+     uiop)
+    VERSION 20210228-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "rove";
-  version = "20211209-git";
+  version = "20220220-git";
 
   description = "Yet another testing framework intended to be a successor of Prove";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."dissect" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/rove/2021-12-09/rove-20211209-git.tgz";
-    sha256 = "1b1fajdxnba743l7mv4nc31az2g7mapalq3z3l57j7r5sximf0qr";
+    url = "http://beta.quicklisp.org/archive/rove/2022-02-20/rove-20220220-git.tgz";
+    sha256 = "1r19alfxf82rdswmg5y0lsc9a5qf3jpiqxdv3ip50z6dx7qm794b";
   };
 
   packageName = "rove";
@@ -20,12 +20,12 @@ rec {
 }
 /* (SYSTEM rove DESCRIPTION
     Yet another testing framework intended to be a successor of Prove SHA256
-    1b1fajdxnba743l7mv4nc31az2g7mapalq3z3l57j7r5sximf0qr URL
-    http://beta.quicklisp.org/archive/rove/2021-12-09/rove-20211209-git.tgz MD5
-    d9f6cb2e26f06cfbd5c83bf3fa4fc206 NAME rove FILENAME rove DEPS
+    1r19alfxf82rdswmg5y0lsc9a5qf3jpiqxdv3ip50z6dx7qm794b URL
+    http://beta.quicklisp.org/archive/rove/2022-02-20/rove-20220220-git.tgz MD5
+    579688f8d99e742a36b5356ed6776c8f NAME rove FILENAME rove DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME dissect FILENAME dissect)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams))
     DEPENDENCIES (alexandria bordeaux-threads dissect trivial-gray-streams)
-    VERSION 20211209-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20220220-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "s-sql";
-  version = "postmodern-20211209-git";
+  version = "postmodern-20220220-git";
 
   parasites = [ "s-sql/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_slash_tests" args."cl-ppcre" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."md5" args."postmodern" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
-    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz";
+    sha256 = "17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5";
   };
 
   packageName = "s-sql";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM s-sql DESCRIPTION Lispy DSL for SQL SHA256
-    1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
-    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME s-sql FILENAME s-sql DEPS
+    17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5 URL
+    http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz
+    MD5 d30fbcddd0b858445622f4f04676561e NAME s-sql FILENAME s-sql DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-base64 FILENAME cl-base64)
@@ -39,5 +39,5 @@ rec {
     (alexandria bordeaux-threads cl-base64 cl-postgres cl-postgres/tests
      cl-ppcre closer-mop fiveam global-vars ironclad md5 postmodern
      split-sequence uax-15 usocket)
-    VERSION postmodern-20211209-git SIBLINGS
+    VERSION postmodern-20220220-git SIBLINGS
     (cl-postgres postmodern simple-date) PARASITES (s-sql/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "serapeum";
-  version = "20211209-git";
+  version = "20220220-git";
 
   description = "Utilities beyond Alexandria.";
 
-  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
+  deps = [ args."alexandria" args."bordeaux-threads" args."closer-mop" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/serapeum/2021-12-09/serapeum-20211209-git.tgz";
-    sha256 = "19ndbi69b60rxh1jvs7jrwg6bgzpkrfd22cnhyd2mir4ybmrdllh";
+    url = "http://beta.quicklisp.org/archive/serapeum/2022-02-20/serapeum-20220220-git.tgz";
+    sha256 = "1935vxiwjpqmsxjh40wb3b93bg1prvy9n91f7d0x2ww1a2ai5n8y";
   };
 
   packageName = "serapeum";
@@ -19,22 +19,16 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM serapeum DESCRIPTION Utilities beyond Alexandria. SHA256
-    19ndbi69b60rxh1jvs7jrwg6bgzpkrfd22cnhyd2mir4ybmrdllh URL
-    http://beta.quicklisp.org/archive/serapeum/2021-12-09/serapeum-20211209-git.tgz
-    MD5 be358e1693fd0883042d849199ab72d1 NAME serapeum FILENAME serapeum DEPS
-    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+    1935vxiwjpqmsxjh40wb3b93bg1prvy9n91f7d0x2ww1a2ai5n8y URL
+    http://beta.quicklisp.org/archive/serapeum/2022-02-20/serapeum-20220220-git.tgz
+    MD5 9930f215892a3cf240aafcfa21481590 NAME serapeum FILENAME serapeum DEPS
+    ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME closer-mop FILENAME closer-mop)
-     (NAME fare-quasiquote FILENAME fare-quasiquote)
-     (NAME fare-quasiquote-extras FILENAME fare-quasiquote-extras)
-     (NAME fare-quasiquote-optima FILENAME fare-quasiquote-optima)
-     (NAME fare-quasiquote-readtable FILENAME fare-quasiquote-readtable)
-     (NAME fare-utils FILENAME fare-utils)
      (NAME global-vars FILENAME global-vars)
      (NAME introspect-environment FILENAME introspect-environment)
      (NAME iterate FILENAME iterate)
      (NAME lisp-namespace FILENAME lisp-namespace)
-     (NAME named-readtables FILENAME named-readtables)
      (NAME parse-declarations-1.0 FILENAME parse-declarations-1_dot_0)
      (NAME parse-number FILENAME parse-number)
      (NAME split-sequence FILENAME split-sequence)
@@ -43,21 +37,16 @@ rec {
      (NAME trivia.level0 FILENAME trivia_dot_level0)
      (NAME trivia.level1 FILENAME trivia_dot_level1)
      (NAME trivia.level2 FILENAME trivia_dot_level2)
-     (NAME trivia.quasiquote FILENAME trivia_dot_quasiquote)
      (NAME trivia.trivial FILENAME trivia_dot_trivial)
      (NAME trivial-cltl2 FILENAME trivial-cltl2)
-     (NAME trivial-features FILENAME trivial-features)
      (NAME trivial-file-size FILENAME trivial-file-size)
      (NAME trivial-garbage FILENAME trivial-garbage)
      (NAME trivial-macroexpand-all FILENAME trivial-macroexpand-all)
-     (NAME type-i FILENAME type-i) (NAME uiop FILENAME uiop))
+     (NAME type-i FILENAME type-i))
     DEPENDENCIES
-    (alexandria babel bordeaux-threads closer-mop fare-quasiquote
-     fare-quasiquote-extras fare-quasiquote-optima fare-quasiquote-readtable
-     fare-utils global-vars introspect-environment iterate lisp-namespace
-     named-readtables parse-declarations-1.0 parse-number split-sequence
+    (alexandria bordeaux-threads closer-mop global-vars introspect-environment
+     iterate lisp-namespace parse-declarations-1.0 parse-number split-sequence
      string-case trivia trivia.balland2006 trivia.level0 trivia.level1
-     trivia.level2 trivia.quasiquote trivia.trivial trivial-cltl2
-     trivial-features trivial-file-size trivial-garbage trivial-macroexpand-all
-     type-i uiop)
-    VERSION 20211209-git SIBLINGS NIL PARASITES NIL) */
+     trivia.level2 trivia.trivial trivial-cltl2 trivial-file-size
+     trivial-garbage trivial-macroexpand-all type-i)
+    VERSION 20220220-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "simple-date";
-  version = "postmodern-20211209-git";
+  version = "postmodern-20220220-git";
 
   parasites = [ "simple-date/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
-    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz";
+    sha256 = "17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5";
   };
 
   packageName = "simple-date";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM simple-date DESCRIPTION
     Simple date library that can be used with postmodern SHA256
-    1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
-    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME simple-date FILENAME simple-date
+    17g6360phwcjy28j1gjj77p67y6fl1l9nrpgf9x9jmmx16mk44d5 URL
+    http://beta.quicklisp.org/archive/postmodern/2022-02-20/postmodern-20220220-git.tgz
+    MD5 d30fbcddd0b858445622f4f04676561e NAME simple-date FILENAME simple-date
     DEPS ((NAME fiveam FILENAME fiveam)) DEPENDENCIES (fiveam) VERSION
-    postmodern-20211209-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
+    postmodern-20220220-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
     (simple-date/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/slynk.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/slynk.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "slynk";
-  version = "sly-20210411-git";
+  version = "sly-20220220-git";
 
   parasites = [ "slynk/arglists" "slynk/fancy-inspector" "slynk/indentation" "slynk/mrepl" "slynk/package-fu" "slynk/profiler" "slynk/retro" "slynk/stickers" "slynk/trace-dialog" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/sly/2021-04-11/sly-20210411-git.tgz";
-    sha256 = "1a96aapsz3fhnnnb8njn8v2ddrh6kwisppd90cc7v8knh043xgks";
+    url = "http://beta.quicklisp.org/archive/sly/2022-02-20/sly-20220220-git.tgz";
+    sha256 = "0g24mmh7fpiinhzjay6ffm8mqpgl6f7hpw3rz2c0rx92xl3mvmhm";
   };
 
   packageName = "slynk";
@@ -21,10 +21,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM slynk DESCRIPTION System lacks description SHA256
-    1a96aapsz3fhnnnb8njn8v2ddrh6kwisppd90cc7v8knh043xgks URL
-    http://beta.quicklisp.org/archive/sly/2021-04-11/sly-20210411-git.tgz MD5
-    7f0ff6b8a07d23599c77cd33c6d59ea6 NAME slynk FILENAME slynk DEPS NIL
-    DEPENDENCIES NIL VERSION sly-20210411-git SIBLINGS NIL PARASITES
+    0g24mmh7fpiinhzjay6ffm8mqpgl6f7hpw3rz2c0rx92xl3mvmhm URL
+    http://beta.quicklisp.org/archive/sly/2022-02-20/sly-20220220-git.tgz MD5
+    87d214f13d8ed08a9b266555d3cac095 NAME slynk FILENAME slynk DEPS NIL
+    DEPENDENCIES NIL VERSION sly-20220220-git SIBLINGS NIL PARASITES
     (slynk/arglists slynk/fancy-inspector slynk/indentation slynk/mrepl
      slynk/package-fu slynk/profiler slynk/retro slynk/stickers
      slynk/trace-dialog)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/smug.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/smug.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "smug";
-  version = "20160421-git";
+  version = "20211230-git";
 
   description = "SMUG: Simple Monadic Uber Go-into, Parsing made easy.";
 
   deps = [ args."asdf-package-system" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/smug/2016-04-21/smug-20160421-git.tgz";
-    sha256 = "0f9ig6r0cm1sbhkasx1v27204rmrjbzgwc49d9hy4zn29ffrg0h2";
+    url = "http://beta.quicklisp.org/archive/smug/2021-12-30/smug-20211230-git.tgz";
+    sha256 = "0j8w8vkxd76r9a6v6yrhgs7k1hv1fpnzkhjykq9dssnnz5cdpb6p";
   };
 
   packageName = "smug";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM smug DESCRIPTION
     SMUG: Simple Monadic Uber Go-into, Parsing made easy. SHA256
-    0f9ig6r0cm1sbhkasx1v27204rmrjbzgwc49d9hy4zn29ffrg0h2 URL
-    http://beta.quicklisp.org/archive/smug/2016-04-21/smug-20160421-git.tgz MD5
-    8139d7813bb3130497b6da3bb4cb8924 NAME smug FILENAME smug DEPS
+    0j8w8vkxd76r9a6v6yrhgs7k1hv1fpnzkhjykq9dssnnz5cdpb6p URL
+    http://beta.quicklisp.org/archive/smug/2021-12-30/smug-20211230-git.tgz MD5
+    8661c0d2306a06f0df4bcfe94b48ab7e NAME smug FILENAME smug DEPS
     ((NAME asdf-package-system FILENAME asdf-package-system)) DEPENDENCIES
-    (asdf-package-system) VERSION 20160421-git SIBLINGS NIL PARASITES NIL) */
+    (asdf-package-system) VERSION 20211230-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/spinneret.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/spinneret.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "spinneret";
-  version = "20211020-git";
+  version = "20220220-git";
 
   description = "Common Lisp HTML5 generator.";
 
-  deps = [ args."alexandria" args."anaphora" args."babel" args."bordeaux-threads" args."cl-ppcre" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parenscript" args."parse-declarations-1_dot_0" args."parse-number" args."serapeum" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-gray-streams" args."trivial-macroexpand-all" args."type-i" ];
+  deps = [ args."alexandria" args."anaphora" args."bordeaux-threads" args."cl-ppcre" args."closer-mop" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parenscript" args."parse-declarations-1_dot_0" args."parse-number" args."serapeum" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-file-size" args."trivial-garbage" args."trivial-gray-streams" args."trivial-macroexpand-all" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/spinneret/2021-10-20/spinneret-20211020-git.tgz";
-    sha256 = "1j3z2sr98j7rd8ssxp8r1yxlj8chvldn0k2nh2vf2jaynhwk3slq";
+    url = "http://beta.quicklisp.org/archive/spinneret/2022-02-20/spinneret-20220220-git.tgz";
+    sha256 = "06pfaxlxjdp6vkin0lczsmnljxyl6cjskxj23qs8f6fqas6r3kjy";
   };
 
   packageName = "spinneret";
@@ -19,18 +19,12 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM spinneret DESCRIPTION Common Lisp HTML5 generator. SHA256
-    1j3z2sr98j7rd8ssxp8r1yxlj8chvldn0k2nh2vf2jaynhwk3slq URL
-    http://beta.quicklisp.org/archive/spinneret/2021-10-20/spinneret-20211020-git.tgz
-    MD5 f10e1537f3bfd16a0a189d16fd86790b NAME spinneret FILENAME spinneret DEPS
+    06pfaxlxjdp6vkin0lczsmnljxyl6cjskxj23qs8f6fqas6r3kjy URL
+    http://beta.quicklisp.org/archive/spinneret/2022-02-20/spinneret-20220220-git.tgz
+    MD5 f2822f2362e1f4f01fd127a8cef68721 NAME spinneret FILENAME spinneret DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
-     (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-ppcre FILENAME cl-ppcre) (NAME closer-mop FILENAME closer-mop)
-     (NAME fare-quasiquote FILENAME fare-quasiquote)
-     (NAME fare-quasiquote-extras FILENAME fare-quasiquote-extras)
-     (NAME fare-quasiquote-optima FILENAME fare-quasiquote-optima)
-     (NAME fare-quasiquote-readtable FILENAME fare-quasiquote-readtable)
-     (NAME fare-utils FILENAME fare-utils)
      (NAME global-vars FILENAME global-vars)
      (NAME introspect-environment FILENAME introspect-environment)
      (NAME iterate FILENAME iterate)
@@ -46,22 +40,18 @@ rec {
      (NAME trivia.level0 FILENAME trivia_dot_level0)
      (NAME trivia.level1 FILENAME trivia_dot_level1)
      (NAME trivia.level2 FILENAME trivia_dot_level2)
-     (NAME trivia.quasiquote FILENAME trivia_dot_quasiquote)
      (NAME trivia.trivial FILENAME trivia_dot_trivial)
      (NAME trivial-cltl2 FILENAME trivial-cltl2)
-     (NAME trivial-features FILENAME trivial-features)
      (NAME trivial-file-size FILENAME trivial-file-size)
      (NAME trivial-garbage FILENAME trivial-garbage)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams)
      (NAME trivial-macroexpand-all FILENAME trivial-macroexpand-all)
      (NAME type-i FILENAME type-i))
     DEPENDENCIES
-    (alexandria anaphora babel bordeaux-threads cl-ppcre closer-mop
-     fare-quasiquote fare-quasiquote-extras fare-quasiquote-optima
-     fare-quasiquote-readtable fare-utils global-vars introspect-environment
-     iterate lisp-namespace named-readtables parenscript parse-declarations-1.0
-     parse-number serapeum split-sequence string-case trivia trivia.balland2006
-     trivia.level0 trivia.level1 trivia.level2 trivia.quasiquote trivia.trivial
-     trivial-cltl2 trivial-features trivial-file-size trivial-garbage
+    (alexandria anaphora bordeaux-threads cl-ppcre closer-mop global-vars
+     introspect-environment iterate lisp-namespace named-readtables parenscript
+     parse-declarations-1.0 parse-number serapeum split-sequence string-case
+     trivia trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
+     trivia.trivial trivial-cltl2 trivial-file-size trivial-garbage
      trivial-gray-streams trivial-macroexpand-all type-i)
-    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20220220-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "str";
-  version = "cl-20210531-git";
+  version = "cl-20220220-git";
 
   description = "Modern, consistent and terse Common Lisp string manipulation library.";
 
   deps = [ args."cl-change-case" args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."flexi-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-str/2021-05-31/cl-str-20210531-git.tgz";
-    sha256 = "16z1axfik0s2m74ly4bxlrv4mbd2r923y7nrrrc487fsjs3v23bb";
+    url = "http://beta.quicklisp.org/archive/cl-str/2022-02-20/cl-str-20220220-git.tgz";
+    sha256 = "12gkp2vj3q57p17zh41s0minq30bwz6z1d1ir4x69gay2s27q5yd";
   };
 
   packageName = "str";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM str DESCRIPTION
     Modern, consistent and terse Common Lisp string manipulation library.
-    SHA256 16z1axfik0s2m74ly4bxlrv4mbd2r923y7nrrrc487fsjs3v23bb URL
-    http://beta.quicklisp.org/archive/cl-str/2021-05-31/cl-str-20210531-git.tgz
-    MD5 05144979ce1bf382fdb0b91db932fe6a NAME str FILENAME str DEPS
+    SHA256 12gkp2vj3q57p17zh41s0minq30bwz6z1d1ir4x69gay2s27q5yd URL
+    http://beta.quicklisp.org/archive/cl-str/2022-02-20/cl-str-20220220-git.tgz
+    MD5 311b14274123e99d8182d86c2dc3dcf0 NAME str FILENAME str DEPS
     ((NAME cl-change-case FILENAME cl-change-case)
      (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME cl-ppcre-unicode FILENAME cl-ppcre-unicode)
@@ -30,4 +30,4 @@ rec {
      (NAME flexi-streams FILENAME flexi-streams))
     DEPENDENCIES
     (cl-change-case cl-ppcre cl-ppcre-unicode cl-unicode flexi-streams) VERSION
-    cl-20210531-git SIBLINGS (str.test) PARASITES NIL) */
+    cl-20220220-git SIBLINGS (str.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
@@ -2,15 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "stumpwm";
-  version = "20211209-git";
+  version = "20220220-git";
+
+  parasites = [ "stumpwm/build" ];
 
   description = "A tiling, keyboard driven window manager";
 
   deps = [ args."alexandria" args."cl-ppcre" args."clx" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/stumpwm/2021-12-09/stumpwm-20211209-git.tgz";
-    sha256 = "1n7wj2jn6sydnyrjmic53lqkqigk1cg140b9pcnk09ngsrq3cn60";
+    url = "http://beta.quicklisp.org/archive/stumpwm/2022-02-20/stumpwm-20220220-git.tgz";
+    sha256 = "0h4pi5p4hw0qcgr9vcgj3narwc8dmlxdm1fi67dj17a3bxcbyrid";
   };
 
   packageName = "stumpwm";
@@ -19,10 +21,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM stumpwm DESCRIPTION A tiling, keyboard driven window manager SHA256
-    1n7wj2jn6sydnyrjmic53lqkqigk1cg140b9pcnk09ngsrq3cn60 URL
-    http://beta.quicklisp.org/archive/stumpwm/2021-12-09/stumpwm-20211209-git.tgz
-    MD5 a556b95108398e56159bafe31c4dbabf NAME stumpwm FILENAME stumpwm DEPS
+    0h4pi5p4hw0qcgr9vcgj3narwc8dmlxdm1fi67dj17a3bxcbyrid URL
+    http://beta.quicklisp.org/archive/stumpwm/2022-02-20/stumpwm-20220220-git.tgz
+    MD5 d877a2526c927db3804ede91ec05ce36 NAME stumpwm FILENAME stumpwm DEPS
     ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME clx FILENAME clx))
-    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20211209-git SIBLINGS
-    (stumpwm-tests) PARASITES NIL) */
+    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20220220-git SIBLINGS
+    (stumpwm-tests) PARASITES (stumpwm/build)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/swank.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "swank";
-  version = "slime-v2.26.1";
+  version = "slime-v2.27";
 
   description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/slime/2020-12-20/slime-v2.26.1.tgz";
-    sha256 = "12q3la9lwzs01x0ii5vss0i8i78lgyjrn3adr3rs027f4b7386ny";
+    url = "http://beta.quicklisp.org/archive/slime/2022-02-20/slime-v2.27.tgz";
+    sha256 = "1aqnsqqb9jazymzc5lb9sq12ky3bq0q4frsndpi9nqa3k3hda4cf";
   };
 
   packageName = "swank";
@@ -19,7 +19,7 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM swank DESCRIPTION System lacks description SHA256
-    12q3la9lwzs01x0ii5vss0i8i78lgyjrn3adr3rs027f4b7386ny URL
-    http://beta.quicklisp.org/archive/slime/2020-12-20/slime-v2.26.1.tgz MD5
-    bd91e1fe29a4f7ebf53a0bfecc9e1e36 NAME swank FILENAME swank DEPS NIL
-    DEPENDENCIES NIL VERSION slime-v2.26.1 SIBLINGS NIL PARASITES NIL) */
+    1aqnsqqb9jazymzc5lb9sq12ky3bq0q4frsndpi9nqa3k3hda4cf URL
+    http://beta.quicklisp.org/archive/slime/2022-02-20/slime-v2.27.tgz MD5
+    fa228382eae3cb59451d41d54264f115 NAME swank FILENAME swank DEPS NIL
+    DEPENDENCIES NIL VERSION slime-v2.27 SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/symbol-munger.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/symbol-munger.nix
@@ -2,16 +2,18 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "symbol-munger";
-  version = "20150407-git";
+  version = "20220220-git";
+
+  parasites = [ "symbol-munger/test" ];
 
   description = "Functions to convert between the spacing and
   capitalization conventions of various environments";
 
-  deps = [ args."alexandria" args."iterate" ];
+  deps = [ args."alexandria" args."iterate" args."lisp-unit2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/symbol-munger/2015-04-07/symbol-munger-20150407-git.tgz";
-    sha256 = "0dccli8557kvyy2rngh646rmavf96p7xqn5bry65d7c1f61lyqv6";
+    url = "http://beta.quicklisp.org/archive/symbol-munger/2022-02-20/symbol-munger-20220220-git.tgz";
+    sha256 = "1zz7lzbnbr4l42dk5z9w0rhnlh2c9b6xszgkcgyf0h3s4rs6lwlf";
   };
 
   packageName = "symbol-munger";
@@ -22,10 +24,11 @@ rec {
 /* (SYSTEM symbol-munger DESCRIPTION
     Functions to convert between the spacing and
   capitalization conventions of various environments
-    SHA256 0dccli8557kvyy2rngh646rmavf96p7xqn5bry65d7c1f61lyqv6 URL
-    http://beta.quicklisp.org/archive/symbol-munger/2015-04-07/symbol-munger-20150407-git.tgz
-    MD5 b1e35b63d7ad1451868d1c40e2fbfab7 NAME symbol-munger FILENAME
+    SHA256 1zz7lzbnbr4l42dk5z9w0rhnlh2c9b6xszgkcgyf0h3s4rs6lwlf URL
+    http://beta.quicklisp.org/archive/symbol-munger/2022-02-20/symbol-munger-20220220-git.tgz
+    MD5 1490f027785e2ca1ec7cd138cd2864ce NAME symbol-munger FILENAME
     symbol-munger DEPS
-    ((NAME alexandria FILENAME alexandria) (NAME iterate FILENAME iterate))
-    DEPENDENCIES (alexandria iterate) VERSION 20150407-git SIBLINGS NIL
-    PARASITES NIL) */
+    ((NAME alexandria FILENAME alexandria) (NAME iterate FILENAME iterate)
+     (NAME lisp-unit2 FILENAME lisp-unit2))
+    DEPENDENCIES (alexandria iterate lisp-unit2) VERSION 20220220-git SIBLINGS
+    NIL PARASITES (symbol-munger/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-cltl2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-cltl2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-cltl2";
-  version = "20200325-git";
+  version = "20211230-git";
 
   description = "Compatibility package exporting CLtL2 functionality";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-cltl2/2020-03-25/trivial-cltl2-20200325-git.tgz";
-    sha256 = "0hahi36v47alsvamg62d0cgay8l0razcgxl089ifj6sqy7s8iwys";
+    url = "http://beta.quicklisp.org/archive/trivial-cltl2/2021-12-30/trivial-cltl2-20211230-git.tgz";
+    sha256 = "0ixds4vjvfy8z7z8pffbgxglk4wj3pkp4rv7vlks11pi42ys8ry4";
   };
 
   packageName = "trivial-cltl2";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM trivial-cltl2 DESCRIPTION
     Compatibility package exporting CLtL2 functionality SHA256
-    0hahi36v47alsvamg62d0cgay8l0razcgxl089ifj6sqy7s8iwys URL
-    http://beta.quicklisp.org/archive/trivial-cltl2/2020-03-25/trivial-cltl2-20200325-git.tgz
-    MD5 aa18140b9840365ceb9a6cddbdbdd67b NAME trivial-cltl2 FILENAME
-    trivial-cltl2 DEPS NIL DEPENDENCIES NIL VERSION 20200325-git SIBLINGS NIL
+    0ixds4vjvfy8z7z8pffbgxglk4wj3pkp4rv7vlks11pi42ys8ry4 URL
+    http://beta.quicklisp.org/archive/trivial-cltl2/2021-12-30/trivial-cltl2-20211230-git.tgz
+    MD5 1724626b5c6081d9d8860640166c69a7 NAME trivial-cltl2 FILENAME
+    trivial-cltl2 DEPS NIL DEPENDENCIES NIL VERSION 20211230-git SIBLINGS NIL
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-garbage.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-garbage.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-garbage";
-  version = "20200925-git";
+  version = "20211230-git";
 
   parasites = [ "trivial-garbage/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-garbage/2020-09-25/trivial-garbage-20200925-git.tgz";
-    sha256 = "00iw2iw6qzji9b2gwy798l54jdk185sxh1k7m2qd9srs8s730k83";
+    url = "http://beta.quicklisp.org/archive/trivial-garbage/2021-12-30/trivial-garbage-20211230-git.tgz";
+    sha256 = "10vv19i3vdli165j7hkmvmrmpkf4c9c6d4b26wwrfdj5cvm2l7gp";
   };
 
   packageName = "trivial-garbage";
@@ -22,8 +22,8 @@ rec {
 }
 /* (SYSTEM trivial-garbage DESCRIPTION
     Portable finalizers, weak hash-tables and weak pointers. SHA256
-    00iw2iw6qzji9b2gwy798l54jdk185sxh1k7m2qd9srs8s730k83 URL
-    http://beta.quicklisp.org/archive/trivial-garbage/2020-09-25/trivial-garbage-20200925-git.tgz
-    MD5 9d748d1d549f419ce474f35906707420 NAME trivial-garbage FILENAME
+    10vv19i3vdli165j7hkmvmrmpkf4c9c6d4b26wwrfdj5cvm2l7gp URL
+    http://beta.quicklisp.org/archive/trivial-garbage/2021-12-30/trivial-garbage-20211230-git.tgz
+    MD5 6e2b3c0360733f30c7ed36357eb8d54a NAME trivial-garbage FILENAME
     trivial-garbage DEPS ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION
-    20200925-git SIBLINGS NIL PARASITES (trivial-garbage/tests)) */
+    20211230-git SIBLINGS NIL PARASITES (trivial-garbage/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-package-local-nicknames.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-package-local-nicknames.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-package-local-nicknames";
-  version = "20200610-git";
+  version = "20220220-git";
 
   description = "Portability library for package-local nicknames";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2020-06-10/trivial-package-local-nicknames-20200610-git.tgz";
-    sha256 = "1wabkcwz0v144rb2w3rvxlcj264indfnvlyigk1wds7nq0c8lwk5";
+    url = "http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2022-02-20/trivial-package-local-nicknames-20220220-git.tgz";
+    sha256 = "1is3yj7jas4blr3a92dh18yn59ay5jsl715cwy435y61cqm0c756";
   };
 
   packageName = "trivial-package-local-nicknames";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM trivial-package-local-nicknames DESCRIPTION
     Portability library for package-local nicknames SHA256
-    1wabkcwz0v144rb2w3rvxlcj264indfnvlyigk1wds7nq0c8lwk5 URL
-    http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2020-06-10/trivial-package-local-nicknames-20200610-git.tgz
-    MD5 b3620521d3400ad5910878139bc86fcc NAME trivial-package-local-nicknames
+    1is3yj7jas4blr3a92dh18yn59ay5jsl715cwy435y61cqm0c756 URL
+    http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2022-02-20/trivial-package-local-nicknames-20220220-git.tgz
+    MD5 d6959b6dd52f354bafa5fa6bcb7b42a1 NAME trivial-package-local-nicknames
     FILENAME trivial-package-local-nicknames DEPS NIL DEPENDENCIES NIL VERSION
-    20200610-git SIBLINGS NIL PARASITES NIL) */
+    20220220-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-utf-8";
-  version = "20211209-git";
+  version = "20220220-git";
 
   parasites = [ "trivial-utf-8/doc" "trivial-utf-8/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."mgl-pax" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-utf-8/2021-12-09/trivial-utf-8-20211209-git.tgz";
-    sha256 = "1bis8shbdva1diwms2lvhlbdz9rvazqqxi9h8d33vlbw4xai075y";
+    url = "http://beta.quicklisp.org/archive/trivial-utf-8/2022-02-20/trivial-utf-8-20220220-git.tgz";
+    sha256 = "1q78zzpjw2m3yw3m415awy5wqkh3qx9adbgqrsf6v5q7387i8d7g";
   };
 
   packageName = "trivial-utf-8";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM trivial-utf-8 DESCRIPTION
     A small library for doing UTF-8-based input and output. SHA256
-    1bis8shbdva1diwms2lvhlbdz9rvazqqxi9h8d33vlbw4xai075y URL
-    http://beta.quicklisp.org/archive/trivial-utf-8/2021-12-09/trivial-utf-8-20211209-git.tgz
-    MD5 65603f3c4421a93d5d8c214bb406988d NAME trivial-utf-8 FILENAME
+    1q78zzpjw2m3yw3m415awy5wqkh3qx9adbgqrsf6v5q7387i8d7g URL
+    http://beta.quicklisp.org/archive/trivial-utf-8/2022-02-20/trivial-utf-8-20220220-git.tgz
+    MD5 7c9e40bde1c7f5579bbc71e1e3c22eb0 NAME trivial-utf-8 FILENAME
     trivial-utf-8 DEPS ((NAME mgl-pax FILENAME mgl-pax)) DEPENDENCIES (mgl-pax)
-    VERSION 20211209-git SIBLINGS NIL PARASITES
+    VERSION 20220220-git SIBLINGS NIL PARASITES
     (trivial-utf-8/doc trivial-utf-8/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/try.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/try.nix
@@ -1,0 +1,39 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "try";
+  version = "20220220-git";
+
+  parasites = [ "try/doc" "try/test" ];
+
+  description = "Try is a test framework.";
+
+  deps = [ args."alexandria" args."cl-ppcre" args."closer-mop" args."ieee-floats" args."mgl-pax" args."mgl-pax_dot_asdf" args."named-readtables" args."pythonic-string-reader" args."trivial-gray-streams" args."try_dot_asdf" args."uiop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/try/2022-02-20/try-20220220-git.tgz";
+    sha256 = "0airdqwram23rczcfas2z2l8liwc4zwg14y972xzgrdi0nlw0xvh";
+  };
+
+  packageName = "try";
+
+  asdFilesToKeep = ["try.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM try DESCRIPTION Try is a test framework. SHA256
+    0airdqwram23rczcfas2z2l8liwc4zwg14y972xzgrdi0nlw0xvh URL
+    http://beta.quicklisp.org/archive/try/2022-02-20/try-20220220-git.tgz MD5
+    b871e436d3cc7953d147061de1175a14 NAME try FILENAME try DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME ieee-floats FILENAME ieee-floats) (NAME mgl-pax FILENAME mgl-pax)
+     (NAME mgl-pax.asdf FILENAME mgl-pax_dot_asdf)
+     (NAME named-readtables FILENAME named-readtables)
+     (NAME pythonic-string-reader FILENAME pythonic-string-reader)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams)
+     (NAME try.asdf FILENAME try_dot_asdf) (NAME uiop FILENAME uiop))
+    DEPENDENCIES
+    (alexandria cl-ppcre closer-mop ieee-floats mgl-pax mgl-pax.asdf
+     named-readtables pythonic-string-reader trivial-gray-streams try.asdf
+     uiop)
+    VERSION 20220220-git SIBLINGS (try.asdf) PARASITES (try/doc try/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/try_dot_asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/try_dot_asdf.nix
@@ -1,0 +1,25 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "try_dot_asdf";
+  version = "try-20220220-git";
+
+  description = "System lacks description";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/try/2022-02-20/try-20220220-git.tgz";
+    sha256 = "0airdqwram23rczcfas2z2l8liwc4zwg14y972xzgrdi0nlw0xvh";
+  };
+
+  packageName = "try.asdf";
+
+  asdFilesToKeep = ["try.asdf.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM try.asdf DESCRIPTION System lacks description SHA256
+    0airdqwram23rczcfas2z2l8liwc4zwg14y972xzgrdi0nlw0xvh URL
+    http://beta.quicklisp.org/archive/try/2022-02-20/try-20220220-git.tgz MD5
+    b871e436d3cc7953d147061de1175a14 NAME try.asdf FILENAME try_dot_asdf DEPS
+    NIL DEPENDENCIES NIL VERSION try-20220220-git SIBLINGS (try) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/vecto.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/vecto.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "vecto";
-  version = "1.5";
+  version = "1.6";
 
   description = "Create vector graphics in PNG files.";
 
   deps = [ args."cl-aa" args."cl-paths" args."cl-vectors" args."salza2" args."trivial-gray-streams" args."zpb-ttf" args."zpng" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/vecto/2017-12-27/vecto-1.5.tgz";
-    sha256 = "05pxc6s853f67j57bbzsg2izfl0164bifbvdp2ji870yziz88vls";
+    url = "http://beta.quicklisp.org/archive/vecto/2021-12-30/vecto-1.6.tgz";
+    sha256 = "09iis5v95gybypxrmqll1fifclqzmg5blaxcr59bwbb72ihvi790";
   };
 
   packageName = "vecto";
@@ -19,13 +19,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM vecto DESCRIPTION Create vector graphics in PNG files. SHA256
-    05pxc6s853f67j57bbzsg2izfl0164bifbvdp2ji870yziz88vls URL
-    http://beta.quicklisp.org/archive/vecto/2017-12-27/vecto-1.5.tgz MD5
-    69e6b2f7fa10066d50f9134942afad73 NAME vecto FILENAME vecto DEPS
+    09iis5v95gybypxrmqll1fifclqzmg5blaxcr59bwbb72ihvi790 URL
+    http://beta.quicklisp.org/archive/vecto/2021-12-30/vecto-1.6.tgz MD5
+    9b7f7ddb9cc4d8de353979e339182c31 NAME vecto FILENAME vecto DEPS
     ((NAME cl-aa FILENAME cl-aa) (NAME cl-paths FILENAME cl-paths)
      (NAME cl-vectors FILENAME cl-vectors) (NAME salza2 FILENAME salza2)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams)
      (NAME zpb-ttf FILENAME zpb-ttf) (NAME zpng FILENAME zpng))
     DEPENDENCIES
     (cl-aa cl-paths cl-vectors salza2 trivial-gray-streams zpb-ttf zpng)
-    VERSION 1.5 SIBLINGS (vectometry) PARASITES NIL) */
+    VERSION 1.6 SIBLINGS (vectometry) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/wild-package-inferred-system.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/wild-package-inferred-system.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "wild-package-inferred-system";
-  version = "20200325-git";
+  version = "20210531-git";
 
   parasites = [ "wild-package-inferred-system/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/wild-package-inferred-system/2020-03-25/wild-package-inferred-system-20200325-git.tgz";
-    sha256 = "1ypnpzy9z4zkna29sgl4afc386ksa61302bm5kznxb3zz2v1sjas";
+    url = "http://beta.quicklisp.org/archive/wild-package-inferred-system/2021-05-31/wild-package-inferred-system-20210531-git.tgz";
+    sha256 = "1ads1hyq9zs1w2pp4i9drmpkpz7kwwszmhi340a6wjm120lfb6kk";
   };
 
   packageName = "wild-package-inferred-system";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM wild-package-inferred-system DESCRIPTION
     Introduces the wildcards `*' and `**' into package-inferred-system SHA256
-    1ypnpzy9z4zkna29sgl4afc386ksa61302bm5kznxb3zz2v1sjas URL
-    http://beta.quicklisp.org/archive/wild-package-inferred-system/2020-03-25/wild-package-inferred-system-20200325-git.tgz
-    MD5 4dfd9f90d780b1e67640543dd4acbf21 NAME wild-package-inferred-system
+    1ads1hyq9zs1w2pp4i9drmpkpz7kwwszmhi340a6wjm120lfb6kk URL
+    http://beta.quicklisp.org/archive/wild-package-inferred-system/2021-05-31/wild-package-inferred-system-20210531-git.tgz
+    MD5 4744e08ef5f50da04a429ae9af60bb80 NAME wild-package-inferred-system
     FILENAME wild-package-inferred-system DEPS ((NAME fiveam FILENAME fiveam))
-    DEPENDENCIES (fiveam) VERSION 20200325-git SIBLINGS (foo-wild) PARASITES
+    DEPENDENCIES (fiveam) VERSION 20210531-git SIBLINGS (foo-wild) PARASITES
     (wild-package-inferred-system/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/yason.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/yason.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "yason";
-  version = "v0.7.8";
+  version = "20220220-git";
 
   description = "JSON parser/encoder";
 
   deps = [ args."alexandria" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/yason/2019-12-27/yason-v0.7.8.tgz";
-    sha256 = "11d51i2iw4nxsparwbh3s6w9zyms3wi0z0fprwz1d3sqlf03j6f1";
+    url = "http://beta.quicklisp.org/archive/yason/2022-02-20/yason-20220220-git.tgz";
+    sha256 = "01axmpai6pvv26qpjpgqvrfq25shrzw35w7nkz4y4b9d2yknyjdi";
   };
 
   packageName = "yason";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM yason DESCRIPTION JSON parser/encoder SHA256
-    11d51i2iw4nxsparwbh3s6w9zyms3wi0z0fprwz1d3sqlf03j6f1 URL
-    http://beta.quicklisp.org/archive/yason/2019-12-27/yason-v0.7.8.tgz MD5
-    7c3231635aa494f1721273713ea8c56a NAME yason FILENAME yason DEPS
+    01axmpai6pvv26qpjpgqvrfq25shrzw35w7nkz4y4b9d2yknyjdi URL
+    http://beta.quicklisp.org/archive/yason/2022-02-20/yason-20220220-git.tgz
+    MD5 0e940b30c70c5748a72ee40b16aa4a5e NAME yason FILENAME yason DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams))
-    DEPENDENCIES (alexandria trivial-gray-streams) VERSION v0.7.8 SIBLINGS NIL
-    PARASITES NIL) */
+    DEPENDENCIES (alexandria trivial-gray-streams) VERSION 20220220-git
+    SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -113,7 +113,19 @@ $out/lib/common-lisp/query-fs"
       '';
     };
   };
-  cffi = addNativeLibs [pkgs.libffi];
+
+  cffi = x: {
+    overrides = y: (x.overrides y) // {
+      propagatedBuildInputs = [ pkgs.libffi ];
+      patches = [
+        pkgs.fetchpatch {
+          url = "https://github.com/cffi/cffi/pull/192.diff";
+          sha256 = "1n4pkzxas7zv065829z27vbx1ylxbl289h614b3lxm18xzv477ag";
+        }
+      ];
+    };
+  };
+
   cl-mysql = x: {
     propagatedBuildInputs = [pkgs.libmysqlclient];
     overrides = y: (x.overrides y) // {
@@ -292,5 +304,6 @@ $out/lib/common-lisp/query-fs"
     };
   };
   lla = addNativeLibs [ pkgs.openblas ];
+  magicl = addNativeLibs [ pkgs.libffi ];
 #  cl-opengl = addNativeLibs [ pkgs.libGL pkgs.glfw ];
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -203,6 +203,7 @@ proc-parse
 prove
 prove-asdf
 puri
+py4cl
 pythonic-string-reader
 query-fs
 quri

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -6,10 +6,263 @@ let quicklisp-to-nix-packages = rec {
   buildLispPackage = callPackage ./define-package.nix;
   qlOverrides = callPackage ./quicklisp-to-nix-overrides.nix {};
 
-  "html-encode" = buildLispPackage
+  "iolib_slash_os" = quicklisp-to-nix-packages."iolib";
+
+
+  "hu_dot_dwim_dot_util_slash_temporary-files" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util";
+
+
+  "lw-compat" = buildLispPackage
     ((f: x: (x // (f x)))
-       (qlOverrides."html-encode" or (x: {}))
-       (import ./quicklisp-to-nix-output/html-encode.nix {
+       (qlOverrides."lw-compat" or (x: {}))
+       (import ./quicklisp-to-nix-output/lw-compat.nix {
+         inherit fetchurl;
+       }));
+
+
+  "hu_dot_dwim_dot_util_slash_source" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util";
+
+
+  "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "contextl" = quicklisp-to-nix-packages."contextl";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_defclass-star" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star";
+           "hu_dot_dwim_dot_defclass-star_plus_contextl" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_contextl";
+           "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "lw-compat" = quicklisp-to-nix-packages."lw-compat";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+       }));
+
+
+  "hu_dot_dwim_dot_defclass-star_plus_contextl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_defclass-star_plus_contextl" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_contextl.nix {
+         inherit fetchurl;
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "contextl" = quicklisp-to-nix-packages."contextl";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_defclass-star" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star";
+           "lw-compat" = quicklisp-to-nix-packages."lw-compat";
+       }));
+
+
+  "hu_dot_dwim_dot_def_plus_contextl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_def_plus_contextl" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_contextl.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "contextl" = quicklisp-to-nix-packages."contextl";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "lw-compat" = quicklisp-to-nix-packages."lw-compat";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+       }));
+
+
+  "contextl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."contextl" or (x: {}))
+       (import ./quicklisp-to-nix-output/contextl.nix {
+         inherit fetchurl;
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "lw-compat" = quicklisp-to-nix-packages."lw-compat";
+       }));
+
+
+  "hu_dot_dwim_dot_util_slash_threads" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util";
+
+
+  "hu_dot_dwim_dot_walker" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_walker" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_walker.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "contextl" = quicklisp-to-nix-packages."contextl";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_common-lisp" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common-lisp";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_def_plus_contextl" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_plus_contextl";
+           "hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_defclass-star" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star";
+           "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_stefil_plus_swank" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil_plus_swank";
+           "hu_dot_dwim_dot_syntax-sugar" = quicklisp-to-nix-packages."hu_dot_dwim_dot_syntax-sugar";
+           "hu_dot_dwim_dot_util" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util";
+           "hu_dot_dwim_dot_util_slash_temporary-files" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util_slash_temporary-files";
+           "iolib_slash_os" = quicklisp-to-nix-packages."iolib_slash_os";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "lw-compat" = quicklisp-to-nix-packages."lw-compat";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+           "swank" = quicklisp-to-nix-packages."swank";
+       }));
+
+
+  "hu_dot_dwim_dot_syntax-sugar" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_syntax-sugar" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_syntax-sugar.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_common-lisp" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common-lisp";
+           "hu_dot_dwim_dot_walker" = quicklisp-to-nix-packages."hu_dot_dwim_dot_walker";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+       }));
+
+
+  "hu_dot_dwim_dot_partial-eval" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_partial-eval" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_partial-eval.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "contextl" = quicklisp-to-nix-packages."contextl";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_common-lisp" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common-lisp";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_def_plus_contextl" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_plus_contextl";
+           "hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_defclass-star" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star";
+           "hu_dot_dwim_dot_defclass-star_plus_contextl" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_contextl";
+           "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def_plus_contextl";
+           "hu_dot_dwim_dot_logger" = quicklisp-to-nix-packages."hu_dot_dwim_dot_logger";
+           "hu_dot_dwim_dot_syntax-sugar" = quicklisp-to-nix-packages."hu_dot_dwim_dot_syntax-sugar";
+           "hu_dot_dwim_dot_util" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util";
+           "hu_dot_dwim_dot_util_slash_source" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util_slash_source";
+           "hu_dot_dwim_dot_walker" = quicklisp-to-nix-packages."hu_dot_dwim_dot_walker";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "local-time" = quicklisp-to-nix-packages."local-time";
+           "lw-compat" = quicklisp-to-nix-packages."lw-compat";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+           "swank" = quicklisp-to-nix-packages."swank";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
+  "hu_dot_dwim_dot_logger" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_logger" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_logger.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_common-lisp" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common-lisp";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_def_slash_namespace" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_slash_namespace";
+           "hu_dot_dwim_dot_defclass-star" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star";
+           "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_syntax-sugar" = quicklisp-to-nix-packages."hu_dot_dwim_dot_syntax-sugar";
+           "hu_dot_dwim_dot_util" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util";
+           "hu_dot_dwim_dot_util_slash_threads" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util_slash_threads";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "local-time" = quicklisp-to-nix-packages."local-time";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
+  "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_defclass-star" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+       }));
+
+
+  "hu_dot_dwim_dot_def_slash_namespace" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+
+
+  "hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_common-lisp" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common-lisp";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+       }));
+
+
+  "hu_dot_dwim_dot_util" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_util" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_util.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "command-line-arguments" = quicklisp-to-nix-packages."command-line-arguments";
+           "cxml" = quicklisp-to-nix-packages."cxml";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_common-lisp" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common-lisp";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_def_slash_namespace" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_slash_namespace";
+           "hu_dot_dwim_dot_defclass-star" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star";
+           "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_logger" = quicklisp-to-nix-packages."hu_dot_dwim_dot_logger";
+           "hu_dot_dwim_dot_partial-eval" = quicklisp-to-nix-packages."hu_dot_dwim_dot_partial-eval";
+           "hu_dot_dwim_dot_syntax-sugar" = quicklisp-to-nix-packages."hu_dot_dwim_dot_syntax-sugar";
+           "hu_dot_dwim_dot_walker" = quicklisp-to-nix-packages."hu_dot_dwim_dot_walker";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+           "swank" = quicklisp-to-nix-packages."swank";
+           "uiop" = quicklisp-to-nix-packages."uiop";
+       }));
+
+
+  "try_dot_asdf" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."try_dot_asdf" or (x: {}))
+       (import ./quicklisp-to-nix-output/try_dot_asdf.nix {
          inherit fetchurl;
        }));
 
@@ -63,9 +316,12 @@ let quicklisp-to-nix-packages = rec {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
            "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_util" = quicklisp-to-nix-packages."hu_dot_dwim_dot_util";
            "iterate" = quicklisp-to-nix-packages."iterate";
            "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
        }));
 
 
@@ -246,6 +502,17 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "numpy-file-format" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."numpy-file-format" or (x: {}))
+       (import ./quicklisp-to-nix-output/numpy-file-format.nix {
+         inherit fetchurl;
+           "ieee-floats" = quicklisp-to-nix-packages."ieee-floats";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "uiop" = quicklisp-to-nix-packages."uiop";
+       }));
+
+
   "simple-date_slash_postgres-glue" = quicklisp-to-nix-packages."simple-date";
 
 
@@ -297,6 +564,14 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "parseq" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."parseq" or (x: {}))
+       (import ./quicklisp-to-nix-output/parseq.nix {
+         inherit fetchurl;
+       }));
+
+
   "wild-package-inferred-system" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."wild-package-inferred-system" or (x: {}))
@@ -306,37 +581,30 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
-  "parseq" = buildLispPackage
+  "try" = buildLispPackage
     ((f: x: (x // (f x)))
-       (qlOverrides."parseq" or (x: {}))
-       (import ./quicklisp-to-nix-output/parseq.nix {
+       (qlOverrides."try" or (x: {}))
+       (import ./quicklisp-to-nix-output/try.nix {
          inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "ieee-floats" = quicklisp-to-nix-packages."ieee-floats";
+           "mgl-pax" = quicklisp-to-nix-packages."mgl-pax";
+           "mgl-pax_dot_asdf" = quicklisp-to-nix-packages."mgl-pax_dot_asdf";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "pythonic-string-reader" = quicklisp-to-nix-packages."pythonic-string-reader";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
+           "try_dot_asdf" = quicklisp-to-nix-packages."try_dot_asdf";
+           "uiop" = quicklisp-to-nix-packages."uiop";
        }));
 
 
-  "colorize" = buildLispPackage
+  "mgl-pax_dot_asdf" = buildLispPackage
     ((f: x: (x // (f x)))
-       (qlOverrides."colorize" or (x: {}))
-       (import ./quicklisp-to-nix-output/colorize.nix {
+       (qlOverrides."mgl-pax_dot_asdf" or (x: {}))
+       (import ./quicklisp-to-nix-output/mgl-pax_dot_asdf.nix {
          inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "html-encode" = quicklisp-to-nix-packages."html-encode";
-           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
-       }));
-
-
-  "_3bmd-ext-code-blocks" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."_3bmd-ext-code-blocks" or (x: {}))
-       (import ./quicklisp-to-nix-output/_3bmd-ext-code-blocks.nix {
-         inherit fetchurl;
-           "_3bmd" = quicklisp-to-nix-packages."_3bmd";
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "colorize" = quicklisp-to-nix-packages."colorize";
-           "esrap" = quicklisp-to-nix-packages."esrap";
-           "html-encode" = quicklisp-to-nix-packages."html-encode";
-           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
-           "trivial-with-current-source-form" = quicklisp-to-nix-packages."trivial-with-current-source-form";
        }));
 
 
@@ -378,6 +646,7 @@ let quicklisp-to-nix-packages = rec {
            "usocket" = quicklisp-to-nix-packages."usocket";
        }));
 
+
   "simple-inferiors" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."simple-inferiors" or (x: {}))
@@ -398,23 +667,6 @@ let quicklisp-to-nix-packages = rec {
          inherit fetchurl;
        }));
 
-
-  "iolib_dot_grovel" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."iolib_dot_grovel" or (x: {}))
-       (import ./quicklisp-to-nix-output/iolib_dot_grovel.nix {
-         inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "babel" = quicklisp-to-nix-packages."babel";
-           "cffi" = quicklisp-to-nix-packages."cffi";
-           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
-           "iolib_dot_base" = quicklisp-to-nix-packages."iolib_dot_base";
-           "iolib_dot_common-lisp" = quicklisp-to-nix-packages."iolib_dot_common-lisp";
-           "iolib_dot_conf" = quicklisp-to-nix-packages."iolib_dot_conf";
-           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
-           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
-           "uiop" = quicklisp-to-nix-packages."uiop";
-       }));
 
   "trivia_dot_quasiquote" = buildLispPackage
     ((f: x: (x // (f x)))
@@ -1369,9 +1621,7 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."lack-util" or (x: {}))
        (import ./quicklisp-to-nix-output/lack-util.nix {
          inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
-           "ironclad" = quicklisp-to-nix-packages."ironclad";
+           "cl-isaac" = quicklisp-to-nix-packages."cl-isaac";
        }));
 
 
@@ -1388,6 +1638,14 @@ let quicklisp-to-nix-packages = rec {
     ((f: x: (x // (f x)))
        (qlOverrides."lack-component" or (x: {}))
        (import ./quicklisp-to-nix-output/lack-component.nix {
+         inherit fetchurl;
+       }));
+
+
+  "cl-isaac" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-isaac" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-isaac.nix {
          inherit fetchurl;
        }));
 
@@ -1478,7 +1736,7 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
-  "cl-ppcre-test" = quicklisp-to-nix-packages."cl-ppcre";
+  "cl-ppcre_slash_test" = quicklisp-to-nix-packages."cl-ppcre";
 
 
   "zpb-ttf" = buildLispPackage
@@ -2225,6 +2483,7 @@ let quicklisp-to-nix-packages = rec {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "iterate" = quicklisp-to-nix-packages."iterate";
+           "lisp-unit2" = quicklisp-to-nix-packages."lisp-unit2";
        }));
 
 
@@ -2326,15 +2585,9 @@ let quicklisp-to-nix-packages = rec {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "anaphora" = quicklisp-to-nix-packages."anaphora";
-           "babel" = quicklisp-to-nix-packages."babel";
            "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
            "closer-mop" = quicklisp-to-nix-packages."closer-mop";
-           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
-           "fare-quasiquote-extras" = quicklisp-to-nix-packages."fare-quasiquote-extras";
-           "fare-quasiquote-optima" = quicklisp-to-nix-packages."fare-quasiquote-optima";
-           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
-           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
            "global-vars" = quicklisp-to-nix-packages."global-vars";
            "introspect-environment" = quicklisp-to-nix-packages."introspect-environment";
            "iterate" = quicklisp-to-nix-packages."iterate";
@@ -2351,10 +2604,8 @@ let quicklisp-to-nix-packages = rec {
            "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
            "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
            "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
-           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
            "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
            "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
-           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
            "trivial-file-size" = quicklisp-to-nix-packages."trivial-file-size";
            "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
            "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
@@ -2416,19 +2667,12 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/serapeum.nix {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "babel" = quicklisp-to-nix-packages."babel";
            "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
            "closer-mop" = quicklisp-to-nix-packages."closer-mop";
-           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
-           "fare-quasiquote-extras" = quicklisp-to-nix-packages."fare-quasiquote-extras";
-           "fare-quasiquote-optima" = quicklisp-to-nix-packages."fare-quasiquote-optima";
-           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
-           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
            "global-vars" = quicklisp-to-nix-packages."global-vars";
            "introspect-environment" = quicklisp-to-nix-packages."introspect-environment";
            "iterate" = quicklisp-to-nix-packages."iterate";
            "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
-           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
            "parse-declarations-1_dot_0" = quicklisp-to-nix-packages."parse-declarations-1_dot_0";
            "parse-number" = quicklisp-to-nix-packages."parse-number";
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
@@ -2438,15 +2682,12 @@ let quicklisp-to-nix-packages = rec {
            "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
            "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
            "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
-           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
            "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
            "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
-           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
            "trivial-file-size" = quicklisp-to-nix-packages."trivial-file-size";
            "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
            "trivial-macroexpand-all" = quicklisp-to-nix-packages."trivial-macroexpand-all";
            "type-i" = quicklisp-to-nix-packages."type-i";
-           "uiop" = quicklisp-to-nix-packages."uiop";
        }));
 
 
@@ -2514,6 +2755,20 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/pythonic-string-reader.nix {
          inherit fetchurl;
            "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+       }));
+
+
+  "py4cl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."py4cl" or (x: {}))
+       (import ./quicklisp-to-nix-output/py4cl.nix {
+         inherit fetchurl;
+           "cl-json" = quicklisp-to-nix-packages."cl-json";
+           "ieee-floats" = quicklisp-to-nix-packages."ieee-floats";
+           "numpy-file-format" = quicklisp-to-nix-packages."numpy-file-format";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+           "uiop" = quicklisp-to-nix-packages."uiop";
        }));
 
 
@@ -2724,9 +2979,18 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."nbd" or (x: {}))
        (import ./quicklisp-to-nix-output/nbd.nix {
          inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
            "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
            "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
+           "iterate" = quicklisp-to-nix-packages."iterate";
            "lisp-binary" = quicklisp-to-nix-packages."lisp-binary";
+           "moptilities" = quicklisp-to-nix-packages."moptilities";
+           "quasiquote-2_dot_0" = quicklisp-to-nix-packages."quasiquote-2_dot_0";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
            "wild-package-inferred-system" = quicklisp-to-nix-packages."wild-package-inferred-system";
        }));
 
@@ -2736,6 +3000,7 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."named-readtables" or (x: {}))
        (import ./quicklisp-to-nix-output/named-readtables.nix {
          inherit fetchurl;
+           "try" = quicklisp-to-nix-packages."try";
        }));
 
 
@@ -2811,11 +3076,8 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."mgl-pax" or (x: {}))
        (import ./quicklisp-to-nix-output/mgl-pax.nix {
          inherit fetchurl;
-           "_3bmd" = quicklisp-to-nix-packages."_3bmd";
-           "_3bmd-ext-code-blocks" = quicklisp-to-nix-packages."_3bmd-ext-code-blocks";
            "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "colorize" = quicklisp-to-nix-packages."colorize";
-           "md5" = quicklisp-to-nix-packages."md5";
+           "mgl-pax_dot_asdf" = quicklisp-to-nix-packages."mgl-pax_dot_asdf";
            "named-readtables" = quicklisp-to-nix-packages."named-readtables";
            "pythonic-string-reader" = quicklisp-to-nix-packages."pythonic-string-reader";
            "swank" = quicklisp-to-nix-packages."swank";
@@ -3050,9 +3312,7 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."lack" or (x: {}))
        (import ./quicklisp-to-nix-output/lack.nix {
          inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
-           "ironclad" = quicklisp-to-nix-packages."ironclad";
+           "cl-isaac" = quicklisp-to-nix-packages."cl-isaac";
            "lack-component" = quicklisp-to-nix-packages."lack-component";
            "lack-util" = quicklisp-to-nix-packages."lack-util";
        }));
@@ -4073,7 +4333,7 @@ let quicklisp-to-nix-packages = rec {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
-           "ironclad" = quicklisp-to-nix-packages."ironclad";
+           "cl-isaac" = quicklisp-to-nix-packages."cl-isaac";
            "lack" = quicklisp-to-nix-packages."lack";
            "lack-component" = quicklisp-to-nix-packages."lack-component";
            "lack-middleware-backtrace" = quicklisp-to-nix-packages."lack-middleware-backtrace";
@@ -4385,7 +4645,7 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/cl-ppcre-unicode.nix {
          inherit fetchurl;
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
-           "cl-ppcre-test" = quicklisp-to-nix-packages."cl-ppcre-test";
+           "cl-ppcre_slash_test" = quicklisp-to-nix-packages."cl-ppcre_slash_test";
            "cl-unicode" = quicklisp-to-nix-packages."cl-unicode";
            "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
        }));
@@ -5174,7 +5434,6 @@ let quicklisp-to-nix-packages = rec {
            "closer-mop" = quicklisp-to-nix-packages."closer-mop";
            "collectors" = quicklisp-to-nix-packages."collectors";
            "iterate" = quicklisp-to-nix-packages."iterate";
-           "swank" = quicklisp-to-nix-packages."swank";
            "symbol-munger" = quicklisp-to-nix-packages."symbol-munger";
        }));
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix/system-info.lisp
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix/system-info.lisp
@@ -490,4 +490,5 @@ Run with --debug and/or --verbose for more info.
   "Make an executable"
   (setf uiop:*image-entry-point* #'main)
   (setf uiop:*lisp-interaction* nil)
+  (require :sb-sprof) ;; required in image to handle HU.DWIM.ASDF
   (uiop:dump-image "quicklisp-to-nix-system-info" :executable t))

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -7,7 +7,7 @@ self = rec {
   buildInputs = [
     gcc
     openssl fuse libuv libmysqlclient libfixposix libev sqlite
-    freetds
+    freetds openblas
     lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info
   ];
   CPATH = lib.makeSearchPath "include"
@@ -22,6 +22,7 @@ self = rec {
       gobject-introspection
       gtk3
       libev
+      libffi
       libfixposix
       libmysqlclient
       libuv


### PR DESCRIPTION
###### Description of changes

lispPackages: update to Quicklisp 2022-02-20

Add package py4cl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

This seemed to fail, though I'm not sure that's related to my change: https://gist.github.com/lukego/91ba66c76dd7e4e04706d0e66a39a070.

- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
