### PR TITLE
fastfetch: init at 1.5.6

### DIFF
--- a/pkgs/tools/misc/fastfetch/default.nix
+++ b/pkgs/tools/misc/fastfetch/default.nix
@@ -1,0 +1,81 @@
+{ chafa
+, cmake
+, dbus
+, dconf
+, fetchFromGitHub
+, glib
+, imagemagick_light
+, lib
+, libglvnd
+, libxcb
+, makeWrapper
+, ocl-icd
+, opencl-headers
+, pciutils
+, pkg-config
+, stdenv
+, vulkan-loader
+, wayland
+, xfce
+, xorg
+, zlib
+, enableChafa ? false
+, enableImageMagick ? false
+, enableOpenCLModule ? true
+, enableOpenGLModule ? true
+, enableVulkanModule ? true
+, enableWayland ? true
+, enableX11 ? true
+, enableXFCE ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fastfetch";
+  version = "1.5.6";
+
+  src = fetchFromGitHub {
+    owner = "LinusDierheimer";
+    repo = pname;
+    rev = version;
+    hash = "sha256-OsK78irfO9r6pSEmlN6mFoKhQZgBqIYO8syj5AHH4IE=";
+  };
+
+  nativeBuildInputs = [ cmake makeWrapper pkg-config ];
+
+  runtimeDependencies =
+    [
+      dbus
+      dconf
+      glib
+      pciutils
+      zlib
+    ]
+    ++ lib.optionals (enableChafa) [ chafa ]
+    ++ lib.optionals (enableImageMagick) [ imagemagick_light ]
+    ++ lib.optionals (enableOpenCLModule) [ ocl-icd ]
+    ++ lib.optionals (enableOpenGLModule) [ libglvnd ]
+    ++ lib.optionals (enableVulkanModule) [ vulkan-loader ]
+    ++ lib.optionals (enableWayland) [ wayland ]
+    ++ lib.optionals (enableX11) [ libxcb ]
+    ++ lib.optionals (enableXFCE) [ xfce.xfconf ];
+
+  buildInputs =
+    runtimeDependencies
+    ++ lib.optionals (enableOpenCLModule) [ opencl-headers ]
+    ++ lib.optionals (enableX11) [ xorg.libX11 ];
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath runtimeDependencies;
+
+  postInstall = ''
+    wrapProgram $out/bin/fastfetch --prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}"
+    wrapProgram $out/bin/flashfetch --prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}"
+  '';
+
+  meta = with lib; {
+    description = "Like neofetch, but much faster";
+    homepage = "https://github.com/LinusDierheimer/fastfetch";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ yureien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1163,6 +1163,8 @@ with pkgs;
 
   ejson2env = callPackage ../tools/admin/ejson2env { };
 
+  fastfetch = callPackage ../tools/misc/fastfetch { };
+
   davinci-resolve = callPackage ../applications/video/davinci-resolve { };
 
   gamemode = callPackage ../tools/games/gamemode {


### PR DESCRIPTION
###### Description of changes

Added fastfetch, essentially a faster version of neofetch.

Source/Homepage: https://github.com/LinusDierheimer/fastfetch

Closes #176799.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
