### PR TITLE
faraday-cli: 2.0.2 -> 2.1.5

### DIFF
--- a/pkgs/development/python-modules/py-sneakers/default.nix
+++ b/pkgs/development/python-modules/py-sneakers/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "py-sneakers";
+  version = "1.0.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-bIhkYTzRe4uM0kbNhbDTr6TiaOEBSiCSkPJKKCivDZY=";
+  };
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "py_sneakers"
+  ];
+
+  meta = with lib; {
+    description = "Library to emulate the Sneakers movie effect";
+    homepage = "https://github.com/aenima-x/py-sneakers";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/faraday-cli/default.nix
+++ b/pkgs/tools/security/faraday-cli/default.nix
@@ -5,13 +5,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "faraday-cli";
-  version = "2.0.2";
+  version = "2.1.5";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "infobyte";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-J3YlFsX/maOqWo4ILEMXzIJeQ8vr47ApGGiaBWrUCMs=";
+    hash = "sha256-kl5yOJTMobccZoaIoWwQubCrswPa69I5Kmuox7JqAXs=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -22,8 +23,10 @@ python3.pkgs.buildPythonApplication rec {
     faraday-plugins
     jsonschema
     log-symbols
+    luddite
     packaging
     pyyaml
+    py-sneakers
     simple-rest-client
     spinners
     tabulate

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6976,6 +6976,8 @@ in {
 
   py-synologydsm-api = callPackage ../development/python-modules/py-synologydsm-api { };
 
+  py-sneakers = callPackage ../development/python-modules/py-sneakers { };
+
   py-tes = callPackage ../development/python-modules/py-tes { };
 
   py-ubjson = callPackage ../development/python-modules/py-ubjson { };


### PR DESCRIPTION
###### Description of changes
https://github.com/infobyte/faraday-cli/releases/tag/v2.1.5
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
