### PR TITLE
`flake.lib.nixosSystem`: Allow `nixpkgs.system` to be set modularly; improve error message

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,18 +20,20 @@
         nixos = import ./nixos/lib { lib = final; };
 
         nixosSystem = args:
-          import ./nixos/lib/eval-config.nix (args // {
-            modules = args.modules ++ [ {
-              system.nixos.versionSuffix =
-                ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
-              system.nixos.revision = final.mkIf (self ? rev) self.rev;
-            } ];
-          } // lib.optionalAttrs (! args?system) {
-            # Allow system to be set modularly in nixpkgs.system.
-            # We set it to null, to remove the "legacy" entrypoint's
-            # non-hermetic default.
-            system = null;
-          });
+          import ./nixos/lib/eval-config.nix (
+            args // {
+              modules = args.modules ++ [{
+                system.nixos.versionSuffix =
+                  ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
+                system.nixos.revision = final.mkIf (self ? rev) self.rev;
+              }];
+            } // lib.optionalAttrs (! args?system) {
+              # Allow system to be set modularly in nixpkgs.system.
+              # We set it to null, to remove the "legacy" entrypoint's
+              # non-hermetic default.
+              system = null;
+            }
+          );
       });
 
       checks.x86_64-linux.tarball = jobs.tarball;

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,11 @@
                 ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
               system.nixos.revision = final.mkIf (self ? rev) self.rev;
             } ];
+          } // lib.optionalAttrs (! args?system) {
+            # Allow system to be set modularly in nixpkgs.system.
+            # We set it to null, to remove the "legacy" entrypoint's
+            # non-hermetic default.
+            system = null;
           });
       });
 

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -9,7 +9,9 @@
 # expressions are ever made modular at the top level) can just use
 # types.submodule instead of using eval-config.nix
 evalConfigArgs@
-{ # !!! system can be set modularly, would be nice to remove
+{ # !!! system can be set modularly, would be nice to remove,
+  #     however, removing or changing this default is too much
+  #     of a breaking change. To set it modularly, pass `null`.
   system ? builtins.currentSystem
 , # !!! is this argument needed any more? The pkgs argument can
   # be set modularly anyway.
@@ -48,7 +50,7 @@ let
       # this.  Since the latter defaults to the former, the former should
       # default to the argument. That way this new default could propagate all
       # they way through, but has the last priority behind everything else.
-      nixpkgs.system = lib.mkDefault system;
+      nixpkgs.system = lib.mkIf (system != null) (lib.mkDefault system);
 
       _module.args.pkgs = lib.mkIf (pkgs_ != null) (lib.mkForce pkgs_);
     };

--- a/nixos/modules/services/misc/dysnomia.nix
+++ b/nixos/modules/services/misc/dysnomia.nix
@@ -186,7 +186,7 @@ in
 
     dysnomia.properties = {
       hostname = config.networking.hostName;
-      inherit (config.nixpkgs.localSystem) system;
+      inherit (pkgs.stdenv.hostPlatform) system;
 
       supportedTypes = [
         "echo"

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -132,7 +132,7 @@ let
 
       # If the host is 64-bit and the container is 32-bit, add a
       # --personality flag.
-      ${optionalString (config.nixpkgs.localSystem.system == "x86_64-linux") ''
+      ${optionalString (pkgs.stdenv.hostPlatform.system == "x86_64-linux") ''
         if [ "$(< ''${SYSTEM_PATH:-/nix/var/nix/profiles/per-container/$INSTANCE/system}/system)" = i686-linux ]; then
           extraFlags+=" --personality=x86"
         fi


### PR DESCRIPTION
###### Description of changes

Got a question today from someone who wanted to set `nixpkgs.system` modularly in a flake. They thought the `system` argument was the only way to set it, which it is not.

This is change is in line with the improvements that were intended for `eval-config.nix` but weren't implemented, presumably because of compatibility concerns.

Note that this is a simplification of the `nixosSystem` _interface_, relying on established options rather than repeating parameters for no good reason. The implementation could eventually be simplified too, by extracting a new entrypoint from `eval-config.nix`, similar to how `eval-config-minimal.nix` was extracted. I'm not doing that here because that would be a distraction.

The new error message when `system` is forgotten is:

```
nix-repl> (lib.nixosSystem { modules = [ { } ]; }).config.system.build.toplevel
error: The option nixpkgs.system has not been set. Please set it, or set nixpkgs.hostPlatform instead. Note that nixos-generate-config will set the latter for you in hardware-configuration.nix.
```

the old message was

```
error: attribute 'currentSystem' missing
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
