### PR TITLE
serfdom: 0.8.1 -> 0.9.8

### DIFF
--- a/pkgs/servers/serf/default.nix
+++ b/pkgs/servers/serf/default.nix
@@ -1,23 +1,43 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "serf";
-  version = "0.8.1";
-  rev = "v${version}";
-
-  goPackagePath = "github.com/hashicorp/serf";
+  version = "0.9.8";
+  rev = "a2bba5676d6e37953715ea10e583843793a0c507";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "serf";
-    inherit rev;
-    sha256 = "1arakjvhyasrk52vhxas2ghlrby3i3wj59r7sjrkbpln2cdbqnlx";
+    rev = "v${version}";
+    sha256 = "sha256-UWCxzwV2bcT8Sfl296HpBThe+qYX19M7sNcEJHs/sXc=";
   };
 
+  vendorSha256 = "sha256-DaPcCuj0KGpuOC6XynltMBE9wO7w5qKrTChC401249o=";
+
+  subPackages = [ "cmd/serf" ];
+
+  # These values are expected by version/version.go
+  # https://github.com/hashicorp/serf/blob/7faa1b06262f70780c3c35ac25a4c96d754f06f3/version/version.go#L8-L22
+  ldflags = lib.mapAttrsToList
+    (n: v: "-X github.com/hashicorp/serf/version.${n}=${v}") {
+      GitCommit = rev;
+      Version = version;
+      VersionPrerelease = "";
+    };
+
+  # There are no tests for cmd/serf.
+  doCheck = false;
+
   meta = with lib; {
-    description = "Tool for service orchestration and management";
-    homepage = "https://www.serf.io/";
-    platforms = platforms.linux ++ platforms.darwin;
+    description = "Service orchestration and management tool";
+    longDescription = ''
+      Serf is a decentralized solution for service discovery and orchestration
+      that is lightweight, highly available, and fault tolerant.
+    '';
+    homepage = "https://www.serf.io";
     license = licenses.mpl20;
     maintainers = with maintainers; [ pradeepchhetri ];
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
