### PR TITLE
crackmapexec: init at 5.2.2

### DIFF
--- a/pkgs/development/python-modules/neo4j/default.nix
+++ b/pkgs/development/python-modules/neo4j/default.nix
@@ -6,7 +6,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "neo4j-driver";
+  pname = "neo4j";
   version = "4.4.4";
   format = "setuptools";
 
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     owner = "neo4j";
     repo = "neo4j-python-driver";
     rev = version;
-    sha256 = "sha256-Sd+ZeyJCzqGsBl3rdxfKPD0gYZ49qAfiRbuXaNGpj8M=";
+    hash = "sha256-Sd+ZeyJCzqGsBl3rdxfKPD0gYZ49qAfiRbuXaNGpj8M=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/psrpcore/default.nix
+++ b/pkgs/development/python-modules/psrpcore/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, xmldiff
+}:
+
+buildPythonPackage rec {
+  pname = "psrpcore";
+  version = "0.1.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "jborean93";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-f1NGE+wSgi8yqBicZZRfUqzinsqazuIaoAje2y+dK1w=";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    xmldiff
+  ];
+
+
+  pythonImportsCheck = [
+    "psrpcore"
+  ];
+
+  meta = with lib; {
+    description = "Library for the PowerShell Remoting Protocol (PSRP)";
+    homepage = "https://github.com/jborean93/psrpcore";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pypsrp/default.nix
+++ b/pkgs/development/python-modules/pypsrp/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, asyncssh
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, gssapi
+, httpcore
+, httpx
+, krb5
+, psrpcore
+, psutil
+, pyspnego
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+, requests
+, requests-credssp
+, xmldiff
+}:
+
+buildPythonPackage rec {
+  pname = "pypsrp";
+  version = "0.8.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "jborean93";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Pwfc9e39sYPdcHN1cZtxxGEglEYzPp4yOYLD5/4SSiU=";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    httpcore
+    httpx
+    psrpcore
+    pyspnego
+    requests
+  ];
+
+  checkInputs = [
+    pytest-mock
+    pytestCheckHook
+    pyyaml
+    xmldiff
+  ];
+
+  passthru.optional-dependencies = {
+    credssp = [
+      requests-credssp
+    ];
+    kerberos = [
+      # pyspnego[kerberos] will have those two dependencies
+      gssapi
+      krb5
+    ];
+    named_pipe = [
+      psutil
+    ];
+    ssh = [
+      asyncssh
+    ];
+  };
+
+  pythonImportsCheck = [
+    "pypsrp"
+  ];
+
+  meta = with lib; {
+    description = "PowerShell Remoting Protocol Client library";
+    homepage = "https://github.com/jborean93/pypsrp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pywerview/default.nix
+++ b/pkgs/development/python-modules/pywerview/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, fetchFromGitHub
+, gssapi
+, impacket
+, ldap3
+, lxml
+, pyasn1
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pywerview";
+  version = "0.4.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "the-useless-one";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-nrPhyBHW13dkXFC5YJfrkiztAxMw4KuEif0zCdjQEq0=";
+  };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    gssapi
+    impacket
+    ldap3
+    lxml
+    pyasn1
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  postPatch = ''
+    # https://github.com/the-useless-one/pywerview/pull/51
+    substituteInPlace setup.py \
+      --replace "bs4" "beautifulsoup4"
+  '';
+
+  pythonImportsCheck = [
+    "pywerview"
+  ];
+
+  meta = with lib; {
+    description = "Module for PowerSploit's PowerView support";
+    homepage = "https://github.com/the-useless-one/pywerview";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/requests-credssp/default.nix
+++ b/pkgs/development/python-modules/requests-credssp/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, gssapi
+, krb5
+, pyspnego
+, pytestCheckHook
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "requests-credssp";
+  version = "2.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "jborean93";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-HHLEmQ+mNjMjpR6J+emrKFM+2PiYq32o7Gnoo0gUrNA=";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    pyspnego
+    requests
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  passthru.optional-dependencies = {
+    kerberos = [
+      # pyspnego[kerberos] will have those two dependencies
+      gssapi
+      krb5
+    ];
+  };
+
+  pythonImportsCheck = [
+    "requests_credssp"
+  ];
+
+  meta = with lib; {
+    description = "HTTPS CredSSP authentication with the requests library";
+    homepage = "https://github.com/jborean93/requests-credssp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/crackmapexec/default.nix
+++ b/pkgs/tools/security/crackmapexec/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "crackmapexec";
+  version = "5.2.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "byt3bl33d3r";
+    repo = "CrackMapExec";
+    rev = "v${version}";
+    hash = "sha256-IgD8RjwVEoEXmnHU3DR3wzUdJDWIbFw9sES5qYg30a8=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    aioconsole
+    beautifulsoup4
+    dsinternals
+    impacket
+    lsassy
+    msgpack
+    neo4j
+    paramiko
+    pylnk3
+    pypsrp
+    pywerview
+    requests
+    requests_ntlm
+    termcolor
+    terminaltables
+    xmltodict
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/byt3bl33d3r/CrackMapExec/pull/580
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/byt3bl33d3r/CrackMapExec/commit/e5c6c2b5c7110035b34ea7a080defa6d42d21dd4.patch";
+      hash = "sha256-5SpoQD+uSYLM6Rdq0/NTbyEv4RsBUuawNNsknS71I9M=";
+    })
+  ];
+
+  pythonRelaxDeps = true;
+
+  pythonRemoveDeps = [
+    "bs4"
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "cme"
+  ];
+
+  meta = with lib; {
+    description = "Tool for pentesting networks";
+    homepage = "https://github.com/byt3bl33d3r/CrackMapExec";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+    mainProgram = "cme";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4979,6 +4979,8 @@ with pkgs;
 
   cpufetch = callPackage ../tools/misc/cpufetch { };
 
+  crackmapexec = callPackage ../tools/security/crackmapexec { };
+
   crackxls = callPackage ../tools/security/crackxls { };
 
   crd2pulumi = callPackage ../development/tools/crd2pulumi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6453,6 +6453,8 @@ in {
 
   pyprecice = callPackage ../development/python-modules/pyprecice { };
 
+  pypsrp = callPackage ../development/python-modules/pypsrp { };
+
   phpserialize = callPackage ../development/python-modules/phpserialize { };
 
   phx-class-registry = callPackage ../development/python-modules/phx-class-registry { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5729,7 +5729,7 @@ in {
 
   neo = callPackage ../development/python-modules/neo { };
 
-  neo4j-driver = callPackage ../development/python-modules/neo4j-driver { };
+  neo4j = callPackage ../development/python-modules/neo4j { };
 
   nessclient = callPackage ../development/python-modules/nessclient { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6445,11 +6445,13 @@ in {
 
   pencompy = callPackage ../development/python-modules/pencompy { };
 
+  phonopy = callPackage ../development/python-modules/phonopy { };
+
   pixcat = callPackage ../development/python-modules/pixcat { };
 
-  pyprecice = callPackage ../development/python-modules/pyprecice { };
+  psrpcore = callPackage ../development/python-modules/psrpcore { };
 
-  phonopy = callPackage ../development/python-modules/phonopy { };
+  pyprecice = callPackage ../development/python-modules/pyprecice { };
 
   phpserialize = callPackage ../development/python-modules/phpserialize { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9142,6 +9142,8 @@ in {
 
   requests-cache = callPackage ../development/python-modules/requests-cache { };
 
+  requests-credssp = callPackage ../development/python-modules/requests-credssp { };
+
   requests-hawk = callPackage ../development/python-modules/requests-hawk { };
 
   requests = callPackage ../development/python-modules/requests { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8885,6 +8885,8 @@ in {
 
   pywemo = callPackage ../development/python-modules/pywemo { };
 
+  pywerview = callPackage ../development/python-modules/pywerview { };
+
   pywick = callPackage ../development/python-modules/pywick { };
 
   pywilight = callPackage ../development/python-modules/pywilight { };


### PR DESCRIPTION
###### Description of changes
Tool for for pentesting networks

https://github.com/byt3bl33d3r/CrackMapExec

Related to https://github.com/NixOS/nixpkgs/issues/81418

This PR also includes the dependencies and fixed the name of `neo4j`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
