### PR TITLE
nixos/openldap: fix systemd rejecting notification

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -312,6 +312,7 @@ in {
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
         Type = "notify";
+        NotifyAccess = "all";
         PIDFile = cfg.settings.attrs.olcPidFile;
       };
     };


### PR DESCRIPTION
On one of the two machines I have running openldap, openldap failed to start due to a "timeout". Increasing the allowed startup delay didn't help.

I noticed the following in logs:
```
openldap.service: Got notification message from PID 5224, but reception only permitted for main PID 5223
```

It turns out that on this machine at least, openldap apparently sends the notification from a non-main process, which means that we need this NotifyAccess setting for systemd to record that it successfully started. Without it, after 30 seconds systemd kills the process because it didn't receive the sd_notify call.

Somehow the other machine I have on nixos running ldap works fine even without this, but I could not figure out what changes the behavior.

Given that AFAIU NotifyAccess still restricts to "from the cgroup of the service", I think this change should be safe.

###### Things done

- Tested with my regular config and `systemd.services.openldap.serviceConfig.NotifyAccess = "all";`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This probably needs a backport to 22.05.

cc @mweinelt for review as you switched to type=notify recently :)