### PR TITLE
pdfrankenstein: init at 0.9.1

### DIFF
--- a/pkgs/applications/office/pdfrankenstein/default.nix
+++ b/pkgs/applications/office/pdfrankenstein/default.nix
@@ -1,0 +1,47 @@
+{ buildGoModule, fetchFromGitHub, lib, pkg-config, makeWrapper, gdk-pixbuf, inkscape, poppler_utils, qpdf, gtk3, glib }:
+
+buildGoModule rec {
+  pname = "pdfrankenstein";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "oxplot";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-1O9eLnOYyY6GgOU6qmstT7ul+h/uIBvRWlzRX6ev5Cc=";
+  };
+
+  vendorSha256 = "sha256-2l22begx1xdCxQLns2jYsDc+F8BrMWIYfFU4Fbp+cO0=";
+
+  ldflags = [ "-s" "-w" ];
+
+  buildInputs = [ gtk3 glib ];
+
+  nativeBuildInputs = [ pkg-config makeWrapper ];
+
+  postInstall = ''
+    install -Dm0644 LICENSE "$out/share/licenses/pdfrankenstein/LICENSE"
+    install -Dm0644 pdfrankenstein.desktop -t "$out/share/applications/"
+    install -Dm0644 icon.svg "$out/share/icons/hicolor/scalable/apps/pdfrankenstein.svg"
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/pdfrankenstein \
+      --set PATH ${lib.makeBinPath [
+        gdk-pixbuf
+        inkscape
+        poppler_utils
+        qpdf
+      ]}
+  '';
+
+
+  meta = with lib; {
+    description = "A capable GUI PDF annotator";
+    longDescription = "GUI tool that intends to fill the gap on Linux where a good capable PDF annotator like Adobe Acrobat does not exist.";
+    homepage = "https://github.com/oxplot/pdfrankenstein";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tchekda ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29697,6 +29697,8 @@ with pkgs;
 
   pdfmixtool = libsForQt5.callPackage ../applications/office/pdfmixtool { };
 
+  pdfrankenstein = callPackage ../applications/office/pdfrankenstein { };
+
   pig = callPackage ../applications/networking/cluster/pig { };
 
   pijul = callPackage ../applications/version-management/pijul { };


### PR DESCRIPTION
###### Description of changes

[Homepage](https://github.com/oxplot/pdfrankenstein)

PDFrankenstein is a GUI tool that intends to fill the gap on Linux where a good capable PDF annotator like Adobe Acrobat does not exist.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
