### PR TITLE
sheldon: init at 0.6.6

### DIFF
--- a/pkgs/tools/misc/sheldon/default.nix
+++ b/pkgs/tools/misc/sheldon/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchCrate
+, rustPlatform
+, pkg-config
+, openssl
+, installShellFiles
+, Security
+, curl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sheldon";
+  version = "0.6.6";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-NjNBTjSaFoh+DAJfcM4G3+Meih1czLxs/RMmMwrXqD4=";
+  };
+
+  cargoSha256 = "sha256-uRcaHuDLQm6OYqt01kLbW/mfZnL4HaDabaweaw1EOfs=";
+
+  buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin [ Security curl ];
+  nativeBuildInputs = [ installShellFiles pkg-config ];
+
+  # Needs network connection
+  checkFlags = [
+    "--skip cli::tests::raw_opt_help"
+    "--skip lock::tests::external_plugin_lock_git_with_matches"
+    "--skip lock::tests::external_plugin_lock_git_with_matches_error"
+    "--skip lock::tests::external_plugin_lock_git_with_matches_not_each"
+    "--skip lock::tests::external_plugin_lock_git_with_uses"
+    "--skip lock::tests::external_plugin_lock_remote"
+    "--skip lock::tests::git_checkout_resolve_branch"
+    "--skip lock::tests::git_checkout_resolve_rev"
+    "--skip lock::tests::git_checkout_resolve_tag"
+    "--skip lock::tests::locked_config_clean"
+    "--skip lock::tests::source_lock_git_and_reinstall"
+    "--skip lock::tests::source_lock_git_git_with_checkout"
+    "--skip lock::tests::source_lock_git_https_with_checkout"
+    "--skip lock::tests::source_lock_local"
+    "--skip lock::tests::source_lock_remote_and_reinstall"
+    "--skip lock::tests::source_lock_with_git"
+    "--skip lock::tests::source_lock_with_remote"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd sheldon \
+      --bash <($out/bin/sheldon completions --shell bash) \
+      --zsh <($out/bin/sheldon completions --shell zsh)
+  '';
+
+  meta = with lib; {
+    description = "A fast and configurable shell plugin manager";
+    homepage = "https://github.com/rossmacarthur/sheldon";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ seqizz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4222,6 +4222,8 @@ with pkgs;
 
   shab = callPackage ../tools/text/shab { };
 
+  sheldon = callPackage ../tools/misc/sheldon { };
+
   shell-hist = callPackage ../tools/misc/shell-hist { };
 
   shellhub-agent = callPackage ../applications/networking/shellhub-agent { };


### PR DESCRIPTION
###### Description of changes

A fast shell plugin manager, was not included in the tree yet.
I'm potato on rust builder but this looks OK-ish. Also I didn't test for darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
