### PR TITLE
mpd: fix socket activation

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -215,6 +215,7 @@ in {
     systemd.sockets.mpd = mkIf cfg.startWhenNeeded {
       wantedBy = [ "sockets.target" ];
       listenStreams = [
+        ""  # Note: this is needed to override the upstream unit
         (if pkgs.lib.hasPrefix "/" cfg.network.listenAddress
           then cfg.network.listenAddress
           else "${optionalString (cfg.network.listenAddress != "any") "${cfg.network.listenAddress}:"}${toString cfg.network.port}")


### PR DESCRIPTION
###### Description of changes

Apparently since systemd v250 a `ListenStream` in an override file won't
override the unit, but will be appended to a list of socket addresses.
The socket unit fails if two or more addresses have the same port,
probably because two systemd processes try to listen to it at once.
The solution is to add an empty `ListenStream=` to reset all previous
definitions.

Fix #175478.

###### Things done

- [x] Tested mpd with socket activation
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).