### PR TITLE
llvmPackages/libllvm: disable failing tests on armv7l

### DIFF
--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -115,6 +115,7 @@ in stdenv.mkDerivation (rec {
     rm test/DebugInfo/X86/convert-inlined.ll
     rm test/DebugInfo/X86/convert-linked.ll
     rm test/tools/dsymutil/X86/op-convert.test
+    rm test/tools/gold/X86/split-dwarf.ll
     rm test/tools/llvm-readobj/ELF/dependent-libraries.test
   '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
     # Seems to require certain floating point hardware (NEON?)

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -104,6 +104,8 @@ in stdenv.mkDerivation (rec {
     rm test/DebugInfo/X86/convert-inlined.ll
     rm test/DebugInfo/X86/convert-linked.ll
     rm test/tools/dsymutil/X86/op-convert.test
+    rm test/tools/gold/X86/split-dwarf.ll
+    rm test/tools/llvm-objcopy/MachO/universal-object.test
   '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
     # Seems to require certain floating point hardware (NEON?)
     rm test/ExecutionEngine/frem.ll

--- a/pkgs/development/compilers/llvm/13/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/13/llvm/default.nix
@@ -94,6 +94,7 @@ in stdenv.mkDerivation (rec {
     rm test/DebugInfo/X86/convert-inlined.ll
     rm test/DebugInfo/X86/convert-linked.ll
     rm test/tools/dsymutil/X86/op-convert.test
+    rm test/tools/gold/X86/split-dwarf.ll
   '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
     # Seems to require certain floating point hardware (NEON?)
     rm test/ExecutionEngine/frem.ll


### PR DESCRIPTION
###### Description of changes

Fix build on armv7l for llvm 11, 12 and 13 too.

llvm_13:
```
100% [===========================================================(B](B ETA: 00:00:00
********************                                                
Failed Tests (1):
  LLVM :: tools/gold/X86/split-dwarf.ll


Testing Time: 1916.56s
  Skipped          :     9
  Unsupported      :  1553
  Passed           : 43080
  Expectedly Failed:   158
  Failed           :     1

1 warning(s) in tests
make[3]: *** [CMakeFiles/check-all.dir/build.make:71: CMakeFiles/check-all] Error 1
make[3]: Leaving directory '/build/source/llvm/build'
make[2]: *** [CMakeFiles/Makefile2:8635: CMakeFiles/check-all.dir/all] Error 2
make[2]: Leaving directory '/build/source/llvm/build'
make[1]: *** [CMakeFiles/Makefile2:8642: CMakeFiles/check-all.dir/rule] Error 2
make[1]: Leaving directory '/build/source/llvm/build'
make: *** [Makefile:228: check-all] Error 2
```

llvm_12:
```
100% [===========================================================(B](B ETA: 00:00:00
********************                                                
Failed Tests (2):
  LLVM :: tools/gold/X86/split-dwarf.ll
  LLVM :: tools/llvm-objcopy/MachO/universal-object.test


Testing Time: 1421.25s
  Unsupported      :  1376
  Passed           : 40547
  Expectedly Failed:   154
  Failed           :     2

1 warning(s) in tests
make[3]: *** [CMakeFiles/check-all.dir/build.make:71: CMakeFiles/check-all] Error 1
make[3]: Leaving directory '/build/llvm/build'
make[2]: *** [CMakeFiles/Makefile2:8401: CMakeFiles/check-all.dir/all] Error 2
make[2]: Leaving directory '/build/llvm/build'
make[1]: *** [CMakeFiles/Makefile2:8408: CMakeFiles/check-all.dir/rule] Error 2
make[1]: Leaving directory '/build/llvm/build'
make: *** [Makefile:228: check-all] Error 2
```

llvm_11
```
100% [===========================================================(B](B ETA: 00:00:00
********************                                                
Failed Tests (1):
  LLVM :: tools/gold/X86/split-dwarf.ll


Testing Time: 995.04s
  Unsupported      :  1059
  Passed           : 37208
  Expectedly Failed:   167
  Failed           :     1

1 warning(s) in tests
make[3]: *** [CMakeFiles/check-all.dir/build.make:71: CMakeFiles/check-all] Error 1
make[3]: Leaving directory '/build/llvm/build'
make[2]: *** [CMakeFiles/Makefile2:8097: CMakeFiles/check-all.dir/all] Error 2
make[2]: Leaving directory '/build/llvm/build'
make[1]: *** [CMakeFiles/Makefile2:8104: CMakeFiles/check-all.dir/rule] Error 2
make[1]: Leaving directory '/build/llvm/build'
make: *** [Makefile:228: check-all] Error 2
```

Related: https://github.com/NixOS/nixpkgs/pull/176361
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] armv7l-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
