### PR TITLE
kde/gear: 22.04.1 -> 22.04.2

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/22.04.1/src -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/release-service/22.04.2/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1859 +4,1859 @@
 
 {
   akonadi = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-22.04.1.tar.xz";
-      sha256 = "109r46dghfg84kcgq8h69m2pkd7abmq37ykgnpqynfzyrpkcvy6s";
-      name = "akonadi-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-22.04.2.tar.xz";
+      sha256 = "0r6d8isvfvci056myjiryk9c7fqllsb8pqh9nndxcb7g7ja010d3";
+      name = "akonadi-22.04.2.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-calendar-22.04.1.tar.xz";
-      sha256 = "1jqil45igxbii7warzil9r9lphd0vm23454zc9k0psl4zvwqd71m";
-      name = "akonadi-calendar-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-calendar-22.04.2.tar.xz";
+      sha256 = "1izcgd55slayzh82yck2c1mbhw3kf0m61gv7ff1mcf382d4wxyfr";
+      name = "akonadi-calendar-22.04.2.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-calendar-tools-22.04.1.tar.xz";
-      sha256 = "1sn0355mkd8cl58nm6aspjb9jzngp7cxgj3jypyvwriv3fcm3ixj";
-      name = "akonadi-calendar-tools-22.04.1.tar.xz";
-    };
-  };
-  akonadi-contacts = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-contacts-22.04.1.tar.xz";
-      sha256 = "03ir95sghhvfxcsaz2v4wp06461xdr85iidgvpp9glfhp45cdwnd";
-      name = "akonadi-contacts-22.04.1.tar.xz";
-    };
-  };
-  akonadi-import-wizard = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-import-wizard-22.04.1.tar.xz";
-      sha256 = "0qgpzz855gfvsq30m3rw935pixpc8b732lsbzjykw6pnl73yji3j";
-      name = "akonadi-import-wizard-22.04.1.tar.xz";
-    };
-  };
-  akonadi-mime = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-mime-22.04.1.tar.xz";
-      sha256 = "03kx6j48rmsz0gy7w1fhs6g0xb8difd753kyv9a2di1ijkqhhn3g";
-      name = "akonadi-mime-22.04.1.tar.xz";
-    };
-  };
-  akonadi-notes = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-notes-22.04.1.tar.xz";
-      sha256 = "119s7vgl8s9ik2fabky6xwq6gvj2xdq2ii0h1j6vx2x98mwwcqsk";
-      name = "akonadi-notes-22.04.1.tar.xz";
-    };
-  };
-  akonadi-search = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadi-search-22.04.1.tar.xz";
-      sha256 = "0arymd5islkmiarxppg3d4fwfrb13fzrj8dpzv7y9llgmngcn7kk";
-      name = "akonadi-search-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-calendar-tools-22.04.2.tar.xz";
+      sha256 = "154r0rkm22d0zaybzz5xd60cckm6kalvgr7i8bn8ic3rr18ap7c6";
+      name = "akonadi-calendar-tools-22.04.2.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akonadiconsole-22.04.1.tar.xz";
-      sha256 = "1yji38rzjn3pr9b1gqbx0jq8k6iiqsi6cwpzk0ak9qp02z8h7bx9";
-      name = "akonadiconsole-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadiconsole-22.04.2.tar.xz";
+      sha256 = "19iq0qqf8y06l3nbl4q0i1065kywbyixsrdaj5zk1xrwzp824zcr";
+      name = "akonadiconsole-22.04.2.tar.xz";
+    };
+  };
+  akonadi-contacts = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-contacts-22.04.2.tar.xz";
+      sha256 = "0d2h202d6wfm0fcsqibbiibzw5qylik9fwf3xdv739hjkmbfg4ky";
+      name = "akonadi-contacts-22.04.2.tar.xz";
+    };
+  };
+  akonadi-import-wizard = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-import-wizard-22.04.2.tar.xz";
+      sha256 = "0xjk95wdb5mbzr04g79xkklhynra5wgyqwd8v8a383sqzk7hp70l";
+      name = "akonadi-import-wizard-22.04.2.tar.xz";
+    };
+  };
+  akonadi-mime = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-mime-22.04.2.tar.xz";
+      sha256 = "09jjgjw5zak5kshzas6d3zg6msq006gwvks5a1mxkg9ssclq8zlj";
+      name = "akonadi-mime-22.04.2.tar.xz";
+    };
+  };
+  akonadi-notes = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-notes-22.04.2.tar.xz";
+      sha256 = "1wm7zjv66vlm562ihvxycngmvngja8jgx76fjnhch0vfcm1j5328";
+      name = "akonadi-notes-22.04.2.tar.xz";
+    };
+  };
+  akonadi-search = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/akonadi-search-22.04.2.tar.xz";
+      sha256 = "0jmh2sglr590z29ppq1zrp07nwvaim9kyi3jwp1h3ckxscs236fq";
+      name = "akonadi-search-22.04.2.tar.xz";
     };
   };
   akregator = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/akregator-22.04.1.tar.xz";
-      sha256 = "18anzq4wcimgqizshb6i3cd18ydsls0i88pbgzc92rajqvv8m7z2";
-      name = "akregator-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/akregator-22.04.2.tar.xz";
+      sha256 = "12rp09d5xfs9xfc3giknywsd3pi9kc36fsx15470aszvp4c3pcnr";
+      name = "akregator-22.04.2.tar.xz";
     };
   };
   analitza = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/analitza-22.04.1.tar.xz";
-      sha256 = "0a0xzxfqxpriq1ak8qfi2f93f4ilfdp3z4v9ivl468fssmxg2x3j";
-      name = "analitza-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/analitza-22.04.2.tar.xz";
+      sha256 = "0sgcyxp047jm6ppyhnwk4inm3kz70cyjqgwdrmri44g5qligwg6q";
+      name = "analitza-22.04.2.tar.xz";
     };
   };
   ark = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ark-22.04.1.tar.xz";
-      sha256 = "1ikdwr803f55fgymp27zpwwfxzsjf79angzm84ysy2mv3l4cnpkn";
-      name = "ark-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ark-22.04.2.tar.xz";
+      sha256 = "0sgv5l1fmdr4g5dw1r4f0qjd3sbqfqvrwidm3nznrxz2idrb99n4";
+      name = "ark-22.04.2.tar.xz";
     };
   };
   artikulate = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/artikulate-22.04.1.tar.xz";
-      sha256 = "176qjgwwh9xalwddjlfn39hkymjajbabzhgzrrrzjpw30zz6nplc";
-      name = "artikulate-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/artikulate-22.04.2.tar.xz";
+      sha256 = "055vp3b0mi9nw8csc3f6iifnf0g7y2mmfqix9rq9ri02sx0b8j2i";
+      name = "artikulate-22.04.2.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/audiocd-kio-22.04.1.tar.xz";
-      sha256 = "1mannh6f79q4i6lpyf1dqvc9ra4hdrk7md40m8jj718v834svrql";
-      name = "audiocd-kio-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/audiocd-kio-22.04.2.tar.xz";
+      sha256 = "0x48k0ccacs47c3mdb5r7956dyi2c2nyqr4kkv20gm3rbbmzhmsd";
+      name = "audiocd-kio-22.04.2.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/baloo-widgets-22.04.1.tar.xz";
-      sha256 = "1bkkdqnl3zdwijn05cmnbf77hc1y9zx7h5r24y9197sg2b0241v8";
-      name = "baloo-widgets-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/baloo-widgets-22.04.2.tar.xz";
+      sha256 = "0c6c4947zgx4ajhvb1m3c6blyv1aajqdymh14dpj59ry9gqnmzcn";
+      name = "baloo-widgets-22.04.2.tar.xz";
     };
   };
   blinken = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/blinken-22.04.1.tar.xz";
-      sha256 = "162cbivfbxi8792l2m2ipm0g67v2khfgxb481fccgraq3690ib2m";
-      name = "blinken-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/blinken-22.04.2.tar.xz";
+      sha256 = "1yfh66354cxhkmqshbsl2d6kiwkx53x18h5wgndrfxwfv5nfkzly";
+      name = "blinken-22.04.2.tar.xz";
     };
   };
   bomber = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/bomber-22.04.1.tar.xz";
-      sha256 = "04siq2vcicm88p31v3hlqrsyxjbvvbayr03zf5kgn08kr3dr24y9";
-      name = "bomber-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/bomber-22.04.2.tar.xz";
+      sha256 = "07cvnpifg4z4bjf81hvngv6zp54q08jk5phgpj9fxg95z32khydv";
+      name = "bomber-22.04.2.tar.xz";
     };
   };
   bovo = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/bovo-22.04.1.tar.xz";
-      sha256 = "0xbfnhvkfyy0pi1d0df02yx91551hcw5vf8mrm163abd4mjpmzls";
-      name = "bovo-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/bovo-22.04.2.tar.xz";
+      sha256 = "0ms0b91gl6wrpvw0pxhmqnnm0ff2y0jyy48rg47bxg5rk31ri0yd";
+      name = "bovo-22.04.2.tar.xz";
     };
   };
   calendarsupport = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/calendarsupport-22.04.1.tar.xz";
-      sha256 = "1axfhc09shmmmwgx1n2ilz7k0sakhlx6d9jvxhr2p29s5jsrbcqh";
-      name = "calendarsupport-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/calendarsupport-22.04.2.tar.xz";
+      sha256 = "1d83aacsr40yyhich0f2n1yb9ij0xf2lgg2zm8yhy5pdg1j9xbfv";
+      name = "calendarsupport-22.04.2.tar.xz";
     };
   };
   cantor = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/cantor-22.04.1.tar.xz";
-      sha256 = "1lc3nnpg601mx2km62s3jwnyhngv0w4brgrylx4q3v4g2h0czbjc";
-      name = "cantor-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/cantor-22.04.2.tar.xz";
+      sha256 = "1j0ywikjml4wv03yw2dbgmqy4y7f0z0f80h7f3mg60kgs7m9icsn";
+      name = "cantor-22.04.2.tar.xz";
     };
   };
   cervisia = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/cervisia-22.04.1.tar.xz";
-      sha256 = "0dr77221ayhb0ihhjgm8rbcsmni8l12hyvp5w0dcd4p58xabnd2w";
-      name = "cervisia-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/cervisia-22.04.2.tar.xz";
+      sha256 = "1gcf8q0qa578g7lnsvj1n7y9js1j9vwp58vql8q1srgi13gw6v5q";
+      name = "cervisia-22.04.2.tar.xz";
     };
   };
   dolphin = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/dolphin-22.04.1.tar.xz";
-      sha256 = "0ywsjz6jqcwr8i5zafiaxlg7855vyf0cm77936li4ggw3z11mxcw";
-      name = "dolphin-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/dolphin-22.04.2.tar.xz";
+      sha256 = "0iyib0z8912pcc38rylv8f6n9la1ysr7jb677m7j4apldz0w9qy2";
+      name = "dolphin-22.04.2.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/dolphin-plugins-22.04.1.tar.xz";
-      sha256 = "1zxh4aqi3mk9wafgslchm0jvcacva405jxf5l8hffkr2llchn8l1";
-      name = "dolphin-plugins-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/dolphin-plugins-22.04.2.tar.xz";
+      sha256 = "0a7gz2nx2dzkrhss3pl5y9hxcq1nsxwavkffxf49yfxmxwv5wsmf";
+      name = "dolphin-plugins-22.04.2.tar.xz";
     };
   };
   dragon = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/dragon-22.04.1.tar.xz";
-      sha256 = "0nq3m5y6yawb5z036gqmqajvsk52yy5pisblkyjnj1a8i0mlkg9p";
-      name = "dragon-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/dragon-22.04.2.tar.xz";
+      sha256 = "0hl12i73vqqcic01j0imgsda70pii7dnd5jv32h7vxabwaj0a28k";
+      name = "dragon-22.04.2.tar.xz";
     };
   };
   elisa = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/elisa-22.04.1.tar.xz";
-      sha256 = "01ay2nz08943iaja8ns3p8gkjbi4hqn632gw30la9kccjgnskgkp";
-      name = "elisa-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/elisa-22.04.2.tar.xz";
+      sha256 = "0dh0hm9x39agsqkh57wf5cynmdf5lh0g1fd83qnjqaq2fyh4vi6v";
+      name = "elisa-22.04.2.tar.xz";
     };
   };
   eventviews = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/eventviews-22.04.1.tar.xz";
-      sha256 = "0j3f1y7wnw1y0c6wxbm5cx298afngzppn2rz6vynslz3pb11825d";
-      name = "eventviews-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/eventviews-22.04.2.tar.xz";
+      sha256 = "13npqh0bdv0xm00jqwkhd79g6b80kq72jnhd280h6fsws97xcvmk";
+      name = "eventviews-22.04.2.tar.xz";
     };
   };
   falkon = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/falkon-22.04.1.tar.xz";
-      sha256 = "09623p10n92fjk5i4kzpjnd5vjxng2m8z7vbz7n0snly8h67i6bl";
-      name = "falkon-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/falkon-22.04.2.tar.xz";
+      sha256 = "1rh3sa09sqal7v3m2m0vk14izn0vr4hkyyvz1712kjzg4qildxhk";
+      name = "falkon-22.04.2.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ffmpegthumbs-22.04.1.tar.xz";
-      sha256 = "0xbqkly4bpzx0ign1diz2z0gqn05dp6pgzn6z1wfxxp8rpf7nbwc";
-      name = "ffmpegthumbs-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ffmpegthumbs-22.04.2.tar.xz";
+      sha256 = "0pb4ak6kn13l4nmk8ixinhq5cx7v05c3pl1ss03n6smik2x30sz4";
+      name = "ffmpegthumbs-22.04.2.tar.xz";
     };
   };
   filelight = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/filelight-22.04.1.tar.xz";
