### PR TITLE
youtube-dl: fallback to throttled downloads instead of aborting

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -25,8 +25,8 @@ buildPythonPackage rec {
   };
 
   patches = [
-    # Fixes throttling on youtube.com. Without the patch downloads are capped at
-    # about 80KiB/s. See, e.g.,
+    # Fixes throttling on youtube.com by decoding a "n-parameter". Without the patch
+    # downloads are capped at about 80KiB/s. See, e.g.,
     #
     #   https://github.com/ytdl-org/youtube-dl/issues/29326
     #
@@ -36,6 +36,20 @@ buildPythonPackage rec {
       name = "fix-youtube-dl-speed.patch";
       url = "https://github.com/ytdl-org/youtube-dl/compare/57044eacebc6f2f3cd83c345e1b6e659a22e4773...1e677567cd083d43f55daef0cc74e5fa24575ae3.diff";
       sha256 = "11s0j3w60r75xx20p0x2j3yc4d3yvz99r0572si8b5qd93lqs4pr";
+    })
+    # The above patch may fail to decode the n-parameter (if, say, YouTube is updated). Failure to decode
+    # it blocks the download instead of falling back to the throttled version. The patch below implements
+    # better fallback behaviour.
+    (fetchpatch {
+      name = "avoid-crashing-if-nsig-decode-fails.patch";
+      url = "https://github.com/ytdl-org/youtube-dl/commit/41f0043983c831b7c0c3614340d2f66ec153087b.diff";
+      sha256 = "sha256-a72gWhBXCLjuBBD36PpZ5F/AHBdiBv4W8Wf9g4P/aBY=";
+    })
+    # YouTube changed the n-parameter format in April 2022, so decoder updates are required.
+    (fetchpatch {
+      name = "fix-n-descrambling.patch";
+      url = "https://github.com/ytdl-org/youtube-dl/commit/a0068bd6bec16008bda7a39caecccbf84881c603.diff";
+      sha256 = "sha256-tSuEns4jputa2nOOo6JsFXpK3hvJ/+z1/ymcLsd3A6w=";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

The issue in #169358 happens because I included a patch (#165131) to help with download throttling. Without the patch, `youtube-dl 2021.12.17` works but downloads will be capped at < 100kB/s. This includes a further patch to fallback to throttled download in case YouTube changes as well as a further change to make unthrottled downloads work with current YouTube. There are three ways to proceed:

1) Merge this PR. This will lead to fast downloads now, but perhaps throttled (but working) downloads if YouTube updates its code again.
2) Track `youtube-dl` master instead of patching the latest released version.
3) Revert the throttling patch from #165131. This will lead to throttled (but working) downloads.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
