### PR TITLE
zlib: backport upstream fix on CRC validation

### DIFF
--- a/pkgs/development/libraries/zlib/comprehensive-crc-validation-for-wrong-implementations.patch
+++ b/pkgs/development/libraries/zlib/comprehensive-crc-validation-for-wrong-implementations.patch
@@ -1,0 +1,51 @@
+From ec3df00224d4b396e2ac6586ab5d25f673caa4c2 Mon Sep 17 00:00:00 2001
+From: Mark Adler <madler@alumni.caltech.edu>
+Date: Wed, 30 Mar 2022 11:14:53 -0700
+Subject: [PATCH] Correct incorrect inputs provided to the CRC functions.
+
+The previous releases of zlib were not sensitive to incorrect CRC
+inputs with bits set above the low 32. This commit restores that
+behavior, so that applications with such bugs will continue to
+operate as before.
+---
+ crc32.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/crc32.c b/crc32.c
+index a1bdce5c2..451887bc7 100644
+--- a/crc32.c
++++ b/crc32.c
+@@ -630,7 +630,7 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
+ #endif /* DYNAMIC_CRC_TABLE */
+ 
+     /* Pre-condition the CRC */
+-    crc ^= 0xffffffff;
++    crc = (~crc) & 0xffffffff;
+ 
+     /* Compute the CRC up to a word boundary. */
+     while (len && ((z_size_t)buf & 7) != 0) {
+@@ -749,7 +749,7 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
+ #endif /* DYNAMIC_CRC_TABLE */
+ 
+     /* Pre-condition the CRC */
+-    crc ^= 0xffffffff;
++    crc = (~crc) & 0xffffffff;
+ 
+ #ifdef W
+ 
+@@ -1077,7 +1077,7 @@ uLong ZEXPORT crc32_combine64(crc1, crc2, len2)
+ #ifdef DYNAMIC_CRC_TABLE
+     once(&made, make_crc_table);
+ #endif /* DYNAMIC_CRC_TABLE */
+-    return multmodp(x2nmodp(len2, 3), crc1) ^ crc2;
++    return multmodp(x2nmodp(len2, 3), crc1) ^ (crc2 & 0xffffffff);
+ }
+ 
+ /* ========================================================================= */
+@@ -1112,5 +1112,5 @@ uLong crc32_combine_op(crc1, crc2, op)
+     uLong crc2;
+     uLong op;
+ {
+-    return multmodp(op, crc1) ^ crc2;
++    return multmodp(op, crc1) ^ (crc2 & 0xffffffff);
+ }

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -42,6 +42,12 @@ stdenv.mkDerivation (rec {
 
   patches = [
     ./fix-configure-issue-cross.patch
+    # Starting zlib 1.2.12, zlib is stricter to incorrect CRC inputs
+    # with bits set above the low 32.
+    # see https://github.com/madler/zlib/issues/618
+    # TODO: remove the patch if upstream releases https://github.com/madler/zlib/commit/ec3df00224d4b396e2ac6586ab5d25f673caa4c2
+    # see https://github.com/NixOS/nixpkgs/issues/170539 for history.
+    ./comprehensive-crc-validation-for-wrong-implementations.patch
   ];
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Starting zlib 1.2.12, CRC validation has become stricter.
This broke Keycloak ≥ 17 in certain situations, for details, see:

- https://github.com/keycloak/keycloak/issues/11316 ;
- https://github.com/NixOS/nixpkgs/issues/170539

This patch makes the CRC validation comprehensive with respect to older
or already existing checksums out there.

I suggest a backport to 22.05 as it is affected by this issue and we are guaranteed to see bug reports due to this.
I tested this patch on a "server system closure" containing Keycloak and much other stuff, but I do not have the hardware to perform the whole universe rebuild, it seems to be working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).