### PR TITLE
mu-editor: start at 1.1.0-alpha.2

### DIFF
--- a/pkgs/applications/editors/mu/default.nix
+++ b/pkgs/applications/editors/mu/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchFromGitHub
+, qt5
+, python3
+}:
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      pyqt5 = super.pyqt5.override { withSerialport = true; };
+    };
+  };
+in python.pkgs.buildPythonApplication rec {
+  pname = "mu-editor";
+  version = "1.1.0-alpha.2";
+
+  src = fetchFromGitHub {
+    owner = "mu-editor";
+    repo = "mu";
+    rev = "${version}";
+    sha256 = "sha256-I38Jy1ArMUKtxCNnAFndA6fpUi0TJP+QJNlU1YzfYL8=";
+  };
+
+  patches = [
+    ./fix-dependencies.patch
+  ];
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
+  propagatedBuildInputs = with python.pkgs; [
+    appdirs
+    black
+    flask
+    nudatus
+    pgzero
+    pycodestyle
+    pyflakes
+    pyqt5
+    pyqtchart
+    pyserial
+    qscintilla-qt5
+    qtconsole
+    semver
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = false;
+
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
+
+  meta = with lib; {
+    description = "A small, simple editor for beginner Python programmers. Written in Python and Qt5.";
+    homepage = "https://codewith.mu/";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ malbarbo ];
+  };
+}

--- a/pkgs/applications/editors/mu/fix-dependencies.patch
+++ b/pkgs/applications/editors/mu/fix-dependencies.patch
@@ -1,0 +1,33 @@
+diff --git a/setup.py b/setup.py
+index c7f1a86..d7c1fec 100644
+--- a/setup.py
++++ b/setup.py
+@@ -21,19 +21,19 @@ with open(os.path.join(base_dir, 'CHANGES.rst'), encoding='utf8') as f:
+ 
+ 
+ install_requires = [
+-    'PyQt5==5.12.1;"arm" not in platform_machine',
+-    'QScintilla==2.11.1;"arm" not in platform_machine',
+-    'PyQtChart==5.12;"arm" not in platform_machine',
+-    'pycodestyle==2.4.0',
+-    'pyflakes==2.0.0',
+-    'pyserial==3.4',
+-    'qtconsole==4.4.3',
+-    'pgzero==1.2',
++    'PyQt5>=5.12.1;"arm" not in platform_machine',
++    'QScintilla>=2.11.1;"arm" not in platform_machine',
++    'PyQtChart>=5.12;"arm" not in platform_machine',
++    'pycodestyle>=2.4.0',
++    'pyflakes>=2.0.0',
++    'pyserial>=3.4',
++    'qtconsole>=4.4.3',
++    'pgzero>=1.2',
+     'appdirs>=1.4.3',
+     'semver>=2.8.0',
+     'nudatus>=0.0.3',
+     'black>=18.9b0;python_version > "3.5"',
+-    'Flask==1.0.2',
++    'Flask>=1.0.2',
+ ]
+ 
+ 

--- a/pkgs/development/python-modules/nudatus/default.nix
+++ b/pkgs/development/python-modules/nudatus/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonPackages
+}:
+
+buildPythonPackage rec {
+  pname = "nudatus";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ZanderBrown";
+    repo = pname;
+    rev = version;
+    sha256 = "yNFidirDkf624Zta8hcG/b/Q5RDzPtoCHEepSXdARXA=";
+  };
+
+  checkInputs = with pythonPackages; [ pytest ];
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "Strip comments from python scripts.";
+    homepage = "https://github.com/ZanderBrown/nudatus";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ malbarbo ];
+  };
+}

--- a/pkgs/development/python-modules/pgzero/default.nix
+++ b/pkgs/development/python-modules/pgzero/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pygame
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "pgzero";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "lordmauve";
+    repo = "pgzero";
+    rev = version;
+    sha256 = "O3fQCs8lwyF42N2vmlJvkk/UqsNS3T4geDiHZj9lS3M=";
+  };
+
+  postPatch= ''
+    rm test/test_screen.py test/test_actor.py test/test_sound_formats.py
+  '';
+
+  propagatedBuildInputs = [ numpy pygame ];
+
+  meta = with lib; {
+    description = "A zero-boilerplate games programming framework for Python 3, based on Pygame.";
+    homepage = "https://github.com/lordmauve/pgzero";
+    license = with licenses; [ lgpl3 ];
+    maintainers = with maintainers; [ malbarbo ];
+  };
+}

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -15,6 +15,7 @@
 , withWebKit ? false
 , withWebSockets ? false
 , withLocation ? false