-      sha256 = "06zrfa8r17sf326msnbqgzyazdijxvxd4plbwdkl6iyvybvswfdn";
-      name = "filelight-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/filelight-22.04.2.tar.xz";
+      sha256 = "093n6r2rdv5igyfpimfn4m4sqk3d703sx23axlzn6jhg5d186r83";
+      name = "filelight-22.04.2.tar.xz";
     };
   };
   granatier = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/granatier-22.04.1.tar.xz";
-      sha256 = "01czy1a4jiwcj7ngajqb6kf47d1dhxrzjk58l9w1npnl4zgjcbqd";
-      name = "granatier-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/granatier-22.04.2.tar.xz";
+      sha256 = "0xkabkb5d2hb24mvqa9q9m1p37hciw234c5fwy8zxaxszz2j5m86";
+      name = "granatier-22.04.2.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/grantlee-editor-22.04.1.tar.xz";
-      sha256 = "0yis7cd7x4z1hn3q3wwkhqjzlfm6l43fkcj218yayb7pdqxa9q44";
-      name = "grantlee-editor-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/grantlee-editor-22.04.2.tar.xz";
+      sha256 = "0gr672g2q909ncacx51cdvg6p7n3d1lz0by80cm8acx088l56np0";
+      name = "grantlee-editor-22.04.2.tar.xz";
     };
   };
   grantleetheme = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/grantleetheme-22.04.1.tar.xz";
-      sha256 = "0aks9sb4ywk461wqa2yhs0nc0h0i8v30rckx44s0f29v18z50ckm";
-      name = "grantleetheme-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/grantleetheme-22.04.2.tar.xz";
+      sha256 = "1gj6lfiiizv00z4mrnfhivihsd5hfdmzdrly17a2hgcddf006md4";
+      name = "grantleetheme-22.04.2.tar.xz";
     };
   };
   gwenview = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/gwenview-22.04.1.tar.xz";
-      sha256 = "0jncx7avdfqdv0x0r0s85h1lxxhc0ni14ia37y5vmqn7nxp8z6pr";
-      name = "gwenview-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/gwenview-22.04.2.tar.xz";
+      sha256 = "11s34kzsp26m1amyxmqviy2qga98h4sj9100asrdchq86j0wxvl4";
+      name = "gwenview-22.04.2.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/incidenceeditor-22.04.1.tar.xz";
-      sha256 = "0h33jgrlvdsa4d2p905hl2spg7j265mn79l02rg21258r8r56bc3";
-      name = "incidenceeditor-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/incidenceeditor-22.04.2.tar.xz";
+      sha256 = "0z5hrk1jysjc5x704sy60b353p2cxqcfgbcjky6srkxs24fc5s2a";
+      name = "incidenceeditor-22.04.2.tar.xz";
     };
   };
   itinerary = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/itinerary-22.04.1.tar.xz";
-      sha256 = "09h0m9g7mmy1qap8k00fx3y63lqa641cwpi7dak91jh57crialcy";
-      name = "itinerary-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/itinerary-22.04.2.tar.xz";
+      sha256 = "1r9isr0i08yrl6x42388ycs1mdy447cvx6sa2igc38h0f2cs533d";
+      name = "itinerary-22.04.2.tar.xz";
     };
   };
   juk = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/juk-22.04.1.tar.xz";
-      sha256 = "1c9cigd72qzmaann85i0kfxivkbdqy1lwcrf2mlrb6ycvbzfmbm0";
-      name = "juk-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/juk-22.04.2.tar.xz";
+      sha256 = "11l2q8gdj2z9wxj7z9fb194aw293ip1pxav487910clfgv0q6hvf";
+      name = "juk-22.04.2.tar.xz";
     };
   };
   k3b = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/k3b-22.04.1.tar.xz";
-      sha256 = "1yslsf736nlkxra8ial067a69mzlfb5zdyakcjg7nmkxbklkg46p";
-      name = "k3b-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/k3b-22.04.2.tar.xz";
+      sha256 = "1rbmaj4ini7gxsl16kx29wqg66wn44a9kwf6aa5pgq91a53h5999";
+      name = "k3b-22.04.2.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kaccounts-integration-22.04.1.tar.xz";
-      sha256 = "1yj4c4qgxk8r5salfwra8dqi418167zrcs8rnpnzlvrr3gqqvvbj";
-      name = "kaccounts-integration-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kaccounts-integration-22.04.2.tar.xz";
+      sha256 = "1s18bq77al8alwv4j9c9n48adfplbf9a1jn0xyncayz86x73c53a";
+      name = "kaccounts-integration-22.04.2.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kaccounts-providers-22.04.1.tar.xz";
-      sha256 = "0mphnjgyzdxlp5iig2hyfzvpykqf7bm6vn4ninnj5wcs91jkjlxq";
-      name = "kaccounts-providers-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kaccounts-providers-22.04.2.tar.xz";
+      sha256 = "18kyjg60zrr94c76jgnpkqfni9ybmx17g7cyrylsxzqc4gnacrqa";
+      name = "kaccounts-providers-22.04.2.tar.xz";
     };
   };
   kaddressbook = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kaddressbook-22.04.1.tar.xz";
-      sha256 = "1n76baf47ran2rdaz6i6b8c411zagqgzz89ap7v7x843vsv6g960";
-      name = "kaddressbook-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kaddressbook-22.04.2.tar.xz";
+      sha256 = "1kc1glax3hq73s9lvxh0dr1rl5zhggs053wc0s2w1ah7930xx5w0";
+      name = "kaddressbook-22.04.2.tar.xz";
     };
   };
   kajongg = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kajongg-22.04.1.tar.xz";
-      sha256 = "0pbym31l4gyzwi9qvhbwmkyrb7199vfn5mipc9fxkjsczsyp0cqg";
-      name = "kajongg-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kajongg-22.04.2.tar.xz";
+      sha256 = "169pavwsh3irb8k49qbf2l6yzk5vhczdlx0v80dsakxchj2c61d9";
+      name = "kajongg-22.04.2.tar.xz";
     };
   };
   kalarm = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kalarm-22.04.1.tar.xz";
-      sha256 = "04cg8ymgwx6ls62q87ma3658xswff3a4kbjbdh05vvipqpkhd0cm";
-      name = "kalarm-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kalarm-22.04.2.tar.xz";
+      sha256 = "08xxkb8cjspjdxlqf2476dm3q8wnjiw8idb4bibnq4hwwqk7cixd";
+      name = "kalarm-22.04.2.tar.xz";
     };
   };
   kalendar = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kalendar-22.04.1.tar.xz";
-      sha256 = "1vk1n6in42frx95mgcsz8qhrhbbg2vz0fwxf966xbsdjcrg6whsn";
-      name = "kalendar-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kalendar-22.04.2.tar.xz";
+      sha256 = "06z5j5p8awq30kvix7wzv2gc91gsy9i5sdkq7cnan22z621p1k95";
+      name = "kalendar-22.04.2.tar.xz";
     };
   };
   kalgebra = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kalgebra-22.04.1.tar.xz";
-      sha256 = "07cyknqhkyr4vsrv7bfl7aqflw079rb1rcqq2lm0k0pp4mi3z5m3";
-      name = "kalgebra-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kalgebra-22.04.2.tar.xz";
+      sha256 = "0cskrl3c3a1z26ykgsycx66yx45lrj96p4rcn2yskwyvkcqwa2lv";
+      name = "kalgebra-22.04.2.tar.xz";
     };
   };
   kalzium = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kalzium-22.04.1.tar.xz";
-      sha256 = "1fn8vn0phnaknd8yrzv75zdz3byq0rmdpb8blvp224nnlmf1733f";
-      name = "kalzium-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kalzium-22.04.2.tar.xz";
+      sha256 = "086f5w5idhs715hvb3fjpzv35y6qk3hxvazdpb3gdaikd9mxjc86";
+      name = "kalzium-22.04.2.tar.xz";
     };
   };
   kamera = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kamera-22.04.1.tar.xz";
-      sha256 = "0c1mb8phip67h9v2crmrv7lnb00ha257l27j6hhq0pi3mpy4jhsg";
-      name = "kamera-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kamera-22.04.2.tar.xz";
+      sha256 = "159lci4h52pdn2f5kwrydkxh3mzs6842pvczglc4g4jw08qrmakh";
+      name = "kamera-22.04.2.tar.xz";
     };
   };
   kamoso = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kamoso-22.04.1.tar.xz";
-      sha256 = "039x5nrrznhlw53v63n550wb9k7x4r5w2d45rc2inw140rj5i32v";
-      name = "kamoso-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kamoso-22.04.2.tar.xz";
+      sha256 = "0jb7y9mx3bwss5yfc1jwprca3g4awpfr4gxn1g0ykmham9xd6rmc";
+      name = "kamoso-22.04.2.tar.xz";
     };
   };
   kanagram = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kanagram-22.04.1.tar.xz";
-      sha256 = "0j0lg5yx8yid1anpvjvgy8p09b1nn8pcvd6w2rlrrxjwpybnx9jc";
-      name = "kanagram-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kanagram-22.04.2.tar.xz";
+      sha256 = "0r875gnrhc08nsz37apz84wvs9amqfapvxh0sdi9drqza9g9j6vq";
+      name = "kanagram-22.04.2.tar.xz";
     };
   };
   kapman = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kapman-22.04.1.tar.xz";
-      sha256 = "1a6mmzmaxmlkn9d14m06b5wzr9rbciskhb3bfdzjpk9gia6j22kk";
-      name = "kapman-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kapman-22.04.2.tar.xz";
+      sha256 = "0rv9vs432xwnypbm3vg8jgblww62a3q3ssyc0i76k4pibjsby74b";
+      name = "kapman-22.04.2.tar.xz";
     };
   };
   kapptemplate = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kapptemplate-22.04.1.tar.xz";
-      sha256 = "16q7pzd47aksbnnfa04cnjf6gbzhzfdmykn9cqwdb37689fs9lmf";
-      name = "kapptemplate-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kapptemplate-22.04.2.tar.xz";
+      sha256 = "12djljr9blcpans1ayknzjpczbz7nvs2vc9hx3br1yygn1fz2a2r";
+      name = "kapptemplate-22.04.2.tar.xz";
     };
   };
   kate = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kate-22.04.1.tar.xz";
-      sha256 = "0jcqa3c1z54k3sjqhz8f7rq3xygkxcqw9728rppk506zgqyw6vpl";
-      name = "kate-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kate-22.04.2.tar.xz";
+      sha256 = "1phpy4ganjnd8dky5q386gvr5axgzl13kb9ylx59328x76vcizkw";
+      name = "kate-22.04.2.tar.xz";
     };
   };
   katomic = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/katomic-22.04.1.tar.xz";
-      sha256 = "1858q8k6pzszrmgjqhp32kkqmax6nbfw04x5h1pjyxhvaxg3xr27";
-      name = "katomic-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/katomic-22.04.2.tar.xz";
+      sha256 = "0ynalhc0zrx4a861lj68n618ki5z2jakfss493pjl8yj7jqn4mci";
+      name = "katomic-22.04.2.tar.xz";
     };
   };
   kbackup = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kbackup-22.04.1.tar.xz";
-      sha256 = "1h84alirmrbn90l9zfzs1xj2nf5q5hzvy0rsbsrkhwcsw35q63z2";
-      name = "kbackup-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kbackup-22.04.2.tar.xz";
+      sha256 = "1qad8gcvi7pl05zp8xb15av84c4z21yw8x9wiccaqrdbb45phg58";
+      name = "kbackup-22.04.2.tar.xz";
     };
   };
   kblackbox = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kblackbox-22.04.1.tar.xz";
-      sha256 = "03gdwfwkzyzwh3qj6pjsd90df2knmaf6y6vgpzh92k4y1zq8n421";
-      name = "kblackbox-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kblackbox-22.04.2.tar.xz";
+      sha256 = "0qiv52970sw1myl09qzmlmb7l7714gyifbrricpgvsnn26niqz1w";
+      name = "kblackbox-22.04.2.tar.xz";
     };
   };
   kblocks = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kblocks-22.04.1.tar.xz";
-      sha256 = "1dglbppjfbdvnmpnk6cf01sp0vclnbxgvw6wnlmdp1vh00qgad3d";
-      name = "kblocks-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kblocks-22.04.2.tar.xz";
+      sha256 = "0ibxmpf4lqbg6nm2f3bqi2pz8czd3rpvyy51kag5skyqy06740v5";
+      name = "kblocks-22.04.2.tar.xz";
     };
   };
   kbounce = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kbounce-22.04.1.tar.xz";
-      sha256 = "1ci5i5d5dppw7xgma6hyrd5v93n1lc8n2bp36p0za1hak9kxisaa";
-      name = "kbounce-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kbounce-22.04.2.tar.xz";
+      sha256 = "11yhfxwxx44m28md32m57fi1l6jy5y18ix6zx95b96fgiv5xh6r5";
+      name = "kbounce-22.04.2.tar.xz";
     };
   };
   kbreakout = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kbreakout-22.04.1.tar.xz";
-      sha256 = "0fmk4nd8c5z8fy2pw88l9fpcv0a59gbcvvgh3v92cmdw0ml65wb0";
-      name = "kbreakout-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kbreakout-22.04.2.tar.xz";
+      sha256 = "0gnmbrksnagz6600fifinvf4qy9ws425s8nqp83258bbnha6bpx6";
+      name = "kbreakout-22.04.2.tar.xz";
     };
   };
   kbruch = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kbruch-22.04.1.tar.xz";
