### PR TITLE
fwupd: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/development/libraries/libxmlb/default.nix
+++ b/pkgs/development/libraries/libxmlb/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libxmlb";
-  version = "0.3.8";
+  version = "0.3.9";
 
   outputs = [ "out" "lib" "dev" "devdoc" "installedTests" ];
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "hughsie";
     repo = "libxmlb";
     rev = version;
-    sha256 = "vT/NGFDzP0ut+TKD8pYVQrjTkepzKEJUo3uKF4MX334=";
+    sha256 = "sha256-4WTuwxpIsE7gHXFiuWuZeu2JMGzPLpsmS1KTEdR3ztg=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,5 +1,5 @@
 diff --git a/data/meson.build b/data/meson.build
-index 2ae29ce5..342cac92 100644
+index 9176aa34..1a0298a9 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -26,7 +26,7 @@ endif
@@ -12,7 +12,7 @@ index 2ae29ce5..342cac92 100644
    install_data(['power.quirk', 'cfi.quirk'],
      install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index 2a7d0f24..091981f7 100644
+index 499b7201..1be13607 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
 @@ -12,13 +12,13 @@ install_data([
@@ -31,7 +31,7 @@ index 2a7d0f24..091981f7 100644
  )
  endif
  
-@@ -26,11 +26,11 @@ if supported_pkcs7 == '1'
+@@ -26,11 +26,11 @@ if supported_pkcs7
  install_data([
      'LVFS-CA.pem',
    ],
@@ -46,7 +46,7 @@ index 2a7d0f24..091981f7 100644
  )
  endif
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
-index 02d8777b..2c89d593 100644
+index 87e794b1..ebeeeca7 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
 @@ -2,7 +2,7 @@ if build_standalone and get_option('lvfs') != 'false'
@@ -83,10 +83,10 @@ index 02d8777b..2c89d593 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index 394f40fa..7b602c73 100644
+index b91dd037..a8de7810 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -187,6 +187,12 @@ endif
+@@ -195,6 +195,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
  
@@ -100,16 +100,16 @@ index 394f40fa..7b602c73 100644
  gio = dependency('gio-2.0', version : '>= 2.45.8')
  giounix = dependency('gio-unix-2.0', version : '>= 2.45.8', required: false)
 diff --git a/meson_options.txt b/meson_options.txt
-index c1b483cb..047dbdd8 100644
+index d00038db..c84652ca 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,4 @@
 +option('sysconfdir_install', type: 'string', value: '', description: 'sysconfdir to use during installation')
  option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
- option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
+ option('consolekit', type : 'feature', description : 'ConsoleKit support', deprecated: {'true': 'enabled', 'false': 'disabled'})
  option('static_analysis', type : 'boolean', value : false, description : 'enable GCC static analysis support')
 diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
-index e9f12879..a0126dbb 100644
+index 00b7ecda..789f34ca 100644
 --- a/plugins/dell-esrt/meson.build
 +++ b/plugins/dell-esrt/meson.build
 @@ -38,6 +38,6 @@ configure_file(
@@ -121,7 +121,7 @@ index e9f12879..a0126dbb 100644
  )
  endif
 diff --git a/plugins/msr/meson.build b/plugins/msr/meson.build
-index 3ea47456..40dbd116 100644
+index 1a278375..f57ae530 100644
 --- a/plugins/msr/meson.build
 +++ b/plugins/msr/meson.build
 @@ -12,7 +12,7 @@ install_data(['fwupd-msr.conf'],
@@ -134,10 +134,10 @@ index 3ea47456..40dbd116 100644
  shared_module('fu_plugin_msr',
    fu_hash,
 diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index 4a0a8664..7d9ba77d 100644
+index 8717d50f..9a703723 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
-@@ -53,7 +53,7 @@ shared_module('fu_plugin_redfish',
+@@ -51,7 +51,7 @@ shared_module('fu_plugin_redfish',
  )
  
  install_data(['redfish.conf'],
@@ -147,10 +147,10 @@ index 4a0a8664..7d9ba77d 100644
  
  if get_option('tests')
 diff --git a/plugins/thunderbolt/meson.build b/plugins/thunderbolt/meson.build
-index 1ba9562f..c074f770 100644
+index aa6c8ce1..61734c4d 100644
 --- a/plugins/thunderbolt/meson.build
 +++ b/plugins/thunderbolt/meson.build
-@@ -37,7 +37,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
+@@ -35,7 +35,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
  )
  
  install_data(['thunderbolt.conf'],
@@ -158,9 +158,9 @@ index 1ba9562f..c074f770 100644
 +  install_dir:  join_paths(sysconfdir_install, 'fwupd')
  )
  # we use functions from 2.52 in the tests
- if get_option('tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
+ if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gio.version().version_compare('>= 2.52')
 diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
-index 04cbd51a..9a8c43de 100644
+index 2d9ba819..0feb5f6b 100644
 --- a/plugins/uefi-capsule/meson.build
 +++ b/plugins/uefi-capsule/meson.build
 @@ -21,7 +21,7 @@ if host_machine.system() == 'linux'
@@ -172,7 +172,7 @@ index 04cbd51a..9a8c43de 100644
    )
  elif host_machine.system() == 'freebsd'
    backend_srcs += 'fu-uefi-backend-freebsd.c'
-@@ -114,7 +114,7 @@ if get_option('compat_cli') and get_option('man')
+@@ -112,7 +112,7 @@ if get_option('compat_cli') and get_option('man')
  endif
  
  install_data(['uefi_capsule.conf'],

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -117,7 +117,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.8.0";
+    version = "1.8.1";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -126,7 +126,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "LAliLnOSowtORQQ0M4z2cNQzKMLyE/RsX//xAWifrps=";
+      sha256 = "sha256-V1ZGZELrkTT7QM3IpG+eAQAyR8jqyC+l2LFvZCA3W3k=";
     };
 
     patches = [

--- a/pkgs/os-specific/linux/firmware/fwupd/efi-app-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/efi-app-path.patch
@@ -1,10 +1,10 @@
 diff --git a/meson.build b/meson.build
-index 4330512e..e53b70ab 100644
+index b91dd037..01d70a61 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -403,7 +403,7 @@ endif
- if build_standalone and get_option('plugin_uefi_capsule')
-   efiboot = dependency('efiboot')
+@@ -413,7 +413,7 @@ if build_standalone and efiboot.found() and efivar.found()
+     conf.set('HAVE_EFI_TIME_T', '1')
+   endif
  
 -  efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
 +  efi_app_location = join_paths(dependency('fwupd-efi').get_pkgconfig_variable('prefix'), 'libexec', 'fwupd', 'efi')

--- a/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
@@ -1,10 +1,10 @@
 diff --git a/libfwupdplugin/meson.build b/libfwupdplugin/meson.build
-index d6a2ed68..12c82a95 100644
+index 1afa28e1..3da81d30 100644
 --- a/libfwupdplugin/meson.build
 +++ b/libfwupdplugin/meson.build
-@@ -216,7 +216,8 @@ fwupdplugin = library(
+@@ -220,7 +220,8 @@ fwupdplugin = library(
    ],
-   link_args : vflag,
+   link_args : cc.get_supported_link_arguments([vflag]),
    link_depends : fwupdplugin_mapfile,
 -  install : true
 +  install : true,
@@ -12,7 +12,7 @@ index d6a2ed68..12c82a95 100644
  )
  
  fwupdplugin_pkgg = import('pkgconfig')
-@@ -276,7 +277,8 @@ if get_option('introspection')
+@@ -280,7 +281,8 @@ if introspection.allowed()
        girtargets,
        fwupd_gir[0],
      ],
@@ -23,10 +23,10 @@ index d6a2ed68..12c82a95 100644
  
    # Verify the map file is correct -- note we can't actually use the generated
 diff --git a/meson.build b/meson.build
-index 38aa36b0..3fb7e579 100644
+index b91dd037..f97b4c26 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -521,7 +521,7 @@ if build_standalone
+@@ -504,7 +504,7 @@ if build_standalone
  if host_machine.system() == 'windows'
    plugin_dir = 'fwupd-plugins-@0@'.format(libfwupdplugin_lt_current)
  else

--- a/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
@@ -1,5 +1,5 @@
 diff --git a/data/installed-tests/meson.build b/data/installed-tests/meson.build
-index b8ec916f0..38209b363 100644
+index b8ec916f..38209b36 100644
 --- a/data/installed-tests/meson.build
 +++ b/data/installed-tests/meson.build
 @@ -83,5 +83,5 @@ configure_file(
@@ -10,10 +10,10 @@ index b8ec916f0..38209b363 100644
 +  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index d8bd9fdc7..ff924d373 100644
+index b91dd037..d7e20b18 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -187,8 +187,8 @@ else
+@@ -188,8 +188,8 @@ else
    datadir = join_paths(prefix, get_option('datadir'))
    sysconfdir = join_paths(prefix, get_option('sysconfdir'))
    localstatedir = join_paths(prefix, get_option('localstatedir'))
@@ -21,10 +21,10 @@ index d8bd9fdc7..ff924d373 100644
 -  installed_test_datadir = join_paths(datadir, 'installed-tests', meson.project_name())
 +  installed_test_bindir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests', meson.project_name())
 +  installed_test_datadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', meson.project_name())
+   daemon_dir = join_paths(libexecdir, 'fwupd')
  endif
  mandir = join_paths(prefix, get_option('mandir'))
- localedir = join_paths(prefix, get_option('localedir'))
-@@ -487,6 +487,7 @@ gnome = import('gnome')
+@@ -492,6 +492,7 @@ gnome = import('gnome')
  i18n = import('i18n')
  
  conf.set_quoted('FWUPD_PREFIX', prefix)
@@ -33,7 +33,7 @@ index d8bd9fdc7..ff924d373 100644
  conf.set_quoted('FWUPD_LIBDIR', libdir)
  conf.set_quoted('FWUPD_LIBEXECDIR', libexecdir)
 diff --git a/meson_options.txt b/meson_options.txt
-index d00038dbc..be1c45b40 100644
+index d00038db..be1c45b4 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -56,6 +56,7 @@ option('systemd', type : 'feature', description : 'systemd support', deprecated:
@@ -45,7 +45,7 @@ index d00038dbc..be1c45b40 100644
  option('soup_session_compat', type : 'boolean', value : true, description : 'enable SoupSession runtime compatibility support')
  option('curl', type : 'feature', description : 'libcurl support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 diff --git a/plugins/redfish/fu-self-test.c b/plugins/redfish/fu-self-test.c
-index 4d19e560f..91cfaa616 100644
+index 4d19e560..91cfaa61 100644
 --- a/plugins/redfish/fu-self-test.c
 +++ b/plugins/redfish/fu-self-test.c
 @@ -27,7 +27,7 @@ fu_test_is_installed_test(void)


### PR DESCRIPTION
###### Description of changes

- https://github.com/fwupd/fwupd/releases/tag/1.8.1
- https://github.com/hughsie/libxmlb/compare/0.3.8...0.3.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
