### PR TITLE
revive: init at 1.2.1

### DIFF
--- a/pkgs/development/tools/revive/default.nix
+++ b/pkgs/development/tools/revive/default.nix
@@ -1,0 +1,53 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "revive";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "mgechev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-xZakVuw+QKzFh6wsnZbltLEEwyb9WcMvVWEzKnS9aWc=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      date -u -d "@$(git -C $out log -1 --pretty=%ct)" "+%Y-%m-%d %H:%M UTC" > $out/DATE
+      git -C $out rev-parse HEAD > $out/COMMIT
+      rm -rf $out/.git
+    '';
+  };
+  vendorSha256 = "sha256-Fpl5i+qMvJ/CDh8X0gps9C/BxF7/Uvln+3DpVOXE0WQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/mgechev/revive/cli.version=${version}"
+    "-X github.com/mgechev/revive/cli.builtBy=nix"
+  ];
+
+  # ldflags based on metadata from git and source
+  preBuild = ''
+    ldflags+=" -X github.com/mgechev/revive/cli.commit=$(cat COMMIT)"
+    ldflags+=" -X 'github.com/mgechev/revive/cli.date=$(cat DATE)'"
+  '';
+
+  # The following tests fail when built by nix:
+  #
+  # $ nix log /nix/store/build-revive.1.2.1.drv | grep FAIL
+  #
+  # --- FAIL: TestAll (0.01s)
+  # --- FAIL: TestTimeEqual (0.00s)
+  # --- FAIL: TestTimeNaming (0.00s)
+  # --- FAIL: TestUnhandledError (0.00s)
+  # --- FAIL: TestUnhandledErrorWithBlacklist (0.00s)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Fast, configurable, extensible, flexible, and beautiful linter for Go";
+    homepage = "https://revive.run";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maaslalani ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16295,6 +16295,10 @@ with pkgs;
 
   reviewdog = callPackage ../development/tools/misc/reviewdog { };
 
+  revive = callPackage ../development/tools/revive {
+    buildGoModule = buildGo118Module;
+  };
+
   rman = callPackage ../development/tools/misc/rman { };
 
   rnix-lsp = callPackage ../development/tools/rnix-lsp { };


### PR DESCRIPTION
###### Description of changes

Adds [revive](https://revive.run) package for fast Go linting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
