### PR TITLE
python3Packages.dropbox: Re-add setuptools to propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -3,6 +3,7 @@
 , pythonOlder
 , fetchFromGitHub
 , requests
+, setuptools
 , six
 , stone
 , mock
@@ -28,6 +29,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     requests
+    setuptools
     six
     stone
   ];


### PR DESCRIPTION
###### Description of changes

Re-added setuptools to propagatedBuildInputs. It was removed in #170289 by @SFrijters. However `dropbox/session.py` still imports `pkg_resources`, which is part of setuptools. So trying to import `dropbox` module results in an error:

```
$ nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/ca2629644d4a5098004e20cb9ca179345f2acd8e.tar.gz -p python3.pkgs.dropbox
[...]
$ python
Python 3.9.12 (main, Mar 23 2022, 21:36:19) 
[GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import dropbox
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/cxzmckapm3ch2j5jybl8bzp9lyq7gr57-python3.9-dropbox-11.31.0/lib/python3.9/site-packages/dropbox/__init__.py", line 3, in <module>
    from dropbox.dropbox_client import (  # noqa: F401 # pylint: disable=unused-import
  File "/nix/store/cxzmckapm3ch2j5jybl8bzp9lyq7gr57-python3.9-dropbox-11.31.0/lib/python3.9/site-packages/dropbox/dropbox_client.py", line 43, in <module>
    from dropbox.session import (
  File "/nix/store/cxzmckapm3ch2j5jybl8bzp9lyq7gr57-python3.9-dropbox-11.31.0/lib/python3.9/site-packages/dropbox/session.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).