### PR TITLE
sile: 0.12.5 → 0.13.0

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -17,8 +17,11 @@
 let
   luaEnv = lua.withPackages(ps: with ps; [
     cassowary
+    cldr
     cosmo
+    fluent
     linenoise
+    loadkit
     lpeg
     lua-zlib
     lua_cliargs
@@ -41,11 +44,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.12.5";
+  version = "0.13.0";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "0z9wdiqwarysh3lhxss3w53vq58ml46bdi9ymr853kfl7m4gz5yy";
+    sha256 = "0ff4gcfabr6259nl1nkyfrn2r7mww2q8srvi0wakwxgh427faby3";
   };
 
   configureFlags = [


### PR DESCRIPTION
Upstream release, [release notes here](https://github.com/sile-typesetter/sile/releases/tag/v0.13.0).

The overall build scheme is unchanged, just 3 new Lua dependencies: loadkit, fluent, and cldr. All three have been add to nixpkgs recently in anticipation of this release, so this bump should be pretty uneventful.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
