### PR TITLE
p3x-onenote: 2020.10.111 -> 2022.4.127

### DIFF
--- a/pkgs/applications/office/p3x-onenote/default.nix
+++ b/pkgs/applications/office/p3x-onenote/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, appimageTools, desktop-file-utils, fetchurl }:
+{ lib, stdenvNoCC, appimageTools, desktop-file-utils, fetchurl }:
 
 let
   version = "2022.4.127";
@@ -8,13 +8,13 @@ let
     aarch64-linux = "-arm64";
     armv7l-linux = "-armv7l";
     x86_64-linux = "";
-  }.${stdenv.hostPlatform.system};
+  }.${stdenvNoCC.hostPlatform.system};
 
   sha256 = {
     aarch64-linux = "09sahxil3lcrr40l1fawglmafl643f5anyi9rlhgi2461yghm4qj";
     armv7l-linux = "14kf455z8705k7ixys4b6rsf1jzsyws6b3gll0bi2ziig0drzzxl";
     x86_64-linux = "05zr0b06qrlg0kbg58l7wn4jn79jcmzxysm6m30qfmkzliyc33sr";
-  }.${stdenv.hostPlatform.system};
+  }.${stdenvNoCC.hostPlatform.system};
 
   src = fetchurl {
     url = "https://github.com/patrikx3/onenote/releases/download/v${version}/P3X-OneNote-${version}${plat}.AppImage";

--- a/pkgs/applications/office/p3x-onenote/default.nix
+++ b/pkgs/applications/office/p3x-onenote/default.nix
@@ -1,23 +1,19 @@
 { lib, stdenv, appimageTools, desktop-file-utils, fetchurl }:
 
 let
-  version = "2020.10.111";
+  version = "2022.4.127";
   name = "p3x-onenote-${version}";
 
   plat = {
     aarch64-linux = "-arm64";
     armv7l-linux = "-armv7l";
-    i386-linux = "-i386";
-    i686-linux = "-i386";
     x86_64-linux = "";
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    aarch64-linux = "0a3c0w1312l6k2jvn7cn8priibnh8wg0184zjcli29f9ds1afl5s";
-    armv7l-linux = "172m2d94zzm8q61pvnjy01cl5fg11ad9hfh1han0gycnv3difniy";
-    i386-linux = "12m0i5sb15sbysp5fvhbj4k36950m7kpjr12n88r5fpkyh13ihsp";
-    i686-linux = "12m0i5sb15sbysp5fvhbj4k36950m7kpjr12n88r5fpkyh13ihsp";
-    x86_64-linux = "0bn48r55l5dh8zcf8ijh3z6hlyp3s6fvfyqc1csvnslm63dfkzcq";
+    aarch64-linux = "09sahxil3lcrr40l1fawglmafl643f5anyi9rlhgi2461yghm4qj";
+    armv7l-linux = "14kf455z8705k7ixys4b6rsf1jzsyws6b3gll0bi2ziig0drzzxl";
+    x86_64-linux = "05zr0b06qrlg0kbg58l7wn4jn79jcmzxysm6m30qfmkzliyc33sr";
   }.${stdenv.hostPlatform.system};
 
   src = fetchurl {
@@ -50,6 +46,6 @@ appimageTools.wrapType2 rec {
     description = "Linux Electron Onenote - A Linux compatible version of OneNote";
     license = licenses.mit;
     maintainers = with maintainers; [ tiagolobocastro ];
-    platforms = platforms.linux;
+    platforms = [ "aarch64-linux" "armv7l-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

i386-linux AppImage is no longer released