-      sha256 = "1zx0cwi8s83j9ix0vdnjxhrkw2pa85y6plpwzy12f2fbxkmzvg1h";
-      name = "kbruch-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kbruch-22.04.2.tar.xz";
+      sha256 = "170zzgfg26l4z4vl8djan2gqfc03w9fa92a2naxm4iv9shn2xigp";
+      name = "kbruch-22.04.2.tar.xz";
     };
   };
   kcachegrind = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kcachegrind-22.04.1.tar.xz";
-      sha256 = "0nvqly26w4wma68glfa6bil1jxh6hmd7mjvcr3s6fvzk4ky51was";
-      name = "kcachegrind-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kcachegrind-22.04.2.tar.xz";
+      sha256 = "1dj19290pzfi5ys01i4kgd32hqnyrb1y61xkrm7gqgd5dr6vr1fn";
+      name = "kcachegrind-22.04.2.tar.xz";
     };
   };
   kcalc = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kcalc-22.04.1.tar.xz";
-      sha256 = "09nfcmmh5bmjx2bkjw33s0a55lky8shkhrgq1q3fd18igw7xpcgl";
-      name = "kcalc-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kcalc-22.04.2.tar.xz";
+      sha256 = "1mw7ans14q1bhhsk563r28cb4bhj559ma3mkxh4573aj2rqf1j4g";
+      name = "kcalc-22.04.2.tar.xz";
     };
   };
   kcalutils = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kcalutils-22.04.1.tar.xz";
-      sha256 = "0vgwz3yinrf2wjwj5qfj22fn7hdl0q5lhzd7v4a903gj4cb27ayq";
-      name = "kcalutils-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kcalutils-22.04.2.tar.xz";
+      sha256 = "0h6n4k2v66b21ccq1hlv5vhan6xxgli19mr5l0j9zgsnpk4kvikv";
+      name = "kcalutils-22.04.2.tar.xz";
     };
   };
   kcharselect = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kcharselect-22.04.1.tar.xz";
-      sha256 = "0s4wfq808dsi3bjf4hq419b3ws0hsir79wgw9mbbry0s0c02nlk9";
-      name = "kcharselect-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kcharselect-22.04.2.tar.xz";
+      sha256 = "1jz3f86if4klsv6w7y9crn7zvzikg64qpdlr9ba8vyxay9lrhdhw";
+      name = "kcharselect-22.04.2.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kcolorchooser-22.04.1.tar.xz";
-      sha256 = "1s9j7r5rxq1zd8aaakxsw2p56rvykhnm80s5rk8krkp4gk58przr";
-      name = "kcolorchooser-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kcolorchooser-22.04.2.tar.xz";
+      sha256 = "17hfx219491s8fjx51mfm81bqlg4nbz91vpg51ygc8j6dsxnapr5";
+      name = "kcolorchooser-22.04.2.tar.xz";
     };
   };
   kcron = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kcron-22.04.1.tar.xz";
-      sha256 = "15g5k3z840zawhnksyzznw5w8ns3pp9vgdmz7pc2pir15mp763jm";
-      name = "kcron-22.04.1.tar.xz";
-    };
-  };
-  kde-dev-scripts = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kde-dev-scripts-22.04.1.tar.xz";
-      sha256 = "1s9cjyz2im8s6gpq1w0zqrfgf3cdw697s4z7srw50cg6aagks4x3";
-      name = "kde-dev-scripts-22.04.1.tar.xz";
-    };
-  };
-  kde-dev-utils = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kde-dev-utils-22.04.1.tar.xz";
-      sha256 = "1bi8i6pnx2yi786y78ad24f1yrb2vjd5ggrgaxislijs9qpdpbnr";
-      name = "kde-dev-utils-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kcron-22.04.2.tar.xz";
+      sha256 = "1k810ggrsqybbmxmbdqir7ya7sqa536di6z3ib5yqc3lbrigak4h";
+      name = "kcron-22.04.2.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdebugsettings-22.04.1.tar.xz";
-      sha256 = "14b0p0n14bivfr5nfjsyamx8jk2sbw283s04hrrxmv93b14068r7";
-      name = "kdebugsettings-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdebugsettings-22.04.2.tar.xz";
+      sha256 = "1i94rih9z927jn5mjjzzmsan8jsk715bgwnk65cg1mbgqnclvi5s";
+      name = "kdebugsettings-22.04.2.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdeconnect-kde-22.04.1.tar.xz";
-      sha256 = "0ym5n311iabrwal8w3yiq76g656rp1gz0yq9fdz61fl0pd4bmnbd";
-      name = "kdeconnect-kde-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdeconnect-kde-22.04.2.tar.xz";
+      sha256 = "0q12qai55383fa70kiliqq474y9hji2amm2gd8cdljl1wn7cp16w";
+      name = "kdeconnect-kde-22.04.2.tar.xz";
+    };
+  };
+  kde-dev-scripts = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/kde-dev-scripts-22.04.2.tar.xz";
+      sha256 = "1x25hidqs03ylbk9h5rq3jwp5ljh02ak0js97yy1y23qwvhqi9xj";
+      name = "kde-dev-scripts-22.04.2.tar.xz";
+    };
+  };
+  kde-dev-utils = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/kde-dev-utils-22.04.2.tar.xz";
+      sha256 = "0zqv0r5s24bb6cgg039dw1sl8vl4pgck5any0k08swb14zbpc63p";
+      name = "kde-dev-utils-22.04.2.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdeedu-data-22.04.1.tar.xz";
-      sha256 = "1lgcn4z4k2djzls35w33y5h7yjw2cs1028bxh0avlprh5ihi8cn2";
-      name = "kdeedu-data-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdeedu-data-22.04.2.tar.xz";
+      sha256 = "1npa7545f2a40gpv0zq8rmfy6gd745m4agsrvjj55g43mncj496d";
+      name = "kdeedu-data-22.04.2.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdegraphics-mobipocket-22.04.1.tar.xz";
-      sha256 = "0p8zsks0fcrzmcnwdzb7gcswq7vkv67vy1x1mi4v0y6lcgx1xqz7";
-      name = "kdegraphics-mobipocket-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdegraphics-mobipocket-22.04.2.tar.xz";
+      sha256 = "078s3a0mwdsdx2gxppmhmn8swranwd9q8q2ymyxlbmriif1sncs3";
+      name = "kdegraphics-mobipocket-22.04.2.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdegraphics-thumbnailers-22.04.1.tar.xz";
-      sha256 = "1y8rkjr5azyffj8bb06jrm46j87n93xzvn2fcyarrmww01dsw1hp";
-      name = "kdegraphics-thumbnailers-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdegraphics-thumbnailers-22.04.2.tar.xz";
+      sha256 = "1m8nndw18simw5hk124xknqsn5ckpz28l65r52424rihvb2kzf1s";
+      name = "kdegraphics-thumbnailers-22.04.2.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdenetwork-filesharing-22.04.1.tar.xz";
-      sha256 = "1h5zh0yvar3lylxm1iri3w7c7qzmdf18ak258jfphc23c9q6w32j";
-      name = "kdenetwork-filesharing-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdenetwork-filesharing-22.04.2.tar.xz";
+      sha256 = "040z92z16vzl4r025i2yajaxb4lqgaaf0sjcq00qh3y5f353n325";
+      name = "kdenetwork-filesharing-22.04.2.tar.xz";
     };
   };
   kdenlive = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdenlive-22.04.1.tar.xz";
-      sha256 = "0kiajmkmf2254464s8rv8d61igwrd2xmrj1dxwzrps4fy50r11xf";
-      name = "kdenlive-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdenlive-22.04.2.tar.xz";
+      sha256 = "1jfw0978xs6dd90f9ddc4fvvf0wlzkjmksbi55dskd49rr780x0z";
+      name = "kdenlive-22.04.2.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdepim-addons-22.04.1.tar.xz";
-      sha256 = "0r5gy56n1nrsm1wvf8687g6ng5m3q9wnl8nkfqaa4a4kk16h0i5f";
-      name = "kdepim-addons-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdepim-addons-22.04.2.tar.xz";
+      sha256 = "1fnd6z80b9mla4sryfcl3s591m9hcs2qapfj91w6w2wzgw8b5gnc";
+      name = "kdepim-addons-22.04.2.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdepim-runtime-22.04.1.tar.xz";
-      sha256 = "0gwhzdlzal2j61hak5axv68n7chhnlf8n9dqnnfili6ffps63yxm";
-      name = "kdepim-runtime-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdepim-runtime-22.04.2.tar.xz";
+      sha256 = "04qrdbj0f91q8vwfrnq3sdrcxb8jpq3kg7hab39ynp3qkfqdlmll";
+      name = "kdepim-runtime-22.04.2.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdesdk-kioslaves-22.04.1.tar.xz";
-      sha256 = "19ay298fbjmn5xcrmpjabch7ljfmn03qkacifv337yx5idv1116q";
-      name = "kdesdk-kioslaves-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdesdk-kioslaves-22.04.2.tar.xz";
+      sha256 = "1r2r8qh8qffvgq8rsm1a9y5djh1zmql5nhm3snqfjm2d88dpd9b8";
+      name = "kdesdk-kioslaves-22.04.2.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdesdk-thumbnailers-22.04.1.tar.xz";
-      sha256 = "0f7d9m13gx552f1ficw1r7ndlal39iicklrc8g8cqh2gvkbydgni";
-      name = "kdesdk-thumbnailers-22.04.1.tar.xz";
-    };
-  };
-  kdev-php = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdev-php-22.04.1.tar.xz";
-      sha256 = "1cxvzybiqxa5kgbv2jb42jq7div5q4jyl3kiar5mdnnc590x4h2y";
-      name = "kdev-php-22.04.1.tar.xz";
-    };
-  };
-  kdev-python = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdev-python-22.04.1.tar.xz";
-      sha256 = "01570g5284llqbmnlrsbrpm6zbkkp5rip49gng4nn7pi4nab9nyr";
-      name = "kdev-python-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdesdk-thumbnailers-22.04.2.tar.xz";
+      sha256 = "0ibnfjigi4rhnrnqcyfhc1mw7r2zy3rm2k2fk5fqsijx2w975ghf";
+      name = "kdesdk-thumbnailers-22.04.2.tar.xz";
     };
   };
   kdevelop = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdevelop-22.04.1.tar.xz";
-      sha256 = "1n6dcs1z88d7aaski7ffjvjpfzqssr9zjrlzlcf84k285l6zbwr2";
-      name = "kdevelop-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdevelop-22.04.2.tar.xz";
+      sha256 = "1dihxx3sq0pmszd9nhp5x9h2s0flrjhbi8miq20w8k1kqs6jnqfk";
+      name = "kdevelop-22.04.2.tar.xz";
+    };
+  };
+  kdev-php = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/kdev-php-22.04.2.tar.xz";
+      sha256 = "1rpnmwyf08r8qcq25fdrnq0in3vqvn8ydh5v5zazjns7bx68n295";
+      name = "kdev-php-22.04.2.tar.xz";
+    };
+  };
+  kdev-python = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/kdev-python-22.04.2.tar.xz";
+      sha256 = "1p1vn8163b5qf0ifcxw6c647qf2rmrygw7xbvzppfi9346j72r4b";
+      name = "kdev-python-22.04.2.tar.xz";
     };
   };
   kdf = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdf-22.04.1.tar.xz";
-      sha256 = "03vr48yhb08fw5f34yn8yjnygflz6993ihq9pfcp6jg916fpwkbp";
-      name = "kdf-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdf-22.04.2.tar.xz";
+      sha256 = "0srdqjf4sk6kidh04n9py8qcbcd2jdclnrrq1v4bn2zlm0qbqa0r";
+      name = "kdf-22.04.2.tar.xz";
     };
   };
   kdialog = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdialog-22.04.1.tar.xz";
-      sha256 = "0qqpvrkbinnxz26a4msak4wa26b4r52yjyz2h5l3q1gw7j2kp4wm";
-      name = "kdialog-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdialog-22.04.2.tar.xz";
+      sha256 = "0csrlc411v0yfizadf0w5nbyr6df2gjdmxn18ds81fjkpvdk1ajp";
+      name = "kdialog-22.04.2.tar.xz";
     };
   };
   kdiamond = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kdiamond-22.04.1.tar.xz";
-      sha256 = "19pj1lfcz7bgq6cxkn165l7b8lr5vwjp4sd724krm6l51jxzmd0x";
-      name = "kdiamond-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kdiamond-22.04.2.tar.xz";
+      sha256 = "09xrld4c3p822mn86hks93wl5llwc6if9cxa10x2hn4y9cfa1zvl";
+      name = "kdiamond-22.04.2.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/keditbookmarks-22.04.1.tar.xz";
-      sha256 = "0bix84hy02i90bpmrxjl5gd433jb2yawlbdcchgwb73py14pcay2";
-      name = "keditbookmarks-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/keditbookmarks-22.04.2.tar.xz";
+      sha256 = "1dmyw99a08l28715ssgnrbi6rfma5a5ad0k1vrczp4sad1flgpam";
+      name = "keditbookmarks-22.04.2.tar.xz";
     };
   };
   kfind = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kfind-22.04.1.tar.xz";
-      sha256 = "1mrrjrnlapvajw3hysqzd1kb1qvjwbwbc4mggawpwpq4cbpap4mc";
-      name = "kfind-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kfind-22.04.2.tar.xz";
+      sha256 = "1bnav9n1ak10824m55kkmf2haz5swfcwy6zsjs463qh3zvwnydz9";
+      name = "kfind-22.04.2.tar.xz";
     };
   };
   kfloppy = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kfloppy-22.04.1.tar.xz";
-      sha256 = "1yc90238v9f5czryjzfx9znjkl5r5smwr3gdx0cgp9sw225gl01q";
-      name = "kfloppy-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kfloppy-22.04.2.tar.xz";
+      sha256 = "0mkc05068d189zq2q1hgz5vw39fq3x2hcnxsyclis7g3p0ff4siv";
+      name = "kfloppy-22.04.2.tar.xz";
     };
   };
   kfourinline = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kfourinline-22.04.1.tar.xz";
