### PR TITLE
adguardhome: Add schema_version

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -763,6 +763,14 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>adguardhome</literal> module no longer uses
+          <literal>host</literal> and <literal>port</literal> options,
+          use <literal>settings.bind_host</literal> and
+          <literal>settings.bind_port</literal> instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The default <literal>kops</literal> version is now 1.25.1 and
           support for 1.22 and older has been dropped.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -242,6 +242,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
   Use `configure.packages` instead.
 - Neovim can not be configured with plug anymore (still works for vim).
 
+- The `adguardhome` module no longer uses `host` and `port` options, use `settings.bind_host` and `settings.bind_port` instead.
+
 - The default `kops` version is now 1.25.1 and support for 1.22 and older has been dropped.
 
 - `k3s` no longer supports docker as runtime due to upstream dropping support.

--- a/nixos/tests/adguardhome.nix
+++ b/nixos/tests/adguardhome.nix
@@ -2,16 +2,13 @@
   name = "adguardhome";
 
   nodes = {
-    minimalConf = { ... }: {
-      services.adguardhome = { enable = true; };
-    };
-
     declarativeConf = { ... }: {
       services.adguardhome = {
         enable = true;
 
         mutableSettings = false;
         settings = {
+          schema_version = 0;
           dns = {
             bind_host = "0.0.0.0";
             bootstrap_dns = "127.0.0.1";
@@ -26,6 +23,7 @@
 
         mutableSettings = true;
         settings = {
+          schema_version = 0;
           dns = {
             bind_host = "0.0.0.0";
             bootstrap_dns = "127.0.0.1";
@@ -36,10 +34,6 @@
   };
 
   testScript = ''
-    with subtest("Minimal config test"):
-        minimalConf.wait_for_unit("adguardhome.service")
-        minimalConf.wait_for_open_port(3000)
-
     with subtest("Declarative config test, DNS will be reachable"):
         declarativeConf.wait_for_unit("adguardhome.service")
         declarativeConf.wait_for_open_port(53)

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
+    schema_version = 14;
     tests.adguardhome = nixosTests.adguardhome;
   };
 

--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -13,6 +13,11 @@ version=$(jq -r '.tag_name' <<<"$latest_release")
 
 echo "got version $version"
 
+schema_version=$(curl --silent "https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/${version}/internal/home/upgrade.go" \
+    | grep -Po '(?<=const currentSchemaVersion = )[[:digit:]]+$')
+
+echo "got schema_version $schema_version"
+
 declare -A systems
 systems[linux_386]=i686-linux
 systems[linux_amd64]=x86_64-linux
@@ -37,3 +42,4 @@ done
 echo '}' >> "$bins"
 
 sed -i -r -e "s/version\s*?=\s*?.*?;/version = \"${version#v}\";/" "$dirname/default.nix"
+sed -i -r -e "s/schema_version\s*?=\s*?.*?;/schema_version = ${schema_version};/" "$dirname/default.nix"


### PR DESCRIPTION
###### Description of changes

This will add `passthru.schema_version` to be used as default value for the adguardhome module.
It will also update the `update.sh` to keep this in sync with the version by inspecting the sourcecode.

Fixes #173938

###### Other notes

There is also a change in `update.sh` to open up the path for `aarch64-darwin`. If this PR merges, I'll open a second one to bump the version and add the platform.

This might break existing configs, if they use deprecated values that don't appear in newer `schema_version`s **and** `schema_version` wasn't set explicitly. Explicit declarations of `schema_version` always have higher priority.

Might also be relevant for https://github.com/AdguardTeam/AdGuardHome/issues/4067 as we have an automated way of getting the `schema_version` from github (although I don't feel like this approach is entirely stable).

Maintainers:
@numkem 
@iagocq 

Other relevant pings:
@rickhull Opened the issue
@mario-kr Validated lost values due to wrong `schema_version`
@aanderse Recommended grabbing the newest `schema_version` (https://github.com/NixOS/nixpkgs/issues/173938#issuecomment-1148494449)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

