### PR TITLE
todoman: disable failing test and unmark broken for darwin

### DIFF
--- a/pkgs/applications/office/todoman/default.nix
+++ b/pkgs/applications/office/todoman/default.nix
@@ -69,6 +69,8 @@ buildPythonApplication rec {
     "test_missing_cache_dir"
     "test_sorting_null_values"
     "test_xdg_existant"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_sorting_fields"
   ];
 
   pythonImportsCheck = [
@@ -76,7 +78,6 @@ buildPythonApplication rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     homepage = "https://github.com/pimutils/todoman";
     description = "Standards-based task manager based on iCalendar";
     longDescription = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The other day I updated my unstable channel and tried switching home-manager to a new generation on my x86 Macbook, but it failed. I tracked it down to `todoman`, which was disabled for darwin in [`37c633f`](https://github.com/NixOS/nixpkgs/commit/37c633f7ae518456af1f3064bd5c386e2de92c37#diff-d6f12ab586366800496d5e0658a7f2642b81342e9374f779b460df8860d46071R79) but seems to build fine for me. I also noticed #173671 (zero-hydra-failures PR) that mentions disabling some packages that were broken on hydra (the PR mentions `todoman`, but didn't actually disable it).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin &larr; I'm wondering if [`37c633f`](https://github.com/NixOS/nixpkgs/commit/37c633f7ae518456af1f3064bd5c386e2de92c37#diff-d6f12ab586366800496d5e0658a7f2642b81342e9374f779b460df8860d46071R79) was addressing it failing on M1 specifically (cc @Mindavi)?
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
