### PR TITLE
platformio: 6.0.1 -> 6.0.2

### DIFF
--- a/pkgs/development/embedded/platformio/chrootenv.nix
+++ b/pkgs/development/embedded/platformio/chrootenv.nix
@@ -1,11 +1,11 @@
-{ lib, buildFHSUserEnv, version, src }:
+{ lib, buildFHSUserEnv, version, src, meta }:
 
 let
   pio-pkgs = pkgs:
     let
       python = pkgs.python3.override {
         packageOverrides = self: super: {
-          platformio = self.callPackage ./core.nix { inherit version src; };
+          platformio = self.callPackage ./core.nix { inherit version src meta; };
         };
       };
     in
@@ -29,13 +29,7 @@ buildFHSUserEnv {
   # disabled temporarily because fastdiff no longer support 32bit
   # multiPkgs = pio-pkgs;
 
-  meta = with lib; {
-    description = "An open source ecosystem for IoT development";
-    homepage = "https://platformio.org";
-    maintainers = with maintainers; [ mog ];
-    license = licenses.asl20;
-    platforms = with platforms; linux;
-  };
+  inherit meta;
 
   extraInstallCommands = ''
     mkdir -p $out/lib/udev/rules.d

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -3,12 +3,21 @@
 , fetchPypi
 , git
 , spdx-license-list-data
-, version, src
+, version, src, meta
 }:
 
 let
   python = python3.override {
     packageOverrides = self: super: {
+      semantic-version = super.semantic-version.overridePythonAttrs (oldAttrs: rec {
+        version = "2.10.0";
+        src = fetchPypi {
+          pname = "semantic_version";
+          inherit version;
+          sha256 = "sha256-vau20zaZjLs3jUuds6S1ah4yNXAdwF6iaQ2amX7VBBw=";
+        };
+      });
+
       starlette = super.starlette.overridePythonAttrs (oldAttrs: rec {
         version = "0.20.0";
         src = fetchFromGitHub {
@@ -96,6 +105,10 @@ with python.pkgs; buildPythonApplication rec {
     "commands/test_lib_complex.py::test_lib_show"
     "commands/test_lib_complex.py::test_lib_stats"
     "commands/test_lib_complex.py::test_search"
+    "misc/test_maintenance.py::test_check_pio_upgrade"
+    "misc/test_misc.py::test_api_cache"
+    "misc/test_misc.py::test_ping_internet_ips"
+    "misc/test_misc.py::test_platformio_cli"
     "package/test_manager.py::test_download"
     "package/test_manager.py::test_install_force"
     "package/test_manager.py::test_install_from_registry"
@@ -108,9 +121,6 @@ with python.pkgs; buildPythonApplication rec {
     "test_builder.py::test_build_unflags"
     "test_builder.py::test_debug_custom_build_flags"
     "test_builder.py::test_debug_default_build_flags"
-    "test_misc.py::test_api_cache"
-    "test_misc.py::test_ping_internet_ips"
-    "test_misc.py::test_platformio_cli"
     "test_pkgmanifest.py::test_packages"
   ]) ++ (map (e: "--ignore=tests/${e}") [
     "commands/pkg/test_install.py"
@@ -126,7 +136,7 @@ with python.pkgs; buildPythonApplication rec {
     "commands/test_run.py"
     "commands/test_test.py"
     "commands/test_update.py"
-    "test_ino2cpp.py"
+    "misc/ino2cpp/test_ino2cpp.py"
     "test_maintenance.py"
   ]) ++ [
     "tests"
@@ -147,11 +157,5 @@ with python.pkgs; buildPythonApplication rec {
       --replace "zeroconf==0.38.*" "zeroconf"
   '';
 
-  meta = with lib; {
-    broken = stdenv.isAarch64;
-    description = "An open source ecosystem for IoT development";
-    homepage = "https://platformio.org";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ mog makefu ];
-  };
+  inherit meta;
 }

--- a/pkgs/development/embedded/platformio/default.nix
+++ b/pkgs/development/embedded/platformio/default.nix
@@ -1,21 +1,29 @@
 
-{ newScope, fetchFromGitHub }:
+{ stdenv, lib, newScope, fetchFromGitHub }:
 
 let
   callPackage = newScope self;
 
-  version = "6.0.1";
+  version = "6.0.2";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "sha256-noLdQctAaMNmfuxI3iybHFx3Q9aTr3gZaUZ+/uO+fnA=";
+    sha256 = "sha256-yfUF9+M45ZSjmB275kTs8+/Q8Q5FMmr63e3Om8dPi2k=";
+  };
+
+  meta = with lib; {
+    broken = stdenv.isAarch64;
+    description = "An open source ecosystem for IoT development";
+    homepage = "https://platformio.org";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mog makefu oxzi ];
   };
 
   self = {
-    platformio-chrootenv = callPackage ./chrootenv.nix { inherit version src; };
+    platformio-chrootenv = callPackage ./chrootenv.nix { inherit version src meta; };
   };
 
 in self

--- a/pkgs/development/embedded/platformio/missing-udev-rules-nixos.patch
+++ b/pkgs/development/embedded/platformio/missing-udev-rules-nixos.patch
@@ -5,7 +5,7 @@ index ef1d3bab..445174fc 100644
 @@ -57,6 +57,7 @@ class MissedUdevRules(InvalidUdevRules):
      MESSAGE = (
          "Warning! Please install `99-platformio-udev.rules`. \nMore details: "
-         "https://docs.platformio.org/page/faq.html#platformio-udev-rules"
+         "https://docs.platformio.org/en/latest/core/installation/udev-rules.html"
 +        "On NixOS add the platformio package to services.udev.packages"
      )
  


### PR DESCRIPTION
###### Description of changes
https://github.com/platformio/platformio-core/releases/tag/v6.0.2

Next to the version bump, I refactored the redundant meta block and
added myself as a maintainer, as I created the last package bumps.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
