### PR TITLE
python310Packages.pikepdf: 5.1.3 -> 5.1.4

### DIFF
--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -1,14 +1,13 @@
 { lib
 , attrs
 , buildPythonPackage
-, defusedxml
 , fetchFromGitHub
 , hypothesis
 , pythonOlder
+, importlib-metadata
 , jbig2dec
 , lxml
 , mupdf
-, packaging
 , pillow
 , psutil
 , pybind11
@@ -17,15 +16,13 @@
 , python-dateutil
 , python-xmp-toolkit
 , qpdf
-, setuptools
 , setuptools-scm
-, setuptools-scm-git-archive
 , substituteAll
 }:
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "5.1.3";
+  version = "5.1.4";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -40,7 +37,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-jkAwc1bQ1jRDf/qY+xAjiLXXO98qKjyX+J7Lu4tYWoI=";
+    hash = "sha256-nCzG1QYwERKo/T16hEGIG//PwSrpWRmKLXdj42WGyls=";
   };
 
   patches = [
@@ -53,6 +50,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i 's|\S*/opt/homebrew.*|pass|' setup.py
+
+    substituteInPlace setup.py \
+      --replace setuptools_scm_git_archive ""
   '';
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -63,7 +63,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    setuptools-scm-git-archive
     setuptools-scm
   ];
 
@@ -78,11 +77,10 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    defusedxml
     lxml
-    packaging
     pillow
-    setuptools
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
   ];
 
   pythonImportsCheck = [ "pikepdf" ];
@@ -92,6 +90,6 @@ buildPythonPackage rec {
     description = "Read and write PDFs with Python, powered by qpdf";
     license = licenses.mpl20;
     maintainers = with maintainers; [ kiwi dotlambda ];
-    changelog = "https://github.com/pikepdf/pikepdf/blob/${version}/docs/release_notes.rst";
+    changelog = "https://github.com/pikepdf/pikepdf/blob/${src.rev}/docs/releasenotes/version${lib.versions.major version}.rst";
   };
 }


### PR DESCRIPTION

###### Description of changes
https://github.com/pikepdf/pikepdf/blob/v5.1.4/docs/releasenotes/version5.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
