### PR TITLE
treewide: remove references to nodejs-10_x

### DIFF
--- a/pkgs/applications/networking/cluster/spacegun/generate-dependencies.sh
+++ b/pkgs/applications/networking/cluster/spacegun/generate-dependencies.sh
@@ -6,7 +6,7 @@ curl https://raw.githubusercontent.com/dvallin/spacegun/f88cfd1cf653995a301ef4db
 curl https://raw.githubusercontent.com/dvallin/spacegun/f88cfd1cf653995a301ef4db4a1e387ef3ca01a1/package-lock.json -o package-lock.json
 
 node2nix \
-  --nodejs-10 \
+  --nodejs-12 \
   --node-env ../../../../development/node-packages/node-env.nix \
   --development \
   --input package.json \

--- a/pkgs/applications/networking/cluster/spacegun/node-composition.nix
+++ b/pkgs/applications/networking/cluster/spacegun/node-composition.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-10_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-12_x"}:
 
 let
   nodeEnv = import ../../../../development/node-packages/node-env.nix {

--- a/pkgs/misc/base16-builder/generate.sh
+++ b/pkgs/misc/base16-builder/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash -p nodePackages.node2nix
-exec node2nix --nodejs-10 \
+exec node2nix --nodejs-12 \
      --input node-packages.json \
      --output node-packages-generated.nix \
      --supplement-input supplement.json \

--- a/pkgs/misc/base16-builder/node-packages.nix
+++ b/pkgs/misc/base16-builder/node-packages.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-10_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-12_x"}:
 
 let
   globalBuildInputs = pkgs.lib.attrValues (import ./supplement.nix {

--- a/pkgs/servers/web-apps/cryptpad/generate.sh
+++ b/pkgs/servers/web-apps/cryptpad/generate.sh
@@ -6,7 +6,7 @@
 cryptpadSrc=$(nix eval '(import ../../../.. {}).cryptpad.src' --raw)
 echo "cryptpad src: $cryptpadSrc"
 
-nix-shell -I nixpkgs=../../../.. -p '(nodePackages.override { nodejs = nodejs-10_x; }).bower2nix' --run "bower2nix $cryptpadSrc/bower.json bower-packages.nix"
+nix-shell -I nixpkgs=../../../.. -p '(nodePackages.override { nodejs = nodejs-12_x; }).bower2nix' --run "bower2nix $cryptpadSrc/bower.json bower-packages.nix"
 
 
 set -euo pipefail

--- a/pkgs/tools/networking/airfield/deps.sh
+++ b/pkgs/tools/networking/airfield/deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash -p nodePackages.node2nix
 
-node2nix --nodejs-10 -i deps.json \
+node2nix --nodejs-12 -i deps.json \
   --no-copy-node-env \
   -e ../../../development/node-packages/node-env.nix -c node.nix

--- a/pkgs/tools/networking/airfield/node.nix
+++ b/pkgs/tools/networking/airfield/node.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-10_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-12_x"}:
 
 let
   nodeEnv = import ../../../development/node-packages/node-env.nix {


### PR DESCRIPTION


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
nodejs-10_x was dropped by https://github.com/NixOS/nixpkgs/pull/175637

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
