### PR TITLE
python3Packages.black: disable all tests on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -60,11 +60,9 @@ buildPythonPackage rec {
     # Fail on Hydra, see https://github.com/NixOS/nixpkgs/pull/130785
     "test_bpo_2142_workaround"
     "test_skip_magic_trailing_comma"
-  ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
-    # they exceed max open files on hydra builders
-    "test_blackd_supported_version"
-    "test_cors_headers_present"
   ];
+  # multiple tests exceed max open files on hydra builders
+  doCheck = !(stdenv.isLinux && stdenv.isAarch64);
 
   propagatedBuildInputs = [
     aiohttp


### PR DESCRIPTION
For now at least.  I'm tired of this channel-blocking chase:
https://github.com/NixOS/nixpkgs/pull/176991#issuecomment-1150736907