### PR TITLE
pythonPackages.myst-parser: init at 0.18.0

### DIFF
--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pythonOlder
+, docutils
+, jinja2
+, markdown-it-py
+, mdit-py-plugins
+, pyyaml
+, sphinx
+, typing-extensions
+, beautifulsoup4
+, pytest-param-files
+, pytest-regressions
+, sphinx-pytest
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "myst-parser";
+  version = "0.18.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "executablebooks";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-GEtrC7o5YnkuvBfQQfhG5P74QMiHz63Fdh1cC/r5CF0=";
+  };
+
+  format = "flit";
+
+  nativeBuildInputs = [ flit-core ];
+
+  propagatedBuildInputs = [
+    docutils
+    jinja2
+    mdit-py-plugins
+    markdown-it-py
+    pyyaml
+    sphinx
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "myst_parser" ];
+
+  checkInputs = [
+    beautifulsoup4
+    pytest-param-files
+    pytest-regressions
+    sphinx-pytest
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # AssertionError due to different files
+    "test_basic"
+    "test_footnotes"
+    "test_gettext_html"
+    "test_fieldlist_extension"
+  ];
+
+  meta = with lib; {
+    description = "Sphinx and Docutils extension to parse MyST";
+    homepage = "https://myst-parser.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ loicreynier ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-param-files/default.nix
+++ b/pkgs/development/python-modules/pytest-param-files/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pytest
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-param-files";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "chrisjsewell";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Q7wWoggJN2w2a2umQHx5TsVcugqpovBEtOKruNMZQ8A=";
+  };
+
+  format = "flit";
+
+  nativeBuildInputs = [ flit-core ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  pythonImportsCheck = [ "pytest_param_files" ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Package to generate parametrized pytests from external files";
+    homepage = "https://github.com/chrisjsewell/pytest-param-files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ loicreynier ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-pytest/default.nix
+++ b/pkgs/development/python-modules/sphinx-pytest/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pytest
+, sphinx
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-pytest";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "chrisjsewell";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-vRHPq6BAuhn5QvHG2BGen9v6ezA3RgFVtustsNxU+n8=";
+  };
+
+  format = "flit";
+
+  nativeBuildInputs = [ flit-core ];
+
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  pythonImportsCheck = [ "sphinx_pytest" ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Helpful pytest fixtures for Sphinx extensions";
+    homepage = "https://github.com/chrisjsewell/sphinx-pytest";
+    license = licenses.mit;
+    maintainers = with maintainers; [ loicreynier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5641,6 +5641,8 @@ in {
 
   mysql-connector = callPackage ../development/python-modules/mysql-connector { };
 
+  myst-parser = callPackage ../development/python-modules/myst-parser { };
+
   nad-receiver = callPackage ../development/python-modules/nad-receiver { };
 
   nagiosplugin = callPackage ../development/python-modules/nagiosplugin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9893,6 +9893,8 @@ in {
 
   sphinx-better-theme = callPackage ../development/python-modules/sphinx-better-theme { };
 
+  sphinx-pytest = callPackage ../development/python-modules/sphinx-pytest { };
+
   sphinxcontrib-actdiag = callPackage ../development/python-modules/sphinxcontrib-actdiag { };
 
   sphinxcontrib-apidoc = callPackage ../development/python-modules/sphinxcontrib-apidoc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8324,6 +8324,8 @@ in {
 
   pytest-ordering = callPackage ../development/python-modules/pytest-ordering { };
 
+  pytest-param-files = callPackage ../development/python-modules/pytest-param-files { };
+
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
   pytest-qt = callPackage ../development/python-modules/pytest-qt { };


### PR DESCRIPTION
###### Description of changes

Add [MyST parser](https://github.com/executablebooks/MyST-Parser) and pytest extensions ([sphinx-pytest](https://github.com/chrisjsewell/sphinx-pytest/) and [pytest-param-files](https://github.com/chrisjsewell/pytest-param-files)) required for `checkPhase`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
