### PR TITLE
top-level: Ignore Emacs lock files when looking for overlays

### DIFF
--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -47,7 +47,12 @@ in
           # it's a directory, so the set of overlays from the directory, ordered lexicographically
           let content = builtins.readDir path; in
           map (n: import (path + ("/" + n)))
-            (builtins.filter (n: builtins.match ".*\\.nix" n != null || builtins.pathExists (path + ("/" + n + "/default.nix")))
+            (builtins.filter
+              (n:
+                (builtins.match ".*\\.nix" n != null &&
+                 # ignore Emacs lock files (.#foo.nix)
+                 builtins.match "\\.#.*" n == null) ||
+                builtins.pathExists (path + ("/" + n + "/default.nix")))
               (builtins.attrNames content))
         else
           # it's a file, so the result is the contents of the file itself


### PR DESCRIPTION
###### Description of changes

While an Emacs user edits a file `foo.nix`, Emacs creates a [lock file](https://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html) `.#foo.nix` as a broken symlink to `USER@HOSTNAME.PID:TIMESTAMP`. If the file is in the `overlays` directory, this breaks all `nixpkgs` imports with this error, until the user saves the file:

`error: getting status of '/home/user/.config/nixpkgs/overlays/user@hostname.683628:1654370645': No such file or directory`

Fix this by ignoring filenames beginning with `.#` in overlay directories.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
