### PR TITLE
nginx-sso: use buildGoModule

### DIFF
--- a/pkgs/servers/nginx-sso/default.nix
+++ b/pkgs/servers/nginx-sso/default.nix
@@ -1,18 +1,23 @@
-{ buildGoPackage, fetchFromGitHub, lib, nixosTests }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nixosTests
+}:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "nginx-sso";
   version = "0.25.0";
-  rev = "v${version}";
-
-  goPackagePath = "github.com/Luzifer/nginx-sso";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "Luzifer";
     repo = "nginx-sso";
-    sha256 = "0z5h92rpr1rcfk11ggsb9w4ipg93fcb9byll7vl4c0mfcqkpm2dr";
+    rev = "v${version}";
+    sha256 = "sha256-uYl6J2auAkboPpT6lRZzI70bCU9LvxfCdCyHfLNIsHw=";
   };
+
+  vendorSha256 = null;
+
+  patches = [ ./rune.patch ];
 
   postInstall = ''
     mkdir -p $out/share

--- a/pkgs/servers/nginx-sso/rune.patch
+++ b/pkgs/servers/nginx-sso/rune.patch
@@ -1,0 +1,13 @@
+diff --git i/main.go w/main.go
+index bf80f3d..632f7d6 100644
+--- i/main.go
++++ w/main.go
+@@ -174,7 +174,7 @@ func handleAuthRequest(res http.ResponseWriter, r *http.Request) {
+ 	case plugins.ErrNoValidUserFound:
+ 		// No valid user found, check whether special anonymous "user" has access
+ 		// Username is set to 0x0 character to prevent accidental whitelist-match
+-		if mainCfg.ACL.HasAccess(string(0x0), nil, r) {
++		if mainCfg.ACL.HasAccess(string(rune(0x0)), nil, r) {
+ 			mainCfg.AuditLog.Log(auditEventValidate, r, map[string]string{"result": "anonymous access granted"}) // #nosec G104 - This is only logging
+ 			res.WriteHeader(http.StatusOK)
+ 			return


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
