### PR TITLE
release-cross.nix: fix cross bootstrap tools eval

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -306,8 +306,6 @@ rec {
 
   # BSDs
 
-  amd64-netbsd = lib.warn "The amd64-netbsd system example is deprecated. Use x86_64-netbsd instead." x86_64-netbsd;
-
   x86_64-netbsd = {
     config = "x86_64-unknown-netbsd";
     libc = "nblibc";

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -1,11 +1,16 @@
 {system ? builtins.currentSystem}:
 
 let
-  make = crossSystem: import ./make-bootstrap-tools.nix {
-    localSystem = { inherit system; };
-    inherit crossSystem;
+  inherit (releaseLib) lib;
+  releaseLib = import ../../top-level/release-lib.nix {
+    # We're not using any functions from release-lib.nix that look at
+    # supportedSystems.
+    supportedSystems = [];
   };
-  lib = import ../../../lib;
+
+  make = crossSystem: import ./make-bootstrap-tools.nix {
+    pkgs = releaseLib.pkgsForCross crossSystem system;
+  };
 in lib.mapAttrs (n: make) (with lib.systems.examples; {
   armv5tel   = sheevaplug;
   pogoplug4  = pogoplug4;


### PR DESCRIPTION
###### Description of changes

In #175484, I changed pkgs/stdenv/linux/make-bootstrap-tools.nix
to take a package set instead of system and localSystem arguments, but
I forgot to update make-bootstrap-tools-cross.nix.

Now that we have a package set in make-bootstrap-tools-cross.nix, we
can use pkgsCross to avoid full re-evaluations of Nixpkgs for each
platform.

I'm not sure why release-cross.nix hardcodes the build system to
x86_64-linux, so I've left that as-is.

Fixes: 5643714dea5 ("stdenvBootstrapTools: inherit {cross,local}System")

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
