### PR TITLE
streamdeck-ui: init at 2.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7835,6 +7835,12 @@
     githubId = 31056089;
     name = "Tom Ho";
   };
+  majiir = {
+    email = "majiir@nabaal.net";
+    github = "Majiir";
+    githubId = 963511;
+    name = "Majiir Paktu";
+  };
   makefu = {
     email = "makefu@syntax-fehler.de";
     github = "makefu";

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, pkgs
+, python3Packages
+, wrapQtAppsHook
+, writeText
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "streamdeck-ui";
+  version = "2.0.4";
+
+  src = python3Packages.fetchPypi {
+    pname = "streamdeck_ui";
+    inherit version;
+    sha256 = "650bef0da4957e0d2e2b4cd9c74a55715bcf1526d9ef2cdd04271364117a5845";
+  };
+
+  # Add udev rules to allow non-root access to the Stream Deck.
+  # To enable these rules on NixOS, add this to your system configuration:
+  #
+  #     system.udev.packages = [ pkgs.streamdeck-ui ];
+  postInstall =
+    let
+      udevRulesName = "70-streamdeck.rules";
+      udevRules = ''
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", TAG+="uaccess"
+      '';
+    in
+      ''
+        mkdir -p "$out/etc/udev/rules.d"
+        cp ${writeText udevRulesName udevRules} $out/etc/udev/rules.d/${udevRulesName}
+      '';
+
+  # Help the 'streamdeck' library find libhidapi-libusb
+  qtWrapperArgs = [ "--prefix LD_LIBRARY_PATH : ${pkgs.hidapi}/lib" ];
+
+  dontWrapQtApps = true;
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = with python3Packages; [
+    setuptools
+    filetype
+    cairosvg
+    pillow
+    pynput
+    pyside2
+    streamdeck
+    xlib
+  ];
+
+  # Skip tests because they require an X server
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Linux compatible UI for the Elgato Stream Deck";
+    homepage = "https://timothycrosley.github.io/streamdeck-ui/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ majiir ];
+  };
+}
+

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -1,4 +1,4 @@
-{ python, fetchurl, lib, stdenv,
+{ python, pythonPackages, fetchurl, lib, stdenv,
   cmake, ninja, qt5, shiboken2 }:
 
 stdenv.mkDerivation rec {
@@ -24,13 +24,22 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake ninja qt5.qmake python ];
-  buildInputs = with qt5; [
+  buildInputs = (with qt5; [
     qtbase qtxmlpatterns qtmultimedia qttools qtx11extras qtlocation qtscript
     qtwebsockets qtwebengine qtwebchannel qtcharts qtsensors qtsvg
+  ])
+  ++ [
+    pythonPackages.setuptools
   ];
   propagatedBuildInputs = [ shiboken2 ];
 
   dontWrapQtApps = true;
+
+  postInstall = ''
+    cd ../../..
+    python setup.py egg_info --build-type=pyside2
+    cp -r PySide2.egg-info $out/${python.sitePackages}/
+  '';
 
   meta = with lib; {
     description = "LGPL-licensed Python bindings for Qt";

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -1,4 +1,4 @@
-{ python, lib, stdenv, pyside2
+{ python, pythonPackages, lib, stdenv, pyside2
 , cmake, qt5, llvmPackages }:
 
 stdenv.mkDerivation {
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   CLANG_INSTALL_DIR = llvmPackages.libclang.out;
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvmPackages.libclang python qt5.qtbase qt5.qtxmlpatterns ];
+  buildInputs = [ llvmPackages.libclang python pythonPackages.setuptools qt5.qtbase qt5.qtxmlpatterns ];
 
   cmakeFlags = [
     "-DBUILD_TESTS=OFF"
@@ -26,6 +26,9 @@ stdenv.mkDerivation {
   dontWrapQtApps = true;
 
   postInstall = ''
+    cd ../../..
+    python setup.py egg_info --build-type=shiboken2
+    cp -r shiboken2.egg-info $out/${python.sitePackages}/
     rm $out/bin/shiboken_tool.py
   '';
 

--- a/pkgs/development/python-modules/streamdeck/default.nix
+++ b/pkgs/development/python-modules/streamdeck/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "streamdeck";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0116a376afc18f3abbf79cc1a4409f81472e19197d5641b9e97e697d105cbdc0";
+  };
+
+  meta = with lib; {
+    broken = stdenv.isDarwin;
+    description = "Python library to control the Elgato Stream Deck";
+    homepage = "https://github.com/abcminiuser/python-elgato-streamdeck";
+    license = licenses.mit;
+    maintainers = with maintainers; [ majiir ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27166,6 +27166,8 @@ with pkgs;
 
   srain = callPackage ../applications/networking/irc/srain { };
 
+  streamdeck-ui = libsForQt5.callPackage ../applications/misc/streamdeck-ui { };
+
   super-productivity = callPackage ../applications/office/super-productivity {
     electron = electron_17;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10099,6 +10099,8 @@ in {
 
   stravalib = callPackage ../development/python-modules/stravalib { };
 
+  streamdeck = callPackage ../development/python-modules/streamdeck { };
+
   streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };
 
   streamlabswater = callPackage ../development/python-modules/streamlabswater { };


### PR DESCRIPTION
###### Description of changes

[**streamdeck-ui**](https://timothycrosley.github.io/streamdeck-ui/) is a Linux compatible UI for the [Elgato Stream Deck](https://www.elgato.com/en/stream-deck).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
