### PR TITLE
apple_sdk_11_0: make available for use on x86_64-darwin

### DIFF
--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -60,3 +60,8 @@ Some common issues when packaging software for Darwin:
   ```
 
   The package `xcbuild` can be used to build projects that really depend on Xcode. However, this replacement is not 100% compatible with Xcode and can occasionally cause issues.
+
+- x86_64-darwin uses the 10.12 SDK by default, but some software is not compatible with that version of the SDK. In that case,
+  the 11.0 SDK used by aarch64-darwin is available for use on x86_64-darwin. To use it, reference `apple_sdk_11_0` instead of
+  `apple_sdk` in your derivation and use `pkgs.darwin.apple_sdk_11_0.callPackage` instead of `pkgs.callPackage`. On Linux, this will
+  have the same effect as `pkgs.callPackage`, so you can use `pkgs.darwin.apple_sdk_11_0.callPackage` regardless of platform.

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -168,8 +168,8 @@ in rec {
   bareFrameworks = (
     lib.mapAttrs framework (import ./frameworks.nix {
       inherit frameworks libs;
-      inherit (pkgs.darwin) libobjc Libsystem;
-      inherit (pkgs.darwin.apple_sdk) libnetwork;
+      inherit (pkgs.darwin.apple_sdk_11_0) libnetwork Libsystem;
+      libobjc = pkgs.darwin.apple_sdk_11_0.objc4;
     })
   ) // (
     lib.mapAttrs privateFramework (import ./private-frameworks.nix {

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -1,4 +1,5 @@
 { stdenvNoCC, fetchurl, newScope, pkgs
+, stdenv, overrideCC
 , xar, cpio, python3, pbzx }:
 
 let
@@ -54,5 +55,21 @@ let
     # questionable aliases
     configd = pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;
     IOKit = pkgs.darwin.apple_sdk.frameworks.IOKit;
+
+    stdenv =
+      let
+        clang = stdenv.cc.override {
+          bintools = stdenv.cc.bintools.override { libc = packages.Libsystem; };
+          libc = packages.Libsystem;
+        };
+      in
+      if stdenv.isAarch64 then stdenv
+      else
+        (overrideCC stdenv clang).override {
+          targetPlatform = stdenv.targetPlatform // {
+            darwinMinVersion = "10.12";
+            darwinSdkVersion = "11.0";
+          };
+        };
   };
 in packages

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchurl, newScope, pkgs
+{ stdenvNoCC, fetchurl, newScope, lib, pkgs
 , stdenv, overrideCC
 , xar, cpio, python3, pbzx }:
 
@@ -55,6 +55,20 @@ let
     # questionable aliases
     configd = pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;
     IOKit = pkgs.darwin.apple_sdk.frameworks.IOKit;
+
+    callPackage = newScope (lib.optionalAttrs stdenv.isDarwin rec {
+      inherit (pkgs.darwin.apple_sdk_11_0) stdenv;
+      darwin = pkgs.darwin.overrideScope (_: prev: {
+        inherit (prev.darwin.apple_sdk_11_0) Libsystem LibsystemCross libcharset libunwind objc4 configd IOKit Security;
+        apple_sdk = prev.darwin.apple_sdk_11_0;
+        CF = prev.darwin.apple_sdk_11_0.CoreFoundation;
+      });
+      xcodebuild = pkgs.xcbuild.override {
+        inherit (pkgs.darwin.apple_sdk_11_0.frameworks) CoreServices CoreGraphics ImageIO;
+        inherit stdenv;
+      };
+      xcbuild = xcodebuild;
+    });
 
     stdenv =
       let

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -70,7 +70,7 @@ in
 
 impure-cmds // appleSourcePackages // chooseLibs // {
 
-  inherit apple_sdk;
+  inherit apple_sdk apple_sdk_10_12 apple_sdk_11_0;
 
   stdenvNoCF = stdenv.override {
     extraBuildInputs = [];


### PR DESCRIPTION
###### Description of changes

I discussed with @toonn on Matrix yesterday and this morning about the possibility of using the aarch64-darwin SDK on x86_64-darwin as an interim solution for software that needs a newer SDK. This was prompted by my wanting to build MoltenVK without needing Xcode.

I opened the PR against master because the changes required were quite small, and there are no rebuilds. The basic functionality tested was MoltenVK built with the SDK from nixpkgs (no Xcode).

See below for a screenshot of a functional demo app built almost entirely with nixpkgs (`vkcube.app` in vulkan-tools unfortunately requires `ibtool` from Xcode, but the actual code is compiled against the 10.12 SDK in nixpkg and linked against a MoltenVK built with the 11.0 SDK). A PR for MoltenVK will be forthcoming once this lands.

<img width="1728" alt="Screen Shot 2022-06-06 at 9 33 22 AM" src="https://user-images.githubusercontent.com/7413633/172296102-07bb1fed-b18c-4869-879e-3bb25843a439.png">

**Sandbox:** set to relaxed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
