### PR TITLE
angband: optionally enable SDL2 frontend

### DIFF
--- a/pkgs/games/angband/default.nix
+++ b/pkgs/games/angband/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, ncurses5 }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, ncurses5
+, enableSdl2 ? false, SDL2, SDL2_image, SDL2_sound, SDL2_mixer, SDL2_ttf
+}:
 
 stdenv.mkDerivation rec {
   pname = "angband";
@@ -11,8 +13,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Fp3BGCZYYdQCKXOLYsT4zzlibNRlbELZi26ofrbGGPQ=";
   };
 
+
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ncurses5 ];
+  buildInputs = [ ncurses5 ]
+  ++ lib.optionals enableSdl2 [
+    SDL2
+    SDL2_image
+    SDL2_sound
+    SDL2_mixer
+    SDL2_ttf
+  ];
+
+  configureFlags = lib.optional enableSdl2 "--enable-sdl2";
+
   installFlags = [ "bindir=$(out)/bin" ];
 
   meta = with lib; {


### PR DESCRIPTION
This makes it possible to compile Angband against SDL2 (and its other
libraries) to have a graphical frontend available, with tiles and
sound.  The default remains ASCII-only Angband; enable SDL2 by using
an override.

###### Description of changes

Add a boolean flag (preserving the previous behaviour as default) to optionally pass the `--enable-sdl2` option to `./configure`. The resulting Angband binary may be still be used as before even when setting the flag; the additional frontend is optional.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

There don't seem to be any tests or packages that depend on `angband`.

As this is my first PR here, any feedback is very welcome :) For instance I'm not quite sure whether adding the `SDL2` packages to the arguments was correct, but I guess laziness does its part here!?