### PR TITLE
firejail: patches for CVE-2022-31214

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -53,6 +53,29 @@ stdenv.mkDerivation rec {
     # Upstream fix: https://github.com/netblue30/firejail/pull/5132
     # Hopefully fixed upstream in version > 0.9.68
     ./fix-opengl-support.patch
+
+    # Fix CVE-2022-31214 by patching in 4 commits from upstream
+    # https://seclists.org/oss-sec/2022/q2/188
+    (fetchpatch {
+      name = "CVE-2022-31214-patch1"; # "fixing CVE-2022-31214"
+      url  = "https://github.com/netblue30/firejail/commit/27cde3d7d1e4e16d4190932347c7151dc2a84c50.patch";
+      sha256 = "sha256-XXmnYCn4TPUvU43HifZDk4tEZQvOho9/7ehU6889nN4=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-31214-patch2"; # "shutdown testing"
+      url  = "https://github.com/netblue30/firejail/commit/04ff0edf74395ddcbbcec955279c74ed9a6c0f86.patch";
+      sha256 = "sha256-PV73hRlvYEQihuljSCQMNO34KJ0hDVFexhirpHcTK1I=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-31214-patch3"; # "CVE-2022-31214: fixing the fix"
+      url  = "https://github.com/netblue30/firejail/commit/dab835e7a0eb287822016f5ae4e87f46e1d363e7.patch";
+      sha256 = "sha256-6plBIliW/nLKR7TdGeB88eQ65JHEasnaRsP3HPXAFyA=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-31214-patch4"; # "CVE-2022-31214: fixing the fix, one more time "
+      url  = "https://github.com/netblue30/firejail/commit/1884ea22a90d225950d81c804f1771b42ae55f54.patch";
+      sha256 = "sha256-inkpcdC5rl5w+CTAwwQVBOELlHTXb8UGlpU+8kMY95s=";
+    })
   ];
 
   prePatch = ''


### PR DESCRIPTION
###### Description of changes

"firejail: local root exploit reachable via --join logic"
https://seclists.org/oss-sec/2022/q2/188

Patches in 4 commits from upstream to fix CVE-2022-31214:
- https://github.com/netblue30/firejail/commit/27cde3d7d1e4e16d4190932347c7151dc2a84c50
- https://github.com/netblue30/firejail/commit/04ff0edf74395ddcbbcec955279c74ed9a6c0f86
- https://github.com/netblue30/firejail/commit/dab835e7a0eb287822016f5ae4e87f46e1d363e7
- https://github.com/netblue30/firejail/commit/1884ea22a90d225950d81c804f1771b42ae55f54

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