-      sha256 = "0964iv2fa96s659crs56yqjcdkbckl7zw5h25x0r9gfycjkddhl2";
-      name = "kfourinline-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kfourinline-22.04.2.tar.xz";
+      sha256 = "0rchr0gj1zqc9anrj2d57l00r0sjx14hdlch7djrwarsj4xfc6rb";
+      name = "kfourinline-22.04.2.tar.xz";
     };
   };
   kgeography = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kgeography-22.04.1.tar.xz";
-      sha256 = "0l6az2fkbgrlg7i8h81f6jhj4vlw92x6jgkywxm93msbaz4ah1fw";
-      name = "kgeography-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kgeography-22.04.2.tar.xz";
+      sha256 = "0fsb2x44b35gvc2h0ksmjavpc8zif9inziaxxqq7mq9hgjdxnr98";
+      name = "kgeography-22.04.2.tar.xz";
     };
   };
   kget = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kget-22.04.1.tar.xz";
-      sha256 = "1v8vv32ncwnw4wn51rvk8n5kixdc2kjw9ds08ajv5x6iz06cvqrd";
-      name = "kget-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kget-22.04.2.tar.xz";
+      sha256 = "0i2pc3jmvqgrzgj9rhjshdd5kkq9bqdmch2h5rbdgbabw47l6xag";
+      name = "kget-22.04.2.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kgoldrunner-22.04.1.tar.xz";
-      sha256 = "0hs7p3allyw16lncr7fwavgggacdlgp893i1wx0mqzgg9yp4p1zm";
-      name = "kgoldrunner-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kgoldrunner-22.04.2.tar.xz";
+      sha256 = "0w5x6ar1km7ycprxfda0k65qx5lwnzmh0ch2w1py97sz3yq0pbfk";
+      name = "kgoldrunner-22.04.2.tar.xz";
     };
   };
   kgpg = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kgpg-22.04.1.tar.xz";
-      sha256 = "0dgc33h7mmbmgk29jmrrsykngzkirk53j6xxwrz8mfwbadvmvgy5";
-      name = "kgpg-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kgpg-22.04.2.tar.xz";
+      sha256 = "1rjdqlnzn269fqza6388mb3rcf43bs9xn9npzyb2anqcfsqin5cy";
+      name = "kgpg-22.04.2.tar.xz";
     };
   };
   khangman = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/khangman-22.04.1.tar.xz";
-      sha256 = "09mx12hf24rhwk0q2kni1gx5hg90nkjh556c0v6zqjmx3whlc1p6";
-      name = "khangman-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/khangman-22.04.2.tar.xz";
+      sha256 = "199k5llgi1iy9grm4am9kk1mjcjnhw33aviyp6bxip2dyw1hhcsg";
+      name = "khangman-22.04.2.tar.xz";
     };
   };
   khelpcenter = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/khelpcenter-22.04.1.tar.xz";
-      sha256 = "0wjjcrmncig6ymrk2an5n12ygy652zg7lxwvi2wi6zrdjk2kazf8";
-      name = "khelpcenter-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/khelpcenter-22.04.2.tar.xz";
+      sha256 = "1m6k61xya0xrpfd22bgargfgnv5981mjf0zyzb4szxlb8v9cjapa";
+      name = "khelpcenter-22.04.2.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kidentitymanagement-22.04.1.tar.xz";
-      sha256 = "0f07r0x8i0k8fkzik49y80wr3laxq96gcmr287n4265f7pj02skl";
-      name = "kidentitymanagement-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kidentitymanagement-22.04.2.tar.xz";
+      sha256 = "1xq73lbxpqp63f537yv0gkkd8x9bwr9y7qxzk203hmlz43jk1g1i";
+      name = "kidentitymanagement-22.04.2.tar.xz";
     };
   };
   kig = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kig-22.04.1.tar.xz";
-      sha256 = "1qz287cfvk7wvx5jp61jcwnmwmjm8y3h6k2hyjpspqr3k1n84345";
-      name = "kig-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kig-22.04.2.tar.xz";
+      sha256 = "02iivp8kj3vp2n9qk58z5fzxplqpq57ch9h2jczyd96kxsn9yc6b";
+      name = "kig-22.04.2.tar.xz";
     };
   };
   kigo = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kigo-22.04.1.tar.xz";
-      sha256 = "094q9q9c728zva64dxl522s2q7lzdybrw055w5mryj66mdb9b43j";
-      name = "kigo-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kigo-22.04.2.tar.xz";
+      sha256 = "06bg1r9assp5f5i6wzh7wvh46mkjkbwq8y5nhs8iqrg7jm9dfp0a";
+      name = "kigo-22.04.2.tar.xz";
     };
   };
   killbots = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/killbots-22.04.1.tar.xz";
-      sha256 = "0kymimgwa5amcc93r6nrfiv6psjb0k96a8b2vr3jbc6vrm9aimjy";
-      name = "killbots-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/killbots-22.04.2.tar.xz";
+      sha256 = "192pcx7dvbbgfsp2vl7h1y26gvz9cnrwa644k1g40iyarc3nckgk";
+      name = "killbots-22.04.2.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kimagemapeditor-22.04.1.tar.xz";
-      sha256 = "1lzqgav4gfq0cay162rjypikh4dx1jjj44ds9br2rfm0wp6x6zds";
-      name = "kimagemapeditor-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kimagemapeditor-22.04.2.tar.xz";
+      sha256 = "1mdrmg2qvs081xqamiqdljryznskhdzmzbnlqscagwg0kz608rpg";
+      name = "kimagemapeditor-22.04.2.tar.xz";
     };
   };
   kimap = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kimap-22.04.1.tar.xz";
-      sha256 = "0r945v0365vmyapcaqb6wabxdyflp33hh441cx26acwj11dpwgvl";
-      name = "kimap-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kimap-22.04.2.tar.xz";
+      sha256 = "1iafjazan4vhvxfafxykci2wm2xhj0752907w9c0rhrnjsj0hcb7";
+      name = "kimap-22.04.2.tar.xz";
     };
   };
   kio-extras = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kio-extras-22.04.1.tar.xz";
-      sha256 = "057qbz1cmmi1mgj38r4dsh49af4dqnihzs5r7w6hwx3dw03m2ix4";
-      name = "kio-extras-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kio-extras-22.04.2.tar.xz";
+      sha256 = "05q7hssrf82xl1c4a7wcxnvp2rzg29a2am15lwi1xv1yfgymk69i";
+      name = "kio-extras-22.04.2.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kio-gdrive-22.04.1.tar.xz";
-      sha256 = "12qb6m2n0nfx62z0xc1p66si140j6yih3lp80n9b43yf9c1hn5h6";
-      name = "kio-gdrive-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kio-gdrive-22.04.2.tar.xz";
+      sha256 = "1mw8w5zdj334ndgfkacycdhyk7as86dxpd0w61i26yjir22nfa90";
+      name = "kio-gdrive-22.04.2.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kipi-plugins-22.04.1.tar.xz";
-      sha256 = "0587pc2nmcxig4nfqyc6yvc1rxaqqa3kgnbdah53177mb4zj1lk8";
-      name = "kipi-plugins-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kipi-plugins-22.04.2.tar.xz";
+      sha256 = "1kdkflizw98zk8vzikm12vj7j00dldqw9hii8al6mch2mbva6qc2";
+      name = "kipi-plugins-22.04.2.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kirigami-gallery-22.04.1.tar.xz";
-      sha256 = "1yjj18vcik38gzqka2kia4yrk8ay9l2d7lh3wspp97v3r49dpl7y";
-      name = "kirigami-gallery-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kirigami-gallery-22.04.2.tar.xz";
+      sha256 = "01hvbixjr90p0j5p3nklrxz5lqdx6k3lv9vjffpm7x0r5d0f6vkl";
+      name = "kirigami-gallery-22.04.2.tar.xz";
     };
   };
   kiriki = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kiriki-22.04.1.tar.xz";
-      sha256 = "0mwdmb14ljr2vvpz05frzd3qpwp16zckivi5qb7awf488vj7iknz";
-      name = "kiriki-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kiriki-22.04.2.tar.xz";
+      sha256 = "0wdfs328axlw0gwapxkyvd80ymkjlx4smz4ph72d58fhmjnhp551";
+      name = "kiriki-22.04.2.tar.xz";
     };
   };
   kiten = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kiten-22.04.1.tar.xz";
-      sha256 = "14zq296qmjfssa0f3gmq2hsadlglp95l1wrrm0v14j19rd1sfzlr";
-      name = "kiten-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kiten-22.04.2.tar.xz";
+      sha256 = "0gpjcf72hz8nif1vzs46him58g8f74r24nfk2dpxil3nxdy10xp9";
+      name = "kiten-22.04.2.tar.xz";
     };
   };
   kitinerary = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kitinerary-22.04.1.tar.xz";
-      sha256 = "0ykbjp3bqhlhjj3r04zgh0pza6mh4qadhxk8gsxdndqvpv4p8sih";
-      name = "kitinerary-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kitinerary-22.04.2.tar.xz";
+      sha256 = "1gvjz1qvz6cy13c1a3drrznf110y78517s0akq8ir3aik4q4kczc";
+      name = "kitinerary-22.04.2.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kjumpingcube-22.04.1.tar.xz";
-      sha256 = "1fgz21wy3nwqhsplpg65j54rlwdpmp6nhdh9g04zsgy3micsghag";
-      name = "kjumpingcube-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kjumpingcube-22.04.2.tar.xz";
+      sha256 = "15djzgaaqdbialfb7a81i8vm7cgkkgx2lvnnr9yi06drf6a0xn81";
+      name = "kjumpingcube-22.04.2.tar.xz";
     };
   };
   kldap = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kldap-22.04.1.tar.xz";
-      sha256 = "1p06v089mid7y1qapdwai781jvypl2a3q8007j0rfpk9nbb93lhb";
-      name = "kldap-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kldap-22.04.2.tar.xz";
+      sha256 = "10rs6hyf31783prsh838sdl4wlm7a8v9bn9k400x53j6lb0k9nb0";
+      name = "kldap-22.04.2.tar.xz";
     };
   };
   kleopatra = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kleopatra-22.04.1.tar.xz";
-      sha256 = "08xfxbm9rlv36bf9zzj61ds052hg5l1q4m1fs9mcwvwcnwsn63nk";
-      name = "kleopatra-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kleopatra-22.04.2.tar.xz";
+      sha256 = "11cks6cizjvj52arj9j78zyqs9hnsaha42s00vnqi5x4cp6qf22n";
+      name = "kleopatra-22.04.2.tar.xz";
     };
   };
   klettres = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/klettres-22.04.1.tar.xz";
-      sha256 = "1clyjlrzjxw534ks6y496l1xr4iz1qxmmlgr5dyaqw8r5n45x687";
-      name = "klettres-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/klettres-22.04.2.tar.xz";
+      sha256 = "1c5pd3dmrny1qyj4lrrww2y26mfg9n52mggsrhgmbmk9m251a4b4";
+      name = "klettres-22.04.2.tar.xz";
     };
   };
   klickety = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/klickety-22.04.1.tar.xz";
-      sha256 = "1ssnrqyvm9w3jn53pshy8gd06q30760wgzk9svhk485j90g6jw9c";
-      name = "klickety-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/klickety-22.04.2.tar.xz";
+      sha256 = "06x2wimz6r0dvwfxwkr9p0glqk7vhg17m9rgcjxn4mkgz65yidip";
+      name = "klickety-22.04.2.tar.xz";
     };
   };
   klines = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/klines-22.04.1.tar.xz";
-      sha256 = "1k3a9vr92xb7m5gqdgz9kg0vnyxq4br1zyxy7d5wgqf28qgh41vf";
-      name = "klines-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/klines-22.04.2.tar.xz";
+      sha256 = "0gvpp4ngmlzblpgv55qslp24irkpgq52352n7miv7jjdilvflid1";
+      name = "klines-22.04.2.tar.xz";
     };
   };
   kmag = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmag-22.04.1.tar.xz";
-      sha256 = "0siiwgrfvzqhm23887j560w6l9i0j43i569kfknyqkiz5p0l28zz";
-      name = "kmag-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmag-22.04.2.tar.xz";
+      sha256 = "12i7xyd8bjgrvb1ml0947k26vc110yzan4rq84gfydbmky3vwqjn";
+      name = "kmag-22.04.2.tar.xz";
     };
   };
   kmahjongg = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmahjongg-22.04.1.tar.xz";
-      sha256 = "0kcdpyh7iabg672y0yd84lb14h0mn4p3cq2w9zi0l71gqm1zs22a";
-      name = "kmahjongg-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmahjongg-22.04.2.tar.xz";
+      sha256 = "0h2krv7940d4k71zjm5p2nbirnzklvvci5bircz712f2mp9pqnxx";
+      name = "kmahjongg-22.04.2.tar.xz";
     };
   };
   kmail = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmail-22.04.1.tar.xz";
-      sha256 = "1s4kbv8y7jhwg6b2qd8kj22xiwdgyllxnljmmna1964kqakl6h54";
-      name = "kmail-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmail-22.04.2.tar.xz";
+      sha256 = "0ahq41xnwlg5qbrwfcnjixbvkpxpr9bj4gj11xxzwr6d83svwlpw";
+      name = "kmail-22.04.2.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmail-account-wizard-22.04.1.tar.xz";
-      sha256 = "119gp8dv84nfnd2lvxgw3qsrfrycmgbqq2xm0hlz8zp2jmikw9fk";
-      name = "kmail-account-wizard-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmail-account-wizard-22.04.2.tar.xz";
+      sha256 = "1bm09zrpa678qgvci783zql1k45b1fjlm4fkk6xxalhfyd8hk12j";
+      name = "kmail-account-wizard-22.04.2.tar.xz";
     };
   };
   kmailtransport = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmailtransport-22.04.1.tar.xz";
