### PR TITLE
cassandra-cpp-driver: init at 2.16.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14784,4 +14784,10 @@
     github = "jali-clarke";
     githubId = 17733984;
   };
+  npatsakula = {
+    email = "nikita.patsakula@gmail.com";
+    name = "Patsakula Nikita";
+    github = "npatsakula";
+    githubId = 23001619;
+  };
 }

--- a/pkgs/development/libraries/cassandra-cpp-driver/default.nix
+++ b/pkgs/development/libraries/cassandra-cpp-driver/default.nix
@@ -1,0 +1,36 @@
+{ fetchFromGitHub,
+  lib, stdenv,
+  cmake, zlib, libuv, openssl,
+  examples ? false
+}: stdenv.mkDerivation rec {
+    pname = "cassandra-cpp-driver";
+    version = "2.16.2";
+
+    src = fetchFromGitHub {
+      owner = "datastax";
+      repo = "cpp-driver";
+      rev = "refs/tags/${version}";
+      sha256 = "sha256-NAvaRLhEvFjSmXcyM039wLC6IfLws2rkeRpbE5eL/rQ=";
+    };
+
+    LIBUV_ROOT_DIR = "${libuv}/";
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ zlib libuv openssl.dev ];
+
+    cmakeFlags = lib.attrsets.mapAttrsToList
+      (name: value: "-DCASS_BUILD_${name}:BOOL=${if value then "ON" else "OFF"}") {
+        EXAMPLES = examples;
+      };
+
+    meta = with lib; {
+      description = "DataStax CPP cassandra driver";
+      longDescription = ''
+        A modern, feature-rich and highly tunable C/C++ client
+        library for Apache Cassandra 2.1+ using exclusively Cassandra’s
+        binary protocol and Cassandra Query Language v3.
+      '';
+      license = with licenses; [ asl20 ];
+      platforms = platforms.x86_64;
+      homepage = "https://docs.datastax.com/en/developer/cpp-driver/";
+    };
+}

--- a/pkgs/development/libraries/cassandra-cpp-driver/default.nix
+++ b/pkgs/development/libraries/cassandra-cpp-driver/default.nix
@@ -32,5 +32,6 @@
       license = with licenses; [ asl20 ];
       platforms = platforms.x86_64;
       homepage = "https://docs.datastax.com/en/developer/cpp-driver/";
+      maintainers = [ maintainers.npatsakula ];
     };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21612,6 +21612,8 @@ with pkgs;
   };
   cassandra = cassandra_3_11;
 
+  cassandra-cpp-driver = callPackage ../development/libraries/cassandra-cpp-driver/default.nix { };
+
   apache-jena = callPackage ../servers/nosql/apache-jena/binary.nix {
     java = jre;
   };


### PR DESCRIPTION
###### Description of changes

Initial implementation of the DataStax CPP Cassandra driver derivation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
