### PR TITLE
smpeg: fix handling of pkg-config

### DIFF
--- a/pkgs/development/libraries/smpeg/default.nix
+++ b/pkgs/development/libraries/smpeg/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
     ./format.patch
     ./gcc6.patch
     ./libx11.patch
+    ./gtk.patch
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/smpeg/gtk.patch
+++ b/pkgs/development/libraries/smpeg/gtk.patch
@@ -1,0 +1,15 @@
+diff '--color=auto' -Naur smpeg-r390.orig/acinclude/gtk-2.0.m4 smpeg-r390/acinclude/gtk-2.0.m4
+--- smpeg-r390.orig/acinclude/gtk-2.0.m4	1970-01-01 08:00:01.000000000 +0800
++++ smpeg-r390/acinclude/gtk-2.0.m4	2021-12-16 15:52:17.776001058 +0800
+@@ -24,10 +24,8 @@
+ 
+   no_gtk=""
+ 
+-  AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+-
+   if test x$PKG_CONFIG != xno ; then
+-    if pkg-config --atleast-pkgconfig-version 0.7 ; then
++    if $PKG_CONFIG --atleast-pkgconfig-version 0.7 ; then
+       :
+     else
+       echo "*** pkg-config too old; version 0.7 or better required."


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
