### PR TITLE
streamdeck-ui: init at 2.0.4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -215,6 +215,7 @@
   ./programs/systemtap.nix
   ./programs/starship.nix
   ./programs/steam.nix
+  ./programs/streamdeck-ui.nix
   ./programs/sway.nix
   ./programs/system-config-printer.nix
   ./programs/thefuck.nix

--- a/nixos/modules/programs/streamdeck-ui.nix
+++ b/nixos/modules/programs/streamdeck-ui.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.streamdeck-ui;
+in {
+  options.programs.streamdeck-ui = {
+    enable = mkEnableOption "streamdeck-ui";
+
+    autoStart = mkOption {
+      default = true;
+      type = types.bool;
+      description = "Whether streamdeck-ui should be started automatically.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [
+      streamdeck-ui
+      (mkIf cfg.autoStart (makeAutostartItem { name = "streamdeck-ui"; package = streamdeck-ui; }))
+    ];
+
+    services.udev.packages = with pkgs; [ streamdeck-ui ];
+  };
+
+  meta.maintainers = with maintainers; [ majiir ];
+}

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -1,0 +1,95 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, poetry
+, copyDesktopItems
+, wrapQtAppsHook
+, writeText
+, makeDesktopItem
+, xvfb-run
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "streamdeck-ui";
+  version = "2.0.4";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "timothycrosley";
+    rev = "v${version}";
+    hash = "sha256-NV4BkHEgfxIOuLfmn0vcPNqivmHLD6v7jLdLZgnrb0Q=";
+  };
+
+  desktopItems = [ (makeDesktopItem {
+    name = "streamdeck-ui";
+    desktopName = "Stream Deck UI";
+    icon = "streamdeck-ui";
+    exec = "streamdeck --no-ui";
+    comment = "UI for the Elgato Stream Deck";
+    categories = [ "Utility" ];
+    noDisplay = true;
+  }) ];
+
+  postInstall =
+    let
+      udevRules = ''
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", TAG+="uaccess"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", TAG+="uaccess"
+      '';
+    in
+      ''
+        mkdir -p "$out/etc/udev/rules.d"
+        cp ${writeText "70-streamdeck.rules" udevRules} $out/etc/udev/rules.d/70-streamdeck.rules
+
+        mkdir -p "$out/share/pixmaps"
+        cp streamdeck_ui/logo.png $out/share/pixmaps/streamdeck-ui.png
+      '';
+
+  dontWrapQtApps = true;
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    poetry
+    copyDesktopItems
+    wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    setuptools
+    filetype
+    cairosvg
+    pillow
+    pynput
+    pyside2
+    streamdeck
+    xlib
+  ];
+
+  checkInputs = [
+    xvfb-run
+    python3Packages.pytest
+    python3Packages.hypothesis-auto
+  ];
+
+  # Ignored tests are not in a running or passing state.
+  # Fixes have been merged upstream but not yet released.
+  # Revisit these ignored tests on each update.
+  checkPhase = ''
+    xvfb-run pytest tests \
+      --ignore=tests/test_api.py \
+      --ignore=tests/test_filter.py \
+      --ignore=tests/test_stream_deck_monitor.py
+  '';
+
+  meta = with lib; {
+    description = "Linux compatible UI for the Elgato Stream Deck";
+    homepage = "https://timothycrosley.github.io/streamdeck-ui/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ majiir ];
+  };
+}

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -24,13 +24,21 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake ninja qt5.qmake python ];
-  buildInputs = with qt5; [
+  buildInputs = (with qt5; [
     qtbase qtxmlpatterns qtmultimedia qttools qtx11extras qtlocation qtscript
     qtwebsockets qtwebengine qtwebchannel qtcharts qtsensors qtsvg
+  ]) ++ [
+    python.pkgs.setuptools
   ];
   propagatedBuildInputs = [ shiboken2 ];
 
   dontWrapQtApps = true;
+
+  postInstall = ''
+    cd ../../..
+    ${python.interpreter} setup.py egg_info --build-type=pyside2
+    cp -r PySide2.egg-info $out/${python.sitePackages}/
+  '';
 
   meta = with lib; {
     description = "LGPL-licensed Python bindings for Qt";

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   CLANG_INSTALL_DIR = llvmPackages.libclang.out;
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvmPackages.libclang python qt5.qtbase qt5.qtxmlpatterns ];
+  buildInputs = [ llvmPackages.libclang python python.pkgs.setuptools qt5.qtbase qt5.qtxmlpatterns ];
 
   cmakeFlags = [
     "-DBUILD_TESTS=OFF"
@@ -26,6 +26,9 @@ stdenv.mkDerivation {
   dontWrapQtApps = true;
 
   postInstall = ''
+    cd ../../..
+    ${python.interpreter} setup.py egg_info --build-type=shiboken2
+    cp -r shiboken2.egg-info $out/${python.sitePackages}/
     rm $out/bin/shiboken_tool.py
   '';
 

--- a/pkgs/development/python-modules/streamdeck/default.nix
+++ b/pkgs/development/python-modules/streamdeck/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, substituteAll
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname = "streamdeck";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0116a376afc18f3abbf79cc1a4409f81472e19197d5641b9e97e697d105cbdc0";
+  };
+
+  patches = [
+    # substitute libusb path
+    (substituteAll {
+      src = ./hardcode-libusb.patch;
+      libusb = "${pkgs.hidapi}/lib/libhidapi-libusb${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  pythonImportsCheck = [ "StreamDeck" ];
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python library to control the Elgato Stream Deck";
+    homepage = "https://github.com/abcminiuser/python-elgato-streamdeck";
+    license = licenses.mit;
+    maintainers = with maintainers; [ majiir ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/development/python-modules/streamdeck/hardcode-libusb.patch
+++ b/pkgs/development/python-modules/streamdeck/hardcode-libusb.patch
@@ -1,0 +1,13 @@
+diff --git a/src/StreamDeck/Transport/LibUSBHIDAPI.py b/src/StreamDeck/Transport/LibUSBHIDAPI.py
+index 824c59c..f13754e 100644
+--- a/src/StreamDeck/Transport/LibUSBHIDAPI.py
++++ b/src/StreamDeck/Transport/LibUSBHIDAPI.py
+@@ -110,7 +110,7 @@ class LibUSBHIDAPI(Transport):
+ 
+             search_library_names = {
+                 "Windows": ["hidapi.dll", "libhidapi-0.dll"],
+-                "Linux": ["libhidapi-libusb.so", "libhidapi-libusb.so.0"],
++                "Linux": ["@libusb@"],
+                 "Darwin": ["libhidapi.dylib"],
+             }
+ 

--- a/pkgs/development/python-modules/xlib/default.nix
+++ b/pkgs/development/python-modules/xlib/default.nix
@@ -22,6 +22,10 @@ buildPythonPackage rec {
     sha256 = "155p9xhsk01z9vdml74h07svlqy6gljnx9c6qbydcr14lwghwn06";
   };
 
+  patches = [
+    ./fix-no-protocol-specified.patch
+  ];
+
   nativeBuildInputs = [ setuptools-scm ];
   buildInputs = [ xorg.libX11 ];
   propagatedBuildInputs = [ six ];

--- a/pkgs/development/python-modules/xlib/fix-no-protocol-specified.patch
+++ b/pkgs/development/python-modules/xlib/fix-no-protocol-specified.patch
@@ -1,0 +1,13 @@
+diff --git a/Xlib/xauth.py b/Xlib/xauth.py
+index 2ed7dd5..303bd49 100644
+--- a/Xlib/xauth.py
++++ b/Xlib/xauth.py
+@@ -120,6 +120,8 @@ class Xauthority(object):
+         matches = {}
+ 
+         for efam, eaddr, enum, ename, edata in self.entries:
++            if enum == b'' and ename not in matches:
++                enum = num
+             if efam == family and eaddr == address and num == enum:
+                 matches[ename] = edata
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27679,6 +27679,8 @@ with pkgs;
 
   srain = callPackage ../applications/networking/irc/srain { };
 
+  streamdeck-ui = libsForQt5.callPackage ../applications/misc/streamdeck-ui { };
+
   super-productivity = callPackage ../applications/office/super-productivity {
     electron = electron_17;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10248,6 +10248,8 @@ in {
 
   stravalib = callPackage ../development/python-modules/stravalib { };
 
+  streamdeck = callPackage ../development/python-modules/streamdeck { };
+
   streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };
 
   streamlabswater = callPackage ../development/python-modules/streamlabswater { };


### PR DESCRIPTION
###### Description of changes

- [**streamdeck-ui**](https://timothycrosley.github.io/streamdeck-ui/) is a Linux compatible UI for the [Elgato Stream Deck](https://www.elgato.com/en/stream-deck).
- [**streamdeck**](https://github.com/abcminiuser/python-elgato-streamdeck) is a Python library to control the Elgato Stream Deck.
- Includes packaging fixes for Python dependencies `shiboken2` and `pyside2`.
- Includes a patch for an upstream bug in Python dependency `xlib`.
- Adds a NixOS module to autostart streamdeck-ui.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
