### PR TITLE
nixos/tests: fix type mismatch in wait_for_open_port

### DIFF
--- a/nixos/tests/3proxy.nix
+++ b/nixos/tests/3proxy.nix
@@ -139,7 +139,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     peer0.wait_for_unit("network-online.target")
 
     peer1.wait_for_unit("3proxy.service")
-    peer1.wait_for_open_port("9999")
+    peer1.wait_for_open_port(9999)
 
     # test none auth
     peer0.succeed(
@@ -153,7 +153,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     )
 
     peer2.wait_for_unit("3proxy.service")
-    peer2.wait_for_open_port("9999")
+    peer2.wait_for_open_port(9999)
 
     # test iponly auth
     peer0.succeed(
@@ -167,7 +167,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     )
 
     peer3.wait_for_unit("3proxy.service")
-    peer3.wait_for_open_port("9999")
+    peer3.wait_for_open_port(9999)
 
     # test strong auth
     peer0.succeed(

--- a/nixos/tests/bazarr.nix
+++ b/nixos/tests/bazarr.nix
@@ -20,7 +20,7 @@ in
 
   testScript = ''
     machine.wait_for_unit("bazarr.service")
-    machine.wait_for_open_port("${toString port}")
+    machine.wait_for_open_port(port)
     machine.succeed("curl --fail http://localhost:${toString port}/")
   '';
 })

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -61,7 +61,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ''
       url = "http://localhost/example.html"
       webserver.wait_for_unit("caddy")
-      webserver.wait_for_open_port("80")
+      webserver.wait_for_open_port(80)
 
 
       def check_etag(url):
@@ -95,13 +95,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           webserver.succeed(
               "${justReloadSystem}/bin/switch-to-configuration test >&2"
           )
-          webserver.wait_for_open_port("8080")
+          webserver.wait_for_open_port(8080)
 
       with subtest("multiple configs are correctly merged"):
           webserver.succeed(
               "${multipleConfigs}/bin/switch-to-configuration test >&2"
           )
-          webserver.wait_for_open_port("8080")
-          webserver.wait_for_open_port("8081")
+          webserver.wait_for_open_port(8080)
+          webserver.wait_for_open_port(8081)
     '';
 })

--- a/nixos/tests/convos.nix
+++ b/nixos/tests/convos.nix
@@ -23,7 +23,7 @@ in
 
   testScript = ''
     machine.wait_for_unit("convos")
-    machine.wait_for_open_port("${toString port}")
+    machine.wait_for_open_port(port)
     machine.succeed("journalctl -u convos | grep -q 'Listening at.*${toString port}'")
     machine.succeed("curl -f http://localhost:${toString port}/")
   '';

--- a/nixos/tests/cryptpad.nix
+++ b/nixos/tests/cryptpad.nix
@@ -12,7 +12,7 @@ with lib;
 
   testScript = ''
     machine.wait_for_unit("cryptpad.service")
-    machine.wait_for_open_port("3000")
+    machine.wait_for_open_port(3000)
     machine.succeed("curl -L --fail http://localhost:3000/sheet")
   '';
 })

--- a/nixos/tests/deluge.nix
+++ b/nixos/tests/deluge.nix
@@ -47,7 +47,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     simple.wait_for_unit("deluged")
     simple.wait_for_unit("delugeweb")
-    simple.wait_for_open_port("8112")
+    simple.wait_for_open_port(8112)
     declarative.wait_for_unit("network.target")
     declarative.wait_until_succeeds("curl --fail http://simple:8112")
 

--- a/nixos/tests/docker-registry.nix
+++ b/nixos/tests/docker-registry.nix
@@ -35,7 +35,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     registry.start()
     registry.wait_for_unit("docker-registry.service")
-    registry.wait_for_open_port("8080")
+    registry.wait_for_open_port(8080)
     client1.succeed("docker push registry:8080/scratch")
 
     client2.start()

--- a/nixos/tests/freeswitch.nix
+++ b/nixos/tests/freeswitch.nix
@@ -24,6 +24,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   testScript = ''
     node0.wait_for_unit("freeswitch.service")
     # Wait for SIP port to be open
-    node0.wait_for_open_port("5060")
+    node0.wait_for_open_port(5060)
   '';
 })

