### PR TITLE
[staging] openldap: remove deprecated options, improve encapsulation

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -319,7 +319,7 @@ in {
         # outside the main process:
         #   Got notification message from PID 6378, but reception only permitted for main PID 6377
         NotifyAccess = "all";
-        RuntimeDirectory = "slapd"; # TODO: openldap, for consistency
+        RuntimeDirectory = "openldap";
         StateDirectory = ["openldap"]
           ++ (map ({olcDbDirectory, ... }: removePrefix "/var/lib/" olcDbDirectory) (attrValues dbSettings));
         StateDirectoryMode = "700";

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -169,8 +169,7 @@ in {
         default = null;
         description = ''
           Use this config directory instead of generating one from the
-          <literal>settings</literal> option. Overrides all NixOS settings. If
-          you use this option,ensure `olcPidFile` is set to `/run/slapd/slapd.conf`.
+          <literal>settings</literal> option. Overrides all NixOS settings.
         '';
         example = "/var/db/slapd.d";
       };
@@ -216,7 +215,6 @@ in {
       attrs = {
         objectClass = "olcGlobal";
         cn = "config";
-        olcPidFile = "/run/slapd/slapd.pid";
       };
       children."cn=schema".attrs = {
         cn = "schema";
@@ -265,7 +263,7 @@ in {
       '';
       serviceConfig = {
         ExecStart = lib.escapeShellArgs ([
-          "${openldap}/libexec/slapd" "-u" cfg.user "-g" cfg.group "-F" configDir
+          "${openldap}/libexec/slapd" "-d" "0" "-u" cfg.user "-g" cfg.group "-F" configDir
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
         Type = "notify";
@@ -273,7 +271,6 @@ in {
         # outside the main process:
         #   Got notification message from PID 6378, but reception only permitted for main PID 6377
         NotifyAccess = "all";
-        PIDFile = cfg.settings.attrs.olcPidFile;
       };
     };
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -236,7 +236,10 @@ in {
     writeConfig = pkgs.writeShellScript "openldap-config" ''
       set -euo pipefail
 
-      ${lib.optionalString (!cfg.mutableConfig) "rm -rf ${configDir}/*"}
+      ${lib.optionalString (!cfg.mutableConfig) ''
+        chmod -R u+w ${configDir}
+        rm -rf ${configDir}/*
+      ''}
       if [ ! -e "${configDir}/cn=config.ldif" ]; then
         ${openldap}/bin/slapadd -F ${configDir} -bcn=config -l ${settingsFile}
       fi

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -269,6 +269,10 @@ in {
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
         Type = "notify";
+        # Fixes an error where openldap attempts to notify from a thread
+        # outside the main process:
+        #   Got notification message from PID 6378, but reception only permitted for main PID 6377
+        NotifyAccess = "all";
         PIDFile = cfg.settings.attrs.olcPidFile;
       };
     };

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -43,7 +43,7 @@ in {
               attrs = {
                 objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
                 olcDatabase = "{1}mdb";
-                olcDbDirectory = "/var/db/openldap";
+                olcDbDirectory = "/var/lib/openldap/db";
                 olcSuffix = "dc=example";
                 olcRootDN = {
                   # cn=root,dc=example

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -29,6 +29,7 @@ in {
       environment.etc."openldap/root_password".text = "notapassword";
       services.openldap = {
         enable = true;
+        urlList = [ "ldapi:///" "ldap://" ];
         settings = {
           children = {
             "cn=schema".includes = [

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -60,25 +60,6 @@ in {
     };
   }) { inherit pkgs system; };
 
-  # Old-style configuration
-  oldOptions = import ./make-test-python.nix ({ pkgs, ... }: {
-    inherit testScript;
-    name = "openldap";
-
-    nodes.machine = { pkgs, ... }: {
-      services.openldap = {
-        enable = true;
-        logLevel = "stats acl";
-        defaultSchemas = true;
-        database = "mdb";
-        suffix = "dc=example";
-        rootdn = "cn=root,dc=example";
-        rootpw = "notapassword";
-        declarativeContents."dc=example" = dbContents;
-      };
-    };
-  }) { inherit system pkgs; };
-
   # Manually managed configDir, for example if dynamic config is essential
   manualConfigDir = import ./make-test-python.nix ({ pkgs, ... }: {
     name = "openldap";

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     "ac_cv_func_memcmp_working=yes"
   ] ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
-  NIX_CFLAGS_COMPILE = [ "-DLDAPI_SOCK=\"/run/slapd/ldapi\"" ];
+  NIX_CFLAGS_COMPILE = [ "-DLDAPI_SOCK=\"/run/openldap/ldapi\"" ];
 
   makeFlags= [
     "CC=${stdenv.cc.targetPrefix}cc"

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -93,18 +93,18 @@ stdenv.mkDerivation rec {
     "ac_cv_func_memcmp_working=yes"
   ] ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
-  makeFlags = [
+  NIX_CFLAGS_COMPILE = [ "-DLDAPI_SOCK=\"/run/slapd/ldapi\"" ];
+
+  makeFlags= [
     "CC=${stdenv.cc.targetPrefix}cc"
     "STRIP="  # Disable install stripping as it breaks cross-compiling. We strip binaries anyway in fixupPhase.
+    "STRIP_OPTS="
     "prefix=${placeholder "out"}"
     "sysconfdir=${placeholder "out"}/etc"
     "systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     # contrib modules require these
     "moduledir=${placeholder "out"}/lib/modules"
     "mandir=${placeholder "out"}/share/man"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    # Can be unconditional, doing it like this to prevent a mass rebuild.
-    "STRIP_OPTS="
   ];
 
   extraContribModules = [


### PR DESCRIPTION
###### Description of changes

This removes options deprecated in #94610. It also picks up a number of changes from  #141240 (cc @poscat0x04), which adds a `mutableConfig` option and starts `slapd` under a systemd-controlled user/group, rather than relying on the daemon to drop privileges.

Tests are refactored to make them faster using the specialization mechanism, and improved to cover various use-cases (starting with an empty DB, mutable config, and immutable config). With these changes, starting with an empty DB works in the test, so this might obsolete  #92544 (cc @mystfox).

A new change in this PR is to change the default Unix socket for OpenLDAP to `/run/openldap/ldapi` (from `/run/ldapi`). The former can be created by openldap running as non-root, the latter cannot (so the default path `ldapi:///` did not previously work on NixOS).

cc also @Mic92 , who was following #141240.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).