### PR TITLE
matrix-commander: unstable-2021-08-05 -> 2.37.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -11,18 +11,19 @@
 , aiofiles
 , notify2
 , dbus-python
+, xdg
 , python-olm
 }:
 
 buildPythonApplication rec {
   pname = "matrix-commander";
-  version = "2.36.0";
+  version = "2.37.3";
 
   src = fetchFromGitHub {
     owner = "8go";
     repo = "matrix-commander";
     rev = "v${version}";
-    sha256 = "sha256-NjOPVQ9BJ2LI7qIr8R8xWDXuFTVIYnvN4hIzfrTCX9I=";
+    sha256 = "sha256-X5tCPR0EqY1dxViwh8/tEjJM2oo81L3H703pPzWzUv8=";
   };
 
   format = "pyproject";
@@ -53,6 +54,7 @@ buildPythonApplication rec {
     aiofiles
     notify2
     dbus-python
+    xdg
     python-olm
   ];
 

--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -1,37 +1,60 @@
-{ stdenv, lib, fetchFromGitHub, cacert, python3 }:
+{ lib
+, fetchFromGitHub
+, buildPythonApplication
+, cacert
+, setuptools
+, matrix-nio
+, python-magic
+, markdown
+, pillow
+, urllib3
+, aiofiles
+, notify2
+, dbus-python
+, python-olm
+}:
 
-stdenv.mkDerivation {
+buildPythonApplication {
   pname = "matrix-commander";
-  version = "unstable-2021-08-05";
+  version = "2.30.0";
 
   src = fetchFromGitHub {
     owner = "8go";
     repo = "matrix-commander";
-    rev = "7ab3fd9a0ef4eb19d882cb3701d2025b4d41b63a";
-    sha256 = "sha256-WWf7GbJxGlqIdsS1d0T1DO0WN2RBepHGgJrl/nt7UIg=";
+    rev = "77cf433af0d2e63a88b8914026795a0da5486b77";
+    sha256 = "sha256-qUyaN0syP2lLRJLCAD5nCWfwR/CW4t/g40a8xDYseIg=";
   };
 
-  buildInputs = [
-    cacert
-    (python3.withPackages(ps: with ps; [
-      matrix-nio
-      magic
-      markdown
-      pillow
-      urllib3
-      aiofiles
-      notify2
-    ]))];
+  format = "pyproject";
 
-  installPhase = ''
-    runHook preInstall
+  postPatch = ''
+    # Dependencies already bundled with Python
+    sed -i \
+      -e '/uuid/d' \
+      -e '/argparse/d' \
+      -e '/asyncio/d' \
+      -e '/datetime/d' \
+      setup.cfg requirements.txt
 
-    mkdir -p $out/bin
-    cp $src/matrix-commander.py $out/bin/matrix-commander
-    chmod +x $out/bin/matrix-commander
-
-    runHook postInstall
+    # Dependencies not correctly detected
+    sed -i \
+      -e '/dbus-python/d' \
+      setup.cfg requirements.txt
   '';
+
+  propagatedBuildInputs = [
+    cacert
+    setuptools
+    matrix-nio
+    python-magic
+    markdown
+    pillow
+    urllib3
+    aiofiles
+    notify2
+    dbus-python
+    python-olm
+  ];
 
   meta = with lib; {
     description = "Simple but convenient CLI-based Matrix client app for sending and receiving";

--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -14,15 +14,15 @@
 , python-olm
 }:
 
-buildPythonApplication {
+buildPythonApplication rec {
   pname = "matrix-commander";
-  version = "2.30.0";
+  version = "2.36.0";
 
   src = fetchFromGitHub {
     owner = "8go";
     repo = "matrix-commander";
-    rev = "77cf433af0d2e63a88b8914026795a0da5486b77";
-    sha256 = "sha256-qUyaN0syP2lLRJLCAD5nCWfwR/CW4t/g40a8xDYseIg=";
+    rev = "v${version}";
+    sha256 = "sha256-NjOPVQ9BJ2LI7qIr8R8xWDXuFTVIYnvN4hIzfrTCX9I=";
   };
 
   format = "pyproject";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28029,7 +28029,7 @@ with pkgs;
       canonicaljson;
   };
 
-  matrix-commander = callPackage ../applications/networking/instant-messengers/matrix-commander { };
+  matrix-commander = python3Packages.callPackage ../applications/networking/instant-messengers/matrix-commander { };
 
   matrix-dl = callPackage ../applications/networking/instant-messengers/matrix-dl { };
 


### PR DESCRIPTION
###### Description of changes

The project switched to pyproject, allowing the use of
`buildPythonApplication` instead of `mkDerivation`.

Some of the modules listed as dependencies but shipping with Python
itself had to be patched out.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
