### PR TITLE
ruby: move jemalloc to propagatedBuildInputs

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -79,13 +79,13 @@ let
           ++ (op opensslSupport openssl)
           ++ (op gdbmSupport gdbm)
           ++ (op yamlSupport libyaml)
-          ++ (op jemallocSupport jemalloc)
           # Looks like ruby fails to build on darwin without readline even if curses
           # support is not enabled, so add readline to the build inputs if curses
           # support is disabled (if it's enabled, we already have it) and we're
           # running on darwin
           ++ op (!cursesSupport && stdenv.isDarwin) readline
           ++ ops stdenv.isDarwin [ libiconv libobjc libunwind Foundation ];
+        propagatedBuildInputs = op jemallocSupport jemalloc;
 
         enableParallelBuilding = true;
 


### PR DESCRIPTION
Alternative malloc implementations in ruby are not fully encapsulated.
Their header files are required when building gems with native
extensions, like bcrypt.

###### Description of changes

Moved jemalloc from `buildInputs` to `propagatedBuildInputs`

###### Motivating example

```nix
{ pkgs ? import <nixpkgs> {} }:

let
  ruby = pkgs.ruby_3_1.override { jemallocSupport = true; };
  buildRubyGem' = pkgs.buildRubyGem.override { inherit ruby; };
in
  buildRubyGem' {
    gemName = "bcrypt";
    version = "3.1.18";
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "048z3fvcknqx7ikkhrcrykxlqmf9bzc7l0y5h1cnvrc9n2qf0k8m";
      type = "gem";
    };
  }
```


```
compiling bcrypt_ext.c
In file included from /nix/store/nxqv538jmznaip5s7l47svq1argx80z6-ruby-3.1.2/include/ruby-3.1.0/ruby/internal/config.h:22,
                 from /nix/store/nxqv538jmznaip5s7l47svq1argx80z6-ruby-3.1.2/include/ruby-3.1.0/ruby/ruby.h:15,
                 from /nix/store/nxqv538jmznaip5s7l47svq1argx80z6-ruby-3.1.2/include/ruby-3.1.0/ruby.h:38,
                 from bcrypt_ext.c:1:
/nix/store/nxqv538jmznaip5s7l47svq1argx80z6-ruby-3.1.2/include/ruby-3.1.0/x86_64-linux/ruby/config.h:74:40: fatal error: jemalloc/jemalloc.h: No such file or directory
   74 | #define RUBY_ALTERNATIVE_MALLOC_HEADER <jemalloc/jemalloc.h>
      |                                        ^
compilation terminated.
make: *** [Makefile:246: bcrypt_ext.o] Error 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
