### PR TITLE
nixos/netboot: use `makeInitrdNG` to shrink ramdisk size

### DIFF
--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -81,7 +81,7 @@ with lib;
 
 
     # Create the initrd
-    system.build.netbootRamdisk = pkgs.makeInitrd {
+    system.build.netbootRamdisk = pkgs.makeInitrdNG {
       inherit (config.boot.initrd) compressor;
       prepend = [ "${config.system.build.initialRamdisk}/initrd" ];
 


### PR DESCRIPTION
### Copy of commit msg
Previously, `makeInitrd` added the whole closure of the squashfs derivation to initrd.
This closure contains the `squashfs.img` and some store paths which are still referenced by the compressed `squashfs.img`.
These extra store paths are unused in stage 1.

With `makeInitrdNG` only the `squashfs.img` is added to the initrd.
(`makeInitrdNG` only resolves shared library references instead of the whole closure).

This shrinks the netboot ramdisk by ~6% for a minimal system and significantly decreases the size of the uncompressed root filesystem in stage 1.

### Discussion

Test this with:
```bash
# nixpkgs-unstable as of 2022-06-07
nix build --out-link /tmp/ramdisk/old $(nix eval --raw nixpkgs/c5d810f4c74c824ae0fb788103003c6c9d366a08#pkgs --apply 'pkgs:
(pkgs.nixos "${pkgs.path}/nixos/modules/installer/netboot/netboot-minimal.nix"
).config.system.build.netbootRamdisk.drvPath
')

# This PR
nix build --out-link /tmp/ramdisk/new $(nix eval --raw github:erikarvstedt/nixpkgs/improve-netboot-initrd#pkgs --apply 'pkgs:
(pkgs.nixos "${pkgs.path}/nixos/modules/installer/netboot/netboot-minimal.nix"
).config.system.build.netbootRamdisk.drvPath
')

du -sh /tmp/ramdisk/{new,old}/initrd
# 787M /tmp/ramdisk/new/initrd
# 835M /tmp/ramdisk/old/initrd

showContents() {
    <$1 unzstd | {
        # Skip `config.system.build.initialRamdisk`
        cpio -it > /dev/null
        # Show appended squashfs
        cpio -it
    }    
}

showContents /tmp/ramdisk/old/initrd
# dev/
# nix/
# nix-store.squashfs
# nix/store/
# nix/store/09yiy5kf76m2y8lw2h6ac14w3z6kv16z-curl-7.83.1/
# nix/store/09yiy5kf76m2y8lw2h6ac14w3z6kv16z-curl-7.83.1/lib/
# nix/store/09yiy5kf76m2y8lw2h6ac14w3z6kv16z-curl-7.83.1/lib/libcurl.la
# nix/store/09yiy5kf76m2y8lw2h6ac14w3z6kv16z-curl-7.83.1/lib/libcurl.so
# ...
# (9634 files total)

showContents /tmp/ramdisk/new/initrd
# nix
# nix-store.squashfs
# nix/store
# nix/store/gzjyqaqalbxzcwk2z32zq62bkw7r8x6f-squashfs.img
# (4 files total)
```

@ofborg test boot.biosNetboot boot.uefiNetboot kexec

cc @flokli, @Lassulus, @lheckemann, @Mic92