### PR TITLE
[nixos-21.05] autoPatchelfHook: fix packages that use stdenvNoCC

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -37,7 +37,6 @@ isExecutable() {
 declare -Ag autoPatchelfCachedDepsAssoc
 declare -ag autoPatchelfCachedDeps
 
-
 addToDepCache() {
     if [[ ${autoPatchelfCachedDepsAssoc[$1]+f} ]]; then return; fi
 
@@ -53,25 +52,70 @@ declare -gi depCacheInitialised=0
 declare -gi doneRecursiveSearch=0
 declare -g foundDependency
 
-getDepsFromSo() {
-    ldd "$1" 2> /dev/null | sed -n -e 's/[^=]*=> *\(.\+\) \+([^)]*)$/\1/p'
+getDepsFromElfBinary() {
+    # NOTE: This does not use runPatchelf because it may encounter non-ELF
+    # files. Caller is expected to check the return code if needed.
+    patchelf --print-needed "$1" 2> /dev/null
+}
+
+getRpathFromElfBinary() {
+    # NOTE: This does not use runPatchelf because it may encounter non-ELF
+    # files. Caller is expected to check the return code if needed.
+    local rpath
+    rpath="$(patchelf --print-rpath "$1" 2> /dev/null)" || return $?
+
+    local IFS=':'
+    printf "%s\n" $rpath
+}
+
+populateCacheForDep() {
+    local so="$1"
+    local rpath found
+    rpath="$(getRpathFromElfBinary "$so")" || return 1
+
+    for found in $(getDepsFromElfBinary "$so"); do
+        local rpathElem
+        for rpathElem in $rpath; do
+            # Ignore empty element or $ORIGIN magic variable which should be
+            # deterministically resolved by adding this package's library
+            # files early anyway.
+            #
+            # shellcheck disable=SC2016
+            # (Expressions don't expand in single quotes, use double quotes for
+            # that.)
+            if [[ -z "$rpathElem" || "$rpathElem" == *'$ORIGIN'* ]]; then
+                continue
+            fi
+
+            local soname="${found%.so*}"
+            local foundso=
+            for foundso in "$rpathElem/$soname".so*; do
+                addToDepCache "$foundso"
+            done
+
+            # Found in this element of the rpath, no need to check others.
+            if [ -n "$foundso" ]; then
+                break
+            fi
+        done
+    done
+
+    # Not found in any rpath element.
+    return 1
 }
 
 populateCacheWithRecursiveDeps() {
-    local so found foundso
-    for so in "${autoPatchelfCachedDeps[@]}"; do
-        for found in $(getDepsFromSo "$so"); do
-            local base="${found##*/}"
-            local soname="${base%.so*}"
-            for foundso in "${found%/*}/$soname".so*; do
-                addToDepCache "$foundso"
-            done
-        done
+    # Dependencies may add more to the end of this array, so we use a counter
+    # with while instead of a regular for loop here.
+    local -i i=0
+    while [ $i -lt ${#autoPatchelfCachedDeps[@]} ]; do
+        populateCacheForDep "${autoPatchelfCachedDeps[$i]}"
+        i=$i+1
     done
 }
 
 getSoArch() {
-    objdump -f "$1" | sed -ne 's/^architecture: *\([^,]\+\).*/\1/p'
+    $OBJDUMP -f "$1" | sed -ne 's/^architecture: *\([^,]\+\).*/\1/p'
 }
 
 # NOTE: If you want to use this function outside of the autoPatchelf function,
@@ -129,25 +173,25 @@ autoPatchelfFile() {
         fi
     fi
 
+    local libcLib
+    libcLib="$(< "$NIX_CC/nix-support/orig-libc")/lib"
+
     echo "searching for dependencies of $toPatch" >&2
 
-    # We're going to find all dependencies based on ldd output, so we need to
-    # clear the RPATH first.
-    runPatchelf --remove-rpath "$toPatch"
-
-    # If the file is not a dynamic executable, ldd/sed will fail,
-    # in which case we return, since there is nothing left to do.
     local missing
-    missing="$(
-        ldd "$toPatch" 2> /dev/null | \
-            sed -n -e 's/^[\t ]*\([^ ]\+\) => not found.*/\1/p'
-    )" || return 0
+    missing="$(getDepsFromElfBinary "$toPatch")" || return 0
 
     # This ensures that we get the output of all missing dependencies instead
     # of failing at the first one, because it's more useful when working on a
     # new package where you don't yet know its dependencies.
 
     for dep in $missing; do
+        # Check whether this library exists in libc. If so, we don't need to do
+        # any futher searching -- it will be resolved correctly by the linker.
+        if [ -f "$libcLib/$dep" ]; then
+            continue
+        fi
+
         echo -n "  $dep -> " >&2
         if findDependency "$dep" "$(getSoArch "$toPatch")"; then
             rpath="$rpath${rpath:+:}${foundDependency%/*}"
@@ -184,7 +228,7 @@ addAutoPatchelfSearchPath() {
     done
 
     while IFS= read -r -d '' file; do
-    addToDepCache "$file"
+        addToDepCache "$file"
     done <  <(find "$@" "${findOpts[@]}" \! -type d \
             \( -name '*.so' -o -name '*.so.*' \) -print0)
 }
@@ -220,10 +264,10 @@ autoPatchelf() {
       segmentHeaders="$(LANG=C $READELF -l "$file")"
       # Skip if the ELF file doesn't have segment headers (eg. object files).
       # not using grep -q, because it can cause Broken pipe
-      [ -n "$(echo "$segmentHeaders" | grep '^Program Headers:')" ] || continue
+      grep -q '^Program Headers:' <<<"$segmentHeaders" || continue
       if isExecutable "$file"; then
           # Skip if the executable is statically linked.
-          [ -n "$(echo "$segmentHeaders" | grep "^ *INTERP\\>")" ] || continue
+          grep -q "^ *INTERP\\>" <<<"$segmentHeaders" || continue
       fi
       # Jump file if patchelf is unable to parse it
       # Some programs contain binary blobs for testing,
@@ -255,6 +299,9 @@ autoPatchelf() {
 # So what we do here is basically run in postFixup and emulate the same
 # behaviour as fixupOutputHooks because the setup hook for patchelf is run in
 # fixupOutput and the postFixup hook runs later.
+#
+# shellcheck disable=SC2016
+# (Expressions don't expand in single quotes, use double quotes for that.)
 postFixupHooks+=('
     if [ -z "${dontAutoPatchelf-}" ]; then
         autoPatchelf -- $(for output in $outputs; do

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -205,7 +205,7 @@ autoPatchelfFile() {
     local dep rpath="" toPatch="$1"
 
     local interpreter
-    interpreter="$(< "$NIX_CC/nix-support/dynamic-linker")"
+    interpreter="$(< "$NIX_BINTOOLS/nix-support/dynamic-linker")"
 
     local interpreterArch interpreterOsabi toPatchArch toPatchOsabi
     interpreterArch="$(getBinArch "$interpreter")"
@@ -235,7 +235,7 @@ autoPatchelfFile() {
     fi
 
     local libcLib
-    libcLib="$(< "$NIX_CC/nix-support/orig-libc")/lib"
+    libcLib="$(< "$NIX_BINTOOLS/nix-support/orig-libc")/lib"
 
     echo "searching for dependencies of $toPatch" >&2
 

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -62,10 +62,9 @@ getRpathFromElfBinary() {
     # NOTE: This does not use runPatchelf because it may encounter non-ELF
     # files. Caller is expected to check the return code if needed.
     local rpath
-    rpath="$(patchelf --print-rpath "$1" 2> /dev/null)" || return $?
+    IFS=':' read -ra rpath < <(patchelf --print-rpath "$1" 2> /dev/null) || return $?
 
-    local IFS=':'
-    printf "%s\n" $rpath
+    printf "%s\n" "${rpath[@]}"
 }
 
 populateCacheForDep() {
@@ -114,8 +113,52 @@ populateCacheWithRecursiveDeps() {
     done
 }
 
-getSoArch() {
-    $OBJDUMP -f "$1" | sed -ne 's/^architecture: *\([^,]\+\).*/\1/p'
+getBinArch() {
+    $OBJDUMP -f "$1" 2> /dev/null | sed -ne 's/^architecture: *\([^,]\+\).*/\1/p'
+}
+
+# Returns the specific OS ABI for an ELF file in the format produced by
+# readelf(1), like "UNIX - System V" or "UNIX - GNU".
+getBinOsabi() {
+    $READELF -h "$1" 2> /dev/null | sed -ne 's/^[ \t]*OS\/ABI:[ \t]*\(.*\)/\1/p'
+}
+
+# Tests whether two OS ABIs are compatible, taking into account the generally
+# accepted compatibility of SVR4 ABI with other ABIs.
+areBinOsabisCompatible() {
+    local wanted="$1"
+    local got="$2"
+
+    if [[ -z "$wanted" || -z "$got" ]]; then
+        # One of the types couldn't be detected, so as a fallback we'll assume
+        # they're compatible.
+        return 0
+    fi
+
+    # Generally speaking, the base ABI (0x00), which is represented by
+    # readelf(1) as "UNIX - System V", indicates broad compatibility with other
+    # ABIs.
+    #
+    # TODO: This isn't always true. For example, some OSes embed ABI
+    # compatibility into SHT_NOTE sections like .note.tag and .note.ABI-tag.
+    # It would be prudent to add these to the detection logic to produce better
+    # ABI information.
+    if [[ "$wanted" == "UNIX - System V" ]]; then
+        return 0
+    fi
+
+    # Similarly here, we should be able to link against a superset of features,
+    # so even if the target has another ABI, this should be fine.
+    if [[ "$got" == "UNIX - System V" ]]; then
+        return 0
+    fi
+
+    # Otherwise, we simply return whether the ABIs are identical.
+    if [[ "$wanted" == "$got" ]]; then
+        return 0
+    fi
+
+    return 1
 }
 
 # NOTE: If you want to use this function outside of the autoPatchelf function,
@@ -126,6 +169,7 @@ getSoArch() {
 findDependency() {
     local filename="$1"
     local arch="$2"
+    local osabi="$3"
     local lib dep
 
     if [ $depCacheInitialised -eq 0 ]; then
@@ -137,7 +181,7 @@ findDependency() {
 
     for dep in "${autoPatchelfCachedDeps[@]}"; do
         if [ "$filename" = "${dep##*/}" ]; then
-            if [ "$(getSoArch "$dep")" = "$arch" ]; then
+            if [ "$(getBinArch "$dep")" = "$arch" ] && areBinOsabisCompatible "$osabi" "$(getBinOsabi "$dep")"; then
                 foundDependency="$dep"
                 return 0
             fi
@@ -162,6 +206,23 @@ autoPatchelfFile() {
 
     local interpreter
     interpreter="$(< "$NIX_CC/nix-support/dynamic-linker")"
+
+    local interpreterArch interpreterOsabi toPatchArch toPatchOsabi
+    interpreterArch="$(getBinArch "$interpreter")"
+    interpreterOsabi="$(getBinOsabi "$interpreter")"
+    toPatchArch="$(getBinArch "$toPatch")"
+    toPatchOsabi="$(getBinOsabi "$toPatch")"
+
+    if [ "$interpreterArch" != "$toPatchArch" ]; then
+        # Our target architecture is different than this file's architecture,
+        # so skip it.
+        echo "skipping $toPatch because its architecture ($toPatchArch) differs from target ($interpreterArch)" >&2
+        return 0
+    elif ! areBinOsabisCompatible "$interpreterOsabi" "$toPatchOsabi"; then
+        echo "skipping $toPatch because its OS ABI ($toPatchOsabi) is not compatible with target ($interpreterOsabi)" >&2
+        return 0
+    fi
+
     if isExecutable "$toPatch"; then
         runPatchelf --set-interpreter "$interpreter" "$toPatch"
         # shellcheck disable=SC2154
@@ -186,14 +247,21 @@ autoPatchelfFile() {
     # new package where you don't yet know its dependencies.
 
     for dep in $missing; do
-        # Check whether this library exists in libc. If so, we don't need to do
-        # any futher searching -- it will be resolved correctly by the linker.
-        if [ -f "$libcLib/$dep" ]; then
+        if [[ "$dep" == /* ]]; then
+            # This is an absolute path. If it exists, just use it. Otherwise,
+            # we probably want this to produce an error when checked (because
+            # just updating the rpath won't satisfy it).
+            if [ -f "$dep" ]; then
+                continue
+            fi
+        elif [ -f "$libcLib/$dep" ]; then
+            # This library exists in libc, and will be correctly resolved by
+            # the linker.
             continue
         fi
 
         echo -n "  $dep -> " >&2
-        if findDependency "$dep" "$(getSoArch "$toPatch")"; then
+        if findDependency "$dep" "$toPatchArch" "$toPatchOsabi"; then
             rpath="$rpath${rpath:+:}${foundDependency%/*}"
             echo "found: $foundDependency" >&2
         else

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -154,7 +154,8 @@ in
     autoconf = autoconf269;
   };
 
-  autoPatchelfHook = makeSetupHook { name = "auto-patchelf-hook"; }
+  autoPatchelfHook = makeSetupHook
+    { name = "auto-patchelf-hook"; deps = [ bintools ]; }
     ../build-support/setup-hooks/auto-patchelf.sh;
 
   appimageTools = callPackage ../build-support/appimage {


### PR DESCRIPTION
###### Description of changes
[I know nixos-21.05 is EOL, but at $dayjob I need to use it because it's the last nixpkgs version that has python-3.6 (don't ask).]

This backports `autoPatchelfHook: fix packages that use stdenvNoCC` and its two dependencies, ref. https://github.com/oxalica/rust-overlay/issues/91.

I'm running nixpkgs-review and will post the results when they are in.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