-      sha256 = "1lmd4lvj66ib0f1bkaanvcdq84f8hcyxx2hgrqdyha5d1mpw47cg";
-      name = "kmailtransport-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmailtransport-22.04.2.tar.xz";
+      sha256 = "0s5vpcp7c6143z9yc7nbljbrx8zljy4n46y57shmsqy5h73lbfwb";
+      name = "kmailtransport-22.04.2.tar.xz";
     };
   };
   kmbox = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmbox-22.04.1.tar.xz";
-      sha256 = "1496mzbcxzdlwyy207b0ql2il934hcqigb2vybxqc6lap4irzf4i";
-      name = "kmbox-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmbox-22.04.2.tar.xz";
+      sha256 = "138nwfr58wav0ybgwjrv9c33asbwwp7gss8aj912kq3izj4sw15r";
+      name = "kmbox-22.04.2.tar.xz";
     };
   };
   kmime = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmime-22.04.1.tar.xz";
-      sha256 = "01favp535b9cjjwyqcaqbprcljamn2pzwl8mf5m59xq4s9h4myd7";
-      name = "kmime-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmime-22.04.2.tar.xz";
+      sha256 = "00wh72s989mrny518gmldb78qcsrwhz46dcydi34v6q06x1jdlk0";
+      name = "kmime-22.04.2.tar.xz";
     };
   };
   kmines = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmines-22.04.1.tar.xz";
-      sha256 = "1rcx9yxml0lgaa8bls836j010bgqbqd6pj08ncjqw42m67fzll24";
-      name = "kmines-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmines-22.04.2.tar.xz";
+      sha256 = "1hxm3kd8in4x6ww6wymba2nw17ggv10wjbzjvl4iyqbk8l3v2851";
+      name = "kmines-22.04.2.tar.xz";
     };
   };
   kmix = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmix-22.04.1.tar.xz";
-      sha256 = "1flf3adk1bm9c6hi4xqana8r1jslgdffy4rri4r5s0lrr3w7kdsw";
-      name = "kmix-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmix-22.04.2.tar.xz";
+      sha256 = "1k739lir73yj7biz98yij8m7hv492y2h64hzl3xpwc63jc5cpfcc";
+      name = "kmix-22.04.2.tar.xz";
     };
   };
   kmousetool = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmousetool-22.04.1.tar.xz";
-      sha256 = "0hlggni1mwn1bf9xx8l643nxwzw7pjh4y9cra7adph30nqfyr4cv";
-      name = "kmousetool-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmousetool-22.04.2.tar.xz";
+      sha256 = "1nzqmd5kqixzyfgb0w58rrfghh19dxsbc4bk7rpynvknd2alm3c3";
+      name = "kmousetool-22.04.2.tar.xz";
     };
   };
   kmouth = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmouth-22.04.1.tar.xz";
-      sha256 = "01j19l02ffijjggi8h1lrncc9177iqgdh62y14dlka83j47f1wh3";
-      name = "kmouth-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmouth-22.04.2.tar.xz";
+      sha256 = "1j7ggfq53ca1578470qn3y8p6bg2cml8j7scwjkkl430zh5nz59m";
+      name = "kmouth-22.04.2.tar.xz";
     };
   };
   kmplot = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kmplot-22.04.1.tar.xz";
-      sha256 = "0fvsygp3sf1mvhws8mb3q3vdf4ljmvvjj9a36rl7904zan14klq8";
-      name = "kmplot-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kmplot-22.04.2.tar.xz";
+      sha256 = "0jgg48mp7niby032r3wxrg5n41mhw0vq213a6bi7fnkn9bjlipbc";
+      name = "kmplot-22.04.2.tar.xz";
     };
   };
   knavalbattle = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/knavalbattle-22.04.1.tar.xz";
-      sha256 = "1araf2f216hjy212ilabz4z4axa2j93j2jvvlq5y5psn4zmrz23v";
-      name = "knavalbattle-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/knavalbattle-22.04.2.tar.xz";
+      sha256 = "08hn8ich5vvk6nk1b4zm7k6rb7wjv4hvsaf7j0ikcm78iky8yccw";
+      name = "knavalbattle-22.04.2.tar.xz";
     };
   };
   knetwalk = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/knetwalk-22.04.1.tar.xz";
-      sha256 = "0psayrbk56zl54vbwhzzzpg4h9rigyw48rxl0si7z7sjwill3xq2";
-      name = "knetwalk-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/knetwalk-22.04.2.tar.xz";
+      sha256 = "0dckkn7n576x9b0yffj3zwa4ynq1cyb3w49n0zhvw94aclix4pih";
+      name = "knetwalk-22.04.2.tar.xz";
     };
   };
   knights = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/knights-22.04.1.tar.xz";
-      sha256 = "018f8y7zhdqn77qkkwqgf5w5m0y1c9i5w7xs08q2hcglpa6pb5jj";
-      name = "knights-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/knights-22.04.2.tar.xz";
+      sha256 = "0x57dxy2n1lr5wlivbb8qq037v43cd8839xx4mxbqjwm4ix4y7cp";
+      name = "knights-22.04.2.tar.xz";
     };
   };
   knotes = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/knotes-22.04.1.tar.xz";
-      sha256 = "1h1afis9d33mzz023b61b6fxy399bdxrvnbmjvb2ncgs7c3nvd21";
-      name = "knotes-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/knotes-22.04.2.tar.xz";
+      sha256 = "0l106f9jrcjx93bz76azg6mn53ddv6d2kpxyf65bzprlgg0v1qn0";
+      name = "knotes-22.04.2.tar.xz";
     };
   };
   kolf = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kolf-22.04.1.tar.xz";
-      sha256 = "15jhd2giakbp7zy3jwz0rqmr11cv7y5n6hbvxdx17xf6rgr20qxf";
-      name = "kolf-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kolf-22.04.2.tar.xz";
+      sha256 = "1pyx524gwsypmqg1i3al42w0a5a3apvif5rs1s5fabkn33djw1af";
+      name = "kolf-22.04.2.tar.xz";
     };
   };
   kollision = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kollision-22.04.1.tar.xz";
-      sha256 = "1g7z7n2ihfnqr10pbba2rfwm826vrir7k6lxvizma4fa65f9dg9c";
-      name = "kollision-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kollision-22.04.2.tar.xz";
+      sha256 = "0q7199z3s231fxygbshjviwmyppxz34d99d40v5z5s1qgnshyv10";
+      name = "kollision-22.04.2.tar.xz";
     };
   };
   kolourpaint = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kolourpaint-22.04.1.tar.xz";
-      sha256 = "1sxgfyvxfjwfn5rjxcgifmdlxin77f5kizwpyn1jan8awk3rcl2d";
-      name = "kolourpaint-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kolourpaint-22.04.2.tar.xz";
+      sha256 = "192n8sjimh2anqqrfs3pmw40393qnriiimz0pd8pwhsl1x05c3lq";
+      name = "kolourpaint-22.04.2.tar.xz";
     };
   };
   kompare = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kompare-22.04.1.tar.xz";
-      sha256 = "0kjkmj5xnvkg22i9h5bqy3r68xbxy57mpp0fynaakl3dj89pxz0m";
-      name = "kompare-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kompare-22.04.2.tar.xz";
+      sha256 = "188siw60ahl84h2lii74siqc0glvmpxvj22f28nm700hchwvv5bk";
+      name = "kompare-22.04.2.tar.xz";
     };
   };
   konqueror = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/konqueror-22.04.1.tar.xz";
-      sha256 = "1vs7x40pf8290bqcxyd0p086nds9z3bczk4rjsadifrymgmf4i17";
-      name = "konqueror-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/konqueror-22.04.2.tar.xz";
+      sha256 = "18fmwawpkbqsgfxcjhr1l5695mwcan92krr252130p4l1scdcnjc";
+      name = "konqueror-22.04.2.tar.xz";
     };
   };
   konquest = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/konquest-22.04.1.tar.xz";
-      sha256 = "0rajwi6yjxzs4g7q8bc07b4sn71p0989cz9fx4k6rs3zwhfdf0dr";
-      name = "konquest-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/konquest-22.04.2.tar.xz";
+      sha256 = "16cd4069n29y6k9p7f3r9p7ici0z54m17avyq34jf39qiz5a83x0";
+      name = "konquest-22.04.2.tar.xz";
     };
   };
   konsole = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/konsole-22.04.1.tar.xz";
-      sha256 = "1qr2d32j0dz1ssd8ym8llxwsdzjmn6x1z5hcbkn6895ym649h14d";
-      name = "konsole-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/konsole-22.04.2.tar.xz";
+      sha256 = "04bi6g2zfk7p189cfd0xacvqg6niv4rhyaqckax3zc0msy6fklcp";
+      name = "konsole-22.04.2.tar.xz";
     };
   };
   kontact = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kontact-22.04.1.tar.xz";
-      sha256 = "19krnikn5374gjp82k7g3vvv1ylakqari2rnsbp1l7vdrymj28wn";
-      name = "kontact-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kontact-22.04.2.tar.xz";
+      sha256 = "1d2p1n68qdzzv6b7f438n0f8xmdv9m1vy2v6s47wnxspbmflfyvb";
+      name = "kontact-22.04.2.tar.xz";
     };
   };
   kontactinterface = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kontactinterface-22.04.1.tar.xz";
-      sha256 = "0sya33b0xg9392jb8p5gdw0cd3iivgfq2jvzbvpr3iiq9cgbj2m3";
-      name = "kontactinterface-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kontactinterface-22.04.2.tar.xz";
+      sha256 = "0pgw9cdfqkb9kdpkjm9g2l4vypz7x9gkjmwgbjx5x9j02fgqqqd6";
+      name = "kontactinterface-22.04.2.tar.xz";
     };
   };
   kontrast = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kontrast-22.04.1.tar.xz";
-      sha256 = "0paharkjyz51mgajan6bspkc8bpywjkgdkszdi909vxyzgszcznz";
-      name = "kontrast-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kontrast-22.04.2.tar.xz";
+      sha256 = "0mkg2j46kan1zwrpvppamh1lx87hv11d5y2kjwv2ncpbk79jab41";
+      name = "kontrast-22.04.2.tar.xz";
     };
   };
   konversation = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/konversation-22.04.1.tar.xz";
-      sha256 = "1gzy1v2vdc100sr1anp3762nn3hj4km5hrjnxnkcc30z2p7g7cyi";
-      name = "konversation-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/konversation-22.04.2.tar.xz";
+      sha256 = "1wj32yvrdvk304d8z1rb72cw2m7arsxivr0w77id9a7c9w28qiir";
+      name = "konversation-22.04.2.tar.xz";
     };
   };
   kopeninghours = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kopeninghours-22.04.1.tar.xz";
-      sha256 = "0w9j1y7h8p6hqvrf9k0rp0hbajjlbipnwj4rc9p204khganbp1nd";
-      name = "kopeninghours-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kopeninghours-22.04.2.tar.xz";
+      sha256 = "0lay8mdiv6zylr86w1y2ap7117yc5xx1lz293bqxcp6pxnd77fpv";
+      name = "kopeninghours-22.04.2.tar.xz";
     };
   };
   kopete = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kopete-22.04.1.tar.xz";
-      sha256 = "1rhykqns68p650s64vd1x655cvfa0jgvban3v2vpa2qh2pl7w1mk";
-      name = "kopete-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kopete-22.04.2.tar.xz";
+      sha256 = "0zxrn2c5wz3aqx2qg5h2i8f22gzq40d965x9h7dyhc7zhr6ccfvw";
+      name = "kopete-22.04.2.tar.xz";
     };
   };
   korganizer = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/korganizer-22.04.1.tar.xz";
-      sha256 = "0d2mshb8gj5akr4jxf85rk759i3dmkg15c3daj7jfpgr7ybyck2r";
-      name = "korganizer-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/korganizer-22.04.2.tar.xz";
+      sha256 = "0x27gs3ggqzhabxwmndfwz7jzi3xkzskxsp2k50apmdnbzsb7qiv";
+      name = "korganizer-22.04.2.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kosmindoormap-22.04.1.tar.xz";
-      sha256 = "0kmla7f8ld0398prqcqanv2pf38lg4c1gkz1qiak93ay2h9nww11";
-      name = "kosmindoormap-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kosmindoormap-22.04.2.tar.xz";
+      sha256 = "0hn0blfmpgvpphrivdmn1ql7q5k9sj7yb4vp3k27p3w4q4hbbyvf";
+      name = "kosmindoormap-22.04.2.tar.xz";
     };
   };
   kpat = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kpat-22.04.1.tar.xz";
-      sha256 = "1wd125nxgmflzxrsasbsi3k99wwws1nrwvimqgsy2rw40fm3i6ga";
-      name = "kpat-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kpat-22.04.2.tar.xz";
+      sha256 = "0gh23av90r89dbajwap4ds9j7w0rmq708q30760x88hw3v89b7r2";
+      name = "kpat-22.04.2.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kpimtextedit-22.04.1.tar.xz";
-      sha256 = "1ixzz4wlmx8sh4bkxaxacllcn3pymr75vwgks00rw1jiqgydxkpn";
-      name = "kpimtextedit-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kpimtextedit-22.04.2.tar.xz";
+      sha256 = "0mcvlyr0xmwmzv6hhv1crbiqcynfzj206hgm6cry2ffbiqpln7g4";
+      name = "kpimtextedit-22.04.2.tar.xz";
     };
   };
   kpkpass = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kpkpass-22.04.1.tar.xz";
