### PR TITLE
colorpanes: init at 3.0.1

### DIFF
--- a/pkgs/tools/misc/colorpanes/default.nix
+++ b/pkgs/tools/misc/colorpanes/default.nix
@@ -1,0 +1,27 @@
+{ lib, rustPlatform, fetchFromGitea }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "colorpanes";
+  version = "3.0.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "papojari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "qaOH+LXNDq+utwyI1yzHWNt25AvdAXCTAziGV9ElroU=";
+  };
+
+  cargoSha256 = "eJne4OmV4xHxntTb8HE+2ghX1hZLE3WQ3QqsjVm9E4M=";
+
+  postInstall = ''
+    ln -s $out/bin/colp $out/bin/colorpanes
+  '';
+
+  meta = with lib; {
+    description = "Panes in the 8 bright terminal colors with shadows of the respective darker color";
+    homepage = "https://codeberg.org/papojari/colorpanes";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ papojari ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -348,6 +348,8 @@ with pkgs;
 
   colorz = callPackage ../tools/misc/colorz { };
 
+  colorpanes = callPackage ../tools/misc/colorpanes { };
+
   colorpicker = callPackage ../tools/misc/colorpicker { };
 
   comedilib = callPackage ../development/libraries/comedilib {  };


### PR DESCRIPTION
###### Description of changes

Add the colorpanes package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
