### PR TITLE
valgrind: fix build error for armv7l

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -20,6 +20,20 @@ stdenv.mkDerivation rec {
       url = "https://bugsfiles.kde.org/attachment.cgi?id=148912";
       sha256 = "Za+7K93pgnuEUQ+jDItEzWlN0izhbynX2crSOXBBY/I=";
     })
+    # Fix build on armv7l.
+    # https://bugs.kde.org/show_bug.cgi?id=454346
+    (fetchpatch {
+      url = "https://bugsfiles.kde.org/attachment.cgi?id=149172";
+      sha256 = "sha256-4MASLsEK8wcshboR4YOc6mIt7AvAgDPvqIZyHqlvTEs=";
+    })
+    (fetchpatch {
+      url = "https://bugsfiles.kde.org/attachment.cgi?id=149173";
+      sha256 = "sha256-jX9hD4utWRebbXMJYZ5mu9jecvdrNP05E5J+PnKRTyQ=";
+    })
+    (fetchpatch {
+      url = "https://bugsfiles.kde.org/attachment.cgi?id=149174";
+      sha256 = "sha256-f1YIFIhWhXYVw3/UNEWewDak2mvbAd3aGzK4B+wTlys=";
+    })
   ];
 
   outputs = [ "out" "dev" "man" "doc" ];


### PR DESCRIPTION
###### Description of changes
This change fixes build error on armv7l:

```
cc1: warning: switch '-mcpu=cortex-a8' conflicts with '-march=armv7-a' switch
In file included from /nix/store/ndmlxj1684gcq9yangm42819yd8vz042-glibc-2.34-210-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/ndmlxj1684gcq9yangm42819yd8vz042-glibc-2.34-210-dev/include/stdio.h:27,
                 from vfp.c:6:
/nix/store/ndmlxj1684gcq9yangm42819yd8vz042-glibc-2.34-210-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wcpp-Wcpp8;;]
  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
gcc -DHAVE_CONFIG_H -I. -I../../..  -I../../.. -I../../../include -I../../../coregrind -I../../../include -I../../../VEX/pub -I../../../VEX/pub -DVGA_arm=1 -DVGO_linux=1 -DVGP_arm_linux=1 -DVGPV_arm_linux_vanilla=1    -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a15 -mfpu=vfpv4 -marm  -c -o vfpv4_fma-vfpv4_fma.o `test -f 'vfpv4_fma.c' || echo './'`vfpv4_fma.c
cc1: warning: switch '-mcpu=cortex-a15' conflicts with '-march=armv7-a' switch
In file included from /nix/store/ndmlxj1684gcq9yangm42819yd8vz042-glibc-2.34-210-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/ndmlxj1684gcq9yangm42819yd8vz042-glibc-2.34-210-dev/include/stdio.h:27,
                 from vfpv4_fma.c:6:
/nix/store/ndmlxj1684gcq9yangm42819yd8vz042-glibc-2.34-210-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wcpp-Wcpp8;;]
  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -Wno-nonnull    -o allexec allexec-allexec.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -mcpu=cortex-a8 -marm    -o ldrt_arm ldrt_arm-ldrt_arm.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a8 -mfpu=neon -mthumb    -o neon128 neon128-neon128.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a8 -mfpu=neon -mthumb    -o neon64 neon64-neon64.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a8 -marm    -o v6intARM v6intARM-v6intARM.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a8 -mthumb    -o v6intThumb v6intThumb-v6intThumb.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a8 -mthumb    -o v6media v6media-v6media.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mfpu=crypto-neon-fp-armv8 -marm    -o v8crypto_a v8crypto_a-v8crypto_a.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mfpu=crypto-neon-fp-armv8 -mthumb    -o v8crypto_t v8crypto_t-v8crypto_t.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mfpu=crypto-neon-fp-armv8 -marm    -o v8fpsimd_a v8fpsimd_a-v8fpsimd_a.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mfpu=crypto-neon-fp-armv8 -mthumb    -o v8fpsimd_t v8fpsimd_t-v8fpsimd_t.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -march=armv8-a -mfpu=crypto-neon-fp-armv8 -marm    -o v8memory_a v8memory_a-v8memory_a.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -march=armv8-a -mfpu=crypto-neon-fp-armv8 -mthumb    -o v8memory_t v8memory_t-v8memory_t.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector       -o vcvt_fixed_float_VFP vcvt_fixed_float_VFP.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a8 -mfpu=neon -mthumb    -o vfp vfp-vfp.o  
gcc -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -O0 -mcpu=cortex-a15 -mfpu=vfpv4 -marm    -o vfpv4_fma vfpv4_fma-vfpv4_fma.o  
gcc -DHAVE_CONFIG_H -I. -I../../..  -I../../.. -I../../../include -I../../../coregrind -I../../../include -I../../../VEX/pub -I../../../VEX/pub -DVGA_arm=1 -DVGO_linux=1 -DVGP_arm_linux=1 -DVGPV_arm_linux_vanilla=1    -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -mcpu=cortex-a8 -mthumb  -c -o ldrt-ldrt.o `test -f 'ldrt.c' || echo './'`ldrt.c
cc1: warning: switch '-mcpu=cortex-a8' conflicts with '-march=armv7-a' switch
gcc -DHAVE_CONFIG_H -I. -I../../..  -I../../.. -I../../../include -I../../../coregrind -I../../../include -I../../../VEX/pub -I../../../VEX/pub -DVGA_arm=1 -DVGO_linux=1 -DVGP_arm_linux=1 -DVGPV_arm_linux_vanilla=1    -Winline -Wall -Wshadow -Wno-long-long -g -fno-stack-protector    -g -mcpu=cortex-a15 -mthumb  -c -o intdiv-intdiv.o `test -f 'intdiv.c' || echo './'`intdiv.c
cc1: warning: switch '-mcpu=cortex-a15' conflicts with '-march=armv7-a' switch
/build/ccNNkjfo.s: Assembler messages:
/build/ccNNkjfo.s:44: Error: selected processor does not support `udiv r3,r9,r10' in Thumb mode
/build/ccNNkjfo.s:86: Error: selected processor does not support `sdiv r3,r9,r10' in Thumb mode
make[5]: *** [Makefile:966: intdiv-intdiv.o] Error 1
make[5]: Leaving directory '/build/valgrind-3.19.0/none/tests/arm'
make[4]: *** [Makefile:1270: check-am] Error 2
make[4]: Leaving directory '/build/valgrind-3.19.0/none/tests/arm'
make[3]: *** [Makefile:2135: check-recursive] Error 1
make[3]: Leaving directory '/build/valgrind-3.19.0/none/tests'
make[2]: *** [Makefile:1041: check-recursive] Error 1
make[2]: Leaving directory '/build/valgrind-3.19.0/none'
make[1]: *** [Makefile:898: check-recursive] Error 1
make[1]: Leaving directory '/build/valgrind-3.19.0'
make: *** [Makefile:1197: check] Error 2
```

Tested by building on top of `nixos-unstable`.

https://bugs.kde.org/show_bug.cgi?id=454346

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] armv7l-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