-      sha256 = "07a1k6gfl0x7p57n0g0199g2zaz097arbwhkjx1y7xsi775asp2y";
-      name = "kpkpass-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kpkpass-22.04.2.tar.xz";
+      sha256 = "0ifq86b53b3w3kha8kdlzdkr936pivcfnffnaipc3wb607g8s4nw";
+      name = "kpkpass-22.04.2.tar.xz";
     };
   };
   kpmcore = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kpmcore-22.04.1.tar.xz";
-      sha256 = "1y34gh1983ihf2hcs9x35xq805wd0cx1w2dgnbb41l2v2b647l3h";
-      name = "kpmcore-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kpmcore-22.04.2.tar.xz";
+      sha256 = "19hyf31b1n0l0vqwwqkpm8kg9a430pys0s4ywxplbcz8n58qpcf6";
+      name = "kpmcore-22.04.2.tar.xz";
     };
   };
   kpublictransport = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kpublictransport-22.04.1.tar.xz";
-      sha256 = "0zssk77hxzprpgdzcw5r00kk3yccpmjcqx0hvix4q2ghj422z1cg";
-      name = "kpublictransport-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kpublictransport-22.04.2.tar.xz";
+      sha256 = "1spkgsa1fbcr74l9kc2rszqwxb92jfrsfgk42g64gnnsprxxaj5a";
+      name = "kpublictransport-22.04.2.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kqtquickcharts-22.04.1.tar.xz";
-      sha256 = "0b1cwsa16bfwlv8x3zwmvhkk5zahrhqpr94vpv5fvai47apihng8";
-      name = "kqtquickcharts-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kqtquickcharts-22.04.2.tar.xz";
+      sha256 = "1wmrnyzf6hpfrw15prc648jln3dhjhyf7rfidpr3cwaq7qw4p8zr";
+      name = "kqtquickcharts-22.04.2.tar.xz";
     };
   };
   krdc = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/krdc-22.04.1.tar.xz";
-      sha256 = "0ccg5a5rk9cb0q844y2adyrxj2z0zc63jp9zcdi14f7lp4rka8zz";
-      name = "krdc-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/krdc-22.04.2.tar.xz";
+      sha256 = "1bpydyxs0zb597mp81xmgl5d9fk7rzf9aagdswvbwk5j0l2lqbzi";
+      name = "krdc-22.04.2.tar.xz";
     };
   };
   kreversi = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kreversi-22.04.1.tar.xz";
-      sha256 = "0kwy7wdrfndmxg4nrqy51j102z33xzh1768ai6jcbgz2vjv6qhln";
-      name = "kreversi-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kreversi-22.04.2.tar.xz";
+      sha256 = "1mwv6qwqm5csga05py8wgm2k8grrgljim1rxxx13n0vpxnb1j9ln";
+      name = "kreversi-22.04.2.tar.xz";
     };
   };
   krfb = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/krfb-22.04.1.tar.xz";
-      sha256 = "00843wncngb4x6l44li6yzaq4qzlfyrzyxvkk6njm5pzmgki4yvp";
-      name = "krfb-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/krfb-22.04.2.tar.xz";
+      sha256 = "137rz2xlrpx0zlrrqgfqi80crwa8nmnxnk1kj13yf4b02z0di91p";
+      name = "krfb-22.04.2.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kross-interpreters-22.04.1.tar.xz";
-      sha256 = "1sh8f0m8hh06i3wspjybhqhn1dhpxag2mass38p7gm3ipkp7q88n";
-      name = "kross-interpreters-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kross-interpreters-22.04.2.tar.xz";
+      sha256 = "1ivkglglwxc102jc08alhf0smc4rc0m9f0v561vds026gma9lz2j";
+      name = "kross-interpreters-22.04.2.tar.xz";
     };
   };
   kruler = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kruler-22.04.1.tar.xz";
-      sha256 = "0vp1290wmy8rji34wdzzpshrgpzpiz3hvjgd0cynqg3skjn8r17p";
-      name = "kruler-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kruler-22.04.2.tar.xz";
+      sha256 = "0yf4yn6bgqysr8fgx0f8qilwvpd46wdhm99427z0q88cj9f93igx";
+      name = "kruler-22.04.2.tar.xz";
     };
   };
   kshisen = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kshisen-22.04.1.tar.xz";
-      sha256 = "0hiwkz2fm4ywm404prphl797j5dn95di6bcnnrb8l8zy6i2gwkvp";
-      name = "kshisen-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kshisen-22.04.2.tar.xz";
+      sha256 = "0yqafi4qxmcnlr7j9amrgb2yw3nzmldz4fngjssvry3g6wfqbj1w";
+      name = "kshisen-22.04.2.tar.xz";
     };
   };
   ksirk = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ksirk-22.04.1.tar.xz";
-      sha256 = "14zb64kz7jk46hqc388g4zv7a3m2bd131sp8pabjmn83ysrpppz7";
-      name = "ksirk-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ksirk-22.04.2.tar.xz";
+      sha256 = "1gz3wq50xk5ik71bn24gcm3cak2kh3r1cfxfqv9cmv1ikpjbv5fh";
+      name = "ksirk-22.04.2.tar.xz";
     };
   };
   ksmtp = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ksmtp-22.04.1.tar.xz";
-      sha256 = "0n7lg7zavy43z73my5569hb1fv4xrsibizpzd9yp631iahn6jigl";
-      name = "ksmtp-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ksmtp-22.04.2.tar.xz";
+      sha256 = "003wrhd0xw04hr8scsz9wpcikm13fzaajic1hlg1n35aqwh1cckn";
+      name = "ksmtp-22.04.2.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ksnakeduel-22.04.1.tar.xz";
-      sha256 = "1sz70hdyfbzl5syq9f2vn2wdqdl4058xxk83vmj2a8niva49nr9m";
-      name = "ksnakeduel-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ksnakeduel-22.04.2.tar.xz";
+      sha256 = "18fwdiy96zdpbygh5jzdvrn2b971vpnma3wbairwwf4xirb69cic";
+      name = "ksnakeduel-22.04.2.tar.xz";
     };
   };
   kspaceduel = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kspaceduel-22.04.1.tar.xz";
-      sha256 = "1k5fl88w1wcsq2sbh36bkikjh272fc9z89v45xnv40hjd00wwxac";
-      name = "kspaceduel-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kspaceduel-22.04.2.tar.xz";
+      sha256 = "00r27q16xag1dpjal9qm920s6qfrgdl10yfdxa1lq2lha0wwi6wy";
+      name = "kspaceduel-22.04.2.tar.xz";
     };
   };
   ksquares = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ksquares-22.04.1.tar.xz";
-      sha256 = "1xlzbl9iqkhbh91v7qkrgk0ha8xi96j680bzyia9yjhxq8bkn0ii";
-      name = "ksquares-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ksquares-22.04.2.tar.xz";
+      sha256 = "1m6bd474rcjhlcpxmz3iqwd884h87kvrphqd5dci4bnlvwgp3cfg";
+      name = "ksquares-22.04.2.tar.xz";
     };
   };
   ksudoku = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ksudoku-22.04.1.tar.xz";
-      sha256 = "03nasma38xiwvbapyxs2wkgk7vv83jk57zg103rgkkr78ybabmgf";
-      name = "ksudoku-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ksudoku-22.04.2.tar.xz";
+      sha256 = "0y372wzlmlbzq0c9vb8v10dcd9rpq12d80wmcdzjp9xfqankfx15";
+      name = "ksudoku-22.04.2.tar.xz";
     };
   };
   ksystemlog = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ksystemlog-22.04.1.tar.xz";
-      sha256 = "0dpb4acglqzy2cwfi32sc48r0p6vl8j7g9g6pc8r6iq25pja2qfp";
-      name = "ksystemlog-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ksystemlog-22.04.2.tar.xz";
+      sha256 = "1ayak3ljzvcwyv1yznp556w935g5yp83wyl9c335j6ji27i237vz";
+      name = "ksystemlog-22.04.2.tar.xz";
     };
   };
   kteatime = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kteatime-22.04.1.tar.xz";
-      sha256 = "0nv5i2arnwzpmd2zm5ra7n87y3ygmadzzpdlr5ylpznaqfypbgym";
-      name = "kteatime-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kteatime-22.04.2.tar.xz";
+      sha256 = "0armjabm4s52715javhl1pq53qbmk80jyjlr9j82rzi9p2lgcfyi";
+      name = "kteatime-22.04.2.tar.xz";
     };
   };
   ktimer = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktimer-22.04.1.tar.xz";
-      sha256 = "1ragzrdzzg9nw6nnxgpw9cm982lk71j1lbcb5b19dfb3jpwwirrw";
-      name = "ktimer-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktimer-22.04.2.tar.xz";
+      sha256 = "1q8kvjwfhn91prpj1phj4ajxd6bpxjjv335ql3qmyh7wn2lnsmx0";
+      name = "ktimer-22.04.2.tar.xz";
     };
   };
   ktnef = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktnef-22.04.1.tar.xz";
-      sha256 = "1rpni8jhbwghzzv4nw646xmz7g3vw7k1y7bnv9kmripn1sag8f49";
-      name = "ktnef-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktnef-22.04.2.tar.xz";
+      sha256 = "0ylvbknscrczgplqnda8arhk4vbd9282fgh5y1jrnrrlklvl5hpz";
+      name = "ktnef-22.04.2.tar.xz";
     };
   };
   ktorrent = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktorrent-22.04.1.tar.xz";
-      sha256 = "1cnq13dgz8fxiw65mlhzbimmb1p25rdcawldffr2b4gxv2gxcngk";
-      name = "ktorrent-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktorrent-22.04.2.tar.xz";
+      sha256 = "16ws3hgwa245abaqc4w61qss6c49njsl88cc9yg561q0xynrl20g";
+      name = "ktorrent-22.04.2.tar.xz";
     };
   };
   ktouch = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktouch-22.04.1.tar.xz";
-      sha256 = "0rz379xc0v3nvwilisvdfqlf84xgy48mhslkgp164mmp670r5ksj";
-      name = "ktouch-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktouch-22.04.2.tar.xz";
+      sha256 = "1a57mg5qd0gqvag9sai12s1dk8m5y132j0vj1vk279i908wdgb3i";
+      name = "ktouch-22.04.2.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-accounts-kcm-22.04.1.tar.xz";
-      sha256 = "15mc8wc4lywn0gi6wbc9h0k38fs38jr8v771r3zpc2r9bpa0qfsl";
-      name = "ktp-accounts-kcm-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-accounts-kcm-22.04.2.tar.xz";
+      sha256 = "09g13wvzrvi2frirdr2mxbx3fj21vd3byi31yylx4yc89xs407av";
+      name = "ktp-accounts-kcm-22.04.2.tar.xz";
     };
   };
   ktp-approver = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-approver-22.04.1.tar.xz";
-      sha256 = "11xrr83s1n0a97bkgyr8gy3f6abggndk1rdj7d4qs399jfzqs7j5";
-      name = "ktp-approver-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-approver-22.04.2.tar.xz";
+      sha256 = "1pxkb8ngrlwaqfsms2whb9h4n0r8gqkyr2lh51y4bzl66m44pg89";
+      name = "ktp-approver-22.04.2.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-auth-handler-22.04.1.tar.xz";
-      sha256 = "1fp2wj3nrnjn8mzyhqdqg8r7gdy7ksm245qagynynb1a2hdd1vpb";
-      name = "ktp-auth-handler-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-auth-handler-22.04.2.tar.xz";
+      sha256 = "03x2scg2sr5zf77zbky3az2j9ydv4sf84rgj32wd4x8s9h4wq2i8";
+      name = "ktp-auth-handler-22.04.2.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-call-ui-22.04.1.tar.xz";
-      sha256 = "0jmbn52pz83d5n11hqawh64s2204izbb6w1aya4zdlsa4l2zyizb";
-      name = "ktp-call-ui-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-call-ui-22.04.2.tar.xz";
+      sha256 = "0skf0r0fas86lf76nky33hmbwxk9l4p1328hvjra9w95f6c67007";
+      name = "ktp-call-ui-22.04.2.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-common-internals-22.04.1.tar.xz";
-      sha256 = "0vmy6sdxhi0d1g4iql2xx2zc259gwi155hh3s6f6nnfdvm4971a3";
-      name = "ktp-common-internals-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-common-internals-22.04.2.tar.xz";
+      sha256 = "0nsdaqr56jqa2nkgrw79pgbr60jsjwgfspv7qafgvb3iry752n72";
+      name = "ktp-common-internals-22.04.2.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-contact-list-22.04.1.tar.xz";
-      sha256 = "1pczacindx828c7g6dkvq90nqadgg32jn4my335sl6ykr735a4pw";
-      name = "ktp-contact-list-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-contact-list-22.04.2.tar.xz";
+      sha256 = "1kfzx7hxb8alzm6f35rjvnhdg93rnns8jg51948ni88q9my8dgyj";
+      name = "ktp-contact-list-22.04.2.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-contact-runner-22.04.1.tar.xz";
-      sha256 = "1hcy2dm8d08bp5lqxa96am6af3i33vialyc7hzdmp6alv062fqgs";
-      name = "ktp-contact-runner-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-contact-runner-22.04.2.tar.xz";
+      sha256 = "14vlwqyjk1jkyd7c12chgnnxlzrwi9rxq5ldnbrvmcvy6a0hyb9m";
+      name = "ktp-contact-runner-22.04.2.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-desktop-applets-22.04.1.tar.xz";
-      sha256 = "19hdfs1pa04d0inqh5id6ysnzsbi3n24jlr6y2qn2lzqfm3kgxl6";
-      name = "ktp-desktop-applets-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-desktop-applets-22.04.2.tar.xz";
+      sha256 = "1wvc5hcrix9jdmcncz9ihignbpfz6xl5gdzjv9nra7bzscipmy9g";
+      name = "ktp-desktop-applets-22.04.2.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-filetransfer-handler-22.04.1.tar.xz";
-      sha256 = "1698ic2y43w8bm2j6r9mms4z3zgyz5wdghyhnw1syh8g0nks6b9a";
-      name = "ktp-filetransfer-handler-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-filetransfer-handler-22.04.2.tar.xz";
+      sha256 = "1jnbp03rwivy4wgz4r10cjqgm8mz5jr4c4wwd04sc7vhk24f0xgl";
+      name = "ktp-filetransfer-handler-22.04.2.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-kded-module-22.04.1.tar.xz";
-      sha256 = "1df6wiyxb4qa6d8nj8hkn7z6f9g2nn0bwi9gywfqq23n1imrnin7";
-      name = "ktp-kded-module-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-kded-module-22.04.2.tar.xz";
+      sha256 = "0dmjrcz2d43if4gprdnx41idq4i1sxdxxdhs1hff745gvkjprvas";
+      name = "ktp-kded-module-22.04.2.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-send-file-22.04.1.tar.xz";
-      sha256 = "0swf599kf769ad721r0lmf74g0mp68h0lxjcvy71wfnjkfgn16rl";
-      name = "ktp-send-file-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-send-file-22.04.2.tar.xz";
+      sha256 = "1jgwbr9hq8i4vsildj35666242r6k7rvhffar5jilajizq5245kg";
+      name = "ktp-send-file-22.04.2.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktp-text-ui-22.04.1.tar.xz";
-      sha256 = "0ldgiq0amr715hivv9573gxdi6p530zjfvq1nmyn4nr3lv3k036f";
-      name = "ktp-text-ui-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktp-text-ui-22.04.2.tar.xz";
+      sha256 = "1k61kyc4arclh63rppjayngn69dpnwdbzk2h4rqnlb7kngl2rlm7";
+      name = "ktp-text-ui-22.04.2.tar.xz";
     };
   };
   ktuberling = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/ktuberling-22.04.1.tar.xz";
