### PR TITLE
gpgme: fix build on armv7l

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
     # debugging is disabled
     lib.optional (qtbase != null) "-DQT_NO_DEBUG"
     # https://www.gnupg.org/documentation/manuals/gpgme/Largefile-Support-_0028LFS_0029.html
-    ++ lib.optional (system == "i686-linux") "-D_FILE_OFFSET_BITS=64"
+    ++ lib.optional stdenv.hostPlatform.is32bit "-D_FILE_OFFSET_BITS=64"
   );
 
   doCheck = true;


### PR DESCRIPTION
###### Description of changes
Enable largefile support on all 32-bit platforms.
This fixes build error on armv7l:
```
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I../../../conf -I../../../lang/cpp/src -I../../../src -DQT_CORE_LIB -I/nix/store/3z1fcym4q6lhxiziz6fv4hmbin2pawys-qtbase-5.15.3-dev/include/QtCore -I/nix/store/3z1fcym4q6lhxiziz6fv4hmbin2pawys-qtbase-5.15.3-dev/include -I/nix/store/8xs074dsdqlrnzrzv5xblwbar067y8x7-libgpg-error-1.42-dev/include -I/nix/store/kxsh1fvx2wbgx1x7f2hrzfz5f5s9ghvh-libassuan-2.5.5-dev/include -I/nix/store/8xs074dsdqlrnzrzv5xblwbar067y8x7-libgpg-error-1.42-dev/include -DBUILDING_QGPGME -Wsuggest-override -Wzero-as-null-pointer-constant -g -O2 -c util.cpp  -fPIC -DPIC -o .libs/util.o
In file included from util.h:37,
                 from util.cpp:34:
../../../src/gpgme.h:111:2: error: #error GPGME was compiled with _FILE_OFFSET_BITS = 64, please see the section "Largefile support (LFS)" in the GPGME manual.
  111 | #error GPGME was compiled with _FILE_OFFSET_BITS = 64, please see the section "Largefile support (LFS)" in the GPGME manual.
      |  ^~~~~
make[4]: *** [Makefile:933: util.lo] Error 1
make[4]: Leaving directory '/build/gpgme-1.17.1/lang/qt/src'
make[3]: *** [Makefile:777: all] Error 2
make[3]: Leaving directory '/build/gpgme-1.17.1/lang/qt/src'
make[2]: *** [Makefile:466: all-recursive] Error 1
make[2]: Leaving directory '/build/gpgme-1.17.1/lang/qt'
make[1]: *** [Makefile:463: all-recursive] Error 1
make[1]: Leaving directory '/build/gpgme-1.17.1/lang'
make: *** [Makefile:540: all-recursive] Error 1
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] armv7l-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
