### PR TITLE
foo2zjs: Fix AirPrint color printing for Dell1250c

### DIFF
--- a/pkgs/misc/drivers/foo2zjs/default.nix
+++ b/pkgs/misc/drivers/foo2zjs/default.nix
@@ -13,11 +13,15 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./no-hardcode-fw.diff
-    # Support HBPL1 printers https://www.dechifro.org/hbpl/
+    # Support HBPL1 printers. Updated patch based on
+    # https://www.dechifro.org/hbpl/
     ./hbpl1.patch
     # Fix "Unimplemented paper code" error for hbpl1 printers
     # https://github.com/mikerr/foo2zjs/pull/2
     ./papercode-format-fix.patch
+    # Fix AirPrint color printing for Dell 1250c
+    # See https://github.com/OpenPrinting/cups/issues/272
+    ./dell1250c-color-fix.patch
   ];
 
   makeFlags = [

--- a/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
+++ b/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/PPD/Dell-1250c.ppd b/PPD/Dell-1250c.ppd
-index 828ecd6..20f3595 100644
+index 828ecd6..032d6c8 100644
 --- a/PPD/Dell-1250c.ppd
 +++ b/PPD/Dell-1250c.ppd
 @@ -92,15 +92,15 @@
@@ -19,7 +19,7 @@ index 828ecd6..20f3595 100644
 +*FoomaticRIPOption ColorModel: enum CmdLine A
 +*OrderDependency: 120 AnySetup *ColorModel
 +*DefaultColorModel: Color
-+*ColorModel RGB/Color: "%% FoomaticRIPOptionSetting: ColorModel=Color"
++*ColorModel RGB/Color: "%% FoomaticRIPOptionSetting: ColorMode=Color"
 +*FoomaticRIPOptionSetting ColorModel=RGB: "-c "
 +*ColorModel Gray/Monochrome: "%% FoomaticRIPOptionSetting: ColorMode=Monochrome"
 +*FoomaticRIPOptionSetting ColorModel=Gray: " "

--- a/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
+++ b/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
@@ -1,13 +1,29 @@
 diff --git a/PPD/Dell-1250c.ppd b/PPD/Dell-1250c.ppd
-index 828ecd6..7e78ce4 100644
+index 828ecd6..20f3595 100644
 --- a/PPD/Dell-1250c.ppd
 +++ b/PPD/Dell-1250c.ppd
-@@ -95,7 +95,7 @@
- *OpenUI *ColorMode/Color Mode: PickOne
- *FoomaticRIPOption ColorMode: enum CmdLine A
- *OrderDependency: 120 AnySetup *ColorMode
+@@ -92,15 +92,15 @@
+ *FoomaticRIPOptionSetting Quality=normal: "  "
+ *CloseUI: *Quality
+ 
+-*OpenUI *ColorMode/Color Mode: PickOne
+-*FoomaticRIPOption ColorMode: enum CmdLine A
+-*OrderDependency: 120 AnySetup *ColorMode
 -*DefaultColorMode: Monochrome
-+*DefaultColorMode: Color
- *ColorMode Color/Color: "%% FoomaticRIPOptionSetting: ColorMode=Color"
- *FoomaticRIPOptionSetting ColorMode=Color: "-c "
- *ColorMode Monochrome/Monochrome: "%% FoomaticRIPOptionSetting: ColorMode=Monochrome"
+-*ColorMode Color/Color: "%% FoomaticRIPOptionSetting: ColorMode=Color"
+-*FoomaticRIPOptionSetting ColorMode=Color: "-c "
+-*ColorMode Monochrome/Monochrome: "%% FoomaticRIPOptionSetting: ColorMode=Monochrome"
+-*FoomaticRIPOptionSetting ColorMode=Monochrome: " "
+-*CloseUI: *ColorMode
++*OpenUI *ColorModel/Color Mode: PickOne
++*FoomaticRIPOption ColorModel: enum CmdLine A
++*OrderDependency: 120 AnySetup *ColorModel
++*DefaultColorModel: Color
++*ColorModel RGB/Color: "%% FoomaticRIPOptionSetting: ColorModel=Color"
++*FoomaticRIPOptionSetting ColorModel=RGB: "-c "
++*ColorModel Gray/Monochrome: "%% FoomaticRIPOptionSetting: ColorMode=Monochrome"
++*FoomaticRIPOptionSetting ColorModel=Gray: " "
++*CloseUI: *ColorModel
+ 
+ *OpenUI *PageSize/Page Size: PickOne
+ *FoomaticRIPOption PageSize: enum CmdLine A

--- a/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
+++ b/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/PPD/Dell-1250c.ppd b/PPD/Dell-1250c.ppd
-index 828ecd6..032d6c8 100644
+index 828ecd6..98f49e1 100644
 --- a/PPD/Dell-1250c.ppd
 +++ b/PPD/Dell-1250c.ppd
 @@ -92,15 +92,15 @@
@@ -18,7 +18,7 @@ index 828ecd6..032d6c8 100644
 +*OpenUI *ColorModel/Color Mode: PickOne
 +*FoomaticRIPOption ColorModel: enum CmdLine A
 +*OrderDependency: 120 AnySetup *ColorModel
-+*DefaultColorModel: Color
++*DefaultColorModel: RGB
 +*ColorModel RGB/Color: "%% FoomaticRIPOptionSetting: ColorMode=Color"
 +*FoomaticRIPOptionSetting ColorModel=RGB: "-c "
 +*ColorModel Gray/Monochrome: "%% FoomaticRIPOptionSetting: ColorMode=Monochrome"

--- a/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
+++ b/pkgs/misc/drivers/foo2zjs/dell1250c-color-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/PPD/Dell-1250c.ppd b/PPD/Dell-1250c.ppd
+index 828ecd6..7e78ce4 100644
+--- a/PPD/Dell-1250c.ppd
++++ b/PPD/Dell-1250c.ppd
+@@ -95,7 +95,7 @@
+ *OpenUI *ColorMode/Color Mode: PickOne
+ *FoomaticRIPOption ColorMode: enum CmdLine A
+ *OrderDependency: 120 AnySetup *ColorMode
+-*DefaultColorMode: Monochrome
++*DefaultColorMode: Color
+ *ColorMode Color/Color: "%% FoomaticRIPOptionSetting: ColorMode=Color"
+ *FoomaticRIPOptionSetting ColorMode=Color: "-c "
+ *ColorMode Monochrome/Monochrome: "%% FoomaticRIPOptionSetting: ColorMode=Monochrome"


### PR DESCRIPTION
###### Description of changes

Color printing fails with Dell 1250 laser printer when shared via AirPrint. This patch fixes `DefaultColorMode` PPD option so that iOS clients will be able to color print on this device, see: https://github.com/OpenPrinting/cups/issues/272

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
