### PR TITLE
mprocs: 0.2.2 -> 0.4.0

### DIFF
--- a/pkgs/tools/misc/mprocs/default.nix
+++ b/pkgs/tools/misc/mprocs/default.nix
@@ -2,21 +2,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mprocs";
-  version = "0.2.2";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "pvolok";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-9wac2jlh8MLggcYuEHVUPYPjhfzGN+4o1XT8B9pj4f8=";
+    sha256 = "sha256-IzaXcEm4eUpLWsn59ZSiIJ0mCegLhBiA3ONKI1Djemk=";
   };
 
-  cargoSha256 = "sha256-vGhoM5VMJO+ppLk8DetNZ8UteU6ifdtRe1HNJ0dSB+0=";
+  cargoSha256 = "sha256-nTFCFmmS3IIm+D2PjvDxUKQGTn2h0ajXtxLuosa9rRY=";
 
   meta = with lib; {
     description = "A TUI tool to run multiple commands in parallel and show the output of each command separately";
     homepage = "https://github.com/pvolok/mprocs";
     license = licenses.mit;
-    maintainers = [ maintainers.GaetanLepage ];
+    maintainers = with maintainers; [ GaetanLepage thehedgeh0g ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Updates the mprocs package. 

All releases between 0.2.2 and 0.4.0:
* [0.4.0 Release Notes](https://github.com/pvolok/mprocs/releases/tag/v0.4.0)
* [0.3.0 Release Notes](https://github.com/pvolok/mprocs/releases/tag/v0.3.0)
* [0.2.3 Release Notes](https://github.com/pvolok/mprocs/releases/tag/v0.2.3)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