+, withSerialport ? false
 }:
 
 buildPythonPackage rec {
@@ -48,6 +49,7 @@ buildPythonPackage rec {
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
+    ++ lib.optional withSerialport qtserialport
   ;
 
   buildInputs = with libsForQt5; [
@@ -61,6 +63,7 @@ buildPythonPackage rec {
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
+    ++ lib.optional withSerialport qtserialport
   ;
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyqtchart/default.nix
+++ b/pkgs/development/python-modules/pyqtchart/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, pythonPackages
+, qtcharts
+, qtbase
+, qmake
+, pkg-config
+}:
+
+
+let
+  inherit (pythonPackages) buildPythonPackage fetchPypi python sip pqtcharts pyqt5 pyqt-builder;
+in buildPythonPackage rec {
+  pname = "PyQtChart";
+  version = qtcharts.version;
+  src = fetchPypi {
+    inherit version;
+    inherit pname;
+    sha256 = "1kxwhkp4mwrhdcfbcqimrhqhiglzsrr2c6mfqr60vralk9ld0m2z";
+  };
+  format = "pyproject";
+
+  nativeBuildInputs = [ sip pkg-config qmake qtcharts pyqt-builder ];
+  propagatedBuildInputs = [ pyqt5 ];
+
+  dontWrapQtApps = true;
+  dontConfigure = true;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]" \
+      --replace "\"PyQtChart-Qt (>=5.15)\"," ""
+  '';
+
+  postInstall = ''
+    export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
+  '';
+
+  pythonImportsCheck = [ "PyQt5.QtChart" ];
+
+  meta = with lib; {
+    description = "PyQtChart is a set of Python bindings for The Qt Company’s Qt Charts library. The bindings sit on top of PyQt5 and are implemented as a single module";
+    homepage = "https://www.riverbankcomputing.com/software/pyqtchart/";
+    license = with licenses; [ lgpl3 ];
+    maintainers = with maintainers; [ malbarbo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28343,6 +28343,8 @@ with pkgs;
 
   mtpaint = callPackage ../applications/graphics/mtpaint { };
 
+  mu-editor = callPackage ../applications/editors/mu { };
+
   mu-repo = python3Packages.callPackage ../applications/misc/mu-repo { };
 
   mucommander = callPackage ../applications/misc/mucommander { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6594,6 +6594,10 @@ in {
 
   pypoolstation = callPackage ../development/python-modules/pypoolstation { };
 
+  pyqtchart = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtchart {
+    pythonPackages = self;
+  };
+
   pyrevolve = callPackage ../development/python-modules/pyrevolve { };
 
   pyrfxtrx = callPackage ../development/python-modules/pyrfxtrx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6421,6 +6421,8 @@ in {
 
   pgspecial = callPackage ../development/python-modules/pgspecial { };
 
+  pgzero = callPackage ../development/python-modules/pgzero { };
+
   phe = callPackage ../development/python-modules/phe { };
 
   phik = callPackage ../development/python-modules/phik { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5921,6 +5921,8 @@ in {
 
   ntplib = callPackage ../development/python-modules/ntplib { };
 
+  nudatus = callPackage ../development/python-modules/nudatus { };
+
   Nuitka = callPackage ../development/python-modules/nuitka { };
 
   nulltype = callPackage ../development/python-modules/nulltype { };


### PR DESCRIPTION
###### Description of changes

The last version of mu is 1.1.1, but starting at 1.1.0-beta.1 it manages parts of the environment using virtualenv, pip and wheels, which is very hard to make work properly in nixos and even in other system (see https://github.com/mu-editor/mu/issues/1954). The last version I could make work was 1.1.0-alpha.2.

Fixes https://github.com/NixOS/nixpkgs/issues/73975.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
