### PR TITLE
pkg-config: fixes for prefixed pkg-config

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -95,6 +95,7 @@ stdenv.mkDerivation rec {
   configureFlags = filter (v: v != null) ([
       "--arch=${stdenv.hostPlatform.parsed.cpu.name}"
       "--target_os=${stdenv.hostPlatform.parsed.kernel.name}"
+      "--pkg-config=${pkg-config.targetPrefix}pkg-config"
     # License
       "--enable-gpl"
       "--enable-version3"

--- a/pkgs/development/libraries/neon/default.nix
+++ b/pkgs/development/libraries/neon/default.nix
@@ -3,6 +3,7 @@
 , sslSupport ? true, openssl ? null
 , static ? stdenv.hostPlatform.isStatic
 , shared ? !stdenv.hostPlatform.isStatic
+, bash
 }:
 
 assert compressionSupport -> zlib != null;
@@ -25,8 +26,10 @@ stdenv.mkDerivation rec {
   patches = optionals stdenv.isDarwin [ ./darwin-fix-configure.patch ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [libxml2 openssl]
+  buildInputs = [libxml2 openssl bash]
     ++ lib.optional compressionSupport zlib;
+
+  strictDeps = true;
 
   configureFlags = [
     (lib.enableFeature shared "shared")

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -32,6 +32,11 @@ python3.pkgs.buildPythonApplication rec {
     passthru.respect_xml_catalog_files_var_patch
   ];
 
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "pkg-config" "$PKG_CONFIG"
+  '';
+
   strictDeps = true;
 
   depsBuildBuild = [

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ gmp ];
 
+  configurePlatforms = [ "build" "host" ];
   configureFlags = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"


### PR DESCRIPTION
###### Description of changes

pkg-config: always prefix with target platform

This reduces the differences between native and cross-compilation.
Due to that it should help preventing some regressions related
to the naming of pkg-config when doing native vs cross-compilation.

Note that some packages may expect pkg-config to not be prefixed,
those will need to be fixed to refer to $PKG_CONFIG rather than
to the hardcoded name pkg-config.

Due to pkg-config not being in the bootstrap packages,
it's relatively easy to change.
For other packages (binutils, gcc) where this change should also
happen, it's a bit harder since the bootstrap binaries are (not yet)
prefixed.

TODO-list:

- [ ] build a lot of packages and see if any of them break
- [ ] write documentation (release notes, usage manual) to make it clear that $PKG_CONFIG should be used and issues may occur when it's hardcoded in a package

Opening as draft since I'm still building some stuff. In principle this seems to work ok, but there'll definitely be packages that are unhappy about this.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @Ericson2314 
