### PR TITLE
nix: patch curl netrc regression

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -3,6 +3,7 @@
 , c-aresSupport ? false, c-ares ? null
 , gnutlsSupport ? false, gnutls ? null
 , gsaslSupport ? false, gsasl ? null
+, patchNetrcRegression ? false
 , gssSupport ? with stdenv.hostPlatform; (
     !isWindows &&
     # disable gss becuase of: undefined reference to `k5_bcmp'
@@ -77,7 +78,7 @@ stdenv.mkDerivation rec {
     # quiche: support ca-fallback
     # https://github.com/curl/curl/commit/fdb5e21b4dd171a96cf7c002ee77bb08f8e58021
     ./7.83.1-quiche-support-ca-fallback.patch
-  ];
+  ] ++ lib.optional patchNetrcRegression ./netrc-regression.patch;
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
   separateDebugInfo = stdenv.isLinux;

--- a/pkgs/tools/networking/curl/netrc-regression.patch
+++ b/pkgs/tools/networking/curl/netrc-regression.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/url.c b/lib/url.c
+index a56e4b0..9f29593 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -2971,6 +2971,12 @@ static CURLcode override_login(struct Curl_easy *data,
+       /* don't update the user name below */
+       userp = NULL;
+     }
++    /* no user was set but a password, set a blank user */
++    if(userp && !*userp && *passwdp) {
++      *userp = strdup("");
++      if(!*userp)
++        return CURLE_OUT_OF_MEMORY;
++    }
+   }
+ #endif

--- a/pkgs/tools/networking/curl/netrc-regression.patch
+++ b/pkgs/tools/networking/curl/netrc-regression.patch
@@ -7,7 +7,7 @@ index a56e4b0..9f29593 100644
        userp = NULL;
      }
 +    /* no user was set but a password, set a blank user */
-+    if(userp && !*userp && *passwdp) {
++    if(userp && !*userp && passwdp && *passwdp) {
 +      *userp = strdup("");
 +      if(!*userp)
 +        return CURLE_OUT_OF_MEMORY;

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -1,6 +1,7 @@
 { lib, fetchFromGitHub
 , version
 , suffix ? ""
+, curl
 , sha256 ? null
 , src ? fetchFromGitHub { owner = "NixOS"; repo = "nix"; rev = version; inherit sha256; }
 , patches ? [ ]
@@ -23,7 +24,6 @@ in
 , bzip2
 , callPackage
 , coreutils
-, curl
 , editline
 , flex
 , gnutar

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -1,6 +1,7 @@
 { lib
 , aws-sdk-cpp
 , boehmgc
+, curl
 , callPackage
 , fetchFromGitHub
 , fetchurl
@@ -31,7 +32,7 @@ let
 
   common = args:
     callPackage
-      (import ./common.nix ({ inherit lib fetchFromGitHub; } // args))
+      (import ./common.nix ({ inherit lib fetchFromGitHub curl; } // args))
       {
         inherit Security storeDir stateDir confDir;
         boehmgc = boehmgc-nix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34178,6 +34178,7 @@ with pkgs;
     storeDir = config.nix.storeDir or "/nix/store";
     stateDir = config.nix.stateDir or "/nix/var";
     inherit (darwin.apple_sdk.frameworks) Security;
+    curl = curl.override { patchNetrcRegression = true; };
   });
 
   nix = nixVersions.stable;


### PR DESCRIPTION
Upstream bug https://github.com/curl/curl/issues/8653

Fixes https://github.com/cachix/cachix/issues/406

This is a hack to not trigger stdenv rebuild but fix Nix in the fastest manner.

Following this merge I'll backport to 22.05 and make a stdenv rebuild version for staging-next.
