### PR TITLE
lib/modules: Make unifyModuleSyntax key optional, remove extensionOffset

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -455,21 +455,19 @@ rec {
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: ${toString (attrNames badAttrs)}) into the explicit `config' attribute."
       else
         { _file = toString m._file or file;
+          key = toString m.key or key;
           disabledModules = m.disabledModules or [];
           imports = m.imports or [];
           options = m.options or {};
           config = addFreeformType (addMeta (m.config or {}));
-        } // optionalAttrs (m?key || key != null) {
-          key = toString m.key or key;
         }
     else
       { _file = toString m._file or file;
+        key = toString m.key or key;
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];
         options = {};
         config = addFreeformType (addMeta (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]));
-      } // optionalAttrs (m?key || key != null) {
-        key = toString m.key or key;
       };
 
   applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -455,19 +455,21 @@ rec {
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: ${toString (attrNames badAttrs)}) into the explicit `config' attribute."
       else
         { _file = toString m._file or file;
-          key = toString m.key or key;
           disabledModules = m.disabledModules or [];
           imports = m.imports or [];
           options = m.options or {};
           config = addFreeformType (addMeta (m.config or {}));
+        } // optionalAttrs (m?key || key != null) {
+          key = toString m.key or key;
         }
     else
       { _file = toString m._file or file;
-        key = toString m.key or key;
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];
         options = {};
         config = addFreeformType (addMeta (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]));
+      } // optionalAttrs (m?key || key != null) {
+        key = toString m.key or key;
       };
 
   applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -579,15 +579,16 @@ rec {
           then value: value
           else value: { config = value; };
 
-        allModules = defs:
-          map
-            ({ value, file }:
-              if isAttrs value
-              then { _file = file; imports = [ (shorthandToModule value) ]; }
-              else if isFunction value
-              then { _file = file; imports = [ value ]; }
-              else value)
-            defs;
+        allModules = defs: map ({ value, file }:
+          if isFunction value
+          then setFunctionArgs
+                (args: lib.modules.unifyModuleSyntax file null (value args))
+                (functionArgs value)
+          else if isAttrs value
+          then
+            lib.modules.unifyModuleSyntax file null (shorthandToModule value)
+          else value
+        ) defs;
 
         base = evalModules {
           inherit specialArgs;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -579,16 +579,15 @@ rec {
           then value: value
           else value: { config = value; };
 
-        allModules = defs: map ({ value, file }:
-          if isFunction value
-          then setFunctionArgs
-                (args: lib.modules.unifyModuleSyntax file null (value args))
-                (functionArgs value)
-          else if isAttrs value
-          then
-            lib.modules.unifyModuleSyntax file null (shorthandToModule value)
-          else value
-        ) defs;
+        allModules = defs:
+          map
+            ({ value, file }:
+              if isAttrs value
+              then { _file = file; imports = [ (shorthandToModule value) ]; }
+              else if isFunction value
+              then { _file = file; imports = [ value ]; }
+              else value)
+            defs;
 
         base = evalModules {
           inherit specialArgs;


### PR DESCRIPTION
###### Description of changes

Tried to make it work in #177080 but that still didn't solve all cases in practice (wip #176557). Found a simpler solution: don't number anonymous modules at all. Keys are assigned at a later stage anyway. We don't have to reinvent that solution in `submoduleWith`.
Numbering was introduced in https://github.com/NixOS/nixpkgs/commit/5002e6afbc70c6bf80efa5f997707b877cb59cdd as part of a solution for improving file locations in error messages. This goal is preserved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
