### PR TITLE
vinagre: pull fix pending upstream inclusiong for -fno-common toolcha…

### DIFF
--- a/pkgs/desktops/gnome/apps/vinagre/default.nix
+++ b/pkgs/desktops/gnome/apps/vinagre/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, gtk3, gnome, vte, libxml2, gtk-vnc, intltool
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, gtk3, gnome, vte, libxml2, gtk-vnc, intltool
 , libsecret, itstool, wrapGAppsHook, librsvg }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,16 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/vinagre/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "cd1cdbacca25c8d1debf847455155ee798c3e67a20903df8b228d4ece5505e82";
   };
+
+  patches = [
+    # Pull fix pending upstream inclusion for -fno-common toolchain support:
+    #   https://gitlab.gnome.org/GNOME/vinagre/-/merge_requests/8
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://gitlab.gnome.org/GNOME/vinagre/-/commit/c51662cf4338516773d64776c3c92796917ff2bd.diff";
+      sha256 = "0zn8cd93hjdz6rw2d7gfl1ghzkc9h0x40k9l0jx3n5qfwdq4sir8";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config intltool itstool wrapGAppsHook ];
   buildInputs = [


### PR DESCRIPTION
…in support

Without the change build fails on upstream gcc-10 as:

    ld: plugins/vnc/vinagre_vinagre-vinagre-vnc-tab.o:plugins/vnc/vinagre-vnc-connection.h:29:
      multiple definition of `scaling_command_line';
        vinagre/vinagre_vinagre-vinagre-reverse-vnc-listener.o:plugins/vnc/vinagre-vnc-connection.h:29: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
