### PR TITLE
pinniped: init at 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15315,4 +15315,10 @@
     githubId = 7775707;
     name = "RB";
   };
+  bpaulin = {
+    email = "brunopaulin@bpaulin.net";
+    github = "bpaulin";
+    githubId = 115711;
+    name = "bpaulin";
+  };
 }

--- a/pkgs/applications/networking/cluster/pinniped/default.nix
+++ b/pkgs/applications/networking/cluster/pinniped/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec{
+  pname = "pinniped";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "vmware-tanzu";
+    repo = "pinniped";
+    rev = "v${version}";
+    sha256 = "sha256-0h7zyKe2gmC1n9EB5FRVI/io7Yj+91ZAtLy+1u3gyO0=";
+  };
+
+  subPackages = "cmd/pinniped";
+
+  vendorSha256 = "sha256-8ohyyciL1ORYOxPu64W0jXASTv+vVZR8StutzbF9N4Y=";
+
+  meta = with lib; {
+    description = "Tool to securely log in to your Kubernetes clusters";
+    homepage = "https://pinniped.dev/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ "bpaulin" ];
+  };
+}

--- a/pkgs/applications/networking/cluster/pinniped/default.nix
+++ b/pkgs/applications/networking/cluster/pinniped/default.nix
@@ -19,6 +19,6 @@ buildGoModule rec{
     description = "Tool to securely log in to your Kubernetes clusters";
     homepage = "https://pinniped.dev/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ "bpaulin" ];
+    maintainers = with maintainers; [ bpaulin ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28923,6 +28923,8 @@ with pkgs;
 
   ktunnel = callPackage ../applications/networking/cluster/ktunnel { };
 
+  pinniped = callPackage ../applications/networking/cluster/pinniped { };
+
   pgo-client = callPackage ../applications/networking/cluster/pgo-client { };
 
   popeye = callPackage ../applications/networking/cluster/popeye { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding https://github.com/vmware-tanzu/pinniped "Pinniped is the easy, secure way to log in to your Kubernetes clusters."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
