### PR TITLE
python3Packages.schwifty: init at 2022.6.0

### DIFF
--- a/pkgs/development/python-modules/schwifty/default.nix
+++ b/pkgs/development/python-modules/schwifty/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, importlib-resources
+, importlib-metadata
+, iso3166
+, pycountry
+, pytestCheckHook
+, pytest-cov
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "schwifty";
+  version = "2022.6.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-MekF96K8IPjop5764Oq6ZcvKJOTc1Qg/gV5Dz2iacBk=";
+  };
+
+  propagatedBuildInputs = [
+    iso3166
+    pycountry
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-resources
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "schwifty"
+  ];
+
+  meta = with lib; {
+    description = "Validate/generate IBANs and BICs";
+    homepage = "https://github.com/mdomke/schwifty";
+    license = licenses.mit;
+    maintainers = with maintainers; [ milibopp ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9468,6 +9468,8 @@ in {
 
   schiene = callPackage ../development/python-modules/schiene { };
 
+  schwifty = callPackage ../development/python-modules/schwifty { };
+
   scikit-bio = callPackage ../development/python-modules/scikit-bio { };
 
   scikit-build = callPackage ../development/python-modules/scikit-build { };


### PR DESCRIPTION
###### Description of changes

added python3Packages.schwifty

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] ~Tested, as applicable:~ (not applicable)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] ~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~ (not applicable)
- [ ] ~Tested basic functionality of all binary files (usually in `./result/bin/`)~ (not applicable)
- [x] Tested import Python package and using basic features
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] ~(Package updates) Added a release notes entry if the change is major or breaking~ (not applicable)
  - [ ] `(Module updates) Added a release notes entry if the change is significant~ (not applicable)
  - [ ] ~(Module addition) Added a release notes entry if adding a new NixOS module~ (not applicable)
  - [ ] ~(Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes~ (not applicable)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).