### PR TITLE
pythonRelaxDepsHook: fix usage in packages with `-` in pname

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -59,10 +59,11 @@ _pythonRemoveDeps() {
 pythonRelaxDepsHook() {
     pushd dist
 
-    local -r package="$pname-$version"
+    # See https://peps.python.org/pep-0491/#escaping-and-unicode
+    local -r pkg_name="${pname//[^[:alnum:].]/_}-$version"
     local -r unpack_dir="unpacked"
-    local -r metadata_file="$unpack_dir/$package/$package.dist-info/METADATA"
-    local -r wheel=$(echo "$package"*".whl")
+    local -r metadata_file="$unpack_dir/$pkg_name/$pkg_name.dist-info/METADATA"
+    local -r wheel=$(printf "$pkg_name"*".whl")
 
     @pythonInterpreter@ -m wheel unpack --dest "$unpack_dir" "$wheel"
     rm -rf "$wheel"
@@ -72,10 +73,10 @@ pythonRelaxDepsHook() {
 
     if (( "${NIX_DEBUG:-0}" >= 1 )); then
         echo "pythonRelaxDepsHook: resulting METADATA:"
-        cat "$unpack_dir/$package/$package.dist-info/METADATA"
+        cat "$unpack_dir/$pkg_name/$pkg_name.dist-info/METADATA"
     fi
 
-    @pythonInterpreter@ -m wheel pack "$unpack_dir/$package"
+    @pythonInterpreter@ -m wheel pack "$unpack_dir/$pkg_name"
 
     popd
 }

--- a/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
+++ b/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
@@ -5,6 +5,7 @@
 , pysigma
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -23,10 +24,15 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [
     pysigma
+  ];
+
+  pythonRelaxDeps = [
+    "pysigma"
   ];
 
   checkInputs = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes issue https://github.com/NixOS/nixpkgs/issues/176695.

When `pname` includes `-` or some other non alpha-numeric characters (with the exception of `.`), the generated `.whl` [file will have its non alpha-numeric characters converted to `_`](https://peps.python.org/pep-0491/#escaping-and-unicode). For example:

- `abc-cde` -> `abc_cde`
- `abc-cde-1.1` -> `abc_cde-1.1`

However we were trying to get the non-normalize name for the file, causing the `pythonRelaxDepsHook` to fail. This PR fixes it by normalizing the `.whl` filename.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
