### PR TITLE
python3Packages.pulumi: fix the version number in setup.py

### DIFF
--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -66,19 +66,18 @@ buildPythonPackage rec {
     black
   ];
 
-  pythonImportsCheck = ["pulumi"];
-
+  sourceRoot="source/sdk/python/lib";
+  # we apply the modifications done in the pulumi/sdk/python/Makefile
+  # but without the venv code
   postPatch = ''
-    cp README.md sdk/python/lib
-    patchShebangs .
-    cd sdk/python/lib
-
-    substituteInPlace setup.py \
-      --replace "{VERSION}" "${version}"
+    cp ../../README.md .
+    sed -i "s/\''${VERSION}/${version}/g" setup.py
   '';
 
   # disabled because tests try to fetch go packages from the net
   doCheck = false;
+
+  pythonImportsCheck = ["pulumi"];
 
   meta = with lib; {
     description = "Modern Infrastructure as Code. Any cloud, any language";


### PR DESCRIPTION
the substituteInPlace didn't work for some reason, thus the deduced version became a negative one , i.e., -3.31 . Pulumi worked but then pulumi_aws was complaining that pulumi bounds were not respected.
I use `sed ` as is done in https://github.com/pulumi/pulumi/blob/d6a112c8e76190a579dbad94fddbe79600024365/sdk/python/Makefile#L31 to fix the issue. Now python3Packages.pulumi-aws accepts the version of pulumi and builds.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
