### PR TITLE
fishPlugins.autopair-fish: init at 1.0.4

### DIFF
--- a/pkgs/shells/fish/plugins/autopair-fish.nix
+++ b/pkgs/shells/fish/plugins/autopair-fish.nix
@@ -6,7 +6,7 @@ buildFishPlugin rec {
 
   src = fetchFromGitHub {
     owner = "jorgebucaran";
-    repo = "autopair.fish";
+    repo = pname;
     rev = version;
     sha256 = "sha256-l6WJ2kjDO/TnU9FSigjxk5xFp90xl68gDfggkE/wrlM=";
   };

--- a/pkgs/shells/fish/plugins/autopair-fish.nix
+++ b/pkgs/shells/fish/plugins/autopair-fish.nix
@@ -2,13 +2,13 @@
 
 buildFishPlugin rec {
   pname = "autopair.fish";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "jorgebucaran";
     repo = pname;
     rev = version;
-    sha256 = "sha256-l6WJ2kjDO/TnU9FSigjxk5xFp90xl68gDfggkE/wrlM=";
+    sha256 = "sha256-s1o188TlwpUQEN3X5MxUlD/2CFCpEkWu83U9O+wg3VU=";
   };
 
   meta = with lib; {

--- a/pkgs/shells/fish/plugins/autopair-fish.nix
+++ b/pkgs/shells/fish/plugins/autopair-fish.nix
@@ -1,0 +1,20 @@
+{ lib, stdenv, buildFishPlugin, fetchFromGitHub }:
+
+buildFishPlugin rec {
+  pname = "autopair.fish";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "jorgebucaran";
+    repo = "autopair.fish";
+    rev = version;
+    sha256 = "sha256-l6WJ2kjDO/TnU9FSigjxk5xFp90xl68gDfggkE/wrlM=";
+  };
+
+  meta = with lib; {
+    description = "Auto-complete matching pairs in the Fish command line.";
+    homepage = "https://github.com/jorgebucaran/autopair.fish";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thehedgeh0g ];
+  };
+}

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -2,6 +2,8 @@
 
 lib.makeScope newScope (self: with self; {
 
+  autopair-fish = callPackage ./autopair-fish.nix { };
+
   buildFishPlugin = callPackage ./build-fish-plugin.nix { };
 
   clownfish = callPackage ./clownfish.nix { };


### PR DESCRIPTION
###### Description of changes
Adds the fish autopair plugin, closes #176594.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
