### PR TITLE
home-assistant: 2022.6.2 -> 2022.6.3

### DIFF
--- a/pkgs/development/python-modules/pyialarmxr-homeassistant/default.nix
+++ b/pkgs/development/python-modules/pyialarmxr-homeassistant/default.nix
@@ -1,24 +1,23 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , lxml
 , pythonOlder
 , xmltodict
 }:
 
 buildPythonPackage rec {
-  pname = "pyialarmxr";
+  pname = "pyialarmxr-homeassistant";
   version = "1.0.18";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "bigmoby";
-    repo = pname;
-    rev = version;
-    hash = "sha256-Q1NsPLA1W4nxSG/9jlMf6BkC3ZrUrhl8oDX7U4aAjxM=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-aQHJiSmaGyABHP17oFH+6JQ9zNJ6pj2+PcE+gsRuhaQ=";
   };
+
   propagatedBuildInputs = [
     lxml
     xmltodict
@@ -33,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Library to interface with Antifurto365 iAlarmXR systems";
-    homepage = "https://github.com/bigmoby/pyialarmxr";
+    homepage = "https://pypi.org/project/pyialarmxr-homeassistant/";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2022.6.2";
+  version = "2022.6.3";
   components = {
     "abode" = ps: with ps; [
       abodepy
@@ -1207,7 +1207,7 @@
       pyialarm
     ];
     "ialarm_xr" = ps: with ps; [
-      pyialarmxr
+      pyialarmxr-homeassistant
     ];
     "iammeter" = ps: with ps; [
     ]; # missing inputs: iammeter

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -166,7 +166,7 @@ let
   extraPackagesFile = writeText "home-assistant-packages" (lib.concatMapStringsSep "\n" (pkg: pkg.pname) extraBuildInputs);
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2022.6.2";
+  hassVersion = "2022.6.3";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -184,7 +184,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256-M0wBvAdvoGrvJrE96ZM9+X1KMp796vtzbzIo8ScXcy8=";
+    hash = "sha256-dYJbYrOwjJ2OO+gYT9UmCam+gNvSycFGUEeHBoGTqSM=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -111,6 +111,7 @@ mapAliases ({
   pydrive = throw "pydrive is broken and deprecated and has been replaced with pydrive2."; # added 2022-06-01
   pyGtkGlade = throw "Glade support for pygtk has been removed"; # added 2022-01-15
   pycallgraph = throw "pycallgraph has been removed, it was using setuptools 2to3 translation feature, which has been removed in setuptools 58"; # added 2022-01-18
+  pyialarmxr = pyialarmxr-homeassistant; # added 2022-06-07
   pylibgen = throw "pylibgen is unmaintained upstreamed, and removed from nixpkgs"; # added 2020-06-20
   pymc3 = pymc; # added 2022-06-05, module was rename starting with 4.0.0
   pymssql = throw "pymssql has been abandoned upstream."; # added 2020-05-04

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7448,7 +7448,7 @@ in {
 
   pyialarm = callPackage ../development/python-modules/pyialarm { };
 
-  pyialarmxr = callPackage ../development/python-modules/pyialarmxr { };
+  pyialarmxr-homeassistant = callPackage ../development/python-modules/pyialarmxr-homeassistant { };
 
   pyicloud = callPackage ../development/python-modules/pyicloud { };
 


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2022.6.3

###### Description of changes

pyialarmxr repo got deleted, so I migrated the package to use homeassistants pypi fork.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
