### PR TITLE
fpm2: 0.79 -> 0.90

### DIFF
--- a/pkgs/tools/security/fpm2/default.nix
+++ b/pkgs/tools/security/fpm2/default.nix
@@ -2,8 +2,6 @@
 , libxml2, intltool, nettle
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "fpm2";
   version = "0.90";
@@ -16,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gnupg gtk3 libxml2 intltool nettle ];
 
-  meta = {
+  meta = with lib; {
     description = "GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements";
     homepage    = "https://als.regnet.cz/fpm2/";
     license     = licenses.gpl2;

--- a/pkgs/tools/security/fpm2/default.nix
+++ b/pkgs/tools/security/fpm2/default.nix
@@ -1,20 +1,20 @@
-{ lib, stdenv, fetchurl, pkg-config, gnupg, gtk2
-, libxml2, intltool
+{ lib, stdenv, fetchurl, pkg-config, gnupg, gtk3
+, libxml2, intltool, nettle
 }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "fpm2";
-  version = "0.79";
+  version = "0.90";
 
   src = fetchurl {
-    url = "https://als.regnet.cz/fpm2/download/fpm2-${version}.tar.bz2";
-    sha256 = "d55e9ce6be38a44fc1053d82db2d117cf3991a51898bd86d7913bae769f04da7";
+    url = "https://als.regnet.cz/fpm2/download/fpm2-${version}.tar.xz";
+    sha256 = "1lfzja3vzd6l6hfvw8gvg4qkl5iy6gra5pa8gjlps9l63k2bjfhz";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ gnupg gtk2 libxml2 intltool ];
+  buildInputs = [ gnupg gtk3 libxml2 intltool nettle ];
 
   meta = {
     description = "GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements";


### PR DESCRIPTION
Among other things switched from gtk2 to gtk3 and fixed build failure
against upstream gcc-10:

    ld: sha256.o:src/fpm.h:187: multiple definition of
      `ini'; main.o:src/fpm.h:187: first defined here

changelog: https://als.regnet.cz/fpm2/changelog

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
