### PR TITLE
nixos-rebuild: Accept only one argument

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -49,6 +49,8 @@ while [ "$#" -gt 0 ]; do
         ;;
       switch|boot|test|build|edit|dry-build|dry-run|dry-activate|build-vm|build-vm-with-bootloader)
         if [ "$i" = dry-run ]; then i=dry-build; fi
+        # exactly one action mandatory, bail out if multiple are given
+        if [ -n "$action" ]; then showSyntax; fi
         action="$i"
         ;;
       --install-grub)


### PR DESCRIPTION
Multiple arguments make no sense but they are accepted, the last one
winning.

Found editing a previous run from shell history and adding a command
rather than replacing it;  observe in verbose mode:

```
$ nixos-rebuild dry-run -v
building the system configuration...
Building in legacy (non-flake) mode.
No --build-host given, running nix-build locally
$ nix-build <nixpkgs/nixos> -A system -k -I nixpkgs=/home/kn/src/nixpkgs -v --dry-run
...
```

```
$ nixos-rebuild dry-run build -v
building Nix...
$ nix-instantiate <nixpkgs/nixos> --add-root /tmp/nixos-rebuild.jgEYqZ/nix.drv --indirect -A config.nix.package.out -I nixpkgs=/home/kn/src/nixpkgs -v
...
```

nixos-rebuild(8) already bails out on zero arguments, so do the same
when passing a second one.

@profpatsch