-      sha256 = "1b1ra5qxf4yba4z9hsjq1r30vfg0kgpxjmj5cpzvm0jdy5vas8j5";
-      name = "ktuberling-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/ktuberling-22.04.2.tar.xz";
+      sha256 = "1acy1q4i4y52wqvpj8vx51gcaar9h0ibhr1d45iyd281522m9hij";
+      name = "ktuberling-22.04.2.tar.xz";
     };
   };
   kturtle = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kturtle-22.04.1.tar.xz";
-      sha256 = "1gs3q23ylxpbk65ml9xpgz7dyz9r2gbwl2jda9i2vqir4n6w1ihm";
-      name = "kturtle-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kturtle-22.04.2.tar.xz";
+      sha256 = "1mcjwgjvxpy26543si1lrd15x845ikw4f5r9ffcfnk30vj58cwjy";
+      name = "kturtle-22.04.2.tar.xz";
     };
   };
   kubrick = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kubrick-22.04.1.tar.xz";
-      sha256 = "13p33kmrdknzjbkpg90wjccgy7ckpk23gfghvn55q13hvvvr492w";
-      name = "kubrick-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kubrick-22.04.2.tar.xz";
+      sha256 = "0mm1v4ni7rf8m8vvw8caggpv8s7nlq40z5r34an1xi4x8iqw6kwv";
+      name = "kubrick-22.04.2.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kwalletmanager-22.04.1.tar.xz";
-      sha256 = "0nhfyz9fyjsjjbj4fgyqqq2rvafm8klbjnlf0sqy5fdd5ldii7i8";
-      name = "kwalletmanager-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kwalletmanager-22.04.2.tar.xz";
+      sha256 = "1qjz5pk8krdcy2y7gh5rj6rr0zflbc0ip91649srhsqnv1s64hg1";
+      name = "kwalletmanager-22.04.2.tar.xz";
     };
   };
   kwave = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kwave-22.04.1.tar.xz";
-      sha256 = "10m847fqk3b8yhs4vji477qc9gh62rz9n72b23ib4y8xpddvkxzz";
-      name = "kwave-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kwave-22.04.2.tar.xz";
+      sha256 = "0k6pm0xpxcz38hkrgk5xrz7zmpffahyj0z8c744wplns27xl2k0m";
+      name = "kwave-22.04.2.tar.xz";
     };
   };
   kwordquiz = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/kwordquiz-22.04.1.tar.xz";
-      sha256 = "0mw8pkwr52bfzwbv8rny6s5yfqf7rz55ql0v7i319vi71pk9m8bz";
-      name = "kwordquiz-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/kwordquiz-22.04.2.tar.xz";
+      sha256 = "1m5fa8g2qs674nrraia79gdq3qhff8pc0s3p9310cqnj1nh6ngkh";
+      name = "kwordquiz-22.04.2.tar.xz";
     };
   };
   libgravatar = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libgravatar-22.04.1.tar.xz";
-      sha256 = "0fy52hm3xkh7kvask339gfxsm2fiv5d2va4wlhgqhnjq972b7fyn";
-      name = "libgravatar-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libgravatar-22.04.2.tar.xz";
+      sha256 = "0mpdnwkax67fdmhlfgp768vhh2vhvpr3r98yzh80bzdcs1xig0jz";
+      name = "libgravatar-22.04.2.tar.xz";
     };
   };
   libkcddb = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkcddb-22.04.1.tar.xz";
-      sha256 = "000bqff7gdy5bhs7jkyf08j975f9wqxv9x4qgs5gnqz4wxrqllqh";
-      name = "libkcddb-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkcddb-22.04.2.tar.xz";
+      sha256 = "0gf9nxmydh5q8558xg89gzd9n037d6gdqds2kpwrj62xrk9530fq";
+      name = "libkcddb-22.04.2.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkcompactdisc-22.04.1.tar.xz";
-      sha256 = "06s56iqmr0rhpp325p98mz7b0bn7siq91y11v6pvvxwp42mfm6w6";
-      name = "libkcompactdisc-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkcompactdisc-22.04.2.tar.xz";
+      sha256 = "00bypyi0fa3d9wjy9bnb3yfi5l1py21z6gahx2d5f6488in37z5m";
+      name = "libkcompactdisc-22.04.2.tar.xz";
     };
   };
   libkdcraw = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkdcraw-22.04.1.tar.xz";
-      sha256 = "19d82bmz8mfp6sajjih5712z4951pp0hsnsw1s46xs0r4lwjv532";
-      name = "libkdcraw-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkdcraw-22.04.2.tar.xz";
+      sha256 = "1z98711cfxz1hb1ilssgn54zllk4vn8vs7rfpbmrzxkx0wlzcsf6";
+      name = "libkdcraw-22.04.2.tar.xz";
     };
   };
   libkdegames = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkdegames-22.04.1.tar.xz";
-      sha256 = "1q6r1y13lzxyfgy1bphrqq6vpn43vssa077inccl1b4hqm9lgs8c";
-      name = "libkdegames-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkdegames-22.04.2.tar.xz";
+      sha256 = "04996k2z32bpbxbrxlh65jpvxw61mgxb4dib28rd3ba06p0zcfn3";
+      name = "libkdegames-22.04.2.tar.xz";
     };
   };
   libkdepim = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkdepim-22.04.1.tar.xz";
-      sha256 = "0x21yw42fsvib28fabilxinm7sl0vrwhw12yzra66mrl7ysvwfwn";
-      name = "libkdepim-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkdepim-22.04.2.tar.xz";
+      sha256 = "08lri4abdlh9c8izmp2a2jn8yk121m5nw51rnnrj6cvgag9g4w2m";
+      name = "libkdepim-22.04.2.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkeduvocdocument-22.04.1.tar.xz";
-      sha256 = "05w76d7js2068wmyjahailw1bmjn6zrr9d49hixn2ic0fih4amai";
-      name = "libkeduvocdocument-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkeduvocdocument-22.04.2.tar.xz";
+      sha256 = "1g51ra4dvrbk7p3bmzvym2i4wa409ignw7i5dl9k0xa0zrv8dk8q";
+      name = "libkeduvocdocument-22.04.2.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkexiv2-22.04.1.tar.xz";
-      sha256 = "1nnmbq3xcl7blflw9ibaqwkk405rf1rfjh8zxvli8yhz76rkhvrp";
-      name = "libkexiv2-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkexiv2-22.04.2.tar.xz";
+      sha256 = "0yrivln91by5jznsv76i6pimng2a4a59p6vkgglh7pci8b6ci5g3";
+      name = "libkexiv2-22.04.2.tar.xz";
     };
   };
   libkgapi = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkgapi-22.04.1.tar.xz";
-      sha256 = "17qa3c2zbsiyj6lqw56flhv0dfnwcd8ak7hisyrksalv50x5zq4l";
-      name = "libkgapi-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkgapi-22.04.2.tar.xz";
+      sha256 = "1fcb0a93c1358c9kya8xd1dqdpwnl3x3wyzqffa1kdid8yhgihwz";
+      name = "libkgapi-22.04.2.tar.xz";
     };
   };
   libkipi = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkipi-22.04.1.tar.xz";
-      sha256 = "1zcskhg1p8ldrf4r0miqnyvyw9yr4x894lp4hkahvlarxm7vf5gg";
-      name = "libkipi-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkipi-22.04.2.tar.xz";
+      sha256 = "02bhvzbgjlai2n4yzjpkjrrf8bqr8rpdc17zqsy936nf5zm31v5c";
+      name = "libkipi-22.04.2.tar.xz";
     };
   };
   libkleo = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkleo-22.04.1.tar.xz";
-      sha256 = "01qqzvna4vpldflq9ah2dj8hl3wmzh6x4hw4ah3vii2rmf5hbmln";
-      name = "libkleo-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkleo-22.04.2.tar.xz";
+      sha256 = "13zii42l6xs45fs9xgdpvkj9hsxjwp27gdsxvx1wyvmfi99q01fw";
+      name = "libkleo-22.04.2.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkmahjongg-22.04.1.tar.xz";
-      sha256 = "0aw79n93f4vc2fg0mrb55cz1584hwf7li4fyvs4c4wpxcpbfk3ff";
-      name = "libkmahjongg-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkmahjongg-22.04.2.tar.xz";
+      sha256 = "0x0f4nwv2ibpmb9c7ll0nv4i6h58jk2myixlwc3qc46g1ccf08c4";
+      name = "libkmahjongg-22.04.2.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libkomparediff2-22.04.1.tar.xz";
-      sha256 = "0gz31j51vqgs13gyk2xrr20h852vnk9cy381sgnnk9m22lqxn174";
-      name = "libkomparediff2-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libkomparediff2-22.04.2.tar.xz";
+      sha256 = "02g6gwv576rs9r8xkma9n7z78ilb6gb6hdmryd8yvrrjgrd3nwd7";
+      name = "libkomparediff2-22.04.2.tar.xz";
     };
   };
   libksane = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libksane-22.04.1.tar.xz";
-      sha256 = "103448xv5y6q552g4g6016nmrgr2b0b6g0mg4d5hy2ibd0kmsxdv";
-      name = "libksane-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libksane-22.04.2.tar.xz";
+      sha256 = "1cs0dh774brzq7qfib8dxhz21gasi0r1dqrdg3n2w1lys5c17b1p";
+      name = "libksane-22.04.2.tar.xz";
     };
   };
   libksieve = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libksieve-22.04.1.tar.xz";
-      sha256 = "06ypiw5xmpxjyr5blwnwv5whm15fsafadzld8mn7qqxfzhibpzrx";
-      name = "libksieve-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libksieve-22.04.2.tar.xz";
+      sha256 = "0r4w7afqp9gnhn1q9prvdklkwlszs8pqgq7xqgsfsncadajf6pzx";
+      name = "libksieve-22.04.2.tar.xz";
     };
   };
   libktorrent = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/libktorrent-22.04.1.tar.xz";
-      sha256 = "1jnxwyvil5mjlj7rvy31nbdg39fziclb014ilsy2f0g1r7nldpap";
-      name = "libktorrent-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/libktorrent-22.04.2.tar.xz";
+      sha256 = "07wl2xxyrvpczwac55xzw8swm99rmqhsrr7v0mlc8fhqkm935232";
+      name = "libktorrent-22.04.2.tar.xz";
     };
   };
   lokalize = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/lokalize-22.04.1.tar.xz";
-      sha256 = "0m4z9qas74x5j7wc1gr0rfzn10mzf1jdf3ffqybrxgli22w8c9my";
-      name = "lokalize-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/lokalize-22.04.2.tar.xz";
+      sha256 = "15fniwvvd70r5vaybz8qzdpgfvmhz2yinlkfiw2plcafxax998lz";
+      name = "lokalize-22.04.2.tar.xz";
     };
   };
   lskat = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/lskat-22.04.1.tar.xz";
-      sha256 = "0gyd8bzdnc5c0dpswmrigm81ajqgbvkvfs97nrdw08hvk5ba3a79";
-      name = "lskat-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/lskat-22.04.2.tar.xz";
+      sha256 = "0manh8na2iq5yz662msp6nr5ca7rz4ms4sd36yh909x16fhngaxz";
+      name = "lskat-22.04.2.tar.xz";
     };
   };
   mailcommon = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/mailcommon-22.04.1.tar.xz";
-      sha256 = "0xfsjl6p629r0gpvcrnxgdx1hfcqk9q1zzwjs4zw1waggpf39has";
-      name = "mailcommon-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/mailcommon-22.04.2.tar.xz";
+      sha256 = "1y3x16h4a6nlw44g2mrpqwy76x93r7l65xp8lm2zf6dr152hxl6r";
+      name = "mailcommon-22.04.2.tar.xz";
     };
   };
   mailimporter = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/mailimporter-22.04.1.tar.xz";
