### PR TITLE
ocamlPackages.posix-time2: init at 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/posix/time2.nix
+++ b/pkgs/development/ocaml-modules/posix/time2.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, posix-base, posix-types, unix-errno }:
+
+buildDunePackage {
+  pname = "posix-time2";
+
+  inherit (posix-base) version src;
+
+  propagatedBuildInputs = [ posix-base posix-types unix-errno ];
+
+  doCheck = true;
+
+  meta = posix-base.meta // {
+    description = "posix-time2 provides the types and bindings for posix time APIs";
+    maintainers = with lib.maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/unix-errno/default.nix
+++ b/pkgs/development/ocaml-modules/unix-errno/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchurl, ctypes, integers, result }:
+
+buildDunePackage rec {
+  pname = "unix-errno";
+  version = "0.6.1";
+
+  minimalOCamlVersion = "4.03.0"; # Specified to be 4.01.0, but it's actually 4.03
+
+  src = fetchurl {
+    url = "https://github.com/xapi-project/ocaml-unix-errno/releases/download/${version}/unix-errno-${version}.tbz";
+    sha256 = "sha256-jZqtHwUKTffjuOP2jdKKQRtEOBKyclhfeiPO96hEj4c=";
+  };
+
+  propagatedBuildInputs = [ ctypes integers result ];
+
+  meta = with lib; {
+    homepage = "https://github.com/xapi-project/ocaml-unix-errno"; # This is the repo used in the opam package
+    description = "Unix errno types, maps, and support for OCaml";
+    license = with licenses; [ isc lgpl21Only ]; # All the files indicate ISC, but there's an LGPL LICENSE file
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1405,6 +1405,8 @@ let
 
     uecc = callPackage ../development/ocaml-modules/uecc { };
 
+    unix-errno = callPackage ../development/ocaml-modules/unix-errno { };
+
     utop = callPackage ../development/tools/ocaml/utop { };
 
     uuidm = callPackage ../development/ocaml-modules/uuidm { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1129,6 +1129,8 @@ let
 
     posix-socket = callPackage ../development/ocaml-modules/posix/socket.nix { };
 
+    posix-time2 = callPackage ../development/ocaml-modules/posix/time2.nix { };
+
     posix-types = callPackage ../development/ocaml-modules/posix/types.nix { };
 
     postgresql = callPackage ../development/ocaml-modules/postgresql {


### PR DESCRIPTION
###### Description of changes

Part of splitting out https://github.com/NixOS/nixpkgs/pull/140777 for easier review

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
