### PR TITLE
gmqcc: init at unstable-2021-07-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9091,6 +9091,12 @@
     githubId = 3747396;
     name = "Nathan Isom";
   };
+  necrophcodr = {
+    email = "nc@scalehost.eu";
+    github = "necrophcodr";
+    githubId = 575887;
+    name = "Steffen Rytter Postas";
+  };
   neilmayhew = {
     email = "nix@neil.mayhew.name";
     github = "neilmayhew";

--- a/pkgs/development/compilers/gmqcc/default.nix
+++ b/pkgs/development/compilers/gmqcc/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, pkgs
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gmqcc";
+  version = "unstable-2021-07-09";
+
+  src = fetchFromGitHub {
+    owner = "graphitemaster";
+    repo = "gmqcc";
+    rev = "297eab9e5e2c9cc4f41201b68821593a5cf9a725";
+    sha256 = "1hl2qn7402ia03kjkblj4q4wfypxkil99sivsyk2vrnwwpdp4nzx";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m755 gmqcc $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://graphitemaster.github.io/gmqcc/";
+    description = "A modern QuakeC compiler";
+    longDescription = ''
+      For an enduring period of time the options for a decent compiler for
+      the Quake C programming language were confined to a specific compiler
+      known as QCC. Attempts were made to extend and improve upon the design
+      of QCC, but many foreseen the consequences of building on a broken
+      foundation. The solution was obvious, a new compiler; one born from
+      the NIH realm of sarcastic wit.
+      We welcome you. You won't find a better Quake C compiler.
+    '';
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ necrophcodr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13020,6 +13020,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  gmqcc = callPackage ../development/compilers/gmqcc {};
+
   gtk-server = callPackage ../development/interpreters/gtk-server {};
 
   # Haskell and GHC


### PR DESCRIPTION
###### Description of changes

This adds GMQCC, a modern QuakeC compiler, from https://graphitemaster.github.io/gmqcc/.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
