### PR TITLE
pkgs/stdenv/linux: add powerpc64 bootstrap files

### DIFF
--- a/pkgs/stdenv/linux/bootstrap-files/powerpc64.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/powerpc64.nix
@@ -1,0 +1,25 @@
+#
+# Files came from this Hydra build:
+#
+#   https://hydra.nixos.org/build/178153111
+#
+# Which used nixpkgs revision 7c7d71d90e7d715847809a65fa2463c668e58ab3
+# to instantiate:
+#
+#   /nix/store/2cvsxg39jq2j119cx349zybibv3p0ns9-stdenv-bootstrap-tools-powerpc64-unknown-linux-gnu.drv
+#
+# and then built:
+#
+#   /nix/store/c8c3qa2bpmi0j6zx8xg2ylz9q0wixq3z-stdenv-bootstrap-tools-powerpc64-unknown-linux-gnu
+#
+{
+  busybox = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/powerpc64/7c7d71d90e7d715847809a65fa2463c668e58ab3/busybox";
+    hash = "sha256-oxKpW9QJ4CjXdQWwYOKkCRgjhRj91+1GSHAf5uFX44Q=";
+    executable = true;
+  };
+  bootstrapTools = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/powerpc64/7c7d71d90e7d715847809a65fa2463c668e58ab3/bootstrap-tools.tar.xz";
+    hash = "sha256-GAvEC7Ow1FQKO3jLdf5nFXvJAvOqcM90kUEhHWJh+FY=";
+  };
+}

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -17,6 +17,7 @@
       aarch64-linux = import ./bootstrap-files/aarch64.nix;
       mipsel-linux = import ./bootstrap-files/loongson2f.nix;
       powerpc64le-linux = import ./bootstrap-files/powerpc64le.nix;
+      powerpc64-linux = import ./bootstrap-files/powerpc64.nix;
       riscv64-linux = import ./bootstrap-files/riscv64.nix;
     };
     musl = {


### PR DESCRIPTION
###### Description of changes

Adds powerpc64 bootstrap files to linux' stdenv, so that nixpkgs is usable from a powerpc64 machine, or using `emulatedSystems = [ "powerpc64-linux" ];`.

I'm not sure I got the hashes right the first time, so they might need to be updated the tarballs are uploaded. I'm not sure how to test it while we are missing the uploads.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] emulated system
  - [ ] native
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
