### PR TITLE
lc3tools: fix build on macOS

### DIFF
--- a/pkgs/development/tools/lc3tools/0004-configure-use-cc.patch
+++ b/pkgs/development/tools/lc3tools/0004-configure-use-cc.patch
@@ -1,0 +1,22 @@
+diff --git a/configure b/configure
+index dfc1b3e..55577af 100755
+--- a/configure
++++ b/configure
+@@ -18,7 +18,7 @@ esac
+ # Some binaries that we'll need, and the places that we might find them.
+ 
+ IFS=:
+-binlist="uname:flex:gcc:wish:rm:cp:mkdir:chmod:sed"
++binlist="uname:flex:cc:wish:rm:cp:mkdir:chmod:sed"
+ pathlist=$PATH
+ libpathlist=$LIBS
+ incpathlist=$INCLUDES
+@@ -109,7 +109,7 @@ fi
+ # Splice it all in to Makefile.def to create the Makefile.
+ 
+ rm -f Makefile
+-sed -e "s __GCC__ $gcc g" -e "s __FLEX__ $flex g" -e "s __EXE__ $EXE g"     \
++sed -e "s __GCC__ $cc g" -e "s __FLEX__ $flex g" -e "s __EXE__ $EXE g"     \
+     -e "s*__OS_SIM_LIBS__*$OS_SIM_LIBS*g" -e "s __RM__ $rm g"               \
+     -e "s __CP__ $cp g" -e "s __MKDIR__ $mkdir g" -e "s __CHMOD__ $chmod g" \
+     -e "s __USE_READLINE__ $USE_READLINE g" -e "s*__RLLPATH__*$RLLPATH*g"   \

--- a/pkgs/development/tools/lc3tools/default.nix
+++ b/pkgs/development/tools/lc3tools/default.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation {
 
     # lc3sim-tk looks for lc3sim in $out/bin instead of $out
     ./0003-lc3sim-tk-path.patch
+
+    # use `cc` instead of `gcc`; on macOS the latter is not present
+    ./0004-configure-use-cc.patch
   ];
 
   nativeBuildInputs = [ unzip ];
@@ -40,8 +43,15 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
+    longDescription = ''
+      The LC-3 tools package contains the lc3as assembler, the lc3sim simulator,
+      and lc3sim-tk, a Tcl/Tk-based GUI frontend to the simulator.
+    '';
     description = "Toolchain and emulator for the LC-3 architecture";
+    homepage = "https://highered.mheducation.com/sites/0072467509/student_view0/lc-3_simulator.html";
     license = licenses.gpl2;
     maintainers = with maintainers; [ anna328p ];
+    mainProgram = "lc3sim-tk";
+    platforms = with lib.platforms; unix ++ windows;
   };
 }


### PR DESCRIPTION
###### Description of changes

The `lc3tools` configure script looks for `gcc` which isn't in the macOS stdenv; this PR patches the configure script to look for `cc` instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).