### PR TITLE
python310Packages.omnilogic: 0.4.5 -> 0.4.6

### DIFF
--- a/pkgs/development/python-modules/omnilogic/default.nix
+++ b/pkgs/development/python-modules/omnilogic/default.nix
@@ -2,29 +2,29 @@
 , aiohttp
 , xmltodict
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
 }:
 
 buildPythonPackage rec {
   pname = "omnilogic";
-  version = "0.4.5";
+  version = "0.4.6";
+
+  disabled = pythonOlder "3.4";
+
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "djtimca";
     repo = "omnilogic-api";
     rev = version;
-    sha256 = "081awb0fl40b5ighc9yxfq1xkgxz7l5dvz5544hx965q2r20wvsg";
+    hash = "sha256-XyAniuUr/Kt8VfBtovD4kKLG+ehOqE26egEG7j8q9LY=";
   };
 
   propagatedBuildInputs = [
     aiohttp
     xmltodict
   ];
-
-  postPatch = ''
-    # Is not used but still present in setup.py
-    substituteInPlace setup.py --replace "'config'," ""
-  '';
 
   # Project has no tests
   doCheck = false;


### PR DESCRIPTION

###### Description of changes
https://github.com/djtimca/omnilogic-api/releases/tag/0.4.6

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
