### PR TITLE
sbsigntool: 0.9.1 -> 0.9.4

### DIFF
--- a/pkgs/tools/security/sbsigntool/autoconf.patch
+++ b/pkgs/tools/security/sbsigntool/autoconf.patch
@@ -1,9 +1,11 @@
---- sbsigntools/configure.ac	2018-09-25 10:30:00.878766256 -0500
-+++ configure.ac.new	2018-09-25 10:34:56.231277375 -0500
-@@ -71,15 +71,16 @@
+diff --git a/configure.ac b/configure.ac
+index 4ffb68f..d8a8265 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -71,15 +71,16 @@ AM_CONDITIONAL(TEST_BINARY_FORMAT, [ test "$EFI_ARCH" = "arm" -o "$EFI_ARCH" = "
  # no consistent view of where gnu-efi should dump the efi stuff, so find it
  ##
- for path in /lib /lib64 /usr/lib /usr/lib64 /usr/lib32 /lib/efi /lib64/efi /usr/lib/efi /usr/lib64/efi; do
+ for path in /lib /lib64 /usr/lib /usr/lib64 /usr/lib32 /lib/efi /lib64/efi /usr/lib/efi /usr/lib64/efi /usr/lib/gnuefi /usr/lib64/gnuefi ; do
 -    if test -e $path/crt0-efi-$EFI_ARCH.o; then
 -       CRTPATH=$path
 +    if test -e @@NIX_GNUEFI@@/$path/crt0-efi-$EFI_ARCH.o; then
@@ -20,7 +22,7 @@
   -DEFI_FUNCTION_WRAPPER"
  CPPFLAGS_save="$CPPFLAGS"
  CPPFLAGS="$CPPFLAGS $EFI_CPPFLAGS"
-@@ -90,5 +91,5 @@
+@@ -90,5 +91,5 @@ AC_SUBST(EFI_ARCH, $EFI_ARCH)
  AC_SUBST(CRTPATH, $CRTPATH)
  
  AC_CONFIG_FILES([Makefile src/Makefile lib/ccan/Makefile]

--- a/pkgs/tools/security/sbsigntool/default.nix
+++ b/pkgs/tools/security/sbsigntool/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tools for maintaining UEFI signature databases";
     homepage    = "http://jk.ozlabs.org/docs/sbkeysync-maintaing-uefi-key-databases";
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = with maintainers; [ hmenke tstrobel ];
     platforms   = [ "x86_64-linux" ]; # Broken on i686
     license     = licenses.gpl3;
   };

--- a/pkgs/tools/security/sbsigntool/default.nix
+++ b/pkgs/tools/security/sbsigntool/default.nix
@@ -3,14 +3,14 @@
 , openssl, libuuid, gnu-efi, libbfd
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "sbsigntool";
-  version = "0.9.1";
+  version = "0.9.4";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git";
-    rev = "v0.9.1";
-    sha256 = "098gxmhjn8acxjw5bq59wq4xhgkpx1xn8kjvxwdzpqkwq9ivrsbp";
+    rev = "v${version}";
+    sha256 = "sha256-dbjdA+hjII/k7wABTTJV5RBdy4KlNkFlBWEaX4zn5vg=";
   };
 
   patches = [ ./autoconf.patch ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream updates. Changelogs are in the commit messages:

https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git/commit/?h=v0.9.2&id=216dbd3331a7e14ff79cc4dd68c29896f1152ae4
https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git/commit/?h=v0.9.3&id=fe88da5f66241d959b7aeca7502d401ad88df410
https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git/commit/?h=v0.9.4&id=d52f7bbb73401aab8a1d59e8d0d686ad9641035e

Fixes https://github.com/NixOS/nixpkgs/issues/176584

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
