### PR TITLE
Fix `extendModules` anonymous module numbering

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -114,8 +114,8 @@ rec {
                 , # This would be remove in the future, Prefer _module.check option instead.
                   check ? true
                   # Internal variable to avoid `_key` collisions regardless
-                  # of `extendModules`. Used in `submoduleWith`.
-                  # Test case: lib/tests/modules, "168767"
+                  # of `extendModules`.
+                  # Test case: lib/tests/modules, "168767", "matrix.nix"
                 , extensionOffset ? 0
                 }:
     let
@@ -345,13 +345,12 @@ rec {
         modules ? [],
         specialArgs ? {},
         prefix ? [],
-        extensionOffset ? length modules,
         }:
           evalModules (evalModulesArgs // {
             modules = regularModules ++ modules;
             specialArgs = evalModulesArgs.specialArgs or {} // specialArgs;
             prefix = extendArgs.prefix or evalModulesArgs.prefix;
-            inherit extensionOffset;
+            extensionOffset = extensionOffset + length modules;
           });
 
       type = lib.types.submoduleWith {

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -332,6 +332,7 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # Anonymous submodules don't get nixed by import resolution/deduplication
 # because of an `extendModules` bug, issue 168767.
 checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
+checkConfigOutput '^{ cookie = "accept"; pill = "red"; }$' config.result ./matrix.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/matrix.nix
+++ b/lib/tests/modules/matrix.nix
@@ -1,0 +1,38 @@
+{ config, lib, extendModules, ... }:
+let
+  inherit (lib) mkOption types;
+
+  extendModule = module: extendModules { modules = [ module ]; };
+
+  choice = choice@{ name, ... }: {
+    options = {
+      value = mkOption {
+        type = types.lazyAttrsOf (extendModule ({ })).type;
+      };
+    };
+  };
+in
+{
+  options = {
+    matrix = mkOption {
+      type = types.lazyAttrsOf (types.submodule choice);
+      default = { };
+    };
+
+    items = mkOption {
+      type = types.attrsOf types.str;
+    };
+
+    result = mkOption {
+      default =
+        let ds = x: lib.deepSeq x x;
+        in ds config.matrix.cookie.value.accept.matrix.pill.value.red.items;
+    };
+  };
+  config = {
+    matrix.pill.value.blue.items.pill = "blue";
+    matrix.pill.value.red.items.pill = "red";
+    matrix.cookie.value.accept.items.cookie = "accept";
+    matrix.cookie.value.reject.items.cookie = "reject";
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -627,7 +627,6 @@ rec {
           (base.extendModules {
             modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
             prefix = loc;
-            extensionOffset = extensionOffset + length defs;
           }).config;
         emptyValue = { value = {}; };
         getSubOptions = prefix: (base.extendModules


### PR DESCRIPTION
###### Description of changes

Found a bug while working on #176557. This is a follow-up on https://github.com/NixOS/nixpkgs/pull/168778. Wish I found the simplification right away.

Quoting the commit message:

evalModules / extendModules has enough information to perform the
numbering by itself, making extendModules safe and simplifying
submoduleWith.

The `extensionOffset` was supposed to be an implementation detail
of `evalModules`/`extendModules` all along.

Zooming out a bit, the number of `+` operations should match the
number of `extendModules` calls, which can be more than the number
of `submoduleWith` calls, which is less related to the problem being
solved by `extensionOffset`, as it can defer that responsibility
to `extendModules`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
