### PR TITLE
htop-vim: unstable-2021-10-11 -> unstable-2022-05-24

### DIFF
--- a/pkgs/tools/system/htop/htop-vim.nix
+++ b/pkgs/tools/system/htop/htop-vim.nix
@@ -2,20 +2,19 @@
 
 htop.overrideAttrs (oldAttrs: rec {
   pname = "htop-vim";
-  version = "unstable-2021-10-11";
+  version = "unstable-2022-05-24";
 
   src = fetchFromGitHub {
     owner = "KoffeinFlummi";
     repo = pname;
-    rev = "ba6fd3891e9af60b41bd092524cc05f2469fec4b";
-    sha256 = "sha256-G83+5GgEz41begDkdK8zNx48UleufFCJ9pOQ9nbtFNs=";
+    rev = "830ef7144940875d9d9716e33aff8651d164026e";
+    sha256 = "sha256-ojStkpWvhb+W3dWyRev0VwjtCVL/I9L8FhtXcQ+ODLA=";
   };
 
   meta = with lib; {
+    inherit (htop.meta) platforms license;
     description = "An interactive process viewer for Linux, with vim-style keybindings";
     homepage = "https://github.com/KoffeinFlummi/htop-vim";
-    license = licenses.gpl2Only;
-    platforms = platforms.all;
     maintainers = with maintainers; [ thiagokokada ];
     mainProgram = "htop";
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Basically this updates from release 3.1.1 to release 3.2.0 from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
