### PR TITLE
iosevka-comfy: init at 0.1.0

### DIFF
--- a/pkgs/data/fonts/iosevka/comfy-private-build-plans.toml
+++ b/pkgs/data/fonts/iosevka/comfy-private-build-plans.toml
@@ -1,0 +1,487 @@
+# The file below is copy/pasted from
+# https://github.com/protesilaos/iosevka-comfy/blob/0.1.0/private-build-plans.toml. It
+# seems like ofborg will prevent me from using fetchurl to download
+# this file automatically.
+[buildPlans.iosevka-comfy]       # <iosevka-comfy> is your plan name
+family = "Iosevka Comfy"         # Font menu family name
+spacing = "normal"               # Optional; Values: `normal`, `quasi-proportional`, `quasi-proportional-extension-only`, `term`, `fontconfig-mono`, or `fixed`
+serifs = "sans"                  # Optional; Values: `sans` or `slab`
+
+###################################################################################################
+# Configure variants
+
+# # Optional; Whether to inherit a `ss##` variant
+# [buildPlans.iosevka-comfy.variants]
+# inherits = "ss01"
+
+# Optional; Configure single character's variant
+[buildPlans.iosevka-comfy.variants.design]
+cv01 = 1    # A cap straight
+cv02 = 1    # B cap straight
+cv03 = 1    # C cap serifless
+cv04 = 6    # D cap curly with top and bottom serif (without serifs TODO reads like TOOO at small point sizes)
+cv05 = 1    # E cap serifless
+cv06 = 1    # F cap serifless
+cv07 = 4    # G cap toothed
+cv08 = 1    # H cap serifless
+cv09 = 1    # I cap long serifs
+cv10 = 2    # J cap serified
+cv11 = 2    # K cap curly
+cv12 = 1    # L cap serifless
+cv13 = 3    # M cap short middle leg slanted sides
+cv14 = 1    # N cap symmetric
+cv15 = 1    # P cap straight
+cv16 = 4    # Q cap crossing tail
+cv17 = 1    # R cap straight
+cv18 = 1    # S cap serifless
+cv19 = 1    # T cap serifless
+cv20 = 3    # U cap serifless
+cv21 = 1    # V cap straight
+cv22 = 1    # W straight
+cv23 = 1    # X cap straight
+cv24 = 1    # Y cap straight
+cv25 = 1    # Z cap straight
+cv26 = 10   # a single storey earless tailed bottom
+cv27 = 1    # b toothed
+cv28 = 1    # c serifless
+cv29 = 1    # d toothed
+cv33 = 1    # h straight
+cv34 = 10   # i serified flat tailed
+cv35 = 6    # j flat hook serified
+cv37 = 10   # l serified flat tailed
+cv42 = 9    # r compact
+cv43 = 1    # s serifless
+cv44 = 2    # t flat hook
+cv45 = 4    # u tailed
+cv49 = 6    # y cursive flat terminal hook
+cv53 = 1    # Λ, Δ lambda and delta cap straight
+cv54 = 2    # α alpha straight tailed
+VXAA = 1    # δ delta rounded top
+cv55 = 1    # Γ gamma cap straight
+cv56 = 6    # ι iota serified flat tailed
+cv57 = 2    # λ lambda top tailed
+VXAC = 1    # μ me tailless
+VXAB = 2    # ξ xe flat top
+cv71 = 13   # 0 oval dashed forward slash
+cv74 = 2    # 3 arched
+cv76 = 2    # 5 open contour
+cv78 = 1    # 7 straight
+cv79 = 3    # 8 two asymmetric circles
+cv81 = 2    # ~ tilde low
+cv82 = 2    # * asterisk five-pointed low
+cv83 = 1    # _ underscore right below baseline
+cv85 = 1    # ^ uptick high
+cv86 = 1    # ( parentheses normal slope
+cv87 = 2    # { braces curly
+cv88 = 1    # # column straight
+cv90 = 4    # @ three-fold, tall height
+cv91 = 2    # $ dollar strike through
+cv92 = 2    # ¢ cent strike through
+cv93 = 1    # % percent dots
+cv94 = 1    # | bar natural slope
+cv95 = 2    # ≥ equal-or-{higher,lower} slanted
+cv96 = 1    # ' single quote straight
+cv97 = 1    # ` grave/backtick straight
+cv98 = 1    # ? smooth
+cv99 = 2    # .:; square punctuation marks
+VXDD = 2    # ijäöü square diacretics
+
+# Optional; Configure single character's variant for Upright and Oblique; Overrides [design]
+[buildPlans.iosevka-comfy.variants.upright]
+cv30 = 1    # e straight
+cv31 = 16   # f serifless bottom flat top crossbar at x height
+cv32 = 9    # g single storey flat hook earless cornered top
+cv36 = 1    # k straight
+cv38 = 6    # m earless double arch short middle leg
+cv39 = 3    # n earless straight
+cv40 = 2    # p earless
+cv41 = 2    # q earless
+cv46 = 1    # v straight
+cv47 = 1    # w straight
+cv48 = 1    # x straight
+cv50 = 1    # z straight
+cv72 = 3    # 1 serified with base
+cv73 = 1    # 2 straight
+cv75 = 3    # 4 semi-open contour
+cv77 = 3    # 6 straight
+cv80 = 3    # 9 straight
+cv89 = 2    # & et open top (ampersand)
+
+# Optional; Configure single character's variant for Italic only; Overrides [design]
+[buildPlans.iosevka-comfy.variants.italic]
+cv30 = 2    # e curly
+cv31 = 14   # f extended flat top bottom hook
+cv32 = 7    # g single storey flat hook
+cv36 = 2    # k curly
+cv38 = 2    # m straight middle shortleg
+cv39 = 1    # n straight
+cv40 = 1    # p straight
+cv41 = 1    # q straight
+cv46 = 2    # v curly
+cv47 = 2    # w curly short middle top
+cv48 = 2    # x curly
+cv50 = 4    # z curly
+cv72 = 2    # 1 serified no base
+cv73 = 2    # 2 curly
+cv75 = 1    # 4 closed contour crossing
+cv77 = 1    # 6 closed contour
+cv80 = 1    # 9 closed contour
+cv89 = 4    # & et open top toothed (ampersand)
+
+# End variant section
+###################################################################################################
+
+###################################################################################################
+# Override default building weights
+# When buildPlans.<plan name>.weights is absent, all weights would built and mapped to
+# default values.
+# IMPORTANT : Currently "menu" and "css" property only support numbers between 0 and 1000.
+#             and "shape" properly only supports number between 100 and 900 (inclusive).
+#             If you decide to use custom weights you have to define all the weights you
+#             plan to use otherwise they will not be built.
+[buildPlans.iosevka-comfy.weights.light]
+shape = 300
+menu  = 300
+css   = 300
+
+[buildPlans.iosevka-comfy.weights.semilight]
+shape = 350
+menu  = 350
+css   = 350
+
+[buildPlans.iosevka-comfy.weights.regular]
+shape = 400
+menu  = 400
+css   = 400
+
+[buildPlans.iosevka-comfy.weights.bold]
+shape = 700
+menu  = 700
+css   = 700
+
+[buildPlans.iosevka-comfy.weights.extrabold]
+shape = 800
+menu  = 800
+css   = 800
+
+# End weight section
+###################################################################################################
+
+###################################################################################################
+# Override default building slope sets
+# When this section is absent, all slopes would be built.
+
+[buildPlans.iosevka-comfy.slopes.upright]
+angle = 0             # Angle in degrees. Valid range [0, 15]
+shape = "upright"     # Slope grade used for shape selection.  `upright` | `oblique` | `italic`
+menu  = "upright"     # Slope grade used for naming.           `upright` | `oblique` | `italic`
+css   = "normal"      # Slope grade used for webfont CSS.      `normal`  | `oblique` | `italic`
+
+[buildPlans.iosevka-comfy.slopes.italic]
+angle = 9.4
+shape = "italic"
+menu  = "italic"
+css   = "italic"
+
+# End slope section
+###################################################################################################
+
+###################################################################################################
+# Override default building widths
+# When buildPlans.<plan name>.widths is absent, all widths would built and mapped to
+# default values.
+# IMPORTANT : Currently "shape" property only supports numbers between 434 and 664 (inclusive),
+#             while "menu" only supports integers between 1 and 9 (inclusive).
+#             The "shape" parameter specifies the unit width, measured in 1/1000 em. The glyphs'
+#             width are equal to, or a simple multiple of the unit width.
+#             If you decide to use custom widths you have to define all the widths you plan to use,
+#             otherwise they will not be built.
+
+# [buildPlans.iosevka-comfy.widths.condensed]
+# shape = 485
+# menu  = 3
+# css   = "condensed"
+
+[buildPlans.iosevka-comfy.widths.normal]
+shape = 525        # Unit Width, measured in 1/1000 em.
+menu  = 5          # Width grade for the font's names.
+css   = "normal"   # "font-stretch' property of webfont CSS.
+
+# [buildPlans.iosevka-comfy.widths.expanded]
+# shape = 600
+# menu  = 7
+# css   = "expanded"
+
+# End width section
+###################################################################################################
+
+###################################################################################################
+# Metric overrides
+# Certain metrics like line height (leading) could be overridden in your build plan file.
+# Edit the values to change the metrics. Remove this section when overriding is not needed.
+
+[buildPlans.iosevka-comfy.metric-override]
+leading = 1100
+
+# End metric override section
+###################################################################################################
+
+
+# Iosevka Comfy variants
+# ======================
+# Same glyph overrides and metrics, except for the spacing.
+
+
+# Fixed spacing (no ligatures)
+# ----------------------------
+[buildPlans.iosevka-comfy-fixed]
+family = "Iosevka Comfy Fixed"
+spacing = "fixed"
+serifs = "sans"
+
+# It seems we can inherit variants, but not weights, slopes, widths,
+# metric-override...
+[buildPlans.iosevka-comfy-fixed.variants]
+inherits = "buildPlans.iosevka-comfy"
+
+[buildPlans.iosevka-comfy-fixed.weights.light]
+shape = 300
+menu  = 300
+css   = 300
+
+[buildPlans.iosevka-comfy-fixed.weights.semilight]
+shape = 350
+menu  = 350
+css   = 350
+
+[buildPlans.iosevka-comfy-fixed.weights.regular]
+shape = 400
+menu  = 400
+css   = 400
+
+[buildPlans.iosevka-comfy-fixed.weights.bold]
+shape = 700
+menu  = 700
+css   = 700
+
+[buildPlans.iosevka-comfy-fixed.weights.extrabold]
+shape = 800
+menu  = 800
+css   = 800
+
+[buildPlans.iosevka-comfy-fixed.slopes.upright]
+angle = 0
+shape = "upright"
+menu  = "upright"
+css   = "normal"
+
+[buildPlans.iosevka-comfy-fixed.slopes.italic]
+angle = 9.4
+shape = "italic"
+menu  = "italic"
+css   = "italic"
+
+[buildPlans.iosevka-comfy-fixed.widths.normal]
+shape = 525
+menu  = 5
+css   = "normal"
+
+[buildPlans.iosevka-comfy-fixed.metric-override]
+leading = 1100
+
+
+
+# Duo spacing (quasi-proportional)
+# --------------------------------
+[buildPlans.iosevka-comfy-duo]
+family = "Iosevka Comfy Duo"
+spacing = "quasi-proportional"
+serifs = "sans"
+
+# It seems we can inherit variants, but not weights, slopes, widths,
+# metric-override...
+[buildPlans.iosevka-comfy-duo.variants]
+inherits = "buildPlans.iosevka-comfy"
+
+# The short middle leg in 'm' that we need in the narrow monospaced
+# variants is necessary for legibility, especially at small point sizes.
+# Otherwise it is a gimmick, so we remove it in the "wider" builds.
+[buildPlans.iosevka-comfy-duo.variants.upright]
+cv38 = 5    # m earless normal middle leg
+
+[buildPlans.iosevka-comfy-duo.variants.italic]
+cv38 = 1    # m straight normal middle leg
+
+[buildPlans.iosevka-comfy-duo.weights.light]
+shape = 300
+menu  = 300
+css   = 300
+
+[buildPlans.iosevka-comfy-duo.weights.semilight]
+shape = 350
+menu  = 350
+css   = 350
+
+[buildPlans.iosevka-comfy-duo.weights.regular]
+shape = 400
+menu  = 400
+css   = 400
+
+[buildPlans.iosevka-comfy-duo.weights.bold]
+shape = 700
+menu  = 700
+css   = 700
+
+[buildPlans.iosevka-comfy-duo.weights.extrabold]
+shape = 800
+menu  = 800
+css   = 800
+
+[buildPlans.iosevka-comfy-duo.slopes.upright]
+angle = 0
+shape = "upright"
+menu  = "upright"
+css   = "normal"
+
+[buildPlans.iosevka-comfy-duo.slopes.italic]
+angle = 9.4
+shape = "italic"
+menu  = "italic"
+css   = "italic"
+
+[buildPlans.iosevka-comfy-duo.widths.normal]
+shape = 525
+menu  = 5
+css   = "normal"
+
+[buildPlans.iosevka-comfy-duo.metric-override]
+leading = 1100
+
+
+
+# Like iosevka-comfy but expanded
+# -------------------------------
+[buildPlans.iosevka-comfy-wide]
+family = "Iosevka Comfy Wide"
+spacing = "normal"
+serifs = "sans"
+
+# It seems we can inherit variants, but not weights, slopes, widths,
+# metric-override...
+[buildPlans.iosevka-comfy-wide.variants]
+inherits = "buildPlans.iosevka-comfy"
+
+# The short middle leg in 'm' that we need in the narrow monospaced
+# variants is necessary for legibility, especially at small point sizes.
+# Otherwise it is a gimmick, so we remove it in the "wider" builds.
+[buildPlans.iosevka-comfy-wide.variants.upright]
+cv38 = 5    # m earless normal middle leg
+
+[buildPlans.iosevka-comfy-wide.variants.italic]
+cv38 = 1    # m straight normal middle leg
+
+[buildPlans.iosevka-comfy-wide.weights.light]
+shape = 300
+menu  = 300
+css   = 300
+
+[buildPlans.iosevka-comfy-wide.weights.semilight]
+shape = 350
+menu  = 350
+css   = 350
+
+[buildPlans.iosevka-comfy-wide.weights.regular]
+shape = 400
+menu  = 400
+css   = 400
+
+[buildPlans.iosevka-comfy-wide.weights.bold]
+shape = 700
+menu  = 700
+css   = 700
+
+[buildPlans.iosevka-comfy-wide.weights.extrabold]
+shape = 800
+menu  = 800
+css   = 800
+
+[buildPlans.iosevka-comfy-wide.slopes.upright]
+angle = 0
+shape = "upright"
+menu  = "upright"
+css   = "normal"
+
+[buildPlans.iosevka-comfy-wide.slopes.italic]
+angle = 9.4
+shape = "italic"
+menu  = "italic"
+css   = "italic"
+
+# For the default width, check buildPlans.iosevka-comfy.widths.normal
+[buildPlans.iosevka-comfy-wide.widths.normal]
+shape = 625
+menu  = 7
+css   = "normal"
+
+[buildPlans.iosevka-comfy-wide.metric-override]
+leading = 1100
+
+
+
+# Like iosevka-comfy-wide but fixed monospace (no ligatures)
+# ----------------------------------------------------------
+[buildPlans.iosevka-comfy-wide-fixed]
+family = "Iosevka Comfy Wide Fixed"
+spacing = "fixed"
+serifs = "sans"
+
+# It seems we can inherit variants, but not weights, slopes, widths,
+# metric-override...
+[buildPlans.iosevka-comfy-wide-fixed.variants]
+inherits = "buildPlans.iosevka-comfy-wide"
+
+[buildPlans.iosevka-comfy-wide-fixed.weights.light]
+shape = 300
+menu  = 300
+css   = 300
+
+[buildPlans.iosevka-comfy-wide-fixed.weights.semilight]
+shape = 350
+menu  = 350
+css   = 350
+
+[buildPlans.iosevka-comfy-wide-fixed.weights.regular]
+shape = 400
+menu  = 400
+css   = 400
+
+[buildPlans.iosevka-comfy-wide-fixed.weights.bold]
+shape = 700
+menu  = 700
+css   = 700
+
+[buildPlans.iosevka-comfy-wide-fixed.weights.extrabold]
+shape = 800
+menu  = 800
+css   = 800
+
+[buildPlans.iosevka-comfy-wide-fixed.slopes.upright]
+angle = 0
+shape = "upright"
+menu  = "upright"
+css   = "normal"
+
+[buildPlans.iosevka-comfy-wide-fixed.slopes.italic]
+angle = 9.4
+shape = "italic"
+menu  = "italic"
+css   = "italic"
+
+# For the default width, check buildPlans.iosevka-comfy.widths.normal
+[buildPlans.iosevka-comfy-wide-fixed.widths.normal]
+shape = 625
+menu  = 7
+css   = "normal"
+
+[buildPlans.iosevka-comfy-wide-fixed.metric-override]
+leading = 1100

