### PR TITLE
map: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10228,6 +10228,12 @@
     githubId = 10473184;
     name = "Jia Xiaodong";
   };
+  pogobanane = {
+    email = "mail@peter-okelmann.de";
+    github = "pogobanane";
+    githubId = 38314551;
+    name = "Peter Okelmann";
+  };
   polarmutex = {
     email = "brian@brianryall.xyz";
     github = "polarmutex";

--- a/pkgs/tools/misc/map/default.nix
+++ b/pkgs/tools/misc/map/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "map";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "soveran";
+    repo = "map";
+    rev = version;
+    sha256 = "sha256-yGzmhZwv1qKy0JNcSzqL996APQO8OGWQ1GBkEkKTOXA=";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    mkdir -p "$out/share/doc/${pname}"
+    cp README* LICENSE "$out/share/doc/${pname}"
+  '';
+
+  doCheck = true;
+
+  checkPhase = "./test/tests.sh";
+
+  meta = with lib; {
+    description = "Map lines from stdin to commands";
+    homepage = "https://github.com/soveran/map";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ pogobanane ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2980,7 +2980,7 @@ with pkgs;
 
   clac = callPackage ../tools/misc/clac {};
 
-  map = callPackage ../tools/misc/map {};
+  map-cmd = callPackage ../tools/misc/map {};
 
   clash = callPackage ../tools/networking/clash {
     buildGoModule = buildGo118Module;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2980,6 +2980,8 @@ with pkgs;
 
   clac = callPackage ../tools/misc/clac {};
 
+  map = callPackage ../tools/misc/map {};
+
   clash = callPackage ../tools/networking/clash {
     buildGoModule = buildGo118Module;
   };


### PR DESCRIPTION
###### Description of changes

Added package/binary `map` which is essentially xargs, but more beautiful. 
https://github.com/soveran/map
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] ~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [x] Tested, as applicable:
  - ~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - ~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~
  - ~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
