### PR TITLE
hwatch: init at 0.3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4969,6 +4969,12 @@
     githubId = 1498782;
     name = "Jesse Haber-Kucharsky";
   };
+  hamburger1984 = {
+    email = "hamburger1984@gmail.com";
+    github = "hamburger1984";
+    githubId = 438976;
+    name = "Andreas Krohn";
+  };
   hamhut1066 = {
     email = "github@hamhut1066.com";
     github = "moredhel";

--- a/pkgs/tools/misc/hwatch/default.nix
+++ b/pkgs/tools/misc/hwatch/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hwatch";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "blacknon";
+    repo = pname;
+    # prefix, because just "0.3.6' causes the download to silently fail:
+    # $ curl -v https://github.com/blacknon/hwatch/archive/0.3.6.tar.gz
+    # ...
+    # < HTTP/2 300
+    # ...
+    # the given path has multiple possibilities: #<Git::Ref:0x00007fbb2e52bed0>, #<Git::Ref:0x00007fbb2e52ae40>
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-uaAgA6DWwYVT9mQh55onW+qxIC2i9GVuimctTJpUgfA=";
+  };
+
+  cargoSha256 = "sha256-Xt3Z6ax3Y45KZhTYMBr/Rfx1o+ZAoPYj51SN5hnrXQM=";
+
+  meta = with lib; {
+    homepage = "https://github.com/blackmon/hwatch";
+    description= "Modern alternative to the watch command";
+    longDescription = ''
+      A modern alternative to the watch command, records the differences in
+      execution results and can check this differences at after.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ hamburger1984 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -400,6 +400,8 @@ with pkgs;
 
   gpick = callPackage ../tools/misc/gpick { };
 
+  hwatch = callPackage ../tools/misc/hwatch { };
+
   hobbes = callPackage ../development/tools/hobbes { stdenv = gcc10StdenvCompat; };
 
   html5validator = python3Packages.callPackage ../applications/misc/html5validator { };


### PR DESCRIPTION
###### Description of changes

This adds a new tool [`hwatch`](https://github.com/blacknon/hwatch) to nixpkgs.

It is..

> A modern alternative to the watch command, records the differences in execution results and can check this differences at after. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