--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -36,7 +36,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   testScript = ''
     start_all()
     agent.wait_for_unit("gocd-server")
-    agent.wait_for_open_port("8153")
+    agent.wait_for_open_port(8153)
     agent.wait_for_unit("gocd-agent")
     agent.wait_until_succeeds(
         "curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].uuid"

--- a/nixos/tests/isso.nix
+++ b/nixos/tests/isso.nix
@@ -22,7 +22,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   ''
     machine.wait_for_unit("isso.service")
 
-    machine.wait_for_open_port("${toString port}")
+    machine.wait_for_open_port(port)
 
     machine.succeed("curl --fail http://localhost:${toString port}/?uri")
     machine.succeed("curl --fail http://localhost:${toString port}/js/embed.min.js")

--- a/nixos/tests/libreddit.nix
+++ b/nixos/tests/libreddit.nix
@@ -14,7 +14,7 @@ with lib;
 
   testScript = ''
     machine.wait_for_unit("libreddit.service")
-    machine.wait_for_open_port("80")
+    machine.wait_for_open_port(80)
     # Query a page that does not require Internet access
     machine.succeed("curl --fail http://localhost:80/settings")
   '';

--- a/nixos/tests/lidarr.nix
+++ b/nixos/tests/lidarr.nix
@@ -14,7 +14,7 @@ with lib;
     start_all()
 
     machine.wait_for_unit("lidarr.service")
-    machine.wait_for_open_port("8686")
+    machine.wait_for_open_port(8686)
     machine.succeed("curl --fail http://localhost:8686/")
   '';
 })

--- a/nixos/tests/mailcatcher.nix
+++ b/nixos/tests/mailcatcher.nix
@@ -24,7 +24,7 @@ import ./make-test-python.nix ({ lib, ... }:
     start_all()
 
     machine.wait_for_unit("mailcatcher.service")
-    machine.wait_for_open_port("1025")
+    machine.wait_for_open_port(1025)
     machine.succeed(
         'echo "this is the body of the email" | mail -s "subject" root@example.org'
     )

--- a/nixos/tests/mailhog.nix
+++ b/nixos/tests/mailhog.nix
@@ -12,8 +12,8 @@ import ./make-test-python.nix ({ lib, ... }: {
     start_all()
 
     machine.wait_for_unit("mailhog.service")
-    machine.wait_for_open_port("1025")
-    machine.wait_for_open_port("8025")
+    machine.wait_for_open_port(1025)
+    machine.wait_for_open_port(8025)
     machine.succeed(
         'echo "this is the body of the email" | swaks --to root@example.org --body - --server localhost:1025'
     )

--- a/nixos/tests/meilisearch.nix
+++ b/nixos/tests/meilisearch.nix
@@ -27,7 +27,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       start_all()
 
       machine.wait_for_unit("meilisearch")
-      machine.wait_for_open_port("7700")
+      machine.wait_for_open_port(7700)
 
       with subtest("check version"):
           version = json.loads(machine.succeed("curl ${apiUrl}/version"))

--- a/nixos/tests/minidlna.nix
+++ b/nixos/tests/minidlna.nix
@@ -32,7 +32,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     start_all()
     server.succeed("mkdir -p /tmp/stuff && chown minidlna: /tmp/stuff")
     server.wait_for_unit("minidlna")
-    server.wait_for_open_port("8200")
+    server.wait_for_open_port(8200)
     # requests must be made *by IP* to avoid triggering minidlna's
     # DNS-rebinding protection
     server.succeed("curl --fail http://$(getent ahostsv4 localhost | head -n1 | cut -f 1 -d ' '):8200/")

--- a/nixos/tests/navidrome.nix
+++ b/nixos/tests/navidrome.nix
@@ -7,6 +7,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
   testScript = ''
     machine.wait_for_unit("navidrome")
-    machine.wait_for_open_port("4533")
+    machine.wait_for_open_port(4533)
   '';
 })

--- a/nixos/tests/ncdns.nix
+++ b/nixos/tests/ncdns.nix
@@ -73,14 +73,14 @@ in
 
       with subtest("DNSKEY bit record is present"):
           server.wait_for_unit("pdns-recursor")
-          server.wait_for_open_port("53")
+          server.wait_for_open_port(53)
           server.succeed("host -t DNSKEY bit")
     '') +
     ''
       with subtest("can resolve a .bit name"):
           server.wait_for_unit("namecoind")
           server.wait_for_unit("ncdns")
