### PR TITLE
python3Packages.vqgan-jax: init at unstable-2022-04-20

### DIFF
--- a/pkgs/development/python-modules/vqgan-jax/default.nix
+++ b/pkgs/development/python-modules/vqgan-jax/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flax
+, jax
+, jaxlib
+, transformers
+}:
+
+buildPythonPackage rec {
+  pname = "vqgan-jax";
+  version = "unstable-2022-04-20";
+
+  src = fetchFromGitHub {
+    owner = "patil-suraj";
+    repo = "vqgan-jax";
+    rev = "1be20eee476e5d35c30e4ec3ed12222018af8ce4";
+    sha256 = "sha256-OZihAXpE0UsgauQ38XDmAF+lrIgz05uK0ro8SCdVsPc=";
+  };
+
+  format = "setuptools";
+
+  buildInputs = [
+    jaxlib
+  ];
+
+  propagatedBuildInputs = [
+    flax
+    jax
+    transformers
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "vqgan_jax"
+  ];
+
+  meta = with lib; {
+    description = "JAX implementation of VQGAN";
+    homepage = "https://github.com/patil-suraj/vqgan-jax";
+    # license unknown: https://github.com/patil-suraj/vqgan-jax/issues/9
+    license = lib.licenses.unfree;
+    maintainers = with maintainers; [ r-burns ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11034,6 +11034,8 @@ in {
 
   vpk = callPackage ../development/python-modules/vpk { };
 
+  vqgan-jax = callPackage ../development/python-modules/vqgan-jax { };
+
   vsts = callPackage ../development/python-modules/vsts { };
 
   vsts-cd-manager = callPackage ../development/python-modules/vsts-cd-manager { };


### PR DESCRIPTION
This is needed along with https://github.com/NixOS/nixpkgs/pull/177315 to run the dalle-mini inference jupyter notebook.

Note that the repo is currently unlicensed - I asked for clarification upstream, and have proceeded with packaging anyway for convenience. The package is very simple so having it built on hydra is not critical.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
