### PR TITLE
geda: pull upstream fixes for -fno-common toolchains

### DIFF
--- a/pkgs/applications/science/electronics/geda/default.nix
+++ b/pkgs/applications/science/electronics/geda/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, guile, gtk2, flex, gawk, perl }:
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, guile, gtk2, flex, gawk, perl }:
 
 stdenv.mkDerivation {
   pname = "geda";
@@ -8,6 +8,20 @@ stdenv.mkDerivation {
     url = "http://ftp.geda-project.org/geda-gaf/stable/v1.8/1.8.2/geda-gaf-1.8.2.tar.gz";
     sha256 = "08dpa506xk4gjbbi8vnxcb640wq4ihlgmhzlssl52nhvxwx7gx5v";
   };
+
+  patches = [
+    # Pull upstream patch for -fno-common toolchains
+    (fetchpatch {
+      name = "fno-common-p1.patch";
+      url = "http://git.geda-project.org/geda-gaf/patch/?id=cb6bac898fe43c5a59b577123ba8698ec04deef6";
+      sha256 = "0njlh20qjrlqf5m8p92vmkl0jsm747f4mbqwvldnf8nd2j608nkq";
+    })
+    (fetchpatch {
+      name = "fno-common-p2.patch";
+      url = "http://git.geda-project.org/geda-gaf/patch/?id=7b9d523a3558290b4487c3ff9a4a5b43e8941158";
+      sha256 = "1z9gzz5ngsbq6c9dw2dfz7kpsq97zhs1ma9saxm7hiybwadbj18k";
+    })
+  ];
 
   configureFlags = [
     "--disable-update-xdg-database"


### PR DESCRIPTION
Without the change builda fails on upstream gcc-10 as:

    ld: gattrib/src/../include/globals.h:97:
      multiple definition of `window'; gattrib/src/../include/globals.h:97: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