--- a/pkgs/data/fonts/iosevka/comfy.nix
+++ b/pkgs/data/fonts/iosevka/comfy.nix
@@ -1,0 +1,24 @@
+{stdenv, lib, nodejs, nodePackages, remarshal, ttfautohint-nox, fetchurl}:
+
+let
+  sets = [ "comfy" "comfy-duo" "comfy-wide" "comfy-wide-fixed"];
+  privateBuildPlan = builtins.readFile ./comfy-private-build-plans.toml;
+  overrideAttrs = (attrs: {
+    version = "0.1.0";
+    meta = with lib; {
+      homepage = "https://github.com/protesilaos/iosevka-comfy";
+      description = ''
+      Custom build of Iosevka with a rounded style and open shapes,
+      adjusted metrics, and overrides for almost all individual glyphs
+      in both roman (upright) and italic (slanted) variants.
+    '';
+      license = licenses.ofl;
+      platforms = attrs.meta.platforms;
+      maintainers = [ maintainers.DamienCassou ];
+    };
+  });
+  makeIosevkaFont = set: (import ./default.nix {
+    inherit stdenv lib nodejs nodePackages remarshal ttfautohint-nox set privateBuildPlan;
+  }).overrideAttrs overrideAttrs;
+in
+builtins.listToAttrs (builtins.map (set: {name=set; value=makeIosevkaFont set;}) sets)

--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     export HOME=$TMPDIR
     runHook preBuild
-    npm run build --no-update-notifier -- --jCmd=$NIX_BUILD_CORES ttf::$pname >/dev/null
+    npm run build --no-update-notifier -- --jCmd=$NIX_BUILD_CORES ttf::$pname
     runHook postBuild
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24657,6 +24657,7 @@ with pkgs;
 
   iosevka = callPackage ../data/fonts/iosevka {};
   iosevka-bin = callPackage ../data/fonts/iosevka/bin.nix {};
+  iosevka-comfy = recurseIntoAttrs (callPackages ../data/fonts/iosevka/comfy.nix {});
 
   ipafont = callPackage ../data/fonts/ipafont {};
   ipaexfont = callPackage ../data/fonts/ipaexfont {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
