### PR TITLE
Clean coqPackages_8_16

### DIFF
--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation {
   owner = "fblanqui";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    {case = range "8.12" "8.15"; out = "1.8.2"; }
+    {case = range "8.12" "8.16"; out = "1.8.2"; }
     {case = range "8.10" "8.11"; out = "1.7.0"; }
     {case = range "8.8"  "8.9";  out = "1.6.0"; }
     {case = range "8.6"  "8.7";  out = "1.4.0"; }

--- a/pkgs/development/coq-modules/ITree/default.nix
+++ b/pkgs/development/coq-modules/ITree/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation rec {
   owner = "DeepSpec";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.10" "8.15";  out = "4.0.0"; }
+    { case = range "8.10" "8.16";  out = "4.0.0"; }
   ] null;
   release."4.0.0".sha256 = "0h5rhndl8syc24hxq1gch86kj7mpmgr89bxp2hmf28fd7028ijsm";
   releaseRev = v: "${v}";

--- a/pkgs/development/coq-modules/LibHyps/default.nix
+++ b/pkgs/development/coq-modules/LibHyps/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation {
   pname = "LibHyps";
   owner = "Matafou";
   inherit version;
-  defaultVersion = if (versions.range "8.11" "8.15") coq.version then "2.0.4.1" else null;
+  defaultVersion = if (versions.range "8.11" "8.16") coq.version then "2.0.4.1" else null;
   release = {
     "2.0.4.1".sha256 = "09p89701zhrfdmqlpxw3mziw8yylj1w1skb4b0xpbdwd1vsn4k3h";
   };

--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -6,7 +6,7 @@ let recent = lib.versions.isGe "8.7" coq.coq-version; in
   owner = "QuickChick";
   inherit version;
   defaultVersion = with lib; with versions; lib.switch [ coq.coq-version ssreflect.version ] [
-      { cases = [ (isGe "8.13") pred.true  ]; out = "1.6.2"; }
+      { cases = [ (range "8.13" "8.15") pred.true  ]; out = "1.6.2"; }
       { cases = [ "8.13" pred.true  ]; out = "1.5.0"; }
       { cases = [ "8.12" pred.true  ]; out = "1.4.0"; }
       { cases = [ "8.11" pred.true  ]; out = "1.3.2"; }

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation {
   owner = "uwplse";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.6" "8.15"; out = "20210328"; }
+    { case = range "8.6" "8.16"; out = "20210328"; }
     { case = range "8.5" "8.13"; out = "20181102"; }
   ] null;
   release."20210328".rev =    "179bd5312e9d8b63fc3f4071c628cddfc496d741";

--- a/pkgs/development/coq-modules/autosubst/default.nix
+++ b/pkgs/development/coq-modules/autosubst/default.nix
@@ -9,7 +9,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = isGe "8.10"; out = "1.7"; }
+    { case = range "8.10" "8.15"; out = "1.7"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp-ssreflect ];

--- a/pkgs/development/coq-modules/coq-bits/default.nix
+++ b/pkgs/development/coq-modules/coq-bits/default.nix
@@ -5,8 +5,8 @@ with lib; mkCoqDerivation {
   repo = "bits";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = isGe "8.10"; out = "1.1.0"; }
-    { case = isGe "8.7";  out = "1.0.0"; }
+    { case = range "8.10" "8.15"; out = "1.1.0"; }
+    { case = range "8.7"  "8.15"; out = "1.0.0"; }
   ] null;
 
   release."1.1.0".sha256 = "sha256-TCw1kSXeW0ysIdLeNr+EGmpGumEE9i8tinEMp57UXaE=";

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation rec {
   owner = "coq-ext-lib";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.8" "8.15"; out = "0.11.6"; }
+    { case = range "8.8" "8.16"; out = "0.11.6"; }
     { case = range "8.8" "8.14"; out = "0.11.4"; }
     { case = range "8.8" "8.13"; out = "0.11.3"; }
     { case = "8.7";              out = "0.9.7"; }

--- a/pkgs/development/coq-modules/coq-record-update/default.nix
+++ b/pkgs/development/coq-modules/coq-record-update/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation rec {
   owner = "tchajed";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.10" "8.15";  out = "0.3.0"; }
+    { case = range "8.10" "8.16";  out = "0.3.0"; }
   ] null;
   release."0.3.0".sha256 = "1ffr21dd6hy19gxnvcd4if2450iksvglvkd6q5713fajd72hmc0z";
   releaseRev = v: "v${v}";

--- a/pkgs/development/coq-modules/coqprime/default.nix
+++ b/pkgs/development/coq-modules/coqprime/default.nix
@@ -6,7 +6,7 @@ with lib; mkCoqDerivation {
   owner = "thery";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.12" "8.15"; out = "8.15"; }
+    { case = range "8.12" "8.16"; out = "8.15"; }
     { case = range "8.10" "8.11"; out = "8.10"; }
     { case = range "8.8"  "8.9";  out = "8.8"; }
     { case = "8.7";               out = "8.7.2"; }

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -7,7 +7,7 @@ with lib; mkCoqDerivation {
   domain = "gitlab.inria.fr";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = isGe "8.8" ;        out = "3.2.0"; }
+    { case = range "8.8" "8.15"; out = "3.2.0"; }
     { case = range "8.8" "8.13"; out = "3.1.0"; }
     { case = range "8.5" "8.9";  out = "3.0.2"; }
   ] null;

--- a/pkgs/development/coq-modules/extructures/default.nix
+++ b/pkgs/development/coq-modules/extructures/default.nix
@@ -10,7 +10,7 @@ with lib;
 
   inherit version;
   defaultVersion = with versions; switch [coq.coq-version ssreflect.version] [
-    { cases = [(isGe "8.11") (isGe "1.12.0") ]; out = "0.3.1"; }
+    { cases = [(range "8.11" "8.15") (isGe "1.12.0") ]; out = "0.3.1"; }
     { cases = [(range "8.11" "8.14") (isLe "1.12.0") ]; out = "0.3.0"; }
     { cases = [(range "8.10" "8.12") (isLe "1.12.0") ]; out = "0.2.2"; }
   ] null;

--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -5,7 +5,7 @@ with lib; let hb = mkCoqDerivation {
   owner = "math-comp";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = isGe "8.15"; out = "1.2.1"; }
+    { case = isEq "8.15"; out = "1.2.1"; }
     { case = range "8.13" "8.14"; out = "1.2.0"; }
     { case = range "8.12" "8.13"; out = "1.1.0"; }
     { case = isEq "8.11";         out = "0.10.0"; }

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -7,7 +7,7 @@ mkCoqDerivation rec {
   domain = "gitlab.inria.fr";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = isGe "8.8"; out = "4.5.1"; }
+    { case = range "8.8" "8.15"; out = "4.5.1"; }
     { case = range "8.8" "8.12"; out = "4.0.0"; }
     { case = range "8.7" "8.11"; out = "3.4.2"; }
     { case = range "8.5" "8.6";  out = "3.3.0"; }

--- a/pkgs/development/coq-modules/iris/default.nix
+++ b/pkgs/development/coq-modules/iris/default.nix
@@ -6,7 +6,7 @@ with lib; mkCoqDerivation rec {
   owner = "iris";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.13" "8.15"; out = "3.6.0"; }
+    { case = range "8.13" "8.16"; out = "3.6.0"; }
     { case = range "8.12" "8.14"; out = "3.5.0"; }
     { case = range "8.11" "8.13"; out = "3.4.0"; }
     { case = range "8.9"  "8.10"; out = "3.3.0"; }

--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -4,7 +4,7 @@ with lib; mkCoqDerivation {
 
   pname = "math-classes";
   inherit version;
-  defaultVersion = if versions.range "8.6" "8.15" coq.coq-version then "8.15.0" else null;
+  defaultVersion = if versions.range "8.6" "8.16" coq.coq-version then "8.15.0" else null;
   release."8.12.0".sha256 = "14nd6a08zncrl5yg2gzk0xf4iinwq4hxnsgm4fyv07ydbkxfb425";
   release."8.13.0".sha256 = "1ln7ziivfbxzbdvlhbvyg3v30jgblncmwcsam6gg3d1zz6r7cbby";
   release."8.15.0".sha256 = "10w1hm537k6jx8a8vghq1yx12rsa0sjk2ipv3scgir71ln30hllw";

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -19,7 +19,7 @@ let
   owner = "math-comp";
   withDoc = single && (args.withDoc or false);
   defaultVersion = with versions; switch coq.coq-version [
-      { case = isGe  "8.11";        out = "1.14.0"; }
+      { case = range "8.11" "8.15"; out = "1.14.0"; }
       { case = range "8.11" "8.15"; out = "1.13.0"; }
       { case = range "8.10" "8.13"; out = "1.12.0"; }
       { case = range "8.7"  "8.12"; out = "1.11.0"; }

--- a/pkgs/development/coq-modules/metalib/default.nix
+++ b/pkgs/development/coq-modules/metalib/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation {
   owner = "plclub";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.14" "8.15"; out = "8.15"; }
+    { case = range "8.14" "8.16"; out = "8.15"; }
     { case = range "8.10" "8.13"; out = "8.10"; }
   ] null;
   releaseRev = v: "coq${v}";

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation {
   owner = "snu-sf";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.12" "8.15"; out = "4.1.2"; }
+    { case = range "8.12" "8.16"; out = "4.1.2"; }
     { case = range "8.9" "8.13"; out = "4.1.1"; }
     { case = range "8.6" "8.13"; out = "4.0.2"; }
     { case = isEq "8.5";         out = "1.2.8"; }

--- a/pkgs/development/coq-modules/parsec/default.nix
+++ b/pkgs/development/coq-modules/parsec/default.nix
@@ -12,7 +12,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with versions; switch coq.version [
-    { case = range "8.12" "8.15"; out = "0.1.1"; }
+    { case = range "8.12" "8.16"; out = "0.1.1"; }
     { case = range "8.12" "8.13"; out = "0.1.0"; }
   ] null;
   release."0.1.1".sha256 = "sha256:1c0l18s68pzd4c8i3jimh2yz0pqm4g38pca4bm7fr18r8xmqf189";

--- a/pkgs/development/coq-modules/semantics/default.nix
+++ b/pkgs/development/coq-modules/semantics/default.nix
@@ -16,7 +16,7 @@ mkCoqDerivation rec {
 
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.10" "8.15"; out = "8.14.0"; }
+    { case = range "8.10" "8.16"; out = "8.14.0"; }
     { case = "8.9"; out = "8.9.0"; }
     { case = "8.8"; out = "8.8.0"; }
     { case = "8.7"; out = "8.7.0"; }

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -6,7 +6,7 @@ with lib; mkCoqDerivation {
   repo = "coq-simple-io";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.11" "8.15"; out = "1.7.0"; }
+    { case = range "8.11" "8.16"; out = "1.7.0"; }
     { case = range "8.7"  "8.13"; out = "1.3.0"; }
   ] null;
   release."1.7.0".sha256 = "sha256:1a1q9x2abx71hqvjdai3n12jxzd49mhf3nqqh3ya2ssl2lj609ci";

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -6,7 +6,7 @@ with lib; mkCoqDerivation rec {
   domain = "gitlab.mpi-sws.org";
   owner = "iris";
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.13" "8.15"; out = "1.7.0"; }
+    { case = range "8.13" "8.16"; out = "1.7.0"; }
     { case = range "8.12" "8.14"; out = "1.6.0"; }
     { case = range "8.11" "8.13"; out = "1.5.0"; }
     { case = range "8.8" "8.10";  out = "1.4.0"; }

--- a/pkgs/development/coq-modules/tlc/default.nix
+++ b/pkgs/development/coq-modules/tlc/default.nix
@@ -6,7 +6,7 @@ with lib; (mkCoqDerivation {
   inherit version;
   displayVersion = { tlc = false; };
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.13" "8.15"; out = "20211215"; }
+    { case = range "8.13" "8.16"; out = "20211215"; }
     { case = range "8.12" "8.13"; out = "20210316"; }
     { case = range "8.10" "8.12"; out = "20200328"; }
     { case = range "8.6"  "8.12"; out = "20181116"; }

--- a/pkgs/development/coq-modules/trakt/default.nix
+++ b/pkgs/development/coq-modules/trakt/default.nix
@@ -10,7 +10,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with versions; switch [ coq.version ] [
-    { cases = [ (isGe "8.13") ]; out = "1.0"; }
+    { cases = [ (range "8.13" "8.15") ]; out = "1.0"; }
   ] null;
 
   propagatedBuildInputs = [ coq-elpi ];


### PR DESCRIPTION
###### Description of changes

Ensure that `coqPackages_8_16` evaluates & builds.

cc @Zimmi48 @proux01.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
