### PR TITLE
dmarc-metrics-exporter: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/bite-parser/default.nix
+++ b/pkgs/development/python-modules/bite-parser/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "bite-parser";
-  version = "0.1.1";
+  version = "0.1.3";
 
   disabled = pythonOlder "3.7";
 
@@ -18,14 +18,8 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8021100bfbd6cc6056605361e763a3591efdea38014b3d8aa76c74c74de4ead4";
+    sha256 = "0f246e98a5556d6ed9a33fda1e94c3ab906305729feb30d25e35344b3e1c1fd9";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'python = "^3.7,<=3.10"' 'python = "^3.7,<3.11"' \
-      --replace poetry.masonry.api poetry.core.masonry.api
-  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -42,6 +36,7 @@ buildPythonPackage rec {
   meta = {
     description = "Asynchronous parser taking incremental bites out of your byte input stream";
     homepage = "https://github.com/jgosmann/bite-parser";
+    changelog = "https://github.com/jgosmann/bite-parser/blob/v${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };

--- a/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
@@ -1,11 +1,10 @@
 { lib
 , python3
-, fetchpatch
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dmarc-metrics-exporter";
-  version = "0.5.1";
+  version = "0.6.0";
 
   disabled = python3.pythonOlder "3.7";
 
@@ -13,21 +12,11 @@ python3.pkgs.buildPythonApplication rec {
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "22ec361f9a4c86abefbfab541f588597e21bf4fbedf2911f230e560b2ec3503a";
+    sha256 = "70f39b373ead42acb8caf56040f7ebf13ab67aea505511025c09ecf4560f8b1b";
   };
-
-  patches = [
-    # https://github.com/jgosmann/dmarc-metrics-exporter/pull/23
-    (fetchpatch {
-      url = "https://github.com/jgosmann/dmarc-metrics-exporter/commit/3fe401f5dfb9e0304601a2a89ac987ff853b7cba.patch";
-      hash = "sha256-MjVLlFQMp2r3AhBMu1lEmRm0Y2H9FdvCfPgAK5kvwWE=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'python = "^3.7,<3.10"' 'python = "^3.7,<3.11"' \
-      --replace poetry.masonry.api poetry.core.masonry.api \
       --replace '"^' '">='
   '';
 
@@ -63,6 +52,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "Export Prometheus metrics from DMARC reports";
     homepage = "https://github.com/jgosmann/dmarc-metrics-exporter";
+    changelog = "https://github.com/jgosmann/dmarc-metrics-exporter/blob/v${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ma27 ];
   };


### PR DESCRIPTION
###### Description of changes
https://github.com/jgosmann/dmarc-metrics-exporter/releases/tag/v0.6.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/pull/177385, closes https://github.com/NixOS/nixpkgs/pull/175726