### PR TITLE
rocksndiamonds: pull upstream fix for -fno-common toolchains

### DIFF
--- a/pkgs/games/rocksndiamonds/default.nix
+++ b/pkgs/games/rocksndiamonds/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeDesktopItem, SDL2, SDL2_image, SDL2_mixer, SDL2_net }:
+{ lib, stdenv, fetchurl, fetchpatch, makeDesktopItem, SDL2, SDL2_image, SDL2_mixer, SDL2_net }:
 
 stdenv.mkDerivation rec {
   pname = "rocksndiamonds";
@@ -8,6 +8,20 @@ stdenv.mkDerivation rec {
     url = "https://www.artsoft.org/RELEASES/unix/${pname}/rocksndiamonds-${version}.tar.gz";
     sha256 = "1k0m6l5g886d9mwwh6q0gw75qsb85mpf8i0rglh047app56nsk72";
   };
+
+  patches = [
+    # Pull upstream fix for -fno-common toolchain.
+    (fetchpatch {
+      name = "fno-common-p1.patch";
+      url = "https://git.artsoft.org/?p=rocksndiamonds.git;a=patch;h=b4271393b10b7c664a58f3db7349a3875c1676fe";
+      sha256 = "0bdy4d2ril917radmm0c2yh2gqfyh7q1c8kahig5xknn2rkf2iac";
+    })
+    (fetchpatch {
+      name = "fno-common-p2.patch";
+      url = "https://git.artsoft.org/?p=rocksndiamonds.git;a=patch;h=81dbde8a570a94dd2e938eff2f52dc5a3ecced21";
+      sha256 = "1mk5yb8pxrpxvvsxw3pjcbgx2c658baq9vmqqipbj5byhkkw7v2l";
+    })
+  ];
 
   desktopItem = makeDesktopItem {
     name = "rocksndiamonds";


### PR DESCRIPTION
Without the change build fails on upstream gcc-10 as:

    ld: libgame/libgame.a(system.o):src/libgame/system.c:41: multiple definition of
      `setup'; main.o:src/main.c:140: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
