### PR TITLE
gnupg: 2.3.4 -> 2.3.6, patch for CVE-2022-34903

### DIFF
--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -15,11 +15,11 @@ assert guiSupport -> pinentry != null && enableMinimal == false;
 
 stdenv.mkDerivation rec {
   pname = "gnupg";
-  version = "2.3.4";
+  version = "2.3.6";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-80aOyvsdf5rXtR/R23rr8XzridLvqKBc8vObTUBUAq4=";
+    sha256 = "sha256-Iff+L8XC8hQYSrBQl37HqOME5Yv64qsJj+xp+Pq9qcE=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -34,6 +34,9 @@ stdenv.mkDerivation rec {
     ./tests-add-test-cases-for-import-without-uid.patch
     ./allow-import-of-previously-known-keys-even-without-UI.patch
     ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
+
+    # Patch from upstream 34c649b36013, https://dev.gnupg.org/T6027
+    ./CVE-2022-34903-g10-fix-garbled-status-messages-in-NOTATION_DATA.patch
   ];
   postPatch = ''
     sed -i 's,\(hkps\|https\)://keyserver.ubuntu.com,hkps://keys.openpgp.org,g' configure configure.ac doc/dirmngr.texi doc/gnupg.info-1

--- a/pkgs/tools/security/gnupg/CVE-2022-34903-g10-fix-garbled-status-messages-in-NOTATION_DATA.patch
+++ b/pkgs/tools/security/gnupg/CVE-2022-34903-g10-fix-garbled-status-messages-in-NOTATION_DATA.patch
@@ -1,0 +1,45 @@
+commit 34c649b3601383cd11dbc76221747ec16fd68e1b
+Author: Werner Koch <wk@gnupg.org>
+Date:   2022-06-14 11:33:27 +0200
+
+    g10: Fix garbled status messages in NOTATION_DATA
+    
+    * g10/cpr.c (write_status_text_and_buffer): Fix off-by-one
+    --
+    
+    Depending on the escaping and line wrapping the computed remaining
+    buffer length could be wrong.  Fixed by always using a break to
+    terminate the escape detection loop.  Might have happened for all
+    status lines which may wrap.
+    
+    GnuPG-bug-id: T6027
+
+diff --git a/g10/cpr.c b/g10/cpr.c
+index 9bfdd3c34..fa8005d6f 100644
+--- a/g10/cpr.c
++++ b/g10/cpr.c
+@@ -372,20 +372,15 @@ write_status_text_and_buffer (int no, const char *string,
+             }
+           first = 0;
+         }
+-      for (esc=0, s=buffer, n=len; n && !esc; s++, n--)
++      for (esc=0, s=buffer, n=len; n; s++, n--)
+         {
+           if (*s == '%' || *(const byte*)s <= lower_limit
+               || *(const byte*)s == 127 )
+             esc = 1;
+           if (wrap && ++count > wrap)
+-            {
+-              dowrap=1;
+-              break;
+-            }
+-        }
+-      if (esc)
+-        {
+-          s--; n++;
++            dowrap=1;
++          if (esc || dowrap)
++            break;
+         }
+       if (s != buffer)
+         es_fwrite (buffer, s-buffer, 1, statusfp);


### PR DESCRIPTION
###### Description of changes

Update `gnupg` to 2.3.6
https://lists.gnu.org/archive/html/info-gnu/2022-04/msg00014.html

Add patch for CVE-2022-34903
https://dev.gnupg.org/rG34c649b3601383cd11dbc76221747ec16fd68e1b

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
