### PR TITLE
hw-probe: init at 1.6.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14801,4 +14801,11 @@
     github = "npatsakula";
     githubId = 23001619;
   };
+  winny = {
+    name = "Winston Weinert";
+    email = "nixpkgs@winny.tech";
+    matrix = "@winny:matrix.org";
+    github = "winny-";
+    githubId = 3893828;
+  };
 }

--- a/pkgs/tools/system/hw-probe/default.nix
+++ b/pkgs/tools/system/hw-probe/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper, perl, perlPackages, dmidecode, edid-decode
+, smartmontools , xz, curl, hwinfo, pciutils, usbutils, iproute2, util-linux
+}:
+let
+    prefixPath = programs:
+      "--prefix PATH ':' '${lib.makeBinPath programs}'";
+    programs = [ dmidecode edid-decode smartmontools xz curl hwinfo pciutils usbutils iproute2 util-linux ];
+in stdenv.mkDerivation rec {
+  pname = "hw-probe";
+  version = "1.6.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxhw";
+    repo = "hw-probe";
+    rev = version;
+    sha256 = "028wnhrbn10lfxwmcpzdbz67ygldimv7z1k1bm64ggclykvg5aim";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ perl perlPackages.DigestSHA1 ];
+  buildInputs = [ perl perlPackages.DigestSHA1 ];
+
+  installPhase = ''
+    make install "prefix=$out"
+    wrapProgram $out/bin/hw-probe \
+      ${prefixPath programs}
+  '';
+
+  meta = with lib; {
+    description = "A tool to probe for hardware and upload result to the Linux Hardware Database";
+    longDescription = ''
+      Hardware Probe Tool is a tool to probe for hardware, check it's
+      operability and find drivers. The probes are uploaded to the Linux
+      hardware database. See https://linux-hardware.org for more information.
+    '';
+    homepage = "https://github.com/linuxhw/hw-probe/";
+    changelog = "https://github.com/linuxhw/hwprobe/blob/${version}/NEWS.md";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ winny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35445,4 +35445,6 @@ with pkgs;
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
 
   mictray = callPackage ../tools/audio/mictray { };
+
+  hw-probe = callPackage ../tools/system/hw-probe { };
 }


### PR DESCRIPTION
###### Description of changes

This adds hw-probe to nixpkgs.  First time creating a package on nix, LMK if there's any gotchas to check out :).

Note:  there are a slew of optional dependencies.  I am thinking this could be added in a follow-up contribution, creating `hw-probe.full` as an alternative package.  See the `hw-probe.pl` file in the source distribution for a list of optional dependencies.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


I did

```bash
docker run -ti --rm -v $PWD:/nixpkgs nixos/nix sh -c 'cd /nixpkgs; nix-build -A hw-probe; /nix/store/*/bin/hw-probe -probe'
```

to verify it works and is not pulling in runtime dependencies from my systemPackages.