-          server.wait_for_open_port("8332")
+          server.wait_for_open_port(8332)
           assert "1.2.3.4" in server.succeed("dig @localhost -p 5333 test.bit")
 
       with subtest("SOA record has identity information"):

--- a/nixos/tests/nghttpx.nix
+++ b/nixos/tests/nghttpx.nix
@@ -54,8 +54,8 @@ in
     testScript = ''
       start_all()
 
-      webserver.wait_for_open_port("80")
-      proxy.wait_for_open_port("80")
+      webserver.wait_for_open_port(80)
+      proxy.wait_for_open_port(80)
       client.wait_until_succeeds("curl -s --fail http://proxy/hello-world.txt")
     '';
   })

--- a/nixos/tests/node-red.nix
+++ b/nixos/tests/node-red.nix
@@ -19,7 +19,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   testScript = ''
     start_all()
     nodered.wait_for_unit("node-red.service")
-    nodered.wait_for_open_port("1880")
+    nodered.wait_for_open_port(1880)
 
     client.wait_for_unit("multi-user.target")
 

--- a/nixos/tests/ombi.nix
+++ b/nixos/tests/ombi.nix
@@ -12,7 +12,7 @@ with lib;
 
   testScript = ''
     machine.wait_for_unit("ombi.service")
-    machine.wait_for_open_port("5000")
+    machine.wait_for_open_port(5000)
     machine.succeed("curl --fail http://localhost:5000/")
   '';
 })

--- a/nixos/tests/pdns-recursor.nix
+++ b/nixos/tests/pdns-recursor.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
   testScript = ''
     server.wait_for_unit("pdns-recursor")
-    server.wait_for_open_port("53")
+    server.wait_for_open_port(53)
     assert "192.0.2.1" in server.succeed("host example.com localhost")
   '';
 })

--- a/nixos/tests/pict-rs.nix
+++ b/nixos/tests/pict-rs.nix
@@ -12,6 +12,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       start_all()
 
       machine.wait_for_unit("pict-rs")
-      machine.wait_for_open_port("8080")
+      machine.wait_for_open_port(8080)
     '';
   })

--- a/nixos/tests/plikd.nix
+++ b/nixos/tests/plikd.nix
@@ -15,7 +15,7 @@ import ./make-test-python.nix ({ lib, ... }: {
     machine.wait_for_unit("plikd")
 
     # Network test
-    machine.wait_for_open_port("8080")
+    machine.wait_for_open_port(8080)
     machine.succeed("curl --fail -v http://localhost:8080")
 
     # Application test

--- a/nixos/tests/podgrab.nix
+++ b/nixos/tests/podgrab.nix
@@ -22,11 +22,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     start_all()
 
     default.wait_for_unit("podgrab")
-    default.wait_for_open_port("${toString defaultPort}")
+    default.wait_for_open_port(defaultPort)
     default.succeed("curl --fail http://localhost:${toString defaultPort}")
 
     customized.wait_for_unit("podgrab")
-    customized.wait_for_open_port("${toString customPort}")
+    customized.wait_for_open_port(customPort)
     customized.succeed("curl --fail http://localhost:${toString customPort}")
   '';
 

--- a/nixos/tests/privoxy.nix
+++ b/nixos/tests/privoxy.nix
@@ -81,23 +81,23 @@ in
     ''
       with subtest("Privoxy is running"):
           machine.wait_for_unit("privoxy")
-          machine.wait_for_open_port("8118")
+          machine.wait_for_open_port(8118)
           machine.succeed("curl -f http://config.privoxy.org")
 
       with subtest("Privoxy can filter http requests"):
-          machine.wait_for_open_port("80")
+          machine.wait_for_open_port(80)
           assert "great day" in machine.succeed(
               "curl -sfL http://example.com/how-are-you? | tee /dev/stderr"
           )
 
       with subtest("Privoxy can filter https requests"):
-          machine.wait_for_open_port("443")
+          machine.wait_for_open_port(443)
           assert "great day" in machine.succeed(
               "curl -sfL https://example.com/how-are-you? | tee /dev/stderr"
           )
 
       with subtest("Blocks are working"):
-          machine.wait_for_open_port("443")
+          machine.wait_for_open_port(443)
           machine.fail("curl -f https://example.com/ads 1>&2")
           machine.succeed("curl -f https://example.com/PRIVOXY-FORCE/ads 1>&2")
 

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -52,7 +52,7 @@ let
     *    testScript = ''
     *      <exporterName>.start()
     *      <exporterName>.wait_for_unit("prometheus-<exporterName>-exporter.service")
-    *      <exporterName>.wait_for_open_port("1234")
+    *      <exporterName>.wait_for_open_port(1234)
     *      <exporterName>.succeed("curl -sSf 'localhost:1234/metrics'")
     *      <exporterName>.shutdown()
     *    '';

--- a/nixos/tests/prowlarr.nix
+++ b/nixos/tests/prowlarr.nix
@@ -12,7 +12,7 @@ with lib;
 
   testScript = ''
     machine.wait_for_unit("prowlarr.service")
-    machine.wait_for_open_port("9696")
+    machine.wait_for_open_port(9696)
     machine.succeed("curl --fail http://localhost:9696/")
   '';
 })

