### PR TITLE
mkPythonDerivation: add relaxDeps option, enable it by default

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -687,7 +687,6 @@ pkg3>=1.0,<=2.0
 we can do:
 
 ```
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "pkg1" "pkg3" ];
   pythonRemoveDeps = [ "pkg2" ];
 ```
@@ -703,7 +702,6 @@ Another option is to pass `true`, that will relax/remove all dependencies, for
 example:
 
 ```
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = true;
 ```
 
@@ -972,7 +970,7 @@ following are specific to `buildPythonPackage`:
 * `permitUserSite ? false`: Skip setting the `PYTHONNOUSERSITE` environment
   variable in wrapped programs.
 * `format ? "setuptools"`: Format of the source. Valid options are
-  `"setuptools"`, `"pyproject"`, `"flit"`, `"wheel"`, and `"other"`.
+  `"setuptools"`, `"pyproject"`, `"flit"`, `"wheel"`, `"egg"`, and `"other"`.
   `"setuptools"` is for when the source has a `setup.py` and `setuptools` is
   used to build a wheel, `flit`, in case `flit` should be used to build a wheel,
   and `wheel` in case a wheel is provided. Use `other` when a custom
@@ -995,6 +993,9 @@ following are specific to `buildPythonPackage`:
 * `postShellHook`: Hook to execute commands after `shellHook`.
 * `removeBinByteCode ? true`: Remove bytecode from `/bin`. Bytecode is only
   created when the filenames end with `.py`.
+* `relaxDeps ? !(builtins.elem format [ "egg" "other" ])`: Relax Python
+  dependencies restrictions for packages build in wheel format. See the
+  dedicated (section)[#using-pythonrelaxdepshook] for more information.
 * `setupPyGlobalFlags ? []`: List of flags passed to `setup.py` command.
 * `setupPyBuildFlags ? []`: List of flags passed to `setup.py build_ext` command.
 

--- a/pkgs/applications/misc/archivy/default.nix
+++ b/pkgs/applications/misc/archivy/default.nix
@@ -31,8 +31,6 @@ buildPythonApplication rec {
     hash = "sha256-ns1Y0DqqnTAQMEt+oBJ/P2gqKqPsX9P3/Z4561qzuns";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
-
   pythonRelaxDeps = true;
 
   propagatedBuildInputs = [

--- a/pkgs/applications/version-management/gitless/default.nix
+++ b/pkgs/applications/version-management/gitless/default.nix
@@ -15,8 +15,6 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-xo5EWtP2aN8YzP8ro3bnxZwUGUp0PHD0g8hk+Y+gExE=";
   };
 
-  nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
-
   propagatedBuildInputs = with python3.pkgs; [
     sh
     pygit2

--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, pythonRelaxDepsHook
 , writeText
 , asttokens
 , pycryptodome
@@ -42,7 +41,6 @@ buildPythonPackage rec {
     # ever since https://github.com/vyperlang/vyper/pull/2816
     git
 
-    pythonRelaxDepsHook
     pytest-runner
     setuptools-scm
   ];

--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -59,10 +59,11 @@ _pythonRemoveDeps() {
 pythonRelaxDepsHook() {
     pushd dist
 
-    local -r package="$pname-$version"
+    # See https://peps.python.org/pep-0491/#escaping-and-unicode
+    local -r pkg_name="${pname//[^[:alnum:].]/_}-$version"
     local -r unpack_dir="unpacked"
-    local -r metadata_file="$unpack_dir/$package/$package.dist-info/METADATA"
-    local -r wheel=$(echo "$package"*".whl")
+    local -r metadata_file="$unpack_dir/$pkg_name/$pkg_name.dist-info/METADATA"
+    local -r wheel=$(printf "$pkg_name"*".whl")
 
     @pythonInterpreter@ -m wheel unpack --dest "$unpack_dir" "$wheel"
     rm -rf "$wheel"
@@ -72,10 +73,10 @@ pythonRelaxDepsHook() {
 
     if (( "${NIX_DEBUG:-0}" >= 1 )); then
         echo "pythonRelaxDepsHook: resulting METADATA:"
-        cat "$unpack_dir/$package/$package.dist-info/METADATA"
+        cat "$unpack_dir/$pkg_name/$pkg_name.dist-info/METADATA"
     fi
 
-    @pythonInterpreter@ -m wheel pack "$unpack_dir/$package"
+    @pythonInterpreter@ -m wheel pack "$unpack_dir/$pkg_name"
 
     popd
 }

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -19,6 +19,7 @@
 , pythonNamespacesHook
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
+, pythonRelaxDepsHook
 , setuptoolsBuildHook
 , setuptoolsCheckHook
 , wheelUnpackHook
@@ -78,6 +79,12 @@
 # However, some packages do provide executables with extensions, and thus bytecode is generated.
 , removeBinBytecode ? true
 
+# Relax Python dependencies version.
+# This works by modifying the METADATA inside wheel, so it only works for
+# formats that builds a wheel
+# See `pythonRelaxDeps` and `pythonRemoveDeps` for its usage
+, relaxDeps ? !(builtins.elem format [ "egg" "other" ])
+
 # Several package formats are supported.
 # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
 # "wheel" : Install from a pre-compiled wheel.
@@ -124,6 +131,8 @@ let
       setuptools pythonCatchConflictsHook
     ] ++ lib.optionals removeBinBytecode [
       pythonRemoveBinBytecodeHook
+    ] ++ lib.optionals relaxDeps [
+      pythonRelaxDepsHook
     ] ++ lib.optionals (lib.hasSuffix "zip" (attrs.src.name or "")) [
       unzip
     ] ++ lib.optionals (format == "setuptools") [

--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -9,7 +9,6 @@
 , fetchFromGitHub
 , numpy
 , pythonOlder
-, pythonRelaxDepsHook
 , scipy
 , typing-extensions
 }:
@@ -27,10 +26,6 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-ZMuDQJ+bmrQlrem/OqU/hIie3ZQkAqayU3N8ZtaW7xo=";
   };
-
-  nativeBuildInputs = [
-    pythonRelaxDepsHook
-  ];
 
   propagatedBuildInputs = [
     aeppl

--- a/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
+++ b/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
@@ -5,6 +5,7 @@
 , pysigma
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -23,10 +24,15 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [
     pysigma
+  ];
+
+  pythonRelaxDeps = [
+    "pysigma"
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
+++ b/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
@@ -5,7 +5,6 @@
 , pysigma
 , pytestCheckHook
 , pythonOlder
-, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonRelaxDepsHook
 , pbr
 , python-mimeparse
 , extras
@@ -21,7 +20,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pbr python-mimeparse extras ];
   buildInputs = [ traceback2 ];
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   # testscenarios has a circular dependency on testtools
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
