### PR TITLE
mozart2: use default jdk and add mozart2WithGui derivation.

### DIFF
--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -1,91 +1,31 @@
-{ lib
-, fetchFromGitHub
-, fetchurl
-, cmake
+{ stdenv
+, lib
+, callPackage
 , unzip
-, makeWrapper
-, boost169
-, pinnedBoost ? boost169
-, llvmPackages
-, llvmPackages_5
-, gmp
 , emacs
-, jre_headless
-, tcl
-, tk
+, makeWrapper
+, installDesktop ? false
 }:
+let
+  mozart2-unwrapped = callPackage ./unwrapped.nix { };
+in
+stdenv.mkDerivation {
 
-let stdenv = llvmPackages.stdenv;
+  nativeBuildInputs = [ makeWrapper unzip ];
 
-in stdenv.mkDerivation rec {
-  pname = "mozart2";
-  version = "2.0.1";
-  name = "${pname}-${version}";
+  propagatedBuildInputs = [ mozart2-unwrapped emacs ];
 
-  src = fetchurl {
-    url = "https://github.com/mozart/mozart2/releases/download/v${version}/${name}-Source.zip";
-    sha256 = "1mad9z5yzzix87cdb05lmif3960vngh180s2mb66cj5gwh5h9dll";
-  };
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 
-  # This is a workaround to avoid using sbt.
-  # I guess it is acceptable to fetch the bootstrapping compiler in binary form.
-  bootcompiler = fetchurl {
-    url = "https://github.com/layus/mozart2/releases/download/v2.0.0-beta.1/bootcompiler.jar";
-    sha256 = "1hgh1a8hgzgr6781as4c4rc52m2wbazdlw3646s57c719g5xphjz";
-  };
-
-  patches = [ ./patch-limits.diff ];
-
-  postConfigure = ''
-    cp ${bootcompiler} bootcompiler/bootcompiler.jar
+  installPhase = ''
+    install -D opi/emacs/oz $out/bin/oz
+  '' + lib.optionalString installDesktop ''
+    cp -r distrib/share/ $out/share
   '';
-
-  nativeBuildInputs = [ cmake makeWrapper unzip ];
-
-  # We cannot compile with both gcc and clang, but we need clang during the
-  # process, so we compile everything with clang.
-  # BUT, we need clang4 for parsing, and a more recent clang for compiling.
-  cmakeFlags = [
-    "-DCMAKE_CXX_COMPILER=${llvmPackages.clang}/bin/clang++"
-    "-DCMAKE_C_COMPILER=${llvmPackages.clang}/bin/clang"
-    "-DBoost_USE_STATIC_LIBS=OFF"
-    "-DMOZART_BOOST_USE_STATIC_LIBS=OFF"
-    "-DCMAKE_PROGRAM_PATH=${llvmPackages_5.clang}/bin"
-    # Rationale: Nix's cc-wrapper needs to see a compile flag (like -c) to
-    # infer that it is not a linking call, and stop trashing the command line
-    # with linker flags.
-    # As it does not recognise -emit-ast, we pass -c immediately overridden
-    # by -emit-ast.
-    # The remaining is just the default flags that we cannot reuse and need
-    # to repeat here.
-    "-DMOZART_GENERATOR_FLAGS='-c;-emit-ast;--std=c++0x;-Wno-invalid-noreturn;-Wno-return-type;-Wno-braced-scalar-init'"
-    # We are building with clang, as nix does not support having clang and
-    # gcc together as compilers and we need clang for the sources generation.
-    # However, clang emits tons of warnings about gcc's atomic-base library.
-    "-DCMAKE_CXX_FLAGS=-Wno-braced-scalar-init"
-  ];
 
   fixupPhase = ''
-    wrapProgram $out/bin/oz --set OZEMACS ${emacs}/bin/emacs
+    wrapProgram $out/bin/oz --set OZHOME ${mozart2-unwrapped} --set OZEMACS ${emacs}/bin/emacs
   '';
 
-  buildInputs = [
-    pinnedBoost
-    llvmPackages_5.llvm
-    llvmPackages_5.clang
-    llvmPackages_5.clang-unwrapped
-    gmp
-    emacs
-    jre_headless
-    tcl
-    tk
-  ];
-
-  meta = {
-    description = "An open source implementation of Oz 3";
-    maintainers = [ lib.maintainers.layus ];
-    license = lib.licenses.bsd2;
-    homepage = "https://mozart.github.io";
-  };
-
+  inherit (mozart2-unwrapped) pname name version src meta;
 }

--- a/pkgs/development/compilers/mozart/unwrapped.nix
+++ b/pkgs/development/compilers/mozart/unwrapped.nix
@@ -1,0 +1,89 @@
+{ lib
+, fetchFromGitHub
+, fetchurl
+, cmake
+, unzip
+, makeWrapper
+, boost169
+, pinnedBoost ? boost169
+, llvmPackages
+, llvmPackages_5
+, gmp
+, emacs-nox
+, jre_headless
+, tcl
+, tk
+}:
+
+let stdenv = llvmPackages.stdenv;
+
+in stdenv.mkDerivation rec {
+  pname = "mozart2";
+  version = "2.0.1";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/mozart/mozart2/releases/download/v${version}/${name}-Source.zip";
+    sha256 = "1mad9z5yzzix87cdb05lmif3960vngh180s2mb66cj5gwh5h9dll";
+  };
+
+  # This is a workaround to avoid using sbt.
+  # I guess it is acceptable to fetch the bootstrapping compiler in binary form.
+  bootcompiler = fetchurl {
+    url = "https://github.com/layus/mozart2/releases/download/v2.0.0-beta.1/bootcompiler.jar";
+    sha256 = "1hgh1a8hgzgr6781as4c4rc52m2wbazdlw3646s57c719g5xphjz";
+  };
+
+  patches = [ ./patch-limits.diff ];
+
+  postConfigure = ''
+    cp ${bootcompiler} bootcompiler/bootcompiler.jar
+  '';
+
+  nativeBuildInputs = [ cmake makeWrapper unzip ];
+
+  # We cannot compile with both gcc and clang, but we need clang during the
+  # process, so we compile everything with clang.
+  # BUT, we need clang4 for parsing, and a more recent clang for compiling.
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=${llvmPackages.clang}/bin/clang++"
+    "-DCMAKE_C_COMPILER=${llvmPackages.clang}/bin/clang"
+    "-DBoost_USE_STATIC_LIBS=OFF"
+    "-DMOZART_BOOST_USE_STATIC_LIBS=OFF"
+    "-DCMAKE_PROGRAM_PATH=${llvmPackages_5.clang}/bin"
+    # Rationale: Nix's cc-wrapper needs to see a compile flag (like -c) to
+    # infer that it is not a linking call, and stop trashing the command line
+    # with linker flags.
+    # As it does not recognise -emit-ast, we pass -c immediately overridden
+    # by -emit-ast.
+    # The remaining is just the default flags that we cannot reuse and need
+    # to repeat here.
+    "-DMOZART_GENERATOR_FLAGS='-c;-emit-ast;--std=c++0x;-Wno-invalid-noreturn;-Wno-return-type;-Wno-braced-scalar-init'"
+    # We are building with clang, as nix does not support having clang and
+    # gcc together as compilers and we need clang for the sources generation.
+    # However, clang emits tons of warnings about gcc's atomic-base library.
+    "-DCMAKE_CXX_FLAGS=-Wno-braced-scalar-init"
+  ];
+
+  buildInputs = [
+    pinnedBoost
+    llvmPackages_5.llvm
+    llvmPackages_5.clang
+    llvmPackages_5.clang-unwrapped
+    gmp
+    emacs-nox
+    jre_headless
+    tcl
+    tk
+  ];
+
+  fixupPhase = "rm -rf $out/bin/oz $out/share/applications $out/share/icons";
+
+  meta = {
+    description = "An open source implementation of Oz 3";
+    maintainers = [ lib.maintainers.layus ];
+    license = lib.licenses.bsd2;
+    homepage = "https://mozart.github.io";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13616,7 +13616,10 @@ with pkgs;
 
   mozart2 = callPackage ../development/compilers/mozart {
     emacs = emacs-nox;
-    jre_headless = jre8_headless; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+  };
+
+  mozart2WithGui = callPackage ../development/compilers/mozart {
+    installDesktop = true;
   };
 
   mozart2-binary = callPackage ../development/compilers/mozart/binary.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The default mozart2 package uses emacs-nox, this PR add a new package called mozart2WithGui that uses emacs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
