### PR TITLE
nixos/modules/resolved.nix: Add services.resolved.dnsovertls

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -322,6 +322,14 @@
           dbus service.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The option <literal>services.resolved.dnsovertls</literal> has
+          been added. If you enabled DNS over TLS via
+          <literal>services.resolved.extraConfig</literal> before,
+          consider using this option instead.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -118,4 +118,6 @@ Use `configure.packages` instead.
 
 - There is a new module for the `xfconf` program (the Xfce configuration storage system), which has a dbus service.
 
+- The option `services.resolved.dnsovertls` has been added. If you enabled DNS over TLS via `services.resolved.extraConfig` before, consider using this option instead.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -119,6 +119,48 @@ in
       '';
     };
 
+    services.resolved.dnsovertls = mkOption {
+      default = "false";
+      example = "opportunistic";
+      type = types.enum [ "true" "opportunistic" "false" ];
+      description = ''
+        If set to
+        <variablelist>
+        <varlistentry>
+          <term><literal>"true"</literal></term>
+          <listitem><para>
+            If true all connections to the server will be encrypted. Note
+            that this mode requires a DNS server that supports DNS-over-TLS
+            and has a valid certificate. If the hostname was specified
+            by using the format format "address#server_name" it is used to
+            validate its certificate and also to enable Server Name
+            Indication (SNI) when opening a TLS connection. Otherwise the
+            certificate is checked against the server's IP. If the DNS
+            server does not support DNS-over-TLS all DNS requests will fail.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>"opportunistic"</literal></term>
+          <listitem><para>
+            DNS request are attempted to send
+            encrypted with DNS-over-TLS. If the DNS server does not
+            support TLS, DNS-over-TLS is disabled. Note that this mode
+            makes DNS-over-TLS vulnerable to "downgrade" attacks, where
+            an attacker might be able to trigger a downgrade to
+            non-encrypted mode by synthesizing a response that suggests
+            DNS-over-TLS was not supported.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>"false"</literal></term>
+          <listitem><para>
+            DNS lookups are sent over UDP.
+          </para></listitem>
+        </varlistentry>
+        </variablelist>
+      '';
+    };
+
     services.resolved.extraConfig = mkOption {
       default = "";
       type = types.lines;
@@ -165,6 +207,7 @@ in
           "Domains=${concatStringsSep " " cfg.domains}"}
         LLMNR=${cfg.llmnr}
         DNSSEC=${cfg.dnssec}
+        DNSOverTLS=${cfg.dnsovertls}
         ${config.services.resolved.extraConfig}
       '';
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
