### PR TITLE
Remove kvark from maintaining Mozilla packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7056,13 +7056,6 @@
     githubId = 449813;
     name = "Roman Kuznetsov";
   };
-  kvark = {
-    name = "Dzmitry Malyshau";
-    email = "kvark@fastmail.com";
-    matrix = "@kvark:matrix.org";
-    github = "kvark";
-    githubId = 107301;
-  };
   kwohlfahrt = {
     email = "kai.wohlfahrt@gmail.com";
     github = "kwohlfahrt";

--- a/pkgs/applications/misc/bikeshed/default.nix
+++ b/pkgs/applications/misc/bikeshed/default.nix
@@ -72,6 +72,6 @@ buildPythonApplication rec {
     '';
     homepage = "https://tabatkins.github.io/bikeshed/";
     license = licenses.cc0;
-    maintainers = [ maintainers.kvark ];
+    maintainers = [];
   };
 }

--- a/pkgs/applications/misc/moz-phab/default.nix
+++ b/pkgs/applications/misc/moz-phab/default.nix
@@ -53,7 +53,7 @@ buildPythonApplication rec {
     '';
     homepage = "https://moz-conduit.readthedocs.io/en/latest/phabricator-user.html";
     license = licenses.mpl20;
-    maintainers = [ maintainers.kvark ];
+    maintainers = [];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/glean-parser/default.nix
+++ b/pkgs/development/python-modules/glean-parser/default.nix
@@ -63,6 +63,6 @@ buildPythonPackage rec {
     description = "Tools for parsing the metadata for Mozilla's glean telemetry SDK";
     homepage = "https://github.com/mozilla/glean_parser";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ kvark ];
+    maintainers = with maintainers; [];
   };
 }

--- a/pkgs/development/python-modules/glean-sdk/default.nix
+++ b/pkgs/development/python-modules/glean-sdk/default.nix
@@ -63,6 +63,6 @@ buildPythonPackage rec {
     description = "Telemetry client libraries and are a part of the Glean project";
     homepage = "https://mozilla.github.io/glean/book/index.html";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ kvark ];
+    maintainers = [];
   };
 }

--- a/pkgs/development/python-modules/json-home-client/default.nix
+++ b/pkgs/development/python-modules/json-home-client/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Client class for calling http+json APIs in Python";
     homepage = "https://github.com/plinss/json_home_client";
     license = licenses.mit;
-    maintainers = [ maintainers.kvark ];
+    maintainers = [];
   };
 }

--- a/pkgs/development/python-modules/python-hglib/default.nix
+++ b/pkgs/development/python-modules/python-hglib/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "Library with a fast, convenient interface to Mercurial. It uses Mercurial’s command server for communication with hg.";
     homepage = "https://www.mercurial-scm.org/wiki/PythonHglibs";
     license = licenses.mit;
-    maintainers = [ maintainers.kvark ];
+    maintainers = [];
   };
 }

--- a/pkgs/development/python-modules/result/default.nix
+++ b/pkgs/development/python-modules/result/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "A simple Result type for Python 3 inspired by Rust, fully type annotated";
     homepage = "https://github.com/rustedpy/result";
     license = licenses.mit;
-    maintainers = [ maintainers.kvark ];
+    maintainers = [];
   };
 }

--- a/pkgs/development/python-modules/uri-template/default.nix
+++ b/pkgs/development/python-modules/uri-template/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
     description = "An implementation of RFC 6570 URI Templates";
     homepage = "https://github.com/plinss/uri_template/";
     license = licenses.mit;
-    maintainers = [ maintainers.kvark ];
+    maintainers = [];
   };
 }

--- a/pkgs/development/python-modules/widlparser/default.nix
+++ b/pkgs/development/python-modules/widlparser/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Stand-alone WebIDL Parser in Python";
     homepage = "https://github.com/plinss/widlparser";
     license = licenses.mit;
-    maintainers = [ maintainers.kvark ];
+    maintainers = [];
   };
 }


### PR DESCRIPTION
I'm sorry for doing this - removing myself from maintaining the packages.
I'm no longer employed by Mozilla, which these packages are from. And I don't currently have a Nix system to test anything. So asking me to review these package updates isn't productive.

I'll be happy to also remove myself from the global maintainers list. I figured that once I start using Nix again, I'll probably want to maintain some packages again. So this PR keeps me in the list, unless you feel different.

cc @nbp @jimblandy