--- a/nixos/tests/rabbitmq.nix
+++ b/nixos/tests/rabbitmq.nix
@@ -22,6 +22,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     machine.wait_until_succeeds(
         'su -s ${pkgs.runtimeShell} rabbitmq -c "rabbitmqctl status"'
     )
-    machine.wait_for_open_port("15672")
+    machine.wait_for_open_port(15672)
   '';
 })

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -30,7 +30,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     machine.wait_for_unit("redis-test")
 
     # The unnamed Redis server still opens a port for backward-compatibility
-    machine.wait_for_open_port("6379")
+    machine.wait_for_open_port(6379)
 
     machine.wait_for_file("${redis.servers."".unixSocket}")
     machine.wait_for_file("${redis.servers."test".unixSocket}")

--- a/nixos/tests/sonarr.nix
+++ b/nixos/tests/sonarr.nix
@@ -12,7 +12,7 @@ with lib;
 
   testScript = ''
     machine.wait_for_unit("sonarr.service")
-    machine.wait_for_open_port("8989")
+    machine.wait_for_open_port(8989)
     machine.succeed("curl --fail http://localhost:8989/")
   '';
 })

--- a/nixos/tests/teleport.nix
+++ b/nixos/tests/teleport.nix
@@ -72,9 +72,9 @@ in
     nodes = { inherit minimal; };
 
     testScript = ''
-      minimal.wait_for_open_port("3025")
-      minimal.wait_for_open_port("3080")
-      minimal.wait_for_open_port("3022")
+      minimal.wait_for_open_port(3025)
+      minimal.wait_for_open_port(3080)
+      minimal.wait_for_open_port(3022)
     '';
   };
 
@@ -86,12 +86,12 @@ in
 
     testScript = ''
       with subtest("teleport ready"):
-          server.wait_for_open_port("3025")
-          client.wait_for_open_port("3022")
+          server.wait_for_open_port(3025)
+          client.wait_for_open_port(3022)
 
       with subtest("check applied configuration"):
           server.wait_until_succeeds("tctl get nodes --format=json | ${pkgs.jq}/bin/jq -e '.[] | select(.spec.hostname==\"client\") | .metadata.labels.role==\"client\"'")
-          server.wait_for_open_port("3000")
+          server.wait_for_open_port(3000)
           client.succeed("journalctl -u teleport.service --grep='DEBU'")
           server.succeed("journalctl -u teleport.service --grep='Starting teleport in insecure mode.'")
     '';

--- a/nixos/tests/vsftpd.nix
+++ b/nixos/tests/vsftpd.nix
@@ -29,7 +29,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   testScript = ''
     client.start()
     server.wait_for_unit("vsftpd")
-    server.wait_for_open_port("21")
+    server.wait_for_open_port(21)
 
     client.succeed("curl -u ftp-test-user:ftp-test-password ftp://server")
     client.succeed('echo "this is a test" > /tmp/test.file.up')


### PR DESCRIPTION
###### Description of changes

Fix some fallout from de3e423 (PR #171280).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
