### PR TITLE
mmc-utils: 2021-05-11 -> unstable-2022-04-26

### DIFF
--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "2021-05-11";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/linux/kernel/git/cjb/mmc-utils.git";
+    url = "git://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git";
     rev = "43282e80e174cc73b09b81a4d17cb3a7b4dc5cfc";
     sha256 = "0l06ahmprqshh75pkdpagb8fgnp2bwn8q8hwp1yl3laww2ghm8i5";
   };
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Configure MMC storage devices from userspace";
-    homepage = "http://git.kernel.org/cgit/linux/kernel/git/cjb/mmc-utils.git/";
+    homepage = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/";
     license = licenses.gpl2;
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -1,12 +1,11 @@
-{ lib, stdenv, fetchgit }:
+{ lib, stdenv, fetchzip }:
 
 stdenv.mkDerivation {
   pname = "mmc-utils";
   version = "2021-05-11";
 
-  src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git";
-    rev = "43282e80e174cc73b09b81a4d17cb3a7b4dc5cfc";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-43282e80e174cc73b09b81a4d17cb3a7b4dc5cfc.tar.gz";
     sha256 = "0l06ahmprqshh75pkdpagb8fgnp2bwn8q8hwp1yl3laww2ghm8i5";
   };
 

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation {
     cp man/mmc.1 $out/share/man/man1/
   '';
 
+  enableParallelBuilding = true;
+
   passthru.updateScript = unstableGitUpdater {
     url = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git";
   };

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -10,10 +10,9 @@ stdenv.mkDerivation {
     sha256 = "D2QgntRsa6Y39nCkXQupXFbJR++JfBpMeEZE0Gv0btc=";
   };
 
-  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "prefix=$(out)" ];
 
-  installPhase = ''
-    make install prefix=$out
+  postInstall = ''
     mkdir -p $out/share/man/man1
     cp man/mmc.1 $out/share/man/man1/
   '';

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Configure MMC storage devices from userspace";
     homepage = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -1,12 +1,13 @@
-{ lib, stdenv, fetchzip }:
+{ lib, stdenv, fetchzip, unstableGitUpdater }:
 
 stdenv.mkDerivation {
   pname = "mmc-utils";
-  version = "2021-05-11";
+  version = "unstable-2022-04-26";
 
-  src = fetchzip {
-    url = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-43282e80e174cc73b09b81a4d17cb3a7b4dc5cfc.tar.gz";
-    sha256 = "0l06ahmprqshh75pkdpagb8fgnp2bwn8q8hwp1yl3laww2ghm8i5";
+  src = fetchzip rec {
+    url = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-${passthru.rev}.tar.gz";
+    passthru.rev = "b7e4d5a6ae9942d26a11de9b05ae7d52c0802802";
+    sha256 = "D2QgntRsa6Y39nCkXQupXFbJR++JfBpMeEZE0Gv0btc=";
   };
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
@@ -16,6 +17,10 @@ stdenv.mkDerivation {
     mkdir -p $out/share/man/man1
     cp man/mmc.1 $out/share/man/man1/
   '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git";
+  };
 
   meta = with lib; {
     description = "Configure MMC storage devices from userspace";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated the upstream to the non-personal git repo now also used by debian, as discussed in #176405.

Unfortunately I'm not able to test the execution of this package beyond the help message.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
