### PR TITLE
bear: 3.0.14 -> 3.0.19

### DIFF
--- a/pkgs/development/tools/build-managers/bear/default.nix
+++ b/pkgs/development/tools/build-managers/bear/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bear";
-  version = "3.0.14";
+  version = "3.0.19";
 
   src = fetchFromGitHub {
     owner = "rizsotto";
     repo = pname;
     rev = version;
-    sha256 = "0qy96dyd29bjvfhi46y30hli5cvshw8am0spvcv9v43660wbczd7";
+    sha256 = "sha256-Jj38dmzr8NDDMercfWyJrMFxGBSExCGPeG2IVEtnSxY=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/tools/build-managers/bear/no-double-relative.patch
+++ b/pkgs/development/tools/build-managers/bear/no-double-relative.patch
@@ -1,22 +1,27 @@
-diff --git i/source/config.h.in w/source/config.h.in
-index ffcce3a..0caba6d 100644
---- i/source/config.h.in
-+++ w/source/config.h.in
-@@ -107,7 +107,7 @@ namespace cmd {
+diff --git a/source/config.h.in b/source/config.h.in
+index 6b659c2..f7bdf22 100644
+--- a/source/config.h.in
++++ b/source/config.h.in
+@@ -108,8 +108,8 @@ namespace cmd {
      }
  
      namespace wrapper {
--        constexpr char DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@PRIVATE_INSTALLDIR@/wrapper";
-+        constexpr char DEFAULT_PATH[] = "@PRIVATE_INSTALLDIR@/wrapper";
-         constexpr char DEFAULT_DIR_PATH[] = "@ROOT_INSTALL_PREFIX@/@PRIVATE_INSTALLDIR@/wrapper.d";
+-        constexpr char DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/bear/wrapper";
+-        constexpr char DEFAULT_DIR_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/bear/wrapper.d";
++        constexpr char DEFAULT_PATH[] = "@CMAKE_INSTALL_LIBDIR@/bear/wrapper";
++        constexpr char DEFAULT_DIR_PATH[] = "@CMAKE_INSTALL_LIBDIR@/bear/wrapper.d";
  
          constexpr char FLAG_VERBOSE[] = "--verbose";
-@@ -120,7 +120,7 @@ namespace cmd {
-     }
- 
-     namespace library {
--        constexpr char DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@PRIVATE_INSTALLDIR@/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
-+        constexpr char DEFAULT_PATH[] = "@PRIVATE_INSTALLDIR@/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
- 
+         constexpr char FLAG_DESTINATION[] = "--destination";
+@@ -134,9 +134,9 @@ namespace cmd {
+         // And use the `libexec.so` path default value with a single path,
+         // that matches both. (The match can be achieved by the $LIB token
+         // expansion from the dynamic loader. See `man ld.so` for more.)
+-        constexpr char DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/$LIB/bear/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
++        constexpr char DEFAULT_PATH[] = "$LIB/bear/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
+ #else
+-        constexpr char DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/bear/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
++        constexpr char DEFAULT_PATH[] = "@CMAKE_INSTALL_LIBDIR@/bear/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
+ #endif
          constexpr char KEY_REPORTER[] = "INTERCEPT_REPORT_COMMAND";
          constexpr char KEY_DESTINATION[] = "INTERCEPT_REPORT_DESTINATION";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

changelog: https://github.com/rizsotto/Bear/releases
diff: https://github.com/rizsotto/Bear/compare/3.0.14...3.0.19

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested generation of `compile_commands.json` with mosquitto.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
