### PR TITLE
beets-bandcamp: init at 2022-06-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14688,4 +14688,11 @@
     github = "npatsakula";
     githubId = 23001619;
   };
+
+  rrix = {
+    email = "nixpkgs@whatthefuck.computer";
+    name = "Ryan Rix";
+    github = "rrix";
+    githubId = 138102;
+  };
 }

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -47,4 +47,5 @@ lib.makeExtensible (self: {
   alternatives = callPackage ./plugins/alternatives.nix { beets = self.beets-minimal; };
   copyartifacts = callPackage ./plugins/copyartifacts.nix { beets = self.beets-minimal; };
   extrafiles = callPackage ./plugins/extrafiles.nix { beets = self.beets-minimal; };
+  beetcamp = callPackage ./plugins/beetcamp.nix { beets = self.beets-minimal; };
 })

--- a/pkgs/tools/audio/beets/plugins/beetcamp.nix
+++ b/pkgs/tools/audio/beets/plugins/beetcamp.nix
@@ -33,5 +33,6 @@ python3Packages.buildPythonApplication {
     description = "Bandcamp autotagger plugin for beets.";
     license = lib.licenses.gpl2;
     inherit (beets.meta) platforms;
+    maintainers = with lib.maintainers; [ rrix ];
   };
 }

--- a/pkgs/tools/audio/beets/plugins/beetcamp.nix
+++ b/pkgs/tools/audio/beets/plugins/beetcamp.nix
@@ -1,0 +1,37 @@
+{ lib, fetchFromGitHub, beets, python3Packages }:
+
+python3Packages.buildPythonApplication {
+  pname = "beets-beetcamp";
+  version = "unstable-2022-06-07";
+
+  src = fetchFromGitHub {
+    repo = "beetcamp";
+    owner = "snejus";
+    rev = "118d4239bd570a59997f13ac0920e6e92890ac67";
+    sha256 = "sha256-yrlpgLdNEzlWMY7Cns0UE93oEbpkOoYZHGLpui6MfC0=";
+  };
+
+  format = "pyproject";
+
+  propagatedBuildInputs = with python3Packages; [ setuptools poetry requests cached-property pycountry dateutil ordered-set ];
+
+  checkInputs = with python3Packages; [
+    # pytestCheckHook
+    pytest-cov
+    pytest-randomly
+    pytest-lazy-fixture
+    rich
+    tox
+    types-setuptools
+    types-requests
+  ] ++ [
+    beets
+  ];
+
+  meta = {
+    homepage = "https://github.com/snejus/beetcamp";
+    description = "Bandcamp autotagger plugin for beets.";
+    license = lib.licenses.gpl2;
+    inherit (beets.meta) platforms;
+  };
+}

--- a/pkgs/tools/audio/beets/plugins/beetcamp.nix
+++ b/pkgs/tools/audio/beets/plugins/beetcamp.nix
@@ -1,4 +1,10 @@
-{ lib, fetchFromGitHub, beets, python3Packages }:
+{ lib,
+  fetchFromGitHub,
+  python3Packages,
+  beets,
+
+  propagateBeets ? false
+}:
 
 python3Packages.buildPythonApplication {
   pname = "beets-beetcamp";
@@ -13,7 +19,8 @@ python3Packages.buildPythonApplication {
 
   format = "pyproject";
 
-  propagatedBuildInputs = with python3Packages; [ setuptools poetry requests cached-property pycountry dateutil ordered-set ];
+  propagatedBuildInputs = with python3Packages; [ setuptools poetry requests cached-property pycountry dateutil ordered-set ]
+                                                ++ (lib.optional propagateBeets [ beets ]);
 
   checkInputs = with python3Packages; [
     # pytestCheckHook

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4523,6 +4523,7 @@ with pkgs;
 
   beetsPackages = lib.recurseIntoAttrs (callPackage ../tools/audio/beets { });
   inherit (beetsPackages) beets beets-unstable;
+  beetcamp = beetsPackages.beetcamp.override({propagateBeets = true;});
 
   bento4 = callPackage ../tools/video/bento4 { };
 


### PR DESCRIPTION
###### Description of changes

This adds [beetcamp](https://github.com/snejus/beetcamp) and makes it available for the `pluginOverrides` as `beetsPackages.beetcamp`. There is a `beetcamp` CLI included which would be nice to expose if the package is included directly in a profile but propagating beets-minimal in this plugin would break the beets-maximal this plugin is eventually included within... 

Happy to take suggestions on how to get the CLI program working. I guess I could add an optional `propagateBeets` option defaulting to no, and add it to top-level with that option enabled?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
