### PR TITLE
certigo: patch tests and enable checks on Darwin

### DIFF
--- a/pkgs/tools/admin/certigo/default.nix
+++ b/pkgs/tools/admin/certigo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+{ lib, stdenv, buildGoModule, fetchFromGitHub, fetchpatch }:
 
 buildGoModule rec {
   pname = "certigo";
@@ -11,12 +11,21 @@ buildGoModule rec {
     sha256 = "sha256-XGR6xIXdFLnJTFd+mJneRb/WkLmi0Jscta9Bj3paM1M=";
   };
 
-  vendorSha256 = "sha256-qS/tIi6umSuQcl43SI4LyL0k5eWfRWs7kVybRPGKcbs=";
+  patches = [
+    (fetchpatch {
+      name = "backport_TestConnect-Apple-Fixes.patch";
+      url = "https://github.com/square/certigo/commit/5332ac7ca20bdea63657cc8319e8b8fda4326938.patch";
+      sha256 = "sha256-mSNuiui2dxkXnCrXJ/asIzC8F1mtPecOVOIu6mE5jq4=";
+    })
 
-  # Go running under Hydra Darwin x86_64 picks CHAPOLY instead of AES-GCM as
-  # the default TLS ciphersuite, and breaks the arguably flakey `TestConnect`
-  # test.
-  doCheck = !(stdenv.isDarwin && stdenv.isx86_64);
+    (fetchpatch {
+      name = "backport_TestConnect-Expected-CipherSuite-Fixes.patch";
+      url = "https://github.com/square/certigo/commit/7ef0417bde4aafc69cbb72f0dd6d3577a56054a1.patch";
+      sha256 = "sha256-TUQ8B23HKheaPUjj4NkvjmZBAAhDNTyo2c8jf4qukds=";
+    })
+  ];
+
+  vendorSha256 = "sha256-qS/tIi6umSuQcl43SI4LyL0k5eWfRWs7kVybRPGKcbs=";
 
   meta = with lib; {
     description = "A utility to examine and validate certificates in a variety of formats";


### PR DESCRIPTION
Worked with the upstream project to get the test updated for modern
macOS and emulated/virtualized hardware.

Bring in unit test fixes in two patches from upstream trunk and
re-enable tests on Darwin.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
