### PR TITLE
darkplaces: init at unstable-2022-05-10

### DIFF
--- a/pkgs/games/darkplaces/default.nix
+++ b/pkgs/games/darkplaces/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, zlib
+, libjpeg
+, SDL2
+, libvorbis
+}:
+stdenv.mkDerivation rec {
+  name = "darkplaces";
+  version = "unstable-2022-05-10";
+
+  src = fetchFromGitHub {
+    owner = "DarkPlacesEngine";
+    repo = "darkplaces";
+    rev = "f16954a9d40168253ac5d9890dabcf7dbd266cd9";
+    hash = "sha256-5KsUcgHbuzFUE6LcclqI8VPSFbXZzBnxzOBB9Kf8krI=";
+  };
+
+  buildInputs = [
+    zlib
+    libjpeg
+    SDL2
+  ];
+
+  buildFlags = "release";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m755 darkplaces-sdl $out/bin/darkplaces
+    install -m755 darkplaces-dedicated $out/bin/darkplaces-dedicated
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    patchelf \
+      --add-needed ${libvorbis}/lib/libvorbisfile.so \
+      --add-needed ${libvorbis}/lib/libvorbis.so \
+      $out/bin/darkplaces
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.icculus.org/twilight/darkplaces/";
+    description = "A quake 1 engine implementation by LadyHavoc";
+    longDescription = ''
+      A game engine based on the Quake 1 engine by id Software.
+      It improves and builds upon the original 1996 engine by adding modern
+      rendering features, and expanding upon the engine's native game code
+      language QuakeC, as well as supporting additional map and model formats.
+    '';
+    maintainers = with maintainers; [ necrophcodr ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31611,6 +31611,8 @@ with pkgs;
 
   cuyo = callPackage ../games/cuyo { };
 
+  darkplaces = callPackage ../games/darkplaces {};
+
   deliantra-server = callPackage ../games/deliantra/server.nix {
     stdenv = gcc10StdenvCompat;
   };


### PR DESCRIPTION
###### Description of changes

A quake 1 engine implementation by LadyHavoc, as seen here: http://www.icculus.org/twilight/darkplaces/

Originally I had added a .desktop as well as icons, but since this is ONLY a game engine and NOT a real game, it was removed again, as it only caused the game engine to start up and display and error and never actually loading any games.

Regardless, this is akin to QuakeSpasm, that is to say this is another quake 1 engine port. I have of course also tested this with the actual Quake 1 game to ensure that this works as intended, but feel free to verify this.

Note that I was unable to run `nixpkgs-review rev HEAD` on this, as it returned errors relating to other packages as of the time of PR creation.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