-      sha256 = "17gklgbi9fppc1k96nlmam8qdw8rzpc47b1vd9y1zrxsbp47fv46";
-      name = "mailimporter-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/mailimporter-22.04.2.tar.xz";
+      sha256 = "1pxa1b8w9qklgfzn7p5xmyvriz5pzflggzkwz3jwzhyz0k1m428d";
+      name = "mailimporter-22.04.2.tar.xz";
     };
   };
   marble = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/marble-22.04.1.tar.xz";
-      sha256 = "0mxqp7q4l0zic3aszfwijyk06pj9b2q3cj7bj3lqghvncd4196rm";
-      name = "marble-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/marble-22.04.2.tar.xz";
+      sha256 = "1nnzd362mq4qxwvbq2q1a1pcw30zgf3jvyk0fp8fq93bs882wcx4";
+      name = "marble-22.04.2.tar.xz";
     };
   };
   markdownpart = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/markdownpart-22.04.1.tar.xz";
-      sha256 = "1ihg3n4ndyipsfac5gfhf7pljr4x3v2zbalvc9369q39xmzvz8c5";
-      name = "markdownpart-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/markdownpart-22.04.2.tar.xz";
+      sha256 = "0klnlhlv38imiap5a6dvrmvskfggm56qj889xippbm41kpdpx4cf";
+      name = "markdownpart-22.04.2.tar.xz";
     };
   };
   mbox-importer = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/mbox-importer-22.04.1.tar.xz";
-      sha256 = "14jl5gwz7rwsac4gzyv1larr1llwwhdrbg6pvapqgwwpmxnmdjzi";
-      name = "mbox-importer-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/mbox-importer-22.04.2.tar.xz";
+      sha256 = "1xvnlv5gsk3fjanjln59nwkl7kv4idgm4ssm63akd825b64ia4sb";
+      name = "mbox-importer-22.04.2.tar.xz";
     };
   };
   messagelib = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/messagelib-22.04.1.tar.xz";
-      sha256 = "0inz5pygvfngd9brd40mk2zvh106m294mj2h52aq0ydnhxf9w0m8";
-      name = "messagelib-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/messagelib-22.04.2.tar.xz";
+      sha256 = "1v1ppq5qn2hd1ns2g2h15md0lzm3xk643vd9899gicrj3i0fq56z";
+      name = "messagelib-22.04.2.tar.xz";
     };
   };
   minuet = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/minuet-22.04.1.tar.xz";
-      sha256 = "0af3fir0njcczqf9wgfb0kygj9nnjf7z18sr39nzd45mm0qmmgk2";
-      name = "minuet-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/minuet-22.04.2.tar.xz";
+      sha256 = "1y27nkhl17k5hxhyd8hn4jsjsgf1ya6jpha9cccv2mpyd9xr3kgr";
+      name = "minuet-22.04.2.tar.xz";
     };
   };
   okular = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/okular-22.04.1.tar.xz";
-      sha256 = "0gqnfzh0k03q6mnb5ixa1shk6sx9qzgcj1l443lji1w2y8nhpqnf";
-      name = "okular-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/okular-22.04.2.tar.xz";
+      sha256 = "1f7cm28ivgj502439vhnyz4qf99pwj1wlk4zbaf5w16kph3dv8f9";
+      name = "okular-22.04.2.tar.xz";
     };
   };
   palapeli = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/palapeli-22.04.1.tar.xz";
-      sha256 = "1a8d0qg04a8h53nxxn8016gpamb6a8vycjhhf7586aglx51nj4ds";
-      name = "palapeli-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/palapeli-22.04.2.tar.xz";
+      sha256 = "0dn4h18pxfz1lhyl4gxprm0rcxkl7an3gm6yd1l7jfkh3r3a78sh";
+      name = "palapeli-22.04.2.tar.xz";
     };
   };
   parley = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/parley-22.04.1.tar.xz";
-      sha256 = "0xvml3svb68gpxrd80a3hqh65d0wavvksdx1wd5mxm8bkdqifb2j";
-      name = "parley-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/parley-22.04.2.tar.xz";
+      sha256 = "1qiglp6kx6kgwqsqvi0asi1figflyb5fm9maq0qzvv300f6va945";
+      name = "parley-22.04.2.tar.xz";
     };
   };
   partitionmanager = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/partitionmanager-22.04.1.tar.xz";
-      sha256 = "08nplvyzbbclqgkm03c7r6gyvmgj6931ml539ifngmfxjfhxj82n";
-      name = "partitionmanager-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/partitionmanager-22.04.2.tar.xz";
+      sha256 = "1xzbnsls8dypq703kwh8v5ay3yr4cpwxdapx7ywichcnsa89869a";
+      name = "partitionmanager-22.04.2.tar.xz";
     };
   };
   picmi = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/picmi-22.04.1.tar.xz";
-      sha256 = "13ipw692n72m3sbcpviyh85f993zvw2d6yqbdk96c5wwfksrhqww";
-      name = "picmi-22.04.1.tar.xz";
-    };
-  };
-  pim-data-exporter = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/pim-data-exporter-22.04.1.tar.xz";
-      sha256 = "15kbvbq7gyxkjrhkafkz1dc3zyblsys3hg6641x0hmyy3zmyigbi";
-      name = "pim-data-exporter-22.04.1.tar.xz";
-    };
-  };
-  pim-sieve-editor = {
-    version = "22.04.1";
-    src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/pim-sieve-editor-22.04.1.tar.xz";
-      sha256 = "02kr6530x6x7y7ngiz98ca4rvfsbcnci9093if71kaybhs2l267k";
-      name = "pim-sieve-editor-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/picmi-22.04.2.tar.xz";
+      sha256 = "10dg85yh3gksd47dnj5wd1vw1gmisw90wsv3212avivhyxfv8x57";
+      name = "picmi-22.04.2.tar.xz";
     };
   };
   pimcommon = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/pimcommon-22.04.1.tar.xz";
-      sha256 = "01l1nj7jjq7kx7db63a8nn1jcl2hpn3in6cklz89w2ilwkcwv51a";
-      name = "pimcommon-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/pimcommon-22.04.2.tar.xz";
+      sha256 = "01amvq972j4b6qkpl08p3yq4zy6kn0yjhkkq7kcqkr2bs47cshg1";
+      name = "pimcommon-22.04.2.tar.xz";
+    };
+  };
+  pim-data-exporter = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/pim-data-exporter-22.04.2.tar.xz";
+      sha256 = "0rq35c5l46nwxb462pzkqwcjv0wjxnqlrkhymkmvblhi2cbyad54";
+      name = "pim-data-exporter-22.04.2.tar.xz";
+    };
+  };
+  pim-sieve-editor = {
+    version = "22.04.2";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/22.04.2/src/pim-sieve-editor-22.04.2.tar.xz";
+      sha256 = "0hfacgyvsr42c12c532zz5s80fvj3dbv2kyja5id0axkglrmh7ri";
+      name = "pim-sieve-editor-22.04.2.tar.xz";
     };
   };
   poxml = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/poxml-22.04.1.tar.xz";
-      sha256 = "0aiw90l716ii6sj82r68li7a0sq28nvy2j5phvdiqwisqcmrhhqn";
-      name = "poxml-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/poxml-22.04.2.tar.xz";
+      sha256 = "0cm0gdszf00mz7677qap5zddcgv35pzsmd0h9c8akjnvg85mlcvx";
+      name = "poxml-22.04.2.tar.xz";
     };
   };
   print-manager = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/print-manager-22.04.1.tar.xz";
-      sha256 = "0ydqf9p0zzsw2l2l49w3di7ihl441h54ifxidww0y1s2why0d77l";
-      name = "print-manager-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/print-manager-22.04.2.tar.xz";
+      sha256 = "0lmng4lwz8wbq1mas947mz9qsb7j0ggzs9rdwijmq287b31jzfmz";
+      name = "print-manager-22.04.2.tar.xz";
     };
   };
   rocs = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/rocs-22.04.1.tar.xz";
-      sha256 = "0jldr3kisfk309ykfnp6fqqny0bg4vfy0c85c593c014v099nnzc";
-      name = "rocs-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/rocs-22.04.2.tar.xz";
+      sha256 = "1y10kisdsdxsvmzkxby4y1zm4g3rssixbjlix5i1qrq3417qrj3a";
+      name = "rocs-22.04.2.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/signon-kwallet-extension-22.04.1.tar.xz";
-      sha256 = "13nh3ggy6wlh18z1ag2hxrcf7gg3bscz1518ajbhcvriz4yc3v1c";
-      name = "signon-kwallet-extension-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/signon-kwallet-extension-22.04.2.tar.xz";
+      sha256 = "0k2ng51qr3kryxlzznkrxaky7j8h3x7p8rcjq1mxxa01ygwrknw1";
+      name = "signon-kwallet-extension-22.04.2.tar.xz";
     };
   };
   skanlite = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/skanlite-22.04.1.tar.xz";
-      sha256 = "1j0ky1b5pf8v8vqym8nrjpjb7z0gssj3nkbvfs0mz725a04gxxv9";
-      name = "skanlite-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/skanlite-22.04.2.tar.xz";
+      sha256 = "1kbjzia403r8znl2jhry09h6si06d7mgq234ablxr98dqjg96898";
+      name = "skanlite-22.04.2.tar.xz";
     };
   };
   skanpage = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/skanpage-22.04.1.tar.xz";
-      sha256 = "1w3w3h58arjmkfp63rgzzgzyl44wkv53dqsp43ny1yk8zyfw6cih";
-      name = "skanpage-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/skanpage-22.04.2.tar.xz";
+      sha256 = "1d6l7nmij33h4w6r7g8kfj0qkpw24fifc022l84w6fjyyv98k4q3";
+      name = "skanpage-22.04.2.tar.xz";
     };
   };
   spectacle = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/spectacle-22.04.1.tar.xz";
-      sha256 = "111q8jg925spgmij52vq17pdiw1wsxrw654ns2yj6vcnf2mwjnrk";
-      name = "spectacle-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/spectacle-22.04.2.tar.xz";
+      sha256 = "0g7pmczjg8q7b6h87hkwb71zi9cfm0ivxk0ak7krdz5c3iwa310y";
+      name = "spectacle-22.04.2.tar.xz";
     };
   };
   step = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/step-22.04.1.tar.xz";
-      sha256 = "03dwp4xg84a3q79gmqlqb5idaybl3k5na5d47668zfv8hw5kwz1m";
-      name = "step-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/step-22.04.2.tar.xz";
+      sha256 = "0ly0dk6ib574sqb1zh8iammjk01h7i9hqzax393884ahgc3w7m4z";
+      name = "step-22.04.2.tar.xz";
     };
   };
   svgpart = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/svgpart-22.04.1.tar.xz";
-      sha256 = "1738p2k9j9lckav86fqm57i6aszwdhin7nja7dx1g637w0a96nsy";
-      name = "svgpart-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/svgpart-22.04.2.tar.xz";
+      sha256 = "0f0fwr2lz37achrfcvb4yls0c0ln180m1v5gdimzazb8q9sw5ff0";
+      name = "svgpart-22.04.2.tar.xz";
     };
   };
   sweeper = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/sweeper-22.04.1.tar.xz";
-      sha256 = "10719rj6pwjq6k8n60x4vg08rvy4pwnf9g2p6warp4mzkwhdn4fh";
-      name = "sweeper-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/sweeper-22.04.2.tar.xz";
+      sha256 = "0afxrnsk3d0h806hfzx84jh89rllx0xip03dssy491wjlj434aj3";
+      name = "sweeper-22.04.2.tar.xz";
     };
   };
   umbrello = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/umbrello-22.04.1.tar.xz";
-      sha256 = "01jk3w17prvqljrn3lfk1j3ifaf59wp917527idnk3yhl6k6abdz";
-      name = "umbrello-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/umbrello-22.04.2.tar.xz";
+      sha256 = "0qwm9wlxah31p0f08bilda2xwdpl0in0ma1g399aw02i2lcr9frw";
+      name = "umbrello-22.04.2.tar.xz";
     };
   };
   yakuake = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/yakuake-22.04.1.tar.xz";
-      sha256 = "1c61cpp8dai5bb3mcdry12iibz1mni3bhnwnsdb2v9kaf0vrhf2k";
-      name = "yakuake-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/yakuake-22.04.2.tar.xz";
+      sha256 = "0a2bp7scg9av5yay38srcb1dr1v5s152bsy616yvhqq3s68pyv04";
+      name = "yakuake-22.04.2.tar.xz";
     };
   };
   zanshin = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/zanshin-22.04.1.tar.xz";
-      sha256 = "0frza7k4fmwkpdaxinnza021wqri1llhpasdphbwx539sxpbwlv8";
-      name = "zanshin-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/zanshin-22.04.2.tar.xz";
+      sha256 = "0qz5r6qflqq9c9jgqlplsjapcbfjhrjnqd8pa8cjb6vshgd316k0";
+      name = "zanshin-22.04.2.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "22.04.1";
+    version = "22.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.04.1/src/zeroconf-ioslave-22.04.1.tar.xz";
-      sha256 = "1bswkxjw0djp60k6wp0jyfz27pvzcvgdkp4219lzf5kxyj6ln1dk";
-      name = "zeroconf-ioslave-22.04.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.04.2/src/zeroconf-ioslave-22.04.2.tar.xz";
+      sha256 = "1lnadhkyzjhn3cgkc733q69nmhrm5ppyv51yvcyv4084xcrpp6zz";
+      name = "zeroconf-ioslave-22.04.2.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

KDE Gear 22.04.2 [was released today](https://kde.org/announcements/gear/22.04.2/)

From the [changelog](https://kde.org/announcements/changelogs/gear/22.04.2/) kdenlive seems to have gotten the biggest amount of changes. Anybody up for testing this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
