### PR TITLE
fsrx: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/fsrx/default.nix
+++ b/pkgs/tools/misc/fsrx/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fsrx";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "coloradocolby";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-pKdxYO8Rhck3UYxqiWHDlrlPS4cAPe5jLUu5Dajop/k=";
+  };
+
+  cargoSha256 = "sha256-5h+ou9FLCG/WWMEQPsCTa1q+PovxUJs+6lzQ0L2bKIs=";
+
+  meta = with lib; {
+    description = "A flow state reader in the terminal";
+    homepage = "https://github.com/coloradocolby/fsrx";
+    license = licenses.mit;
+    maintainers = with maintainers; [ MoritzBoehme ];
+  };
+}

--- a/pkgs/tools/misc/fsrx/default.nix
+++ b/pkgs/tools/misc/fsrx/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, testers, fsrx }:
+{ lib, fetchFromGitHub, rustPlatform, gitUpdater, testers, fsrx }:
 
 rustPlatform.buildRustPackage rec {
   pname = "fsrx";
@@ -13,8 +13,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-5h+ou9FLCG/WWMEQPsCTa1q+PovxUJs+6lzQ0L2bKIs=";
 
-  passthru.tests.version = testers.testVersion {
+  passthru = {
+    updateScript = gitUpdater {
+      inherit pname version;
+      rev-prefix = "v";
+    };
+    tests.version = testers.testVersion {
       package = fsrx;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/tools/misc/fsrx/default.nix
+++ b/pkgs/tools/misc/fsrx/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform }:
+{ lib, fetchFromGitHub, rustPlatform, testers, fsrx }:
 
 rustPlatform.buildRustPackage rec {
   pname = "fsrx";
@@ -12,6 +12,10 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-5h+ou9FLCG/WWMEQPsCTa1q+PovxUJs+6lzQ0L2bKIs=";
+
+  passthru.tests.version = testers.testVersion {
+      package = fsrx;
+  };
 
   meta = with lib; {
     description = "A flow state reader in the terminal";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1286,6 +1286,8 @@ with pkgs;
 
   flycast = callPackage ../applications/emulators/flycast { };
 
+  fsrx = callPackage ../tools/misc/fsrx { };
+
   fsuae = callPackage ../applications/emulators/fs-uae { };
 
   fsuae-launcher = callPackage ../applications/emulators/fs-uae/launcher.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`fsrx` stands for (f)low (s)tate (r)eading e(x)change and is a simple tool designed to enable flow state reading in the terminal.
As it says on its [GitHub Page](https://github.com/coloradocolby/fsrx) it is inpired by [Bionic Reading](https://bionic-reading.com/).

Demo:
![demo](https://github.com/coloradocolby/assets/raw/main/fsrx/demo.gif)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
