### PR TITLE
python310Packages.splinter: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/splinter/default.nix
+++ b/pkgs/development/python-modules/splinter/default.nix
@@ -1,20 +1,29 @@
 { lib
 , buildPythonPackage
+, isPy27
 , fetchFromGitHub
 , selenium
+, cssselect
+, django
 , flask
+, lxml
 , pytestCheckHook
+, zope-testbrowser
 }:
 
 buildPythonPackage rec {
   pname = "splinter";
-  version = "0.17.0";
+  version = "0.18.0";
+
+  disabled = isPy27;
+
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "cobrateam";
     repo = "splinter";
     rev = version;
-    hash = "sha256-7QhFz/qBh2ECyeyvjCyqOYy/YrUK7KVX13VC/gem5BQ=";
+    hash = "sha256-kJ5S/fBesaxTbxCQ0yBR30+CfCV6U5jgbfDZA7eF6ac=";
   };
 
   propagatedBuildInputs = [
@@ -22,27 +31,35 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    cssselect
+    django
     flask
+    lxml
     pytestCheckHook
+    zope-testbrowser
   ];
 
   disabledTests = [
     # driver is present and fails with a different error during loading
+    "test_browser_local_driver_not_present"
     "test_local_driver_not_present"
   ];
 
   disabledTestPaths = [
     "samples"
-    # TODO: requires optional dependencies which should be defined in passthru.optional-dependencies.$name
-    "tests/test_djangoclient.py"
-    "tests/test_flaskclient.py"
+    # We run neither Chromium nor Firefox nor ...
+    "tests/test_async_finder.py"
+    "tests/test_html_snapshot.py"
+    "tests/test_iframes.py"
+    "tests/test_mouse_interaction.py"
     "tests/test_popups.py"
+    "tests/test_screenshot.py"
+    "tests/test_shadow_root.py"
     "tests/test_webdriver.py"
     "tests/test_webdriver_chrome.py"
     "tests/test_webdriver_edge_chromium.py"
     "tests/test_webdriver_firefox.py"
     "tests/test_webdriver_remote.py"
-    "tests/test_zopetestbrowser.py"
   ];
 
   pythonImportsCheck = [ "splinter" ];

--- a/pkgs/development/python-modules/zope-cachedescriptors/default.nix
+++ b/pkgs/development/python-modules/zope-cachedescriptors/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "zope-cachedescriptors";
+  version = "4.3.1";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "zope.cachedescriptors";
+    inherit version;
+    sha256 = "1f4d1a702f2ea3d177a1ffb404235551bb85560100ec88e6c98691734b1d194a";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "src/zope/cachedescriptors/tests.py"
+  ];
+
+  pythonImportsCheck = [ "zope.cachedescriptors" ];
+
+  meta = {
+    description = "Method and property caching decorators";
+    homepage = "https://github.com/zopefoundation/zope.cachedescriptors";
+    license = lib.licenses.zpl21;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/zope-testbrowser/default.nix
+++ b/pkgs/development/python-modules/zope-testbrowser/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, zope_interface
+, zope_schema
+, zope-cachedescriptors
+, pytz
+, webtest
+, beautifulsoup4
+, soupsieve
+, wsgiproxy2
+, six
+, mock
+, zope_testing
+, zope_testrunner
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "zope-testbrowser";
+  version = "5.6.1";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "zope.testbrowser";
+    inherit version;
+    sha256 = "035bf63d9f7244e885786c3327448a7d9fff521dba596429698b8474961b05e7";
+  };
+
+  postPatch = ''
+    # remove test that requires network access
+    substituteInPlace src/zope/testbrowser/tests/test_doctests.py \
+      --replace "suite.addTests(wire)" ""
+  '';
+
+  propagatedBuildInputs = [
+    setuptools
+    zope_interface
+    zope_schema
+    zope-cachedescriptors
+    pytz
+    webtest
+    beautifulsoup4
+    soupsieve
+    wsgiproxy2
+    six
+  ];
+
+  checkInputs = [
+    mock
+    zope_testing
+    zope_testrunner
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -m zope.testrunner --test-path=src
+  '';
+
+  pythonImportsCheck = [
+    "zope.testbrowser"
+    "zope.testbrowser.browser"
+    "zope.testbrowser.interfaces"
+    "zope.testbrowser.testing"
+    "zope.testbrowser.wsgi"
+  ];
+
+  meta = {
+    description = "Programmable browser for functional black-box tests";
+    homepage = "https://github.com/zopefoundation/zope.testbrowser";
+    license = lib.licenses.zpl21;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11671,6 +11671,8 @@ in {
 
   zope_size = callPackage ../development/python-modules/zope_size { };
 
+  zope-testbrowser = callPackage ../development/python-modules/zope-testbrowser { };
+
   zope_testing = callPackage ../development/python-modules/zope_testing { };
 
   zope_testrunner = callPackage ../development/python-modules/zope_testrunner { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11633,6 +11633,8 @@ in {
 
   zope_broken = callPackage ../development/python-modules/zope_broken { };
 
+  zope-cachedescriptors = callPackage ../development/python-modules/zope-cachedescriptors { };
+
   zope_component = callPackage ../development/python-modules/zope_component { };
 
   zope_configuration = callPackage ../development/python-modules/zope_configuration { };


### PR DESCRIPTION
###### Description of changes
https://github.com/cobrateam/splinter/releases/tag/0.18.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
