### PR TITLE
fix(protonvpn-cli): protonvpn-cli depends on dbus-python

### DIFF
--- a/pkgs/applications/networking/protonvpn-cli/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli/default.nix
@@ -3,6 +3,7 @@
 , pythonOlder
 , fetchFromGitHub
 , protonvpn-nm-lib
+, dbus-python
 , pythondialog
 , dialog
 }:
@@ -23,6 +24,7 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     protonvpn-nm-lib
+    dbus-python
     pythondialog
     dialog
   ];


### PR DESCRIPTION
###### Description of changes

protonvpn-cli does not work without dbus-python. This adds the
dependency. Without this patch:

```
$ protonvpn-cli status
Traceback (most recent call last):
  File "/nix/store/4lyfsgv6ik3i8d861fds7bc5s4hnqyfw-protonvpn-cli-3.11.1/bin/.protonvpn-cli-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/4lyfsgv6ik3i8d861fds7bc5s4hnqyfw-protonvpn-cli-3.11.1/lib/python3.9/site-packages/protonvpn_cli/main.py", line 21, in main
    ProtonVPNCLI()
  File "/nix/store/4lyfsgv6ik3i8d861fds7bc5s4hnqyfw-protonvpn-cli-3.11.1/lib/python3.9/site-packages/protonvpn_cli/cli.py", line 65, in __init__
    res = getattr(self, args.command)()
  File "/nix/store/4lyfsgv6ik3i8d861fds7bc5s4hnqyfw-protonvpn-cli-3.11.1/lib/python3.9/site-packages/protonvpn_cli/cli.py", line 174, in status
    return self.cli_wrapper.status()
  File "/nix/store/4lyfsgv6ik3i8d861fds7bc5s4hnqyfw-protonvpn-cli-3.11.1/lib/python3.9/site-packages/protonvpn_cli/cli_wrapper.py", line 857, in status
    if not self.protonvpn.get_active_protonvpn_connection():
  File "/nix/store/1jhp3mgs9f21nrgb58gy3qg7gjrqq44v-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/api.py", line 407, in get_active_protonvpn_connection
    return self._env.connection_backend\
  File "/nix/store/1jhp3mgs9f21nrgb58gy3qg7gjrqq44v-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/environment.py", line 43, in connection_backend
    from .connection_backend import ConnectionBackend
  File "/nix/store/1jhp3mgs9f21nrgb58gy3qg7gjrqq44v-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/connection_backend/__init__.py", line 1, in <module>
    from .nm_client import nm_client # noqa
  File "/nix/store/1jhp3mgs9f21nrgb58gy3qg7gjrqq44v-python3.9-protonvpn-nm-lib-3.9.0/lib/python3.9/site-packages/protonvpn_nm_lib/core/connection_backend/nm_client/nm_client.py", line 3, in <module>
    from dbus.mainloop.glib import DBusGMainLoop
ModuleNotFoundError: No module named 'dbus'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
