### PR TITLE
elisp updates

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -4102,21 +4102,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.3.2";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.3.2.tar";
-          sha256 = "03hmk4gr9kjy3238n0ys9na00py035j9s0y8d87c45f5af6c6g2c";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -767,16 +767,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    consult = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+    consult = callPackage ({ compat, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "consult";
         ename = "consult";
-        version = "0.17";
+        version = "0.18";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/consult-0.17.tar";
-          sha256 = "16yrp6scxg93anxrp5nww08ixxqk8ra9dn9zm8w5dry997kmkasa";
+          url = "https://elpa.gnu.org/packages/consult-0.18.tar";
+          sha256 = "0nvi8f0jrji26sjmji8f7rvc8gr1zq49kliq39z7h970d8p10cx2";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ compat emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/consult.html";
           license = lib.licenses.free;
@@ -801,10 +801,10 @@
       elpaBuild {
         pname = "corfu";
         ename = "corfu";
-        version = "0.23";
+        version = "0.25";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/corfu-0.23.tar";
-          sha256 = "1l988jmvn3x1x77sc89pg5ivwl9i4r2v4k74ymkplgcc9wpffm1v";
+          url = "https://elpa.gnu.org/packages/corfu-0.25.tar";
+          sha256 = "1ix65l80q8id8vxkvx4wd780cav53lws2z1x3pnj4wmm0n4qwyd9";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -861,10 +861,10 @@
       elpaBuild {
         pname = "cpupower";
         ename = "cpupower";
-        version = "1.0.4";
+        version = "1.0.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/cpupower-1.0.4.tar";
-          sha256 = "12910d3qbkapr4bvqv88lr85fz6rkim0zrc24nxnvkhkh3yi8qvd";
+          url = "https://elpa.gnu.org/packages/cpupower-1.0.5.tar";
+          sha256 = "1hg5jwdkxl6mx145wwdmnhc8k3z3srvpm757kppj1ybmvjbpxx0y";
         };
         packageRequires = [];
         meta = {
@@ -921,10 +921,10 @@
       elpaBuild {
         pname = "csv-mode";
         ename = "csv-mode";
-        version = "1.19";
+        version = "1.20";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/csv-mode-1.19.tar";
-          sha256 = "0sslxlnw10ba6m711p4ps4zsfjz56dsp2945ga5z0y8d860pliqh";
+          url = "https://elpa.gnu.org/packages/csv-mode-1.20.tar";
+          sha256 = "08im1llz04s3ckpj3c3j4wxq4g00fyld2m8ylnh878ss5izzs0lg";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {
@@ -1034,6 +1034,21 @@
         packageRequires = [ cl-lib nadvice ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/delight.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    detached = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "detached";
+        ename = "detached";
+        version = "0.7";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/detached-0.7.tar";
+          sha256 = "1a2w6cmzy7c861rih9k2qbnmizyybrs1kwqp6lbz3wfs2h0zisrw";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/detached.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -1202,16 +1217,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    dtache = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+    dtache = callPackage ({ detached, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "dtache";
         ename = "dtache";
-        version = "0.6";
+        version = "0.7";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/dtache-0.6.tar";
-          sha256 = "1nv5hzn4rnm8pzfr5i209djaafj4ymg5j886yq2j19zkjadc8yx3";
+          url = "https://elpa.gnu.org/packages/dtache-0.7.tar";
+          sha256 = "0cws662f53f2j1viicrwijmniiqxz1n4mh6kwck25pl954xa61gf";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ detached emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/dtache.html";
           license = lib.licenses.free;
@@ -1326,10 +1341,10 @@
       elpaBuild {
         pname = "eev";
         ename = "eev";
-        version = "20220416";
+        version = "20220605";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/eev-20220416.tar";
-          sha256 = "174hwb3cyiqimzcsl62yhq51hb4gxmj5wni6w5ng4m24bfkx87nc";
+          url = "https://elpa.gnu.org/packages/eev-20220605.tar";
+          sha256 = "1d8bmps72519hv3raqyjx1sbd7vmihckq8qrzd2v0rglx4smikdk";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1444,10 +1459,10 @@
       elpaBuild {
         pname = "embark";
         ename = "embark";
-        version = "0.16";
+        version = "0.17";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/embark-0.16.tar";
-          sha256 = "1fgsy4nqwl1cah287fbabpi9lwmbiyn36c4z918514iwr5hgrmfi";
+          url = "https://elpa.gnu.org/packages/embark-0.17.tar";
+          sha256 = "05r5z59sv0j4sawybd4353ziya87q6yzx4l8sjklybcn2mslpp1q";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1464,10 +1479,10 @@
       elpaBuild {
         pname = "embark-consult";
         ename = "embark-consult";
-        version = "0.5";
+        version = "0.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/embark-consult-0.5.tar";
-          sha256 = "1z4n5gm30yan3gg2aqwb1ygql56v9sg2px1dr0gdl32lgmn9kvg6";
+          url = "https://elpa.gnu.org/packages/embark-consult-0.6.tar";
+          sha256 = "1c8rx9ikazbnap293ab6s26djikdy85i7z330wdwwrgmipkfawaj";
         };
         packageRequires = [ consult emacs embark ];
         meta = {
@@ -1714,10 +1729,10 @@
       elpaBuild {
         pname = "fontaine";
         ename = "fontaine";
-        version = "0.2.1";
+        version = "0.2.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/fontaine-0.2.1.tar";
-          sha256 = "11g03gaiypqf0xi7s3xyjnbi2w154lkd7j0ybmn8scs6pbzdyl95";
+          url = "https://elpa.gnu.org/packages/fontaine-0.2.2.tar";
+          sha256 = "14q10r5086pyknpm8kd9f0scwwbgygqjp8b08k6a4f30a3pl3rqi";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2144,6 +2159,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    inspector = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "inspector";
+        ename = "inspector";
+        version = "0.5";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/inspector-0.5.tar";
+          sha256 = "19f2a0fw0zcrfirjhq7my910jiqxqkishyjprj87cahpksdp4cp9";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/inspector.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     ioccur = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "ioccur";
@@ -2558,10 +2588,10 @@
       elpaBuild {
         pname = "logos";
         ename = "logos";
-        version = "0.3.2";
+        version = "0.4.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/logos-0.3.2.tar";
-          sha256 = "1qpbp9f9lz7yrky42cq8b4k295593s7l892zsrdyifnqcgs50bfd";
+          url = "https://elpa.gnu.org/packages/logos-0.4.0.tar";
+          sha256 = "12yypzfd6lf71qyix0a1088vkamh9ilq8inpmv2882w3r5dii345";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2772,10 +2802,10 @@
       elpaBuild {
         pname = "modus-themes";
         ename = "modus-themes";
-        version = "2.3.0";
+        version = "2.4.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-themes-2.3.0.tar";
-          sha256 = "028c1z4p1bbgf34fml4i0prihxn44x288iyprz9gxrp7x3gl05n8";
+          url = "https://elpa.gnu.org/packages/modus-themes-2.4.1.tar";
+          sha256 = "0wm4wj2dsv93p8yq7byrwni079caxny9cgn8d5xz0a6g1igqzx4q";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2821,10 +2851,10 @@
       elpaBuild {
         pname = "multishell";
         ename = "multishell";
-        version = "1.1.9";
+        version = "1.1.10";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/multishell-1.1.9.tar";
-          sha256 = "0gi5qmx27v7kaczr9b3sic69br3l7mcws3sdrs8c14iipcyl5qhb";
+          url = "https://elpa.gnu.org/packages/multishell-1.1.10.tar";
+          sha256 = "1ipn9rlh9jg55i04adjy32n8dkjhhw1bcd72w97mlsdk66g8j6l3";
         };
         packageRequires = [ cl-lib ];
         meta = {
@@ -2931,10 +2961,10 @@
       elpaBuild {
         pname = "nano-modeline";
         ename = "nano-modeline";
-        version = "0.7";
+        version = "0.7.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/nano-modeline-0.7.tar";
-          sha256 = "1fsjzbdawkn4vmk6zs6az1b42mx5ka7a618fgx5zdncr79wl0vjw";
+          url = "https://elpa.gnu.org/packages/nano-modeline-0.7.1.tar";
+          sha256 = "18a4mp27z6pj87yhp81x5a79g0kv6mzzd0axq2p31003r675l0hx";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2954,6 +2984,21 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/nano-theme.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    nftables-mode = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "nftables-mode";
+        ename = "nftables-mode";
+        version = "1.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/nftables-mode-1.1.tar";
+          sha256 = "0wcd31frnvxzkns4jdfxraai0bfi1184wcn64r8lg73h933p47iz";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/nftables-mode.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -3130,10 +3175,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "9.5.3";
+        version = "9.5.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-9.5.3.tar";
-          sha256 = "0i8lx7gsdz79qv0h3qdbwqd0m91z6ky33wjmkcbify75giixiv25";
+          url = "https://elpa.gnu.org/packages/org-9.5.4.tar";
+          sha256 = "1rcr1kyvd2l5h1i22z40x998jm4b6vk47i77y376blcrcx2dp26m";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3190,10 +3235,10 @@
       elpaBuild {
         pname = "org-remark";
         ename = "org-remark";
-        version = "1.0.4";
+        version = "1.0.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-remark-1.0.4.tar";
-          sha256 = "1mbsp92vw8p8l2pxs53r7wafrplrwfx0rmfk723cl9hpvghvl9vf";
+          url = "https://elpa.gnu.org/packages/org-remark-1.0.5.tar";
+          sha256 = "01pgfg9j5wrhggjklkc9nbfiwjd5qnmhcbcccc06jz3hmd0rnxr2";
         };
         packageRequires = [ emacs org ];
         meta = {
@@ -3265,10 +3310,10 @@
       elpaBuild {
         pname = "osm";
         ename = "osm";
-        version = "0.7";
+        version = "0.8";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/osm-0.7.tar";
-          sha256 = "0k2phmh2sl50vx88cgndghcjfz0i20mjs2hg4mlh4hb5q9yjpcj4";
+          url = "https://elpa.gnu.org/packages/osm-0.8.tar";
+          sha256 = "1vvd149n4pa6jy7xk5dmhi0nfwcjd4rvxn283f1jxp5jvv47m202";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3340,10 +3385,10 @@
       elpaBuild {
         pname = "parser-generator";
         ename = "parser-generator";
-        version = "0.1.5";
+        version = "0.1.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/parser-generator-0.1.5.tar";
-          sha256 = "06cl9whk321l1q5xcjmgq5c59l10ybwcdsmmbrkrllnbpqxy23bj";
+          url = "https://elpa.gnu.org/packages/parser-generator-0.1.6.tar";
+          sha256 = "0qql5klnh8fbnbkb4mhv6axxvw4qv09cy1h556m0qzg30sckxas1";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3400,10 +3445,10 @@
       elpaBuild {
         pname = "phps-mode";
         ename = "phps-mode";
-        version = "0.4.20";
+        version = "0.4.22";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/phps-mode-0.4.20.tar";
-          sha256 = "0xb4i3s6yira1kfqwrs72ajvpqc6pw7gqlxmfmdhyyvib6p93l6m";
+          url = "https://elpa.gnu.org/packages/phps-mode-0.4.22.tar";
+          sha256 = "1094dmvihx0ff7fyjldd2zfn47nq89p6bjp90ma0xf01hf6ggn6c";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3535,10 +3580,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "4.2.0";
+        version = "4.2.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-4.2.0.tar";
-          sha256 = "1yb6yv92987kq0ls38d0fqwbj5jrf4cg3jvdbwjzr61gg3izf414";
+          url = "https://elpa.gnu.org/packages/pyim-4.2.1.tar";
+          sha256 = "15hsz1ji8xa7zqzzmbi0vk95vgsvl4dsd1rann04vfaz30a1rdzv";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3550,10 +3595,10 @@
       elpaBuild {
         pname = "pyim-basedict";
         ename = "pyim-basedict";
-        version = "0.5.0";
+        version = "0.5.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-basedict-0.5.0.tar";
-          sha256 = "0h946wsnbbii32kl2kpv0k1kq118ymvpd5q1mphfsf126dz9sv78";
+          url = "https://elpa.gnu.org/packages/pyim-basedict-0.5.3.tar";
+          sha256 = "1x3zmcbp5yck5dxfms8d9ym0fdbvwr40fn8wrq0qfl9a58k8i5bx";
         };
         packageRequires = [];
         meta = {
@@ -3815,10 +3860,10 @@
       elpaBuild {
         pname = "rec-mode";
         ename = "rec-mode";
-        version = "1.8.3";
+        version = "1.8.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/rec-mode-1.8.3.tar";
-          sha256 = "0lkmvvdj4xx3qhxqggizrcdawav0accyrza2wmhfdq88g2zh5575";
+          url = "https://elpa.gnu.org/packages/rec-mode-1.8.4.tar";
+          sha256 = "03n0g6inhj0mqqcqimh6nfi6rdzgh4w59vdjicvn880r5n8zwn4d";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4057,6 +4102,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.3.2";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.3.2.tar";
+          sha256 = "03hmk4gr9kjy3238n0ys9na00py035j9s0y8d87c45f5af6c6g2c";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";
@@ -4260,10 +4320,10 @@
       elpaBuild {
         pname = "sql-beeline";
         ename = "sql-beeline";
-        version = "0.1";
+        version = "0.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/sql-beeline-0.1.tar";
-          sha256 = "0yvj96aljmyiz8y6xjpypqjfrl1jdcrcc4jx4kbgl6mkv4z2aq1g";
+          url = "https://elpa.gnu.org/packages/sql-beeline-0.2.tar";
+          sha256 = "1bqzs53x506bzgchvjfr1ljqxbb9y041n7aj9n7ajb2634i7lllr";
         };
         packageRequires = [];
         meta = {
@@ -4298,6 +4358,21 @@
         packageRequires = [ cl-lib ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/sql-indent.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    srht = callPackage ({ elpaBuild, emacs, fetchurl, lib, plz }:
+      elpaBuild {
+        pname = "srht";
+        ename = "srht";
+        version = "0.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/srht-0.1.tar";
+          sha256 = "1cdylp2hma83iv062nf7qyz21a3r8562gwx2lk6cf45k2kh3hbv8";
+        };
+        packageRequires = [ emacs plz ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/srht.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -4553,10 +4628,10 @@
       elpaBuild {
         pname = "tmr";
         ename = "tmr";
-        version = "0.2.3";
+        version = "0.3.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tmr-0.2.3.tar";
-          sha256 = "0lys6g96cvfyhwr7z0yv9cx2ykzyixjppv5fh29qzq3h3dywx5wb";
+          url = "https://elpa.gnu.org/packages/tmr-0.3.0.tar";
+          sha256 = "1cv90hg7hsaffkcxryp9d5cyjvmfpxcmrw5knipad77yxzaf4s6b";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4583,10 +4658,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.2.4";
+        version = "2.5.2.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.2.4.tar";
-          sha256 = "0ap1d34p1akrrm8z1r7ln6mj13xg2nrvjln2v3g8plhhp354jldz";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.2.5.tar";
+          sha256 = "05f59x7jl4m187y2cidhnfz7p8q85gav4xpipazfvm5dicxz4j7c";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4802,10 +4877,10 @@
       elpaBuild {
         pname = "vc-got";
         ename = "vc-got";
-        version = "1.1";
+        version = "1.1.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vc-got-1.1.tar";
-          sha256 = "1myck30ybq8ggf4yk3s2sqjqj8m1kfl8qxygkk3ynfa6jxxy4x1r";
+          url = "https://elpa.gnu.org/packages/vc-got-1.1.1.tar";
+          sha256 = "0f8rwd4scvlyn9i9xq7d2sly7r0ddzi8z565jx1h2lkcs5nbihcb";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4894,10 +4969,10 @@
       elpaBuild {
         pname = "vertico";
         ename = "vertico";
-        version = "0.23";
+        version = "0.24";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-0.23.tar";
-          sha256 = "1d2r2y1bhvipn4xqzla5rv09cdpg7f19m9hrnv1pqypjvbgqv1m2";
+          url = "https://elpa.gnu.org/packages/vertico-0.24.tar";
+          sha256 = "17vsx1yijx9clly977lvc6y296kq8g859hqwwq1v8zh4k0wqr9hc";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4947,10 +5022,10 @@
       elpaBuild {
         pname = "visual-filename-abbrev";
         ename = "visual-filename-abbrev";
-        version = "1.1";
+        version = "1.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/visual-filename-abbrev-1.1.tar";
-          sha256 = "1l2wq7q28lcl78flxqvsxc9h96whpynqq8kpmbiy3nzlw2mrgr8g";
+          url = "https://elpa.gnu.org/packages/visual-filename-abbrev-1.2.tar";
+          sha256 = "0sipyqrgf723ii2zd6r8hvihn5kax5qd0dwwrrxqy6f58wnhyq1r";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -49,10 +49,10 @@
       elpaBuild {
         pname = "annotate";
         ename = "annotate";
-        version = "1.5.4";
+        version = "1.6.0";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/annotate-1.5.4.tar";
-          sha256 = "1d11q4ddc2rw7n8jrxdddc5h42hf16sbc1l4v6zmmsriahxhgfdd";
+          url = "https://elpa.nongnu.org/nongnu/annotate-1.6.0.tar";
+          sha256 = "12843875nvrw5cs2pzag9i2k4vgajbs4rr56js7h6mx9w6jmg8hc";
         };
         packageRequires = [];
         meta = {
@@ -258,10 +258,10 @@
       elpaBuild {
         pname = "cider";
         ename = "cider";
-        version = "1.4.0";
+        version = "1.4.1";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/cider-1.4.0.tar";
-          sha256 = "11a3ysvrywp79pp1yivpsgi8azgzbg7ayiai94p1dyd3viy29qn0";
+          url = "https://elpa.nongnu.org/nongnu/cider-1.4.1.tar";
+          sha256 = "0l36pqmjqzv6ykmw593h6qd24pygq7171qfinvlp2fh8897ac2nj";
         };
         packageRequires = [
           clojure-mode
@@ -322,6 +322,26 @@
         packageRequires = [ color-theme ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/color-theme-tangotango.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    corfu-terminal = callPackage ({ corfu
+                                  , elpaBuild
+                                  , emacs
+                                  , fetchurl
+                                  , lib
+                                  , popon }:
+      elpaBuild {
+        pname = "corfu-terminal";
+        ename = "corfu-terminal";
+        version = "0.4";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/corfu-terminal-0.4.tar";
+          sha256 = "1rmfj2lzdab2s49k9ja79i7xcw74r9cr5kv7rgrisqxwgcnvsi95";
+        };
+        packageRequires = [ corfu emacs popon ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/corfu-terminal.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -598,16 +618,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    evil-matchit = callPackage ({ elpaBuild, emacs, evil, fetchurl, lib }:
+    evil-matchit = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "evil-matchit";
         ename = "evil-matchit";
-        version = "2.4.4";
+        version = "3.0.0";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/evil-matchit-2.4.4.tar";
-          sha256 = "1p8xsi0068wabsfn3jwhyinkk2684xp9hlapcbj6y58wkpzqj0f6";
+          url = "https://elpa.nongnu.org/nongnu/evil-matchit-3.0.0.tar";
+          sha256 = "036zf7l8pkhbyk7gz91r00v4fqi2wfdnqv95xkh7jpm2i9xcgg5p";
         };
-        packageRequires = [ emacs evil ];
+        packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/evil-matchit.html";
           license = lib.licenses.free;
@@ -670,6 +690,27 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/flymake-kondor.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    flymake-popon = callPackage ({ elpaBuild
+                                 , emacs
+                                 , fetchurl
+                                 , flymake ? null
+                                 , lib
+                                 , popon
+                                 , posframe }:
+      elpaBuild {
+        pname = "flymake-popon";
+        ename = "flymake-popon";
+        version = "0.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/flymake-popon-0.2.tar";
+          sha256 = "08wpfia4q12nhc6l0xmdc54f1s73c0ds6hxwgkk5hjw906rpgn4a";
+        };
+        packageRequires = [ emacs flymake popon posframe ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/flymake-popon.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -1270,10 +1311,10 @@
       elpaBuild {
         pname = "kotlin-mode";
         ename = "kotlin-mode";
-        version = "1.0.0";
+        version = "2.0.0";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/kotlin-mode-1.0.0.tar";
-          sha256 = "0ajnnsh6a8psfh7gd34d2wfii08jxr7x7k6na0assjldsxy7afwj";
+          url = "https://elpa.nongnu.org/nongnu/kotlin-mode-2.0.0.tar";
+          sha256 = "0q1pfjcsk6c17hs5xg7wb6f4i29hn3zxgznjcr3v11dm4xmrj9iv";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1524,14 +1565,29 @@
           license = lib.licenses.free;
         };
       }) {};
+    org-auto-tangle = callPackage ({ async, elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "org-auto-tangle";
+        ename = "org-auto-tangle";
+        version = "0.4.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/org-auto-tangle-0.4.1.tar";
+          sha256 = "169i1agnv66gkpgn5wxxri42610n2dp1gz9bfafk2n2a8b08mhn1";
+        };
+        packageRequires = [ async emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-auto-tangle.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     org-contrib = callPackage ({ elpaBuild, emacs, fetchurl, lib, org }:
       elpaBuild {
         pname = "org-contrib";
         ename = "org-contrib";
-        version = "0.3";
+        version = "0.4";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/org-contrib-0.3.tar";
-          sha256 = "0fqhyby7624drskfsasgvzyxbgjb42rd6vw8l6xgb3h22kaprl0q";
+          url = "https://elpa.nongnu.org/nongnu/org-contrib-0.4.tar";
+          sha256 = "05r7w0h9v1vfhv1dd2vaabq2gm8ra70s1cirlp75s343b0z28ca6";
         };
         packageRequires = [ emacs org ];
         meta = {
@@ -1579,10 +1635,10 @@
       elpaBuild {
         pname = "org-mime";
         ename = "org-mime";
-        version = "0.2.6";
+        version = "0.3.1";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/org-mime-0.2.6.tar";
-          sha256 = "1l6mniyhmw3vbkvahw24038isd4ysbx505c3r0ar1rh7fbdf58cf";
+          url = "https://elpa.nongnu.org/nongnu/org-mime-0.3.1.tar";
+          sha256 = "0dm7addyc98kh1lm4d8x7nvnkh6bwkw300ms2zlwm1ii91jzfkkg";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1742,6 +1798,21 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/php-mode.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    popon = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "popon";
+        ename = "popon";
+        version = "0.4";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/popon-0.4.tar";
+          sha256 = "1c3brjhkdnpawi8jsc20jvhc1vl3l39da12rn3lfx2bfxvjvz76w";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/popon.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -1918,10 +1989,10 @@
       elpaBuild {
         pname = "shellcop";
         ename = "shellcop";
-        version = "0.0.9";
+        version = "0.1.0";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/shellcop-0.0.9.tar";
-          sha256 = "0rv98s3w3pd2l477100d8kn2kqx21xn3axzcfbxbkgl8bc78mvci";
+          url = "https://elpa.nongnu.org/nongnu/shellcop-0.1.0.tar";
+          sha256 = "0z0aml86y1m11lz8a8wdjfad5dzynjsqw69qin0a4vv2b8gy8mhr";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2061,6 +2132,21 @@
         packageRequires = [ emacs seq ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/swift-mode.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    swsw = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "swsw";
+        ename = "swsw";
+        version = "2.1.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/swsw-2.1.1.tar";
+          sha256 = "0k6cysa4pmxv1kmpn0fqvardbdfayj92cq0r3gxrx9pgqxlqwfix";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/swsw.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -2209,10 +2295,10 @@
       elpaBuild {
         pname = "vc-fossil";
         ename = "vc-fossil";
-        version = "20210928";
+        version = "20220707";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/vc-fossil-20210928.tar";
-          sha256 = "0n4h1cj1336mv5cswq0139bkry5gnv4hrrwzd4bqhrxp5kbhqa5y";
+          url = "https://elpa.nongnu.org/nongnu/vc-fossil-20220707.tar";
+          sha256 = "0l33y8mij6rw4h47ryqpjxr1i2xzis98rbi230izkvsc6w7qf89q";
         };
         packageRequires = [];
         meta = {
@@ -2220,14 +2306,29 @@
           license = lib.licenses.free;
         };
       }) {};
+    vcomplete = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "vcomplete";
+        ename = "vcomplete";
+        version = "1.2.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/vcomplete-1.2.1.tar";
+          sha256 = "1fcchgv4kdmhzgincfy1jm625lwj3qrjskd0cswag5z15by6b5xf";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/vcomplete.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     visual-fill-column = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "visual-fill-column";
         ename = "visual-fill-column";
-        version = "2.4";
+        version = "2.5";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/visual-fill-column-2.4.tar";
-          sha256 = "0100v17s9w9nqjpr7h3zianfy1i4i71idk2qrlzqzcd8qn1m3vjx";
+          url = "https://elpa.nongnu.org/nongnu/visual-fill-column-2.5.tar";
+          sha256 = "0mqhm7xkxpzjk96n6qybqg2780kbjg1w7ash88zhnbp8kvy0rrwi";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2239,10 +2340,10 @@
       elpaBuild {
         pname = "web-mode";
         ename = "web-mode";
-        version = "17.2.0";
+        version = "17.2.2";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/web-mode-17.2.0.tar";
-          sha256 = "15m7rx7sz7f6h0x90811bcl8gdcpn216ia48nmkqhqrm85synlja";
+          url = "https://elpa.nongnu.org/nongnu/web-mode-17.2.2.tar";
+          sha256 = "19ajwjcxv7vqysk085jyys77vry8nw7rzc7c43khyxb54qvg36i3";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2337,10 +2438,10 @@
       elpaBuild {
         pname = "xah-fly-keys";
         ename = "xah-fly-keys";
-        version = "17.7.20220429090059";
+        version = "17.13.20220526011611";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-17.7.20220429090059.tar";
-          sha256 = "006lqjx88b0g0szxai82qdn3bv8qajp2x281arpmp3rpb7faggvq";
+          url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-17.13.20220526011611.tar";
+          sha256 = "1lg8805s5y61jr6yrm44zdjm0nad6adc5xr78zm0i0qzigbhhdcq";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -273,8 +273,8 @@
     20210923,
     950
    ],
-   "commit": "0d6aace2ffd184137618a0c6e7f29826cbd8d1f9",
-   "sha256": "1rf989ll07xqmamdigzqmamhfscx7wk0xh5yaqam1q3hj13yywm5"
+   "commit": "9c8c26c0de493f21cf4a68abad49f944d427bd88",
+   "sha256": "18lidpmi0sp9za6ykidgnssdvnx1p7kyr51k4b21cqjrnal606zl"
   }
  },
  {
@@ -939,8 +939,8 @@
  },
  {
   "ename": "ac-math",
-  "commit": "7fabdb05de9b8ec18a3a566f99688b50443b6b44",
-  "sha256": "02c821zabxp9qkwx252pxjmssdbmas0iwanw09r03bmiby9d4nsl",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "16qsbx65q8z6dsq7z1mvfqw2bjwdrnhsfsc0sl8awm5f4463bi10",
   "fetcher": "github",
   "repo": "vspinu/ac-math",
   "unstable": {
@@ -1810,8 +1810,8 @@
  },
  {
   "ename": "ado-mode",
-  "commit": "337f21eb8f4af233b4c0bc658cd82e8479b49aaa",
-  "sha256": "1gybsnj7s21vm1iakz4hy5d6skzcfi6455wnikv9dpwy1069rw32",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0x070d95krvmq08hknclx8qj8zsm2afmiw3nv891ks8dg211glnj",
   "fetcher": "github",
   "repo": "louabill/ado-mode",
   "unstable": {
@@ -1834,20 +1834,20 @@
  },
  {
   "ename": "adoc-mode",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "0jd3zr4zpb4qqn504azl0y02cryv7n9wphv64b0fbpipr7w5hm2c",
+  "commit": "221950c9703432a8e3c2a99f2cc709dff7bcbdbb",
+  "sha256": "13d2mj9bf9z5ky7gi1dajky210h1kzr2bh1vvl5cvq7slsrjfazi",
   "fetcher": "github",
-  "repo": "sensorflo/adoc-mode",
+  "repo": "emacsorphanage/adoc-mode",
   "unstable": {
    "version": [
-    20160314,
-    2130
+    20220529,
+    551
    ],
    "deps": [
     "markup-faces"
    ],
-   "commit": "745884359a1b8826ede2c4cfd2f0b5478953ac40",
-   "sha256": "199da15f6p84809z33w3m35lrk9bgx8qpgnxsxgisli373mpzvd8"
+   "commit": "cacd4e8f6773da85ebe17b733eb5e74f2f7c379c",
+   "sha256": "08w8xirp2frkap74d646j6pbaby72j1233hlz0nk3pzlh0lglzc0"
   },
   "stable": {
    "version": [
@@ -1893,14 +1893,14 @@
   "repo": "minad/affe",
   "unstable": {
    "version": [
-    20220407,
-    2313
+    20220603,
+    548
    ],
    "deps": [
     "consult"
    ],
-   "commit": "a61d593d0cbff65a93111be96b9f53d3e640cf8d",
-   "sha256": "1pkqr7asz6h4gjkrg8mc8qikxy4agiv0x6ragbasy0xm3q4wxm0h"
+   "commit": "e8cb221892ae4d82fc52fffb72b45b5b89ada334",
+   "sha256": "0gwg60c3f2ypjwpai3j4dhzdjn29lxskf3s0nw75pnipngf0sh9r"
   },
   "stable": {
    "version": [
@@ -2062,11 +2062,11 @@
   "url": "https://bitbucket.org/agriggio/ahg",
   "unstable": {
    "version": [
-    20210412,
-    847
+    20220529,
+    1200
    ],
-   "commit": "77bc2a628df006dcd2dc359ac12acdf8091a1356",
-   "sha256": "1wmvz9d40aznqh2y078v8k7n3l66m48vnf873vifi8rwg6158kqh"
+   "commit": "d93cc73f79f6c29d533c468112181cd4c7b11935",
+   "sha256": "1jq411g0ryxkqw4wig6mlm0dpjzx87cw3x277bcj796s3nxl95ln"
   }
  },
  {
@@ -2489,11 +2489,11 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20220427,
-    1911
+    20220521,
+    816
    ],
-   "commit": "68365b48f142d75ef4bdc3a274256d97752e3b65",
-   "sha256": "1nf6z5i9gpbv1qdrm7r0qb0mbzipdn9mnfwc478rrazmn2l0m5cs"
+   "commit": "ca1ef30004d3fb76aaa70bd47cb83e9fe017a7f7",
+   "sha256": "149i1wh2wk4j6x8zyz8macz6pfhkmpvf9j6xqhn3psnbdpikjvqp"
   },
   "stable": {
    "version": [
@@ -2641,15 +2641,15 @@
   "repo": "seagle0128/all-the-icons-ivy-rich",
   "unstable": {
    "version": [
-    20220510,
-    752
+    20220607,
+    1820
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "7c382ccbc8b1b2d0e18d280b24ee2029dca070d8",
-   "sha256": "0145agd3kg1m7ylishf4ypg6bc01jrps17rwxw0kdqrh3gp7xvg3"
+   "commit": "e489b08aeae53c0288474495b5c0e6847ba1005d",
+   "sha256": "150p4aqg7dd3k277518ia3zsjkyn8f8a5msmgh9x812gypcrgcpm"
   },
   "stable": {
    "version": [
@@ -2715,8 +2715,8 @@
     20220212,
     1526
    ],
-   "commit": "45deed4b9aadcd5e2a5482b0fe5110bb78ba1dd6",
-   "sha256": "0g77kdr0lhv2w4gdcmc2bf4ix5kpjg9g358v0kjn26gr36m843j6"
+   "commit": "e79c3762130749b02689d1274adce8b93aac9b7a",
+   "sha256": "0vpcran6yxp9vyy9xhwc9kj7hw3shsvz6igy4yvj0i4xkpkib4p8"
   },
   "stable": {
    "version": [
@@ -2846,14 +2846,14 @@
   "url": "https://repo.or.cz/amread-mode.git",
   "unstable": {
    "version": [
-    20220210,
-    1354
+    20220519,
+    45
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a3358645582148e81bff54e18877451b747173bb",
-   "sha256": "0nl1w5ysq90bxl16jrdh87wyp6ffawbjc3c6zrbhsfmfd24jiq28"
+   "commit": "21f3cf796c08625cf70d534a990f4ae2273a5d4f",
+   "sha256": "1rs5ybxh779fzb2xr0y8rhh4qzdpgrfgir4r81rpfxyhksls88xx"
   }
  },
  {
@@ -3229,11 +3229,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20220428,
-    1339
+    20220603,
+    1023
    ],
-   "commit": "e982a7b74a681a8c2c823d8dcaafd185ab5f719e",
-   "sha256": "13vnc9qkz2n121yf482sj19daxa262pnp49cy8p5cvrr75narh1r"
+   "commit": "7f48fad362b15546da7b015b533609a2452497b0",
+   "sha256": "01kv6bjsnsarnmmy7jrbs74q1pdabz2k4p0330hcny7nl9xp51jj"
   },
   "stable": {
    "version": [
@@ -3271,8 +3271,8 @@
     20200914,
     644
    ],
-   "commit": "9a5f2b4a8cd14edbde9d16dcdfcb8db2a91be0d8",
-   "sha256": "1pn3w2prmz9ibhy5l22c6mmccr7lfy561gkd2s41hlcjsyd4ar00"
+   "commit": "6385f850a185523bb5241a71f5a7614a148f6b53",
+   "sha256": "0dllhhbr265dm12nkiil0s7cb24l7pjdjgfwgcsy98imn8pl8z4p"
   },
   "stable": {
    "version": [
@@ -3624,19 +3624,19 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20220512,
-    1952
+    20220604,
+    2239
    ],
-   "commit": "b5dbab53eadf64529a0bfe217c7750f1d7d85fce",
-   "sha256": "1w7x7k5mrvp5yq5ppq9zps5z2c7h67yjxyaxcvbkjibvswb0c616"
+   "commit": "67853e98b190cc735a8ad31bd1de64f76f2990c4",
+   "sha256": "1jbidfz0s7lz190hzwvj7qxh2f3lmbwaynqrarr183pksja4jqwc"
   },
   "stable": {
    "version": [
-    2,
+    3,
     0
    ],
-   "commit": "84b04329d7c0ddf41e41433b3f732714995a2bfd",
-   "sha256": "0kd0aydpfvxzq8qc6cknx11hcc6vwp7lxzjwbkcr5w4jynza59v1"
+   "commit": "18ccacc5cf0806ecf11d0a3d462de1803e46a9ad",
+   "sha256": "0fpqh4wv69msfsnv3k88cai3nbja70ab5c02xf8gwfgg3613pjdd"
   }
  },
  {
@@ -3741,8 +3741,8 @@
     20210802,
     1715
    ],
-   "commit": "ea9a32aa33580b0695e7298d56c3d5f050a02b87",
-   "sha256": "13wm9g184lxzf55cwx1cc88d5a17yghbfqsqvyihsb7yv2i2xg8i"
+   "commit": "9b84a7cb74d687745df37ba15113933fc6256274",
+   "sha256": "0ng2wzfmardlfjga60850izq7xh22qcc1i69n4ap6f74s334k8iq"
   },
   "stable": {
    "version": [
@@ -3892,11 +3892,11 @@
   "repo": "nbarrientos/archive-rpm",
   "unstable": {
    "version": [
-    20220314,
-    1647
+    20220527,
+    632
    ],
-   "commit": "515d2230352fffcc982ae2e322d95cbee6aca760",
-   "sha256": "1x8mwhfwcpbwaha5qb5hnl6ga29cbi27a26m0q4840agpr53s1km"
+   "commit": "cb48fee04cb0cbb26f760a3b95649f7dac78c6ec",
+   "sha256": "088rcqlwhdcaal99cbwsfg93nvzil2kix28zib2lxv6lfapjpzwp"
   },
   "stable": {
    "version": [
@@ -4033,6 +4033,25 @@
    ],
    "commit": "5437b4221b64b238c273a651d4792c577dba6d45",
    "sha256": "1yvirfmvf6v5khl7zhx2ddv9bbxnx1qhwfzi0gy2nmbxlykb6s2j"
+  }
+ },
+ {
+  "ename": "arxiv-citation",
+  "commit": "92d5032fee7e103ccf1517b7bbc18e4c5059eba7",
+  "sha256": "1n5v28s071gdgd6yzv0ywa9vhkc2x21ax3b3b1x7z3y8xvqwrr2s",
+  "fetcher": "gitlab",
+  "repo": "slotThe/arxiv-citation",
+  "unstable": {
+   "version": [
+    20220601,
+    652
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "ce4bf6958109b3b15bfc3f808ba4882b41fcb3ff",
+   "sha256": "0q74qgsdy2dahzvxlv9mayd6f6fgyf1q4lf6gvwc0xm9ms5qwf4c"
   }
  },
  {
@@ -4280,10 +4299,10 @@
  },
  {
   "ename": "async-backup",
-  "commit": "79cfb4a1c6b89cc5d93020089804b5e6ae711387",
-  "sha256": "0w56q76x2b31adhjjsqm38jfgxi2305s9lxvwbq8w13693i5fv8a",
+  "commit": "4f3fa2076ce777618f2982a7ba69b497d68aebc3",
+  "sha256": "1m1kj4bj1a9514pprd43i15bgshkm1lcqq44h7grg8pxxxks1xxw",
   "fetcher": "git",
-  "url": "https://tildegit.org/contrapunctus/async-backup.git",
+  "url": "https://codeberg.org/contrapunctus/async-backup.git",
   "unstable": {
    "version": [
     20220131,
@@ -4336,8 +4355,8 @@
     20201026,
     339
    ],
-   "commit": "43ca538ecece4e14bb9bcd887854aeb14b3d45f4",
-   "sha256": "05l6wbhyh2jy5cqmy0b3bg5klafcc1fcfp5944r9wdah0lpg169k"
+   "commit": "d407daa17e0557f366d485c7c39880d2cd19938a",
+   "sha256": "1hmf0n6gm95ajr15s3vmd1ybk28zklna2n5xp0hrn9q5vj6wv7a5"
   },
   "stable": {
    "version": [
@@ -4360,8 +4379,8 @@
     20210731,
     609
    ],
-   "commit": "e0d11744d9b2bca780322b1b282fb5ffb18cfd75",
-   "sha256": "1va7fhh4ppb9aily009m6nf43z5l8fdwinsqy46qj81w5apmbpg5"
+   "commit": "bac60d0c76f0fe48b5f634502c79e87d7ab057b6",
+   "sha256": "1yldbkxywmybzv80ynisklzl8qyb7xb5wxlb4q7i355v6654ciap"
   },
   "stable": {
    "version": [
@@ -4661,8 +4680,8 @@
     "keytar",
     "s"
    ],
-   "commit": "5c6f0952f28ce722f4a75139f3dc1afc99e12396",
-   "sha256": "0v83s1gfyh1zbaaqgj2q9vg193k705kr18mszp6p8rdyffdw5fqi"
+   "commit": "66ee3b73b7739fd35d848fabbeec0b2c44b0b532",
+   "sha256": "16gkm4ysh0pgg9ag0b6q4xpx8mr1gk6sghr236hjkvjvca5b85sj"
   },
   "stable": {
    "version": [
@@ -4767,15 +4786,15 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20220422,
-    1600
+    20220517,
+    1501
    ],
    "deps": [
     "compat",
     "packed"
    ],
-   "commit": "16de66c381dab3c1fb7bc248e0f81ef68966bd7d",
-   "sha256": "0ls5n124rl8s3dyj0kr7n1sv3dkn9bw7k61s2f2ads43gp3744qp"
+   "commit": "b204e2f85aaa4d41af4eb1819633c9613f5172bf",
+   "sha256": "0wqiypznwg7pcqb1qvf4ba2kx4f8x01ms8zxbxy134j9idm4g39f"
   },
   "stable": {
    "version": [
@@ -4805,8 +4824,8 @@
     "cl-lib",
     "popup"
    ],
-   "commit": "d546b18c3e83e38686d9b7316c6c705597e1a8b3",
-   "sha256": "1fwg2zn7digz22vf22h4kim3wkz2i2wvs42ak12lxg8aa3w6wn94"
+   "commit": "72c44902f893bfffe4ff0075e992541d79cfbb5d",
+   "sha256": "0rbawimh6540mj0m0xapj7swhz119921vdwgvxrvpyd8n3alww4g"
   },
   "stable": {
    "version": [
@@ -5148,8 +5167,8 @@
    "deps": [
     "ht"
    ],
-   "commit": "e31a2d2bb97ffcbeb493f3501311b30c3f10952f",
-   "sha256": "0md8dlx1g5lxb4f5yxhm617kj49zysya9y6awjrvpj30crp78g5z"
+   "commit": "26ad2261866d19994f8927002dcc53a80540ffd3",
+   "sha256": "0zakrvsnbliv0rsm6pm0d98bpf1llbl97cw8r55g7g8r79mjjxrp"
   },
   "stable": {
    "version": [
@@ -5298,8 +5317,8 @@
     20210805,
     1344
    ],
-   "commit": "85b02fa6ce76ab872c025a82c2f14614af3d89e1",
-   "sha256": "1rnigp11xlxhzrfwqna0dqrd0a655gs0qf5m6bkzq41ssdvvdis8"
+   "commit": "ba5e28cd4ca7515f7d7a8c243f913d571ca976d6",
+   "sha256": "00cv35q52nprj12396c1447bpbi710sapqw3s9v5jm5m3x7w4z9m"
   },
   "stable": {
    "version": [
@@ -5503,11 +5522,11 @@
   "url": "https://git.sr.ht/~pkal/autocrypt",
   "unstable": {
    "version": [
-    20220215,
-    1204
+    20220526,
+    1846
    ],
-   "commit": "c439cbe029f7ffeca6de0ea72258069c41350509",
-   "sha256": "1r7qan2v3kaykacnf98s2zcfb5ryk4jqpw7acrfvajgvdn3w03sh"
+   "commit": "5fae83ac0501a26c92e022218341c21cc71e463c",
+   "sha256": "01ib6lzywssm81mwi72aaavkp078kkbgvnhi0gl09vgn2pba78va"
   }
  },
  {
@@ -5567,8 +5586,8 @@
     20190331,
     2230
    ],
-   "commit": "09166f32d3ece2b297da036f0abbeba63329580e",
-   "sha256": "09j3mxa0803piywmfkvxg0jpgbx6qbvibsik8wsms898bg5n3s4d"
+   "commit": "7725c08f00a463ba7210efcb759c934223c85b00",
+   "sha256": "1dqascm5ds9jzp4m4hdb4l9wwfcnkc1ba3y4m24ybx43gjj38sxn"
   }
  },
  {
@@ -5711,20 +5730,20 @@
     "avy",
     "embark"
    ],
-   "commit": "81c7f751be1de33dee9f7523fd3429ee3fe9a0d1",
-   "sha256": "11yvhhq251qmbnljjcfxnc53dqa63jm6ximfd0618hcwcgxlkkdc"
+   "commit": "63f0d4dc09afb058450dc10dd3916027a93ee487",
+   "sha256": "0q8l4ckdmcagiiccvb0s94gc1lywgqh02d8p16ygpcfxz8967w4a"
   },
   "stable": {
    "version": [
     0,
-    16
+    17
    ],
    "deps": [
     "avy",
     "embark"
    ],
-   "commit": "5faf1389162dd64bfe3511dfb8f52c18efb5140b",
-   "sha256": "04xxwhh577aam0fqfmprxqaw0v1l6yidikr6chajcf16mf1wd2gv"
+   "commit": "97270d725761ee02db461b45b18ec16ae31f203e",
+   "sha256": "1s0ssf4q9kg4c5w87h2ypyvrhi31mz3s6k4h7pxi9a47lkccq8n1"
   }
  },
  {
@@ -5925,8 +5944,8 @@
     20220512,
     1931
    ],
-   "commit": "b52fa715285e7ad182c8e679ebf05b130dd5b5e2",
-   "sha256": "1hb4npfpg1iy9j0p29q1jrjgx0mrn333m45nmsnxw8nlaxzd97x6"
+   "commit": "847cc6e728b692ad3fdaec28d0c8c49ec0378a56",
+   "sha256": "02nf2vn6s6pc63yw2rggdx9capn9432w6j56m9v0c5ygarpxb53p"
   }
  },
  {
@@ -6271,25 +6290,25 @@
  },
  {
   "ename": "base16-theme",
-  "commit": "30862f6be74882cfb57fb031f7318d3fd15551e3",
-  "sha256": "115dhr3gfvdz5wv76fwpv3b4dywiwbk69qrhkfhij8vpcfybrpzx",
+  "commit": "a91349e3285531fd7040b8bf192c15cccbcac8d1",
+  "sha256": "1j49gan9i0wqr2zvc23811yiv72gyiwiqyf4jckik4vcfx3gsk1f",
   "fetcher": "github",
-  "repo": "belak/base16-emacs",
+  "repo": "base16-project/base16-emacs",
   "unstable": {
    "version": [
-    20220510,
-    423
+    20220526,
+    1015
    ],
-   "commit": "43f3257aaf53e9c50f5db11b81fd66ec41ab2883",
-   "sha256": "07k73bgjb6ixfgbiwf8zswf6n0kb3bf1ka1pcv88h3a9hhndvgv5"
+   "commit": "26b84fc93505219517a512eb01e6370365174989",
+   "sha256": "0qp71j77zg8gippcn277s0j5a9n6dbwv3kdp2nya6li4b412vgba"
   },
   "stable": {
    "version": [
-    2,
-    4
+    3,
+    0
    ],
-   "commit": "7b2bb8d05562fa8d75366e82eef895c03ab7b31c",
-   "sha256": "1jgqq52q2q7sgf46xip0sfpwyi8k43v2l688hx7p0whncjhd7cmr"
+   "commit": "26b84fc93505219517a512eb01e6370365174989",
+   "sha256": "0qp71j77zg8gippcn277s0j5a9n6dbwv3kdp2nya6li4b412vgba"
   }
  },
  {
@@ -6300,11 +6319,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20220328,
-    844
+    20220531,
+    1104
    ],
-   "commit": "29b5fc860a5b0db9828acfceca09b773fbdb8e8a",
-   "sha256": "1gj62v4j3s21kbm1zapb7scv1zh4q9k1jjpgrr4wy0fqk7gzfprq"
+   "commit": "8e9c20dbfe01d8bf6c61db231593623a201c75c6",
+   "sha256": "1jq6nx5kpln15yv0k9njql8xl7id7yswdl7hkkbwha99i1cn0nqd"
   },
   "stable": {
    "version": [
@@ -6534,14 +6553,17 @@
  },
  {
   "ename": "bbdb",
-  "commit": "caaa21f235c4864f6008fb454d0a970a2fd22a86",
-  "sha256": "0mm8n3dbi8lap3pjr97n2f675iy7sg476sm1vxygbc3j67rq1zb2",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0gnjdlb338gxpsmdx8scj5vb1rbvfkmm71xq37sahy0m4r402al1",
   "fetcher": "git",
   "url": "https://git.savannah.nongnu.org/git/bbdb.git",
   "unstable": {
    "version": [
     20220416,
     405
+   ],
+   "deps": [
+    "cl-lib"
    ],
    "commit": "ed7648f723d3fd03476b8a007a76e9058f7f7f47",
    "sha256": "05a6rh2chyafsw9n3aar4dscvq8wdb9bbl3b12vawilj3b5bv9jy"
@@ -6552,6 +6574,9 @@
     2,
     2,
     2
+   ],
+   "deps": [
+    "cl-lib"
    ],
    "commit": "ed7648f723d3fd03476b8a007a76e9058f7f7f47",
    "sha256": "05a6rh2chyafsw9n3aar4dscvq8wdb9bbl3b12vawilj3b5bv9jy"
@@ -6938,8 +6963,8 @@
     20210715,
     1004
    ],
-   "commit": "f04dad824b9879f7382f36780a0151e4ef544815",
-   "sha256": "1a3s6za2dlavknpmcbkbrdf4a75a1a0qgni3igq1657xfxk658gw"
+   "commit": "72dae979d4cf33ac1b63c73df337fcc2c2aafd72",
+   "sha256": "08cn2pvg8gxb6a88z8fiklcyyf3sagl9h5x7k7f44jfyqwqzpky7"
   },
   "stable": {
    "version": [
@@ -7022,8 +7047,8 @@
    "deps": [
     "reformatter"
    ],
-   "commit": "b4003950a925d1c659bc359ab5e88e4441775d77",
-   "sha256": "1x5hbs9j4ms93p080267kjyqpk81il3x7q87awf6qzz5xhc20d3b"
+   "commit": "94bc804220248b43b68c073545858692816d307a",
+   "sha256": "1ad4fil4x55p1vba2vb7065pggm0yj8mbzvrgwzwxgihhqzaln0p"
   },
   "stable": {
    "version": [
@@ -7133,8 +7158,8 @@
     "a",
     "pdf-tools"
    ],
-   "commit": "2f38f3583295e05c9ea491b7d1f6b4791169ba86",
-   "sha256": "0jyy8nl4r70l0dwc55lg75k7chcwb9zprl185x0122fjqgmnq1ri"
+   "commit": "4359c640c7822a23976e9a5ca4ce63452d796912",
+   "sha256": "176qjbhvdg1bqy45qk6zf5ij12qif6xkd3ppd1a5wg67p2rv21z8"
   }
  },
  {
@@ -7592,11 +7617,11 @@
   "repo": "pythonic-emacs/blacken",
   "unstable": {
    "version": [
-    20220110,
-    1841
+    20220529,
+    1541
    ],
-   "commit": "563c744f545552cb92e8e84d5be4e2cdbabc93ca",
-   "sha256": "0pf9yllx0h78m925sdrg6hbv54ky2pi7cpkdsnx891qjsahvjnpy"
+   "commit": "764912ada13c3bf57e770fcd978c81a1ce26666a",
+   "sha256": "1s2wml00wdgzxf8zp3gl0zxgmsfjflf90j04zqnp5jzsp6cmifsq"
   },
   "stable": {
    "version": [
@@ -7639,20 +7664,26 @@
   "repo": "Artawower/blamer.el",
   "unstable": {
    "version": [
-    20220404,
-    1917
+    20220531,
+    1900
    ],
-   "commit": "f5c0b5ef2ae46062ba13dd03215cdfc49d0fd30b",
-   "sha256": "1acwh5xcfizmd6m4kwlvpyysznknjwzqmgppc33khldqiv3ga9sp"
+   "deps": [
+    "posframe"
+   ],
+   "commit": "b86822f460a54c60fdfede62d4a86bd4991baa21",
+   "sha256": "1vqfqzjgip1a3mcbd22dgkp1wc2x4r375npbwjs99jn7br1d73ny"
   },
   "stable": {
    "version": [
     0,
-    4,
-    6
+    5,
+    0
    ],
-   "commit": "f5c0b5ef2ae46062ba13dd03215cdfc49d0fd30b",
-   "sha256": "1acwh5xcfizmd6m4kwlvpyysznknjwzqmgppc33khldqiv3ga9sp"
+   "deps": [
+    "posframe"
+   ],
+   "commit": "330c0ac2e3bbc242c2e769655bb6b68555aada70",
+   "sha256": "1wmz3kp5k7n5xj2yx4rz7f7a5khvhll1jvda40b3c8x6mx9n416f"
   }
  },
  {
@@ -7827,11 +7858,11 @@
   "repo": "kennethloeffler/blox",
   "unstable": {
    "version": [
-    20210225,
-    1900
+    20220521,
+    807
    ],
-   "commit": "2bf0e618451fb1da11263d8a35ffcd9210590c0a",
-   "sha256": "0lkhdm9jhy8wlmrmd9nqrbrczh5k75q38n6bq3gfhppycmysh9d5"
+   "commit": "9ebebb65fb38b5570ba8dfbb5ec835633c06b67d",
+   "sha256": "0cbmqzhv8bnfjracdc7xc5ba7cr8fqfh8l617sxarw51daallxri"
   },
   "stable": {
    "version": [
@@ -8147,21 +8178,21 @@
  },
  {
   "ename": "borg",
-  "commit": "325cca8031b99c6abe2ee9858a6b547d1af0cdde",
-  "sha256": "0rklhjm6zpmyjvw39475fsfn5n5mxkf33b8hkfx0pjjdp0ylr21n",
+  "commit": "af5c1593052d63146e850683c461a760ab166033",
+  "sha256": "0gn4hf7hn190gl0kg59nr6jzjnb39c0hy9b3brrsfld9hyxga9jr",
   "fetcher": "github",
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20220511,
-    1643
+    20220527,
+    2237
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "55271c12e05c14e30102bd64bd609af29d58846e",
-   "sha256": "104kf3km7450jj7brgjhmw5idrvk3s1qjxclzpv7xypyvi53ab8l"
+   "commit": "1f87dfcca69decc9db651af6b9f38034ab9fbd51",
+   "sha256": "1k2lp2g6nsm843gf3a5ddck75pg62dpvnnpjpwbxzjhraswr9z5c"
   },
   "stable": {
    "version": [
@@ -8238,8 +8269,8 @@
  },
  {
   "ename": "bpe",
-  "commit": "1a99263c2672d4c2433835cf948101130126e14b",
-  "sha256": "08zfqcgs7i2ram2qpy8vrzksx5722aahr66vdi4d9bcxm03s19fm",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0lbbbfd66p5hdxv083k6370c4hkaydh2vq35753i25gnhzxs9hhl",
   "fetcher": "github",
   "repo": "yuutayamada/bpe",
   "unstable": {
@@ -8652,11 +8683,11 @@
   "repo": "astoff/buffer-env",
   "unstable": {
    "version": [
-    20220506,
-    1506
+    20220606,
+    1330
    ],
-   "commit": "7b7e5c2a79ad3b31b465387df0ccc18a5809f9d1",
-   "sha256": "1r4lbz5hadsxw9dkhi10xr54zmsgknmklfmb78yxnvqhwl30kk20"
+   "commit": "fc98ca9e2a8b6edcec7199bf52eaf1848bd3e35c",
+   "sha256": "1i629jdlp3lxjk3awarx64s7czbzg15yy101ns9hrjk914bvskbc"
   }
  },
  {
@@ -8854,8 +8885,8 @@
     20200924,
     345
    ],
-   "commit": "b918ba023212b0e223a7ca7df3a2ec12a7c54206",
-   "sha256": "0xj9k2i7dmnqg99k1kraq58fc1kzgvriy08g46zhka3dz2l2m5br"
+   "commit": "124529e089c7ea70877cfa881e55b3a21f28ffd1",
+   "sha256": "1g7nizs3iy4avaifnw91fps72i2iifkbrlh8fkdymcynnmhkqdvf"
   },
   "stable": {
    "version": [
@@ -8906,8 +8937,8 @@
  },
  {
   "ename": "bufshow",
-  "commit": "543a734795eed11aa47a8e1348d14e362b341af0",
-  "sha256": "027cd0jzb8yxm66q1bhyi75f2m9f2pq3aswgav1d18na3ybwg65h",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "01ywg76zvkwv67li5phyz797gdn866bnxxqfwg4adzakhhbc8pzm",
   "fetcher": "github",
   "repo": "pjones/bufshow",
   "unstable": {
@@ -9756,8 +9787,8 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20220511,
-    1104
+    20220604,
+    1655
    ],
    "deps": [
     "dash",
@@ -9767,8 +9798,8 @@
     "s",
     "transient"
    ],
-   "commit": "232fa1cf3af08200af439d1cbb5a131f38286183",
-   "sha256": "1ncyrrzk0a1wfyr3khvznda7l59g4vg9h3nglzbihnbvfkxqh6cn"
+   "commit": "e4ce01a08f0e9cbbaea03ab5259d0cc029e9f2ad",
+   "sha256": "0jd5d9inxhiymzphf4gw11wwg5lv4jp3hflj9w24grcd77i6wkdg"
   },
   "stable": {
    "version": [
@@ -9796,16 +9827,16 @@
   "repo": "beacoder/call-graph",
   "unstable": {
    "version": [
-    20220506,
-    1214
+    20220528,
+    27
    ],
    "deps": [
     "hierarchy",
     "ivy",
     "tree-mode"
    ],
-   "commit": "42023e5d1781c75f425e8c72b63b28e53dae6e9c",
-   "sha256": "029ssw7k9prmh7rv4drjmwzcykrihpqkmkylz0fla40l7ycmdr5c"
+   "commit": "b37836ed04a1268301c0ef84496f165c671f55e4",
+   "sha256": "1vy8l4ra6pwvchn9fb0z8hskn744kbl1djya8l44hir4ma75kxhh"
   },
   "stable": {
    "version": [
@@ -9934,11 +9965,11 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20220506,
-    1814
+    20220607,
+    1615
    ],
-   "commit": "e72edf2d6357beb64798ef1894cc807190f80901",
-   "sha256": "0l6slrbh7sr3r3zgxh4r1r0g2131mvpmy2vd1hrkjf9q9c5hpqq0"
+   "commit": "67c48f1c3609f1426f02c5d8b81e23b1e8b89659",
+   "sha256": "15cq18pc97lhibz4nyyjavhgyalyg8wrc6wc9pzg2iq1gp0yrq2x"
   },
   "stable": {
    "version": [
@@ -9960,17 +9991,17 @@
     20210707,
     2310
    ],
-   "commit": "02dc92c900babbd232fbcdd14f7ccf44d234ee77",
-   "sha256": "0gar2j9vis9b2wj1fhqahcrmaw867z3pmsn5d70bb8mdr3xq3dmm"
+   "commit": "81b25899ca8321f507f204b4777f223c26e4d6ab",
+   "sha256": "1a2fx5zf36770bim9spnhlvdv8mjbhpyg3mvwni5mgjdn4zidb2g"
   },
   "stable": {
    "version": [
     0,
-    9,
+    10,
     1
    ],
-   "commit": "b49431c48d40490ef979247d308af63345376cee",
-   "sha256": "0cbiwkmd29abih8rjjm35dfkrkr8c6axbzq3fkryay6jyvpi42c5"
+   "commit": "5cff5efc2bbb19b2512b940f79c8c696e0737424",
+   "sha256": "1cf76mllnm43wndzl26rrlfg2bc7r2a0ig6v9lm41nil9x6simsm"
   }
  },
  {
@@ -10120,8 +10151,8 @@
   "repo": "cask/cask",
   "unstable": {
    "version": [
-    20220504,
-    1421
+    20220605,
+    2031
    ],
    "deps": [
     "ansi",
@@ -10132,8 +10163,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "2eb520e64c2e1047319761df0bcc6fa5149f8cd6",
-   "sha256": "1fg8c8wksban6kblrdsp008ga8srhyp7dbhzbk46dgmprvwmxbwn"
+   "commit": "f2c6609590380bf4791fa18b7581ed6a8db2cbbb",
+   "sha256": "1zvibg876q5zi7fh72wfl6avskgvvn4az75gjc3bkdckv9rpy43a"
   },
   "stable": {
    "version": [
@@ -10283,11 +10314,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20220330,
-    1021
+    20220515,
+    435
    ],
-   "commit": "352ebf62099e95cb4a71060a7d4a228f00358b97",
-   "sha256": "01qh2q0vlgpni66mks4xzvdzm22yq314n5n4jx20bdknbhlvb8rq"
+   "commit": "784684c54a0d94c4a1cff8a69fcbdcd5d916e0a5",
+   "sha256": "0f7nm16fmb9chpc1cii4y035ykhq5mhbzq0m9xp0hdi7pjmarf3l"
   }
  },
  {
@@ -10563,8 +10594,8 @@
     20200507,
     1529
    ],
-   "commit": "4093821cc9759ca5a3c6e527d4cc915fc3a5ad74",
-   "sha256": "0r6dzhhlpbkh2n9dmb7iyd78b5rsnkxhk84wm0kgqjy541gfvbhk"
+   "commit": "ebaeb80fba0bafdf6f95706308123dec2cf4b99f",
+   "sha256": "0rf6csfn3sprr4mlwq5gzl5di9xyhd4v46927vjhjj3k1qahvmpb"
   }
  },
  {
@@ -10631,6 +10662,30 @@
   }
  },
  {
+  "ename": "cern-root-mode",
+  "commit": "c4f2e661e24ff3320b45cbebbc51a7b45ce3520c",
+  "sha256": "18srgi3695j4dpbcwjfj1ccc1ppn0idv9y5skgyssnrin8s3cb3g",
+  "fetcher": "github",
+  "repo": "jaypmorgan/cern-root-mode",
+  "unstable": {
+   "version": [
+    20220531,
+    1304
+   ],
+   "commit": "0227ab66f67276d3142a95cfc858bf621f501346",
+   "sha256": "1h0kjf92qxvw0128igsj8x7qyxhdkcjvlcxa29hpl97ad774qqnq"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    4
+   ],
+   "commit": "2df8781df1d807bf522eb19ac7b03b4bfaeb89c0",
+   "sha256": "159q50m8sr4adw7czkq0mq6hq43svkk2psx0wnmmb1aa8ivhwyip"
+  }
+ },
+ {
   "ename": "ceylon-mode",
   "commit": "09cd1a2ccf33b209a470780a66d54e1b1d597a86",
   "sha256": "0dgqmmb8qmvzn557h0fw1mx4y0p96870l8f8glizkk3fifg7wgq4",
@@ -10664,8 +10719,8 @@
     20171115,
     2108
    ],
-   "commit": "0d98e5a6f0c08e2b1d2c8e96c3dfc7e619210f72",
-   "sha256": "1i5icnrvfi83kxf4n6a83aksllnaddb653kcjnmg3n70q5mffavf"
+   "commit": "798512dd6a94abd432e9f1712147a39f623ea718",
+   "sha256": "1bg2dzr8bqwg3y78r9smllx6bji4gyl3hbbp08ff7q0va0b9zmnd"
   },
   "stable": {
    "version": [
@@ -10820,8 +10875,8 @@
     20220318,
     1007
    ],
-   "commit": "0a526709f55f8074f8846f8e7b9090431f1d6a47",
-   "sha256": "118pc03zpv9c7haxvmf4xkd6lby7xrxsal6pwq5lw5sw840g1nhr"
+   "commit": "c44b4e950af73dd82805181da5473db2c93e2eaf",
+   "sha256": "0jbpl17f5jdil9slv92ldvq4b60zpgr60cv0rk4qf3nwm4ijpk21"
   },
   "stable": {
    "version": [
@@ -10868,8 +10923,8 @@
  },
  {
   "ename": "chapel-mode",
-  "commit": "f84c693e9e90069b028be6149dd730f2ba5f4aff",
-  "sha256": "0yi1xjm1myxywjdb3n1505mz7vnylrvpd067aibjc4vgq0gqvq6f",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1a870d100d9x2lnb9c4lc6b2g912pznw784fyv0rhk7jq5jkafa5",
   "fetcher": "github",
   "repo": "damon-kwok/chapel-mode",
   "unstable": {
@@ -11110,8 +11165,8 @@
     20210601,
     1653
    ],
-   "commit": "ae36c823ca151f1dc6144ec96b2f5e98181c0dbb",
-   "sha256": "1n01h4lwfcm0skf0pgh7p87bmk4x3r6qsr5jcgm1ldafsx35x60g"
+   "commit": "af591400c55dc2a427a85cbca28e3f9b5361f14b",
+   "sha256": "0qgwvnqldbf9w95vbm6spkzx6x07hvlhkdky4vicakikh1g0zmwc"
   }
  },
  {
@@ -11125,8 +11180,8 @@
     20210713,
     1551
    ],
-   "commit": "05fc1449db497e715b33b8e08359fa17c3148c7b",
-   "sha256": "16sdhias8ws93lhfhbf5hm05gff1r3imphk7gdziy51xfgyml619"
+   "commit": "151594b11fa6555c73b998ed1f15ee9b5f979f67",
+   "sha256": "1f4fas6z2d7zn505nmnlgv4b66k495zq3358php44jblhc1vrg8v"
   }
  },
  {
@@ -11218,8 +11273,8 @@
  },
  {
   "ename": "chinese-word-at-point",
-  "commit": "c9b7785eca577218feade982c979694389f37ec3",
-  "sha256": "0pjs4ckncv84qrdj0pyibrbiy86f1gmjla9n2cgh10xbc7j9y0c4",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "05h047nzy2v0d6lxsm2f6jqkp51j6h4b517q4wkxwkiw0a9q4p5v",
   "fetcher": "github",
   "repo": "xuchunyang/chinese-word-at-point.el",
   "unstable": {
@@ -11329,22 +11384,22 @@
  },
  {
   "ename": "chronometrist",
-  "commit": "1cead898505916ff42bbc5c2d978df55dc09da69",
-  "sha256": "1nvgbddhci7bpznq2s3yakk3qpd1f8fzskrf3klnc88d5v6xj3qi",
+  "commit": "4f3fa2076ce777618f2982a7ba69b497d68aebc3",
+  "sha256": "10hab6h4pjgkldq0qlsyr69hq40g9hfsmhaxngfjl4yra355zr6b",
   "fetcher": "git",
-  "url": "https://tildegit.org/contrapunctus/chronometrist.git",
+  "url": "https://codeberg.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20220415,
-    1213
+    20220604,
+    344
    ],
    "deps": [
     "dash",
     "seq",
     "ts"
    ],
-   "commit": "f7b2defceed8bafb87da704ce3e7774f53abf1c4",
-   "sha256": "176imva32l766llrj4171r7bb3z5isvprrr5cl28cm41vqg4szfx"
+   "commit": "b80d6ac5b661a90e84ab84bad9badb596c1d1965",
+   "sha256": "01sdf2w73zapjv1x1dcasy16qs2nsnya3xz5q5avpi5gvmrarb36"
   },
   "stable": {
    "version": [
@@ -11363,10 +11418,10 @@
  },
  {
   "ename": "chronometrist-goal",
-  "commit": "d5c27f29f3ab4633e6a1d69b3a82e47ba216bf39",
-  "sha256": "05z9jwjf9py0bfxgilh2x05pqjyg9zamf4zl6s6fb7fiz7mfm9k5",
+  "commit": "4f3fa2076ce777618f2982a7ba69b497d68aebc3",
+  "sha256": "0wd64bz1qfwqzfkj2yf0sxwvakmych1h4rhakjqixvjpx75nm658",
   "fetcher": "git",
-  "url": "https://tildegit.org/contrapunctus/chronometrist-goal.git",
+  "url": "https://codeberg.org/contrapunctus/chronometrist-goal.git",
   "unstable": {
    "version": [
     20210510,
@@ -11382,10 +11437,10 @@
  },
  {
   "ename": "chronometrist-key-values",
-  "commit": "1cead898505916ff42bbc5c2d978df55dc09da69",
-  "sha256": "0xh06qd76na7vxr4v8v5nn37vq4v3v6cbbyzvrbg90nmkki0hhwr",
+  "commit": "4f3fa2076ce777618f2982a7ba69b497d68aebc3",
+  "sha256": "17fjmdgm8n9za3mwkahqhvz1d69lwhc7yqqryx16myn4kyg0i835",
   "fetcher": "git",
-  "url": "https://tildegit.org/contrapunctus/chronometrist.git",
+  "url": "https://codeberg.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
     20220414,
@@ -11394,8 +11449,8 @@
    "deps": [
     "chronometrist"
    ],
-   "commit": "f7b2defceed8bafb87da704ce3e7774f53abf1c4",
-   "sha256": "176imva32l766llrj4171r7bb3z5isvprrr5cl28cm41vqg4szfx"
+   "commit": "b80d6ac5b661a90e84ab84bad9badb596c1d1965",
+   "sha256": "01sdf2w73zapjv1x1dcasy16qs2nsnya3xz5q5avpi5gvmrarb36"
   },
   "stable": {
    "version": [
@@ -11412,10 +11467,10 @@
  },
  {
   "ename": "chronometrist-spark",
-  "commit": "14000772028841fc06aa3baf3545ea193d5705c6",
-  "sha256": "04gm5srg62zb80av5b5i2k1d790cf9xb6zn0bisf7l4i7cvjxafk",
+  "commit": "b4de903fe96f70798f0c5668c9845eb78907e50b",
+  "sha256": "1kkvwk964sddzw6wmlvfcqfaazzhikjkynbhrzffy6qacfbi5rsv",
   "fetcher": "git",
-  "url": "https://tildegit.org/contrapunctus/chronometrist.git",
+  "url": "https://codeberg.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
     20220321,
@@ -11425,8 +11480,8 @@
     "chronometrist",
     "spark"
    ],
-   "commit": "f7b2defceed8bafb87da704ce3e7774f53abf1c4",
-   "sha256": "176imva32l766llrj4171r7bb3z5isvprrr5cl28cm41vqg4szfx"
+   "commit": "b80d6ac5b661a90e84ab84bad9badb596c1d1965",
+   "sha256": "01sdf2w73zapjv1x1dcasy16qs2nsnya3xz5q5avpi5gvmrarb36"
   },
   "stable": {
    "version": [
@@ -11498,8 +11553,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20220507,
-    1357
+    20220531,
+    616
    ],
    "deps": [
     "clojure-mode",
@@ -11509,14 +11564,14 @@
     "sesman",
     "spinner"
    ],
-   "commit": "69d374818bd0af1489ee8828b258c689ccc24a66",
-   "sha256": "0r585myfkdsqrmd7fydbfdakwsfh4wq4bkjgngyag8mkam88ms16"
+   "commit": "b9e1cc26e2afda003a4b6c1f2a26e04f1c45f3d0",
+   "sha256": "15a9khkd21dfrw9r435x46533cs3246l1dgjg86cvkgjjhl21f9z"
   },
   "stable": {
    "version": [
     1,
     4,
-    0
+    1
    ],
    "deps": [
     "clojure-mode",
@@ -11526,8 +11581,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "b2cee7fc301735b403920583cc2c23dcf70990a3",
-   "sha256": "08gj8nm6qjjgn75aijhkbdhpwfd1qx6fy2c77m8ca99pbqvabmcq"
+   "commit": "11156e7b0cab470f4aab39d3af5ee3cb1e0b09d0",
+   "sha256": "08635ln514nrglx6qyhaq1x7y7lw4mcd659ba8zs071yjiariarm"
   }
  },
  {
@@ -11662,8 +11717,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "794821e129ea47b04fdeedc61d9ccb3c4240c72d",
-   "sha256": "0yvh3f165j3i4qk4qixk7xnqvfckz4dh5z7sdm3940f3wgk2g2mv"
+   "commit": "2f33f991c726d5214d6a17bbbd19836302a8e423",
+   "sha256": "0jpq67q7vhmgvsjh4qqk5lb40w9rkdr2v8bd5gh32k8wkbgykpgg"
   },
   "stable": {
    "version": [
@@ -11730,14 +11785,14 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20220421,
-    1956
+    20220526,
+    1206
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "710f057fedae6e9b820cce9336fef24b7d057e4c",
-   "sha256": "0lrxd4hanaxj85nafsc0wss677slmyaks3qb7a95mj7vic3ib937"
+   "commit": "41cdc116b09818d33f5cb0fc1d72c025c23aa2f1",
+   "sha256": "0hmclqaagnqvyvxb93vi1qdyvqm53hsyjyv1b4zh79hwzvn6s8g3"
   },
   "stable": {
    "version": [
@@ -11802,35 +11857,36 @@
  },
  {
   "ename": "citar",
-  "commit": "b2aa35ca3930920d61e50dd75394f70ccd1c737b",
-  "sha256": "0x66iwimvrihyxs5h816f2k2f2wgdn1kmiahvh5nfff6kx1xdplj",
+  "commit": "d96246c6f08d0ab2ccd2b04222e304c7ab8914ca",
+  "sha256": "1arf0fki9by8zx12vgdj1jvvaz9sq32jn9yv6xb2qkx5pzg4sw6j",
   "fetcher": "github",
-  "repo": "bdarcus/citar",
+  "repo": "emacs-citar/citar",
   "unstable": {
    "version": [
-    20220509,
-    2336
+    20220602,
+    2157
    ],
    "deps": [
     "citeproc",
     "org",
     "parsebib"
    ],
-   "commit": "9a6fc6da11ad2b475244cc4cbd51c77615e9aad3",
-   "sha256": "0q1hl8xsqb64lx10kcc4az3azaa8j3zly3pkf3lixh0qrc74bil2"
+   "commit": "1976f2938b3fc2ebb963429dce78f2372edb483c",
+   "sha256": "0fdasl6nzrp8q29njda5z4x79fjlfigjyx4xxgpq0wkq41kw3zy0"
   },
   "stable": {
    "version": [
     0,
-    9
+    9,
+    5
    ],
    "deps": [
+    "citeproc",
     "org",
-    "parsebib",
-    "s"
+    "parsebib"
    ],
-   "commit": "348ffb9853e04fbe3e0cbc25185236ecf65ccb35",
-   "sha256": "15jhpl2j4rm97cvvqzlfzxarvxvcsg64raz068psrsd2y7y2zh4c"
+   "commit": "d55cac7a2b8b848990ebd713de8667bf3fe93c6b",
+   "sha256": "04asi5gr4p1d8llra3qwly2jp1ll3zs0hjcysrrvdcax0jcr473b"
   }
  },
  {
@@ -11920,19 +11976,20 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20220427,
-    1203
+    20220523,
+    745
    ],
-   "commit": "87e2cbf3b2ae6d59ec919a2dcb38e56ccfa5ec14",
-   "sha256": "1wycbcwmls7lf1vn83pwfrb1bhxf8d5p7w25b1c9lrzq7l769i2k"
+   "commit": "1c0ca637c7993559a0175e3001941457b8c71211",
+   "sha256": "0ybv61akxv7nrxpc5zfjbbxrv8xs38sgrbsbslx2mqzcv9915q2i"
   },
   "stable": {
    "version": [
     0,
-    2
+    2,
+    1
    ],
-   "commit": "32b79a94db62194d96e73064ab804b7efa920795",
-   "sha256": "10lryjy3771hs8lavh7818a5ia9ia1qwrhzfmgr5sb4c0gn36wcg"
+   "commit": "1c0ca637c7993559a0175e3001941457b8c71211",
+   "sha256": "0ybv61akxv7nrxpc5zfjbbxrv8xs38sgrbsbslx2mqzcv9915q2i"
   }
  },
  {
@@ -12198,20 +12255,20 @@
   "repo": "redguardtoo/cliphist",
   "unstable": {
    "version": [
-    20210813,
-    750
+    20220525,
+    1034
    ],
-   "commit": "a794c95e2f70a9b042af7bd07e2483fde75f2a2e",
-   "sha256": "0rbgg6vrvsmjlgwq0v450g41qx4gx9ixx4j30aa4i78ryxz4d76r"
+   "commit": "d02b97a2aa0da13711d9a6f845649115de8ac11b",
+   "sha256": "05s8lqfbsq3m0k4fx3ap4506f3gnmsxb9lv8hc095i9xsk7mvaab"
   },
   "stable": {
    "version": [
     0,
     6,
-    2
+    3
    ],
-   "commit": "a794c95e2f70a9b042af7bd07e2483fde75f2a2e",
-   "sha256": "0rbgg6vrvsmjlgwq0v450g41qx4gx9ixx4j30aa4i78ryxz4d76r"
+   "commit": "d02b97a2aa0da13711d9a6f845649115de8ac11b",
+   "sha256": "05s8lqfbsq3m0k4fx3ap4506f3gnmsxb9lv8hc095i9xsk7mvaab"
   }
  },
  {
@@ -12456,8 +12513,8 @@
  },
  {
   "ename": "clocker",
-  "commit": "dadd3f5abad2e1f7863c4d654ff065f641395f64",
-  "sha256": "0cckrk40k1labiqjh7ghzpx5zi136xz70j3ipp117x52qf24k10k",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1gjp66pvmzkqb40js6nas5gr9pipw6qcq21z8wbb365k5jcswzlg",
   "fetcher": "github",
   "repo": "roman/clocker.el",
   "unstable": {
@@ -12485,6 +12542,40 @@
    ],
    "commit": "4a4831ed4e42e18976edd16b844cb16cb78f3c17",
    "sha256": "0hz6a7gj0zfsdaifkhwf965c96rkjc3kivvqlf50zllsw0ysbnn0"
+  }
+ },
+ {
+  "ename": "clockodo",
+  "commit": "7e69c0409dbe1fa03956027a549b651e652be9a5",
+  "sha256": "09aapriw3fp82m6cna1nsz6al8jd313r8zfpljr09jgqaagplx3z",
+  "fetcher": "github",
+  "repo": "santifa/clockodo-el",
+  "unstable": {
+   "version": [
+    20220604,
+    2049
+   ],
+   "deps": [
+    "org",
+    "request",
+    "ts"
+   ],
+   "commit": "6329aaebc4373edaa4cd1d046582a4cc36db4888",
+   "sha256": "03n11mr39wj3nyabs24l5caqbzc7lm0wp4wazcsrsxwm7pij9vrs"
+  },
+  "stable": {
+   "version": [
+    0,
+    8,
+    0
+   ],
+   "deps": [
+    "org",
+    "request",
+    "ts"
+   ],
+   "commit": "6329aaebc4373edaa4cd1d046582a4cc36db4888",
+   "sha256": "03n11mr39wj3nyabs24l5caqbzc7lm0wp4wazcsrsxwm7pij9vrs"
   }
  },
  {
@@ -12912,17 +13003,17 @@
     20220322,
     1258
    ],
-   "commit": "a1c61a7e1a9f7a019809010e097f1e4c42c50022",
-   "sha256": "1qabbyqn450lhb5f1kaxqwv37fc9ahj89rka5c374kgzscjgjdna"
+   "commit": "aaf5353c47965cae7e12aa03884be3ae67e9b09a",
+   "sha256": "00201mylx581g4q2j81v4x39x2axx5xq7himpk9ywxpvygh1r0dv"
   },
   "stable": {
    "version": [
     3,
     23,
-    1
+    2
    ],
-   "commit": "efe08e289466683b0945a5396f6848064dec5ae0",
-   "sha256": "1sm70am8h6fxbpxv7ky2vnx394i3qvg0vl215hg2lqaf9p9ll0ld"
+   "commit": "a8bd06dfd47a56e09e660de5e58f26579105d2d4",
+   "sha256": "09kk81nd4m6p07k7rwg2cfjv2rrwcmkmsz6xi58milq2byqw1n3j"
   }
  },
  {
@@ -12984,8 +13075,8 @@
  },
  {
   "ename": "cnfonts",
-  "commit": "0d5787ffeeee68ffa41f3e777071815084e0ed7a",
-  "sha256": "1pryn08fkdrdj7w302205nj1qhfbk1jzqxx6717crrxakkdqmn9w",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "026jayflpi4k0xydh9farn2b5ap6gc8bnj31pdnx7hb0hr4svzjc",
   "fetcher": "github",
   "repo": "tumashu/cnfonts",
   "unstable": {
@@ -13074,11 +13165,11 @@
   "repo": "astoff/code-cells.el",
   "unstable": {
    "version": [
-    20220305,
-    1320
+    20220606,
+    852
    ],
-   "commit": "8660bdeedee360e5eb632f1eb1356eb09d7dfbee",
-   "sha256": "0mvfsdlhc3znc0d2p8vm7apkbpvbs688wmwvd0sms33qly53f546"
+   "commit": "27ac22bc0be905f31abf8c09e63d371b0b0059d3",
+   "sha256": "1j704wncimabcydxazbllsqlp4wlh2mwv2zdf7kpcaychsw9990c"
   }
  },
  {
@@ -13574,8 +13665,8 @@
    "deps": [
     "s"
    ],
-   "commit": "fa85a6b9d852d725730a6ad1cc5afeb4ede93ca7",
-   "sha256": "1xmr4gxj3k4vy654270jgs3x8nv72q4hyk7q8zixycnymbqvby5f"
+   "commit": "902b30b6577ffd14d8b5169c85249033581c4f1a",
+   "sha256": "03nildwfjrbkcp25whbcklgm4gaqbwj6c65j1ngmykd2a1l1ghw7"
   },
   "stable": {
    "version": [
@@ -13861,14 +13952,14 @@
   "repo": "ddoherty03/commify",
   "unstable": {
    "version": [
-    20210904,
-    1106
+    20220531,
+    1301
    ],
    "deps": [
     "s"
    ],
-   "commit": "d6656bd3a909917a51ba033a11d4ab5f5fe55f83",
-   "sha256": "1zbk2nc1qnryapsj68hlqmkn0ab7llzpmnls6y3s2656lxcn2b0k"
+   "commit": "c4aeccae5b4a073fc3f4e8bd780a2ebbb7d5e533",
+   "sha256": "0ph5z31hibsjy6711gwfxa1qmlyyg3fh3wvgsafsgnkg6mlf2h3h"
   }
  },
  {
@@ -14051,8 +14142,8 @@
     "axiom-environment",
     "company"
    ],
-   "commit": "b52fa715285e7ad182c8e679ebf05b130dd5b5e2",
-   "sha256": "1hb4npfpg1iy9j0p29q1jrjgx0mrn333m45nmsnxw8nlaxzd97x6"
+   "commit": "847cc6e728b692ad3fdaec28d0c8c49ec0378a56",
+   "sha256": "02nf2vn6s6pc63yw2rggdx9capn9432w6j56m9v0c5ygarpxb53p"
   }
  },
  {
@@ -14367,8 +14458,8 @@
     "emojify",
     "ht"
    ],
-   "commit": "6f095b419468b0443e1dcd8537ef4b84092f155c",
-   "sha256": "1ssjzhbngb5v7wzh40zzh1j0pfzv0paqync8jvd0diwaz983rwzx"
+   "commit": "464b0a8e877ef2c80180336be4afe0d8c0b4c72d",
+   "sha256": "0cdp159qk4cq1fbqymh3v4sjnkj1ijk9x0picj6fqqr7wnqn1gwa"
   },
   "stable": {
    "version": [
@@ -14471,8 +14562,8 @@
     "ht",
     "s"
    ],
-   "commit": "e2e8a39976506cbf149f9c62a69c7a438be09579",
-   "sha256": "1lra119f4bbx6rhpm118yml6qnqy7s1lj2w1dnm8vbl68r255zyp"
+   "commit": "1f9c92a27bbf50783275a16dd3988666d1ecb023",
+   "sha256": "1c4bh80gwrdvy98xm92g7qqvi5lnaki5y4ng317px0zg3frj1i24"
   },
   "stable": {
    "version": [
@@ -14824,8 +14915,8 @@
     "maxima",
     "seq"
    ],
-   "commit": "ce5fd160c193e387d9e2bacdba4065c4b4262cb1",
-   "sha256": "18bjr4n1m1y76kh0pp6ci7ywklrmw611ka3avrj23lb0wwrljf86"
+   "commit": "1334f44725bd80a265de858d652f3fde4ae401fa",
+   "sha256": "1h1lqrl3p9qgkicds8v44vdry19g53rya56hdj3cz5q8xj1nisn1"
   },
   "stable": {
    "version": [
@@ -15167,27 +15258,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20220509,
-    2300
+    20220601,
+    1652
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "c05f8a43c6ff07a8b5a3ba8df7a2ec35677b7484",
-   "sha256": "0752dyl4fhi0jvbm238s5p1sv7z4jlkmkdrxvwn0dlhfr0rhfw1c"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   },
   "stable": {
    "version": [
     5,
-    2
+    2,
+    1
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
-   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   }
  },
  {
@@ -15256,8 +15348,8 @@
     "company-quickhelp",
     "popup"
    ],
-   "commit": "75a2f5c7669833646fc653cabd531737b52fb469",
-   "sha256": "0zkjicfa5dlzq2834p70ks3mr48086lf0dlr0r5df7jrw8wrw8c9"
+   "commit": "a34e0d8c7eca37e99c135e4b7fa5aaff8a15f576",
+   "sha256": "0l9syc32jsx75jhkphbv506gmilvl3vianja8f732wj3y694bnza"
   },
   "stable": {
    "version": [
@@ -15381,8 +15473,8 @@
  },
  {
   "ename": "company-shell",
-  "commit": "bbaa05d158f3806b9f79a2c826763166dbee56ca",
-  "sha256": "0my9jghf3s4idkgrpki8mj1lm5ichfvznb09lfwf07fjhg0q1apz",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1j918rbgxs7jclmd6qqgwrxi8djdpcl796wn700ky5jijhahjalp",
   "fetcher": "github",
   "repo": "Alexander-Miller/company-shell",
   "unstable": {
@@ -15844,11 +15936,11 @@
   "repo": "paldepind/composable.el",
   "unstable": {
    "version": [
-    20201024,
-    1458
+    20220608,
+    1148
    ],
-   "commit": "6f2efaa7018feb854720cc2518e4274ad708f793",
-   "sha256": "101shj0z8piww7idb6ha67synhw12x1lwgp3w48w1khrcw43zq7f"
+   "commit": "205a69c64ea95ef67070423c31ed70ec44ec980c",
+   "sha256": "0wlqfdiab60ciznrl9ny4rspva7xdwl8w9k8jxd2gpcb11fy1nn0"
   },
   "stable": {
    "version": [
@@ -15952,8 +16044,8 @@
   "repo": "necaris/conda.el",
   "unstable": {
    "version": [
-    20220315,
-    1533
+    20220604,
+    1727
    ],
    "deps": [
     "dash",
@@ -15961,14 +16053,14 @@
     "pythonic",
     "s"
    ],
-   "commit": "9c28d7a853b4b4bd00215cf7f07856c1563f2ad7",
-   "sha256": "03r9f2pvxxv6nlxgljnd5cmnlvsykypdl38cfi79iw3spr0lcrxn"
+   "commit": "e4154db0dbfb7faf46b645eddfaad9326e4ea18d",
+   "sha256": "1ily4abrn85fwy90hfm1nq9kwazb80amdgx4disaa2s62yx6k62j"
   },
   "stable": {
    "version": [
     0,
     0,
-    11
+    12
    ],
    "deps": [
     "dash",
@@ -15976,8 +16068,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "78e1aad076f6cefc6aa7cc77d08e174b13050994",
-   "sha256": "02l9m5wx0z865w3cdwbw7c22fmdjbsw4svivqg72nbl7yrq7rv5v"
+   "commit": "e4154db0dbfb7faf46b645eddfaad9326e4ea18d",
+   "sha256": "1ily4abrn85fwy90hfm1nq9kwazb80amdgx4disaa2s62yx6k62j"
   }
  },
  {
@@ -16116,22 +16208,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20220508,
-    928
+    20220603,
+    1902
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1dfdf55f3d941f08089e5d0e611cd9daa8a44b19",
-   "sha256": "1hsxavf55xmy91xmv8yh6fb4aphv6sv947hs35ghvfm5s74sk47v"
+   "commit": "b816d1c42f420411c31fe0968ddc868aa2186de7",
+   "sha256": "014sbc3d2w7p5a8jsyag7qxlmixvs7zycpdrylxxbs9gkivfyyxw"
   },
   "stable": {
    "version": [
     0,
-    17
+    18
    ],
-   "commit": "f517b70dd8a3be0b8c883633f2a7721448b40f0f",
-   "sha256": "08l3h7b5j1q9nwcq660667b245qspl20ikhfdvd9k3g3n2p6p5kz"
+   "deps": [
+    "compat"
+   ],
+   "commit": "0f55ad146b327d82a4a6dfa674349bfbbf3820e4",
+   "sha256": "0sy4rn1vjk1g50r8z14hzj8lds6s7ij2zkjqfi6mfash5il75wnq"
   }
  },
  {
@@ -16250,8 +16345,8 @@
  },
  {
   "ename": "consult-flycheck",
-  "commit": "5a141c728f28e53b9f92ccbbff07c2af1dde3706",
-  "sha256": "1cwbm7qsni8ycasx2v20yd1749lmlhf98kz28i1p8m0yqkjc3my0",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "12zwy7jwbg7njm009c1rns0q382rv5lmbzjb4giy4wwwpjg3nfgf",
   "fetcher": "github",
   "repo": "minad/consult-flycheck",
   "unstable": {
@@ -16388,15 +16483,15 @@
   "url": "https://codeberg.org/jao/consult-notmuch.git",
   "unstable": {
    "version": [
-    20220421,
-    717
+    20220513,
+    1647
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "16eb2c100ca144140f07014c32e99487c6a73e18",
-   "sha256": "0ynla60n7aksp8fqikpsxv45li68ccgklr3xq601z3zyiyjg54a2"
+   "commit": "4138855cddee0ef126cff6a5fc5ca9c49fd2682d",
+   "sha256": "1wqp0pp408bxywxzq3gk1hk5vr19k4vsz5b979b4gbk89i1gxamb"
   },
   "stable": {
    "version": [
@@ -16462,8 +16557,8 @@
  },
  {
   "ename": "consult-projectile",
-  "commit": "ba7bac7fc95ba11094d3ad64d658be0ec7a16817",
-  "sha256": "03v8srjc8glybfmnfh9nwxz9fkvkrbyji19xvglzl0cy4dwivca9",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1yic707260ld5l1i8ll7sxpz07835hsn0ka4q670zpygazy3jiy0",
   "fetcher": "gitlab",
   "repo": "OlMon/consult-projectile",
   "unstable": {
@@ -16548,10 +16643,10 @@
  },
  {
   "ename": "contextual",
-  "commit": "de20db067590624bbd2ca5a7a537b7f11ada84f2",
-  "sha256": "1xwjjchmn3xqxbgvqishh8i75scc4kjgdzlp5j64d443pfgyr56a",
+  "commit": "7325c1a705d07d6916d55a1fc2bb7012e22504fd",
+  "sha256": "0zsyshy2n17zmk3l2shpd4ci9l0xwyx3bmv0psqlpcd0zcjdsfdv",
   "fetcher": "github",
-  "repo": "e-user/contextual",
+  "repo": "outergod/contextual",
   "unstable": {
    "version": [
     20180726,
@@ -16819,14 +16914,14 @@
   "repo": "galeo/corfu-doc",
   "unstable": {
    "version": [
-    20220429,
-    1348
+    20220606,
+    1654
    ],
    "deps": [
     "corfu"
    ],
-   "commit": "5a6f4f879de6dc2ca6e22789878d416e88e85905",
-   "sha256": "1rvymrs2vgcqr05xij719fyv5hd3bi34f8aragcabbiwbmjfhz7z"
+   "commit": "616a2a9fc6fb3222ea2273435ddbc63eba72670d",
+   "sha256": "0hkcpwkwz9ls2yawlpi2zx2zvrggyqc5qrnl1q4fc3dajnkl1gy4"
   }
  },
  {
@@ -16907,15 +17002,15 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20220402,
-    953
+    20220529,
+    1130
    ],
    "deps": [
     "ivy",
     "swiper"
    ],
-   "commit": "8bf8027e4bd8c093bddb76a813952d2a0dcbf21d",
-   "sha256": "1rdv8r6zw0lziycwv5kd2yyflfwby4gnqgfvv67b1y2l3psjwp94"
+   "commit": "f8d80a4055514f92d94f128f5fcb1cda79e5cd22",
+   "sha256": "1cmafp5rssp27lhvszyzf4mc1z130kkgkl9d36lgg97qk5jp58g8"
   },
   "stable": {
    "version": [
@@ -17145,26 +17240,26 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20220405,
-    510
+    20220526,
+    1436
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "c74ae94297c4a2dc0b6878c2e9460a4f386158d4",
-   "sha256": "01a11dij88ysnrpmrs0flc9m43mlbc41zcahwmaqdp58rvgc24ji"
+   "commit": "05d364b556aadcfe49df727c0729abc3f0c14372",
+   "sha256": "1v77lpp0nij1rjg2k9wj42kqk7xqg1dzs9vmadha6f2j8j6375m8"
   },
   "stable": {
    "version": [
     1,
     10,
-    0
+    1
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "dc7b9f9b381dffd19c79cb7ee53b79034590d309",
-   "sha256": "1zmx7vfi02c8k9wnbsmka5yx3ci8fv9wl8r0cc28jn40vgrivn8c"
+   "commit": "05d364b556aadcfe49df727c0729abc3f0c14372",
+   "sha256": "1v77lpp0nij1rjg2k9wj42kqk7xqg1dzs9vmadha6f2j8j6375m8"
   }
  },
  {
@@ -17175,14 +17270,14 @@
   "repo": "CsBigDataHub/counsel-fd",
   "unstable": {
    "version": [
-    20210606,
-    1724
+    20220514,
+    2227
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "e9513a3c7f6cdbdf038f951e828e631c0455e7d4",
-   "sha256": "005l1is12jq35nn1ap87a7p74qin26zpgbk599619lh9vai157ww"
+   "commit": "c1ba2e36fe69111e7f6f42ea1b0e3b7a45d96de0",
+   "sha256": "1jpaknp9v9xyxqs9gkm9v1ylwp9pn2smla9zk4qk49i6ff5db6dd"
   }
  },
  {
@@ -17782,26 +17877,26 @@
   "repo": "emacsfodder/emacs-theme-creamsody",
   "unstable": {
    "version": [
-    20170222,
-    1058
+    20220527,
+    927
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "32fa3f4e461da92700523b1b20e7b28974c19a26",
-   "sha256": "01q1l8ajw6lpp1bb4yp8r70d86hcl4hy0mz7x1hzqsvb7flhppp0"
+   "commit": "4e1f00a590628034282a914d483fd6008a76c8f8",
+   "sha256": "0yw40fmisw5wby45pk4jblpshj1vsdhs43d7b25xpvjc6l0j5jz4"
   },
   "stable": {
    "version": [
     0,
     3,
-    7
+    14
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "32fa3f4e461da92700523b1b20e7b28974c19a26",
-   "sha256": "01q1l8ajw6lpp1bb4yp8r70d86hcl4hy0mz7x1hzqsvb7flhppp0"
+   "commit": "4e1f00a590628034282a914d483fd6008a76c8f8",
+   "sha256": "0yw40fmisw5wby45pk4jblpshj1vsdhs43d7b25xpvjc6l0j5jz4"
   }
  },
  {
@@ -17866,8 +17961,8 @@
  },
  {
   "ename": "creole",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "1q1c6f953g39xal1p7rj8dlcx2crk5cz1q07zp8bgp5jx4nd2z9n",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "12z7vhdqqjnwilm95hjd4ad07dwkcwcqgi6y9fwkq4jmsshpsf5c",
   "fetcher": "github",
   "repo": "nicferrier/elwikicreole",
   "unstable": {
@@ -18138,8 +18233,8 @@
  },
  {
   "ename": "csound-mode",
-  "commit": "b46e83f2ea2c4df1ef343c79c7e249605c9639b3",
-  "sha256": "0fpfgk5s45w69sxd1vmd8irb518x07hqfq6cmlm2ahpnsdljd1v3",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "19gsq761ahblikv5l5y70alh0f0pc29b1shqpqd5nxm4q34p4qk9",
   "fetcher": "github",
   "repo": "hlolli/csound-mode",
   "unstable": {
@@ -18285,15 +18380,15 @@
   "repo": "neeasade/ct.el",
   "unstable": {
    "version": [
-    20210219,
-    1344
+    20220514,
+    2027
    ],
    "deps": [
     "dash",
     "hsluv"
    ],
-   "commit": "c302ee94feee0c5efc511e8f9fd8cb2f6dfe3490",
-   "sha256": "0230h5qvg5jbpyry4xxmh41c0wpinmm04k5hc1qsc2mvqhv3n9n5"
+   "commit": "6bc55d01780fa921ced0e648d04497e27e23fe54",
+   "sha256": "03yfk0kwckb6gpp9ndnb9i1vcvx61wcy30jg35zkyfd2h93vjnp2"
   }
  },
  {
@@ -18369,19 +18464,19 @@
   "repo": "radian-software/ctrlf",
   "unstable": {
    "version": [
-    20220509,
-    2344
+    20220601,
+    1649
    ],
-   "commit": "d37d7a997e1e3ef5e2223aeecbbef92f369b0760",
-   "sha256": "1lfd20xknpxxb9qiqhj9mqabsgibzdkhf335mm4vl9jvgim6j7vs"
+   "commit": "cefb0aff9d316bd03e911f7f483f8d01f15cf5a2",
+   "sha256": "19kh2h2bbk43hwzmz57jzhq20d8rq7pfzfisq3by3ckrwb1vrvax"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
-   "commit": "282eaa836d2198bb5947dfd3c454ae5305f55efb",
-   "sha256": "04w708g7d1pnsc18h8fjyqkhk08jkq853alaidriamxyycvdwk0i"
+   "commit": "495b9bc1002d27356929c101c458e69e4201e214",
+   "sha256": "1nd1yk86s0dyf87q77dg724f6629p270q3ar85jgp8gclw5plvyz"
   }
  },
  {
@@ -18458,8 +18553,8 @@
  },
  {
   "ename": "cubicaltt",
-  "commit": "1be42b49c206fc4f0df6fb50fed80b3d9b76710b",
-  "sha256": "1wgy6965cnw201wx4a2pn71sa40mh2712y0d0470klr156krj0n9",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "18x0i4m8zk10mvpx07nh56a6cknl97yja4hv0xzsiqrqmr0290rw",
   "fetcher": "github",
   "repo": "mortberg/cubicaltt",
   "unstable": {
@@ -18858,17 +18953,17 @@
     20211111,
     1407
    ],
-   "commit": "89591f7c85f6b8eb580ac8f3a00014f28c61a139",
-   "sha256": "0yj3i2jrajh33v0h6djlzsl5l5gb2958z365d1zjbabqxj202wg3"
+   "commit": "8e29b6d47f6f5b10ec1a37f06db440156ac2ac2e",
+   "sha256": "13vcbw8abqc92hq6cd9izr5fdq4zah3snd1c9ly8pr40gcfhwvdx"
   },
   "stable": {
    "version": [
     0,
     29,
-    28
+    30
    ],
-   "commit": "27b6709241461f620fb25756ef9f1192cc4f589a",
-   "sha256": "0k5wnrvnwq699mvvngraq5d93pyyiz77sn9dcqjrazc74b63sm8w"
+   "commit": "a6f04ef2430fb4e7383a068cd1ae9a115d7a78df",
+   "sha256": "141qywx4ym817lrpqis4x2i2bll0hcjljn1qfnn1dwmhmydhhkwx"
   }
  },
  {
@@ -18894,20 +18989,20 @@
   "repo": "Emacs-D-Mode-Maintainers/Emacs-D-Mode",
   "unstable": {
    "version": [
-    20210119,
-    1853
+    20220601,
+    1949
    ],
-   "commit": "199743df55c6bfce3cdb08405bd8519768c8dfa9",
-   "sha256": "18jzrql5g2sd322w25phws7d1v8906lyc0ipn6cknlrv4pjmdazv"
+   "commit": "024aca97d07e72bf3500fb6bf0cdf50c4992a741",
+   "sha256": "0mwd412d2kha8avkyhvvkh8r7an859xk18f7phgx7kj989pr3xkr"
   },
   "stable": {
    "version": [
     2,
     0,
-    11
+    12
    ],
-   "commit": "cfd1d0869d51b7548b3fb738b2f2593c76533d44",
-   "sha256": "0vkl470vvmxap8ca773a0jvjvalmvdbbax3qvgjdclp54ml75al4"
+   "commit": "024aca97d07e72bf3500fb6bf0cdf50c4992a741",
+   "sha256": "0mwd412d2kha8avkyhvvkh8r7an859xk18f7phgx7kj989pr3xkr"
   }
  },
  {
@@ -19066,8 +19161,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20220512,
-    513
+    20220518,
+    629
    ],
    "deps": [
     "bui",
@@ -19079,8 +19174,8 @@
     "posframe",
     "s"
    ],
-   "commit": "52ac284dafff3fbae561d1743b73131339421d76",
-   "sha256": "112qpba47csbhqha4y3vlccgzm14x7x522r2n1p9q4ssknn7va4i"
+   "commit": "67fd9e5d4e157e72b09ab34daca67619cb98c673",
+   "sha256": "0ggi7bcx7pmvdlngkv4spbbcb912ih8pn2d57395sx4iykkswyry"
   },
   "stable": {
    "version": [
@@ -19327,11 +19422,11 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20220417,
-    2250
+    20220607,
+    1100
    ],
-   "commit": "7fd71338dce041b352f84e7939f6966f4d379459",
-   "sha256": "1q2p51348bpg35h9c9cg21k27c7svh52qvi6zlslvnig7wcx662s"
+   "commit": "0c49a33a61c739eb12e4c3680138c1659926202d",
+   "sha256": "0wv0hkifzn8qmwa5pxs6lc2dywc0pc6wyfcf13kvjhnj7md4wplh"
   },
   "stable": {
    "version": [
@@ -19406,8 +19501,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "7fd71338dce041b352f84e7939f6966f4d379459",
-   "sha256": "1q2p51348bpg35h9c9cg21k27c7svh52qvi6zlslvnig7wcx662s"
+   "commit": "0c49a33a61c739eb12e4c3680138c1659926202d",
+   "sha256": "0wv0hkifzn8qmwa5pxs6lc2dywc0pc6wyfcf13kvjhnj7md4wplh"
   },
   "stable": {
    "version": [
@@ -19430,11 +19525,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20220409,
-    620
+    20220526,
+    738
    ],
-   "commit": "0a86c0eabe6bb5e188e6ae915d971103248a3d26",
-   "sha256": "1ki4g5s4n2c4zvsk56w4ync2rrwbchz63ms68a2xjkmnihy83x90"
+   "commit": "34d1f97200055e6b521c131270d8322efc6c52be",
+   "sha256": "03mnvxv0rjnby56y67f5x44s4wcnn9vxzcq1gxkxxz14kn8k42kn"
   },
   "stable": {
    "version": [
@@ -19457,15 +19552,15 @@
   "repo": "hyakt/emacs-dashboard-hackernews",
   "unstable": {
    "version": [
-    20190109,
-    205
+    20220516,
+    1809
    ],
    "deps": [
     "dashboard",
     "request"
    ],
-   "commit": "b71814716d8f78181b9d1990f06072460de0797e",
-   "sha256": "1dvv10xn2mh0nh85cd78y23cn8p9ygdhj4k7xs4fa6r7bhp0xvqm"
+   "commit": "dd5f8ec998d7b7bf162b4eb72474b683b8aa0a14",
+   "sha256": "037gn5q12lfkgp5cz2v54zdk1pcwsw5kb8b6lgn7fg04dlrahm8i"
   }
  },
  {
@@ -19482,8 +19577,8 @@
    "deps": [
     "dashboard"
    ],
-   "commit": "f9e199a20c654c3d1d8f405fdec9acb294afc004",
-   "sha256": "0l0bylzd9r6cc04r1b5ky3dqshzc2k6j47hqini35ibk331dm804"
+   "commit": "cd7c32f972f653a665e64aadf9bb88ed9fc10d5e",
+   "sha256": "0jy63yqix10pkw79i3x48przzbmbh5dm1hjd6w72yfa7ln01c4q4"
   },
   "stable": {
    "version": [
@@ -19689,8 +19784,8 @@
  },
  {
   "ename": "db",
-  "commit": "79ac40439b65c217e1caaa7175d26556b6a6c889",
-  "sha256": "05jhga9n6gh1bmj8gda14sb703gn7jgjlvy55mlr5kdb2z3rqw1n",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0yb2kgaqw31sl7h7mpmack2s8m9w1qhrvhn78z8gzjf4xn8pln09",
   "fetcher": "github",
   "repo": "nicferrier/emacs-db",
   "unstable": {
@@ -19931,8 +20026,8 @@
  },
  {
   "ename": "decl",
-  "commit": "8c2ecd46180643a0c493e05ec86fe50bc1e55146",
-  "sha256": "0wdhmp226wmrjvjgpbz8ihvhxxv3rrxh97sdqm3mgsav3n071n6k",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0w2099qqs89lb1lyd7y10yz11akpcc7afk9xgap4ikgafh2mi9gy",
   "fetcher": "github",
   "repo": "preetpalS/decl.el",
   "unstable": {
@@ -20093,8 +20188,8 @@
     "s",
     "wiki-summary"
    ],
-   "commit": "51fd884c52faf61339aef3a3429fe91672b3e6a8",
-   "sha256": "10ch8ds5d27kry1ih2cwyp5pl2dlhwwfdsr0smpd1r23i74qlhmm"
+   "commit": "749d3fc788cb26032dd30e509596a8988b7b6a7d",
+   "sha256": "1c58v122k1qa5vv5f2fcway5qkcr8j8kbp6y8fz4b5nj9di8azj9"
   },
   "stable": {
    "version": [
@@ -20458,6 +20553,29 @@
   }
  },
  {
+  "ename": "detached",
+  "commit": "f3cbb8f0ec4406a862e1d0066d5c9868ab060391",
+  "sha256": "1sfd9mw39n62kib403bnlsbfsnbcfwbb1znj9yc9b4kfmw6q68sy",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~niklaseklund/detached.el",
+  "unstable": {
+   "version": [
+    20220603,
+    1446
+   ],
+   "commit": "24b925435c5fb7d5927fd4db5217fbfd4f8ed9c8",
+   "sha256": "0lvx39i879d8n5m3b2pgjpw7i0a6wlfr2zk3bfk6kjm1vcrhhaz6"
+  },
+  "stable": {
+   "version": [
+    0,
+    7
+   ],
+   "commit": "8402e7ef4574c719f114b15f89b4aecdddea1e1e",
+   "sha256": "160h60vrpxslw6y290ndc065cc75dab58aq7kjqash94vkifnii2"
+  }
+ },
+ {
   "ename": "detour",
   "commit": "010af7946b10ded846225a19d375434b5d9427a8",
   "sha256": "0w63vqlzkvx54y8y71gzzdyxzm4430bqfyapzyrzrsmxh773hnmn",
@@ -20480,11 +20598,11 @@
   "repo": "astoff/devdocs.el",
   "unstable": {
    "version": [
-    20220410,
-    1627
+    20220606,
+    1342
    ],
-   "commit": "4257e59dafbffb2616d240f84c5c25770ee28cac",
-   "sha256": "1ddzydqrgz2c12s24gy3c1gb2d9344z7ykxy2yn5gn6dzjynfnl9"
+   "commit": "d5d0cfbfbcd037ef8f84f41b2adc3f5a23baa11f",
+   "sha256": "1q81ddnvdsfmfas2sfkxzpcr51f8zmmwmig0p3i3hcc9jf1wviid"
   }
  },
  {
@@ -20525,14 +20643,14 @@
   "repo": "psibi/dhall-mode",
   "unstable": {
    "version": [
-    20200822,
-    258
+    20220519,
+    1115
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "ad259c8a2292fb398dff1ce7d25c686edb02945d",
-   "sha256": "1vp8cjkkiih7cz5d8kcpc2ysq3iz4wr5wi2lkkkhp94k04jl5h1r"
+   "commit": "c77f1c1e75b6d2725019c5275fc102ae98d25628",
+   "sha256": "0b0pahi122rnfqpjk2svdcyywka2md6sch609d0x7vqlpylk66dx"
   }
  },
  {
@@ -20697,11 +20815,11 @@
   "url": "https://codeberg.org/ideasman42/emacs-diff-ansi.git",
   "unstable": {
    "version": [
-    20220507,
-    1118
+    20220524,
+    18
    ],
-   "commit": "bfcce7f609a95b4b5e11c384c75fef8c7c972b95",
-   "sha256": "0gddzdx0f6l982ij9q2ljm9dbpjrwi12glxhqr599jnxnlcrxshn"
+   "commit": "7e493019234d468354758f7e60032a1fb379de44",
+   "sha256": "0ri50ralsbmi3j0fbrk0xspnyw7ivpjii59dd09791sgyycaakh4"
   }
  },
  {
@@ -20727,14 +20845,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20220506,
-    2102
+    20220515,
+    1714
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "14f2db367e8023ab0027713315a38ecd703afdbf",
-   "sha256": "0ciyg1g9sil1pvmd53r57gyds85f11457anjcfi96p4jjyjg9sxx"
+   "commit": "e84209e959a17c7b96148e099e391daa29a4835e",
+   "sha256": "1jjgdjlbpi8d5yb83143jhkb2v4375kvmxkn1q5v3wyqx0f21npx"
   },
   "stable": {
    "version": [
@@ -21089,8 +21207,8 @@
     20220218,
     1541
    ],
-   "commit": "3b3b24eb231af889b0eea50e6e0a20c2bca9c439",
-   "sha256": "0x2vx80rx8mcj1jf6p7qbf1sfy4zymnrbpkm1gzrs8k4jibmwyz7"
+   "commit": "29c33c7636195f12a10b241448df7eb6760536e1",
+   "sha256": "1x182g34y13is7x7z32dgrcpbhzyc2narmdl3m702zpnvpd96dn7"
   },
   "stable": {
    "version": [
@@ -21477,8 +21595,8 @@
  },
  {
   "ename": "dired-imenu",
-  "commit": "e346de86b7f7fd5dad548f0936cde54ac11e3f79",
-  "sha256": "09yix4fkr03jq6j2rmvyg6gkmcnraw49a8m9649r3m525qdnhxs1",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "07n2kgfva4alvwcn91fa2s79inc6gv1fsg80znvvpvjw7pf8zd8i",
   "fetcher": "github",
   "repo": "DamienCassou/dired-imenu",
   "unstable": {
@@ -21788,14 +21906,14 @@
   "repo": "jojojames/dired-sidebar",
   "unstable": {
    "version": [
-    20220413,
-    753
+    20220601,
+    1536
    ],
    "deps": [
     "dired-subtree"
    ],
-   "commit": "0521cdc53e4a7ae7ea4728e5ac9f69287528dc56",
-   "sha256": "0r25hnij6yfdnspp0kmcp1j8dkw44xgq05ldvxqmricawxnsaxw8"
+   "commit": "bede31ae5f4ecdcb8cac01a9ffe746988838a344",
+   "sha256": "0i7y5xd1q862xg4bsg3apqcm7mha96ark7sk2cq2lpwndy3i4mxf"
   },
   "stable": {
    "version": [
@@ -22011,14 +22129,14 @@
   "repo": "wbolster/emacs-direnv",
   "unstable": {
    "version": [
-    20220103,
-    1342
+    20220513,
+    656
    ],
    "deps": [
     "dash"
    ],
-   "commit": "d71ceb415732c3b76a2948147fa3559622aceba2",
-   "sha256": "01fgn8gcprx747x382ka1y5yjfcarjdhpmfr9gal8blhvlknqc8f"
+   "commit": "416ed17efa93503b37eba196a14f967e0899bce4",
+   "sha256": "0s8p96w6jvlcv2fqf3f3a3fkpk0b6a6znj6xr5nwl49xvdivlaw7"
   },
   "stable": {
    "version": [
@@ -22133,20 +22251,20 @@
   "repo": "alexluigit/dirvish",
   "unstable": {
    "version": [
-    20220512,
-    1734
+    20220608,
+    1236
    ],
-   "commit": "e40cc2dd1594d4285ec78100e98a0b0516d23782",
-   "sha256": "0qzz9bzl0rjllr84hqfczjg6h4ra4ylpcsikhdx25gc7jfvah1zi"
+   "commit": "f47331477af930a9759cadc9ade8cf81bc03497d",
+   "sha256": "12h6z8z51bcnvlsb3274zxfpg3rrfhxbldyar0jn2ix0msy6kc50"
   },
   "stable": {
    "version": [
     1,
-    2,
-    0
+    3,
+    21
    ],
-   "commit": "f03db6106adc61e050ea242dcfbd3fcae71dee23",
-   "sha256": "1aniq3lylc2fmw3snsjmbpzzgjspryjfq6vsc10daihnihnff0qg"
+   "commit": "5e57c8ba2ec278e14c6d3e2c79ae1c29f775bb46",
+   "sha256": "1pr17dmi57lwmwj5d17w239pdscb747zm36vdmjyy2d3yn1dns4h"
   }
  },
  {
@@ -22174,8 +22292,8 @@
  },
  {
   "ename": "disaster",
-  "commit": "a4654b3646b96f967e2c75440e664a417cd0f517",
-  "sha256": "1ad8q81n0s13cwmm216wqx3s92195pda1amc4wxvpb3lq7dbd3yn",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "11nc8cpapmnl7syjwglxq58fpmhksphzk1baizcda82zlk5ipahw",
   "fetcher": "github",
   "repo": "jart/disaster",
   "unstable": {
@@ -22622,8 +22740,8 @@
  },
  {
   "ename": "django-theme",
-  "commit": "4ede3b4fb214b915a8230e7f220ffe71c73ad7c4",
-  "sha256": "1rydl857zfpbvd7aziz6h7n3rrh584z2cbfxlss3wgfclzmbyhgf",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "18vvn7hb5krxkk03z72h36y9qcim8qbwlnm2wmh6dhyldhlwwzgb",
   "fetcher": "github",
   "repo": "andrzejsliwa/django-theme.el",
   "unstable": {
@@ -22849,8 +22967,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20220409,
-    1157
+    20220530,
+    603
    ],
    "deps": [
     "aio",
@@ -22861,8 +22979,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "cf137f5b8af7cbda17ef1d09c626db35e0e84078",
-   "sha256": "0rdi882r746nv8zzpcc3rv9p110ylwv1bk7nbzcychn7qsc05ydz"
+   "commit": "44f0bbec9b3deb027d17f4c10d8ec4106ed89dfb",
+   "sha256": "0w62z4y77fx2flyybhk44n2207r55j3djhpdn5xgj0hd1gnprfzr"
   },
   "stable": {
    "version": [
@@ -23052,20 +23170,20 @@
  },
  {
   "ename": "docstr",
-  "commit": "d2638156924dc2a327dca5f20ca63479878690c2",
-  "sha256": "1kga9h5vy4nzwhcvshxk1lpg1n7lfbygxbdpln7vfizpw065f3m7",
+  "commit": "97d68e8842fdfcda9c8865ccc53b1d0d7c42a7e7",
+  "sha256": "0zq6pm84l6cqa57198hn5pk596wlkcnk46g01q1072650i8bp58x",
   "fetcher": "github",
-  "repo": "jcs-elpa/docstr",
+  "repo": "emacs-vs/docstr",
   "unstable": {
    "version": [
-    20220214,
-    1539
+    20220608,
+    532
    ],
    "deps": [
     "s"
    ],
-   "commit": "bb7485d24a4fb147fc7fc7fcd1e1c7ddd3ff64b5",
-   "sha256": "18h39vrr66y0m16nfax6646qlnw1l0qd5c7dqpnr060ma52sbfkv"
+   "commit": "0a48429c2d0c2aa1de34ea24d2d3f9c8176519de",
+   "sha256": "145b9rgkrsxbnwjplkm6qx6bdzq1zgx99qrwnrl9kkk13091xhk2"
   },
   "stable": {
    "version": [
@@ -23088,11 +23206,11 @@
   "repo": "progfolio/doct",
   "unstable": {
    "version": [
-    20220227,
-    205
+    20220529,
+    1851
    ],
-   "commit": "4033a8fd8681d3989550f7a2532d6b4e3c45bfe8",
-   "sha256": "1vfwxjn86rprfz3cfc6w6hw5lqnbh093kydv0lapgz508f5yjazg"
+   "commit": "8464809754f3316d5a2fdcf3c01ce1e8736b323b",
+   "sha256": "01sjb41kii5hhh7gdd132k4iaqqfd0psy9hlc3bi7g4bplp7h7gf"
   }
  },
  {
@@ -23225,16 +23343,15 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20220412,
-    853
+    20220608,
+    936
    ],
    "deps": [
-    "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "85bdd9ed8674710f6b9815e9a1c41ad4b5a45ace",
-   "sha256": "1wmy080z709mn29w7h9m17a18jnr6a8dzip92k86kcg5z3mjg5ki"
+   "commit": "999790c984a83288c2b62d0a7294123f8eaf4b52",
+   "sha256": "0skdczk429p5cp8k24wc9inv6dripm9m5fb306nifq3akpc37dvx"
   },
   "stable": {
    "version": [
@@ -23278,14 +23395,14 @@
   "repo": "doomemacs/themes",
   "unstable": {
    "version": [
-    20220504,
-    1557
+    20220526,
+    2301
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e9bdd137116fa2037ed60037b8421cf68c64888d",
-   "sha256": "178ri980kwkndb73dawhsfr1dkl6xjdb451z0iar9ghk8z0r0wpg"
+   "commit": "ec199971005e720f138b3bf12b4004714a074c8c",
+   "sha256": "0457frpjinqg9vzbhjdmz5vcw22bg1n3g4gv7j80lw8lbj9ljr61"
   },
   "stable": {
    "version": [
@@ -23749,29 +23866,6 @@
   }
  },
  {
-  "ename": "dtache",
-  "commit": "0d69cbd12938e72bcaea6b2a79385f48a462713d",
-  "sha256": "08cmfhjdn30wnyfypx5qjscbi4wbfvypxnwfrcx09nn137qc3h55",
-  "fetcher": "git",
-  "url": "https://git.sr.ht/~niklaseklund/dtache",
-  "unstable": {
-   "version": [
-    20220512,
-    1524
-   ],
-   "commit": "5a39733299cae60da2aab0e0b9f559bcc022369f",
-   "sha256": "166sbnq9n70yp7w8in2qkv921gzkzhzwkr3bjgnj427gxn34m1xd"
-  },
-  "stable": {
-   "version": [
-    0,
-    6
-   ],
-   "commit": "4ecda689e4ccddc23805a22484c95c4f3f65e3bb",
-   "sha256": "0lrj4dwcrx3s9mxnik9h9cppqjdfnbnlknfa40qwhlzxdvhxmfmq"
-  }
- },
- {
   "ename": "dtb-mode",
   "commit": "0c33d49a8d79ee60571775fc224453a351b0ff48",
   "sha256": "0s8jwmg2kafg31scl04swbx56dnxr2y3j56g95a4k4ffnb0q28n3",
@@ -23794,8 +23888,8 @@
   "repo": "dtk01/dtk",
   "unstable": {
    "version": [
-    20220309,
-    759
+    20220602,
+    2129
    ],
    "deps": [
     "cl-lib",
@@ -23803,8 +23897,8 @@
     "s",
     "seq"
    ],
-   "commit": "56b339bc76926defa775c406113e306ec6d31b36",
-   "sha256": "0g33sn95zk4fp1jyh472k3qyvbm062njbxkmnv0qavrbli097q80"
+   "commit": "092cb79d1985a0c5017070353abbb93b8977803d",
+   "sha256": "1lgjph43lc13iil6cp6ihn4w8d9yy7kc0s6y912hialykrscvcas"
   }
  },
  {
@@ -23830,11 +23924,11 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20220226,
-    1354
+    20220518,
+    807
    ],
-   "commit": "66fc30af02901db023e464a24d2b5fb3ff472794",
-   "sha256": "0ihwmkxgbd0mgfvzisjiwvyypa9z21ckyxdnkf9y5lxywjyr39zh"
+   "commit": "57f4072fa8acd5f7af40b11f5f33607bca324fe1",
+   "sha256": "1pimn792p93i2rs08al32xr3p9csp645ai5830mgjza6nkkqhxml"
   },
   "stable": {
    "version": [
@@ -23912,16 +24006,16 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20211018,
-    1545
+    20220524,
+    2122
    ],
    "deps": [
     "dash",
     "popup",
     "s"
    ],
-   "commit": "dbb915441a2b66f2fbb954ff5de2723c5a4771d4",
-   "sha256": "0gbxhl50j6m6c0kq2v3ph9b3mdrmjdslxiy6lhms4l01zyrg621g"
+   "commit": "1dd583011f4025b1b8c75fd785691851b6c5dfa3",
+   "sha256": "1c4w5hxydn59ga9731mcg0r0hlbn2fzjalvv0w2flnx77pkl8g6a"
   },
   "stable": {
    "version": [
@@ -23964,17 +24058,17 @@
     20210909,
     1010
    ],
-   "commit": "862831cd6e1146b0c18e6bdbf7daafb42868d439",
-   "sha256": "0kfykznv16lmbxhccnp9f1qn9wswadizp3mhq1kf1b29pvppf1yr"
+   "commit": "1c74870571c21e7e95c0ec53d3b714d08fcf2b83",
+   "sha256": "1y0gihaksjrxbxp8rr43xwbqcjy0y4a60kz7g1qqdafb1y38x5kr"
   },
   "stable": {
    "version": [
     3,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "09eac98ced1fff7dea4e5ac45b59e00c1874067e",
-   "sha256": "0ljv4gnalxq77byic23c8hrjmsqvn87gqj0ijm7rdx4xr1pff1jg"
+   "commit": "43af00f79e41ce9101d42b36dab13e1f68d49a7a",
+   "sha256": "0fa8fkj2piis8b56phl6p77pl1na81krdnmmvyw16hq45zbmm9rk"
   }
  },
  {
@@ -24311,8 +24405,8 @@
  },
  {
   "ename": "e2wm-bookmark",
-  "commit": "45488849da42ac775e532f30f588bfabb7af3cae",
-  "sha256": "1myaqxzrgff5gxcn3zn1bsmyf5122ql1mwr05wamd450lq8nmbw5",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "03pjwl9bi9bpsrkqdq8dzf34ksivamlpnp0rc09qrhss765mx2cz",
   "fetcher": "github",
   "repo": "myuhe/e2wm-bookmark.el",
   "unstable": {
@@ -24482,11 +24576,11 @@
   "repo": "redguardtoo/eacl",
   "unstable": {
    "version": [
-    20220101,
-    1517
+    20220526,
+    1434
    ],
-   "commit": "4d9d42fa05e550dbac71a2c93e1da71c48af9449",
-   "sha256": "1bpnrvjiz6k9s36v23y1b6pjyl78741g4rc2mpdwxcnk0vzmi0aj"
+   "commit": "4fe2cafbfeb73d806ebea8801c3522ff2886f30b",
+   "sha256": "05m121lw90rjs1a6wq8gvqxzydm4940x30xp3kh1v5x4zwwcf03b"
   },
   "stable": {
    "version": [
@@ -24500,8 +24594,8 @@
  },
  {
   "ename": "earthfile-mode",
-  "commit": "3df5031b52e919ace5b07c588eec343ed35cb416",
-  "sha256": "1gcdbfzd0v5rs6wfssh8dgby9rmgyar2zqphh2whjvzqp95axh5g",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1md8c7mds7zqzkfblijz64qywz1195sszixay6srr0r4lc1jlvyp",
   "fetcher": "github",
   "repo": "earthly/earthly-emacs",
   "unstable": {
@@ -24760,11 +24854,11 @@
   "repo": "flexibeast/ebuku",
   "unstable": {
    "version": [
-    20220106,
-    902
+    20220530,
+    453
    ],
-   "commit": "5004d377f8c89436c28d4a7ffbef407a2b28861e",
-   "sha256": "05cwxlqkj9wwy35pc8dq37rdvmkrc8528s64qw0pji406r6qs9l3"
+   "commit": "83ec048a6d9b5376b4416ec8a07c14f243a1b45f",
+   "sha256": "1zl89afgj085sc6hqb8ibz0fmm4gjwaf3wzpwr8dhdh2qkl8wdiy"
   }
  },
  {
@@ -25228,8 +25322,8 @@
  },
  {
   "ename": "edit-server-htmlize",
-  "commit": "219b037401a81ce70bd2106dabffa16d8b0c7cef",
-  "sha256": "007lv3698a88wxan7kplz2117azxxpzzgshin9c1aabg059hszlj",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0fcq988gjwmpa1cwm3nw36mn8ry8c0vby6f3lv7k2p1mhb68q960",
   "fetcher": "github",
   "repo": "frobtech/edit-server-htmlize",
   "unstable": {
@@ -25403,8 +25497,8 @@
     20220404,
     2105
    ],
-   "commit": "d1a3c37235dd87e0bce6ffc75f5568218d6d83b4",
-   "sha256": "19k9mi6phdny1ihxf5apkxfv67cvyihl0za7al29dvim6172km4y"
+   "commit": "940a4adbbeb3b6b1a72270a814d52770dd89a997",
+   "sha256": "1gsx2qgv5xm9r0i0axd4hf31g2rq2m4a1hvnif48g4xb0llss73c"
   }
  },
  {
@@ -25415,8 +25509,8 @@
   "repo": "sebastiw/edts",
   "unstable": {
    "version": [
-    20220415,
-    1722
+    20220521,
+    1345
    ],
    "deps": [
     "auto-complete",
@@ -25427,8 +25521,8 @@
     "popup",
     "s"
    ],
-   "commit": "5c096ecdf9462b125f2eb4092899ff63636cfc40",
-   "sha256": "1l97a55kg8dcvbdv9c2bk1acz4y9vl3x68mbybhbm0rs78170hx3"
+   "commit": "77e0dc91f603e8bedebfdccc90352ebbfd217c99",
+   "sha256": "1ny3nk6x428ksfnhpgfy6z0rd272nbsnqdzaxdshld8b0cj5rz6b"
   }
  },
  {
@@ -25463,11 +25557,11 @@
   "repo": "suntsov/efar",
   "unstable": {
    "version": [
-    20211122,
-    1943
+    20220530,
+    1412
    ],
-   "commit": "49dc9b89a8b9bf2523c202ac8830d1245768f3f4",
-   "sha256": "18pxs3mml90hd97fdhpgxyww4vjcj7jjiz0xzlzj0fd83pxxjr3n"
+   "commit": "bcf74e57031bb700c0e8b0a49c6e4583112b7eda",
+   "sha256": "1mfv5v120d49gsxf01imj4m71d7ijrvzi0h9nsfpd9yn93i8sraf"
   },
   "stable": {
    "version": [
@@ -25623,8 +25717,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20220509,
-    1904
+    20220519,
+    900
    ],
    "deps": [
     "eldoc",
@@ -25634,8 +25728,8 @@
     "seq",
     "xref"
    ],
-   "commit": "ba618d2cee55c8c339d46621b7e721957cc30a72",
-   "sha256": "08ynxy8wpb1ran8r7h51n5r1njpjvz7hdxkgvr5njlhwp5wz2jd5"
+   "commit": "aa50b4bb9e52d15472c7a4f9c6101506dfa4f8b4",
+   "sha256": "1sjr6x2xbbyda0g3b04zqd6a7hm2n23dxpcb89yawssiwjn5v8xp"
   },
   "stable": {
    "version": [
@@ -25661,16 +25755,16 @@
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20220409,
-    1811
+    20220605,
+    1329
    ],
    "deps": [
     "eglot",
     "fsharp-mode",
     "jsonrpc"
    ],
-   "commit": "5208b54098c7534f4768b87c5f4c8a01b638737b",
-   "sha256": "04s37djxzy8v5xwc5hh8gq37zh7f6ih3y07g07q2fc39rk1xslpd"
+   "commit": "c7842fe63b8bae5aa8bd6a9891036c5ce04e4030",
+   "sha256": "17ibcl9ilm7ml4gjlvcx40hni8awccm1zk37y0nfvcscigf3i8pr"
   },
   "stable": {
    "version": [
@@ -25765,11 +25859,11 @@
   "url": "https://forge.chalec.org/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20220316,
-    619
+    20220531,
+    452
    ],
-   "commit": "23c78f4850f44d18eef66c694e7e05882d841ba6",
-   "sha256": "1icj34anks7f0cjdqc1kgj3bva3bnhily5xc5mzx21w0iciqvpk6"
+   "commit": "a32b9266414d9173dfa92fa44b17064ebb39522f",
+   "sha256": "09v74b78vq0vw93pm2xgkdyp6f7ql0l52bzgj1pyayjr5y6y65mg"
   },
   "stable": {
    "version": [
@@ -25798,14 +25892,14 @@
  },
  {
   "ename": "ein",
-  "commit": "215e163755fe391ce1f049622e7b9bf9a8aea95a",
-  "sha256": "14blq1cbrp00rq0ilk7z9qppqfj0r4n3jidw3abcpchvh5ln086r",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "1m00w3cg69xrg2cbcm9sxpfx9f80ksaj44bswh8y2bhbakv0wcxn",
   "fetcher": "github",
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20220419,
-    735
+    20220608,
+    1138
    ],
    "deps": [
     "anaphora",
@@ -25816,8 +25910,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "388c8f753cfb99b4f82acbdff26bbe27189d2299",
-   "sha256": "03idq7z0ry3mjvsw0w3acnsnfjijqkp9lr1v1xn5jn3s58ciyw80"
+   "commit": "7b9b14435c1dee85dd1eb5faf5d58edfa5ca5cbb",
+   "sha256": "1k8qj7h0kshf5crpk05q7bmp7pn6mzzbj80vwd0x9w4dwyrw0kin"
   }
  },
  {
@@ -25852,8 +25946,8 @@
   "repo": "kostafey/ejc-sql",
   "unstable": {
    "version": [
-    20220511,
-    1619
+    20220517,
+    1303
    ],
    "deps": [
     "clomacs",
@@ -25861,8 +25955,8 @@
     "direx",
     "spinner"
    ],
-   "commit": "900cf3ff0a8cffeeb0155ca131fa2e425ca9137d",
-   "sha256": "0r7rfpfxxn620cafw2h3in384lql3qbnpdrc8j2yyqlqgp73yygk"
+   "commit": "5e100426be90fc193154b1219ab1058534a4fb52",
+   "sha256": "0mxl8z86wi4kjnxl2bmk5j8p7fvlihcgpd7lkxnlsifqysnvpp86"
   },
   "stable": {
    "version": [
@@ -25926,28 +26020,28 @@
   "repo": "xgqt/emacs-el-fetch",
   "unstable": {
    "version": [
-    20220510,
-    1536
+    20220529,
+    1847
    ],
-   "commit": "3aa9594e807cb03af228c13224b381ecdd7ba2e3",
-   "sha256": "0rpdmhck3qn325jscysvgj2nzdy09rl895wsk5jhssmgmnp92zxs"
+   "commit": "7dea7aeffa68ede2cb34678ac2734502309ccbe5",
+   "sha256": "0fk48py9vx1mamwix2p3b20s3l7bfn9n4adqxrzli3810q3xd1mv"
   },
   "stable": {
    "version": [
-    2,
-    0,
+    3,
+    1,
     0
    ],
-   "commit": "3fa818577238adf9db7264e302d9614ce973d307",
-   "sha256": "0fbbnwxm96zmj2hlsjjxki901vs98qcxn8shyz8bs3qzb6kvlwyw"
+   "commit": "7dea7aeffa68ede2cb34678ac2734502309ccbe5",
+   "sha256": "0fk48py9vx1mamwix2p3b20s3l7bfn9n4adqxrzli3810q3xd1mv"
   }
  },
  {
   "ename": "el-fly-indent-mode",
-  "commit": "237311b98eec4b577409f55e16d8e640936d41a2",
-  "sha256": "00iqiawbzijm515lswbkzxf1m6ys242xrg6lzf8k40g2ygyd1q1r",
+  "commit": "fa9d1ac8f71a14e975e3d39a7ddd7351b2f4ba7f",
+  "sha256": "1wph83wczq3n5vavpkd5ad3fhswlcl0b2d1h79qji1xwigi22r88",
   "fetcher": "github",
-  "repo": "jiahaowork/el-fly-indent-mode.el",
+  "repo": "jiahaoli95/el-fly-indent-mode.el",
   "unstable": {
    "version": [
     20180422,
@@ -25968,8 +26062,8 @@
     20211224,
     959
    ],
-   "commit": "9353309744e4f8a7c9b1adf22ec99536fb2146b0",
-   "sha256": "14r7n9dkx1kf3j549h0kmdnsl89nwxadbx0qqmj2xzin7n9c412y"
+   "commit": "bf3dba444dcd240b8cb358a0850c8c5a92606134",
+   "sha256": "07wfy24lcmd1ccwjidxz704sziy95cjd1al59yava5g7nvw20wbn"
   },
   "stable": {
    "version": [
@@ -26413,19 +26507,20 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20220501,
-    1128
+    20220607,
+    2112
    ],
-   "commit": "7275089749779599d87bee878e5103921ea919f9",
-   "sha256": "07p8qz4fx2gvgk46sl076w1rgqmdpbxsn54m330627sla5wk5bpf"
+   "commit": "61e3d10df55c8600f3a1f504dd718a1fe368ab50",
+   "sha256": "1aswsj7b2913v6v22drl3xc5n286xyf7w0zp3681jpmsba1h2xv3"
   },
   "stable": {
    "version": [
     1,
-    1
+    1,
+    2
    ],
-   "commit": "e08d0135a7b484686a969f5987f07bc72285ded4",
-   "sha256": "1ipjrifscjynrbf0nm4siyv57cd7jdi0v16kb2byv9y0yr481ag1"
+   "commit": "a837e383093dce56b36548b8a91b611b58bdc3fe",
+   "sha256": "1a7r2r48fb789nackny6y437nng119bwb40apar8m74233iz1063"
   }
  },
  {
@@ -26571,10 +26666,10 @@
  },
  {
   "ename": "electric-cursor",
-  "commit": "639747f3e5b2f8753478826a69b27727e1738d04",
-  "sha256": "12rlgyp9r4dgp0mid95rx0p5ygpxjzhvlxkmidlzakyirc1i0jlw",
-  "fetcher": "github",
-  "repo": "duckwork/electric-cursor",
+  "commit": "5485aeeb5c536e88cd1c2cfb1163d0b3ab44b8a1",
+  "sha256": "0adjj9fhh1xzgijf7bpbxy2hrrbrxm473jsy52y47a6fnprpbhc8",
+  "fetcher": "git",
+  "url": "https://codeberg.org/acdw/electric-cursor.el",
   "unstable": {
    "version": [
     20220108,
@@ -26835,8 +26930,8 @@
   "repo": "remyhonig/elfeed-org",
   "unstable": {
    "version": [
-    20220420,
-    1234
+    20220529,
+    1958
    ],
    "deps": [
     "cl-lib",
@@ -26845,8 +26940,8 @@
     "org",
     "s"
    ],
-   "commit": "e6bf4268485703907a97896fb1080f59977c9e3d",
-   "sha256": "1md7nxayysd6pkxyp85jmmz3jh6civpd3y0qgn0zq865jcjv86l6"
+   "commit": "d28c858303e60dcb3a6eb18ea85ee3cb9e3dd623",
+   "sha256": "189hr2pqpm9vpz06frkl6r3k6q6ispx97zj24lczcli44l7d8gsz"
   }
  },
  {
@@ -26857,15 +26952,15 @@
   "repo": "fasheng/elfeed-protocol",
   "unstable": {
    "version": [
-    20220419,
-    1358
+    20220524,
+    336
    ],
    "deps": [
     "cl-lib",
     "elfeed"
    ],
-   "commit": "eaf1329ff221098eb6d4709245010d070c89b173",
-   "sha256": "14zn3h7v9vygi6syjnywd5j56xlqv4a1z2grlkgrr0jd0y427jzk"
+   "commit": "b813574faefc1ac4825da19b40f620339b6badff",
+   "sha256": "0k9rkghp9rg7aidmx7q0n4wpb9z5cwr7j8z167yzaqgf9s3y4jj2"
   },
   "stable": {
    "version": [
@@ -26889,14 +26984,14 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20220428,
-    123
+    20220528,
+    2320
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "419de17d681d75789271b8457509fa3f942eab54",
-   "sha256": "1mx134xj9n73v55i0yjn86zn19sg93m95gqacs2c6dxzq1v3q14f"
+   "commit": "ff8cfdfcb3fce9ecdfe7e58463c5c5814cb3d1c2",
+   "sha256": "1x909sbwcnjkamhvi0jkd4qy99a971zxc3ydqx3x2k12slhvaczz"
   },
   "stable": {
    "version": [
@@ -26919,15 +27014,28 @@
   "repo": "SqrtMinusOne/elfeed-summary",
   "unstable": {
    "version": [
-    20220506,
-    720
+    20220604,
+    850
    ],
    "deps": [
     "elfeed",
     "magit-section"
    ],
-   "commit": "641a453cfd03e098b5e6376e035eafd080b08781",
-   "sha256": "00sxk4pf58678lhjmzdi42dkiiszpnnjhv0dwdgi60mc31d7kqdc"
+   "commit": "1cf73acae8b791e214dc347c2adf7ec17e8ff41a",
+   "sha256": "0k7g5v616gw5lsl4rga2k7dzha1mjw50sh2fhk4lkgz41z8jssa1"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "elfeed",
+    "magit-section"
+   ],
+   "commit": "1cf73acae8b791e214dc347c2adf7ec17e8ff41a",
+   "sha256": "0k7g5v616gw5lsl4rga2k7dzha1mjw50sh2fhk4lkgz41z8jssa1"
   }
  },
  {
@@ -27063,11 +27171,11 @@
   "repo": "xuchunyang/elisp-demos",
   "unstable": {
    "version": [
-    20210312,
-    542
+    20220513,
+    1626
    ],
-   "commit": "924b07d28e4f5b82f0e1377bcde800068f0a6d9d",
-   "sha256": "1pf37rlpmr8fjaxqk47p7dv84nksgh3r63m23jpi1g49myvwfzgi"
+   "commit": "01c301b516e9949d0239d20f6834afbc9acf0abb",
+   "sha256": "07rjc6kkhhc0y2wwgsv09z66i9qyfl2b189jrxqcha02rw5sb0lp"
   },
   "stable": {
    "version": [
@@ -27348,17 +27456,17 @@
   "stable": {
    "version": [
     0,
-    21,
+    22,
     0
    ],
    "deps": [
-    "dash",
     "f",
     "reformatter",
-    "s"
+    "s",
+    "seq"
    ],
-   "commit": "5df694e307cf8fa5a3555d800984aa4ebb40664f",
-   "sha256": "0iwk4fmw8hq3ry4ky1zc7lgl4cpbnrjyk74c2xzddfspi3ks41fd"
+   "commit": "1e277684d8a6681a2410cce2dd589ee30a998369",
+   "sha256": "1gnr61ibzcznfqy5f8capmbz75rcfikwy106rjdmp45qz2jwp4di"
   }
  },
  {
@@ -27428,8 +27536,8 @@
  },
  {
   "ename": "elmine",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "1xkx1wwrzd2dl13z8n4qh3gl202j0i9crab5b3788z8mq0g4v4bn",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1zh0wc0n9r60y72jg26bhnmlbz2h282vwxr4p0k0v65jc1j20a75",
   "fetcher": "github",
   "repo": "leoc/elmine",
   "unstable": {
@@ -27620,17 +27728,17 @@
  },
  {
   "ename": "elpa-mirror",
-  "commit": "d64ce7042c45f29fb394be25ce415912182bac8b",
-  "sha256": "1jnviav2ybr13cgllg26kfjrwrl25adggnqiiwyjwgbbzxfycah8",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "056ci878vsmab9d2j72wy2skdipvi9hz0cnlhyfc3zj3shr6cbnj",
   "fetcher": "github",
   "repo": "redguardtoo/elpa-mirror",
   "unstable": {
    "version": [
-    20220123,
-    1237
+    20220526,
+    1512
    ],
-   "commit": "3e0fe0f91d1c5798752c255b89950617f88b8d9e",
-   "sha256": "1vfhxbn9m3412hpgpnpf523lm9cl4lkbk1fgjvqldlknwks376jh"
+   "commit": "b200d979bcbfe2df0f7c0074aeb5497251ed47a8",
+   "sha256": "1gmwf3wv984vxnr42936kyb4npkwc3mwpm81akprxm5ggzz0zigd"
   },
   "stable": {
    "version": [
@@ -27650,11 +27758,11 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20220503,
-    833
+    20220530,
+    1219
    ],
-   "commit": "bf0dd36eb2f5b339c6b561dbe3ee9693565b484b",
-   "sha256": "0dv71zc95m5sa4824vk3d1xk726nh2v50i0yp6w3ydfzzsfph6j6"
+   "commit": "79c241f1ce5d4e4f2ba377485f4434e93391eb0f",
+   "sha256": "00av8qfxvr9f4jfai7pr7c1sf50m07z6gfxwy3lzvsv6i88s43fs"
   },
   "stable": {
    "version": [
@@ -28038,17 +28146,17 @@
   "repo": "tecosaur/emacs-everywhere",
   "unstable": {
    "version": [
-    20220407,
-    329
+    20220517,
+    1401
    ],
-   "commit": "54b9ba1ac0d7f8b644354fd6d27c9e3aff111dcc",
-   "sha256": "165ba97ll0k8fsr3k2bxpwg4lnmd3513vn4mdgxcx9ll5p1jr4nd"
+   "commit": "0d0d1854299aa50edb3fd57317949c00f3fcbb03",
+   "sha256": "1x7c4sj7rj17mc3iwim96vn9m9ar04hj6a8lvilf4814lgvz9q4k"
   }
  },
  {
   "ename": "emacsc",
-  "commit": "acc9b816796b9f142c53f90593952b43c962d2d8",
-  "sha256": "1fbf9al3yds0il18jz6hbpj1fsjlpb1kgp450gb6r09lc46x77mk",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "06yhv7g579fpzbpinzn046i7zwsc6z43vrzawvxppzxpjcz8nh4r",
   "fetcher": "github",
   "repo": "knu/emacsc",
   "unstable": {
@@ -28371,19 +28479,19 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20220509,
-    2259
+    20220608,
+    17
    ],
-   "commit": "81c7f751be1de33dee9f7523fd3429ee3fe9a0d1",
-   "sha256": "11yvhhq251qmbnljjcfxnc53dqa63jm6ximfd0618hcwcgxlkkdc"
+   "commit": "63f0d4dc09afb058450dc10dd3916027a93ee487",
+   "sha256": "0q8l4ckdmcagiiccvb0s94gc1lywgqh02d8p16ygpcfxz8967w4a"
   },
   "stable": {
    "version": [
     0,
-    16
+    17
    ],
-   "commit": "5faf1389162dd64bfe3511dfb8f52c18efb5140b",
-   "sha256": "04xxwhh577aam0fqfmprxqaw0v1l6yidikr6chajcf16mf1wd2gv"
+   "commit": "97270d725761ee02db461b45b18ec16ae31f203e",
+   "sha256": "1s0ssf4q9kg4c5w87h2ypyvrhi31mz3s6k4h7pxi9a47lkccq8n1"
   }
  },
  {
@@ -28394,27 +28502,27 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20220507,
-    143
+    20220526,
+    1525
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "81c7f751be1de33dee9f7523fd3429ee3fe9a0d1",
-   "sha256": "11yvhhq251qmbnljjcfxnc53dqa63jm6ximfd0618hcwcgxlkkdc"
+   "commit": "63f0d4dc09afb058450dc10dd3916027a93ee487",
+   "sha256": "0q8l4ckdmcagiiccvb0s94gc1lywgqh02d8p16ygpcfxz8967w4a"
   },
   "stable": {
    "version": [
     0,
-    16
+    17
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "5faf1389162dd64bfe3511dfb8f52c18efb5140b",
-   "sha256": "04xxwhh577aam0fqfmprxqaw0v1l6yidikr6chajcf16mf1wd2gv"
+   "commit": "97270d725761ee02db461b45b18ec16ae31f203e",
+   "sha256": "1s0ssf4q9kg4c5w87h2ypyvrhi31mz3s6k4h7pxi9a47lkccq8n1"
   }
  },
  {
@@ -28544,8 +28652,8 @@
  },
  {
   "ename": "emms",
-  "commit": "4caa7403144670c07e326ed3a7d982c427d4a254",
-  "sha256": "0ml66fgzxl4wsk5g7d78mqhr9gqmbld6qh31nfc6z19c8107jrd5",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "07r44rvnwvw7fcqjy4c7kjl0qmjynkibjhwraaiv1y92l1m9z8m1",
   "fetcher": "git",
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
@@ -28594,8 +28702,8 @@
  },
  {
   "ename": "emms-info-mediainfo",
-  "commit": "d08c28c6ff4caf14f0bf4b0f40f16660dac2d5d9",
-  "sha256": "17x8vvfhx739hcj9j1nh6j4r6zqnwa5zq9zpi9b6lxc8979k3m4w",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0hmja2s6120yka2h6p60v1b5hgkd1ywz82igwcv5wf9mxm9mmfw9",
   "fetcher": "github",
   "repo": "fgallina/emms-info-mediainfo",
   "unstable": {
@@ -28842,8 +28950,8 @@
     "emojify",
     "request"
    ],
-   "commit": "434ccc9df8eb884f248d5934e7d465348bb203a4",
-   "sha256": "07mbh3a34qcb1d37fvy3g5z3mc436lc5vlqqk46x7bjwdbkzlsfs"
+   "commit": "f683f95ceae812c77c54d398e0dc02c6da4ae17f",
+   "sha256": "0ghv79g1iirqzy1d10ywspcdcbb5br4vd86fxg44bk4iw7jn40ng"
   },
   "stable": {
    "version": [
@@ -29021,14 +29129,14 @@
   "repo": "hrs/engine-mode",
   "unstable": {
    "version": [
-    20200611,
-    1825
+    20220519,
+    1916
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e0910f141f2d37c28936c51c3c8bb8a9ca0c01d1",
-   "sha256": "15zx4a8gvgk077pnj7wr78nfjrzrj2i9ma6cj6jj6i8ikz6wyvjz"
+   "commit": "57045918301f5a96f67bd409f7683987a72272cd",
+   "sha256": "1a2c9c9kwkczg6jjn9rf46f1qgvqr6r695srp9cijq192f23d83n"
   },
   "stable": {
    "version": [
@@ -29155,15 +29263,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20220218,
-    1627
+    20220604,
+    1519
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "4730b31ff1479b6d822ccc7517251dcb52de45b3",
-   "sha256": "0w2fnqqihiqkkqw1x1gghgd0644gf7r5wp12dr7h1ljhfcb4kz83"
+   "commit": "7f36664fc6d97a7ca77c6c3e0c6577b72fa0b70d",
+   "sha256": "0858d36xgc6r4s116hc4pb8jf1j1l9ixws9xpk39a8h1diw3gplm"
   },
   "stable": {
    "version": [
@@ -29294,8 +29402,8 @@
  },
  {
   "ename": "epkg",
-  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
-  "sha256": "1cj53l3fdxjwkky3j3rfmv3l11m5xkn4l8qx8x2fr35rkldii5w3",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0vvkjjaffvwvsvld3c6hwd18icmp2lc7f9yqvclifpadi98dhpww",
   "fetcher": "github",
   "repo": "emacscollective/epkg",
   "unstable": {
@@ -29459,14 +29567,14 @@
   "repo": "emacsomancer/equake",
   "unstable": {
    "version": [
-    20220424,
-    350
+    20220607,
+    2211
    ],
    "deps": [
     "dash"
    ],
-   "commit": "ea5c0570f58b8e62249e001ed434a1056a50abe7",
-   "sha256": "0l85xks1m8yprd5q84gp0ryaagjd74kwb40r0mwdly6y4dzi0kvr"
+   "commit": "1f1f269edd27ffce8b6ead5b317e49fa433b039f",
+   "sha256": "0am0lixinl10x6j62hz86wg0pdminmm74vfyklzxh0yhvbvlcc5l"
   }
  },
  {
@@ -29865,8 +29973,8 @@
  },
  {
   "ename": "erefactor",
-  "commit": "18063e16a6f556b1871e1a5b74e353a85a794e63",
-  "sha256": "0ma9sbrq4n8y5w7vvbhhgmw25aiykbq5yhxzm0knj32bgpviprw7",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1fvs0zqd57jpv6yj234w1dqynldnpfifm10swwrmnyjfc6wv5a9i",
   "fetcher": "github",
   "repo": "mhayashi1120/Emacs-erefactor",
   "unstable": {
@@ -29954,8 +30062,8 @@
     20200914,
     644
    ],
-   "commit": "9a5f2b4a8cd14edbde9d16dcdfcb8db2a91be0d8",
-   "sha256": "1pn3w2prmz9ibhy5l22c6mmccr7lfy561gkd2s41hlcjsyd4ar00"
+   "commit": "6385f850a185523bb5241a71f5a7614a148f6b53",
+   "sha256": "0dllhhbr265dm12nkiil0s7cb24l7pjdjgfwgcsy98imn8pl8z4p"
   },
   "stable": {
    "version": [
@@ -29979,18 +30087,16 @@
     20220215,
     1844
    ],
-   "commit": "4bf325feb5885056ad3315d9a0316b652613b3d9",
-   "sha256": "0dwjafw8ab71bqvwpv49cwqarrcd5pa0wyh7yxjn3spnl6f80j1l"
+   "commit": "5f870f8af2d4cad995589414aa5eda92486fa508",
+   "sha256": "1w0lyvx1fdi3qgkc4fc61rabp1j6qscnm3m26k887q8gwl8k5ss3"
   },
   "stable": {
    "version": [
     25,
-    0,
-    -1,
-    3
+    0
    ],
-   "commit": "47f121af8ee55a0dbe2a8c9ab85031ba052bad6b",
-   "sha256": "1ir42hz81bzxn1shqq0gn824hxd6j774889vjy68psi95psfs8r2"
+   "commit": "4ed7957623e5ccbd420a09a506bd6bc9930fe93c",
+   "sha256": "1nf72yiirdpxcs8m10xc04ryghxxc73x954x38m5a6fhv2hfhp2n"
   }
  },
  {
@@ -30132,8 +30238,8 @@
   "repo": "rejeep/ert-runner.el",
   "unstable": {
    "version": [
-    20201005,
-    2336
+    20220513,
+    1142
    ],
    "deps": [
     "ansi",
@@ -30143,8 +30249,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "80cf4f60ec8c1f04f58054ed8ad2dcfacc17d8b5",
-   "sha256": "1zxhiy8hpyz1nbi238gnwvs2pyrl1h8pgfyqrjhqwni8bih4kzx7"
+   "commit": "69d66b934223d5f1801ba3a4c8dbfb3453f2a041",
+   "sha256": "12hy1wnrs9dq2hl88fbybjv18a5fh5az5vpcrrxihrwy2gi2yrw0"
   },
   "stable": {
    "version": [
@@ -30512,26 +30618,26 @@
   "repo": "Phundrak/eshell-info-banner.el",
   "unstable": {
    "version": [
-    20220402,
-    1721
+    20220531,
+    940
    ],
    "deps": [
     "s"
    ],
-   "commit": "53fc69b8712b9869cee49468a6e418d64d2c3ab9",
-   "sha256": "16ma3z7sxj95p3jfaszdvaj45rjkmb806mlm2vv5pgcbzqjfhrp6"
+   "commit": "b7f2bfc0137be9cdc3dfe26a71e1984d3c3bcdc4",
+   "sha256": "0xj9cmcm8cfmmnvjs2wwhqc9j7jwydywscbwq16clwb3v4v5gj1i"
   },
   "stable": {
    "version": [
     0,
     8,
-    7
+    8
    ],
    "deps": [
     "s"
    ],
-   "commit": "9c17e92f0229c9002e071842a88396c3f2439d72",
-   "sha256": "08kqqlvia3hzl9yq5yia92a27rk3fsahdizlf7rpywkmj5aix43l"
+   "commit": "27b0be266beaedd594bf0022582567454107af5f",
+   "sha256": "0xj9cmcm8cfmmnvjs2wwhqc9j7jwydywscbwq16clwb3v4v5gj1i"
   }
  },
  {
@@ -30932,11 +31038,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20220225,
-    1523
+    20220509,
+    801
    ],
-   "commit": "39eba283000a7b0220303d7c5a4f3ee05efc1e9c",
-   "sha256": "1avzxbdj2ghzv94mjmikqdb6za4dxkby2pnyrz0519fs4sc17a06"
+   "commit": "e83ac622fe7e3cbfc848481a9257e5ed5c7b5afb",
+   "sha256": "1qi399iidac2hbz1c2ydqcbfcqr5f7ldgqbhchk96az2l41yb6sp"
   },
   "stable": {
    "version": [
@@ -30992,14 +31098,14 @@
   "repo": "ShuguangSun/ess-r-insert-obj",
   "unstable": {
    "version": [
-    20211209,
-    812
+    20220531,
+    31
    ],
    "deps": [
     "ess"
    ],
-   "commit": "dd367cb918c90ec6d3824da869f7a75bb1ca49b6",
-   "sha256": "17vrs3wz3gpjvnq8i5gz14jnsds8s359ynx73wwh0ydcrx79f9dh"
+   "commit": "105a8edf97cc1e82ce1e959e7b7bd049851a255a",
+   "sha256": "02ydx9l074wl4f57b0l7lv2vnjvj8rbzppjd2gqh5g7gpy9lggv6"
   },
   "stable": {
    "version": [
@@ -31045,8 +31151,8 @@
  },
  {
   "ename": "ess-smart-underscore",
-  "commit": "b4d6166f5c80cf37c79256402fa633ad2274d065",
-  "sha256": "01pki1xa8zpgvldcbjwg6vmslj7ddf44hsx976xipc95vrdk15r2",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1mkx4530j1mwdikxh2j9gzfqqv8v29z9ril303vzrhhj8lbzrvm1",
   "fetcher": "github",
   "repo": "mattfidler/ess-smart-underscore.el",
   "unstable": {
@@ -31308,8 +31414,8 @@
  },
  {
   "ename": "ethan-wspace",
-  "commit": "9454f3a58e3416fa60d8411b0db19c408935408f",
-  "sha256": "0k4kqkf5c6ysyhh1vpi9v4220yxm5ir3ippq2gmvvhnk77pg6hws",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "1dr7ydicqa7iv88n68nlnrzh7sg8lrcnmkmc6629gi00kwxlgjbp",
   "fetcher": "github",
   "repo": "glasserc/ethan-wspace",
   "unstable": {
@@ -31354,8 +31460,8 @@
  },
  {
   "ename": "euslisp-mode",
-  "commit": "b04fffe5e52f26e92930a112a64531228f94e340",
-  "sha256": "0v92lry9ynkvsvx060njaw1j5lj9sb1i3srs2hfqqwyqni5ldkri",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0ixg22yw4x0g4gzy3jnq4n0b6dhvavwzp3gp0gy0lk5l2iv9i4nz",
   "fetcher": "github",
   "repo": "iory/euslisp-mode",
   "unstable": {
@@ -31550,15 +31656,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20220510,
-    2302
+    20220518,
+    859
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "5a9cfbc443219c4063b17853b7828ec0a00d2736",
-   "sha256": "1vr46xn72l5m0r9v3d1xaz86q607ga5adxlqdh7mlymw15w004ha"
+   "commit": "157af04d2cf466e301e82b0e667c5e7203fd96a2",
+   "sha256": "1aqavbxg5656ycjia2pbsvif3zaf0r99v87cym6442pszhdv2hsy"
   },
   "stable": {
    "version": [
@@ -31727,8 +31833,8 @@
  },
  {
   "ename": "evil-colemak-minimal",
-  "commit": "828c744062069027f19fe5f2f233179f9149dc16",
-  "sha256": "0qi5k17b9k227zz9binbrd22cwmlqxkay98by9yxcbyhl4hjhdyy",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "149hpqcv9pak4bvka3hljfl8lf0bwfipi0kq8rn9rj6sc624nxzj",
   "fetcher": "github",
   "repo": "bmallred/evil-colemak-minimal",
   "unstable": {
@@ -31751,28 +31857,28 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20220505,
-    619
+    20220607,
+    105
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "9707efcae4fc76fa204b1c29565aae35b99b865a",
-   "sha256": "0iyhxmaiqk0c72lmggv9jppxmlkb0vd9y0zqxgzjnznz9p08l3vz"
+   "commit": "79fc09b0140311377726551ee31622f61d28c571",
+   "sha256": "05q9fqcj1fq8dqg014i5kk0zwh1d5q13m35052276pjmkgfnfrk7"
   },
   "stable": {
    "version": [
     0,
     0,
-    7
+    8
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "f31162b2536d14bf97fe96d6e54be0d091ba9493",
-   "sha256": "1f5mbg2k527brn6b7njdjizpbzj252c53crzl8sf2564czcprqj0"
+   "commit": "a63cb007bf15c3fd4c3322f29f85d18d5574f7ba",
+   "sha256": "159i3qvjnp7jiffwpr517nnxcy3w3g40302vyzxvz6mb6qay6f2c"
   }
  },
  {
@@ -32210,8 +32316,8 @@
  },
  {
   "ename": "evil-lion",
-  "commit": "8a7a0691775afec6d2c7be3d6739b55bd1d2053d",
-  "sha256": "1rwmpc5ifblb41c1yhhv26ayff4nk9iza7w0wb5ganny2r82fg2v",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0qi7syxhni4m5m33lkb6ajw36naysm14mp2qwidmdq8h66zmy53p",
   "fetcher": "github",
   "repo": "edkolev/evil-lion",
   "unstable": {
@@ -32317,26 +32423,20 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20220513,
-    230
+    20220608,
+    1134
    ],
-   "deps": [
-    "evil"
-   ],
-   "commit": "b47931128c6b7924ea432895f469769986de410d",
-   "sha256": "1zjdwqqrc2znk2y8f424ygnkxsvx0hq46gicjb4nllbvvvbx6kyb"
+   "commit": "271551560c3c8c066b29d335f781ff9b5aefe746",
+   "sha256": "1vzpmr33smi1kgcrxj7jl8wvk1ffvy2bf6p6pki0r53lk03mf8fr"
   },
   "stable": {
    "version": [
-    2,
-    4,
-    4
+    3,
+    0,
+    0
    ],
-   "deps": [
-    "evil"
-   ],
-   "commit": "b314e816bacfc01bb7df9b19a06b18638af5cdbe",
-   "sha256": "01r85bnmqbmvwlhv5ihglp0dhws1g2wsw2vy0vsw5mi5mmx2xsqr"
+   "commit": "7a2a7384b6e752a805d6fbb78cf9425e54c2b18b",
+   "sha256": "0a55hhqi14g0hy80cfi5anxs44rcdxm1jkkyl561b4d4g823bpbi"
   }
  },
  {
@@ -32452,11 +32552,11 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20220414,
-    1201
+    20220524,
+    1231
    ],
-   "commit": "95ed1ad2448e7f49f1ee417061b61edbb69a0749",
-   "sha256": "0hypgk03yksvgakx24mrz9nrx2z0d691ls80by2fw96788d68k8x"
+   "commit": "386cd758a477d1b1ba742ef698ecc19916b43fbe",
+   "sha256": "1gg6g14nyizfagn5dgqr8qrfcyvlbcm0jvlb2wqp5z2wp1dyzqkg"
   },
   "stable": {
    "version": [
@@ -32603,8 +32703,8 @@
  },
  {
   "ename": "evil-paredit",
-  "commit": "88db86e1351410bcff6f3ed80681946afcec9959",
-  "sha256": "0xvxxa3gjgsrv10a61y0591bn3gj8v1ff2wck8s0svwfl076gyfy",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1wsgb4whd3lq8830vja5k6d574azwfy5i918xblsihddn7m35dkd",
   "fetcher": "github",
   "repo": "roman/evil-paredit",
   "unstable": {
@@ -33053,14 +33153,11 @@
   "repo": "7696122/evil-terminal-cursor-changer",
   "unstable": {
    "version": [
-    20220422,
-    255
+    20220514,
+    258
    ],
-   "deps": [
-    "evil"
-   ],
-   "commit": "69d562932f9ab9869ab1ed923e9789cbfa0ff14c",
-   "sha256": "14d9hyv2hhv0vzvmq5m1d59imzxmlm1qc484kn3sbc99553q0s1x"
+   "commit": "81ede5cfa5d8944aa4777987c846a27e28457266",
+   "sha256": "01q3h1dmhpcjqs9zchq7wfpibd49pycfnrpn0gj0sh5bspzrqfm7"
   }
  },
  {
@@ -33077,8 +33174,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "5a9cfbc443219c4063b17853b7828ec0a00d2736",
-   "sha256": "1vr46xn72l5m0r9v3d1xaz86q607ga5adxlqdh7mlymw15w004ha"
+   "commit": "157af04d2cf466e301e82b0e667c5e7203fd96a2",
+   "sha256": "1aqavbxg5656ycjia2pbsvif3zaf0r99v87cym6442pszhdv2hsy"
   },
   "stable": {
    "version": [
@@ -33280,15 +33377,15 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20220423,
-    947
+    20220527,
+    1400
    ],
    "deps": [
     "evil",
     "tree-sitter"
    ],
-   "commit": "bfdef5a292f7dde36967bb86eb2f7009b03631b1",
-   "sha256": "18nxwn051rq2r4jhc21hy2lmla7aghc2l9cvj7ib97q2l4f0jv64"
+   "commit": "fba268b2fd15657404da308b3e91efa87d9f15be",
+   "sha256": "0av546si5h8ka9qm07sqwfklq6d864di16cfwg80g4s7anhh7f11"
   }
  },
  {
@@ -33886,15 +33983,15 @@
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "dash",
     "ht"
    ],
-   "commit": "fb4349fb7dbddcebc189cce52dda25ab42d27b06",
-   "sha256": "18ihdfm8hbfl0nhk5k02m0f5dni5pmljnv0my87pmhqa4bzi1b38"
+   "commit": "e668666770858e92de83d8217c7e384de3ba1e34",
+   "sha256": "0hlm8c1sif4z8fl6k9k9akc26nzxby792ca6wkrqxcjsc65a65zv"
   }
  },
  {
@@ -34310,21 +34407,21 @@
  },
  {
   "ename": "f",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "18qax8i24gpccif4xcxccclpwl00plxjf3zbq9dry37b1r4mj57s",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1sfji40z03mwdkdf922rdykxkaidihfkmy7isgn4fr6hbgjkqgi7",
   "fetcher": "github",
   "repo": "rejeep/f.el",
   "unstable": {
    "version": [
-    20220511,
-    1502
+    20220608,
+    943
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "ad2c7dd369a15988f1c6298b5edb901ce2e1f446",
-   "sha256": "0rjggym7a7sb12bspdydk2vx12hqjqv0qmkpfi0z6s7mcnpl7fhq"
+   "commit": "d2019d4f9625bcc44349c69fe46d6645fd9ff4ff",
+   "sha256": "0vml6p19zwab2zrln2g6g2hb31czlz2rqln5wi8lc37h8lgfx7fy"
   },
   "stable": {
    "version": [
@@ -34454,8 +34551,8 @@
  },
  {
   "ename": "factlog",
-  "commit": "9075a42edee1ac7de0812d2eefcba5681859eb6e",
-  "sha256": "163482vfpa52b5ya5xps4qnclbaql1x0q54gqdwwmm04as8qbfz7",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "1x1pn2r54b5njl3wangjpwgwsaxq37zz3kh4dj6razifb9277pcq",
   "fetcher": "github",
   "repo": "tkf/factlog",
   "unstable": {
@@ -34487,25 +34584,25 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20220512,
-    21
+    20220527,
+    1238
    ],
-   "commit": "33b3344848ae17d45c19d222e53b368ea6867e7e",
-   "sha256": "1yi2xzp1a945p11h6ac5ci0n56ffd40sm3ja6i4hrw4dd41axgyg"
+   "commit": "cb0ce3ef4430eda81aa6225f7083beb8ae03a425",
+   "sha256": "0zq8k1ggv40fdz6a5ri5nxg7yznvlwx7j3cpl7gig1v1p97h0b8k"
   },
   "stable": {
    "version": [
     3,
-    2
+    3
    ],
-   "commit": "fffae9ada9057e81812f90edbd589f4a4f346768",
-   "sha256": "1rcjawwjk0jkihv26wrhhp0ncnj9qq1q16gkb9c8ys1qvaqyaiah"
+   "commit": "cb0ce3ef4430eda81aa6225f7083beb8ae03a425",
+   "sha256": "0zq8k1ggv40fdz6a5ri5nxg7yznvlwx7j3cpl7gig1v1p97h0b8k"
   }
  },
  {
   "ename": "fakir",
-  "commit": "d0a8abd5fd77a14b957f53b5bc8474403cc1e18f",
-  "sha256": "07bicglgpm6qkcsxwj6rswhx4hgh27rfg8s1cki7g8qcvk2f7b25",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1pdil5shyrvwg4h3y4apnyvj7dq4f5ghg7kb3ybf52i2vimnmi7z",
   "fetcher": "github",
   "repo": "nicferrier/emacs-fakir",
   "unstable": {
@@ -34618,14 +34715,14 @@
   "repo": "condy0919/fanyi.el",
   "unstable": {
    "version": [
-    20220310,
-    358
+    20220519,
+    105
    ],
    "deps": [
     "s"
    ],
-   "commit": "b01cb24209d223ae0e7281c279daab87800ee7f4",
-   "sha256": "1jaw9xwh58p1n0x943f6fly0scxf6zd6czq87xrb3fnkmv8qdnhk"
+   "commit": "b09d122a17724668f73d44b9fe0b47add7f596c1",
+   "sha256": "1ys3aymskjsrvkqq3k91ml1rxms8bp64i9r4q4ya5k8xdz828m5z"
   }
  },
  {
@@ -35033,8 +35130,8 @@
     "f",
     "s"
    ],
-   "commit": "d81983cf389dd5d2ec6cf9d702ff28ffd1be676b",
-   "sha256": "109d5sz2prlih28nbzaq3anyr7kyjm9cr7krndgsf7n68w6dz5b4"
+   "commit": "cab1b591a541f2a5ee25529572c6895e7f78cc4f",
+   "sha256": "1zziwgx9w76sww9wcnfvj1msmcp3z5lxgv8pkc0szp7a1ckm07hi"
   },
   "stable": {
    "version": [
@@ -35207,8 +35304,8 @@
     20210707,
     354
    ],
-   "commit": "02ab2b3854df5515245ca2a924f89bf830f9c4de",
-   "sha256": "1jp3jcr9ni3rslhjv3wg7gqjg2iihdi3six4b65chcxryhkd21jd"
+   "commit": "1191c3454c8ae10aafe9ae08e98563948284c677",
+   "sha256": "1dbxnl14mzxij6209qsa69zbxp64qkz0q2pkayxl6fmi4s2sp3rs"
   },
   "stable": {
    "version": [
@@ -35237,10 +35334,10 @@
  },
  {
   "ename": "filldent",
-  "commit": "4e3d46311b4d15314b6d1a0d5ff95c5f7e366223",
-  "sha256": "0if5fxr5vy4b8w36d0vi43cba5xpvqc2ma46d80bpark95jj8cvq",
-  "fetcher": "github",
-  "repo": "duckwork/filldent.el",
+  "commit": "cf2e923e6036542b89ee9cb36fca699092a24b64",
+  "sha256": "1z0yhg57nb6wf8iwbj84b22qjhy969zmvrxq766yl08950093k0r",
+  "fetcher": "git",
+  "url": "https://codeberg.org/acdw/filldent.el",
   "unstable": {
    "version": [
     20220423,
@@ -35357,8 +35454,8 @@
     20220430,
     107
    ],
-   "commit": "116b976b526680c038109882d5cd2d9f218b62a5",
-   "sha256": "0sq8fyq19jw1hm0m6hiqnvzzvx0c3xigfx7x6i40ib5hnfjlqs0a"
+   "commit": "38ebbc21e32a6e616d315f5f898df4ca825f916d",
+   "sha256": "1hla8vvm8ia9rxsrrcwh8adg9ygnlpw9s1jci58jbiq2a0ng3mkp"
   },
   "stable": {
    "version": [
@@ -35549,11 +35646,11 @@
   "repo": "jming422/fira-code-mode",
   "unstable": {
    "version": [
-    20210702,
-    1631
+    20220531,
+    1555
    ],
-   "commit": "eaff81f867d9c84e25891368f3d0cac7513984e8",
-   "sha256": "0gc77fkc6jczb52f5hil3h0hv74f7cxbijc8mjprh7zzgb09b6za"
+   "commit": "7b469ca0c22b7e6a907cd65eebdfa9723998a131",
+   "sha256": "1jgkgnpi5zmmqmm622p3cl0hj72cbag68c8mbi9bakw2fkq64xm2"
   }
  },
  {
@@ -35722,8 +35819,8 @@
  },
  {
   "ename": "fix-muscle-memory",
-  "commit": "c6b0501714a6d82657b88d11e3f79d75eea17d8e",
-  "sha256": "0qhasnjw0bj5hzw27r8vj6shhwc3zxcp3wmxijh1rpdw4773f7n8",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1y46amy0a566pk5918xargyiipcnf91xpmmfdb442456argbji8w",
   "fetcher": "github",
   "repo": "jonnay/fix-muscle-memory",
   "unstable": {
@@ -35904,11 +36001,11 @@
   "repo": "seblemaguer/flatfluc-theme",
   "unstable": {
    "version": [
-    20210908,
-    1423
+    20220522,
+    1657
    ],
-   "commit": "33726cd072ad83c6943e1c3b83db2fff60f324ce",
-   "sha256": "1nai41dzpnmv63k75xnhc64vipb9nqyv3k75mp2g8csxz569ph2l"
+   "commit": "1679983d22a3b213262e09b3b25db75818a9d37a",
+   "sha256": "1ikkr45bdkajg1s3slq00wwrk06iyly2rnrigzm5vnbw6b5ildn4"
   }
  },
  {
@@ -35928,8 +36025,8 @@
  },
  {
   "ename": "flatland-theme",
-  "commit": "0a081fd0c5598fdf5bc0ab92f4d009f32132a29e",
-  "sha256": "14drqwcp9nv269aqm34d426a7gx1a7kr9ygnqa2c8ia1fsizybl3",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "13b3s62xrdds2w5c1ppvq9ipybxncnmbnzcd2303rr56k9da920a",
   "fetcher": "github",
   "repo": "gchp/flatland-emacs",
   "unstable": {
@@ -36217,11 +36314,11 @@
   "repo": "amake/flutter.el",
   "unstable": {
    "version": [
-    20220502,
-    50
+    20220526,
+    1214
    ],
-   "commit": "e49cbcb70235fa39a7d243521e03ad874451a39a",
-   "sha256": "1hjfkcdi99yfld9jakhhrncpm2yvg03xz35dngc6nn23dkwdpidm"
+   "commit": "b4148db1e6e6822a6a0da1eda3c58affe562d1dc",
+   "sha256": "0ga6jw948w0zwab4jixcrlmv6f9ck0vf7v40g3z4l6ddi2ibsy15"
   }
  },
  {
@@ -36239,8 +36336,8 @@
     "flutter",
     "flycheck"
    ],
-   "commit": "e49cbcb70235fa39a7d243521e03ad874451a39a",
-   "sha256": "1hjfkcdi99yfld9jakhhrncpm2yvg03xz35dngc6nn23dkwdpidm"
+   "commit": "b4148db1e6e6822a6a0da1eda3c58affe562d1dc",
+   "sha256": "0ga6jw948w0zwab4jixcrlmv6f9ck0vf7v40g3z4l6ddi2ibsy15"
   }
  },
  {
@@ -36350,8 +36447,8 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20220504,
-    830
+    20220514,
+    1743
    ],
    "deps": [
     "dash",
@@ -36359,8 +36456,8 @@
     "pkg-info",
     "seq"
    ],
-   "commit": "1d7c1b20782ccbaa6f97e37f5e1d0cee3d5eda8a",
-   "sha256": "01hr9xpjyws32aap2jlyncbgl1rfig8ylspln01yxf1lljysicc2"
+   "commit": "66a973afca1d03b8284baaa7590eb2b8615a1e6a",
+   "sha256": "1acvldcdac11p92c47a25q5k3lxsibigr98b3b2zcmf5l90l0y49"
   },
   "stable": {
    "version": [
@@ -36691,8 +36788,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "35daaccc75b0367844b249a8cb05bf73bcebd52a",
-   "sha256": "0id3jp0d2bkrk17l6svj5c518yp6ndlqg7py962qdrvzz82004j7"
+   "commit": "6fb8d0204b0293478b5565e378797acab1f2e038",
+   "sha256": "1f1sg9rv91hgwzwx8nrc15nvk7m1hxm0f25gh592vjr6yy2n668r"
   },
   "stable": {
    "version": [
@@ -37148,14 +37245,14 @@
   "repo": "emacs-elsa/flycheck-elsa",
   "unstable": {
    "version": [
-    20200203,
-    1758
+    20220523,
+    1105
    ],
    "deps": [
     "seq"
    ],
-   "commit": "911ffb3498e411c538eebce20c6b20b39d725af6",
-   "sha256": "1b0g9lqg6kmvhvh4a6g6xmag4jmkx3br6b37z8kb7p7x3wb691f4"
+   "commit": "39c486096d76344f3045e69620b277ee34b6e5e8",
+   "sha256": "1i7r9k28d0x4gsr4if2xx6karny8f5jrbxvi5529sh8sacl6dyfh"
   }
  },
  {
@@ -37276,8 +37373,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "c52ba814f299f62a2a339bae679f3d6d04566854",
-   "sha256": "11l69nj1f61lvw4arn9k0g9n5pczypn15qq4c02x1kljjlx0h1zs"
+   "commit": "71109b55b3809b8e3be827cec1b61914adf6b45b",
+   "sha256": "0xr6v7ah9a1qr3x4a6ajk2p0mqs7jcx0d6bwm49z2sfx2nz88kz9"
   },
   "stable": {
    "version": [
@@ -37355,8 +37452,8 @@
     "grammarly",
     "s"
    ],
-   "commit": "abc66e71d542f65a90c394058cdd3a7b2002c6a6",
-   "sha256": "0irp6cpi9qy80wssrncdlxjr2612l2mnprrfjjm5hjggflp5wygg"
+   "commit": "46584fee0a8e72c2b1687f4a4ec45feb1bcb1607",
+   "sha256": "1hj259iz1n07vj7jw4000l8hq8l4ivkys6xisb3apixr03sz8zg5"
   },
   "stable": {
    "version": [
@@ -37649,14 +37746,14 @@
   "repo": "jojojames/flycheck-jest",
   "unstable": {
    "version": [
-    20180411,
-    328
+    20220530,
+    1418
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "08f27c5ed97c83c445f99fab58f0b6c826f14449",
-   "sha256": "1ipr1yyk5vf2i8q7923r18a216sgf759x5f6j5776jcjkhp98c98"
+   "commit": "8181c5d2e1318c6ddcff21c6f3f6d76413545645",
+   "sha256": "0lhvgffn08ipafyh7icldbkgslcvqr1pja70fas54f3s077sql2k"
   }
  },
  {
@@ -37781,8 +37878,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "63674d8b928377d763df40317e15f4ca257f77d6",
-   "sha256": "14fjv2wckymhfw0sm89bkbn6lvmcxsivv5m1dva0wr5j0gppaj47"
+   "commit": "e866e3ac1bea1ef7078a6aa926abbee9ca598e5b",
+   "sha256": "185lgdvvhnps626c50xr5r45pyvy131hn24mgm39n6gqpcmlgxhh"
   },
   "stable": {
    "version": [
@@ -38108,8 +38205,8 @@
     "flycheck",
     "pest-mode"
    ],
-   "commit": "43447a2c70f98edd1139005e32f437d3f142442b",
-   "sha256": "1ccpb1jbynlqqzhsm3h7xk2s7n9nbpnnxmixz77kxskdxj5as79a"
+   "commit": "af677327f185113442e95b00986097b30cab650c",
+   "sha256": "01wy3v1aj2891wgbr7rwpaw9xavfrqbyiqiv01q6jjdvc5vl0rwi"
   },
   "stable": {
    "version": [
@@ -38328,8 +38425,8 @@
  },
  {
   "ename": "flycheck-projectile",
-  "commit": "2760b15caa9b23c344ad9a6685fd6994110cba36",
-  "sha256": "1xpl0p07m95gh187jikiz850396h388d24mg97zr6sa6krq8vv55",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0rgm6czkvqnksmhw596xj88g8kdbksy0rdclamm7dvjbjyyaq4p9",
   "fetcher": "github",
   "repo": "nbfalcon/flycheck-projectile",
   "unstable": {
@@ -39041,8 +39138,8 @@
     "flymake",
     "let-alist"
    ],
-   "commit": "8f36fed9eef834cf94931fc8b813f9ac8db6d2a4",
-   "sha256": "0586g7qdcp2bh51ll1sv73ji6vh8l3xxsndpkqxgfkyckmc3iyhh"
+   "commit": "46afe132148da1e3f989e25b00ee17ae4bf1716c",
+   "sha256": "046kmnfid30bwihfzp6mv7ya4vf48b8isfq6hm7y15925y695cg9"
   }
  },
  {
@@ -39088,8 +39185,8 @@
    "deps": [
     "flymake"
    ],
-   "commit": "6ce75c17bc02ae9755deda50d5ac366785c94091",
-   "sha256": "0nbggmz3b6r2rixbn20r58dca05h45lsdyfbbw74syd4fv5g8s9c"
+   "commit": "99fcfbd002dbfd99ab66910265507bf767f52ce6",
+   "sha256": "0ik8rpw1gqrzc7p5ky22clprhvpd0a5i5zrb1p4fnwcywa5mzqr2"
   },
   "stable": {
    "version": [
@@ -39316,8 +39413,8 @@
     "grammarly",
     "s"
    ],
-   "commit": "74ab6bb817205dbf1cd77a161be76904c1e17b75",
-   "sha256": "0ngs38h3zcg2znqbfy0m886g4spn39bnch4s1zcl8f8zcn3s24mg"
+   "commit": "2c5711952922358ea9ca9a7351eb45588238f661",
+   "sha256": "0l0fc2qsg77gv0kha45q6il74xvi0vnh42fkr01dhyf0g1bq4mpq"
   },
   "stable": {
    "version": [
@@ -39578,8 +39675,8 @@
    "deps": [
     "s"
    ],
-   "commit": "c24339b50a4b42cc2bd7e8e167c77a75d8227774",
-   "sha256": "1lvpyn9s3x9wyhdsa9krra03appn8p0dv8086hixpmqm10d21wl1"
+   "commit": "5f9eef8fe3f342f17593e0caeaba906ba7cab24a",
+   "sha256": "1mz18inlv78lg40jgq68qq3v62b6mgmz89lcgczg93lyfh81pjp3"
   },
   "stable": {
    "version": [
@@ -39695,8 +39792,8 @@
    "deps": [
     "flymake"
    ],
-   "commit": "06d819c6d1292f8c87ebc0681c83c9fb48620bbe",
-   "sha256": "1blzcr2c176wlqv8fr4mna0qqm20cd77s8b4gz21jzrq44d7qqf8"
+   "commit": "2e98ef45d764cd8d4e146097ff763c5ec92c6570",
+   "sha256": "1mckr39zgx2f0n56iw4mmy26bayb1y0wjcrr6nnxpbl6jr28rqvw"
   },
   "stable": {
    "version": [
@@ -39725,8 +39822,8 @@
    "deps": [
     "pest-mode"
    ],
-   "commit": "43447a2c70f98edd1139005e32f437d3f142442b",
-   "sha256": "1ccpb1jbynlqqzhsm3h7xk2s7n9nbpnnxmixz77kxskdxj5as79a"
+   "commit": "af677327f185113442e95b00986097b30cab650c",
+   "sha256": "01wy3v1aj2891wgbr7rwpaw9xavfrqbyiqiv01q6jjdvc5vl0rwi"
   },
   "stable": {
    "version": [
@@ -39784,8 +39881,8 @@
    "deps": [
     "flymake-easy"
    ],
-   "commit": "10d3e7e1c31c104e3da694b2b52cd34df61efa5e",
-   "sha256": "1gzg5xz2vchz6kq7hyc1pvd250kfnwkpy88gmh857v3mnzrq71dg"
+   "commit": "abee6b8f50a631e5bc52499b938fcfd88f958a44",
+   "sha256": "0vxi77x11ipsgyy008b9gwav7psdv0wx3bg07sbg6fmhaa3y4fqi"
   },
   "stable": {
    "version": [
@@ -40150,20 +40247,20 @@
   "repo": "shaohme/flymake-yamllint",
   "unstable": {
    "version": [
-    20220311,
-    636
+    20220531,
+    913
    ],
-   "commit": "a93bf9a6697566f0e29fb51a87c5cc7b2a972d2d",
-   "sha256": "0h1w5b2krdvvr73w2k54bxc3dbgs1kbgb2za0z7wc8w02cl8fg57"
+   "commit": "f269e6614993f3c56d545e7d7b225ca2ba1da342",
+   "sha256": "0pw2c22nvy4fkcqbhkrj94q66sx7ggcan26wvy9z6wp04qzaiva8"
   },
   "stable": {
    "version": [
     0,
     1,
-    3
+    4
    ],
-   "commit": "a93bf9a6697566f0e29fb51a87c5cc7b2a972d2d",
-   "sha256": "0h1w5b2krdvvr73w2k54bxc3dbgs1kbgb2za0z7wc8w02cl8fg57"
+   "commit": "f269e6614993f3c56d545e7d7b225ca2ba1da342",
+   "sha256": "0pw2c22nvy4fkcqbhkrj94q66sx7ggcan26wvy9z6wp04qzaiva8"
   }
  },
  {
@@ -40207,11 +40304,11 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20220131,
-    834
+    20220520,
+    630
    ],
-   "commit": "e8027a412262bc04056a5b5440efdb7f370c3320",
-   "sha256": "15db543hnx2m5vcykd13gkxc6j52piyk4jab3wq46223qwpxi0xn"
+   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
+   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
   },
   "stable": {
    "version": [
@@ -40231,15 +40328,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20210124,
-    1143
+    20220520,
+    630
    ],
    "deps": [
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "e8027a412262bc04056a5b5440efdb7f370c3320",
-   "sha256": "15db543hnx2m5vcykd13gkxc6j52piyk4jab3wq46223qwpxi0xn"
+   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
+   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
   },
   "stable": {
    "version": [
@@ -40263,15 +40360,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20210124,
-    1143
+    20220520,
+    630
    ],
    "deps": [
     "flyspell-correct",
     "helm"
    ],
-   "commit": "e8027a412262bc04056a5b5440efdb7f370c3320",
-   "sha256": "15db543hnx2m5vcykd13gkxc6j52piyk4jab3wq46223qwpxi0xn"
+   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
+   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
   },
   "stable": {
    "version": [
@@ -40295,15 +40392,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20210124,
-    1143
+    20220520,
+    630
    ],
    "deps": [
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "e8027a412262bc04056a5b5440efdb7f370c3320",
-   "sha256": "15db543hnx2m5vcykd13gkxc6j52piyk4jab3wq46223qwpxi0xn"
+   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
+   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
   },
   "stable": {
    "version": [
@@ -40327,15 +40424,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20210124,
-    1143
+    20220520,
+    630
    ],
    "deps": [
     "flyspell-correct",
     "popup"
    ],
-   "commit": "e8027a412262bc04056a5b5440efdb7f370c3320",
-   "sha256": "15db543hnx2m5vcykd13gkxc6j52piyk4jab3wq46223qwpxi0xn"
+   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
+   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
   },
   "stable": {
    "version": [
@@ -40569,8 +40666,8 @@
  },
  {
   "ename": "fold-this",
-  "commit": "9853fcb99bd8717c77fa2b3bafb6e85d0d5d491c",
-  "sha256": "1iri4a6ixw3q7qr803cj2ik7rvmww1b6ybj5q2pvkf1v25r8655d",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0v0rppl53cxfr1y1yi8vcy761ipp9lpsw52hhmd2iv67d4xa2s05",
   "fetcher": "github",
   "repo": "magnars/fold-this.el",
   "unstable": {
@@ -40679,8 +40776,8 @@
     20170305,
     1356
    ],
-   "commit": "a5fafe89d4032fd1f0c21b7b04708ef2cce2517b",
-   "sha256": "0m9dwcgja1d33h6d5fbc42lgfxafwvzc3zwnj4ywx6vai9yqljhd"
+   "commit": "26fe027e03911f24b3658b44611d3b38fb6df455",
+   "sha256": "0zcj78r7ixlrag1h58s64g63xx87m1qn3wv6rs6qxcqxwlcl9n96"
   },
   "stable": {
    "version": [
@@ -40764,8 +40861,8 @@
     20191004,
     1850
    ],
-   "commit": "2f38f3583295e05c9ea491b7d1f6b4791169ba86",
-   "sha256": "0jyy8nl4r70l0dwc55lg75k7chcwb9zprl185x0122fjqgmnq1ri"
+   "commit": "4359c640c7822a23976e9a5ca4ce63452d796912",
+   "sha256": "176qjbhvdg1bqy45qk6zf5ij12qif6xkd3ppd1a5wg67p2rv21z8"
   }
  },
  {
@@ -40836,14 +40933,14 @@
  },
  {
   "ename": "forge",
-  "commit": "6cee0395aa57874032cb75c9f3f71e62bd139235",
-  "sha256": "0a1yvdxx43zq9ivwmg34wyybkw4vhgzd2c54cchsbrbr972x9522",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0pzlh2b77qfg4fgpxm8zxvrnfwl7q38srxsvf39r4hgip30sk3lp",
   "fetcher": "github",
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20220506,
-    420
+    20220526,
+    1854
    ],
    "deps": [
     "closql",
@@ -40857,8 +40954,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "05babf69068de7a982bd2e8ad888f37dc7319003",
-   "sha256": "02mck5c2cbz61j2xwgpwaqlpbnp5svn6g05lylhmw7g0sprzcdvb"
+   "commit": "66b3993c98c724e0d3e6411036ccdfab95c7a504",
+   "sha256": "0mfg16vb006avbgw8gygylbqa74cp1fp5cfdr2mp32z6fc77sqcd"
   },
   "stable": {
    "version": [
@@ -41052,8 +41149,8 @@
  },
  {
   "ename": "fountain-mode",
-  "commit": "27cc1d093ce12b559a4266184fb9077c9810d542",
-  "sha256": "1jmb5xm0d1wffw3gj0idv114dzs845n41312dvghv7bblbxyd7bj",
+  "commit": "af5c1593052d63146e850683c461a760ab166033",
+  "sha256": "1ljfdk79lvy04whx0sl211xam5nkj5i31myrdnl6kkg8azbdsj4d",
   "fetcher": "github",
   "repo": "rnkn/fountain-mode",
   "unstable": {
@@ -41497,6 +41594,21 @@
   }
  },
  {
+  "ename": "frimacs",
+  "commit": "80c47d487c434b7e551a265b32e49da6baa818b6",
+  "sha256": "0lg5yarriaab4x1zsdfhfci3sivmj2gslwvnc35jmhp2jq4fa9q9",
+  "fetcher": "github",
+  "repo": "pdo/frimacs",
+  "unstable": {
+   "version": [
+    20220602,
+    1847
+   ],
+   "commit": "4713aa13c96183bccaeccc135b932f94522c2c05",
+   "sha256": "02i6niy6axhwdxw56vqqcnin9iba8vblnmf0fprk06rwlxyj7svc"
+  }
+ },
+ {
   "ename": "fringe-current-line",
   "commit": "eaaa6f7f2f753a7c8489415ae406c4169eda9fa8",
   "sha256": "125yn0wbrrxrmdn7qfxj0f4538sb3xnqb3r2inz3gpblc1vxnqb8",
@@ -41612,11 +41724,11 @@
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20220429,
-    1847
+    20220605,
+    1329
    ],
-   "commit": "5208b54098c7534f4768b87c5f4c8a01b638737b",
-   "sha256": "04s37djxzy8v5xwc5hh8gq37zh7f6ih3y07g07q2fc39rk1xslpd"
+   "commit": "c7842fe63b8bae5aa8bd6a9891036c5ce04e4030",
+   "sha256": "17ibcl9ilm7ml4gjlvcx40hni8awccm1zk37y0nfvcscigf3i8pr"
   },
   "stable": {
    "version": [
@@ -41682,8 +41794,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "041430cda31c73fd51d7c16e736dcf08db13eb11",
-   "sha256": "10kv8hpqh08mgyhn04i72kvzncdaqyflai6h0flg89wv1air0m46"
+   "commit": "6900d1eab9750001e8525f3990ed6fa4a73a8c44",
+   "sha256": "0vxak1s31ql6zk1i3c2kj35dxqi5sdp41ip56b586y0f1p9hfcab"
   },
   "stable": {
    "version": [
@@ -41829,6 +41941,35 @@
   }
  },
  {
+  "ename": "fussy",
+  "commit": "c62fcc6f8f487390423a66aca59700d8856287c9",
+  "sha256": "1rsdrnbnqhd0vk56il7z5vcnz356xhvhmimry3diiaqswl79mk20",
+  "fetcher": "github",
+  "repo": "jojojames/fussy",
+  "unstable": {
+   "version": [
+    20220606,
+    1543
+   ],
+   "deps": [
+    "flx"
+   ],
+   "commit": "1e77aa133b1bed8164a927b9090af839d0383774",
+   "sha256": "0jiip3gcrqvm91bcv647j30kqxbpfqi10w21zi986ggdjjhdcdjs"
+  },
+  "stable": {
+   "version": [
+    1,
+    4
+   ],
+   "deps": [
+    "flx"
+   ],
+   "commit": "4526f81bb76b5af3af13e540ff7a5f1ac0d8ed4f",
+   "sha256": "0mk31kf9aj0mmdynv42h3lwzd4x9ys1d9s1r9qyy0kdi8y8vcs21"
+  }
+ },
+ {
   "ename": "futhark-mode",
   "commit": "97210774b450b7611d2bfdf36e04a425835d86b9",
   "sha256": "1sck984a8m0i9n07jnhpnin6k060756g73ix34ghzd65j5f0pvlw",
@@ -41872,8 +42013,8 @@
  },
  {
   "ename": "fuzzy",
-  "commit": "9e0197df173fbd7ec1e7e35c47476fcf2aaa483f",
-  "sha256": "1hwdh9bx4g4vzzyc20vdwxsii611za37kc9ik40kwjjk62qmll8h",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0hcl2qw1685nn9kv32dj1lnf4wv91nkp5h23rbzzvjaa81z3x8j3",
   "fetcher": "github",
   "repo": "auto-complete/fuzzy-el",
   "unstable": {
@@ -41881,8 +42022,8 @@
     20211231,
     1837
    ],
-   "commit": "7691a73a85f014a34cc161650e989801f2aba5a3",
-   "sha256": "1xm0cmfyvypxhygl36m3r68asixmrdq23q4c3vkx8y7i7yaml4w1"
+   "commit": "bfba20e435a6f5bba328309a8a5ca20dea7a301d",
+   "sha256": "0y4lv1cbpfcz8d1dwvqc728s5hyn6b7fb2n0gg4lhz76h1i411ky"
   },
   "stable": {
    "version": [
@@ -42124,8 +42265,8 @@
  },
  {
   "ename": "gather",
-  "commit": "595e40c7102294684badf86deb72d86bbc3c1426",
-  "sha256": "1f0cqqp1a7w8g1pfvzxxb0hjrxq4m79a4n85dncqj2xhjxrkm0xk",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1y7n7qavqj5dv03y3cvmhj59pccyiz66axvxi7b99q9ya6ig7hsg",
   "fetcher": "github",
   "repo": "mhayashi1120/Emacs-gather",
   "unstable": {
@@ -42571,8 +42712,8 @@
  },
  {
   "ename": "geiser-stklos",
-  "commit": "6530db79aafe4ac4cefa01f77a8cc1e259385171",
-  "sha256": "0bbxxxvzp4dd22lrlmg0lnishvqj1pcm82scds27nrkzrcdycs8s",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1msv27dfasy18mdjh5ymgqakgjj73gw77nzarcg0s34dbdssrzp0",
   "fetcher": "gitlab",
   "repo": "emacs-geiser/stklos",
   "unstable": {
@@ -43074,8 +43215,8 @@
  },
  {
   "ename": "ghub",
-  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
-  "sha256": "1xqhjhr08qrbv4g6i73f60h6ph4rc2m419f2p5n54hrq929qsdri",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "15kjyi8ialpr1zjqvw68w9pa5sigcwy2szq21yvcy295z7ylzy4i",
   "fetcher": "github",
   "repo": "magit/ghub",
   "unstable": {
@@ -43447,16 +43588,16 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20220506,
-    1936
+    20220607,
+    1403
    ],
    "deps": [
     "compat",
     "transient",
     "with-editor"
    ],
-   "commit": "12272c825d216148454b7cfa57fef202cdfe0c7d",
-   "sha256": "0h9f52c1kmgzr0w85knwvf1r2b6dw0dariy2sn9mpqsvpj3cyv2c"
+   "commit": "2dfeaa6839c643a54d96c9f855bae11d5cba2453",
+   "sha256": "052zdj08296s34b7a5p6fapxym7ni1mlw3iqpvw6jhkv9qihmqv2"
   },
   "stable": {
    "version": [
@@ -43567,8 +43708,8 @@
  },
  {
   "ename": "git-gutter+",
-  "commit": "b2db25d23c2a1a4f38867aac25d687a150e95c2b",
-  "sha256": "1w78p5cz6kyl9kmndgvwnfrs80ha707s8952hycrihgfb6lixmp0",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "02f314ks9hv8fgbajq1cci3gd9vycz08w87xngz3wa8r1f7ga6gc",
   "fetcher": "github",
   "repo": "nonsequitur/git-gutter-plus",
   "unstable": {
@@ -43630,8 +43771,8 @@
  },
  {
   "ename": "git-gutter-fringe+",
-  "commit": "ad46c349d13f7d40db706b487319ede40b96b09c",
-  "sha256": "1zkjb8p08cq2nqskn79rjszlhp9mrblplgamgi66yskz8qb1bgcc",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "18h9jkp5blfw4lgxh36x51wjh7fh669q4g7qsifj3lhg595lb757",
   "fetcher": "github",
   "repo": "nonsequitur/git-gutter-fringe-plus",
   "unstable": {
@@ -44910,11 +45051,11 @@
   "url": "https://codeberg.org/akib/emacs-gnu-indent.git",
   "unstable": {
    "version": [
-    20220330,
-    422
+    20220515,
+    1719
    ],
-   "commit": "cd5dc79ac65c24e9e775bd2582ad620e316f2182",
-   "sha256": "07ccrjlh5ph8sdsrd7k5ihrjl4qgsjf9qr54y90fq5b9hzy9ksgp"
+   "commit": "ff3e10edbdf9b919747ec2ba3434d5858f5cc9fa",
+   "sha256": "040vlkzhgi7mhp6m4nrqz2srh8fr8xgpgbiqm8mbcs7py41smkg0"
   }
  },
  {
@@ -45770,11 +45911,11 @@
   "repo": "lorniu/go-translate",
   "unstable": {
    "version": [
-    20220404,
-    1240
+    20220514,
+    1046
    ],
-   "commit": "b0898e6cd647e38e6f70e6cd121b789610573237",
-   "sha256": "19nffy0zqcjgqigbq0p03ldf31xki1cci48yfj620nh0cxvyd0vp"
+   "commit": "3b48787f5e91b9480ef5066bf3657f67306524ca",
+   "sha256": "1c27rk6r9103lwmb0mqkfiph521w7af34p2hli9ahjj8da5y91cb"
   },
   "stable": {
    "version": [
@@ -46043,8 +46184,8 @@
     20220210,
     1659
    ],
-   "commit": "1faa779a126c3564e74d6254d596da8dd2b4bf56",
-   "sha256": "0lhlpl3ilkrpfk3r638avp85wvbyk3arlssa94xw99a4nz7ix4a2"
+   "commit": "25bd3525fa8277d40a0163df04f6a06277e6265b",
+   "sha256": "0nwjz13zyi9fvy96frzjw9y9k42vzgy4h1rpx4p9ar5agi9nrk17"
   }
  },
  {
@@ -46092,8 +46233,8 @@
  },
  {
   "ename": "google-this",
-  "commit": "1e6aed365c42987d64d0cd9a8a6178339b1b39e8",
-  "sha256": "0hg9y1b03aiamyn3mam3hyxmxy21wygxrnrww91zcbwlzgp4dd2c",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "02jfrjan40a5dwjwigr4aff413v6dd20przy7l4jbrbaazq705w2",
   "fetcher": "github",
   "repo": "Malabarba/emacs-google-this",
   "unstable": {
@@ -46268,8 +46409,8 @@
     20210323,
     332
    ],
-   "commit": "ea845966423ce90526d717bb27d0022101c75796",
-   "sha256": "0cwp00677vw20xzrrf7sjjivdz5ny9imqdhj8719ibgqa0cq52zc"
+   "commit": "6fa81449dac4b5b0a0245ff29f13b44cc72cf940",
+   "sha256": "0d0c3zfy8ffg26nzbwy6i26niyikdxf15f8z2147kahlwl23nsvp"
   },
   "stable": {
    "version": [
@@ -46355,8 +46496,8 @@
     20210323,
     422
    ],
-   "commit": "d4db955860de830ebc067b065cba16a776717e76",
-   "sha256": "0d9429y6nwmjywj7rbyjdxs9h98177s16szj6mr54clixvws57rg"
+   "commit": "8046c9d4839438437281fece36858575c0810706",
+   "sha256": "0w09j5k7kvlhq6zdwimx2kmcxc6hbyc3kf2dx3w2b3bc4c8k2xq9"
   },
   "stable": {
    "version": [
@@ -46385,8 +46526,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "b4c0b4fe98b2692cf84e445ad2528911e3e1a622",
-   "sha256": "1wcr3bw7ck5v5w1x3ivhmgm4lq7ln0fvszl7sw0cyj95jqcd7brd"
+   "commit": "b4847059960b2faa100c7066f104be86c561229d",
+   "sha256": "16x2n3xb7yx7ihl4bgzwdwqxv20arlmz7nmiw8j7gy8qvfjnrk0q"
   },
   "stable": {
    "version": [
@@ -46620,8 +46761,8 @@
     "s",
     "websocket"
    ],
-   "commit": "3e14e53b87465ca35b08b5355061e380afb87b31",
-   "sha256": "0zia9hpamwjhyc38l903jwfij06y237j5c2sx600g5r9y36byg9z"
+   "commit": "37d4d7d068c51afefebd58dfa6021662c9c64cf1",
+   "sha256": "0knwcljmq52xlrnl8nzmja0kacc0bb68g4sgi3gkj7g3rl5g2crs"
   },
   "stable": {
    "version": [
@@ -46737,8 +46878,8 @@
  },
  {
   "ename": "graphql",
-  "commit": "3e801ae56f11b64a5a3e52cf1a6c152940ab8c97",
-  "sha256": "139fng2psn535ymqa7c6hm1r7ja1gs5mdvb487jj6fh0bl9wq8la",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1az0pczmyifsig8yaq9qf8w29vr8vcy2s9dqgfdx09zjypy540nm",
   "fetcher": "github",
   "repo": "vermiculus/graphql.el",
   "unstable": {
@@ -46767,15 +46908,15 @@
   "repo": "ifitzpatrick/graphql-doc.el",
   "unstable": {
    "version": [
-    20210808,
-    8
+    20220527,
+    1721
    ],
    "deps": [
     "promise",
     "request"
    ],
-   "commit": "6ba7961fc9c5c9818bd60abce6ba9dfef2dad452",
-   "sha256": "0hb6nxyiz36r3ii8iava76cv0k4nckslli20q2iw8s1nszgwbxky"
+   "commit": "d37140267e0c426c7c18aff31900aa1650257394",
+   "sha256": "008wnng94pm2p1xjpbvzzm2l29yq1635j45xywgcj66vknsvvijg"
   },
   "stable": {
    "version": [
@@ -47541,8 +47682,8 @@
  },
  {
   "ename": "guru-mode",
-  "commit": "e60af6ccb902d8ef00cfecbb13cafebbe3b00d89",
-  "sha256": "0j25nxs3ndybq1ik36qyqdprmhav4ba8ny7v2z61s23id8hz3xjs",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0daan2hhi24agbc33rss9j298caszfnx6qqx8kh69s16yk5hm4h0",
   "fetcher": "github",
   "repo": "bbatsov/guru-mode",
   "unstable": {
@@ -48001,16 +48142,16 @@
   "repo": "otavioschwanck/harpoon.el",
   "unstable": {
    "version": [
-    20220402,
-    446
+    20220604,
+    50
    ],
    "deps": [
     "f",
     "hydra",
     "project"
    ],
-   "commit": "a23571eaab94fb2da0569ed5ab3c1b469f123b97",
-   "sha256": "0xl7lfj9cc9qp72ibjyilrdxrknvfd07fk206c8933yngrkqf376"
+   "commit": "b08d4af6e4ab404c8a1031ff8cbfff49d5c8aec4",
+   "sha256": "103z74y5x3pfanbalf6xgrm7cny30f1n3lihliabfiav96xzpmq7"
   }
  },
  {
@@ -48139,11 +48280,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20220331,
-    1645
+    20220529,
+    1859
    ],
-   "commit": "4ec2aa32b1772e629a6a2b47b84048e1990d6728",
-   "sha256": "0m0irwlwz17dmx4k1x82slmbxaxkmhxdjm9ha1490jf4wbbh93q4"
+   "commit": "5a9f8072c7b9168f0a8409adf9d62a3e4ad4ea3d",
+   "sha256": "0np1wrwdq7b9hpqpl9liampacnkx6diphyk8h2sbz2mfn9qr7pxs"
   },
   "stable": {
    "version": [
@@ -48239,26 +48380,26 @@
   "repo": "purplg/hass",
   "unstable": {
    "version": [
-    20220402,
-    1326
+    20220526,
+    2124
    ],
    "deps": [
     "request"
    ],
-   "commit": "c6bded14ae4b68194bd9e35428e9973ca144569b",
-   "sha256": "1qklrp1gskcr93j8gzi1nsp6kzjq7pra1rnyls67l4nchff2knl3"
+   "commit": "5da5404c8de483ca70dcab13ad07805f1b37e4bd",
+   "sha256": "1a9m8pny9x8mfi1jkk7y4357hbhqfi7i71shs26ilr0gyivfvxbp"
   },
   "stable": {
    "version": [
     2,
-    1,
-    2
+    2,
+    1
    ],
    "deps": [
     "request"
    ],
-   "commit": "22873f7df205cc1144ebff7aa2dc9bb85031c8a3",
-   "sha256": "1qklrp1gskcr93j8gzi1nsp6kzjq7pra1rnyls67l4nchff2knl3"
+   "commit": "5da5404c8de483ca70dcab13ad07805f1b37e4bd",
+   "sha256": "1a9m8pny9x8mfi1jkk7y4357hbhqfi7i71shs26ilr0gyivfvxbp"
   }
  },
  {
@@ -48309,8 +48450,8 @@
     20210108,
     1835
    ],
-   "commit": "6641a0d7c00ce633887baf3f8c594d9a8a504e9b",
-   "sha256": "0395f1pwrga0vfd153s7xlgiw5m2d89s5lx6xn9dm8x31q78ghq6"
+   "commit": "063785e0a9e54826e758571281c6715f4dd82387",
+   "sha256": "0hl54ksfiv0gnvhnfxa913n8jhysv94nmhryd4ipg2lljlr11zxr"
   },
   "stable": {
    "version": [
@@ -48366,8 +48507,8 @@
  },
  {
   "ename": "hc-zenburn-theme",
-  "commit": "01ccd40bd5fc2699a4756ebf503ac50f562cf600",
-  "sha256": "0jcddk9ppgcizyyciabj3sgk1pmingl97knf9nmr0mi89h7n2g5y",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "14ag9y0i5ma07ja0f2n9lmnivhy11r1l9ixy41xl3wc4gjdhmyn2",
   "fetcher": "github",
   "repo": "edran/hc-zenburn-emacs",
   "unstable": {
@@ -48449,15 +48590,15 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20220512,
-    1048
+    20220607,
+    1243
    ],
    "deps": [
     "helm-core",
     "popup"
    ],
-   "commit": "0f7d7acf5724d79ed51ae22349ceb743c4868a3e",
-   "sha256": "177gpf0s722xdya74gdx8my3jw49f38im31i3impw5c25g8x9ajs"
+   "commit": "9e706bc154deab9b5932d7849eff249f7c4bf1c9",
+   "sha256": "1kgh0srn59sbjkrjb1kwvyiyklp3aj6bf8c161b3k73g6gpz3kj4"
   },
   "stable": {
    "version": [
@@ -48556,8 +48697,8 @@
    "deps": [
     "helm"
    ],
-   "commit": "9820ba1893c8a7e31e756c891f9b4cf0eff1e50b",
-   "sha256": "173n4s1i9zi4yizvlzfr2qsj6rb2qizkmhwm21ijd701ac3v9xcs"
+   "commit": "6a45f2f6a6c5a957eb43ed32c6e77069c5251e1c",
+   "sha256": "04fq30hashpvss4f1ar9w2nc5pw7drhx0l5d37x7dy2y7pf85mal"
   },
   "stable": {
    "version": [
@@ -48573,8 +48714,8 @@
  },
  {
   "ename": "helm-ag-r",
-  "commit": "6aa1cf029db913dafb561e4c8ccc1ca9099524de",
-  "sha256": "0ivh7f021lbmbaj6gs4y8m99s63js57w04q7cwx7v4i32cpas7r9",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "00z4xg144axzha993iv3ci3wpsh4rbdbff9ywapfa19j4q76fb72",
   "fetcher": "github",
   "repo": "yuutayamada/helm-ag-r",
   "unstable": {
@@ -49355,14 +49496,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20220512,
-    856
+    20220607,
+    1243
    ],
    "deps": [
     "async"
    ],
-   "commit": "0f7d7acf5724d79ed51ae22349ceb743c4868a3e",
-   "sha256": "177gpf0s722xdya74gdx8my3jw49f38im31i3impw5c25g8x9ajs"
+   "commit": "9e706bc154deab9b5932d7849eff249f7c4bf1c9",
+   "sha256": "1kgh0srn59sbjkrjb1kwvyiyklp3aj6bf8c161b3k73g6gpz3kj4"
   },
   "stable": {
    "version": [
@@ -49538,14 +49679,14 @@
   "repo": "emacs-helm/helm-dictionary",
   "unstable": {
    "version": [
-    20220319,
-    955
+    20220514,
+    714
    ],
    "deps": [
     "helm"
    ],
-   "commit": "69f1e5bf03d67c9e5cb0065e702e8c311ac9d3db",
-   "sha256": "0haq758rxayl4qwyxm44w7mq1s5g0gpfxspd0q9c546qvws4kwrr"
+   "commit": "65fdf36e9a5c6dd8dffa71dfb6c65bc03879abe2",
+   "sha256": "1r62xrq95lzgg3if0q86idl9l8gmks76pgpxr615vm8ndhq8a545"
   }
  },
  {
@@ -49919,8 +50060,8 @@
    "deps": [
     "helm"
    ],
-   "commit": "f9ffd81c3b7fa3e5f79f511a6c2226b5e99b73e6",
-   "sha256": "0g4gy812ahch4p4nqw8wz0a7qsn637lm85x3iahphy53qvyzc9rf"
+   "commit": "5814015490c4540a5779168511d596022c6ebb44",
+   "sha256": "0rivhzxk0yifjkphf59sq4h37485kggdy8ww7s10nf40n360prz3"
   },
   "stable": {
    "version": [
@@ -50184,8 +50325,8 @@
     "flx",
     "helm"
    ],
-   "commit": "dd092e8eea5257d49bbdf694df4fefd86252e54b",
-   "sha256": "1w6625gd5k149wm54m7ci6l9pzrcma6z8hppj965vqlwqc8fj4xa"
+   "commit": "99bb20cd7ec89ac1e2ae6eaecd9ac4b30f570bee",
+   "sha256": "1srns7jr7nbgq25x4qapc44p6ivfzlm18xxqnbdadf05ld9jgh2v"
   },
   "stable": {
    "version": [
@@ -50531,8 +50672,8 @@
    "deps": [
     "helm"
    ],
-   "commit": "6285c083d885ea8e110868c6a5b9df69c3f3c4af",
-   "sha256": "1di39sbwf3yi01jh8nbiayqqnms1dddfqnz5g0gg935f5w3l1phm"
+   "commit": "c97a2fe68632938c2414249abbc9c7004eed3255",
+   "sha256": "1scjp0rrgsvlk963vrx6s8fmgz4fga24prlvbck07c3wvrfz37lx"
   },
   "stable": {
    "version": [
@@ -50790,8 +50931,8 @@
  },
  {
   "ename": "helm-j-cheatsheet",
-  "commit": "681b43eb224942155b97181bbb78bcd295347d04",
-  "sha256": "0lppzk60vl3ps9fqnrh020awiy5w46gwlb6d91pr889x24ryphmm",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1k3ajip1k225zrcb901887a8lqp0wkyavqikajfb0jszk8v63ysk",
   "fetcher": "github",
   "repo": "abo-abo/helm-j-cheatsheet",
   "unstable": {
@@ -50985,14 +51126,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20220418,
-    657
+    20220605,
+    434
    ],
    "deps": [
     "helm"
    ],
-   "commit": "c6494a462e605d6fd16c9355e32685c3e0085589",
-   "sha256": "02gx6a8n7csip5wm818bmhrq4r0r394r3vvfsn8fja8fagmg3z1a"
+   "commit": "27a0fae5c8927c5980f49726bd29d0a7274af337",
+   "sha256": "03k5gpz3vinj4w7k0cfmpjn6rxwiyyscn4jl9zyj2bgdf2m39wfm"
   },
   "stable": {
    "version": [
@@ -51382,8 +51523,8 @@
  },
  {
   "ename": "helm-org",
-  "commit": "5c14f6b048ec9983e31fcd3e7cdea45ebe806ce8",
-  "sha256": "02zyc7nssl4zvbbw03fl0nbf4d6qmqxywa2hnfyiwfzn5jzxkl95",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0j486w0nzn9iw96h8gh9vwichhnasvl4h0wd48dfxnvzymz6z5gj",
   "fetcher": "github",
   "repo": "emacs-helm/helm-org",
   "unstable": {
@@ -51463,14 +51604,14 @@
     "org-ql",
     "s"
    ],
-   "commit": "46f523d94a376b168176c75bbd0e3e0d00e61170",
-   "sha256": "0vrk7lx4n4imvsnqv50w6fmqnndr48x89gcmm375fw6zgy2m90bl"
+   "commit": "64a9234733904af20fd495861792f1d5c2b37190",
+   "sha256": "1w3vly4jh854gb9bgnwqfzry6214v498fmiwm491gi8m5g0d05xp"
   },
   "stable": {
    "version": [
     0,
     6,
-    1
+    2
    ],
    "deps": [
     "dash",
@@ -51478,8 +51619,8 @@
     "org-ql",
     "s"
    ],
-   "commit": "f666fe150f1bf3c3ce43d0e15f90b20d43c2e772",
-   "sha256": "1mpq3v8lxqllnb4afqh7p9av0p9bha8ld7741zaw4hxb1252xgm2"
+   "commit": "115500c8a0a3190ec6a69d1120fe81944d819125",
+   "sha256": "0iamqv5j43ngj1xdqr36rkgk9lqpk9bg8y531jsldnvwzrp3srpf"
   }
  },
  {
@@ -52079,8 +52220,8 @@
  },
  {
   "ename": "helm-recoll",
-  "commit": "0a0d168f96470753c22b92ad863be98d8c421ccd",
-  "sha256": "0pr2pllplml55k1xx9inr3dm90ichg2wb62dvgvmbq2sqdf4606b",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0bq0gp1cqmx39fsfpccxn7dsa34f75bdi3kyni7d55rvlvascaqz",
   "fetcher": "github",
   "repo": "emacs-helm/helm-recoll",
   "unstable": {
@@ -52357,8 +52498,8 @@
     "s",
     "searcher"
    ],
-   "commit": "d0a3aa7c4a882c6563c053c3317600582043d71c",
-   "sha256": "10hvm4xym1886b02jqpg83p2pz6s9nkkrs7ifnydhn2zn5khn855"
+   "commit": "6409eef130d3561e024813f3af82a61f73c9ae5b",
+   "sha256": "1l0csk24ls9784k4fry15mdkmryn2dcvssiqv07jjl90n04pjq62"
   },
   "stable": {
    "version": [
@@ -52733,15 +52874,15 @@
   "repo": "emacs-helm/helm-system-packages",
   "unstable": {
    "version": [
-    20210628,
-    1727
+    20220515,
+    812
    ],
    "deps": [
     "helm",
     "seq"
    ],
-   "commit": "a16bb1c3708416984106a98353700d456414b6a1",
-   "sha256": "09acgs1mjkqmm7n88x4hck2bp3jv5fifdkd406r8fh874vyfib38"
+   "commit": "e93f4aeaa77b73c6e529141c3fa0ac49b40b6306",
+   "sha256": "1i5dy2hi5xiyb2p2795pk24h8kzmd38pasd51azyx5d0qmjjvb8m"
   },
   "stable": {
    "version": [
@@ -52759,8 +52900,8 @@
  },
  {
   "ename": "helm-systemd",
-  "commit": "35763febad20f29320d459394f810668db6c3353",
-  "sha256": "1m1by9i37ban3zkznyamp5vxizj8zsz06fdscdhmky1grf6ri4r8",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "03hzx0202kw5bhmbn51wsaf1jajk2cmxx3nkk4pa8dawgrh8mg95",
   "fetcher": "github",
   "repo": "Lompik/helm-systemd",
   "unstable": {
@@ -52838,8 +52979,8 @@
    "deps": [
     "helm-core"
    ],
-   "commit": "b6bd3379b98d306935731e9632907387b078e000",
-   "sha256": "0ki38i2qiysba6xm6hc4xmy4vkpsvc85lh1vgjy8741wkysija2x"
+   "commit": "7b39adc0e80e791390f34aab866a963df317c235",
+   "sha256": "0jllvylilc81gxkdhy4cl0bma8jrkjhj8c1m7vzjdxr3mplnl1sj"
   },
   "stable": {
    "version": [
@@ -53179,14 +53320,14 @@
   "repo": "duncanburke/help-find",
   "unstable": {
    "version": [
-    20210826,
-    928
+    20220513,
+    1028
    ],
    "deps": [
     "dash"
    ],
-   "commit": "576d6505b9e42f50f121b1a6a675f17f03a04406",
-   "sha256": "064asvq6hfmrh3fnkm8dnarwmdgfm8f97mjng1bkf13wmnzglhck"
+   "commit": "6dd61bbb6290e06e30c002c011da71e348ac045f",
+   "sha256": "00b4vbk3m0br5k2x9mqx1v58j7jpd4k1nln18s99ggxpmx5klk02"
   }
  },
  {
@@ -53221,8 +53362,8 @@
   "repo": "Wilfred/helpful",
   "unstable": {
    "version": [
-    20220412,
-    421
+    20220513,
+    302
    ],
    "deps": [
     "dash",
@@ -53230,23 +53371,22 @@
     "f",
     "s"
    ],
-   "commit": "c2729a236a84a1fbd3d184c163fbd10e0fd62077",
-   "sha256": "0q5a1s4wkxjp56gy95qzkxzz8w46djacgh9fhwm509rkkdxpp30c"
+   "commit": "209971ba9f576ba080352642cfbf25df5692b1d7",
+   "sha256": "1qrxr0ybvdvx6qw6akb1pv074bmffv4m57855kk8fr1vp4w07z0i"
   },
   "stable": {
    "version": [
     0,
-    18
+    19
    ],
    "deps": [
     "dash",
-    "dash-functional",
     "elisp-refs",
     "f",
     "s"
    ],
-   "commit": "5a5eb62ae1f9cfdd4897ec6e878ec96231c52bdd",
-   "sha256": "0gdjxykqkal2x765mi51m99i5ql23i1fy909wy4mzj5ajhjfgqcc"
+   "commit": "2afbde902742b1aa64daa31a635ba564f14b35ae",
+   "sha256": "0qwsifzsjw95l83m7z07fr9h1sqbhggwmcps1qgbddpan2a8ab8a"
   }
  },
  {
@@ -54203,11 +54343,11 @@
   "url": "https://codeberg.org/ideasman42/emacs-hl-prog-extra.git",
   "unstable": {
    "version": [
-    20220507,
-    1118
+    20220607,
+    140
    ],
-   "commit": "a8e2ee5d43ce70c59e57d2ab90b39a6cf9e7b851",
-   "sha256": "08vs56lvq9ihhxd7vhcgd9lry2bm8q14mx18ap1izj6r52njdsy5"
+   "commit": "e7e24735cd020746e4070c908a6ebd2515c4c19b",
+   "sha256": "00r7fdgi9mda69sw1c0q9zhjwjdrn74gyw3hk9ml3n3qxnagkfva"
   }
  },
  {
@@ -54261,13 +54401,13 @@
  },
  {
   "ename": "hledger-mode",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "15s8rqc94z70jzv13961nvcm9a9qadq04pf0m6xrzf8qqk71zn52",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "05nyifa0r398w5yw1751rzn90w9dh9w5y7fhn9h5xmd7qdq8zibq",
   "fetcher": "github",
   "repo": "narendraj9/hledger-mode",
   "unstable": {
    "version": [
-    20210706,
+    20220515,
     1225
    ],
    "deps": [
@@ -54275,8 +54415,8 @@
     "htmlize",
     "popup"
    ],
-   "commit": "9ac07ff0adbce6a402c17e789b1750f9da0d22f4",
-   "sha256": "0x3dgws8nh7q8x7zzjwbm5k9n7gi7qqd3ww7y51fbx6p6ii3jpp4"
+   "commit": "400bde42a8d2712af80cd7c773c9cdfbb63a515a",
+   "sha256": "0xmcfpr3rxli1adwypg18npl8hb8ak5rg6a6i26inzzqja6vr897"
   }
  },
  {
@@ -54357,8 +54497,8 @@
  },
  {
   "ename": "hoa-mode",
-  "commit": "b46e83f2ea2c4df1ef343c79c7e249605c9639b3",
-  "sha256": "0cg7jg8ddcrpr47imix21m84h65z2xls3p20b32pasiqav3n8zsm",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1j8fi6bv25lgj8n6ykki2n1k9hbwbm7gw9g5jh2ds5n475291gcj",
   "fetcher": "git",
   "url": "https://gitlab.lrde.epita.fr/spot/emacs-modes.git",
   "unstable": {
@@ -54554,11 +54694,11 @@
   "repo": "axelf4/hotfuzz",
   "unstable": {
    "version": [
-    20210924,
-    936
+    20220607,
+    1906
    ],
-   "commit": "95a1be449624aa2b25128b900b6211034d0e17bb",
-   "sha256": "1lfwa6r3z79kvahgily4drmpf2y4sfwkv5gqbpn57fjxh2sq4rwp"
+   "commit": "50ea5b54c21dc6a2437e37b17c7ea14f8ba06771",
+   "sha256": "11aw2b5wixf6qlh3b2wnnms4n1fgp23g1yy48ykb3g6hkwrs2nrs"
   }
  },
  {
@@ -54696,8 +54836,8 @@
  },
  {
   "ename": "ht",
-  "commit": "6c7589bca1c1dfcc0fe76779f6847fda946ab981",
-  "sha256": "16vmxksannn2wyn8r44jbkdp19jvz1bg57ggbs1vn0yi7nkanwbd",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1fcqidqkzxnqrdm6qljn0dy26f1bk0ipkamcq56f5myrd8mnqhgd",
   "fetcher": "github",
   "repo": "Wilfred/ht.el",
   "unstable": {
@@ -54848,8 +54988,8 @@
     20200929,
     559
    ],
-   "commit": "049efcadbd9b51a601cca60fc78616bcef0799ae",
-   "sha256": "09l1n4jmw2cr89jfss3zmlbzpbglir1h548kv3zdl44hbyb4wlk9"
+   "commit": "1bacc5a6348e29ab506cd530e2ebb7348caf77fd",
+   "sha256": "0pjm45973khr48w17srwvp4ns1sjifjy8pv2q0gnhks00ab5p5n1"
   },
   "stable": {
    "version": [
@@ -55827,8 +55967,8 @@
  },
  {
   "ename": "ido-completing-read+",
-  "commit": "6104efc035bcf469d133ab9a2caf42c9d4482334",
-  "sha256": "0rxdv3cd0bg0p8c1bck5vichdq941dki934k23qf5p6cfgw8gw4z",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0amf3v21f86pd7z3ijvlqgxrc6fpl6afwcc84r206ywzxbw11k6j",
   "fetcher": "github",
   "repo": "DarwinAwardWinner/ido-completing-read-plus",
   "unstable": {
@@ -56014,8 +56154,8 @@
  },
  {
   "ename": "ido-select-window",
-  "commit": "775c8361322c2ba9026130dd60083e0255170b8f",
-  "sha256": "03xqfpnagy2sk67yq7n7s6ma3im37d558zzx8sdzd9pbfxy9ij23",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0fjc5j5s7g109lac0pv75vw8g50a0217kyngcyrmylfpy210cd4f",
   "fetcher": "github",
   "repo": "pjones/ido-select-window",
   "unstable": {
@@ -56159,15 +56299,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20220105,
-    1300
+    20220519,
+    917
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "65d6db1b7574ceccd3d97eee3790c2f74aa9724d",
-   "sha256": "0dc5mfm0gh7y4yzsz2lgc3802m4pv85l213j04k347xqqcl414lc"
+   "commit": "3c1f8f8410d909229d12d0227399f2d5c16b1ea4",
+   "sha256": "1is7n7j7h6w3x5i7byqn3kc41qk2p5wb0cdnr6cjxvlc3zar3wb0"
   },
   "stable": {
    "version": [
@@ -56606,11 +56746,11 @@
   "repo": "petergardfjall/emacs-immaterial-theme",
   "unstable": {
    "version": [
-    20220214,
-    1859
+    20220519,
+    635
    ],
-   "commit": "ca82a1700cf7834b55ada36e53811f6effde6283",
-   "sha256": "1c9d895g4dw0jp1ipm1mlhs2ln5f61ng83rv294jh32nrl3wrs81"
+   "commit": "e022d1a2fdc899b4c22254ebcf8997f5690d7c60",
+   "sha256": "0knpyh0ci777g6h83lr4pvy7w1syf068gy1p409rg3ssnwjnkxnl"
   },
   "stable": {
    "version": [
@@ -56707,8 +56847,8 @@
    "deps": [
     "impatient-mode"
    ],
-   "commit": "6825147ebacb1d738b1c96baf0534a5ed3e6b289",
-   "sha256": "10kjxm93cdll6a5l1lzk0ciya5z6d02x5rl7har507ac1laj1v23"
+   "commit": "832e6725d4b95b2f00ff8be94cd75dc3cc873ca4",
+   "sha256": "0d54m7hkfaidxjynz762i7cjrgdqy9d3rrkm2r16ql9rmk8hdwvn"
   },
   "stable": {
    "version": [
@@ -56797,8 +56937,8 @@
     "epc",
     "f"
    ],
-   "commit": "701dfcca5f3ab42be0f26a8d381d7116c79be850",
-   "sha256": "035830aizamh4c8hpnmfrbz9v9gy23d3nx0dv366l3q8mrh36l44"
+   "commit": "570fb4f519d5e84dd681f932447cb995e8460840",
+   "sha256": "1xrlnighvzgmfb4fwnp07bnj1wyym1pn4ap62swq0h0mcq8gjr80"
   },
   "stable": {
    "version": [
@@ -56848,8 +56988,8 @@
     20220227,
     653
    ],
-   "commit": "6fb6c9326077105febe2cd9c77b683b7c310cf03",
-   "sha256": "069mcbj3gwpbw1fwrpyfb81s0kyk3vklymfj9z7nr7yl8ra986ym"
+   "commit": "e04850bb05a816395a92c69b7ad7cd32d33eb62a",
+   "sha256": "1fvvhpbqq22cab2pa480sanp1jnjyipysa8jgxwrf3r438yhi729"
   },
   "stable": {
    "version": [
@@ -57054,14 +57194,14 @@
   "repo": "clojure-emacs/inf-clojure",
   "unstable": {
    "version": [
-    20220421,
-    559
+    20220603,
+    1523
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "abeab8d6d4cb3bdded5e9083776aab0c06cbdf57",
-   "sha256": "0b73dm3kyard035jfijcah8vp96vzgywmkl0ajnhyzzxmbl26hqa"
+   "commit": "8f295050a856b03d6ec14f0fd5e782e7acde6e2d",
+   "sha256": "0gm2psay483202vjzf27gvlmy7l2y8gawwviv5rbfbsxyb4l5xrm"
   },
   "stable": {
    "version": [
@@ -57452,8 +57592,8 @@
  },
  {
   "ename": "initsplit",
-  "commit": "5a908c8fad08cd4d7dbb586570d0f0b384bf9071",
-  "sha256": "0n9dk3x62vgxfn39jkmdg8wxsik0xqkprifgvqzyvn8xcx1blyyq",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1jkn4d7mlchpnzn79rln8ypcwqac7h3lv44ax3dpppzxq5y6ylx1",
   "fetcher": "github",
   "repo": "dabrahams/initsplit",
   "unstable": {
@@ -58084,8 +58224,8 @@
    "deps": [
     "f"
    ],
-   "commit": "e6c9d5e19533eda6b74505a86198416eeecb915a",
-   "sha256": "00chrr0i1bw0dzrlznahca8zj4q9yqwl187m9dm9d1kgh0dwhn3s"
+   "commit": "85efbf0c1c651a94062fa820faf48f7bc8d4f8af",
+   "sha256": "1yhmzrns7bzncg0mc7mxwg5jxvblhfkg7nim5c66hmq3mr60gb48"
   },
   "stable": {
    "version": [
@@ -58117,8 +58257,8 @@
  },
  {
   "ename": "isend-mode",
-  "commit": "8ef6e4dab78a4c333647a85ed07a81da8083ec0c",
-  "sha256": "0sk80a08ny9vqw94klqfgii297qm633000wlcldha76ip8viikdv",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "16xd41z7b1kf599ggwkikdamd41ldlfvc37hq25z8hz7g1ajbcar",
   "fetcher": "github",
   "repo": "ffevotte/isend-mode.el",
   "unstable": {
@@ -58317,11 +58457,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20220406,
-    1052
+    20220529,
+    1130
    ],
-   "commit": "8bf8027e4bd8c093bddb76a813952d2a0dcbf21d",
-   "sha256": "1rdv8r6zw0lziycwv5kd2yyflfwby4gnqgfvv67b1y2l3psjwp94"
+   "commit": "f8d80a4055514f92d94f128f5fcb1cda79e5cd22",
+   "sha256": "1cmafp5rssp27lhvszyzf4mc1z130kkgkl9d36lgg97qk5jp58g8"
   },
   "stable": {
    "version": [
@@ -58348,8 +58488,8 @@
     "avy",
     "ivy"
    ],
-   "commit": "8bf8027e4bd8c093bddb76a813952d2a0dcbf21d",
-   "sha256": "1rdv8r6zw0lziycwv5kd2yyflfwby4gnqgfvv67b1y2l3psjwp94"
+   "commit": "f8d80a4055514f92d94f128f5fcb1cda79e5cd22",
+   "sha256": "1cmafp5rssp27lhvszyzf4mc1z130kkgkl9d36lgg97qk5jp58g8"
   },
   "stable": {
    "version": [
@@ -58595,8 +58735,8 @@
     "ivy",
     "s"
    ],
-   "commit": "942b2565097c97c1afc4fa395fac5788eabc730b",
-   "sha256": "03q15h6ckbrxmwskf19dhzcr8whgcipbf4nilpqfnhpsn5f4zl8l"
+   "commit": "bb576866d81ee4ee428c8d56663d3e30edf57998",
+   "sha256": "1plpjs2vkc9n1cb05p7ldfrm0ic2b82lpnmghkd60x64j36yjp20"
   },
   "stable": {
    "version": [
@@ -58716,8 +58856,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "8bf8027e4bd8c093bddb76a813952d2a0dcbf21d",
-   "sha256": "1rdv8r6zw0lziycwv5kd2yyflfwby4gnqgfvv67b1y2l3psjwp94"
+   "commit": "f8d80a4055514f92d94f128f5fcb1cda79e5cd22",
+   "sha256": "1cmafp5rssp27lhvszyzf4mc1z130kkgkl9d36lgg97qk5jp58g8"
   },
   "stable": {
    "version": [
@@ -58917,27 +59057,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20220509,
-    2300
+    20220601,
+    1652
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "c05f8a43c6ff07a8b5a3ba8df7a2ec35677b7484",
-   "sha256": "0752dyl4fhi0jvbm238s5p1sv7z4jlkmkdrxvwn0dlhfr0rhfw1c"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   },
   "stable": {
    "version": [
     5,
-    2
+    2,
+    1
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
-   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   }
  },
  {
@@ -58973,8 +59114,8 @@
  },
  {
   "ename": "ivy-rich",
-  "commit": "35763febad20f29320d459394f810668db6c3353",
-  "sha256": "1il1lhxxg694j9w65qwzjm4p4l3q1h1hfndybj6z1cb72ijw27fr",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1qwfnz3lgsp9brbhv2kv9bzlzyjzj6j6plzs1nhczpz06c62123s",
   "fetcher": "github",
   "repo": "Yevgnen/ivy-rich",
   "unstable": {
@@ -59049,8 +59190,8 @@
     "s",
     "searcher"
    ],
-   "commit": "17a93eadb8a681d878e1d66b90073ed1be2e1dc2",
-   "sha256": "0m0lvpqamikmg957jj2nkr8xqzxl0kxyjl68577h4r83b60xrnhh"
+   "commit": "22867f0987b77e2cba0d251b62f5bd6324cc366f",
+   "sha256": "0kk39km7nw7izhb5r2rlhbaxcypvjngnmxmxnb2b0jx101kwzrhr"
   },
   "stable": {
    "version": [
@@ -60056,11 +60197,11 @@
   "repo": "Michael-Allan/Java_Mode_Tamed",
   "unstable": {
    "version": [
-    20220510,
-    430
+    20220524,
+    2327
    ],
-   "commit": "f968413df2c2bd1e00c5b6c61c53bdd208b90ee3",
-   "sha256": "0gyf61krqy6d5sjvj5c9z57vqx2nq0fia2pxmk32slisxc9drcqm"
+   "commit": "5e8eb048dd398597378eaf20842e410398bd5b55",
+   "sha256": "0qhp1p49b8mjnyr8lxlvwjdhnl36l5byyzb9psnf1iid7f306rki"
   }
  },
  {
@@ -60720,8 +60861,8 @@
  },
  {
   "ename": "json-rpc",
-  "commit": "82c6b97cdfe2970f028a00146b01e5734710291b",
-  "sha256": "1v1pfmm9g18p6kgn27q1m1bjgwbzvwfm0jbsxp8gdsssaygky71k",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0m986dlzsvr068nywrrrad72wwnv22dvw00d8y66h5rmx1nh87hs",
   "fetcher": "github",
   "repo": "skeeto/elisp-json-rpc",
   "unstable": {
@@ -60843,8 +60984,8 @@
  },
  {
   "ename": "jss",
-  "commit": "e3dc3607f512df378ba141327802820da4991a97",
-  "sha256": "050hskqcjz5kc8nni255vj3hc9m936w1rybvg5kqyz4p4lpzj00k",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0jm2gfba3i12k269xrvhy0y4s536x7arcpx0018adylg7b4mmsh6",
   "fetcher": "github",
   "repo": "segv/jss",
   "unstable": {
@@ -60990,8 +61131,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20220512,
-    539
+    20220523,
+    435
    ],
    "deps": [
     "dash",
@@ -61001,8 +61142,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "88ce4fadc065736e154506538d365a8f1dd643e1",
-   "sha256": "1gj9mnv0kyq20hdz506qlz80kx28zwng12vnnahshji6bh6wbwj5"
+   "commit": "326da9a7d0463ed2727f66dcbd4cb58b517ffe25",
+   "sha256": "0irspd2j644g1fwai51wwawmq5ni0fpwzby3j4yka2w0pwvqvg6w"
   },
   "stable": {
    "version": [
@@ -61029,14 +61170,14 @@
   "repo": "shg/julia-vterm.el",
   "unstable": {
    "version": [
-    20220510,
-    2259
+    20220524,
+    1328
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "5374776991232de966efca245f9ce24c59728588",
-   "sha256": "0cg5mqiciawigb5n7w8q5hi8q1h253nbjif3p9n7vhbckwx318rx"
+   "commit": "c5f67a372777bb6a855ba2a89228a713c8dda957",
+   "sha256": "15h92yq88na3banbf7x0k99bya9z5216qckyrgx3f5ksdci1bbih"
   },
   "stable": {
    "version": [
@@ -61598,15 +61739,15 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20220422,
-    1305
+    20220519,
+    720
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "51b1f719bc300a4f684b6dc7511dfb044f75f575",
-   "sha256": "0nq78kb751lgz398w8xbbl63cznb1g3l6j0j4limylmi8rlzvsnd"
+   "commit": "5fd75d41647d9535eb730b99b5adddc9edf55cd2",
+   "sha256": "1pi9xhrlw76b35zsndgkfc4g5v1kk29y023xd0iczf74v8ih08ps"
   },
   "stable": {
    "version": [
@@ -61694,11 +61835,11 @@
   "repo": "delaanthonio/kconfig-mode",
   "unstable": {
    "version": [
-    20211018,
-    2142
+    20220604,
+    1415
    ],
-   "commit": "241436a507782d18f09dab7d1f373ddea60fad3d",
-   "sha256": "0ayizg9ih98yn9127737i0g9q8f484v0fc9qwda0al3r69iqxpxq"
+   "commit": "cd87b71c8c1739d026645ece0bbd20055a7a2d4a",
+   "sha256": "114hjz7k8p8xmpfbv2img98qfkb46wn4mz5sdbl7278f973z2yqv"
   }
  },
  {
@@ -62011,14 +62152,14 @@
   "repo": "dacap/keyfreq",
   "unstable": {
    "version": [
-    20210630,
-    1318
+    20220607,
+    1613
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7bb36e910ae04ff1dce387e3ce73b669d299680b",
-   "sha256": "188055yg9fqw92p1wip7mx7nz5gz5jbwb6lgcjncxzs4i9v7w8kr"
+   "commit": "dd88193cd7a91a92113121191573758ea2a3ceb1",
+   "sha256": "1rld3pwrdpgvpbn1pfwa71bb0kapv5a0ny0dh7ck2g07k1wql7lh"
   },
   "stable": {
    "version": [
@@ -62131,8 +62272,8 @@
  },
  {
   "ename": "keystore-mode",
-  "commit": "7870d808fc19096ed6ecde5e9297b28254466210",
-  "sha256": "1r1my7jgjv2zvkhdwd8ml6489x48gzanz4lvdiw5m2hymb53fdg6",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1sbafmwn286k4hj99dp9kz3s1pnx2i27f2k157pnkzgywn8n63pi",
   "fetcher": "github",
   "repo": "peterpaul/keystore-mode",
   "unstable": {
@@ -62175,8 +62316,8 @@
     20220222,
     639
    ],
-   "commit": "d6fe2d51769ee5d1d84a74adeae5c3a0aa66a602",
-   "sha256": "0hkp0dl8aqc2javsnl3pm37iy9f534l6wf1vgh44ba6ws6bxxgl5"
+   "commit": "468b528add57e15c2413c8984937fb428fb257f3",
+   "sha256": "1r481kpijmyawv5v32y202nz932mv24l5v7vrgandrjnaxjv0kgs"
   },
   "stable": {
    "version": [
@@ -62431,8 +62572,8 @@
     20210318,
     2106
    ],
-   "commit": "93ccd2058c1980207848810942dbb1a6d9edebe9",
-   "sha256": "1ciqb2simq7fdc31pjav30rlskami70dcg4abqairfq3yvx5nb7k"
+   "commit": "37292f00a8a457762a94011d7719e2c7d03d821c",
+   "sha256": "1zagb6lx5nhn1za7ybkdz6b33vmmw0k7ms3swxgw1fv2dzyqns4c"
   },
   "stable": {
    "version": [
@@ -62633,11 +62774,11 @@
   "repo": "Emacs-Kotlin-Mode-Maintainers/kotlin-mode",
   "unstable": {
    "version": [
-    20210917,
-    1911
+    20220527,
+    1646
    ],
-   "commit": "3e0c34087ba4965a8bf08d3f27325f0a1e631bfb",
-   "sha256": "15gxznanmcgjgcqlcazschxcwlsmd4rzivw0jb6pvz3m7zabd16r"
+   "commit": "99499e1500034b5fd5fdce9bfef367d90c61b5ce",
+   "sha256": "067m5idlnfz01aiynmnxh3x3vv4c2nkkldskv7g1cssxqaxagnxj"
   }
  },
  {
@@ -62920,41 +63061,41 @@
   "repo": "emacsfodder/kurecolor",
   "unstable": {
    "version": [
-    20220508,
-    929
+    20220527,
+    829
    ],
    "deps": [
     "s"
    ],
-   "commit": "61d7211469ea3e2c429937869c5a29584103361a",
-   "sha256": "0mi5jln34pd372h7f3rvigis6dll6sxdqg9izj9bip93917cff0y"
+   "commit": "d17a77d9210b3e7b8141d03c04d1898bcab2b876",
+   "sha256": "0gnh0yzip0238ycprx03147xaclcbmiy4lkp6wqil2waavwrkwbf"
   },
   "stable": {
    "version": [
     1,
     2,
-    7
+    9
    ],
    "deps": [
     "s"
    ],
-   "commit": "1c80df0f2c542f54920f18aa4eb837f0a51c7676",
-   "sha256": "0hmsf7kgzmpzri3ggb7l6y3pvfpinfv0d24fnxpbp1zd17lfwks1"
+   "commit": "076de3e420210fc479675389acb3fed6ada9c8e0",
+   "sha256": "0a36bnnyg0ay60kpjwv6s5cl5m3cvygjgq7kfpj8wkjv1gf19q05"
   }
  },
  {
   "ename": "kuronami-theme",
-  "commit": "f1fe04f11b3ab6ee00a36d2d171d7042aebe3115",
-  "sha256": "00f5lxhpqy1p7nlaw7nka90hy95dqrg7flfv5i9f8nrx9r3r7rpp",
+  "commit": "d1630a13d841c740a700a5fa34de8a0e9d20b17e",
+  "sha256": "02ps0q7nk91jdxwyzyyr26m4xsbynsfvwj3yxnnjjapqvvqlk7h4",
   "fetcher": "github",
-  "repo": "super3ggo/kuronami",
+  "repo": "inj0h/kuronami",
   "unstable": {
    "version": [
-    20220309,
-    604
+    20220602,
+    339
    ],
-   "commit": "910e8fa56a0cfe89dae888522f9fec4045d017fb",
-   "sha256": "0pghi50ffzlp7igvq81dmrbrwyj9ivl5kkxm47hff7qgb9rvx8n1"
+   "commit": "a51d5ff3883bd94d0a181bb5d60f747190eda4f6",
+   "sha256": "0mrk8d0z09cbvqisl44ln50bbmfim0j876v91x73428vr7k46z0d"
   },
   "stable": {
    "version": [
@@ -62968,8 +63109,8 @@
  },
  {
   "ename": "kv",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "0c10r7mhg517p62lc87ccqypsjrm28xh3bgv4f01fnx569jqgzgp",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1dv3vbhgs7q5q92idyy5mn9gwmx2k6xigb1vchfh7p21f2is86x8",
   "fetcher": "github",
   "repo": "nicferrier/emacs-kv",
   "unstable": {
@@ -63167,8 +63308,8 @@
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "67ae434d6ce2073e9c914817d21269f5c6a2a66f",
-   "sha256": "14m9i4ikppbf4ffrxibhdlvanyvjfhx68xalga66lj5chhhdqbk5"
+   "commit": "1fb1d9aa8d162279e0496d976b286fffc721f332",
+   "sha256": "0qwv6jpszhp47hx4bmj5qp85lpmcka75c7f1jsd8q10r95gmd7l4"
   },
   "stable": {
    "version": [
@@ -63235,8 +63376,8 @@
  },
  {
   "ename": "langtool",
-  "commit": "503845e79e67c921f1fde31447f3dd4da2b6f993",
-  "sha256": "1xq70jyhzg0qmvialy015crbdk9rdibhwpl36khab9hi2999wxyw",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1vsxdkq8qdjn446rf7gjcnr1hwaasqrp0ibv4nsvnib7n85ldl7s",
   "fetcher": "github",
   "repo": "mhayashi1120/Emacs-langtool",
   "unstable": {
@@ -63330,26 +63471,26 @@
   "repo": "PillFall/languagetool.el",
   "unstable": {
    "version": [
-    20220127,
-    2215
+    20220514,
+    309
    ],
    "deps": [
     "request"
    ],
-   "commit": "ea50c120ee3418489b43d51ed750288791d6eb95",
-   "sha256": "0xm6yh6aybz8mnf6lh0dx9qgbk05kr2chiw4pnk9w6n9apssx9xa"
+   "commit": "503d18bd3c074fe8f495cfa6a34ccca1ef6961ce",
+   "sha256": "0zid9ip540qknnj9sdky2jrxp5l5kym76dr3wgff3ika6g7y75p6"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "request"
    ],
-   "commit": "ea50c120ee3418489b43d51ed750288791d6eb95",
-   "sha256": "0xm6yh6aybz8mnf6lh0dx9qgbk05kr2chiw4pnk9w6n9apssx9xa"
+   "commit": "503d18bd3c074fe8f495cfa6a34ccca1ef6961ce",
+   "sha256": "0zid9ip540qknnj9sdky2jrxp5l5kym76dr3wgff3ika6g7y75p6"
   }
  },
  {
@@ -63406,6 +63547,24 @@
    ],
    "commit": "2366de7824b6c5f8e9ec6811d219dc06794e8630",
    "sha256": "065nbgcs2q8gqw8alfa6lbabma6vjsqzl4mfkfpzgk566dan2x1p"
+  }
+ },
+ {
+  "ename": "latex-change-env",
+  "commit": "f213f7787cd06b2f6ff8f4e2cf035f44b6407384",
+  "sha256": "1z4g784k19dbyf7azdgrbqdbgpc8jnza0r4mvyi91lzn7h1bfr1y",
+  "fetcher": "gitlab",
+  "repo": "slotThe/change-env",
+  "unstable": {
+   "version": [
+    20220531,
+    726
+   ],
+   "deps": [
+    "auctex"
+   ],
+   "commit": "b5c31c9551bea70835762360a57407fba6e37b4e",
+   "sha256": "1q88pg2izz2m22n0xgd281vhna5znrs3q6nfg3v6bkxp73y17k13"
   }
  },
  {
@@ -63534,8 +63693,8 @@
  },
  {
   "ename": "launch",
-  "commit": "8e46ed1761fa2e69f0dc2f58e422ea1de8a8cb49",
-  "sha256": "043gwz583pa1wv84fl634p1v86lcsldsw7qkjbm6y678q5mms0m6",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1zcfnk8qd727ngr9bmgj5sf28g6kj9xa9qnkpxy73yz0z1ga7b7p",
   "fetcher": "github",
   "repo": "sfllaw/emacs-launch",
   "unstable": {
@@ -63682,14 +63841,14 @@
   "repo": "AnselmC/le-thesaurus.el",
   "unstable": {
    "version": [
-    20220509,
-    2120
+    20220519,
+    610
    ],
    "deps": [
     "request"
    ],
-   "commit": "2af1ab37097cdd17044ab217e9aa6839add98626",
-   "sha256": "1w2k2pvzgd5v008ma9bc6y16aiyjixhgvrn7bxf6cy43056mh0wf"
+   "commit": "3ea30714e7197f660dea59ec6c762cde0a44f74e",
+   "sha256": "0dbaxxa81bsfqnkqz0sfx67kqghi3qscclwnsvk638m3xrp6sbbz"
   }
  },
  {
@@ -63960,11 +64119,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20220307,
-    854
+    20220604,
+    1632
    ],
-   "commit": "11e850395448ee7012dba16bd6df103f5552ebfb",
-   "sha256": "0hzky36vrlb7kvpyz4gy3zn01zdlmlx0s58w6ggk5djbcvjc2rfx"
+   "commit": "1e6ddafa0fdf8f009c35488fdd6d0b0c8485ad34",
+   "sha256": "1f2djjxr8sy9adysprfk5zk9dkphnfa4dcv8hzknszchjm6a3lgh"
   },
   "stable": {
    "version": [
@@ -64191,8 +64350,8 @@
  },
  {
   "ename": "leuven-theme",
-  "commit": "c75a5db2c9724a513ad3f64fc138d8565d608eeb",
-  "sha256": "0468jbv04gwxhh9ag3yblzv1y1rxfr6yqr6dqfp11x6j8c910byr",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "11jnwyqf7vkw7h5qy7nrp0vvmyskbxc54nwc8p8carhzvpqm41d6",
   "fetcher": "github",
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
@@ -64202,6 +64361,15 @@
    ],
    "commit": "d7dd9188a65e2ab7cf73c2e575a830baae38cb0c",
    "sha256": "0wvx4wcn845v1fh5jlljlh7l28nwycpivaay7flqb52zz47xj116"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    2
+   ],
+   "commit": "c72db2d5aeb5ed8e4ca066c803ae8d30e7540f79",
+   "sha256": "1mv5lv98b3351cwkiw51bq8xx4hmnvk93sx6lkdmq0sciw2qz22i"
   }
  },
  {
@@ -64526,8 +64694,8 @@
    "deps": [
     "request"
    ],
-   "commit": "e03f4a30c4abf354fb961babe4dce1dfa733aa82",
-   "sha256": "11mjypjv1h2qsfbqxfwknv6lp2fql4cnfsivcpj68475grn1g3s5"
+   "commit": "053e7f6517b20d5c9c93952428bd7d98a2700722",
+   "sha256": "1x99hanrlr8x07d16v19k00q9jgq3s121wsxr0x97d6dpi9hq8l5"
   },
   "stable": {
    "version": [
@@ -64568,8 +64736,8 @@
     20220209,
     755
    ],
-   "commit": "7d706986636b5cfc04f14341c19046b56b61b51c",
-   "sha256": "0v7306fq02q36smg157xcsil0r99vznzf7fx0xnys2df5id0ww36"
+   "commit": "c917420838b088da68b148652d3be468d7b746b5",
+   "sha256": "1mwa0ggbw4v8cd3v9l2rsydn0hklzc5z37gfxljg843v9b594z97"
   },
   "stable": {
    "version": [
@@ -64598,8 +64766,8 @@
     "indicators",
     "ov"
    ],
-   "commit": "c0cebef629a98556f5696f78436f4d8428ce8135",
-   "sha256": "0k7gzx3g33wf7w3wbpiv6b3amnl2miyynvr3x6wlpzmh3q57s11a"
+   "commit": "e8fe451f1c22ad2f90c82da42b4da73d5152d835",
+   "sha256": "1yfvzyy1gkk53ivlzcxpyl2dp6hhw127sl7bkg0ansgdfsnm1zgl"
   },
   "stable": {
    "version": [
@@ -64642,10 +64810,10 @@
  },
  {
   "ename": "lines-at-once",
-  "commit": "513d0f0c6976f685fc0df6b6bb0da3162f58f537",
-  "sha256": "1hiij6i47i9px82ll87dvx5pgp5jzz8qis7hdm8n6hd3c9rnabma",
+  "commit": "dcf4e93b13a279485fcbc8d2bb329008b2120b0a",
+  "sha256": "04ljzb7711mncmjh2ahhdkxngmh0g1kpxija3rqnmz4csnvmqp0f",
   "fetcher": "github",
-  "repo": "jiahaowork/lines-at-once.el",
+  "repo": "jiahaoli95/lines-at-once.el",
   "unstable": {
    "version": [
     20180422,
@@ -64844,8 +65012,8 @@
     20211004,
     1429
    ],
-   "commit": "22dd4c3ea4c0d2bd82270e2fb272317d0bc87752",
-   "sha256": "02aa3ci9cfxswpv5nf0bqpp9lkbqirpmksg5hwxl0xxr672mv7kc"
+   "commit": "13738280c854654b8118f90c9ab1a6a74410f0c4",
+   "sha256": "0c5qzp3zw5nz8hwv3zxy26bh67bsxkrnal596c6m8x8747rfvd31"
   },
   "stable": {
    "version": [
@@ -64998,16 +65166,16 @@
   "repo": "noctuid/lispyville",
   "unstable": {
    "version": [
-    20210702,
-    2031
+    20220519,
+    2339
    ],
    "deps": [
     "cl-lib",
     "evil",
     "lispy"
    ],
-   "commit": "9c14bed0359f659e246d345c706f895737c3d172",
-   "sha256": "1jlxcr9vikczhryw3xslfy6hzs2ikcf9khbwaw53ymwdxrmphcci"
+   "commit": "32d6b1f4b3f5bc792a0610c7e91123a70b582a91",
+   "sha256": "1h87j2yc79skb56i8j5239nr0hialgwg0fkz418caxzkrjglrf8m"
   }
  },
  {
@@ -65308,11 +65476,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20220322,
-    133
+    20220524,
+    217
    ],
-   "commit": "dc4f9d64a8483aa6e394178087c589cdefc571e2",
-   "sha256": "08hhp74s56h9k3hlfqky68aiv4qy79gnci46r5nh4mbkrybsijnq"
+   "commit": "4bfc686f5ee5d781f99d6d4d9b7dd057054c8b1c",
+   "sha256": "0r0mzfj6yxlzh89cs249s2xlryi6z6acvd43picz0jv7ff616fph"
   },
   "stable": {
    "version": [
@@ -65435,11 +65603,11 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20220512,
-    34
+    20220518,
+    204
    ],
-   "commit": "7eaf6dc55caaaa65c5d6937b25e1748df75dbdb3",
-   "sha256": "0gcszam4qsl64jx5yggbawsawrj74cqsp7mbzmvvs40gr8pvx2yp"
+   "commit": "054b959fef7e696864ae29575583d0dec414f2d6",
+   "sha256": "0ldrdl9bqjfc472wn8qp3d9mj6kadcl082cl106bgl0p365ngarj"
   },
   "stable": {
    "version": [
@@ -65834,8 +66002,8 @@
     "ht",
     "s"
    ],
-   "commit": "b3366ec866b6e3b5c608fee23e86eb832d132ef8",
-   "sha256": "106fgd8id9xrrl7qyyzxxmi690m29i7zcfk6anc5h52lm52ydk0j"
+   "commit": "f9addea83793b771b3a61d167ed5419749a349c1",
+   "sha256": "01yjhy33i0c8xswkqajjj6ibn0xi9s0vlblnng0q7gi4h3glfxwf"
   },
   "stable": {
    "version": [
@@ -65913,15 +66081,15 @@
   "repo": "doublep/logview",
   "unstable": {
    "version": [
-    20201014,
-    2033
+    20220607,
+    1757
    ],
    "deps": [
     "datetime",
     "extmap"
    ],
-   "commit": "5a543c53d04d32f0adcc023253888198e0b69589",
-   "sha256": "01vvyf7bbkaj8338dinp6x1w4alld165njb0sh432gdkpa6y2wkm"
+   "commit": "a17cafb5445b584e8fa386709192317da5ac4530",
+   "sha256": "0ck9milv8jv0qxqbb77f1z5q36d8c3hwgryq3mxllc2i0mvssyq6"
   },
   "stable": {
    "version": [
@@ -66016,8 +66184,8 @@
  },
  {
   "ename": "loop",
-  "commit": "ba481ca96469b3bd518e4fd8f24947338c8af014",
-  "sha256": "0pav16kinzljmzx84vfz63fvi39af4628vk1jw79jk0pyg9rjbar",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1qyg1qy7jdh7ncihg59wd467laylx46lsw9vxf0hjpbrq19rj0dz",
   "fetcher": "github",
   "repo": "Wilfred/loop.el",
   "unstable": {
@@ -66076,8 +66244,8 @@
     "map",
     "seq"
    ],
-   "commit": "98537cb29e28d32d3607fa61253ff1bf04db2539",
-   "sha256": "1skl536wmygbnnvcdh307zh5d3y0vz31q0nkwvbd5rpifl4rpk2h"
+   "commit": "a2dbc79bd33a1d194c4804c1157caf27e67b5066",
+   "sha256": "0ccwf2sh52689ajpx7zf0kz8win7nclhm70sc08wk44ygazywjfx"
   },
   "stable": {
    "version": [
@@ -66108,8 +66276,8 @@
     "dash",
     "loopy"
    ],
-   "commit": "98537cb29e28d32d3607fa61253ff1bf04db2539",
-   "sha256": "1skl536wmygbnnvcdh307zh5d3y0vz31q0nkwvbd5rpifl4rpk2h"
+   "commit": "a2dbc79bd33a1d194c4804c1157caf27e67b5066",
+   "sha256": "0ccwf2sh52689ajpx7zf0kz8win7nclhm70sc08wk44ygazywjfx"
   },
   "stable": {
    "version": [
@@ -66189,8 +66357,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20220430,
-    1535
+    20220522,
+    1902
    ],
    "deps": [
     "dap-mode",
@@ -66200,13 +66368,13 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "7ca60ce9a703ad7a950dcd5ec36ef4251f57d207",
-   "sha256": "1snsnd9pgq2lz3avypps73qfdl3ky2i5sx04sybj7gj41yz834bc"
+   "commit": "4d28d13d8b468bfb8f992da0ea450269d672562c",
+   "sha256": "1z936j2x5sy5hagn0i4a4j16ippmkh1d2ccd7kw6ilal4zi4smk9"
   },
   "stable": {
    "version": [
     1,
-    21,
+    22,
     0
    ],
    "deps": [
@@ -66217,8 +66385,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "813d3c92db02596a8e8aa7802977c50ec1262f9d",
-   "sha256": "1l0208bys0zq9qgnih27aldi5v3rp5bj8i9nar24hgfm42ld75gz"
+   "commit": "4d28d13d8b468bfb8f992da0ea450269d672562c",
+   "sha256": "1z936j2x5sy5hagn0i4a4j16ippmkh1d2ccd7kw6ilal4zi4smk9"
   }
  },
  {
@@ -66229,8 +66397,8 @@
   "repo": "emacs-lsp/lsp-docker",
   "unstable": {
    "version": [
-    20220501,
-    1056
+    20220513,
+    1434
    ],
    "deps": [
     "dash",
@@ -66239,8 +66407,8 @@
     "lsp-mode",
     "yaml"
    ],
-   "commit": "c57863609abfb93fccabf81dc3112ac38f93c4a2",
-   "sha256": "007rf2zbkskidskmcnlsx56dxv0saqm2nl9ih1rk6h9vm27yl24z"
+   "commit": "a0d7cbf80652429c0be4dc7d39e1887ba4691ec7",
+   "sha256": "1mf3c76c8979pqwkikx5dpi0nnfq7w111c6fa65sp4s9y1aip63z"
   }
  },
  {
@@ -66283,8 +66451,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20220511,
-    707
+    20220530,
+    2101
    ],
    "deps": [
     "grammarly",
@@ -66293,8 +66461,8 @@
     "request",
     "s"
    ],
-   "commit": "709c522df7a68e2724dbfb5bd210199dff5a2264",
-   "sha256": "188sx0a6n1kl9awcic1pjbzxsqhq2cbbk8chbp8zgpl0x67ph7d6"
+   "commit": "d56ca607cd597e622969c91a78ec74e463260b32",
+   "sha256": "1rxnfzdyv4ad0b3b1prgxhpnk9y9ayjr5s9r7x38ch43khfqz0cq"
   },
   "stable": {
    "version": [
@@ -66551,8 +66719,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "8c2ba735ed1e21777408167f6a7c7d9681d9e7bc",
-   "sha256": "1iqmvy870vllb794cpmsnpm65hindxym9dnhb0pnxz0mf6hcvz2v"
+   "commit": "8a133cee26ea8c69831817295136c985039f19ce",
+   "sha256": "0zfwn3nald6w4xi3swnrd098sinaw93w4aaqdfhdqkq90j81whri"
   },
   "stable": {
    "version": [
@@ -66621,8 +66789,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20220511,
-    1331
+    20220607,
+    937
    ],
    "deps": [
     "dash",
@@ -66632,8 +66800,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "465bcc5fbeb6293446a3241f5f2c1b872337958c",
-   "sha256": "151vc741rwi2gggkw39msql1y050b1n46rrjnzalz9nqsk6l5dp2"
+   "commit": "358b5df8df10b4837193af78c2e72df2c381b1fa",
+   "sha256": "1bqd1ga9jcwhkcm527sisx65lvh3lfsg01xln0iilyi2y7ahvzy7"
   },
   "stable": {
    "version": [
@@ -66915,14 +67083,15 @@
   "repo": "merrickluo/lsp-tailwindcss",
   "unstable": {
    "version": [
-    20211211,
-    248
+    20220601,
+    1509
    ],
    "deps": [
+    "f",
     "lsp-mode"
    ],
-   "commit": "8c04fc4ac6f5eb8053ecdaaedffa35e0f7a5b865",
-   "sha256": "01qn3qkr06jz0xsqvz76pc2x8aby0hv1f84mh1v3zsmcjdb64vy8"
+   "commit": "09377d5bbb742f11c458481905ddbb022dd2b0da",
+   "sha256": "090ymnd24cd2665b9kb32yxwvbbrcxc884s68b9g1x59z7wmw42g"
   },
   "stable": {
    "version": [
@@ -66981,16 +67150,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20220510,
-    627
+    20220514,
+    2010
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "eba9c4eaa255a14e2facd658e7122674c05390f8",
-   "sha256": "09c6qy17dlqh2jnzk6xf6cj8r7gbwgn59cmhaadzhh3v3n13362z"
+   "commit": "a0b97db2ada163453c9072d3640202a0b27c29f5",
+   "sha256": "1dpbx7mny2h7qrd67z6n0grl6nv95zwc9yiiv5b0fby6gank5hv9"
   },
   "stable": {
    "version": [
@@ -67064,8 +67233,8 @@
  },
  {
   "ename": "lusty-explorer",
-  "commit": "efedaa3b1de5f6406c7dcd842eee42eefaf8ab50",
-  "sha256": "0xqanmmkyvzcg2g4zvascq5j004bqz7vmz1a19c25g9cs3rdh0ps",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1qmv4077xd8156k1gh25cwv6x1ig27wka5j2ka0j0k0fp8xvwlw1",
   "fetcher": "github",
   "repo": "sjbach/lusty-emacs",
   "unstable": {
@@ -67325,14 +67494,14 @@
   "repo": "amake/macports.el",
   "unstable": {
    "version": [
-    20220512,
-    1330
+    20220606,
+    34
    ],
    "deps": [
     "transient"
    ],
-   "commit": "ebca27f8e16d3607070582849bea81d40ca5f584",
-   "sha256": "0xz5y5smfa69ylngkfck935c03ak40i4aazzklzyslv385vv9kd4"
+   "commit": "bb5c789af7adaaf5b7c0a6013d0397b4cd801b10",
+   "sha256": "0v63m2i505074i63642ywiaplis65mszg66rn4h7r7x960a6bpyq"
   }
  },
  {
@@ -67519,8 +67688,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20220512,
-    1218
+    20220607,
+    1443
    ],
    "deps": [
     "compat",
@@ -67530,8 +67699,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "12272c825d216148454b7cfa57fef202cdfe0c7d",
-   "sha256": "0h9f52c1kmgzr0w85knwvf1r2b6dw0dariy2sn9mpqsvpj3cyv2c"
+   "commit": "2dfeaa6839c643a54d96c9f855bae11d5cba2453",
+   "sha256": "052zdj08296s34b7a5p6fapxym7ni1mlw3iqpvw6jhkv9qihmqv2"
   },
   "stable": {
    "version": [
@@ -67897,8 +68066,8 @@
     "libgit",
     "magit"
    ],
-   "commit": "12272c825d216148454b7cfa57fef202cdfe0c7d",
-   "sha256": "0h9f52c1kmgzr0w85knwvf1r2b6dw0dariy2sn9mpqsvpj3cyv2c"
+   "commit": "2dfeaa6839c643a54d96c9f855bae11d5cba2453",
+   "sha256": "052zdj08296s34b7a5p6fapxym7ni1mlw3iqpvw6jhkv9qihmqv2"
   },
   "stable": {
    "version": [
@@ -68046,15 +68215,15 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20220506,
-    1936
+    20220513,
+    1429
    ],
    "deps": [
     "compat",
     "dash"
    ],
-   "commit": "12272c825d216148454b7cfa57fef202cdfe0c7d",
-   "sha256": "0h9f52c1kmgzr0w85knwvf1r2b6dw0dariy2sn9mpqsvpj3cyv2c"
+   "commit": "2dfeaa6839c643a54d96c9f855bae11d5cba2453",
+   "sha256": "052zdj08296s34b7a5p6fapxym7ni1mlw3iqpvw6jhkv9qihmqv2"
   },
   "stable": {
    "version": [
@@ -68117,14 +68286,14 @@
   "repo": "magit/magit-tbdiff",
   "unstable": {
    "version": [
-    20220306,
-    2311
+    20220527,
+    2213
    ],
    "deps": [
     "magit"
    ],
-   "commit": "ae9345d867539a4c5c635be04df2e26468444da8",
-   "sha256": "1klns192jlp0ba9gklkkjjhl33k7dha0ircpm4d11y8vcy3c3zh3"
+   "commit": "ff416b87a77a2f7cea234d9063ff629fc0e4c6c8",
+   "sha256": "11l5vkh5ylg91czl69s4al50pyyhfkarl2qqp32ma2rymsq0mhsm"
   },
   "stable": {
    "version": [
@@ -68629,8 +68798,8 @@
     20210108,
     1832
    ],
-   "commit": "e1af20253fbc5a91034ccd01cf00141130c11863",
-   "sha256": "1pvyv1yhhm5ziqrlvd0hfphp3mcdh8iwwqs5awb54frj9j61fsi8"
+   "commit": "7d886dddf81568c9387410701f60302cd33b4f63",
+   "sha256": "1yalwmbmh993qhp8n4ybh5f6mi82gf68119ziy0w0hxpxpv7x2bc"
   },
   "stable": {
    "version": [
@@ -68655,8 +68824,8 @@
    "deps": [
     "manage-minor-mode"
    ],
-   "commit": "e4c38aeb8ef6a85d8c082ad683720e5a4174aa79",
-   "sha256": "18w2xazs6hw49z7v2z8dcjwbzn696vny22ncdh0s2szp0acwvlaa"
+   "commit": "884aca19bd6affec69c58cbfcac46bab4cd87bde",
+   "sha256": "1y000660813hdpzjl2bx699qi8am90qrhxnykfr1zjiv4i942sja"
   },
   "stable": {
    "version": [
@@ -68688,8 +68857,8 @@
  },
  {
   "ename": "mandoku",
-  "commit": "1aac4ae2c908de2c44624fb22a3f5ccf0b7a4912",
-  "sha256": "1pg7ir3y6yk92kfs5agbxapcxf7gy60m353rjv8g3kfkx5zyh3mv",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "00w246svp3lmbhq7cak2p7fmabnl6dbbsa3cx7wbiwq0f4hpjiaw",
   "fetcher": "github",
   "repo": "mandoku/mandoku",
   "unstable": {
@@ -68952,11 +69121,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20220508,
-    1219
+    20220603,
+    300
    ],
-   "commit": "5b6e660c13ca3f4d15dbc1aa3d7ab2f228491ef9",
-   "sha256": "11phyiblvxzx3dqqqrqlfi0q67ih1hy1630rlx6pi7w835npn0wz"
+   "commit": "1f709778ac7990f4a07fdf11fe37bc6541810b29",
+   "sha256": "1gwx11rzyaz7ym5lzaddcr1mz1pzysykz8kajkkfx2rq65k9skpw"
   },
   "stable": {
    "version": [
@@ -69084,8 +69253,8 @@
  },
  {
   "ename": "markup",
-  "commit": "a75c955ad6b2f68b8933329e545625d948f6f8f4",
-  "sha256": "0yw4b42nc2n7nanqvj596hwjf0p4qc7x6g2d9g5cwi7975iak8pf",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0v4lnwgh10rj5njgn4mw8mf39rg29jb4s9imxhsdimnqaizh83wk",
   "fetcher": "github",
   "repo": "leoc/markup.el",
   "unstable": {
@@ -69167,8 +69336,8 @@
     20200720,
     1034
    ],
-   "commit": "c36dcf8c282f547da5b3666f025a3000b5dbd1d9",
-   "sha256": "135j7i4y5jhypbknknmpha6mfjfzphb3n7pb303dss0amxfs0430"
+   "commit": "5e8518a5f89c19d4aa9d7146cfdb213194d24e5d",
+   "sha256": "0471f234wi2bd3das0l96j4c3ka4cs6gs4w85hrw8b8bwx19d5xm"
   },
   "stable": {
    "version": [
@@ -69242,21 +69411,21 @@
  },
  {
   "ename": "mastodon",
-  "commit": "891defb51d73e742486b18cbe4495c951b26fc47",
-  "sha256": "0450xbgv0hy5gvcycxin6yvb0vd65y5dsgxlx6xjnzij3rkb4xsj",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0jmmcnd76sw0fapac370d8mkg1v1qhhdy015pds0v7j5g5wwrssz",
   "fetcher": "git",
   "url": "https://codeberg.org/martianh/mastodon.el",
   "unstable": {
    "version": [
-    20220405,
-    1531
+    20220513,
+    1124
    ],
    "deps": [
     "request",
     "seq"
    ],
-   "commit": "e5ff349d23c71a521db41dcdb1ac9765bac5388f",
-   "sha256": "1iq7m0acvhb86l5p7ah2pq2fz1716l94dw1m7pbi6asbnypgnavy"
+   "commit": "4ab5a4bb8d603b189a99cc4a4eea4c42e8f97cf0",
+   "sha256": "00rvnpcbpxpnqqplqvgjny5ddj6ggdk3i532hdw8i9z38r2gafyl"
   },
   "stable": {
    "version": [
@@ -69303,16 +69472,16 @@
   "repo": "matsievskiysv/math-preview",
   "unstable": {
    "version": [
-    20220512,
-    1853
+    20220604,
+    1107
    ],
    "deps": [
     "dash",
     "json",
     "s"
    ],
-   "commit": "0f0b2315d23e5d18b627c9faa8f231f175b728a0",
-   "sha256": "003ih3nrv753rj4ssdvs6ddqzxgl63vzmrypd41xf4g5dfsbmsf0"
+   "commit": "a7254ba89a524f30c1acfdbde07a179271f02658",
+   "sha256": "1d1s1ff49xb5rdmphgx2g5n5mmjrkrdi38wqijlkr6jj15d5lrig"
   },
   "stable": {
    "version": [
@@ -69458,15 +69627,15 @@
   "repo": "sasanidas/maxima",
   "unstable": {
    "version": [
-    20210526,
-    1525
+    20220531,
+    1751
    ],
    "deps": [
     "s",
     "test-simple"
    ],
-   "commit": "ce5fd160c193e387d9e2bacdba4065c4b4262cb1",
-   "sha256": "18bjr4n1m1y76kh0pp6ci7ywklrmw611ka3avrj23lb0wwrljf86"
+   "commit": "1334f44725bd80a265de858d652f3fde4ae401fa",
+   "sha256": "1h1lqrl3p9qgkicds8v44vdry19g53rya56hdj3cz5q8xj1nisn1"
   },
   "stable": {
    "version": [
@@ -69882,11 +70051,11 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20220501,
-    1918
+    20220515,
+    2054
    ],
-   "commit": "72d6ff36b62a57aa9c9dbfbd44cdb3002a0e940a",
-   "sha256": "0vaam51wg8a7ilk9kp3lvz3p0vfcc3fl2nkpwswdadgr69f2d4qb"
+   "commit": "0a978e0232947d8e3a0895d104fe7f8671daed6f",
+   "sha256": "0phzafaj4zvih9h5ky7jryixwhv0kxwjvcxijvch7sn1i6fdpvkf"
   },
   "stable": {
    "version": [
@@ -69906,11 +70075,11 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20220502,
-    811
+    20220517,
+    1602
    ],
-   "commit": "49324b4fdc14987164ed7a3a8c3681df5b4866ee",
-   "sha256": "1hjgwwwmg20nmgvl96s9jay6mipcn7hil1jjvzmbrbkix6f2ymzm"
+   "commit": "88c0c2e66d65e3a6ba30c14a8dcef6685b285a55",
+   "sha256": "19cq56369dlzhdf6kxm2iz0qc7w6kxjrm8cjv0rwmswzp5lnsd44"
   },
   "stable": {
    "version": [
@@ -69938,8 +70107,8 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "49324b4fdc14987164ed7a3a8c3681df5b4866ee",
-   "sha256": "1hjgwwwmg20nmgvl96s9jay6mipcn7hil1jjvzmbrbkix6f2ymzm"
+   "commit": "88c0c2e66d65e3a6ba30c14a8dcef6685b285a55",
+   "sha256": "19cq56369dlzhdf6kxm2iz0qc7w6kxjrm8cjv0rwmswzp5lnsd44"
   },
   "stable": {
    "version": [
@@ -69971,8 +70140,8 @@
     "company",
     "merlin"
    ],
-   "commit": "49324b4fdc14987164ed7a3a8c3681df5b4866ee",
-   "sha256": "1hjgwwwmg20nmgvl96s9jay6mipcn7hil1jjvzmbrbkix6f2ymzm"
+   "commit": "88c0c2e66d65e3a6ba30c14a8dcef6685b285a55",
+   "sha256": "19cq56369dlzhdf6kxm2iz0qc7w6kxjrm8cjv0rwmswzp5lnsd44"
   },
   "stable": {
    "version": [
@@ -70033,8 +70202,8 @@
     "iedit",
     "merlin"
    ],
-   "commit": "49324b4fdc14987164ed7a3a8c3681df5b4866ee",
-   "sha256": "1hjgwwwmg20nmgvl96s9jay6mipcn7hil1jjvzmbrbkix6f2ymzm"
+   "commit": "88c0c2e66d65e3a6ba30c14a8dcef6685b285a55",
+   "sha256": "19cq56369dlzhdf6kxm2iz0qc7w6kxjrm8cjv0rwmswzp5lnsd44"
   },
   "stable": {
    "version": [
@@ -70362,8 +70531,8 @@
   "repo": "danielsz/meyvn-el",
   "unstable": {
    "version": [
-    20211025,
-    106
+    20220521,
+    17
    ],
    "deps": [
     "cider",
@@ -70373,8 +70542,8 @@
     "projectile",
     "s"
    ],
-   "commit": "80ece19a6ce6fd3dac374911edb9734286978450",
-   "sha256": "0qqr88r1g3lwzl4m9qjiwba23ylp44g5hspawwfzchlbs9js6yj7"
+   "commit": "ae02f9e3b93730672f2f0a476a4e32bf1a024937",
+   "sha256": "0j0p3s4n0z873191w8z27p2fl77ybpb958v0wzjdi1alq0rl1bdf"
   },
   "stable": {
    "version": [
@@ -70916,20 +71085,20 @@
   "repo": "hlissner/emacs-mips-mode",
   "unstable": {
    "version": [
-    20211114,
-    1645
+    20220608,
+    1204
    ],
-   "commit": "5676174bea9a5780ddd33d2d8111b8678dfa4e99",
-   "sha256": "0nlxhchcy3swmyfzdd8qmdzq05a4lzlgs1psnsvfjbbi9w8g8w5v"
+   "commit": "98795cdc81979821ac35d9f94ce354cd99780c67",
+   "sha256": "1wpgp08q1f2gbkn4ksd3chfz2s3cn8fdfyz04wmj37ss43mai355"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "e6c25201a3325b555e64388908d584f3f81d9e32",
-   "sha256": "0ai4ff6hinajvnp8r86s5pv0rrv8h68ncdz4k98kka1ws2f79zdf"
+   "commit": "98795cdc81979821ac35d9f94ce354cd99780c67",
+   "sha256": "1wpgp08q1f2gbkn4ksd3chfz2s3cn8fdfyz04wmj37ss43mai355"
   }
  },
  {
@@ -71212,8 +71381,8 @@
  },
  {
   "ename": "mocker",
-  "commit": "16a4fe34a6f354d396c24ff13e15157510202259",
-  "sha256": "1g90jp1czrrzrmn7n4linby3q4fb4gcflzv2amjv0sdimw1ln1w3",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1c44ws77r0sp9b46a2xk39039m28mf8sqd46dbzwsms5glkwl82c",
   "fetcher": "github",
   "repo": "sigma/mocker.el",
   "unstable": {
@@ -71402,8 +71571,8 @@
  },
  {
   "ename": "modern-sh",
-  "commit": "b0db199b134810cd2912aaaaa9793d9a59bdedef",
-  "sha256": "1lz14cwv61kn765ahs91dzgpp18kzyhj0a10p6y39pk481fp7wbl",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0liizd9w6yh1p1x3pvmalv97rn6676rknh8r1lcka9xgcng8lap1",
   "fetcher": "github",
   "repo": "damon-kwok/modern-sh",
   "unstable": {
@@ -71466,20 +71635,20 @@
   "url": "https://git.sr.ht/~protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20220512,
-    1808
+    20220605,
+    1714
    ],
-   "commit": "b6285162d80fe438b4ac99acff74d33b5f901c35",
-   "sha256": "139ycd3p63hlxs70g266xj6i7bng1p2xavwcsxf4j4nvfayib9r7"
+   "commit": "6f2b048528d1c40bf5bead0d3e01beff28b78d2b",
+   "sha256": "0hr7202jhmjcx3z71dn2lzwv7980lalj0kbvjn6jjg4dm71fywjn"
   },
   "stable": {
    "version": [
     2,
-    3,
-    3
+    4,
+    1
    ],
-   "commit": "ee0670f85bc55a3178c18774e141b4e58b2f6fe7",
-   "sha256": "14nfb94y9vcnpmwj9acwl6h5v0h1c6swqf33ch4zimxxqgx9zrm4"
+   "commit": "467aab71377a6e1476dcab7ab5f2c55d1ffc28fe",
+   "sha256": "0b4y8dzyc9qwwaf2ngqiwyfcnhwlr49kxhc96laqk20lvjlfsrnx"
   }
  },
  {
@@ -71490,11 +71659,11 @@
   "repo": "kuanyui/moe-theme.el",
   "unstable": {
    "version": [
-    20220111,
-    1220
+    20220608,
+    1159
    ],
-   "commit": "edf3fe47fb986e283e3b04cba443dcb39fe8720e",
-   "sha256": "1wr6xd3hhgnqjrr2d8llbrdaagi4wz77zfxh1jg2f2mj28i52ksz"
+   "commit": "4d9e876d24d69d18c4111fa42bd34fe01a124866",
+   "sha256": "1a18pg8fwx0iicxrab2qj7wfh05pbqb4bh13nhlp2r94w024idd9"
   },
   "stable": {
    "version": [
@@ -71789,11 +71958,11 @@
   "repo": "jessieh/mood-one-theme",
   "unstable": {
    "version": [
-    20210221,
-    18
+    20220608,
+    25
    ],
-   "commit": "42e402a89473458f55a71c5bbe785575e9a927ba",
-   "sha256": "1ma5138src6iglkhd2h8w9k4gqqaxvsngz08cd4v2s8dhqkcayw8"
+   "commit": "65e98bafa0277b9c706c6e3564f11edbca5d5699",
+   "sha256": "1sc8z0fp7q9xkjm5d2x8gv0l0km4m28q71li1pkvdzmxmzn40ayd"
   },
   "stable": {
    "version": [
@@ -72122,8 +72291,8 @@
     20210306,
     1053
    ],
-   "commit": "247db142f7251062978ade3fd27c815259eaa05b",
-   "sha256": "16bdqpmj4lsc3nx78ikvgqslb6jrzc5qmkhfl8m5gy26gfd37dxn"
+   "commit": "73f289987769fe1dd381bf436b5888a2a663e276",
+   "sha256": "09y3x603xgk51jgnry3x59hysv7z8d7v0p3bsp015z9lx3m83b4v"
   },
   "stable": {
    "version": [
@@ -72524,16 +72693,16 @@
   "repo": "xzz53/mu4e-alert",
   "unstable": {
    "version": [
-    20220416,
-    1840
+    20220528,
+    1923
    ],
    "deps": [
     "alert",
     "ht",
     "s"
    ],
-   "commit": "b34d0ea7b75709cc25d842a783cebea855dc9f7d",
-   "sha256": "09qzph8madnhd8kqnj662sgfcyvp1wg35ll6i5xbh98yazc0r64s"
+   "commit": "85489fae322a655e275be2483b9d02486b172ea8",
+   "sha256": "17d2nqndb760k96s8wskpx4g6xmfzwaifmbs25pj9114zvpz2byy"
   },
   "stable": {
    "version": [
@@ -72613,14 +72782,14 @@
   "repo": "agpchil/mu4e-maildirs-extension",
   "unstable": {
    "version": [
-    20201028,
-    921
+    20220517,
+    1852
    ],
    "deps": [
     "dash"
    ],
-   "commit": "1167bc6e08996f866e73e9a02f563fd21ac317fd",
-   "sha256": "0bnznfz3bfk348hw5avri6n5w7x8376j0vzybwdxrqb6hfbvwzw0"
+   "commit": "cdc2e141d8ecd59508a5cd50d6d02120073bf4f1",
+   "sha256": "0nkkz4x0wk3sc1d97zl47x4d80d29r5nmh6f3sy7xw342gnb8gsj"
   },
   "stable": {
    "version": [
@@ -72722,10 +72891,10 @@
  },
  {
   "ename": "muban",
-  "commit": "3576c6b7d79ce6d4df40ce83400fa2468f8fbcdf",
-  "sha256": "1njphxx6sgw952p7v2qkbjwa8sb2mwrxrzv35bzp0d4c84ny2sa0",
+  "commit": "167ddaca39085bd570bb9392408ae31e58509793",
+  "sha256": "13p1xbz90q055iczyclwcw0bkwwphq3c9bgy1ykr84jhfhvpm80a",
   "fetcher": "github",
-  "repo": "jiahaowork/muban.el",
+  "repo": "jiahaoli95/muban.el",
   "unstable": {
    "version": [
     20180415,
@@ -72987,14 +73156,14 @@
   "repo": "magnars/multiple-cursors.el",
   "unstable": {
    "version": [
-    20220328,
-    1724
+    20220528,
+    1215
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "aae47aebc0ae829211fa1e923232715d8e327b36",
-   "sha256": "1rpimqf8srlvilnqi02lr7my9ccxc89gc14pzs6jdffc60gb4659"
+   "commit": "fd8441bfc8738d463601823e5a3d9c2d7123bfbf",
+   "sha256": "1201q60cnydglq431hkf68kz6gx4i1fs1v00jldliqrxkxm0ignx"
   },
   "stable": {
    "version": [
@@ -73059,8 +73228,8 @@
  },
  {
   "ename": "mustache",
-  "commit": "d1bcf9599ca6d2c29333071a80f96808d4ab52e2",
-  "sha256": "1pjr00xx77mlfw1myxaz6i3y2gbivhbiq5hyjxxbjlfrkm1vxc8g",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1qag8yv1xh65ny7gni4ncz42ij3h6ca4nzp13pbfy5bmyw9hfzlj",
   "fetcher": "github",
   "repo": "Wilfred/mustache.el",
   "unstable": {
@@ -73115,8 +73284,8 @@
  },
  {
   "ename": "mustang-theme",
-  "commit": "2ed3691edd1cba6abc0c30d2aab732e2ba51bf00",
-  "sha256": "0771l3x6109ki914nwpfz3fj7pbvpcg9vf485mrccq2wlxymr5dr",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0984cjy659w4f0hxpvijs6wz6978vwabkp7nbwnqb9pmpgaf1ia2",
   "fetcher": "github",
   "repo": "mswift42/mustang-theme",
   "unstable": {
@@ -73271,11 +73440,11 @@
   "repo": "redguardtoo/mybigword",
   "unstable": {
    "version": [
-    20201030,
-    1253
+    20220526,
+    1438
    ],
-   "commit": "4c1386252444df2ade734e02078069a06f3f0f97",
-   "sha256": "0gbynsf84dgsg2m6h2m2xj54ph0a7kiz9njd33j4xp7r36d268f8"
+   "commit": "ffbfa2a938a58c4e60ccc4c2ec0ae32a11eac485",
+   "sha256": "1aknn89k9chrn65jxxj82pjia4rqfqp8s71j7x1hb10fscmscdbp"
   },
   "stable": {
    "version": [
@@ -73289,8 +73458,8 @@
  },
  {
   "ename": "mykie",
-  "commit": "e10504a19e052c080be2ccc9b1b8fd2e73a852e0",
-  "sha256": "12ram39fp3m9ar6q184rsnpkxb14y0ajibng7ia2ck54ck7n36cj",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "18s3cb0gxji5xvslbpw9dcw2d3msj6lv7zg8kl3vifjzjsp5b94p",
   "fetcher": "github",
   "repo": "yuutayamada/mykie-el",
   "unstable": {
@@ -73591,8 +73760,8 @@
  },
  {
   "ename": "namespaces",
-  "commit": "de404e9ad3d1e27af24e868e84218d872d5fc795",
-  "sha256": "02pb7762khxpah4q6xg8r7dmlv1kwyzinffi7pcaps6ycj29q2fr",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0mcyi74zvd60kmvyi1zq43arnk57rmahdyl4g75v31ka6fd5yspm",
   "fetcher": "github",
   "repo": "chrisbarrett/elisp-namespaces",
   "unstable": {
@@ -74012,20 +74181,20 @@
   "repo": "babashka/neil",
   "unstable": {
    "version": [
-    20220501,
-    2053
+    20220514,
+    2039
    ],
-   "commit": "239c16655431b27ee558bf250bece4f4b10a0e83",
-   "sha256": "1d31g7a9js378cq56gqwrd978bzc57848j169lsykz24yqx3sf22"
+   "commit": "12fadb994054306984010d0096b051a972af75cc",
+   "sha256": "08fbm2sfdw4g0skbwyn9wbb1jcf46l8f23j552y202znfmyqhz2v"
   },
   "stable": {
    "version": [
     0,
     0,
-    28
+    31
    ],
-   "commit": "6e8620c1a3001d1541ad934ae2847905451a21cf",
-   "sha256": "0ipg6d8vm7i4jgdxa56w8a4al2nnj09pivfplfja7791mgl0qk30"
+   "commit": "61e9d2f4c55601a5a03e1525eb75cfa6ce7325b1",
+   "sha256": "1sg29z2hca6ssplj4hcam0334rabix0bqbm94blgl0yn1r5cac7r"
   }
  },
  {
@@ -74527,11 +74696,11 @@
   "repo": "m-cat/nimbus-theme",
   "unstable": {
    "version": [
-    20220513,
-    240
+    20220525,
+    220
    ],
-   "commit": "958a92a979c88bee909d03a78b2faf6726d0069b",
-   "sha256": "0l4bi6hnwk4lssmya8x6av0j0nhvwccxaiv2ar1byiy7i3bxvr16"
+   "commit": "a5f51bc847553dc1ac7ad54fa5af32cd4623a66d",
+   "sha256": "12m9vcnpg8vv6kbi6yw0n2x8gall2wz8y5gl1jgiil9nycyxnikg"
   },
   "stable": {
    "version": [
@@ -74554,17 +74723,17 @@
     20181024,
     1439
    ],
-   "commit": "7905dee5ac62f7a1e0dfec4d936b97d96c7566d7",
-   "sha256": "17q8sqnrrsyxz6zld2zarp44wsjn53nsp8bz8k007wd5lbwylvg2"
+   "commit": "55f54511d35716c43637dee2bcb5fbc7839f967b",
+   "sha256": "0pmxi8nsd9zid9nys8ba26281k34s0gv7dszk2rlx92rb8c3k22i"
   },
   "stable": {
    "version": [
     1,
-    10,
-    2
+    11,
+    0
    ],
-   "commit": "e72d1d581c945c158ed68d9bc48911063022a2c6",
-   "sha256": "0mspq4mvx41qri2v2zlg2y3znx5gfw6d8s3czbcfpr2218qbpz55"
+   "commit": "51edeeb063a82693573db43782d9e3733b2840e4",
+   "sha256": "14wqccblr3nc2pjgv1a5fsjznp7iyp6z993jp1ddknz01dvhr765"
   }
  },
  {
@@ -74857,16 +75026,16 @@
   "repo": "dickmao/nnhackernews",
   "unstable": {
    "version": [
-    20220107,
-    1537
+    20220604,
+    2100
    ],
    "deps": [
     "anaphora",
     "dash",
     "request"
    ],
-   "commit": "6748065db2f12ae6ea07058e7d643f586fb4b3bc",
-   "sha256": "0b566hb8j0mwl8b8plaf10majn8v70r9j7ffwsk1jnkixc8y4l37"
+   "commit": "ec99d579b9fa26fdb5f5e00dfd77e968ed8386f0",
+   "sha256": "0bnalbgf3bdvwnvmdjy1vq439n6vkfzmp9a5rgn0kdr32ar75kfw"
   }
  },
  {
@@ -74886,8 +75055,8 @@
  },
  {
   "ename": "nnreddit",
-  "commit": "4581c76fee699eb9f41eb0f00e4ccd4a008b8399",
-  "sha256": "0pfb57pwdyhsrmgzbf83xrq10xjhm6sk6xyz8rd15gjqka2mc8c2",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "07m8q4nymchx16pj6l2brmks6011i586dyycaczv1zqdvvhd4b8g",
   "fetcher": "github",
   "repo": "dickmao/nnreddit",
   "unstable": {
@@ -74909,8 +75078,8 @@
  },
  {
   "ename": "nntwitter",
-  "commit": "39b3ec38c4a6762afdea13c17e0447caa976181f",
-  "sha256": "0788lajp113rqc38d0s1qypvgmfnxw1mjcj97syi27jda5jw3lbl",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "1sgj1fn06zk2rblf5c4jlqyjdrlxvn56pj1q9vylglswy7dgz9xp",
   "fetcher": "github",
   "repo": "dickmao/nntwitter",
   "unstable": {
@@ -74950,14 +75119,14 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20220509,
-    1733
+    20220530,
+    1845
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fed46eb7060aca624bfe1a18f13b73f94e70f013",
-   "sha256": "169asd32iask7h6m861j1qfg60mxnmxxcwc3f8ddxkpfjb6b27sq"
+   "commit": "a5aa3faada054f96b70b32ba9d9447f7a4cf403c",
+   "sha256": "1gykaxdzv1j5q6h9m36ms5708h3jsn5yjilnajrngv3nkh6mb0qs"
   },
   "stable": {
    "version": [
@@ -74995,15 +75164,14 @@
   "repo": "thomp/noaa",
   "unstable": {
    "version": [
-    20220509,
-    1600
+    20220515,
+    2359
    ],
    "deps": [
-    "dash",
     "request"
    ],
-   "commit": "507831164b09a2d769bd68d5a45608fc0de626dd",
-   "sha256": "1xsnr4y3al9ps2v1y8yjapmghrvcgk8671h300l3w9w0gjcwkbhj"
+   "commit": "1ebacdfbaa996319adf88a49258814c28ba49b1b",
+   "sha256": "1gz3blbj1snvdq9vyc2f2brbpkarxid221lpqm8h58jlzxx0by86"
   }
  },
  {
@@ -75292,11 +75460,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20220226,
-    1200
+    20220602,
+    1121
    ],
-   "commit": "37492858b61907e4728b2e68e67238c68e9a0d49",
-   "sha256": "0kc750z3p23rkn2nr3z7y205xb58qi77f2vr8w33nj4ykgil65ar"
+   "commit": "3a6b479a7360fbdbc1c6def4c1e1581bfd63e8a2",
+   "sha256": "1r7vr10yz0vjhlv5wbgv1x3519fg9lhdp165ksr1gg8mcp5yca37"
   },
   "stable": {
    "version": [
@@ -75810,11 +75978,11 @@
   "repo": "enricoflor/numbex",
   "unstable": {
    "version": [
-    20220504,
-    1329
+    20220518,
+    29
    ],
-   "commit": "55d4977c74ca33d1ad4c10fea7369f4bcdfd3f86",
-   "sha256": "0d43ad14b2k1w3my2nwrnw58z594hw18k6p37xvvpnx8r4fdxbl2"
+   "commit": "aa3903f190946e54f41601dd7831f3aa973a8be7",
+   "sha256": "1fnll6ccys7wmwbw4xp638ln0qsdy9bfczphgrdjps0h8xr3awpc"
   }
  },
  {
@@ -75921,11 +76089,11 @@
   "repo": "dpk/nxml-uxml",
   "unstable": {
    "version": [
-    20220130,
-    1405
+    20220606,
+    1213
    ],
-   "commit": "94440741f7e8b83504d53991f26f63b4855cce27",
-   "sha256": "17k0d6ik2zj99kdvxdj5jg2kjj83lpy983mgcr3vv36axlw58wyr"
+   "commit": "95bbd0018ab218b9f39f5bf1f1e809f60fbc3edc",
+   "sha256": "10rah19x3pnvksi7ikji36i5bci9jhh6xjqlv6cn6xm7fdwrrkd8"
   }
  },
  {
@@ -76024,27 +76192,27 @@
   "repo": "rocher/ob-ada-spark",
   "unstable": {
    "version": [
-    20220401,
-    926
+    20220515,
+    2014
    ],
    "deps": [
     "f"
    ],
-   "commit": "1213b877bc893ac5990a20052ea2bf2d8f086260",
-   "sha256": "18v4psk9ilvbnsbdksarix7zak7pbyxbn0rfy3kv9r2p0nrw9brj"
+   "commit": "b4f16b255947240e458127e5c737d793ac894ac1",
+   "sha256": "1vfkp4k5wz6aqq13f8p3la825q7qa3q1m05s2a5mdffn2r7f7nb9"
   },
   "stable": {
    "version": [
     1,
     2,
     5,
-    2
+    3
    ],
    "deps": [
     "f"
    ],
-   "commit": "1213b877bc893ac5990a20052ea2bf2d8f086260",
-   "sha256": "18v4psk9ilvbnsbdksarix7zak7pbyxbn0rfy3kv9r2p0nrw9brj"
+   "commit": "b4f16b255947240e458127e5c737d793ac894ac1",
+   "sha256": "1vfkp4k5wz6aqq13f8p3la825q7qa3q1m05s2a5mdffn2r7f7nb9"
   }
  },
  {
@@ -76110,8 +76278,8 @@
    "deps": [
     "axiom-environment"
    ],
-   "commit": "b52fa715285e7ad182c8e679ebf05b130dd5b5e2",
-   "sha256": "1hb4npfpg1iy9j0p29q1jrjgx0mrn333m45nmsnxw8nlaxzd97x6"
+   "commit": "847cc6e728b692ad3fdaec28d0c8c49ec0378a56",
+   "sha256": "02nf2vn6s6pc63yw2rggdx9capn9432w6j56m9v0c5ygarpxb53p"
   }
  },
  {
@@ -76622,15 +76790,15 @@
   "repo": "shg/ob-julia-vterm.el",
   "unstable": {
    "version": [
-    20220512,
-    820
+    20220518,
+    1429
    ],
    "deps": [
     "julia-vterm",
     "queue"
    ],
-   "commit": "448b1d0d2edf908c13a99a2424fec20de636f5a3",
-   "sha256": "040k25ikvngczd8yxm8i6qa0q6vbqgsiq1ddwq1wlvhaw9iam6qm"
+   "commit": "39dbdb265785ae72bcd53706bc53190ec5e11bf0",
+   "sha256": "0wnvfv2ddvfwm6w446xx3x024g2vi8wzxyj85wdhpdh2hzssfchi"
   },
   "stable": {
    "version": [
@@ -77037,15 +77205,15 @@
   "url": "https://repo.or.cz/ob-spice.git",
   "unstable": {
    "version": [
-    20220210,
-    1415
+    20220529,
+    404
    ],
    "deps": [
     "org",
     "spice-mode"
    ],
-   "commit": "6dc2c6b9391ea8dd8123224f6c282b673b89dc94",
-   "sha256": "15lnmqzpgaz8n6zh0x9dm6hynl7rf1pcyf5m3fk7bbinqbxclljn"
+   "commit": "b1106ef2a74b2e88b294b05b83af22810feef4f6",
+   "sha256": "1k0ylhlaz8g2f1p1chn9vrzid78fswpyjalim73566pslc09lxsp"
   },
   "stable": {
    "version": [
@@ -77370,20 +77538,20 @@
   "repo": "ocaml-ppx/ocamlformat",
   "unstable": {
    "version": [
-    20220307,
-    1315
+    20220519,
+    1004
    ],
-   "commit": "c490e5b7c4b5f5e5848a5cbdb1e669588dfeaae3",
-   "sha256": "1kq8290g494z48a1g1myzyazzfl33gz1hws984kxv8i29lp7jqr3"
+   "commit": "3b59f18b040e8bf7484a91435bfffcc34db55864",
+   "sha256": "11nm1idxnpzrdipnaxi35hzppwmylzdpvmjfnlgrqbmb6bcjinxs"
   },
   "stable": {
    "version": [
     0,
-    21,
-    0
+    22,
+    4
    ],
-   "commit": "63e478f1186a03c7e4dfeeb39b3d8fe2ef1cb429",
-   "sha256": "10vy102a0isd8cg94y61pm4qfgy74d6003dw0qn0bdmbd19r5071"
+   "commit": "838ba9fa00cc27703441220b9a5d3880b17430fb",
+   "sha256": "171lq3vx4y8xj4by5zy93isx8nhg6ysxg1hxmkqkq16fdaiz8mnc"
   }
  },
  {
@@ -77567,26 +77735,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20220402,
-    1505
+    20220603,
+    1106
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "df7180a8d75dedb2fd8878843a3d3cc654be508d",
-   "sha256": "0wf02hziqxmjvcxbnl8nr6dmgw9ivmx2n1ybrqh2k75zz1rnzasc"
+   "commit": "0c455d31516baa02603f54917d5ff1f309e31925",
+   "sha256": "1y8vw5m9z9jc8yam5hxsamiz9hpn2v9q5rmrf9f9s7m4xm5iq10j"
   },
   "stable": {
    "version": [
     4,
     4,
-    0
+    4
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "df7180a8d75dedb2fd8878843a3d3cc654be508d",
-   "sha256": "0wf02hziqxmjvcxbnl8nr6dmgw9ivmx2n1ybrqh2k75zz1rnzasc"
+   "commit": "0c455d31516baa02603f54917d5ff1f309e31925",
+   "sha256": "1y8vw5m9z9jc8yam5hxsamiz9hpn2v9q5rmrf9f9s7m4xm5iq10j"
   }
  },
  {
@@ -78315,11 +78483,11 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20220418,
-    2119
+    20220527,
+    2228
    ],
-   "commit": "75eeae21971d86b51a712ed8ecd6434463b2d866",
-   "sha256": "0rl3na97qkl5a5p2ifs1sli80rq38qqmjqkv6khn60f05rj5yvk3"
+   "commit": "8b9af2796fa0eb87eea4140bc08d16880a493803",
+   "sha256": "0vbxg9k4w6yc770l330ir2h0fz108msmxhjq7p8alcql45vmhwn8"
   },
   "stable": {
    "version": [
@@ -78477,30 +78645,30 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20220302,
-    1706
+    20220525,
+    903
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "c1790b1cdd2e5733cf64c7507a89da0b6179cf7d",
-   "sha256": "10r8k14dlm017c4kahim2jv2nkx0898r0dc21z5szp4hw7l1z4n9"
+   "commit": "c084599a199f794b7e25d5ca4d58f0c0ad87c160",
+   "sha256": "1h0dlph8cxs8spdqy0zs515hnza5jp15szbv7qgnricbg9k3pkx7"
   },
   "stable": {
    "version": [
+    1,
     0,
-    0,
-    9
+    2
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "c1790b1cdd2e5733cf64c7507a89da0b6179cf7d",
-   "sha256": "10r8k14dlm017c4kahim2jv2nkx0898r0dc21z5szp4hw7l1z4n9"
+   "commit": "c084599a199f794b7e25d5ca4d58f0c0ad87c160",
+   "sha256": "1h0dlph8cxs8spdqy0zs515hnza5jp15szbv7qgnricbg9k3pkx7"
   }
  },
  {
@@ -78594,26 +78762,26 @@
   "repo": "yilkalargaw/org-auto-tangle",
   "unstable": {
    "version": [
-    20211115,
-    543
+    20220607,
+    2042
    ],
    "deps": [
     "async"
    ],
-   "commit": "c3cbde261fd66b747374b667cb715ca9ee8c52ba",
-   "sha256": "084pfgjyf41nmwyixvza9vhmfbaq587hx78knpg7c19aiki2r8zx"
+   "commit": "87b867b46e9d75bb65c6b4d02565c67e225bd429",
+   "sha256": "1zb7vcmhmjiqpbbhqrqci689rnpn10p985cs5jk9sgg66xsbrgs3"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
    "deps": [
     "async"
    ],
-   "commit": "c3cbde261fd66b747374b667cb715ca9ee8c52ba",
-   "sha256": "084pfgjyf41nmwyixvza9vhmfbaq587hx78knpg7c19aiki2r8zx"
+   "commit": "87b867b46e9d75bb65c6b4d02565c67e225bd429",
+   "sha256": "1zb7vcmhmjiqpbbhqrqci689rnpn10p985cs5jk9sgg66xsbrgs3"
   }
  },
  {
@@ -78624,11 +78792,11 @@
   "repo": "calvinwyoung/org-autolist",
   "unstable": {
    "version": [
-    20211225,
-    658
+    20220530,
+    1620
    ],
-   "commit": "48666001f9ae1fdf9e295410d5a494e79284e2f7",
-   "sha256": "0ij0j96ns4scrlcf52ljwhi3y4q9jfv9kra3nw162fs3f4q6lp7m"
+   "commit": "da3a45f95f2e9f7281d533d1e5cec1764ae26a9c",
+   "sha256": "0zj4g6vfwyyxlpci6fcawvf35bgk7b84rrnm9s9myv53b6nri73f"
   },
   "stable": {
    "version": [
@@ -78674,8 +78842,8 @@
  },
  {
   "ename": "org-beautify-theme",
-  "commit": "f55f1ee9890f720e058401a052e14c7411252967",
-  "sha256": "0rrlyn61xh3szw8aihxpbmg809xx5ac66xqzj895dn1raz129h2w",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "08f8lzbsyx919i83k070zyykn5hmndj5krschby52mimsllcrl80",
   "fetcher": "github",
   "repo": "jonnay/org-beautify-theme",
   "unstable": {
@@ -78931,14 +79099,14 @@
   "repo": "dfeich/org-clock-convenience",
   "unstable": {
    "version": [
-    20220503,
-    530
+    20220515,
+    849
    ],
    "deps": [
     "org"
    ],
-   "commit": "988d4e3c9f0ae6df098b0ab1985b79eed2c5b808",
-   "sha256": "0b1i013likxba92z3bwrg9in3g3daaz31fdsn1cfxbn3yha6yzai"
+   "commit": "9201db80862d144459f1316d571842f5389a47eb",
+   "sha256": "010wl014dh8sipfqnyasxy1rq5q726bgxm50v4fyqlqkpc6r07d2"
   }
  },
  {
@@ -79047,6 +79215,26 @@
    ],
    "commit": "2eeeb0f506e30ef82263e67279d837a79cbde021",
    "sha256": "02an98pc52yfxsxmz1kib692yx93rqdi1q3lpvblzyd3hhd51rlr"
+  }
+ },
+ {
+  "ename": "org-contacts",
+  "commit": "40c73fda1fc5fd5cf01680838a9556fb3fa528cf",
+  "sha256": "11xh2qpibpxcfw6wbv7i18294pd9ccdhdqnka2p3jcrpac1m8ai9",
+  "fetcher": "git",
+  "url": "https://repo.or.cz/org-contacts.git",
+  "unstable": {
+   "version": [
+    20220604,
+    102
+   ],
+   "deps": [
+    "cl-lib",
+    "gnus",
+    "org"
+   ],
+   "commit": "c1c4cadf3f7890a07d03c531ef823e1fb5f3ef2f",
+   "sha256": "07jkgmi9i9k0pnlxhrmhx3rjqaxl3q69mz9zmyxrpk7y9dv6hc92"
   }
  },
  {
@@ -79312,6 +79500,25 @@
   }
  },
  {
+  "ename": "org-edit-indirect",
+  "commit": "53497135511754f2d6fb11b4f9ffd34f6715bd2c",
+  "sha256": "0kbhj4qihb442f2yvnv5i6d0gy8hdqa6qbawj563zgrfi19swi0r",
+  "fetcher": "github",
+  "repo": "agzam/org-edit-indirect.el",
+  "unstable": {
+   "version": [
+    20220508,
+    2141
+   ],
+   "deps": [
+    "edit-indirect",
+    "org"
+   ],
+   "commit": "f146d1b406308298b4004a28aaa11124b02d015b",
+   "sha256": "18w6gpdj8ch8zgyidaglym8mxp23y4aa6a0z2qix7skka0vlknjq"
+  }
+ },
+ {
   "ename": "org-edit-latex",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0nkiz4682qgk5dy4if3gij98738482ys8zwm8yx834za38xxbwry",
@@ -79535,8 +79742,8 @@
     "request",
     "request-deferred"
    ],
-   "commit": "554c48fb57dc46877202028019197b0699961ca0",
-   "sha256": "1l48dgzwwh230l5kxd17jdmjwhbkaqzmj95znxzhs9jrfm7jixyb"
+   "commit": "f8075bd8eac7288eea1060077ca103d5fd01fb65",
+   "sha256": "0vmf9l3cc5i0kqyqdvbhd4sndla2j57rvy551rib5knhqx1ry0sd"
   },
   "stable": {
    "version": [
@@ -79654,23 +79861,24 @@
     "org-edna",
     "transient"
    ],
-   "commit": "4e0fcf9a440e463d395f8f37efe8f1e691ed07dc",
-   "sha256": "0672pcklp743k8fz39hwf1zxb7f1sywdjsm8d8ha8r6h2rjbyl6k"
+   "commit": "66918121e8daf8e0b355b12717dc898150f0f2e1",
+   "sha256": "128r3nfhx7pqfhfjymny7idrnid7g9xc3rjmxa71r80bj936j86b"
   },
   "stable": {
    "version": [
-    1,
-    1,
-    1
+    2,
+    0,
+    0
    ],
    "deps": [
     "f",
     "org",
     "org-agenda-property",
-    "org-edna"
+    "org-edna",
+    "transient"
    ],
-   "commit": "13f04f46ed027cd119f21377b050288a96b344cf",
-   "sha256": "15my09gz094z0ihrakxa1x0zcb073s85azwmp891iv62qjhgl5x6"
+   "commit": "4e0fcf9a440e463d395f8f37efe8f1e691ed07dc",
+   "sha256": "0672pcklp743k8fz39hwf1zxb7f1sywdjsm8d8ha8r6h2rjbyl6k"
   }
  },
  {
@@ -79956,8 +80164,8 @@
  },
  {
   "ename": "org-kanban",
-  "commit": "a9f3a10c126fa43a6fa60ee7f8e50c7a9661dbc1",
-  "sha256": "1flgqa2pwzw6b2zm3j09i9bvz1i8k03mbwj6l75yrk29lh4njq41",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1gfkmqrhhbbwg4q6h56nrjknh9m0fzd3svm7y0l6wlfh5bg6hqjr",
   "fetcher": "github",
   "repo": "gizmomogwai/org-kanban",
   "unstable": {
@@ -80036,14 +80244,14 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20220503,
-    458
+    20220605,
+    239
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "b20e296b497360de12d5d973aa273cab70c77126",
-   "sha256": "17vcrz99759sh75swd94w1pajq5kknj7bgw5n12frwgfjlq6hi3s"
+   "commit": "47d54dd736abc9ef5406e3e7394d54c5110d355d",
+   "sha256": "0g3j3xnyk1fxs3m7c3vsb7ai7cxjj6iv3qji19a50rjcc7l6s4ja"
   }
  },
  {
@@ -80120,8 +80328,8 @@
    "deps": [
     "seq"
    ],
-   "commit": "075e0e6d36eb50406a608bc8a2f0dd359ec63938",
-   "sha256": "133smvw9iaxg0p3y5wl0rc4fwwgbxgw6hxngpmar8qf4grwy4w27"
+   "commit": "d2f4b9e8f1c7c9b495f71deeaa77e4f6f47bc7bf",
+   "sha256": "1p9mz0fz6s63wy7zh4r1ifa7kcycymlcgmqjbpgv85m2783ab0l6"
   }
  },
  {
@@ -80165,20 +80373,20 @@
   "repo": "org-mime/org-mime",
   "unstable": {
    "version": [
-    20220204,
-    42
+    20220521,
+    1422
    ],
-   "commit": "98504d043c8421ac390b7358b146733c7c0b4479",
-   "sha256": "0n0bm9xddlgvlrmc2yjkdyvag7690yphdkcjx4w3cb04xlcac9ns"
+   "commit": "cf96f585c68ad14751a3f73d937cbfcb890171b9",
+   "sha256": "17380kpf08j5ai30nn5iks0k3x8sm3kmz8lkyr1v0qvpr5a8s70b"
   },
   "stable": {
    "version": [
     0,
-    2,
-    6
+    3,
+    1
    ],
-   "commit": "a7bf07316f93015e4f853ea0fc5b8d05b4a7695d",
-   "sha256": "01f04xpqkgja34a0z4smh2kxzn3lvx2391fnbfxmq92pxqp3gk0j"
+   "commit": "cf96f585c68ad14751a3f73d937cbfcb890171b9",
+   "sha256": "17380kpf08j5ai30nn5iks0k3x8sm3kmz8lkyr1v0qvpr5a8s70b"
   }
  },
  {
@@ -80208,21 +80416,21 @@
   "repo": "ndwarshuis/org-ml",
   "unstable": {
    "version": [
-    20211231,
-    700
+    20220601,
+    1412
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "3974435bbf72722801f7ed78855381d77a773162",
-   "sha256": "0zdvz8lzrf7dj6giryy98wkxrrcawigvhab3prxwhjrkp8n9wvbv"
+   "commit": "f191ebfee6dcf6a05b5d1db43cf75f4a20faa8b4",
+   "sha256": "1vcdbpq746xa5a3rlq9vj4r42ygmws0wg7r7q4zylkvx9gv0c3n5"
   },
   "stable": {
    "version": [
     5,
-    7,
+    8,
     1
    ],
    "deps": [
@@ -80230,8 +80438,8 @@
     "org",
     "s"
    ],
-   "commit": "0a96482452fc60170e3f5b8cf3a259b2b09c9ef5",
-   "sha256": "1ca6wgjwslv3582fmsxna81mgryziw9v9zh1836sbp3yszqddday"
+   "commit": "7b0022b3a751bb4396b07f47546c66ddcd5be922",
+   "sha256": "1vcdbpq746xa5a3rlq9vj4r42ygmws0wg7r7q4zylkvx9gv0c3n5"
   }
  },
  {
@@ -80260,11 +80468,11 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20220422,
-    940
+    20220605,
+    2206
    ],
-   "commit": "ff1046705b3950b7a49da50bc34c11da86c6226d",
-   "sha256": "0zg2bi6jprigvqy4zglb8f8357sxikcfx0b8vjbwcjl08iimxp6j"
+   "commit": "b352680d9ee8c6e6966cc21d595513c3595e3bb7",
+   "sha256": "1mc1m6x9bj92lfsbrxnasp78sc501mjiad4jrb5m1j42j0d1cs83"
   },
   "stable": {
    "version": [
@@ -80498,8 +80706,8 @@
  },
  {
   "ename": "org-octopress",
-  "commit": "fba6c3c645ba903f636814b5a2bb1baca0b5283b",
-  "sha256": "0r6ms9j4xxsrik4206g7gz4wz41wr4ylpal6yfqs4hhz88yhxrhw",
+  "commit": "4d846f217178edce928aa586147c3cd71312eb2a",
+  "sha256": "1qwmm2c226m1g8hwkj2f5yxczg8d1wvya0b1gadgcbwrxlcrjm8s",
   "fetcher": "github",
   "repo": "yoshinari-nomura/org-octopress",
   "unstable": {
@@ -80894,8 +81102,8 @@
   "repo": "alphapapa/org-ql",
   "unstable": {
    "version": [
-    20220318,
-    1534
+    20220602,
+    1651
    ],
    "deps": [
     "dash",
@@ -80909,14 +81117,14 @@
     "transient",
     "ts"
    ],
-   "commit": "46f523d94a376b168176c75bbd0e3e0d00e61170",
-   "sha256": "0vrk7lx4n4imvsnqv50w6fmqnndr48x89gcmm375fw6zgy2m90bl"
+   "commit": "64a9234733904af20fd495861792f1d5c2b37190",
+   "sha256": "1w3vly4jh854gb9bgnwqfzry6214v498fmiwm491gi8m5g0d05xp"
   },
   "stable": {
    "version": [
     0,
     6,
-    1
+    2
    ],
    "deps": [
     "dash",
@@ -80930,8 +81138,8 @@
     "transient",
     "ts"
    ],
-   "commit": "f666fe150f1bf3c3ce43d0e15f90b20d43c2e772",
-   "sha256": "1mpq3v8lxqllnb4afqh7p9av0p9bha8ld7741zaw4hxb1252xgm2"
+   "commit": "115500c8a0a3190ec6a69d1120fe81944d819125",
+   "sha256": "0iamqv5j43ngj1xdqr36rkgk9lqpk9bg8y531jsldnvwzrp3srpf"
   }
  },
  {
@@ -80954,8 +81162,8 @@
  },
  {
   "ename": "org-random-todo",
-  "commit": "80fad6244ea3e5bdf7f448c9f62374fae45bae78",
-  "sha256": "0yflppdbkfn2phd21zkjdlidzasfm846mzniay83v3akz0qx31lr",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1abhpazwr7gp9bvl83zdg2nvw51mg70myqi18l3hzic033pbhxwz",
   "fetcher": "github",
   "repo": "unhammer/org-random-todo",
   "unstable": {
@@ -81010,28 +81218,28 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20220402,
-    1456
+    20220523,
+    1744
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "c787ebf93d51b63b8726df241e3e2fcda35d4ae1",
-   "sha256": "02y6qm4va43c25i7b0q3pvk888war64rrb2p9bmv5p8176dy1mjw"
+   "commit": "93ba4e91f1d007669d39fc76c097ff5d6a64489e",
+   "sha256": "0qwlyikci53z1qc33nsg19fazg5p1jrjsjc481afyjf364ds2j1i"
   },
   "stable": {
    "version": [
     3,
-    13,
+    14,
     0
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "c787ebf93d51b63b8726df241e3e2fcda35d4ae1",
-   "sha256": "02y6qm4va43c25i7b0q3pvk888war64rrb2p9bmv5p8176dy1mjw"
+   "commit": "ac67832e7b342326deef650db6601b95127627bc",
+   "sha256": "1kcr1zpafgaykbkxfav4iia6fbglpjv4kvj5yjn8wcm1liiaj6ck"
   }
  },
  {
@@ -81186,8 +81394,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20220509,
-    1414
+    20220601,
+    2032
    ],
    "deps": [
     "avy",
@@ -81198,11 +81406,12 @@
     "htmlize",
     "hydra",
     "org",
+    "ox-pandoc",
     "parsebib",
     "s"
    ],
-   "commit": "0d2355d1eb4dcac1095a03d885788a12fe566610",
-   "sha256": "019pbp02fnbb7rcr80cfyi7pa9b413lgdfmbwaak2icb5cpmj452"
+   "commit": "cbe9e870a5f488cdfc5e6a3b5478845ea8acdcde",
+   "sha256": "05js4f3xnms8c06s63agmhfcwj6cjsp2z83pqmlwga8h74z7f5y7"
   },
   "stable": {
    "version": [
@@ -81278,28 +81487,29 @@
   "repo": "akirak/org-reverse-datetree",
   "unstable": {
    "version": [
-    20220310,
-    1646
+    20220521,
+    1755
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "9ebd42b521e7adf26a35cbb17144113a83f73264",
-   "sha256": "0wjz26qmjwiz1594b4s9vycbbz7zhs52xpa0ksph92fcl21c5fp5"
+   "commit": "0b24765e270a2dfd84adf3a0f9afa8b72aabad30",
+   "sha256": "1z529iy3zm8szyr98kmi7m3rfpkx139xcpjz4vazk23zj93mpxrc"
   },
   "stable": {
    "version": [
     0,
     3,
-    10
+    11,
+    1
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "c42078f8601b7f600135f66e75246a53c5f9975f",
-   "sha256": "1afmv6ncjbm6dalgz459lhh0rif8rlag23n05jwdv7izibwb1dm2"
+   "commit": "0b24765e270a2dfd84adf3a0f9afa8b72aabad30",
+   "sha256": "1z529iy3zm8szyr98kmi7m3rfpkx139xcpjz4vazk23zj93mpxrc"
   }
  },
  {
@@ -81349,8 +81559,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20220512,
-    1634
+    20220608,
+    1621
    ],
    "deps": [
     "dash",
@@ -81359,8 +81569,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "2657f0b444194e1de6957f9cfc112383980d62f9",
-   "sha256": "1x1222nvy5fq2cyz8ds271xq03bcyn4252vxzdch9gai3n0vg00b"
+   "commit": "fcefc1b1b4027185dc35cc1fe16c268ae65bc076",
+   "sha256": "0brfmiz97sg7wz7pi148xw422jcmvcfk60rb9nfvw71xdnncqaj0"
   },
   "stable": {
    "version": [
@@ -82004,15 +82214,15 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20220427,
-    1552
+    20220602,
+    940
    ],
    "deps": [
     "all-the-icons",
     "org-pretty-tags"
    ],
-   "commit": "88fde267441118836a5c4ed28bb5958fca37a800",
-   "sha256": "1f7acxpc133abqzhc667syd7dkazarazndwl1dg8clcms4v6xaqq"
+   "commit": "481f44aa4067b287e0c724c6d5e1185c62d1560c",
+   "sha256": "016p3fjdd5vpri7bg2yfmk3ldkng7jp65fb0fv9i89kmzkkcq4az"
   }
  },
  {
@@ -82385,8 +82595,8 @@
     20220220,
     1757
    ],
-   "commit": "2f38f3583295e05c9ea491b7d1f6b4791169ba86",
-   "sha256": "0jyy8nl4r70l0dwc55lg75k7chcwb9zprl185x0122fjqgmnq1ri"
+   "commit": "4359c640c7822a23976e9a5ca4ce63452d796912",
+   "sha256": "176qjbhvdg1bqy45qk6zf5ij12qif6xkd3ppd1a5wg67p2rv21z8"
   }
  },
  {
@@ -82824,8 +83034,8 @@
     "ht",
     "s"
    ],
-   "commit": "6fe53900ead434f3e18e63e9d22a8fa8380ccb37",
-   "sha256": "0h33ih533dirghhpjlyzm3k8iss007f9npk2fpbc75z3q4ws67wp"
+   "commit": "f9347e8d1f7cf770c7a2bc594ccf3f3c730f9b81",
+   "sha256": "0k27dy8r1g6ikd61n8vv4dv4la4rpl88a05x4fg8702573vqq1cx"
   },
   "stable": {
    "version": [
@@ -83028,8 +83238,8 @@
     20211126,
     2201
    ],
-   "commit": "bc981b957967be8d872c08be9ba7f2dbde5caf1d",
-   "sha256": "1gn9bs5fxrshyyi7wqm30p2d4izjdrspvh5cx8fs803mxl593wim"
+   "commit": "e54b5cc7f95ded5dc39f60fbf6d72f64f469da58",
+   "sha256": "1i0h9f45jzw3m341pp242ihcqf7jvzddxidnn1qv971fpvibjvxx"
   },
   "stable": {
    "version": [
@@ -83169,14 +83379,14 @@
   "repo": "vyorkin/ormolu.el",
   "unstable": {
    "version": [
-    20211020,
-    2229
+    20220530,
+    921
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "1941a8ce48027b5670d226bacc2fa10b00774b3a",
-   "sha256": "1bs6c6059g585dwsd4ldl49v38l6jlr54z9rj9qhc1a1gg6pzb3b"
+   "commit": "a6b1d3f8838d067ac5352fb0673c3c3dae7abd73",
+   "sha256": "098az157nsgwdxl8pbvznha1lvh2mpilm7m90p9v6pwdfvmcjb3x"
   }
  },
  {
@@ -83244,19 +83454,19 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20220511,
-    1756
+    20220513,
+    1002
    ],
-   "commit": "471f21f0f8bffc078d5ccfd86610a83e5269c2a0",
-   "sha256": "1w8xc4g2fgg9l0yibqc0190afgk71z697ni4yx1v1z1vy46s76c4"
+   "commit": "563d9646b1f8df37cefcec5d51d20249eba407da",
+   "sha256": "039ac364f00slx1dxxgsgfcr4x47v9ymn8arcs0fyhdhw7jnky5j"
   },
   "stable": {
    "version": [
     0,
-    7
+    8
    ],
-   "commit": "e3ea969ce1bf84343f357efa2de97e1dd857f481",
-   "sha256": "0d037512llpny669m6mhvwhnm90g6ysgjqdx45gqxfwdc65s4a46"
+   "commit": "563d9646b1f8df37cefcec5d51d20249eba407da",
+   "sha256": "039ac364f00slx1dxxgsgfcr4x47v9ymn8arcs0fyhdhw7jnky5j"
   }
  },
  {
@@ -83992,14 +84202,14 @@
   "url": "https://git.sr.ht/~jakob/ox-haunt",
   "unstable": {
    "version": [
-    20200202,
-    229
+    20220602,
+    143
    ],
    "deps": [
     "org"
    ],
-   "commit": "f3c8fda6fee78f45a259e5d218a519dfd11c00c7",
-   "sha256": "1rs1n228c2fmpvirc57bqgf2616ijpphkgf4w9ln5j46snmkam25"
+   "commit": "4d585c51d5701b4d43c02db78c7032658cae47fd",
+   "sha256": "19pwg5qds5xmrv3yxkmhd3ibln3spcldwkmfwixkaq20an9z2d6k"
   },
   "stable": {
    "version": [
@@ -84039,27 +84249,26 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20220512,
-    1805
+    20220531,
+    2158
    ],
    "deps": [
     "tomelr"
    ],
-   "commit": "cab606a2098524ea7ac97704cc8df6d2d9d190f8",
-   "sha256": "13gfchjdhalijbf5d4xmz1zvl904syl4lm07ssrqck4h66y4nr9y"
+   "commit": "df0b12ef1aff2b322403f24006f0ec17676d3606",
+   "sha256": "0xxj133j2l0002yp4hm4k01klrcvpbzxp6f75rhyvijny0ggmnw4"
   },
   "stable": {
    "version": [
     0,
-    11,
+    12,
     1
    ],
    "deps": [
-    "org",
     "tomelr"
    ],
-   "commit": "4fc594eda0d0cb41cc3b634b43fbd055db7ae67e",
-   "sha256": "1qrxy32g8brmc3psfg458ca6r91wqq55bgmsk76w6zm8cgrvsnyc"
+   "commit": "3c8c0bf28cf02128ceff9a972db3ebad01083953",
+   "sha256": "0q4gyjzvxzw6a0phw2x2v9n43i28n3g9m7szwbhzch4j6ggxzcw4"
   }
  },
  {
@@ -84400,14 +84609,14 @@
   "repo": "yjwen/org-reveal",
   "unstable": {
    "version": [
-    20220410,
-    1533
+    20220524,
+    1144
    ],
    "deps": [
     "org"
    ],
-   "commit": "862b41df7734f57019543f6bd82ff7dad7183358",
-   "sha256": "1009w8bp2rkqjvks97xlzbprrb1fxhcdb9fzx08ak229glvwav08"
+   "commit": "43ebe238ef747985b336880305ae5065da67235c",
+   "sha256": "1j7bz4g6dd5zcsdj24ry71i5sadldcza2ib7k4yayz6xi5qv3gl5"
   }
  },
  {
@@ -84448,14 +84657,14 @@
   "repo": "choppsv1/org-rfc-export",
   "unstable": {
    "version": [
-    20220206,
-    1046
+    20220604,
+    1114
    ],
    "deps": [
     "org"
    ],
-   "commit": "0849028a2e4a274bfb0fc85d9538203ddf72a9e8",
-   "sha256": "1syzqc1lhnpkrzzd2hwxmaqr31dn44gcqwy5db44y8fr6nkrj6n0"
+   "commit": "f0fe3503f8732ea5e95a4016c6b7ce5b47cf6295",
+   "sha256": "0a1gp9s92m7scxdf2sc4dqh6ixyv1x7cf190z5d2lz8yz3aw9hkw"
   }
  },
  {
@@ -84876,28 +85085,25 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20220510,
-    2024
+    20220530,
+    1027
    ],
-   "commit": "899bb08963c21028a02894426a9d86f768fe06d8",
-   "sha256": "1zw68gg8ai5921kly35fnxapnxqzdqx8ll7w8bdxpv8f06vq24xj"
+   "commit": "6bbe65de495110970c2c33497ca640a0774e41b3",
+   "sha256": "0g6x0p6dbz7zk4xrh5n3367zhv026h3a9hbb8jf2f0qw95685cbr"
   },
   "stable": {
    "version": [
     3,
-    0
+    1
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "032e9bd086029b2fdff09c3c2e606e29682e1fb1",
-   "sha256": "0jjb1gl6qqkrvf4v03fp9sv69xc6qh3lc65blms46zkx64995c6r"
+   "commit": "1604b3a5f0040c6f487d38561388abab2f3d54c5",
+   "sha256": "1gkqav0ipfk5gsklxrbggqrbphr12qg1qr6dpdi4f0hs0i11fr23"
   }
  },
  {
   "ename": "package-filter",
-  "commit": "89312eaf69f3d7ac46647255c847fcb45415e78d",
-  "sha256": "0am73zch2fy1hfjwzk8kg0j3lgbcz3hzxjrdf0j0a9w0myp0mmjm",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0l1hq3a7bx1mp17g9lii4b7m31b1n328b8r6rqv5g2ab1d2cs0ks",
   "fetcher": "github",
   "repo": "milkypostman/package-filter",
   "unstable": {
@@ -84917,15 +85123,15 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20220412,
-    1648
+    20220607,
+    738
    ],
    "deps": [
     "cl-lib",
     "let-alist"
    ],
-   "commit": "80a9d9815ab2919c992ad29ae4846443dec43a35",
-   "sha256": "0sfxpw19vi7hsr3j86wbwxfi02020z38qg1w72j8k6mm0m9m21yi"
+   "commit": "70529b2ecba5f3a037be8b2c6ecbca769c64b00e",
+   "sha256": "1s26jbxlpqd9p1ahmxga6m28d142l1lnv315bkzsf642kk57446k"
   },
   "stable": {
    "version": [
@@ -84954,8 +85160,8 @@
    "deps": [
     "package-lint"
    ],
-   "commit": "80a9d9815ab2919c992ad29ae4846443dec43a35",
-   "sha256": "0sfxpw19vi7hsr3j86wbwxfi02020z38qg1w72j8k6mm0m9m21yi"
+   "commit": "70529b2ecba5f3a037be8b2c6ecbca769c64b00e",
+   "sha256": "1s26jbxlpqd9p1ahmxga6m28d142l1lnv315bkzsf642kk57446k"
   },
   "stable": {
    "version": [
@@ -85046,8 +85252,8 @@
  },
  {
   "ename": "packed",
-  "commit": "57a2fb9524df3fdfdc54c403112e12bd70888b23",
-  "sha256": "103z6fas2fkvlhvwbv1rl6jcij5pfsv5vlqqsb4dkq1b0s7k11jd",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "19bqa1j2g453gk9h0k4pvi1mgpyx9f9rh7ang28sq13hzd9c8mjb",
   "fetcher": "github",
   "repo": "emacscollective/packed",
   "unstable": {
@@ -85389,27 +85595,27 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20211208,
-    2229
+    20220519,
+    2008
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "c1429887287b7ee9601196e26f97c908b6e4f5c0",
-   "sha256": "1zw92bkp5mjzc78vrvsaj3ycqn0j5mqzxxxv2nkb891spgandpvy"
+   "commit": "2a4e726a29d38e7c2379787cad619e5392ad2da0",
+   "sha256": "1yn9mdlxcv9d33nvgy3wp09qhynb2m50cyhsv1xf77wyzlwdlb2p"
   },
   "stable": {
    "version": [
     2,
-    31
+    32
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "500e80666fb779457be8771c5613c177187ba0cc",
-   "sha256": "1c3gay9fkikg7h46djw1nf86fzckmv7w1zbz5fbar20klcr12pbm"
+   "commit": "2a4e726a29d38e7c2379787cad619e5392ad2da0",
+   "sha256": "1yn9mdlxcv9d33nvgy3wp09qhynb2m50cyhsv1xf77wyzlwdlb2p"
   }
  },
  {
@@ -85446,8 +85652,8 @@
     20200510,
     5
    ],
-   "commit": "2f38f3583295e05c9ea491b7d1f6b4791169ba86",
-   "sha256": "0jyy8nl4r70l0dwc55lg75k7chcwb9zprl185x0122fjqgmnq1ri"
+   "commit": "4359c640c7822a23976e9a5ca4ce63452d796912",
+   "sha256": "176qjbhvdg1bqy45qk6zf5ij12qif6xkd3ppd1a5wg67p2rv21z8"
   }
  },
  {
@@ -85520,8 +85726,8 @@
    "deps": [
     "autothemer"
    ],
-   "commit": "95e8248edbdb01fedc7db4472bcce90d2d872106",
-   "sha256": "13rcajw03sbddks5wgzznvrz7ibd7m0jx8mcw1amfk97ghs57h7s"
+   "commit": "f6738f8e6075cb6b275210d7e978b1420ee9a056",
+   "sha256": "0f6vphpxvky4x6fnwyp1gx56awsvhdmazf1p6qg191inn3h5wygj"
   },
   "stable": {
    "version": [
@@ -85538,8 +85744,8 @@
  },
  {
   "ename": "paredit",
-  "commit": "caaa21f235c4864f6008fb454d0a970a2fd22a86",
-  "sha256": "01qh8kfb5hyfi0jfl1kq3inkyzr0rf3wncmzgxlkfdc8zlq4v653",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0mpay7xqb4910nlp0gmdj8q2zkinq77zh5b9lcg6ah2d9vzxzc9s",
   "fetcher": "git",
   "url": "https://mumble.net/~campbell/git/paredit.git",
   "unstable": {
@@ -85747,8 +85953,8 @@
    "deps": [
     "s"
    ],
-   "commit": "c2bdc5ee1d1f029886245f9a5c409e47c1db2cb8",
-   "sha256": "050b932qa0ll66pa68i8bbjdmi8bgdvklqm65cvm5ssc5hcwjq3k"
+   "commit": "079da5e65a5ded0b5ebe7cfe799eac668d7323db",
+   "sha256": "1w00ifh8qa12f9b38acv47c9cb3vnzpyk72p5qf6jf4pjc2izx9c"
   },
   "stable": {
    "version": [
@@ -85848,15 +86054,15 @@
   "repo": "clojure-emacs/parseedn",
   "unstable": {
    "version": [
-    20220512,
-    1328
+    20220520,
+    835
    ],
    "deps": [
     "map",
     "parseclj"
    ],
-   "commit": "35e9f3173a6cca60b6851dddace470b29654ac77",
-   "sha256": "06in2r87rn398bnqfc7bmpfvfbvrx9ybqs8r5yzy5y84f9gbfnm4"
+   "commit": "a09686fbb9113b8b1b4f20c9e1dc0d6fea01a64f",
+   "sha256": "0wjzzjwz92rk5nx1km1fw46lgspqahj93p5mfyrxwcw27cb8z1av"
   },
   "stable": {
    "version": [
@@ -85922,8 +86128,8 @@
  },
  {
   "ename": "passmm",
-  "commit": "8ae2a1e10375f9cd55d19502c9740b2737eba209",
-  "sha256": "0p6qps9ww7s6w5x7p6ha26xj540pk4bjkr629lcicrvnfr5jsg4b",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "17rd9pgi9p9w9m9grpnhn1d4mrx3bfrzl04z37mf4gd8qzzzqvqs",
   "fetcher": "github",
   "repo": "pjones/passmm",
   "unstable": {
@@ -86237,8 +86443,8 @@
  },
  {
   "ename": "paxedit",
-  "commit": "106b272c2f0741d21d31a0ddfa4f521c575559c1",
-  "sha256": "06ymilr0zrwfpyzql7dcpg48lhkx73f2jlaw3caxgsjaz7x3n4ic",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "08mf53y7ipiqw8p21y6fly0qh3fqgmcwl8r95m1a2lqh3wg5xi9j",
   "fetcher": "github",
   "repo": "promethial/paxedit",
   "unstable": {
@@ -86441,8 +86647,8 @@
  },
  {
   "ename": "pcre2el",
-  "commit": "f04a25e467cc4c7d9a263330a7a1a53d67c6eb9b",
-  "sha256": "1l72hv9843qk5p8gi9ibr15wczm804j3ws2v1x7nx4dr7pc5c7l3",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1ri005gw9i93l8flvvgcmk0ww3b6lvnpwpls7k69cm0pbxhyvm40",
   "fetcher": "github",
   "repo": "joddie/pcre2el",
   "unstable": {
@@ -86470,8 +86676,8 @@
  },
  {
   "ename": "pcsv",
-  "commit": "80ffaf99b2a4566a3f9d0309cd7b63f563f3826e",
-  "sha256": "1zphndkbva59g1fd319a240yvq8fjk315b1fyrb8zvmqpgk9n0dl",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1z6if6cpj2kz2d975f5ar10yaqvys1cspzbak2sza3858vf9wph5",
   "fetcher": "github",
   "repo": "mhayashi1120/Emacs-pcsv",
   "unstable": {
@@ -86524,22 +86730,22 @@
  },
  {
   "ename": "pdf-tools",
-  "commit": "10a057a573123c7093159e662fafdc97c2dd4a02",
-  "sha256": "1x0yd86r3iybpiq7ypln1fy0cl55wznkcgvqszzqjdrnlpqs0abc",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "1632b6qr7mpj655vs3ylkfzcm2yx1bi2v2lb1w3wqfjickmy0p2v",
   "fetcher": "github",
   "repo": "vedang/pdf-tools",
   "unstable": {
    "version": [
-    20220512,
-    145
+    20220522,
+    13
    ],
    "deps": [
     "let-alist",
     "nadvice",
     "tablist"
    ],
-   "commit": "fedd930a09a497c03df3ce5204ccbd80da724662",
-   "sha256": "13yl83ld5z1asjqrsfdzyhnz4nrrr064lwbsgfvk3mmlqpas7b08"
+   "commit": "f9ccdf99e560bae70d3a13325cec9dc0e3cc45b0",
+   "sha256": "19hj0hbg3rssw9xjia1g0nmknmvcrxhgb3p0y5vy8nlk0d2h5v4z"
   },
   "stable": {
    "version": [
@@ -86846,11 +87052,11 @@
   "repo": "Bad-ptr/persp-mode.el",
   "unstable": {
    "version": [
-    20220206,
-    1742
+    20220507,
+    32
    ],
-   "commit": "7a594a3d8f1c4ba9234dcd831a589e87f3f4ae86",
-   "sha256": "0ckcnqg2fn4m5zp06jlw5cj81clizrm8cxjiwz5rd4d9m9lwdrgd"
+   "commit": "d0f8eb099e852b6073d4ec06d32587c60a7dce3f",
+   "sha256": "02518lq9wma0hsm96lws7fg2bdjsp52jg2rj33iczsj515w5mdgl"
   },
   "stable": {
    "version": [
@@ -86942,14 +87148,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20220420,
-    1550
+    20220521,
+    2138
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4e38680793585a907ae46b148697030c2b552a00",
-   "sha256": "0jgd2vzfza3pnnksh1kss5mqhbirqn93lvzanhgjr4vb4fv8x13f"
+   "commit": "794afdbc5188ef6f2d78d26302cd78903ce618fa",
+   "sha256": "1adn4knbhsygsy67q6w86qbhqx2gg6rw5hcnan7x40wq8fi7hr0p"
   },
   "stable": {
    "version": [
@@ -87034,8 +87240,8 @@
     20200321,
     504
    ],
-   "commit": "43447a2c70f98edd1139005e32f437d3f142442b",
-   "sha256": "1ccpb1jbynlqqzhsm3h7xk2s7n9nbpnnxmixz77kxskdxj5as79a"
+   "commit": "af677327f185113442e95b00986097b30cab650c",
+   "sha256": "01wy3v1aj2891wgbr7rwpaw9xavfrqbyiqiv01q6jjdvc5vl0rwi"
   },
   "stable": {
    "version": [
@@ -87216,8 +87422,8 @@
  },
  {
   "ename": "phi-rectangle",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "111fqqa7h5cajq92sbiqhavm25l5bcapxhfh38y7irq4mv08xifw",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "133d0iphybwg7gpbv257vdxamm5d6yk96qv2fgq1cxw0b778ylx0",
   "fetcher": "github",
   "repo": "zk-phi/phi-rectangle",
   "unstable": {
@@ -87392,26 +87598,26 @@
   "repo": "OVYA/php-cs-fixer",
   "unstable": {
    "version": [
-    20220510,
-    1407
+    20220516,
+    1008
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "225ca7127052e2b3d660495d04319e817ec302ab",
-   "sha256": "1zwl6hpw0ka4pdsk9i67dbv42idb0nhi5i3yajy1wzdihj7hqg3y"
+   "commit": "efe4368d891f1eec6311363cfd6be3e9eadb5e0a",
+   "sha256": "1j0ivk4d8xd2r9ssdn9y4xl3lr2isg4sks5va7wjvk6h7jnf81bj"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0,
-    2
+    0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "ac2d64c4b672a01744d14cc8ad80e9c9ff55c63c",
-   "sha256": "1jyjqwv4haibv526bwpvyyszs7ga9lmsjhn47hyk3ddffrr84c0y"
+   "commit": "efe4368d891f1eec6311363cfd6be3e9eadb5e0a",
+   "sha256": "1j0ivk4d8xd2r9ssdn9y4xl3lr2isg4sks5va7wjvk6h7jnf81bj"
   }
  },
  {
@@ -87431,17 +87637,17 @@
  },
  {
   "ename": "php-mode",
-  "commit": "5593a586ce7579fd3a136e2416b89721157f98e1",
-  "sha256": "1xa9dmjinm6qm4cbzqanw5njmif71sg3jxnvgvi17jj9j3125d9f",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "097bznn3k1z68mxdmp8zm4cn590sl9qgc1g7dm3abcli77xy4436",
   "fetcher": "github",
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20220120,
-    1959
+    20220606,
+    1831
    ],
-   "commit": "4503672471b8fdaaea6c454344817a119c87fcc6",
-   "sha256": "0fxmqhpw0i54davcg9h8gxf8zxix02g2wnxxly6m0p5g785yng2h"
+   "commit": "81717a56b74d7ab76a1126eb4f45167d5eb61c32",
+   "sha256": "1bnn1lwsqd9rlx1qjrl4h2v6j29cnhagd4ay82psq309yvr4av5x"
   },
   "stable": {
    "version": [
@@ -88034,15 +88240,16 @@
   "repo": "pwalsh/pipenv.el",
   "unstable": {
    "version": [
-    20210127,
-    1444
+    20220514,
+    123
    ],
    "deps": [
+    "load-env-vars",
     "pyvenv",
     "s"
    ],
-   "commit": "8f50c68d415307a2cbc65cc4df20df18e1776e9b",
-   "sha256": "0l81vbwp7gmcg1n7i8cwa01rpwc24db7gxqvmhln8piy1r2ymh6x"
+   "commit": "3af159749824c03f59176aff7f66ddd6a5785a10",
+   "sha256": "1ak9dvjqhdm12i7yamgbqjmc4zmvy2f0gd1nia1q9dy3n6576ryq"
   }
  },
  {
@@ -88153,8 +88360,8 @@
  },
  {
   "ename": "pkgbuild-mode",
-  "commit": "ca7bf43ef8893bf04e9658390e306ef69e80a156",
-  "sha256": "1lp7frjahcpr4xnzxz77qj5hbpxbxm2g28apkixrnc1xjha66v3x",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0hsm4qqh555fkbd34mi0cah5j69rcsxfglj9lr927bv828663mrb",
   "fetcher": "github",
   "repo": "juergenhoetzel/pkgbuild-mode",
   "unstable": {
@@ -89506,8 +89713,8 @@
  },
  {
   "ename": "popup",
-  "commit": "083fb071191bccd6feb3fb84569373a597440fb1",
-  "sha256": "151g00h9rkid76qf6c53n8bncsfaikmhj8fqcb3r3a6mbngcd5k2",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "009446in223b8391n1mq3fn8gdvwlp3x7lc32mhzcsnyijhvc73y",
   "fetcher": "github",
   "repo": "auto-complete/popup-el",
   "unstable": {
@@ -89515,8 +89722,8 @@
     20211231,
     1823
    ],
-   "commit": "114d646f0f4dd49de19dfedd78630018f71470e5",
-   "sha256": "1hgia0d2j81mlkcl8bilznn4044qjjpy00cdd96zs7p2lbvaz3sb"
+   "commit": "976bd8e06100df5a266377d0e5f63b104ba93119",
+   "sha256": "0ssr7anniahn8l72gykc24c6yma4lkjwrxc3a8wvi6r7qkbdafxq"
   },
   "stable": {
    "version": [
@@ -89659,8 +89866,8 @@
     20210215,
     1849
    ],
-   "commit": "f90f3a09622993bf34704bb11c24984f6b1f10e2",
-   "sha256": "05gmc5wrj4pn1s1k4p6vvnl1z75bj4w163mpy8rybxdhsqhhf9a4"
+   "commit": "71a0ab27b13733df0fa37fd1a5fcba8799a35df9",
+   "sha256": "1c7h9xhi366alh4y7jycfb79ssrhnd61pa4pk9ncfwh3lspp2sf0"
   },
   "stable": {
    "version": [
@@ -89757,11 +89964,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20220124,
-    859
+    20220528,
+    27
    ],
-   "commit": "c91d4d53fa479ceb604071008ce0a901770eff57",
-   "sha256": "15h809mf8d8w8axbfzjs40j8yrh5ms88x4pmlx1qlcac8j6qrilf"
+   "commit": "0d23bc5f7cfac00277d83ae7ba52c48685bcbc68",
+   "sha256": "1p42kyh1l9m3h48fl4pq27rcz2dbhgk28qnrf5h1mmxjln1lbb2w"
   },
   "stable": {
    "version": [
@@ -90034,15 +90241,15 @@
   "repo": "LaurenceWarne/prefab.el",
   "unstable": {
    "version": [
-    20220403,
-    1026
+    20220605,
+    1310
    ],
    "deps": [
     "f",
     "transient"
    ],
-   "commit": "ffcf9c640c8c458a58b752ef2608e07a929a1104",
-   "sha256": "119gbadnzgxhrw5y5swyzkm5268wjpjnxfy21ybsxw8dj2rsvvzj"
+   "commit": "5ca61a420d8de5e3707a5c2f01153f4ab2ea3ec1",
+   "sha256": "16fhcry3a66acwnms7qshw4q1jzqqcqhl4g3yddhxramcgbp2x3f"
   },
   "stable": {
    "version": [
@@ -90081,19 +90288,20 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20220509,
-    2300
+    20220601,
+    1652
    ],
-   "commit": "c05f8a43c6ff07a8b5a3ba8df7a2ec35677b7484",
-   "sha256": "0752dyl4fhi0jvbm238s5p1sv7z4jlkmkdrxvwn0dlhfr0rhfw1c"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   },
   "stable": {
    "version": [
     5,
-    2
+    2,
+    1
    ],
-   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
-   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   }
  },
  {
@@ -90149,28 +90357,29 @@
   "repo": "jscheid/prettier.el",
   "unstable": {
    "version": [
-    20211018,
-    955
+    20220603,
+    1338
    ],
    "deps": [
+    "editorconfig",
     "iter2",
     "nvm"
    ],
-   "commit": "485417c0677255249e944b1174225547e4c61c00",
-   "sha256": "17jh6xccqs4z2slj6c3hhdk29nv300d4lmvrgz9cn8cxrk157vcy"
+   "commit": "3fcf3ba3507f47b8ac1392e7901aa2c418147758",
+   "sha256": "0sg6ibcwfgnwgfg760v8wnijz79n86f61b7rlgizvgi8v7ky88f6"
   },
   "stable": {
    "version": [
     1,
-    1,
+    3,
     0
    ],
    "deps": [
     "iter2",
     "nvm"
    ],
-   "commit": "8b38172bb6644b71b718c0732e5b9f1cd32e587a",
-   "sha256": "0zkicnfj1y2zpwbwm4ccrpvzr5z6rpkk82mdzaszkx0sksd3hzxm"
+   "commit": "1c0a1bd97635090a611cf6cda3ba9146c84fa41d",
+   "sha256": "14plfh1hqjygcpp1ijkhzkpsshqfpzmn6c44bac6rk13072sg097"
   }
  },
  {
@@ -90559,16 +90768,16 @@
   "repo": "rejeep/prodigy.el",
   "unstable": {
    "version": [
-    20220507,
-    1753
+    20220523,
+    1728
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "535789e32028133fa9dfb4c9135b6a65c199472f",
-   "sha256": "0x68c7c40cafg4lbi1lwlli3bghnhcb21wm4idg6qr07y351fjqd"
+   "commit": "a3be00d3b90a77118c2d7d9f5a2f26151091fa07",
+   "sha256": "0pijzj4a8q6acm8rsrx92gam04vhz5xgc5jzzv5ykl6d4xx4zskk"
   },
   "stable": {
    "version": [
@@ -90671,8 +90880,8 @@
     20210715,
     1213
    ],
-   "commit": "d47f08f64cce595cbd4e9fbe3544986b3c4cee83",
-   "sha256": "0pp9f8kcgnsgz0mykss4jppnwvlfx7ny58y4pb1rm4l2xvs8y6yj"
+   "commit": "f0f8d70317fb6f505ec2762aa82962322b14a9f0",
+   "sha256": "07dxxr610dmjbx9mm9xyhpfg3piqmj5njxz2arrz47h49xsgl4b0"
   },
   "stable": {
    "version": [
@@ -90795,11 +91004,11 @@
   "repo": "buzztaiki/project-rootfile.el",
   "unstable": {
    "version": [
-    20220512,
-    443
+    20220516,
+    1419
    ],
-   "commit": "cb87657c4426e39aa2c481190e594c68fb0de8be",
-   "sha256": "07gb9b72gkwz748xwnsjayn68x5qn8b0ka8wmwvqgwgak14f1da3"
+   "commit": "65e46311dae24f3458e43c2490ad265c711aa624",
+   "sha256": "03x0mlndml6mm3jfpk95rnq2fhcdyr199pj9hmxjb1ny1j72lvdl"
   }
  },
  {
@@ -90837,17 +91046,17 @@
  },
  {
   "ename": "projectile",
-  "commit": "ca7bf43ef8893bf04e9658390e306ef69e80a156",
-  "sha256": "1kf8hql59nwiy13q0p6p6rf5agjvah43f0sflflfqsrxbihshvdn",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0p592fq6gp4dzar30fiw6ks6i75kc9q1pm1agrx0qxwk84f4j76f",
   "fetcher": "github",
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20220430,
-    800
+    20220530,
+    615
    ],
-   "commit": "a4f86f981c84a546530d5904253fa266431ef806",
-   "sha256": "02303v7y79vdl4n2qga42892cqd5hdajwzp4vk3a4fxcyl8yhv8k"
+   "commit": "e60883ff370c1545499b97cf56479de1a58c5b3b",
+   "sha256": "08h4q3fghhc749pb8zak2z5p1sify01bkxhhv9iyrg0iiwl9bl6p"
   },
   "stable": {
    "version": [
@@ -90964,8 +91173,8 @@
     "projectile",
     "ripgrep"
    ],
-   "commit": "4ed5c741233a81d96115f556784269042070901e",
-   "sha256": "1bz9srlimpr5lzsjd02jq23h0vg2lnk921m24g0wsrdrccvmfxi2"
+   "commit": "872e250e8f93b8bb0a8a1de8bde17fd9bd116e31",
+   "sha256": "1n3jkj8a37ap4ndh9an5qm8dn8nxcgv9vqr8bcnxx5l0wnsvdg8z"
   },
   "stable": {
    "version": [
@@ -91249,11 +91458,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20220329,
-    655
+    20220525,
+    1052
    ],
-   "commit": "2a8701209b273db5a35f15145ec62f32799e03b1",
-   "sha256": "05l65cwyw2pdyv6rn14h0axplgnlm5z7v90iwcxk9vysz74icdd7"
+   "commit": "ac9ba11fda58800a1cec699fbda8811644847bbe",
+   "sha256": "03bn22byy8p80wjdpal2w1cq2jkxdnivdd6xdkfh3vl5mb5vwc68"
   }
  },
  {
@@ -91339,27 +91548,25 @@
  },
  {
   "ename": "protobuf-mode",
-  "commit": "b4e7f5f641251e17add561991d3bcf1fde23467b",
-  "sha256": "1hh0w93fg6mfwsbb9wvp335ry8kflj50k8hybchpjcn6f4x39xsj",
+  "commit": "5be08102d4de84c35b18cd1e3321fe8b6836ff56",
+  "sha256": "0ksrgr2ymac30qcwmjzrf1jfdkkfpy91irbyp87fjnipi4dfnp6h",
   "fetcher": "github",
-  "repo": "google/protobuf",
+  "repo": "protocolbuffers/protobuf",
   "unstable": {
    "version": [
     20220303,
     1716
    ],
-   "commit": "b3cbea18ea02ab82379ba5d014899035aad4b8f4",
-   "sha256": "0x60jy244xm1gkqvsidyj8xfqdfwpn0q8knr28n4giycwlzncgyr"
+   "commit": "c0fc2e881bc36aafb0bf539bf41889611370f60c",
+   "sha256": "108i14rd0wvj04kk6mqz577g142sqs33avbflc728mnkkp9wqmpy"
   },
   "stable": {
    "version": [
     21,
-    0,
-    -1,
     1
    ],
-   "commit": "3cede25cef0c2f5f5b60461b608d8c07a621ac04",
-   "sha256": "0q024rd5y8kd9pjslh118vhl3awr95gfvc6zxxr6i4qwqq1jy5nj"
+   "commit": "e73ed1630fdec85d7fb513c166629ed49cd4eb18",
+   "sha256": "0h2an911grs5kdvsf4cgypa4x022rgm81arxg42ks6sdzf8895x2"
   }
  },
  {
@@ -91533,29 +91740,28 @@
   "repo": "emacs-php/psysh.el",
   "unstable": {
    "version": [
-    20190709,
-    106
+    20220607,
+    1642
    ],
    "deps": [
-    "f",
     "php-runtime",
     "s"
    ],
-   "commit": "21250984ad8137aa3440ac12e52475ef03f19fcb",
-   "sha256": "1r0aiwdmj0y96faqvbz39wgxw91i9bj6rnwlj3a277pzlhzmyyxl"
+   "commit": "796b26a5cd75df9d2ecb206718b310ff21787063",
+   "sha256": "01j8dfgck3wlayh5spklfwvkzzckd0zwa4d5mrhpii2xsjy28r8a"
   },
   "stable": {
    "version": [
     0,
-    0,
-    5
+    1,
+    1
    ],
    "deps": [
-    "f",
+    "php-runtime",
     "s"
    ],
-   "commit": "4709a57cdcf7103c4a606be89849ea3ead2d38a5",
-   "sha256": "1apf6mnqp9bg5dfykgvsn02z0xpyx6k34sd2pvicicig7w09kzvb"
+   "commit": "796b26a5cd75df9d2ecb206718b310ff21787063",
+   "sha256": "01j8dfgck3wlayh5spklfwvkzzckd0zwa4d5mrhpii2xsjy28r8a"
   }
  },
  {
@@ -91761,11 +91967,11 @@
   "repo": "AmaiKinono/puni",
   "unstable": {
    "version": [
-    20220405,
-    1808
+    20220517,
+    1536
    ],
-   "commit": "bb9b1e271b51b3dfae984da15f0e40f5be5b2473",
-   "sha256": "1m581adq9pp6q22n2dfazzmnlyb375ggk4f0ihpccrwccf2kzdk3"
+   "commit": "a8f6e66be99051f34f0ab2704bdea04667d8b005",
+   "sha256": "0h6isykcwh7b1vxm5qikcfd3g6v0lv487q7gf5j9p6v5gs1f9yb9"
   }
  },
  {
@@ -91945,11 +92151,11 @@
   "url": "https://codeberg.org/ideasman42/emacs-py-autopep8.git",
   "unstable": {
    "version": [
-    20220502,
-    310
+    20220522,
+    1152
    ],
-   "commit": "89c9ed8de2deab6bb891ae25c85cc6498e60b90a",
-   "sha256": "0ygvl8zq8d6lbv8x6j6vklxhc6xrmii4fd9c74py1bjqvx4d1fjh"
+   "commit": "d904639f1fca12435e38adb6cc602cd468fa618b",
+   "sha256": "1sr64n1cg1pdxfa3n8ckq3hy92asnwi2b5nl88qy3jy1mybah4d2"
   },
   "stable": {
    "version": [
@@ -92126,11 +92332,11 @@
   "repo": "statmobile/pydoc",
   "unstable": {
    "version": [
-    20211119,
-    2211
+    20220531,
+    1457
    ],
-   "commit": "3aaffe41e1c5a9d53fbc1de02686c386fd002890",
-   "sha256": "1z6p1glspxr5vl9igzhginaws65iqs9h2ymi21f62x7ydm54i96y"
+   "commit": "c8b667e17bfe3e63221f822c5c4d58c8fb4fea90",
+   "sha256": "082ar5w28dknaa63mf587vdzr78xlnvh8lbxqq3hk6qa2c72akam"
   },
   "stable": {
    "version": [
@@ -92219,8 +92425,8 @@
   "repo": "dwcoates/pygn-mode",
   "unstable": {
    "version": [
-    20211021,
-    2325
+    20220531,
+    1422
    ],
    "deps": [
     "ivy",
@@ -92229,8 +92435,8 @@
     "tree-sitter-langs",
     "uci-mode"
    ],
-   "commit": "eb1da7e3eb5f5754b60d404b0e341206eebe19ca",
-   "sha256": "1nf5ihyppviwys3qay07v25f96jj5a2yr4qh1iygv2423y63q7gp"
+   "commit": "9a56e701cfcdf9024dda15175e0d0fc645446019",
+   "sha256": "1g24545512vr07773k7lcjf4ispwkf7y3y4nivgp66fqr1lqh34z"
   },
   "stable": {
    "version": [
@@ -92249,34 +92455,34 @@
  },
  {
   "ename": "pyim",
-  "commit": "151a0af91a58e27f724854d85d5dd9668229fe8d",
-  "sha256": "1ly4xhfr3irlrwvv20j3kyz98g7barridi9n8jppc0brh2dlv98j",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1g730kh9hmc5g87n6661cbl65i7nzcmr15s975brdw3wv6nqzly2",
   "fetcher": "github",
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20220512,
-    930
+    20220608,
+    343
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "dcdae4db85646de85b1ca75e4604691cf9273273",
-   "sha256": "1432ph59plnh41xrmq59n9z987r41xf34qsxl3sbzfw6v8m927ys"
+   "commit": "21eb4d60d0af85099ddd820e4a367e662185beac",
+   "sha256": "1bj63c8hp05hah0cwsn4df3wjqfp556brqbhhr4n5sx57mfgr2xj"
   },
   "stable": {
    "version": [
     4,
     2,
-    0
+    1
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "cd1bfd2bbc10fe0ac47d0ec383cde453f6019e6c",
-   "sha256": "0lvf50p97fns4pc6ilm4pqzp7s4srhcx2gyg6x5ywd5wv32nd04d"
+   "commit": "6b4cea1b541f5efd18067d4cafa1ca4b059a0c63",
+   "sha256": "1qcdf1v20sm99gbirjycppm3rnig1qvk8iiv50zmd6z38l48j7vh"
   }
  },
  {
@@ -92287,20 +92493,20 @@
   "repo": "tumashu/pyim-basedict",
   "unstable": {
    "version": [
-    20210517,
-    43
+    20220531,
+    555
    ],
-   "commit": "86f6de3e3a1523eb278bd3afe7c4ceba2a0e2972",
-   "sha256": "07jrp0n5cfhlfhjjfkiqrc3aadjx1vn33dw1f39snqhqly4x4yq8"
+   "commit": "0e6da11c4f500f6a3642dca167592eb27066ba52",
+   "sha256": "0h3w44q1ivhrrhy19ckis4z54kqrh7madzjif1ai2fnxfqk0zi5p"
   },
   "stable": {
    "version": [
     0,
-    3,
-    1
+    5,
+    3
    ],
-   "commit": "f71d0ffd9d2421f2b51cd0ccb89fd9eb43c09585",
-   "sha256": "0576r8ap9gp91ycjf1d47pn13kxp0f9fysn09zlq44hr0s1y2y5d"
+   "commit": "4aa30ff9f83cf6435230a987d323e48230f1f40e",
+   "sha256": "1xy48cvmx37sx8kcyfwjy92ym22p81a7qm48967a79bh98pydgsp"
   }
  },
  {
@@ -92347,14 +92553,14 @@
   "repo": "tumashu/pyim-wbdict",
   "unstable": {
    "version": [
-    20210902,
-    1714
+    20220604,
+    1340
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "4db1ca7fee75bd3aa394d620e5af2f42b3caf3c4",
-   "sha256": "141rzf15334r4sdqy791n3kspad8jcz4iig55mvcqabii4bqx9p1"
+   "commit": "e3b128cfcf218e4a0ca04189b0bd46909761227e",
+   "sha256": "04bp6fvqvp9myiakjak0jj4zinqcljr03v3w986zm7gs9i7hxx4f"
   },
   "stable": {
    "version": [
@@ -92441,17 +92647,17 @@
     20210411,
     1931
    ],
-   "commit": "2ea65b12176e575748db64d740ef834cba577d70",
-   "sha256": "18fv0kibj3rj8aydyxzda4mk7qi19hg82q3rm2mdi85082628wmy"
+   "commit": "72855d5d08a91ca5faa8c5442ff6f4aedfadf7ca",
+   "sha256": "1f4q7yb159jg57wmd29300sjis8y53nr9b880cd5yb8da7j3fbzb"
   },
   "stable": {
    "version": [
     2,
-    13,
-    8
+    14,
+    1
    ],
-   "commit": "45cbae2bab9001bb2f159103490a02d63e75ee5b",
-   "sha256": "1wc3h25p7pid3pzh6vaiaynzs1bqrl62dpb2g486hp3kbqdzlwp3"
+   "commit": "6447553ab509c9e811b7da53168e17fe2cadf187",
+   "sha256": "1v2qid36mig87q7cqblv0nzja7xj4ls15q5hy7jzvhpj20fsmp5f"
   }
  },
  {
@@ -92765,20 +92971,20 @@
   "repo": "jdtsmith/python-mls",
   "unstable": {
    "version": [
-    20220505,
-    1523
+    20220528,
+    1502
    ],
-   "commit": "6016c780865b3b9dcf90d9452367e0d39bbc1d1f",
-   "sha256": "00n2vrc7yq2cfsiwpwdga0yjl483rd59zvbdf41nxa92sircvjp2"
+   "commit": "bbfe9a8b2ea081c032eccfd541dac2bc46aa54a6",
+   "sha256": "0686f0a2jglby8nmwjfbzxjm7xd7h71safa4bphj1rb9v23kxzwl"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    3
    ],
-   "commit": "97e58c6b785f7096c0e02f6c1d12b008cc0219c1",
-   "sha256": "0nhk2jwzlnc0c1fzzdbc7dwil9wwk2ghizgynvdp9b2kg3jyd76n"
+   "commit": "e0af9d48023c9f999160245df64c524ec54c2af6",
+   "sha256": "188wrjm7yp5q08q6gkyalqy5b6cc7lkjx3xza21gkpc1iwd75436"
   }
  },
  {
@@ -92789,11 +92995,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20220512,
-    1206
+    20220608,
+    1625
    ],
-   "commit": "97bb2d5ca50bec43a22ffc6187d13e3afb38238f",
-   "sha256": "02i5mqx3ip6k9n09yzr395ayhf4i1l7n8sk9q0ibcm2zadxnlqc7"
+   "commit": "68f5313712e20e2f292e723a84ebb5db609e38e5",
+   "sha256": "1lhnfac9jc5p80pvi9akv4b288g3i9x2j5658z5v0g5rwfipqncz"
   },
   "stable": {
    "version": [
@@ -92879,16 +93085,16 @@
   "repo": "wavexx/python-x.el",
   "unstable": {
    "version": [
-    20190611,
-    1303
+    20220602,
+    2108
    ],
    "deps": [
     "cl-lib",
     "folding",
     "python"
    ],
-   "commit": "b1f8eaccee210d7c0580dba6dc9bd361fcf3765d",
-   "sha256": "0vyipfsppissa87pdnbksamdby0yl2q8nzawqivv6smn33jp6vsn"
+   "commit": "fef5162af9dfc1225339098ae00e053a2e16b799",
+   "sha256": "17nyjvbydclp2v2nrmdayxic2mj7j0frksc359ad999r05qq0nv7"
   },
   "stable": {
    "version": [
@@ -93099,8 +93305,8 @@
   "repo": "quarto-dev/quarto-emacs",
   "unstable": {
    "version": [
-    20220405,
-    1556
+    20220602,
+    1714
    ],
    "deps": [
     "markdown-mode",
@@ -93108,8 +93314,8 @@
     "polymode",
     "request"
    ],
-   "commit": "2a199735866dc34126a061c6f2990378b381e687",
-   "sha256": "0bdigc8d2b9g2dgdcalf5f0a7hh56sji7k78vv23ikdydmag5bi1"
+   "commit": "3cf4546a01766775d56b92e1c974c850ec35d5a9",
+   "sha256": "0r2f4m5vqxhb6jpkciywj86mxvw9zw5wxpmh56d1znids4jyypxz"
   }
  },
  {
@@ -93173,8 +93379,8 @@
     "leaf",
     "quelpa"
    ],
-   "commit": "ea60d14a6c8dbe65ad0b3353185945d43ae4393d",
-   "sha256": "0xddhjal99q3s537kcdrcimykmzca73ic3v2abv2ymwby2wm52b9"
+   "commit": "9b2197770304772fa5262d0b9bfd26908746a2fb",
+   "sha256": "0v9ky8s3yfxvdyvc83b7qlv4xxb9j65g4iwkzc3kdn0zsbakrjp0"
   },
   "stable": {
    "version": [
@@ -93312,8 +93518,8 @@
     20210904,
     1553
    ],
-   "commit": "30e9a1333fe4a83424385df53ddaf7016df3679d",
-   "sha256": "1k6iyzajrw7kvz027l7yddvxq4a0jsahrdhsv8is4bnz8ws36s15"
+   "commit": "314beae43cac2e4943e9ed4850e8e147bc3d2fac",
+   "sha256": "029swfgl8jzla9y6d0s4nfzpgnbn9j0b9wn0gzzdb02khp5sanqh"
   },
   "stable": {
    "version": [
@@ -93471,11 +93677,11 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20220512,
-    1447
+    20220607,
+    1810
    ],
-   "commit": "3b351fbb0d3e81bf260cb3fc7b623f1b782550cc",
-   "sha256": "0gcyb47ld10jvrf3wm63njz0d9y70fi8dwsx14pbdcrw2xs2p4s3"
+   "commit": "1c88636d5da4537b897e7b9b23edfd9495a24d10",
+   "sha256": "12nfrdvgndn11a17zaawv2i6mbjfiw1gih683l0cj0xknx11rg8j"
   }
  },
  {
@@ -94175,8 +94381,8 @@
  },
  {
   "ename": "real-auto-save",
-  "commit": "35763febad20f29320d459394f810668db6c3353",
-  "sha256": "1li0b2d93ffxjq4jdyzyvjdy5h7q5xllys0w4748d2bhr8q35p3w",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1n0hsms3g0z06b3i55gpp0xqxfychqscvfifpz4jmar87z7lvwp2",
   "fetcher": "github",
   "repo": "ChillarAnand/real-auto-save",
   "unstable": {
@@ -94475,11 +94681,11 @@
   "repo": "xendk/reaper",
   "unstable": {
    "version": [
-    20220426,
-    2048
+    20220527,
+    2122
    ],
-   "commit": "2cfe54e9f5470415ab5f59d3c0829bfce41525ad",
-   "sha256": "1050bv05ljgr61jpvcahfd0cjc00n5kvdvdsawnq4fgpfj2j3vih"
+   "commit": "a8ec93656698c5c02a02279ee7d7976325cc74cd",
+   "sha256": "075x71llqa8g4a872m57vij49bsxiv42yr0sbrwcxjm6dp6q08wa"
   },
   "stable": {
    "version": [
@@ -94842,8 +95048,8 @@
     "promise",
     "request"
    ],
-   "commit": "911a1c6310b42226392fd03dc1746a4c6fc4eb95",
-   "sha256": "0zljjqd1qyxh0p5rjphkljbl4b1kpmjw279axxp8y4hd67rk8fc2"
+   "commit": "c00407087e155c4fb672e5544e2ef3cb33f1f7eb",
+   "sha256": "14mfv9fx3zdca1xbbs31m3c2hjxjq25692j8ln73knlgy0y659dd"
   }
  },
  {
@@ -95799,8 +96005,8 @@
     "f",
     "s"
    ],
-   "commit": "dd72004f6f7b0d554dbd979f22a31c350e211089",
-   "sha256": "126dn4d0f301pybvrkjw3h5c729kbnaglzbgpsv5v7r35wrmxfgs"
+   "commit": "a94de082d8f6a1219532e85f432b4919c175fe9b",
+   "sha256": "0hs61cl97r6bwl2di5fjgrh6cmhjjfgk750159028a7pfcm3qyjd"
   },
   "stable": {
    "version": [
@@ -95970,15 +96176,15 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20220511,
-    1328
+    20220521,
+    1653
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "c46c5167ac03f68fd6fee07972017282c62bc942",
-   "sha256": "1pkbkh260k2r7x158b691ppqvxxzqkyylbapwlrxzc2ly23rmaxs"
+   "commit": "51596cb516d7af1737d964ffdbb4c4d416d6dfaf",
+   "sha256": "0pka31i87mf9ih40cb8yc1scvzklb5h5agscac2v7faklranih7i"
   },
   "stable": {
    "version": [
@@ -96174,8 +96380,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20220421,
-    1811
+    20220522,
+    2351
    ],
    "deps": [
     "cl-lib",
@@ -96183,8 +96389,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "e6a89e9fa9eabc32063bffb2eacfcece46f7a049",
-   "sha256": "0rzynl2n6bk5lwff2rvpj0p3djnr421i1a9vm53554hk0vljzksr"
+   "commit": "0b4a2709159f5e975544b26302b8463deb7640d8",
+   "sha256": "1sk09z05xvg94pkf4181hvlg9q0m71kinzxv8223ls8df6ymc43k"
   },
   "stable": {
    "version": [
@@ -96275,11 +96481,11 @@
   "repo": "nlamirault/ripgrep.el",
   "unstable": {
    "version": [
-    20220309,
-    1746
+    20220520,
+    1410
    ],
-   "commit": "4ed5c741233a81d96115f556784269042070901e",
-   "sha256": "1bz9srlimpr5lzsjd02jq23h0vg2lnk921m24g0wsrdrccvmfxi2"
+   "commit": "872e250e8f93b8bb0a8a1de8bde17fd9bd116e31",
+   "sha256": "1n3jkj8a37ap4ndh9an5qm8dn8nxcgv9vqr8bcnxx5l0wnsvdg8z"
   },
   "stable": {
    "version": [
@@ -96374,11 +96580,11 @@
   "repo": "jgkamat/rmsbolt",
   "unstable": {
    "version": [
-    20220510,
-    1621
+    20220526,
+    1719
    ],
-   "commit": "3fe322e5739e57cceea37c4104ac7bc5231555c3",
-   "sha256": "1nc7hh3psw548mzzbcz7226i7pbyrdadmlrw955cl91z51rahxah"
+   "commit": "9c56c62993b9644a3c8bf6fc0a3a6599c0956707",
+   "sha256": "035cbj2ppxrjx8fdyjq3w7zjznzljxkcnr5pg61xw2vigd9mcjva"
   }
  },
  {
@@ -96536,11 +96742,11 @@
   "repo": "DerBeutlin/ros.el",
   "unstable": {
    "version": [
-    20220314,
-    2026
+    20220604,
+    749
    ],
-   "commit": "5e2bcd808f301b1a92cd583f2799d520bd802480",
-   "sha256": "0gb5bk1c10n4hr9dbwpgyk17qmd6bfqj9v9l0bmrbdvxafmnii8p"
+   "commit": "f66d2177b00b277a36c058549c477d854148623c",
+   "sha256": "07magls67fy99ckvy759lqk2q41mi4dvljx78ahclckyp7adwl21"
   }
  },
  {
@@ -96614,15 +96820,15 @@
   "repo": "pezra/rspec-mode",
   "unstable": {
    "version": [
-    20220401,
-    306
+    20220517,
+    2325
    ],
    "deps": [
     "cl-lib",
     "ruby-mode"
    ],
-   "commit": "a54ac64097b6ccc6acc52a8b077ceb63766fc4d1",
-   "sha256": "0s512jgd62rh0x5x24jzkmnw7hs6m1s1bcys41hr1vv27i0j2zvh"
+   "commit": "41224216cb7762a18eb0e309095796f3eb319e01",
+   "sha256": "0ym2i3w071iqh32p36fb22br62cbfs6zyhpm9khbspgmvpxaas8x"
   },
   "stable": {
    "version": [
@@ -96967,8 +97173,8 @@
  },
  {
   "ename": "ruby-refactor",
-  "commit": "8d223ef5b9e51265c510f1cf7888b621e47bfdcf",
-  "sha256": "0nwinnnhy72h1ihjlnjl8k8z3yf4nl2z7hfv085gwiacr6nn2rby",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0zz913v8hwc97qpz1c910adrhcj5ca7s72ixjnr32xq4qscmw9x2",
   "fetcher": "github",
   "repo": "ajvargo/ruby-refactor",
   "unstable": {
@@ -97120,17 +97326,18 @@
   "repo": "semenInRussia/emacs-run-command-recipes",
   "unstable": {
    "version": [
-    20220301,
-    2010
+    20220604,
+    1330
    ],
    "deps": [
     "dash",
     "f",
+    "ht",
     "run-command",
     "s"
    ],
-   "commit": "02a4d366e309b7dd6a45f8a94669a25d6fe80ea1",
-   "sha256": "0j634n2v8sqpybbmd62jayyamz28dzlmvr45bsijbwxn6b4pa8k0"
+   "commit": "6cff6fff2c3ac23384d044a9c64d0e4b80721d4c",
+   "sha256": "1bg1ha4mlbxr13w3v7xkbdi9mqp3amljikbnkfcc5wijx572c396"
   }
  },
  {
@@ -97235,8 +97442,8 @@
     20220217,
     2009
    ],
-   "commit": "d17be3051b22a06d7742178cd1367aed61807a66",
-   "sha256": "0yslscybdvnmak1h99qgjrwqim9aiwxhnp5kw4wb4nfqr1nwm3yd"
+   "commit": "0df2f22479b98f76d97de90e1c390ff1b0902a46",
+   "sha256": "0c8bhdsip75wa966zhli2khncqf1zhbxyxfqics1lh10ncxa7qw0"
   },
   "stable": {
    "version": [
@@ -97279,8 +97486,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20220509,
-    716
+    20220531,
+    1820
    ],
    "deps": [
     "dash",
@@ -97294,13 +97501,13 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "3b379fc25b7a097a014147d9c8b83ec1a418cd76",
-   "sha256": "129mclfyy6nji7c3avni4y3kzi3z67dv3cv40jmlv1m4isxf59n1"
+   "commit": "2c5b46e4e103edb6a4f60a6e38f3bc0c3099d470",
+   "sha256": "1rqfbkl16c287gg4p7y6hny5020j2q11yldamdcmrk83is7v06px"
   },
   "stable": {
    "version": [
     3,
-    0
+    1
    ],
    "deps": [
     "dash",
@@ -97314,8 +97521,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "b3f4442f7198eee758958196f89a150f8de8963a",
-   "sha256": "18br5yfakfwcbw3vkawhw5sm41xg78cz4bimz36x5xcgbwi88k3p"
+   "commit": "3bdc3042d3d321a0b0c45147c22732dc6bdfcdf3",
+   "sha256": "1bryx1w388ryhxk0ydigqf14hfdy518g8h06gimdim6bi1npvyl0"
   }
  },
  {
@@ -97378,8 +97585,8 @@
  },
  {
   "ename": "s",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "0dars9212z0yv97mj4615h23vd22vy8b6cw2n433z9jhif3aybqa",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "04mcdjm4i1vws26l3n7s5d4nkwf9l7gr95ab18a40si7wiza5pk1",
   "fetcher": "github",
   "repo": "magnars/s.el",
   "unstable": {
@@ -97402,8 +97609,8 @@
  },
  {
   "ename": "s-buffer",
-  "commit": "f1bf91527219e7afc8e113134a958f3adb862a5a",
-  "sha256": "07kivgzv24psjq1240gwj9wkndq4bhvjh38x552k90m9v6jz8l6m",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0c65zz03gw7wpx2cy889z2k4f7j1nfhi43jjff9vpcnlviyhqc9f",
   "fetcher": "github",
   "repo": "nicferrier/emacs-s-buffer",
   "unstable": {
@@ -97585,21 +97792,6 @@
    ],
    "commit": "6a1fedb4da7181b00f1bebfc88c87dd2f0c58766",
    "sha256": "1vygzx7i3cxghji4517sa2v9w5yl84mjpfixf000mf897xpk7288"
-  }
- },
- {
-  "ename": "sane-term",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "08b8zlr8qzxfrpg9lqiyam3sb8a8rzak79ra4r6ljjppyj4zmwi7",
-  "fetcher": "github",
-  "repo": "adamrt/sane-term",
-  "unstable": {
-   "version": [
-    20181130,
-    101
-   ],
-   "commit": "369178c2dd0348250c2ec0019567688376c637f7",
-   "sha256": "1klwn7crvn7769b5kan91fj5lpz5sanghi4way8h77b2iciya7bf"
   }
  },
  {
@@ -97804,8 +97996,8 @@
     20200830,
     301
    ],
-   "commit": "b929e705e76e8ff47d170c5e9849f86002f3e09f",
-   "sha256": "1iflrjldvabilvji1zmx1rmkl6z16s50k3hldn3l871gz16wa0h6"
+   "commit": "6aae7963498675dfb5bedaaef2cb8e56bdcddcab",
+   "sha256": "1ildv2wi9j1gp99l2d69gdc2a5h4i1jm17f59xr987l942mwnwnf"
   }
  },
  {
@@ -98074,8 +98266,8 @@
  },
  {
   "ename": "scratch-log",
-  "commit": "bec9692973db8853f9d329aebc0cc9e81bb34003",
-  "sha256": "1yp3p0dzhmqrd0krqii3x79k4zc3p59148cijhk6my4n1xqnhs69",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "15mn3i9mg6p1vcm5bdmp5wc0q945f9f1bkx1pwvns1iqj9pxdkv5",
   "fetcher": "github",
   "repo": "mori-dev/scratch-log",
   "unstable": {
@@ -98156,8 +98348,8 @@
  },
  {
   "ename": "scribble-mode",
-  "commit": "6469c2b389d757003da69da727905228eb564d50",
-  "sha256": "0idagikxhr86h2k6fb45zdzg73wpmpiszx0gi6d8jx7s1xqd6s50",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "09l54fmpkvwikf8b1kqxndka21j2v5cj09vxkhvlc659j6l1qh88",
   "fetcher": "github",
   "repo": "emacs-pe/scribble-mode",
   "unstable": {
@@ -98293,11 +98485,11 @@
   "repo": "t-e-r-m/sculpture-themes",
   "unstable": {
    "version": [
-    20220512,
-    2235
+    20220601,
+    1349
    ],
-   "commit": "be3adaf9db276e899b44e5093316cae2014b22c9",
-   "sha256": "0wn066zc72djac8ccss95ydi69ggngknkjh2hg0hi17g3m2pj6f6"
+   "commit": "ff2fdd1c38cb9f3f1abf420b77d1ef3a2786ce57",
+   "sha256": "1pwj9snqr87x16h02fnls90m63c3v6y35zcnr2f5sq9ydfxrzijn"
   },
   "stable": {
    "version": [
@@ -98383,8 +98575,8 @@
     "dash",
     "f"
    ],
-   "commit": "26ecae6a6d028fcbffc576a69ef8f787646bc12a",
-   "sha256": "1v9clc25pwbdq50xqabk36iypg2n68ip7znnhy6qwk9b3ir00zm5"
+   "commit": "2a0e37f818f4486dd624300a8dd77ac1b6d96070",
+   "sha256": "1dy336ga5268mqqhw1fpwd9zbagfldfbp11jc3yd1aasj9y32s99"
   },
   "stable": {
    "version": [
@@ -98615,17 +98807,17 @@
  },
  {
   "ename": "selectrum",
-  "commit": "4273a6e55cf797d1fab1825618aab7e9b6c01886",
-  "sha256": "012jmgr7w6x0gy8ygpzyyk23adyzmr7cknz2w51zjapcilkf6ghv",
+  "commit": "ebc43ea653ed9623745d0379576a023729ce9f32",
+  "sha256": "0gjkfdny0b8l6sf44z5c3psqglvh2kp4mp60lj2ajgybv80pzb44",
   "fetcher": "github",
-  "repo": "raxod502/selectrum",
+  "repo": "radian-software/selectrum",
   "unstable": {
    "version": [
-    20220323,
-    10
+    20220513,
+    2106
    ],
-   "commit": "7da932eeb89f1aa8060a73ddd040f95bbb127343",
-   "sha256": "14hplki838svbjpasmm9ik8c5xm0ji2xxrp61cq82dc6r0axg5w9"
+   "commit": "810ea697bdd559d97b86b795e01769cddfa3daf2",
+   "sha256": "1bci9vnpki7lf3v3wwcixq1ak5mgbvlxplsw5c04nckir163cqvb"
   },
   "stable": {
    "version": [
@@ -98644,27 +98836,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20220509,
-    2300
+    20220601,
+    1652
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "c05f8a43c6ff07a8b5a3ba8df7a2ec35677b7484",
-   "sha256": "0752dyl4fhi0jvbm238s5p1sv7z4jlkmkdrxvwn0dlhfr0rhfw1c"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   },
   "stable": {
    "version": [
     5,
-    2
+    2,
+    1
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
-   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
+   "commit": "07d61b7779c4cca3009390383e7f98a55de7e17e",
+   "sha256": "0z97d7nnl1hgxj4fsvgw3hb3j4dc9wkdq2vq3dw607f29lwqiadk"
   }
  },
  {
@@ -98777,34 +98970,34 @@
   "repo": "abailly/sensei",
   "unstable": {
    "version": [
-    20220502,
-    2012
+    20220530,
+    1226
    ],
    "deps": [
     "projectile",
     "request"
    ],
-   "commit": "1294a96f544fd1be9ddaea3a85369fcf437403e9",
-   "sha256": "0cg7rwvfc0yf9pld50f6hnpcyq3g7r7rh62sb9wzdnwiv9n249lk"
+   "commit": "3538990de9ab57154e3da08d10fbd2c6228d87b8",
+   "sha256": "1f7q7s0ajrpgaa78j3zrff5dr1p2j82kgpvpal2lgqns4947m726"
   },
   "stable": {
    "version": [
     0,
-    41,
-    1
+    43,
+    3
    ],
    "deps": [
     "projectile",
     "request"
    ],
-   "commit": "1294a96f544fd1be9ddaea3a85369fcf437403e9",
-   "sha256": "0cg7rwvfc0yf9pld50f6hnpcyq3g7r7rh62sb9wzdnwiv9n249lk"
+   "commit": "3538990de9ab57154e3da08d10fbd2c6228d87b8",
+   "sha256": "1f7q7s0ajrpgaa78j3zrff5dr1p2j82kgpvpal2lgqns4947m726"
   }
  },
  {
   "ename": "sensitive",
-  "commit": "5e5468ce136fabe59e1434f8a7f265f41c5e64c1",
-  "sha256": "0v988k0x3mdp7ank2ihghphh8sanvv96s4sg6pnszg5hczak1vr3",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1q53y2lf28z8vdja13bhn1w7yrzqirbk1m02sv2w6chf40797fxy",
   "fetcher": "github",
   "repo": "timvisher/sensitive.el",
   "unstable": {
@@ -98827,15 +99020,15 @@
   "repo": "noctuid/emacs-sentence-navigation",
   "unstable": {
    "version": [
-    20180408,
-    1619
+    20220522,
+    1137
    ],
    "deps": [
     "ample-regexps",
     "cl-lib"
    ],
-   "commit": "7c5d2edeaed01196aec25031782e89adeaa089f0",
-   "sha256": "15za4fg7c8fsih86wz1npyx6gdmw0xhizklfsyfh84416dsmgswp"
+   "commit": "ea6e94a5518643acda5b6e98e4e7f47dfc107d29",
+   "sha256": "1wpr37gwkly0jl0m8kh7f1pkp9dwg5i1r3bpx3sd1z8c57sfn8da"
   }
  },
  {
@@ -98855,8 +99048,8 @@
  },
  {
   "ename": "separedit",
-  "commit": "297ba98f4bc011948c34aad30ae28b7adc611938",
-  "sha256": "00p4crbzr5fkcj8lhpfd9w44ynpmhd9fay9yrwgz0yh87lll6nqx",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1k7wd8aaq5yq9l1jpj4sl5kjcp0rhknv3gdb8hqx65kscpmksdzh",
   "fetcher": "github",
   "repo": "twlz0ne/separedit.el",
   "unstable": {
@@ -98902,8 +99095,8 @@
  },
  {
   "ename": "sequences",
-  "commit": "4cf716df68fb2d6a41fe75fac0b41e356bddcf30",
-  "sha256": "12wnkywkmxfk2sx40h90k53d5qmc8hiky5vhlyf0ws3n39zvhplh",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0s3n454zizak773svgw3rj0cn5nyq4xrhwr9vywd9x9f0xcfj3n8",
   "fetcher": "github",
   "repo": "timvisher/sequences.el",
   "unstable": {
@@ -99555,26 +99748,26 @@
   "repo": "redguardtoo/shellcop",
   "unstable": {
    "version": [
-    20220414,
-    530
+    20220526,
+    1424
    ],
-   "commit": "327f5ac43e5d543149a772aef06cdb616477eb43",
-   "sha256": "1rmv2swyir91c6x94bggkrwankfkipfzhxzmg2c1455ybm48n3lx"
+   "commit": "4e71f5b9199a0ad10017104a6b2bf5ef5f207dfc",
+   "sha256": "10aydyxli33h4vg0mkbmni41swy78cbj85k9j0qf1lhiqxzah8k5"
   },
   "stable": {
    "version": [
     0,
-    0,
-    9
+    1,
+    0
    ],
-   "commit": "327f5ac43e5d543149a772aef06cdb616477eb43",
-   "sha256": "1rmv2swyir91c6x94bggkrwankfkipfzhxzmg2c1455ybm48n3lx"
+   "commit": "4e71f5b9199a0ad10017104a6b2bf5ef5f207dfc",
+   "sha256": "10aydyxli33h4vg0mkbmni41swy78cbj85k9j0qf1lhiqxzah8k5"
   }
  },
  {
   "ename": "shelldoc",
-  "commit": "551623175e55629be6cfe44a595f25f09bd889e8",
-  "sha256": "1xlp03aaidp7dp8349v8drzhl4lcngvxgdrwwn9cahfqlrvvbbbx",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0ihw3c2rg01zrmpdp61wh9xw7klbrcnh29gbsxs2143a70bmms1x",
   "fetcher": "github",
   "repo": "mhayashi1120/Emacs-shelldoc",
   "unstable": {
@@ -99672,20 +99865,20 @@
   "repo": "redguardtoo/shenshou",
   "unstable": {
    "version": [
-    20220324,
-    1137
+    20220607,
+    39
    ],
-   "commit": "bc16a637edaaca831a5147b6f479ba1dbdc02454",
-   "sha256": "0mli3h3i511vq8g69b2y8hq9591bv5yjblvx7cnh1nrjpb4flak0"
+   "commit": "317a87ca4b1a3f1860d9ce88aeabac154598a834",
+   "sha256": "045z3h0yk5bkdiipp158s47bphmbz1fgmfx9fdm5acf1w1sdqm8q"
   },
   "stable": {
    "version": [
     0,
     0,
-    1
+    4
    ],
-   "commit": "8e12d366ca371fc259294485047a431a7c610605",
-   "sha256": "09w57wq9mw3yjklxsqm87xl2q229qwqp48ssxlp5xpwhwljgwd2j"
+   "commit": "317a87ca4b1a3f1860d9ce88aeabac154598a834",
+   "sha256": "045z3h0yk5bkdiipp158s47bphmbz1fgmfx9fdm5acf1w1sdqm8q"
   }
  },
  {
@@ -99696,14 +99889,14 @@
   "repo": "purcell/emacs-shfmt",
   "unstable": {
    "version": [
-    20210803,
-    222
+    20220602,
+    1535
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "ceb1ed4df3d7e198e4c5af0c2fd44c4d9d65832e",
-   "sha256": "1apaka8w4iwpa2ba652zpl5kl17ixjfnws0pnmx52yyvfj7bjv7n"
+   "commit": "279a51defa3e0d97dc40b8a26e078699d4e22e90",
+   "sha256": "1kzi8gy37cm1z4x69400gbkawx4k0jafvz8m50w0b48nvrvsy6ys"
   },
   "stable": {
    "version": [
@@ -99767,11 +99960,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20220426,
-    715
+    20220606,
+    2301
    ],
-   "commit": "7baf17355289c29d18f993f383c5d6a187f33b35",
-   "sha256": "1a2m6jkvnv852q07wvi80nbm7437wnvdfdyiq4iffhffmz8c2mrr"
+   "commit": "45155e42ea10990295d47d5ee3cb29be16a1f9f6",
+   "sha256": "1cjz3sli309i2qrwxic63x1am4hpn8r9gwjnfjb62b954wdhhf97"
   }
  },
  {
@@ -99846,8 +100039,8 @@
     20210715,
     1227
    ],
-   "commit": "09aaba23300b9fa3cfd15ceb0e62da4a3d53e7e5",
-   "sha256": "160ck71cwlzsi59wazxf3nl5sim6rflbs2dxhiavmv9rz2xjgk46"
+   "commit": "b59e0fcca14dd2d8424d8ba0800da2e35bb52cc7",
+   "sha256": "1vz7fvx36r0dmim7n61zi00zvdk03sjxqsh5xcd6vxfv5869hxz5"
   },
   "stable": {
    "version": [
@@ -99957,15 +100150,15 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20210829,
-    1013
+    20220523,
+    1440
    ],
    "deps": [
     "language-detection",
     "org"
    ],
-   "commit": "b8a23e097b25d6c7754f9aaf4de89259f8a0b17d",
-   "sha256": "0krd112xglcvkgjl0dj6z4h9gwzh99avh10hlp4idcsm8b7hgdc9"
+   "commit": "b3916e1ebe2477c031db1440d9b57e373c0354fe",
+   "sha256": "0m357d795qcn1l2gynglzdrdc9h197vj68436hkwnc1j72zhcpl4"
   },
   "stable": {
    "version": [
@@ -100464,8 +100657,8 @@
  },
  {
   "ename": "simple-rtm",
-  "commit": "a784f931849ca836557390999b179ef9f6e775f3",
-  "sha256": "0v5f0vr8sh62yvb7znx00wgybb83dfnkvgl8afyk3ry8n9xkhf5b",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "09m5akqrdn22lxr50z3x2zyldh1m62b8sbwkq6pb428bhanvhky2",
   "fetcher": "gitlab",
   "repo": "mbunkus/simple-rtm",
   "unstable": {
@@ -100504,11 +100697,11 @@
   "repo": "rolandwalker/simpleclip",
   "unstable": {
    "version": [
-    20210406,
-    1221
+    20220518,
+    1251
    ],
-   "commit": "67c8c17adbbe6d9407a5ce4159d097a8b8bf6adb",
-   "sha256": "0lggdlgkcxzl1myddis7xy7x2qi1q91grgxpq2rlkkz70rz0xcv0"
+   "commit": "023f239275115169c3a3637ad95fae4a036c005e",
+   "sha256": "1mvjlcmldcx3vd6xkk3nriy8lghp6nqa6l13a6kax5n8dc0hi4qi"
   },
   "stable": {
    "version": [
@@ -100603,11 +100796,11 @@
   "repo": "smallwat3r/emacs-simplicity-theme",
   "unstable": {
    "version": [
-    20220217,
-    1928
+    20220519,
+    1439
    ],
-   "commit": "2a0aaf19cf1e99c50df0d2e6225a2d2931a203d2",
-   "sha256": "0xv1gf0a9i3ajxd6cprr7b62xvar6r6ia5qd4sjvr8pnaw3cav45"
+   "commit": "692d908961990f463632089041d4705cbb1c5912",
+   "sha256": "0a1igxk9jrybrf8qgh8nqdqkk7i7gvq7jq66w34gi9lbckmfvi05"
   }
  },
  {
@@ -100945,15 +101138,15 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20220510,
-    2050
+    20220526,
+    1343
    ],
    "deps": [
     "cl-lib",
     "macrostep"
    ],
-   "commit": "c5342a3086367c371e8d88b3140e6db070365d43",
-   "sha256": "008qav1p8angqczv8l1yd2ics0pyp69x93s8xvapcrxvhv8ishgn"
+   "commit": "1f9a95f3a07b2aa5b01d8be427b90837be5cea6a",
+   "sha256": "12fndsp7rkzvs7r1srrccywv5lmr6xbp7fx96ijymff82fqblcy9"
   },
   "stable": {
    "version": [
@@ -101184,11 +101377,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20220302,
-    1053
+    20220603,
+    843
    ],
-   "commit": "4513c382f07a2a2cedb3c046231b69eae2f5e6f0",
-   "sha256": "10bzxhi5d7h18hqclxqy2z857d0sfbsnyxvrhmfkdi0h75zz7m4n"
+   "commit": "b501b4335096fd4306c2c1eb86382b69e91c09e5",
+   "sha256": "1naj8cm0rd4pimrncmv6dka73l22avypclhr00dmpnh174vizpnp"
   }
  },
  {
@@ -101415,11 +101608,11 @@
   "repo": "hrehfeld/emacs-smart-hungry-delete",
   "unstable": {
    "version": [
-    20211020,
-    1822
+    20220516,
+    1538
    ],
-   "commit": "78acd1f16fb99b66a6c9bd605a988c3c74280577",
-   "sha256": "0c4yrnngq1m5nwis5y26qf0mfp12qnargh7s4hd3wm5xl4n5369x"
+   "commit": "e06525cc1841805ebe470c876d6b966de90bc275",
+   "sha256": "0226lpiqnrjjdnay6nafgm118g8dkr59ilvygk4xrjcb52jjhn7z"
   }
  },
  {
@@ -101636,8 +101829,8 @@
  },
  {
   "ename": "smart-tabs-mode",
-  "commit": "b46e83f2ea2c4df1ef343c79c7e249605c9639b3",
-  "sha256": "0wxrpn145z2ivdadls7p7ha16py9fani3zlwlh6s8rz18hj4ad9x",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1ylzsa069lfnxv6cf4qsqn4jil6ib5zyjwsyhgn7b7knbp00f7v8",
   "fetcher": "github",
   "repo": "jcsalomon/smarttabs",
   "unstable": {
@@ -102724,8 +102917,8 @@
     "cl-lib",
     "deferred"
    ],
-   "commit": "112450888f3f90f0f2a0e43e49eb5a7e49b1b6db",
-   "sha256": "1dmchr5mg84xsyny0xnwwvvqcn09kca4r85amy1h7b0qv7p60vv4"
+   "commit": "f65456e9d91487cde6f4b31134033466e7db716f",
+   "sha256": "06khvgz76gn6d0594rl8g37y8gkx11axv85vhiwvcl8cg0qawikl"
   },
   "stable": {
    "version": [
@@ -103111,11 +103304,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20220511,
-    143
+    20220518,
+    117
    ],
-   "commit": "701e7c49c38babaa2b2071febd2b112fef600683",
-   "sha256": "1wkqrlwh9n827x49m71j5ilkgk9xn6smxi11cfbd35hbdkdf5gyn"
+   "commit": "e23ac498e9c96f5e93569271d192e6c247134412",
+   "sha256": "1dyc7ax2idr30ph2y05lxb94pg0qnpj23l17bg0rscv00pg8883c"
   }
  },
  {
@@ -103153,11 +103346,11 @@
   "repo": "brailcom/speechd-el",
   "unstable": {
    "version": [
-    20211231,
-    758
+    20220608,
+    1422
    ],
-   "commit": "a4be22b5b62a6be1e749df6f64b06e16a6b09790",
-   "sha256": "192fw278mmgqcbagigl97rwlj0jks63vmzgdpakhcr8as8ybc9gz"
+   "commit": "7e30c439729d5635ddd341ad5ab16f832a4619ea",
+   "sha256": "18xgqp8r1bgj63g2n08jbx4jwdcjn3p2lpdndyvfm394y2nzkcxr"
   }
  },
  {
@@ -103245,8 +103438,8 @@
     20220507,
     1118
    ],
-   "commit": "2f2fd6de0003edb1038b7c639cf23264d1406993",
-   "sha256": "1p23c2y124xmd3zwfns4zmk460vxd459dds0w0k9mnjnm9p8dkq2"
+   "commit": "1299bfca2ec9bdca0424fcaa330ddadc8f8d1143",
+   "sha256": "0w8ydbl1wnjn4wj8zfypab5pngxgmg4d06srkarfym2v75ksass7"
   }
  },
  {
@@ -103666,6 +103859,21 @@
   }
  },
  {
+  "ename": "sql-trino",
+  "commit": "141f76317967d6561d722b6dc390adf65774654e",
+  "sha256": "075fj37qc6h1hqshybddavppv5dnhnxbsfnfc37j7snqjndzxkmi",
+  "fetcher": "github",
+  "repo": "regadas/sql-trino",
+  "unstable": {
+   "version": [
+    20220502,
+    851
+   ],
+   "commit": "bad7be0bf2f6d2d653a787a4b5bc6a281a8bea88",
+   "sha256": "0b27b8nbghxfqynr6sfadpmwlsixn4hhqqmczc3i9i69sbm2m8a0"
+  }
+ },
+ {
   "ename": "sqlformat",
   "commit": "6bdaa1ccae12f2ea779ac6989607d8027feac2c9",
   "sha256": "07lf2gx629429b41qr04gl98gplb538gb5hw7idzrmi3higrmv8m",
@@ -103725,11 +103933,11 @@
   "repo": "pekingduck/emacs-sqlite3-api",
   "unstable": {
    "version": [
-    20220501,
-    1217
+    20220529,
+    1106
    ],
-   "commit": "68eda59d5f3d29d0a64d6256d58b8c1f93ba3583",
-   "sha256": "0yrfwb3yvhp1ib4izxh1ds68b3zw8gjkjhlk1kivarxnfjnjnly2"
+   "commit": "2f6095201b1d943d92cc017e100eec571a8d2aab",
+   "sha256": "00kxjvfgw3qcy49l5qkkxar32m7kk25knc9kij7xr8fz8pqhr633"
   },
   "stable": {
    "version": [
@@ -103833,11 +104041,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20220406,
-    1831
+    20220526,
+    2233
    ],
-   "commit": "dbcdc58d3ea9e0767b24bb0f05fc8de8849889fe",
-   "sha256": "1a7s7p3lq5gvgkw9ldzgg8nvjap4j6szdk0gw5njq02jccfzc7ll"
+   "commit": "3e5fbaef46126634c58d0f39be4bc522c05de1f9",
+   "sha256": "1wahhk2fssjasiz691pkh61qd6x8dbabv4vrwzvc32r9vy8xpyg5"
   },
   "stable": {
    "version": [
@@ -103988,14 +104196,14 @@
   "repo": "death/ssh-tunnels",
   "unstable": {
    "version": [
-    20220410,
-    1424
+    20220606,
+    1229
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a74488a71c2827dcaf42d9381d0d974aca96e27f",
-   "sha256": "0lrfrzxwjrhj90ampkg92pcpblb4i7744kwx2sl6ivkp7ldklyfn"
+   "commit": "191013b83f3ec3214394a1ed698c4cf38e4d9047",
+   "sha256": "0l50d8vkfc5hv1j5j807a398ghv4ap19mpiv75c8l5k1mbrysald"
   }
  },
  {
@@ -104273,11 +104481,11 @@
   "repo": "wavexx/stem-reading-mode.el",
   "unstable": {
    "version": [
-    20220418,
-    1136
+    20220522,
+    1053
    ],
-   "commit": "a8bacd80fab6013c09e4e8d337fd88267cbe2ff8",
-   "sha256": "0ib2rqybwjxclgqy6bp0gmgr6mvyp434mf9ix6m8by3jrkpppvgq"
+   "commit": "6efc9962e3a19a452c7ab9636cf1e2566a51bd38",
+   "sha256": "04kjf6byxp66v6iprp8wcymi283c46fb4w4wiyj64pp76y3g59az"
   }
  },
  {
@@ -104375,8 +104583,21 @@
   "repo": "beacoder/stock-tracker",
   "unstable": {
    "version": [
-    20220430,
-    1144
+    20220523,
+    1424
+   ],
+   "deps": [
+    "async",
+    "dash"
+   ],
+   "commit": "14fe70fcce24a045f34e42617432a2d830906b98",
+   "sha256": "0854qx7vfycf8dfr8amksb0iv4nydbqn0g5357s3dfwmpj6rvvzk"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    6
    ],
    "deps": [
     "async",
@@ -104384,19 +104605,6 @@
    ],
    "commit": "58018a1747273df23dec08ec5d318da1960428c1",
    "sha256": "0jbj24pbc07gjb6zk29yzjrd80c4aaqfp2mffc4qqisws0f8gfvb"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    4
-   ],
-   "deps": [
-    "async",
-    "dash"
-   ],
-   "commit": "34632dd99903d4ffbb78a2deb5b658291a6cf040",
-   "sha256": "0rq8qimc3xfh1x9g691x2bmmy9a1bglv6180hdc5z6irv5gfszvn"
   }
  },
  {
@@ -104476,20 +104684,20 @@
  },
  {
   "ename": "string-edit",
-  "commit": "20fd24f22ef734fe064c66692bf3e18eb896f1ac",
-  "sha256": "1l1hqsfyi6pp4x4g1rk4s7x9zjc03wfmhy16izia8nkjhzz88fi8",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1z2m9dskxcvbrcdx296qy5spbqd9gf1fvgqwsf9jy5487n03nyhh",
   "fetcher": "github",
   "repo": "magnars/string-edit.el",
   "unstable": {
    "version": [
-    20210405,
-    1836
+    20220604,
+    2128
    ],
    "deps": [
     "dash"
    ],
-   "commit": "0e225df6f8740467231c787a50025e4552b3eddb",
-   "sha256": "1x5b3iq1c25c74jb77qw3zijblp6zx9kp9hzsb0wfx66lp4wn2wi"
+   "commit": "d7c4b9db6c4987b5c022a9858e6302a4c53aff5f",
+   "sha256": "1fr17145rk62wc8h4vr164ya8vr6ifyy0h4kzbsgwwkh6qji6aym"
   },
   "stable": {
    "version": [
@@ -104828,14 +105036,14 @@
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
    "deps": [
     "transient"
    ],
-   "commit": "ee2b1f20521e647472be7553242eb2253809e1d1",
-   "sha256": "1j8q47vvvsdfb9hg2r72dgmg2a886aa15yrvi6ahp7g5z4jmp19k"
+   "commit": "e9acece0f840bc6ea096ae56e77573939a2c510c",
+   "sha256": "0pynzc34bzppdfl1bxkhb0r7z4c0kd1bil5vblnyn4gnjx00jb94"
   }
  },
  {
@@ -105055,11 +105263,11 @@
   "repo": "bbatsov/super-save",
   "unstable": {
    "version": [
-    20220426,
-    1056
+    20220531,
+    1745
    ],
-   "commit": "71c26cbd47d993fff37e572523ea79c9c49f5caf",
-   "sha256": "1r56g3h7cn2p64lk5d9zw2hmr7f5xzim1ccydzi8i1g7m7rzlgjp"
+   "commit": "6f6512bc44b09f7187e58772892fa330f4518c12",
+   "sha256": "1nbkx8hphszwn42g75f92n22zkp8kjl3pr0rbfpwdzbsla5lm2dz"
   },
   "stable": {
    "version": [
@@ -105169,14 +105377,38 @@
   "repo": "rougier/svg-tag-mode",
   "unstable": {
    "version": [
-    20211229,
-    920
+    20220525,
+    1752
    ],
    "deps": [
     "svg-lib"
    ],
-   "commit": "07640c97a1dcc305010a384fffdaa7788c342da7",
-   "sha256": "0f5p07li2nr65jil57b52qiryp8b5blzcnymx05cc4pm4m539aff"
+   "commit": "efd22edf650fb25e665269ba9fed7ccad0771a2f",
+   "sha256": "1qwbhkl0fd22yymncmsw5ivrhwsl42mch64kai6zpn1q0aclk1dx"
+  }
+ },
+ {
+  "ename": "svgo",
+  "commit": "63366b06071a7c5a54a47cfc7a0529f83e44a1c4",
+  "sha256": "1dg3ziia58jd88y02ndr617cyxvwpwsp70v9226ilgi76xdw58d6",
+  "fetcher": "github",
+  "repo": "hupf/svgo.el",
+  "unstable": {
+   "version": [
+    20220525,
+    2059
+   ],
+   "commit": "40ddd6f47966561344bec8f46235e40dad99115f",
+   "sha256": "1h06dimzii1acnf42jg0irwr5sjlr9br9dkrndx9wl2wwhjnwzdz"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    3
+   ],
+   "commit": "9b01cc9eb1fdf2731cd2b931a7dfe1f601b70786",
+   "sha256": "1qdyzf5k1azqqkhpqm3qwz4h4pm57x141i0z0wq40sf5lwdk9wk9"
   }
  },
  {
@@ -105469,8 +105701,8 @@
    "deps": [
     "ivy"
    ],
-   "commit": "8bf8027e4bd8c093bddb76a813952d2a0dcbf21d",
-   "sha256": "1rdv8r6zw0lziycwv5kd2yyflfwby4gnqgfvv67b1y2l3psjwp94"
+   "commit": "f8d80a4055514f92d94f128f5fcb1cda79e5cd22",
+   "sha256": "1cmafp5rssp27lhvszyzf4mc1z130kkgkl9d36lgg97qk5jp58g8"
   },
   "stable": {
    "version": [
@@ -105674,20 +105906,20 @@
  },
  {
   "ename": "sxiv",
-  "commit": "7a9ad1ddf9387323c8c3a48f7e1443be01f95440",
-  "sha256": "1yiwdrg3cgxpjijk7hxl7dv7q9l3sk0ga2896110yc2f2prjm9fc",
+  "commit": "4f3fa2076ce777618f2982a7ba69b497d68aebc3",
+  "sha256": "179mqhkm52mccyxbwfl1sa5ky3zrivz6lb2vjnk54117l5ifzv07",
   "fetcher": "git",
-  "url": "https://tildegit.org/contrapunctus/sxiv",
+  "url": "https://codeberg.org/contrapunctus/sxiv.el.git",
   "unstable": {
    "version": [
-    20210514,
-    918
+    20220530,
+    14
    ],
    "deps": [
     "dash"
    ],
-   "commit": "028409c3a9ff7ba33a1cc2158abfc1793ed50717",
-   "sha256": "0zscfz1f6sgf4b9arfj9bmyvxqlpphm7q36k73zn5hn28kzd9di4"
+   "commit": "47f5b2fbb94c569dc5e71cbe4de9c6eabbbc69e8",
+   "sha256": "0j0dqab5br92qz9wz3ssjps84dr0q28x11065cx90b6gis9wvv5j"
   },
   "stable": {
    "version": [
@@ -105838,8 +106070,8 @@
  },
  {
   "ename": "symon",
-  "commit": "3f4bbc6b3d7b2e2a9fbe7ff7f1d47cda9c859cc0",
-  "sha256": "11llnvngyc3xz8nd6nj86ism0hhs8p54wkscvs4yycbakbyn61lz",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0xrfvx09qb0pbpr7ck0w3sr6hyw0wl6vkcc9z6qkym37qg9harwm",
   "fetcher": "github",
   "repo": "zk-phi/symon",
   "unstable": {
@@ -106370,14 +106602,14 @@
   "repo": "mclear-tools/tabspaces",
   "unstable": {
    "version": [
-    20220507,
-    607
+    20220607,
+    526
    ],
    "deps": [
     "project"
    ],
-   "commit": "24266c6c9a766261a8c8620692dfa4000f3e1d5d",
-   "sha256": "1fyfpi31qy03qpxw8hpjgykn67pvflgah3agwf053iqpj1krh1gz"
+   "commit": "0ce73ece84027939428ade3d46706cbd0a61ec3f",
+   "sha256": "09li624kg8p5637lq85sl6f4lrmlc71a9cgy1xj0rs63jv2wf3w3"
   }
  },
  {
@@ -106397,8 +106629,8 @@
  },
  {
   "ename": "tagedit",
-  "commit": "8968e2cd0bd49d54a5479b2467bd4f0a97d7a969",
-  "sha256": "0vfkbrxmrw4fwdz324s734zxdxm2nj3df6i8m6lgb9pizqyp2g6z",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1qykq6y6vqswwj9f6m5srp4imd841l94jhajzkpyaaa51saywp56",
   "fetcher": "github",
   "repo": "magnars/tagedit",
   "unstable": {
@@ -106492,11 +106724,11 @@
   "repo": "tmalsburg/tango-plus-theme",
   "unstable": {
    "version": [
-    20211222,
-    1100
+    20220525,
+    1311
    ],
-   "commit": "774b03f932bbc336ce5f943af175d5faa651f2e0",
-   "sha256": "0nl73ggirjs0a6zapqpp4h2wszkfbj8956qn3yg86fc0hk9jiz05"
+   "commit": "bdf1dd6ea9c43d07b22dfa15fec0dcfd03544c63",
+   "sha256": "01q6c2k9lkz1zpi816b9s99lwrnlf4ni9r0z45jx4fljsy59c0i3"
   }
  },
  {
@@ -106737,15 +106969,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20220503,
-    349
+    20220602,
+    2031
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "29010616931f52e3a5aa9d155c14873c09c7306b",
-   "sha256": "17cshy0ba7jiq36rj66k6m8swijzvpnwpfrgy0xvhgxsz115bhp6"
+   "commit": "892ac2e88f764af516abc307ff199cb819442e4e",
+   "sha256": "17ysqxb5j2qi3kkjwnb8rvwan6yz90av5967sypdss2by0hlwd97"
   },
   "stable": {
    "version": [
@@ -106998,8 +107230,8 @@
     "key-intercept",
     "term+"
    ],
-   "commit": "fd0771fd66b8c7a909aaac972194485c79ba48c4",
-   "sha256": "1dql2w8xkdw52zlrc2p9x391zn8wv4dj8a6293p4s08if7gg260w"
+   "commit": "2d98e976877a5ca71500ab57377b6e5a129fa2f3",
+   "sha256": "0jyl3jwbx6msbd2x1qlicdfbyrv71f1zwdh43zb7zif4i6r40znq"
   }
  },
  {
@@ -107017,8 +107249,8 @@
     "tab-group",
     "term+"
    ],
-   "commit": "81b60e80cf008472bfd7fad9233af2ef722c208a",
-   "sha256": "12gfvcf7hl29xhg231cx76q04ll7cvfpvhkb0qs3qn1sqb50fs2q"
+   "commit": "cd12a3744d4b7d37a002f4f7fcc4a45ea5be95c3",
+   "sha256": "1qxzs6z0wgzcrfl8mm0fvliax8k8ns0fww03pjjvjfskkfzlwmrk"
   }
  },
  {
@@ -107217,22 +107449,19 @@
   "repo": "davidshepherd7/terminal-here",
   "unstable": {
    "version": [
-    20220510,
-    806
+    20220519,
+    552
    ],
-   "commit": "24cb30dea30195108f85aceea28f086a84d47e5e",
-   "sha256": "0cqj8g1pbq24d6zgsd0dq85sam2sl7w2y29ksnv4a93krjw1i2hr"
+   "commit": "c16a500926416c09cd2faee6ab9541686b51e34f",
+   "sha256": "1iv1c2mbvhn00ha46c6f98j9syc71xhjpk8m5wa5p32sk4wcc9f4"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "e176d1675dc5c41b6aebd05122fb2efc44b6cff0",
-   "sha256": "0dj3z8czvziszb20sizgf1yriv4im811rcfadm7ga9zs2al56kqy"
+   "commit": "c16a500926416c09cd2faee6ab9541686b51e34f",
+   "sha256": "1iv1c2mbvhn00ha46c6f98j9syc71xhjpk8m5wa5p32sk4wcc9f4"
   }
  },
  {
@@ -107707,17 +107936,17 @@
   "repo": "monkeyjunglejuice/matrix-emacs-theme",
   "unstable": {
    "version": [
-    20220503,
-    1325
+    20220607,
+    322
    ],
-   "commit": "f2f69c3aa9c76dc3c27e9bf3c965e66f8b7f61cc",
-   "sha256": "00jylvw3h1r8lvpw50ca9gwiq4g8frxh7rhibdm9zisvjzw27p5w"
+   "commit": "403226efb0c38898a8a848c60b8da0f94470b055",
+   "sha256": "19dqbynjhwcyxdzp0zxx6kxzdb2kz9bal8xhpblf16ajga593g3g"
   }
  },
  {
   "ename": "theme-anchor",
-  "commit": "74f79dc5db5246a2f70e4d4ad76601be8b5c79d8",
-  "sha256": "15819kkxvhk03yfzd0qp78d5ayc33cm064gy7fdpi0aq28nbw6ba",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "12vdip9v2hz16scc936kbxr4jp9cnmkzri5w1sz9w56hfrav927l",
   "fetcher": "github",
   "repo": "GongYiLiao/theme-anchor",
   "unstable": {
@@ -107904,18 +108133,18 @@
     20200212,
     1903
    ],
-   "commit": "200776bcf1296360707c5b8a3f18d2b8817da888",
-   "sha256": "0s1pzpcx6g12hnn48gfyfp9wai5yk6rnsjzn82661rdmhjwm2z64"
+   "commit": "d00a78590a91c6fccb361713d32b846c22164af5",
+   "sha256": "059wbqiij52hxmx0i65baifk421d2i2qrnsp51i5ayk5w8ai1iwh"
   },
   "stable": {
    "version": [
     2022,
-    5,
-    9,
+    6,
+    6,
     0
    ],
-   "commit": "321b08352d043708869d5c15f961610392afca16",
-   "sha256": "0pynyavfwwylqibj4az58a3q45di540d0j6dwdwywihn470cinvz"
+   "commit": "954b49b17037fe12fdcbffadcf42c0e525b3233e",
+   "sha256": "1w4yjqpqah3w2c58m6b73qsamknsy9i1i8rwgqnw9srr1ba6as55"
   }
  },
  {
@@ -107971,8 +108200,8 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "39389e4080144c6734dbe3020cc35185f025ebf0",
-   "sha256": "14gb1az5gmlq6j7lx4d2cdkb9kr0jad6whd4b0l9h608s86057v7"
+   "commit": "fda9c1ecb3722698935245e5409ef8ccdfca16c8",
+   "sha256": "117r67apl06z2smyb5j2a45m4a9s2i8izjxllascc18q4vjlrqxl"
   },
   "stable": {
    "version": [
@@ -107995,8 +108224,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20220429,
-    1501
+    20220514,
+    614
    ],
    "deps": [
     "cl-lib",
@@ -108005,8 +108234,8 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "83c34c636f47cb0c10c7d1a728fa308bfec40890",
-   "sha256": "19yg6zij9jx39d8b6c41ipa0z99q0af4l59pmnpxv8pfadxvi9qg"
+   "commit": "96bfc5da11a9b83b32368c38e933a405270652de",
+   "sha256": "1py0z8nrkgh3lzsmgxq62bi2nbdx3c97194frjyb5wl81kh4pbbp"
   },
   "stable": {
    "version": [
@@ -108033,11 +108262,11 @@
   "repo": "emiliotorres/tikz",
   "unstable": {
    "version": [
-    20210927,
-    1704
+    20220526,
+    521
    ],
-   "commit": "f9ea0793affa34be29e1861bfa559fd248b7d22e",
-   "sha256": "03jcj6vkb8i7jqfwyiix5achq5bgwvjz97w2pwr46v3hbrf4r62q"
+   "commit": "4b205afc5c88f050639135d1d57f1276db323842",
+   "sha256": "0ykhlyq45r0nzv03kbmdwxbhrydpls6iihcf0g43nq0fhswb20g7"
   }
  },
  {
@@ -108220,19 +108449,19 @@
   "repo": "aimebertrand/timu-rouge-theme",
   "unstable": {
    "version": [
-    20220501,
-    1753
+    20220525,
+    1239
    ],
-   "commit": "935e4907f01fba2c7c2ecaab88eb7c4163955c3b",
-   "sha256": "0651q30pvxqdfv31mn87jxxkhds3f7bqh8bl1dsn7k9l1j6l3xfz"
+   "commit": "5c6f406bf5815e6b72b09093b651b09c7c6769fc",
+   "sha256": "04wjz4xzbb5ps16bfvwd39ifh7y880g4n1di76kn9mylc445a0kq"
   },
   "stable": {
    "version": [
     1,
-    2
+    4
    ],
-   "commit": "fe86f7d9864d986c7c8c430b6100070ab86dbbf1",
-   "sha256": "0651q30pvxqdfv31mn87jxxkhds3f7bqh8bl1dsn7k9l1j6l3xfz"
+   "commit": "02281cde75ab7e5bb624003dc0de035dc14f2469",
+   "sha256": "1xv0cjiwl86hvyb9f8awjwx14b158qpnlmfxlxn7f0z3lzim9d7x"
   }
  },
  {
@@ -108243,19 +108472,19 @@
   "repo": "aimebertrand/timu-spacegrey-theme",
   "unstable": {
    "version": [
-    20220501,
-    1509
+    20220525,
+    1238
    ],
-   "commit": "1318c58a118c6c5a95a82e71da5eda6bfcf8f143",
-   "sha256": "1vav4f6g86fh71ddprql0m8b05f4h8l04n7jfskfmvpfwgw2w87r"
+   "commit": "d9ff61d8e5393952e19da434b9f226be75eee493",
+   "sha256": "0649npmyj4x1hi57dic7gmr49723q0dv5ccj824qjq3jb0ng21hm"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
-   "commit": "9e1a12a494537472fb1f9f9f23dc38b8bca1f9af",
-   "sha256": "0bndwcpz2alzimlmkcpcdxsl5xvckks22xmqn78rkg9pscl10gjq"
+   "commit": "d8db5dceb95144ad50c1dc3577196eef7a10d5b3",
+   "sha256": "14r325a9qq9xigqbp03dbblc8lnw3hz7hbnmj9d58jshd6avdcnc"
   }
  },
  {
@@ -108341,17 +108570,17 @@
  },
  {
   "ename": "titlecase",
-  "commit": "b82998e77fb69c640077db8d9a37c7c25859f820",
-  "sha256": "1rvlzq2b7rvp91ac689na04mdfirryxmp820xfzvxz4cm483knc8",
-  "fetcher": "github",
-  "repo": "duckwork/titlecase.el",
+  "commit": "eb90d69154a8977fab35f4a272274b34320af4cd",
+  "sha256": "0qc5xqjj742qr46ylb949wagvm06j6xwkh6n00w8h9a76ims1v9c",
+  "fetcher": "git",
+  "url": "https://codeberg.org/acdw/titlecase.el",
   "unstable": {
    "version": [
-    20220510,
-    331
+    20220516,
+    1909
    ],
-   "commit": "8f609e46d4d0c06cd442352ca7d296e2ccb1b62a",
-   "sha256": "12ghq6zcv3ldcfr9c0zhlrq8kscf7fz2irpil7zq926alcqiqxkl"
+   "commit": "ca79d9b25e8bab5eef92b13dc69ac0c38ac39172",
+   "sha256": "179h6pzz2nw6b7zbp6w67xckhh12fibk02wh1jyv1i8nic32sfr1"
   },
   "stable": {
    "version": [
@@ -108474,16 +108703,16 @@
   "repo": "abrochard/emacs-todoist",
   "unstable": {
    "version": [
-    20220412,
-    2337
+    20220517,
+    1814
    ],
    "deps": [
     "dash",
     "org",
     "transient"
    ],
-   "commit": "f6906be346073f082a6d1f9ae14932ec2bfd99f5",
-   "sha256": "0iwsic69cffwiy63dhxmypy89zvadrr82pjcn228ipdnimkgd11p"
+   "commit": "f9ec1e730705f1fc8888f11a2b4ef1a4907e2f0b",
+   "sha256": "0kay18q6nr8skib17hx2sswcxdzgp00wf23avnnqacy90x540pv8"
   }
  },
  {
@@ -108548,8 +108777,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "09166f32d3ece2b297da036f0abbeba63329580e",
-   "sha256": "09j3mxa0803piywmfkvxg0jpgbx6qbvibsik8wsms898bg5n3s4d"
+   "commit": "7725c08f00a463ba7210efcb759c934223c85b00",
+   "sha256": "1dqascm5ds9jzp4m4hdb4l9wwfcnkc1ba3y4m24ybx43gjj38sxn"
   }
  },
  {
@@ -108605,11 +108834,11 @@
   "repo": "topikettunen/tok-theme",
   "unstable": {
    "version": [
-    20220509,
-    1324
+    20220601,
+    708
    ],
-   "commit": "a1a224d96665ee14c059eed63dc4b458f6b7a8d8",
-   "sha256": "0amcvd7x1llfjk2a78rkgia6n7vmrpqnh4xq28aczsi1z6khnkvz"
+   "commit": "3e7e946f0e474fa2d2a5bbdddf7f168e6ed759ba",
+   "sha256": "0jd54rxrc3b26z3d9p4d8bg9dxs5p20s5qkc0h3vfbwfhcjj2vwf"
   }
  },
  {
@@ -108626,8 +108855,8 @@
    "deps": [
     "magit-section"
    ],
-   "commit": "181021cd881eecd604a546d4a717866a81c7a511",
-   "sha256": "0gcjlcfxd4bg123gjf7d0vfvfd6zpd0da8svynglca1qhp77jkx1"
+   "commit": "08db7ef62b3bcab5e1e1abf0a427d478db04420b",
+   "sha256": "01zyk465w5j74jal1nqcn00ppn093mg227zj5glgx21qvym0lms2"
   },
   "stable": {
    "version": [
@@ -108658,8 +108887,8 @@
  },
  {
   "ename": "toml",
-  "commit": "bab369a63ca0e7fcfacfcb9ac3847ac4e631b28c",
-  "sha256": "0kqv6zkywa7kqh8kg1dzcgkbi91lwx335przdakndm1lfai38i9b",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0f081wsvnycbqxpxz61figphw3sn5pg05lxr0vwvzypdkrvwb8xv",
   "fetcher": "github",
   "repo": "gongo/emacs-toml",
   "unstable": {
@@ -108739,20 +108968,20 @@
   "repo": "trevorpogue/topspace",
   "unstable": {
    "version": [
-    20220512,
-    2008
+    20220608,
+    1302
    ],
-   "commit": "86127bf20f241a3c421b13523f0de6590fe42055",
-   "sha256": "1ahi1kgfis3khbgr3ps9ms71nc4b10aydd97q9mpm6h5rxvl2iv8"
+   "commit": "6692cd1346ce0b0a1fbdcbfa496b49365bcd660b",
+   "sha256": "18lj15y63lx57vzximsa0f7rhbr4vr39abj0r4b7fl5ivs46k3gy"
   },
   "stable": {
    "version": [
     0,
-    2,
-    1
+    3,
+    0
    ],
-   "commit": "9760a3ab5ebcde43ab93246fd9cb93732c5d8647",
-   "sha256": "1xk4nyivzhlxigsxbxfhvf7zp8bwbmp5hkzcqnz8xg9b6zdn7lz8"
+   "commit": "6ed32d242666b4a38276de433aca9f6387dd867b",
+   "sha256": "1yxcig19wkr0592iips3bh7mj1g9yhv0v2yaw19jaxqg1rzg3hip"
   }
  },
  {
@@ -108934,32 +109163,32 @@
  },
  {
   "ename": "tr-ime",
-  "commit": "b7ea719d0923650050b252ec0ff6fc8bd7484e99",
-  "sha256": "0py1qq6wnyg3mn0smnrxijvx5spy92cgn0awa0svn375css79kbk",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "1ij930ixa6dcxwsgi4gjwrzrhldyqspqf12flma983ykhn3km39k",
   "fetcher": "github",
   "repo": "trueroad/tr-emacs-ime-module",
   "unstable": {
    "version": [
-    20211120,
-    718
+    20220604,
+    1107
    ],
    "deps": [
     "w32-ime"
    ],
-   "commit": "e6313639afb51d91efcc417bd0c81afd13bb079c",
-   "sha256": "0hcqpvvjndddwcg81c2xz3msjghilym5lvbayc6wj0hk47xs9ylc"
+   "commit": "87f0677220b755f947fe5f373b6a34e1afb82f3c",
+   "sha256": "1xvhagynkhx4l0smbg9lz1kas7y25jpg66m1q5b32z3aagm90sb1"
   },
   "stable": {
    "version": [
     0,
-    4,
-    1
+    5,
+    0
    ],
    "deps": [
     "w32-ime"
    ],
-   "commit": "5cb95d1fa59f46215d637916168a9eb1fc5e857f",
-   "sha256": "1xixsfzkv4hdirwm06d55dvdkfh2jvhpkl8r91a1xlqqg20f6rag"
+   "commit": "87f0677220b755f947fe5f373b6a34e1afb82f3c",
+   "sha256": "1xvhagynkhx4l0smbg9lz1kas7y25jpg66m1q5b32z3aagm90sb1"
   }
  },
  {
@@ -109015,8 +109244,8 @@
     20210713,
     1609
    ],
-   "commit": "710f057fedae6e9b820cce9336fef24b7d057e4c",
-   "sha256": "0lrxd4hanaxj85nafsc0wss677slmyaks3qb7a95mj7vic3ib937"
+   "commit": "41cdc116b09818d33f5cb0fc1d72c025c23aa2f1",
+   "sha256": "0hmclqaagnqvyvxb93vi1qdyvqm53hsyjyv1b4zh79hwzvn6s8g3"
   },
   "stable": {
    "version": [
@@ -109113,20 +109342,20 @@
  },
  {
   "ename": "transient",
-  "commit": "325cca8031b99c6abe2ee9858a6b547d1af0cdde",
-  "sha256": "1pq7pimnkx1j5mia4wjahn9bd4c0jzm98bhhr4am8j8pg2pym49s",
+  "commit": "af5c1593052d63146e850683c461a760ab166033",
+  "sha256": "11a2m4vdccn2yfn5aj2g5smiml69vidir9ss8c70pld17z1wzx07",
   "fetcher": "github",
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20220509,
-    1943
+    20220527,
+    2213
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6fc09a663e408ade0d1b88f47701c96a9b051e34",
-   "sha256": "0xihkzz94s84xkl60hi388lhcdiwnlyq2mpnnqn0vf54amjfdh7x"
+   "commit": "2e4426fe8161893382f09b3f4635e152ee02488e",
+   "sha256": "1ila9yn99vbbllmzn3ysfvwhavc930g9av6faqai8m4abs0j05k5"
   },
   "stable": {
    "version": [
@@ -109279,8 +109508,8 @@
     20200910,
     1636
    ],
-   "commit": "1e151e5fc841688f1c4d68e9acc0f7b410cd754c",
-   "sha256": "1x3xdv789b3j8zm1zpd8v1m0712p1z9xi553yspp714w30dzxrs5"
+   "commit": "4128b85b1ee075a55c88fd53d04823cb48a3cce6",
+   "sha256": "1b8df9bnsyx8gx70inp2waxi00n5bq7j0w7sgjp9bcz3514iwd76"
   },
   "stable": {
    "version": [
@@ -109423,8 +109652,8 @@
  },
  {
   "ename": "tree-sitter",
-  "commit": "f07a741d1a14f99a634041cc9b4c200e75461ae5",
-  "sha256": "0rnk77pk0rmfl9azag4l2q3x2f1achykxjdm0q7aj82rvf60f5mb",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0y02pqxwpz6q00n2d2m9xnry9ig7kp1f88lshs3crvm1bl7j8609",
   "fetcher": "github",
   "repo": "emacs-tree-sitter/elisp-tree-sitter",
   "unstable": {
@@ -109556,8 +109785,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20220511,
-    1852
+    20220601,
+    1749
    ],
    "deps": [
     "ace-window",
@@ -109569,8 +109798,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109606,8 +109835,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109637,8 +109866,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109667,8 +109896,8 @@
    "deps": [
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109698,8 +109927,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109731,8 +109960,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109764,8 +109993,8 @@
     "perspective",
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109796,8 +110025,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -109827,8 +110056,8 @@
     "dash",
     "treemacs"
    ],
-   "commit": "dca83bd42918b510173759df4cc8b3663d5d480d",
-   "sha256": "1cxz5kx9qiv0imlzsbwjkydks2xfrcdchcnia2hyxhjpldff5vnq"
+   "commit": "faa2d10b894df9df0b6789047ea7ae05434d3030",
+   "sha256": "0p0fj8d0cjpw4v2a4xhnf9x983h8xxfz7ardyc9g4qcm9ybs58xr"
   },
   "stable": {
    "version": [
@@ -110152,11 +110381,18 @@
  },
  {
   "ename": "ttl-mode",
-  "commit": "f91dc8c20b7b8a06cc2ee25b6f376aac3a6ad2c8",
-  "sha256": "07jryy2dws2q0v3184fzijx68gz65rv83csfwr5llm9ic6xmw5ky",
-  "error": "Not in archive",
+  "commit": "0575169e8fb9a2537582f5aa77fc9950f1f1384c",
+  "sha256": "1fi8xxzwz3h7kgn69h4p1wlvhvia0v8qqh7k64pgh44b2fq040p1",
   "fetcher": "github",
-  "repo": "nxg/ttl-mode"
+  "repo": "nxg/ttl-mode",
+  "unstable": {
+   "version": [
+    20170920,
+    1329
+   ],
+   "commit": "8aa647178942c9be58e5c9cea1e6ede30c8fd562",
+   "sha256": "0sy8v6m4769390mj8qws106m4vky0hkc3dqg5142icsqiybhmsw0"
+  }
  },
  {
   "ename": "tuareg",
@@ -110574,11 +110810,20 @@
   "repo": "md-arif-shaikh/tzc",
   "unstable": {
    "version": [
-    20220126,
-    604
+    20220513,
+    434
    ],
-   "commit": "3af821d2125a67786f93d50d532a71f681f381cc",
-   "sha256": "0zd0g5qdm4w0jj37n0ijcknz74xgb3f9s0w72qz8zapf5n8q9mbp"
+   "commit": "f4e2273b65ace1ea56c9824c3bdb97925c98c8ba",
+   "sha256": "0aij1425cwj7423nls1dywxsr2xvzbmz0y6b2rargicxl066swrf"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "f4e2273b65ace1ea56c9824c3bdb97925c98c8ba",
+   "sha256": "0aij1425cwj7423nls1dywxsr2xvzbmz0y6b2rargicxl066swrf"
   }
  },
  {
@@ -110852,8 +111097,8 @@
     20200719,
     618
    ],
-   "commit": "b7b5bffe242fd15b9eb8fe5cb7c9b45e474babbc",
-   "sha256": "0rbm3gq1b1w1f3gg7h9sncjp088dg7rd5vn3vakh140p289rwirx"
+   "commit": "1bba7a3d42885a7ce432ca18d3755c40f2af6d27",
+   "sha256": "0hql80w0zl87piwwp2q3ccl71vd3c064kppv9kdrz6lnh3amjh3k"
   },
   "stable": {
    "version": [
@@ -110947,8 +111192,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "ec95d5038425bca375865803701c971a9c748114",
-   "sha256": "0k6mrsbfhacz4ipcggb4x3gln8bqz2nxk8zapidz6vb11fgay8my"
+   "commit": "81350551de9cdc4a9a3e4f00ff5907714eef24dd",
+   "sha256": "0s95cskrkyrz60v7hvsf3s4nkil82xclmkphg1fax7xgf27vnc1l"
   },
   "stable": {
    "version": [
@@ -111275,20 +111520,20 @@
   "repo": "DamienCassou/unify-opening",
   "unstable": {
    "version": [
-    20171122,
-    2012
+    20220521,
+    911
    ],
-   "commit": "502469ddba6d8d52159f53976265f7d956b6b17c",
-   "sha256": "0mni9vnbs50wvgnwfjwgzlwfff38h3wbrpr20nv84dmfh8ac0v61"
+   "commit": "9d537094220f5ec329b196e269e18b45dbdd1fa2",
+   "sha256": "06awa2bmdpxxazy3j24pd11wqmym6p9xzd9dg407wg2v0n3x7im3"
   },
   "stable": {
    "version": [
     2,
-    1,
+    2,
     0
    ],
-   "commit": "502469ddba6d8d52159f53976265f7d956b6b17c",
-   "sha256": "0mni9vnbs50wvgnwfjwgzlwfff38h3wbrpr20nv84dmfh8ac0v61"
+   "commit": "4c6e3447e203a51af116a2117e88d41114950205",
+   "sha256": "0pmln3z3vz3qnxbv79n8lrk28k9759czz6wllk81m1np5k6yjhnj"
   }
  },
  {
@@ -111796,8 +112041,8 @@
     20220220,
     150
    ],
-   "commit": "0cb20745e3889f4eb8ea49c4a748f34f9ddf1fa6",
-   "sha256": "1840m49s0wnk376va05n2vq9877x3siri15da8z6mqrh02sj1fa9"
+   "commit": "4cc7a372f035674f4037a0051c125739bc2e3299",
+   "sha256": "0dpwsfg3nmr39vxidk2jlsd1f4dryalzcbh6fcszpmhijx2pk63p"
   },
   "stable": {
    "version": [
@@ -111932,8 +112177,8 @@
  },
  {
   "ename": "v-mode",
-  "commit": "247cab604cf0ef6078f5b0f5887526bcbbcefb70",
-  "sha256": "0jky9y06fqj06m4mg95h8k3h5fihf9j9qj4w3n836qg5lnb4ywga",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0a5arb0d6r868j4y83d4j8wi1vn5xfx5ccsp41ix5fz5ldpzpw1w",
   "fetcher": "github",
   "repo": "damon-kwok/v-mode",
   "unstable": {
@@ -112204,11 +112449,11 @@
   "repo": "venks1/emacs-fossil",
   "unstable": {
    "version": [
-    20210928,
-    737
+    20220607,
+    617
    ],
-   "commit": "7815c30d739a01e1100961abb3f2b93e0ea9920f",
-   "sha256": "0j33cmnl9ka2r7ahf84dkj6y2lf8m455986y7rms1d62ih9fq6ds"
+   "commit": "8ce6113aa272583130e5f929fefd67115c8f572a",
+   "sha256": "087na2g22dnyw52cwaxkzdgbl13p2ldvby7lmqg05bm02cmsv9c2"
   }
  },
  {
@@ -112243,26 +112488,26 @@
   "repo": "redguardtoo/vc-msg",
   "unstable": {
    "version": [
-    20211224,
-    1354
+    20220526,
+    1435
    ],
    "deps": [
     "popup"
    ],
-   "commit": "3ad560afc1e0610acd1ce4b9509aedae66276b91",
-   "sha256": "02lbjpfyy1hl6kdml9mm7m8aaawaphwqzk3cljw50a0z2m7xrk63"
+   "commit": "720c6f0e699f25463cd37642ee23adb4e23bc60b",
+   "sha256": "0pn4gpxzgxlz12h4yymqdfmvic51jc5s3b973wl3qjizv1j1062l"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "popup"
    ],
-   "commit": "6c94578b5c692ade27c8b34bf5d99333ee7b4680",
-   "sha256": "1p54m71ypvz7x5wyzv0lfrxfsx23ipmb4zkq6dm0ppgh9al9hd7k"
+   "commit": "720c6f0e699f25463cd37642ee23adb4e23bc60b",
+   "sha256": "0pn4gpxzgxlz12h4yymqdfmvic51jc5s3b973wl3qjizv1j1062l"
   }
  },
  {
@@ -112389,16 +112634,16 @@
   "repo": "justbur/emacs-vdiff-magit",
   "unstable": {
    "version": [
-    20210908,
-    135
+    20220518,
+    1948
    ],
    "deps": [
     "magit",
     "transient",
     "vdiff"
    ],
-   "commit": "d3a39c3f8cb7ad9a6a769ce45f633b613b067490",
-   "sha256": "0ci5zsmd4r7z8h7g19ddd29y09lja0ikkm9rp8d2whxi9fz37dha"
+   "commit": "413f32c9f7e66f8379c23b5ab6341695dbcc2f20",
+   "sha256": "1zr6j6lw0x5w06sjlx8vnrrp1kx87zhm505plkb31hspf0ggsqlq"
   },
   "stable": {
    "version": [
@@ -112638,8 +112883,8 @@
  },
  {
   "ename": "verona-mode",
-  "commit": "342867cf256c6e6c242387b6d8c439a7a90f17dc",
-  "sha256": "1w94hs8mkd6qfklgm7hxb8j7ykvif25czpha0yq7ghbfc0vb3595",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0qkrfgf9mpf3jphspzpw9sk3d0x9nfx1rcf7ff3s6m470vmg7xbr",
   "fetcher": "github",
   "repo": "damon-kwok/verona-mode",
   "unstable": {
@@ -113071,19 +113316,19 @@
   "url": "https://codeberg.org/joostkremers/visual-fill-column.git",
   "unstable": {
    "version": [
-    20220426,
-    2045
+    20220519,
+    1959
    ],
-   "commit": "cdfe574a51c4fc3519536fa3b169b01d5482d5df",
-   "sha256": "1gimqhpnagv675wsb1yr50wxf8fwxlviks515yhyxn65hgl2x4wn"
+   "commit": "453d698d7fc243a547665f8ba43c55eee574e0db",
+   "sha256": "168wiywaffhhn7j4nfbnq4lfxpxl0x17z9ckk3nwkpaz45d9a2q6"
   },
   "stable": {
    "version": [
     2,
-    4
+    5
    ],
-   "commit": "6fa9e7912af412533aec0da8b8f62c227f9f3f54",
-   "sha256": "1wfww6bqdphv871in80fc84ml8gkl04il6w51z2ycx99km8b723l"
+   "commit": "453d698d7fc243a547665f8ba43c55eee574e0db",
+   "sha256": "168wiywaffhhn7j4nfbnq4lfxpxl0x17z9ckk3nwkpaz45d9a2q6"
   }
  },
  {
@@ -113299,11 +113544,11 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20220414,
-    930
+    20220515,
+    714
    ],
-   "commit": "2801a2354d93920dcd12da3d1090954aec9f7402",
-   "sha256": "1w4fkb7yp8cmpyxqyghiz4rqkzajjh1nqf5wjnxhvjv0av1lddhn"
+   "commit": "29694e7951374a8711a0a84a6fd76c70946cc2cb",
+   "sha256": "1h37hrpiiarw8lhqqw92zkxqb4wyl488kw5l3hp7q36p3dxbs4g1"
   },
   "stable": {
    "version": [
@@ -113322,11 +113567,11 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20220414,
-    931
+    20220515,
+    714
    ],
-   "commit": "73e8431576e5b65c227dcf37c7d1a5c609221ac9",
-   "sha256": "0fxwcxdr7ssj7v5bsx42zinas6fp3iigdh98j1mqm54xm61a58jc"
+   "commit": "718c458901ec58db2844a2960ebe01581574efe4",
+   "sha256": "1fn1s34g3nys5z2rc1w1lm8879043afp9fz4i4zhxyl5dq4ly5jk"
   },
   "stable": {
    "version": [
@@ -113414,14 +113659,14 @@
   "repo": "jixiuf/vterm-toggle",
   "unstable": {
    "version": [
-    20220416,
-    1034
+    20220606,
+    1524
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "644e9df9f741c3338c248291799375a1778eb98b",
-   "sha256": "19c8z0nfhavimxr8nc5m67k8yxfzr7vaanjrxs3c6zip35nqrn8w"
+   "commit": "02519323aa0a2e6af641cd205b230f48a04a5ca3",
+   "sha256": "15na73bil1kfyg3915d1gm7lsl6k4p81x7ybwr79lx8qpw9rlqvg"
   }
  },
  {
@@ -113655,11 +113900,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20220508,
-    2259
+    20220606,
+    2300
    ],
-   "commit": "7baf17355289c29d18f993f383c5d6a187f33b35",
-   "sha256": "1a2m6jkvnv852q07wvi80nbm7437wnvdfdyiq4iffhffmz8c2mrr"
+   "commit": "45155e42ea10990295d47d5ee3cb29be16a1f9f6",
+   "sha256": "1cjz3sli309i2qrwxic63x1am4hpn8r9gwjnfjb62b954wdhhf97"
   }
  },
  {
@@ -113771,10 +114016,10 @@
  },
  {
   "ename": "walkclj",
-  "commit": "44472b35938fe70d4cb3d15397495fe321fcd464",
-  "sha256": "0m971dlazildhgj8jqg4x679i6s6p80mbpri7l24ynxk45wix22m",
+  "commit": "27981293c1787aa41ede18d529b9c2efa30b3608",
+  "sha256": "10d44mxk03dq0vvwy634ca6a15byf9gb5vljzrrqn3bhrh2am8q5",
   "fetcher": "github",
-  "repo": "plexus/walkclj",
+  "repo": "corgi-emacs/walkclj",
   "unstable": {
    "version": [
     20220422,
@@ -113872,15 +114117,11 @@
   "repo": "cmpitg/wand",
   "unstable": {
    "version": [
-    20210511,
-    725
+    20220519,
+    1214
    ],
-   "deps": [
-    "dash",
-    "s"
-   ],
-   "commit": "08c3d9156517a31dd98ea64bfc269fae730b643c",
-   "sha256": "18xgi1anficjl6cnhhv197zbrnb0p63pnj8gshvixb6fr4ybw8k0"
+   "commit": "e4afc0469c818e7ce73ef31c38d911477947d72e",
+   "sha256": "1gcmzqpv8s87s5md3nr2s0vvbp68c4na5zmmwc080x9nf8q3hnm4"
   }
  },
  {
@@ -114169,18 +114410,20 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20220319,
-    653
+    20220531,
+    615
    ],
-   "commit": "efa853e5cfff8e0bcacbda9d1c6696b33da91b03",
-   "sha256": "1hpdr9r1wvvh44iqkv1lcfnjlvn16yrsgdq2ald2p6sxh9hkvn66"
+   "commit": "cdbd74b5e71d78ca7cb0768771f38e7b764fa0ac",
+   "sha256": "0ghkdnq1iad2flz49fwjxxn9q1ryiwq65276axbx1j7572rxshwa"
   },
   "stable": {
    "version": [
-    17
+    17,
+    2,
+    1
    ],
-   "commit": "d115f8dc3052e5779938d782d9cdaa4533ef20ff",
-   "sha256": "0jr5a1nzp8nbdng0k2fcaymiiv9ngrbknbrqaswgqn3akvx793jk"
+   "commit": "8edf9048c326e8230c4245d8bf3461395b38af84",
+   "sha256": "0sd2ysysn8x4iwz2fhnvh8knr3pdqgkvhkhsl948smmfl0dwj42f"
   }
  },
  {
@@ -114376,15 +114619,15 @@
   "repo": "etu/webpaste.el",
   "unstable": {
    "version": [
-    20211211,
-    658
+    20220524,
+    1745
    ],
    "deps": [
     "cl-lib",
     "request"
    ],
-   "commit": "78272662e6992b8614e79a571ff2395fa9630357",
-   "sha256": "07hj9nr7x6c9w2dnvc58cfbprgp9cqzdxflp5qlpglzdw0bi9s3c"
+   "commit": "d96da58fe42988d5c433c71ee9f8e6fb75d595a9",
+   "sha256": "0h4cp334ga2vk89gmkhycqzakxsjldql98a687y57ixpq7ri8qsq"
   },
   "stable": {
    "version": [
@@ -114706,11 +114949,11 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20220419,
-    227
+    20220518,
+    1941
    ],
-   "commit": "129f4ebfc74f207ac82978f6d90d8b4bb1a55cf9",
-   "sha256": "065jfwnz9ymv5xiiyhnhsi5sm03ah5985hnm5psay6z9msskcnx8"
+   "commit": "1ab1d0cc88843c9a614ed3226c5a1070e32e4823",
+   "sha256": "0i4wxihcly3i8pgmw1gv7lriqcyis9q476akvwrdgjwxnn2gmk0w"
   },
   "stable": {
    "version": [
@@ -114845,8 +115088,8 @@
     20210510,
     533
    ],
-   "commit": "b2e35321f03914cae90be4f942d911b7e7175899",
-   "sha256": "14ralz7jn98ckcmwshq1yg35bpybjlfw04cxy9qcnk67sfnp3ggv"
+   "commit": "f60154a992ca4048c71e3815a628be2ec9185c79",
+   "sha256": "03jbi0xrc8zrb9hnynf5b98pmn5xkymcid55km0pxmimsnrl0hk3"
   },
   "stable": {
    "version": [
@@ -114941,11 +115184,11 @@
   "url": "https://codeberg.org/akib/emacs-why-this.git",
   "unstable": {
    "version": [
-    20220510,
-    1146
+    20220601,
+    1132
    ],
-   "commit": "71baf80f9ae7c1117f3b1bf531e23e43bf567424",
-   "sha256": "1cwasg2dyy86c3hh71xqqsl7wy5c6mf9mnaf251l5fa5895xhbff"
+   "commit": "0975f5b57ffc77bf4aa871aa313085b80c5e43cd",
+   "sha256": "1lilp6adi8k1f6ww02mzr729h22paz7daqvlych07qm7aznl37aq"
   }
  },
  {
@@ -115167,8 +115410,8 @@
  },
  {
   "ename": "window-layout",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "061mvxcj4mg2pmkln7nn6gyscs08aid4cfc6xck0x5gzr1snr639",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "1ypr77ygr4g47mykd7kgcyf30fjcb29bj14wjdklkjk08wjj09xg",
   "fetcher": "github",
   "repo": "kiwanami/emacs-window-layout",
   "unstable": {
@@ -115205,8 +115448,8 @@
  },
  {
   "ename": "window-numbering",
-  "commit": "ce1dc80f69894736b276885e4ec3ce571a8612c9",
-  "sha256": "0x3n0ni16q69lfpyjz61spqghmhvc3cwa4aj80ihii3pk80f769x",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "0d70c31rxnhxjkpcmjvwkyky1dpyv9ksmw9hx3jzgvxng60wi00g",
   "fetcher": "github",
   "repo": "nschum/window-numbering.el",
   "unstable": {
@@ -115432,11 +115675,11 @@
   "url": "https://hg.sr.ht/~arnebab/wisp",
   "unstable": {
    "version": [
-    20220208,
-    636
+    20220529,
+    1522
    ],
-   "commit": "d266109b95e73281ae3aa1ed9a023346b6d39d28",
-   "sha256": "0fr3p6cfqxxj01bix9aiglfb2ls2grr62l735wdkn2r7lfvf5hjx"
+   "commit": "1a01003d400db8a42838cabcb26c06d627246a17",
+   "sha256": "04sn6k7v8551lzxrbld59kzks55c96siwkr4v8l4havczz6yqcz7"
   }
  },
  {
@@ -115471,20 +115714,20 @@
  },
  {
   "ename": "with-editor",
-  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
-  "sha256": "1cyq6i54dhmj5pvdq475v39s82k2a0zg55zf7vz38n32cnasdhz1",
+  "commit": "af5c1593052d63146e850683c461a760ab166033",
+  "sha256": "1wsl1vwvywlc32r5pcc9jqd0pbzq1sn4fppxk3vwl0s5h40v8rnb",
   "fetcher": "github",
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20220506,
-    420
+    20220608,
+    1017
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4ab8c6148bb2698ff793d4a8acdbd8d0d642e133",
-   "sha256": "1mc0ayfhxl8jpdgw2p6prdi4m3ab3hh7hv0p0kyxmlc9m6f3ablc"
+   "commit": "cfcbc2731e402b9169c0dc03e89b5b57aa988502",
+   "sha256": "02kdsksjn76g4fcqxnidzdy1zql25650fpdjjsx2ccdnbyj9fqax"
   },
   "stable": {
    "version": [
@@ -115791,14 +116034,14 @@
   "url": "https://codeberg.org/martianh/wordreference.el",
   "unstable": {
    "version": [
-    20220504,
-    2021
+    20220601,
+    650
    ],
    "deps": [
     "s"
    ],
-   "commit": "785a5d3245efdc3f32ce61fad1c7596230682f3a",
-   "sha256": "0g23d58lm6fvk2v5z8zvn09c9q3nffdq6w4mdhygj2xc2l3c6rcp"
+   "commit": "f1f0354dee403b0ee9b2187bc346e9badff69ec3",
+   "sha256": "0yq5vrampjibn7p9ixx8fp0jzdhw4acr7i5jxjczypnhp96f6vk0"
   }
  },
  {
@@ -115910,11 +116153,11 @@
   "url": "https://codeberg.org/akib/emacs-workroom.git",
   "unstable": {
    "version": [
-    20220501,
-    1500
+    20220607,
+    1715
    ],
-   "commit": "001fe2777f49ac73b6ab24401094a1c3c5efc887",
-   "sha256": "0haj4w8xcpm1yb3anla4ql2zi339hs6bcznxzl7qla575ff5sivp"
+   "commit": "c38489669e8b0ddc7a6a13544a099fc51b65d388",
+   "sha256": "1jng8a0qwsdxghpisvibjgxd0yr7l4nn5gvv16fpm2vfqjgaglwh"
   }
  },
  {
@@ -116138,11 +116381,11 @@
   "repo": "redguardtoo/wucuo",
   "unstable": {
    "version": [
-    20211201,
-    1214
+    20220526,
+    1431
    ],
-   "commit": "09fc58a02621b6c9615f8289c457e30ca6f63bcb",
-   "sha256": "15jva7qp723fpwv6f24300h8knmxrlsjb2icg9rzr0994g9f36qs"
+   "commit": "fe5dfb4e4db38f9fc944509a687812b8f419b958",
+   "sha256": "05h5wxzwzl5almgsk2mjas8in7h5kfmb06r3lfrwgydwxl3wmqnl"
   },
   "stable": {
    "version": [
@@ -116229,14 +116472,14 @@
   "repo": "jobbflykt/x509-mode",
   "unstable": {
    "version": [
-    20210407,
-    627
+    20220607,
+    715
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "470769edba111aed8eabce58a3f2a02da0767624",
-   "sha256": "19xvfzmsnc271a2zhjbnspb269c5mnps4l94ifrdlqn7y886qr4r"
+   "commit": "2b44e4aec3a733bd22e00a56906eb5151f8b8d81",
+   "sha256": "01w6bddbrx0bh2dkrwd1p98hpnp0k6w5r7nb3p9l95gk8pvvmnby"
   }
  },
  {
@@ -116353,8 +116596,8 @@
  },
  {
   "ename": "xenops",
-  "commit": "605c8ca551d54c79246310bcee678cdd854548b0",
-  "sha256": "0l9pwjbdyfs2mkp2n9xg16pv02y063l92302fmi0h8rwra81xrvv",
+  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
+  "sha256": "0lhi2qv43lfbivr9rz77qhadjqjwk086qn2r8ib2vdp94frwnwgs",
   "fetcher": "github",
   "repo": "dandavison/xenops",
   "unstable": {
@@ -116676,17 +116919,17 @@
  },
  {
   "ename": "xref-rst",
-  "commit": "2f6748512dc546f84b13733086cefb158bc7787c",
-  "sha256": "0crzzalphr4865a78wih085ycscg78h288hlq0dh6qk50siaxk1m",
-  "fetcher": "gitlab",
-  "repo": "ideasman42/emacs-xref-rst",
+  "commit": "6a5393b31e8bd789e14b998d68c25221905617aa",
+  "sha256": "00fmff7ph9wca7yp2iv31cs73h4kmnfjay99y1sglp5248wwqlxc",
+  "fetcher": "git",
+  "url": "https://codeberg.org/ideasman42/emacs-xref-rst.git",
   "unstable": {
    "version": [
-    20220406,
-    2311
+    20220518,
+    1102
    ],
-   "commit": "7964709276ff033cd138efabfafb4f2179e75c22",
-   "sha256": "15sdarz7iqifk9jazgp8l4v8ni48jb6rrixzmf1h60d5r3rf0z68"
+   "commit": "bc76bc228d51f64a2e57be8f230cf8a7746ea54a",
+   "sha256": "1yrvymgqwxib93dd6q57p3glj8ll6385wbnpzf3q7pbmdiihi82y"
   }
  },
  {
@@ -116996,20 +117239,20 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20220311,
-    332
+    20220518,
+    1229
    ],
-   "commit": "34c300b08579b72c7c92aefee1f4b500913f0c85",
-   "sha256": "1lwhm3c7xmx1j9ggf9ka0whpm7g5p6b11gfv1bxkdx1j8ypvxn0m"
+   "commit": "adb3e52a214a5154267085639f95a3ffae1ec2d3",
+   "sha256": "0ziqjiszidr6kwnpwnzfsi1as0iawjvbg7nb9jhkbzvbal1mxh2s"
   },
   "stable": {
    "version": [
     0,
     3,
-    4
+    5
    ],
-   "commit": "84b88c9ed178af16da18b230c1f61c57cefedf28",
-   "sha256": "13fjxrr7iyfagbm21p5is5jw1zv56ns2mnac145v8lqli6mrr5gx"
+   "commit": "adb3e52a214a5154267085639f95a3ffae1ec2d3",
+   "sha256": "0ziqjiszidr6kwnpwnzfsi1as0iawjvbg7nb9jhkbzvbal1mxh2s"
   }
  },
  {
@@ -117242,8 +117485,8 @@
     20220212,
     1742
    ],
-   "commit": "25f6bf7415f6821a4097037a8decd03813d08722",
-   "sha256": "1dvrm7paaiy3f8mchhk2wxaaba3qzvl0hcld40k3miyjpdn2lfgs"
+   "commit": "48cad7618fece0d86023d0b1e0f1f0e37f63d2f5",
+   "sha256": "15hpv4sxmhq8g23my75kqzhkvqyanvna7knrsfgcdp0barx027wn"
   },
   "stable": {
    "version": [
@@ -117750,36 +117993,6 @@
   }
  },
  {
-  "ename": "zel",
-  "commit": "25b445a1dea5e8f1042bed6b5372471c25129fd8",
-  "sha256": "0fwc1fghsw2rg4fv10kgc9d6rhbq20xa9diqcvp1f1cqs12rfhpd",
-  "fetcher": "github",
-  "repo": "rudolfochrist/zel",
-  "unstable": {
-   "version": [
-    20171014,
-    832
-   ],
-   "deps": [
-    "frecency"
-   ],
-   "commit": "9dae2d212224d1deae1f62561fa8e4d689fd09f2",
-   "sha256": "1518wp3zjfdvzz5r22cjgn735c4yxr345qzj40b5agww4dsxmwmp"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    2
-   ],
-   "deps": [
-    "frecency"
-   ],
-   "commit": "1d938ac01a42e7a985a3f92f5e97bc09e057676e",
-   "sha256": "1hk84x4aqcfd3jggk9san1v4kr58v2zhikbv9sh3dcii6x5w2nv0"
-  }
- },
- {
   "ename": "zen-and-art-theme",
   "commit": "692cfa0e9edbc1b7114e2ae2f36bef34b20ad17c",
   "sha256": "0b2lflji955z90xl9iz2y1vm04yljghbw4948gh5vv5p7mwibgf2",
@@ -117826,11 +118039,11 @@
   "repo": "bbatsov/zenburn-emacs",
   "unstable": {
    "version": [
-    20220412,
-    2023
+    20220527,
+    1800
    ],
-   "commit": "89c0e39317850d5ccf14dcbbaff06b0a193454a6",
-   "sha256": "06f7jaglgrckfw36l2pb63y1qxn64svc7wa3c6np3hjpjs5y13f5"
+   "commit": "b600814c8ddfe8812582f4ba4b62db817d665860",
+   "sha256": "1d08g55z9m3cj3v9fvw647i6x7dz4g7z9c3y3yq35dlaz6rlsk0m"
   },
   "stable": {
    "version": [
@@ -118033,6 +118246,70 @@
   }
  },
  {
+  "ename": "zetteldesk",
+  "commit": "2d08d8964dbabc93de6a05ea29e9af3edfbe8957",
+  "sha256": "1kghvlbrqcg6fcq90igvjjy6zb544k1vkb0y82mf43n8zfsja12w",
+  "fetcher": "github",
+  "repo": "Vidianos-Giannitsis/zetteldesk.el",
+  "unstable": {
+   "version": [
+    20220528,
+    1904
+   ],
+   "deps": [
+    "org-roam"
+   ],
+   "commit": "177771d7e1eddf86e0b6f6e94332200cf26dedaa",
+   "sha256": "0zncqyzhmcvxprg4ba9wn6mgi35sih465r45bygcc97g19hlxy43"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "org-roam"
+   ],
+   "commit": "0237a5a0f9cc40dc543c9713c37bbb34d548de50",
+   "sha256": "1isqd3a0mkcfqqj386h3glmxq02323a1gdykf8wpsm67x8myjgij"
+  }
+ },
+ {
+  "ename": "zetteldesk-kb",
+  "commit": "6ade7599f12a93517f24f5871091fa74c6c2e387",
+  "sha256": "1mbvjn9hzdzq7bz39y0jyfxqa98zqh00npqrpli33xdjnrrlq6a4",
+  "fetcher": "github",
+  "repo": "Vidianos-Giannitsis/zetteldesk.el",
+  "unstable": {
+   "version": [
+    20220530,
+    2045
+   ],
+   "deps": [
+    "hydra",
+    "major-mode-hydra",
+    "zetteldesk"
+   ],
+   "commit": "177771d7e1eddf86e0b6f6e94332200cf26dedaa",
+   "sha256": "0zncqyzhmcvxprg4ba9wn6mgi35sih465r45bygcc97g19hlxy43"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "hydra",
+    "major-mode-hydra",
+    "zetteldesk"
+   ],
+   "commit": "0237a5a0f9cc40dc543c9713c37bbb34d548de50",
+   "sha256": "1isqd3a0mkcfqqj386h3glmxq02323a1gdykf8wpsm67x8myjgij"
+  }
+ },
+ {
   "ename": "zettelkasten",
   "commit": "ed12df24029a4154fe55588f3e8ca0670af3f5f3",
   "sha256": "07gbkpanzs4rk066gg3nm95mfv3ng1f0si17mv2qax2dfx5k0lzd",
@@ -118064,8 +118341,8 @@
  },
  {
   "ename": "zetz-mode",
-  "commit": "ad2add185cf31a92ca1fcd3a9efcbcdb0aa9e583",
-  "sha256": "0k30c0f2h96vvb8yacpg710gi64swwslm1gljpzcwxni5kdpqkzm",
+  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
+  "sha256": "121sjp8iy71mp2jm7h9fl05zmy32148y28q7v9l6hm6flz0wmi1j",
   "fetcher": "github",
   "repo": "damon-kwok/zetz-mode",
   "unstable": {
@@ -118102,11 +118379,11 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20211227,
-    1108
+    20220521,
+    1148
    ],
-   "commit": "aa20d630b8c413dab8d6bd120ec3ed5db5c9da70",
-   "sha256": "0d081n6244q4y2sbhdya87gacw742v5f62pfs7c3bwgq0pcng997"
+   "commit": "dbc648f5bca8f3b9ca2cc7827f326f5530115144",
+   "sha256": "0hwkkwhc5b2pzyqa2h0xw8wxijsrp1fk70fhyv8hx19shzlc4la3"
   }
  },
  {
@@ -118157,11 +118434,11 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20220509,
-    2156
+    20220604,
+    1536
    ],
-   "commit": "9a3ed5e743c38725e7d9a7e4eaecfe624654c68d",
-   "sha256": "1az7n1f0203kk7x50ljjz3dcirkbk0zxzc54b3xxv64sd806vfw6"
+   "commit": "2dee0650892494410c0e0a340c565b79606f53e4",
+   "sha256": "1bf19614bp7954j4d23d7mx30jshvb6dpd4cdpxkxil1h7dc7f5q"
   },
   "stable": {
    "version": [
@@ -118180,14 +118457,14 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20220509,
-    802
+    20220604,
+    1536
    ],
    "deps": [
     "zk"
    ],
-   "commit": "9a3ed5e743c38725e7d9a7e4eaecfe624654c68d",
-   "sha256": "1az7n1f0203kk7x50ljjz3dcirkbk0zxzc54b3xxv64sd806vfw6"
+   "commit": "2dee0650892494410c0e0a340c565b79606f53e4",
+   "sha256": "1bf19614bp7954j4d23d7mx30jshvb6dpd4cdpxkxil1h7dc7f5q"
   },
   "stable": {
    "version": [
@@ -118423,8 +118700,8 @@
     20201205,
     1038
    ],
-   "commit": "402f85f5d7d18e26289adcd452d42c73dc1df580",
-   "sha256": "1x7awisyb1vizpykmflvxw17x58xd2hj6dxq92xkpbswjj6fk238"
+   "commit": "9b052ac33d4eafe724d0e37d3376926deba91676",
+   "sha256": "1w59qa0xnnqc4pz6hfj3q9qq199ryyzd0nwwi84nyb48cpgbsyxh"
   },
   "stable": {
    "version": [
@@ -118591,8 +118868,8 @@
     20220302,
     522
    ],
-   "commit": "2133eb000b5239b08a1c2532629a19a19f8e6309",
-   "sha256": "15r4v3m9plygnkajaaf2y76a09am7r29d8h4yxh5fk7vb7cfyrw3"
+   "commit": "41c090402816b15eb226ff9368f0ca40c7244f92",
+   "sha256": "09hvl5ddggkgl4ckmnfhlwf2wwli1pw799sy5f5i6dr6r07mqi37"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
###### Description of changes

@AndersonTorres 

Thanks for your previous updates, let me help this time.

###### Things done



- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


