### PR TITLE
python310Packages.keyring: 23.5.1 -> 23.6.0

### DIFF
--- a/pkgs/development/python-modules/keyring/default.nix
+++ b/pkgs/development/python-modules/keyring/default.nix
@@ -13,23 +13,22 @@
 
 buildPythonPackage rec {
   pname = "keyring";
-  version = "23.5.1";
+  version = "23.6.0";
   disabled = pythonOlder "3.7";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-3uUCzfGKmCEb70KO6hFFajPABxiy8IUk/Vcnx/Qkv/0=";
+    hash = "sha256-OsAMJuTJNznhkQMJGpmGqfeWZaeM8VpN8dun6prI2i8=";
   };
 
   nativeBuildInputs = [
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
-    # this should be optional, however, it has a different API
-    importlib-metadata # see https://github.com/jaraco/keyring/issues/503#issuecomment-798973205
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
   ] ++ lib.optionals stdenv.isLinux [
     jeepney
     secretstorage

--- a/pkgs/development/python-modules/onlykey-solo-python/default.nix
+++ b/pkgs/development/python-modules/onlykey-solo-python/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , click
 , ecdsa
+, fetchpatch
 , fetchPypi
 , fido2
 , intelhex
@@ -18,6 +19,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-Mbi5So2OgeXjg4Fzg7v2gAJuh1Y7ZCYu8Lrha/7PQfY=";
   };
+
+  patches = [
+    # https://github.com/trustcrypto/onlykey-solo-python/pull/2
+    (fetchpatch {
+      url = "https://github.com/trustcrypto/onlykey-solo-python/commit/c5a86506f940d4e8fbb670ed665ddca48779cbe9.patch";
+      hash = "sha256-LhCUR5QH9Je/Nr185HgQxfkCtat8W2Huv62zr5Mlrn4=";
+    })
+  ];
 
   propagatedBuildInputs = [ click ecdsa fido2 intelhex pyserial pyusb requests ];
 

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'cryptography = "^2.1 || ^3.0"' 'cryptography = "*"'
+      --replace 'fido2 = ">=0.9, <1.0"' 'fido2 = ">*"'
     substituteInPlace "ykman/pcsc/__init__.py" \
       --replace 'pkill' '${procps}/bin/pkill'
   '';


### PR DESCRIPTION

###### Description of changes
https://github.com/jaraco/keyring/blob/v23.6.0/CHANGES.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
