### PR TITLE
fetchFromGitLab: support for private repositories

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -21,6 +21,8 @@ lib.makeOverridable (
     deepClone ? false,
     forceFetchGit ? false,
     sparseCheckout ? [ ],
+    private ? false,
+    varPrefix ? null,
     ... # For hash agility
   }@args:
 
@@ -51,13 +53,56 @@ lib.makeOverridable (
       "tag"
       "fetchSubmodules"
       "forceFetchGit"
+      "private"
+      "varPrefix"
       "leaveDotGit"
       "deepClone"
     ];
 
+    varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITLAB_PRIVATE_";
     useFetchGit =
       fetchSubmodules || leaveDotGit || deepClone || forceFetchGit || (sparseCheckout != [ ]);
     fetcher = if useFetchGit then fetchgit else fetchzip;
+
+    privateAttrs = lib.optionalAttrs private (
+      lib.throwIfNot (protocol == "https") "private token login is only supported for https" {
+        netrcPhase = ''
+          if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
+            echo "Error: Private fetchFromGitLab requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
+            exit 1
+          fi
+        ''
+        + (
+          if useFetchGit then
+            # GitLab supports HTTP Basic Authentication only when Git is used:
+            # https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html#project-access-tokens
+            ''
+              cat > netrc <<EOF
+              machine ${domain}
+                      login ''$${varBase}USERNAME
+                      password ''$${varBase}PASSWORD
+              EOF
+            ''
+          else
+            # Access via the GitLab API requires a custom header and does not work
+            # with HTTP Basic Authentication:
+            # https://docs.gitlab.com/ee/api/#personalprojectgroup-access-tokens
+            ''
+              # needed because fetchurl always sets --netrc-file if a netrcPhase is present
+              touch netrc
+
+              cat > private-token <<EOF
+              PRIVATE-TOKEN: ''$${varBase}PASSWORD
+              EOF
+              curlOpts="$curlOpts --header @./private-token"
+            ''
+        );
+        netrcImpureEnvVars = [
+          "${varBase}USERNAME"
+          "${varBase}PASSWORD"
+        ];
+      }
+    );
 
     gitRepoUrl = "${protocol}://${domain}/${slug}.git";
 
@@ -84,6 +129,7 @@ lib.makeOverridable (
             };
           }
       )
+      // privateAttrs
       // passthruAttrs
       // {
         inherit name;


### PR DESCRIPTION
###### Description of changes

This is an attempt to add support for private GitLab repositories (via password/token login), similar to `fetchFromGitHub`. I tried to maintain a similar structure as for GitHub, but some details in GitLab API seem to work differently: the `.netrc` file can only be used for the `fetchgit` approach; a custom header to curl needs to be used for `fetchzip` instead ([API doc](https://docs.gitlab.com/ee/api/repositories.html#get-file-archive))

Let me know if it would be better to rebase on `staging` instead of `master`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
