### PR TITLE
distrobox: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/virtualization/distrobox/default.nix
+++ b/pkgs/applications/virtualization/distrobox/default.nix
@@ -2,13 +2,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "distrobox";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "89luca89";
     repo = pname;
     rev = version;
-    sha256 = "sha256-31SDi9B6Ug6lRDMgaMp6lwdSsmQ7ywEwjG1Ez/jXjBc=";
+    sha256 = "sha256-7qPEtWDshe3bHUvbf35k31EnL2sQEXeDmMUGBPkiB9U=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes

Mainly bugfix release:

What's Changed
all: allow users to specify non_interactive=true/false by [@dfaggioli](https://github.com/dfaggioli) in [#302](https://github.com/89luca89/distrobox/pull/302)

all: improve code readability and formatting, follow happy paths

create: make it clearer to the user the container creation output, specifying the image and name used. This is useful in case the user is using default image or name

create: remove check about clone and image name Fix [#320](https://github.com/89luca89/distrobox/issues/320)

docs: Fix typo by [@rugk](https://github.com/rugk) in [#308](https://github.com/89luca89/distrobox/pull/308)

docs: Update gnome instruction by [@jswinner](https://github.com/jswinner) in [#314](https://github.com/89luca89/distrobox/pull/314)

docs: remove WSL2 entry, cannot actively check if works correctly. Better not give false hopes

docs: typo fix by [@misobarisic](https://github.com/misobarisic) in [#317](https://github.com/89luca89/distrobox/pull/317)

enter: automatically create containers during 'distrobox-enter' (if they don't exist!) by [@dfaggioli](https://github.com/dfaggioli) in [#302](https://github.com/89luca89/distrobox/pull/302)

export: add --root to rooful containers. Fix [#313](https://github.com/89luca89/distrobox/issues/313)

export: export: fix regression in export app introduces in [4522f29](https://github.com/89luca89/distrobox/commit/4522f29ef5000b68c8a6f4716c0c2fa4145a1304)

export: fix DBusActivatable not working by [@89luca89](https://github.com/89luca89) in [#300](https://github.com/89luca89/distrobox/pull/300)

host-exec docs: 755 -> 644 by [@misobarisic](https://github.com/misobarisic) in [#304](https://github.com/89luca89/distrobox/pull/304)

host-exec: change [N/y] to [y/N] by [@misobarisic](https://github.com/misobarisic) in [#306](https://github.com/89luca89/distrobox/pull/306)

init: fix apt hooks to make systemd install work by [@89luca89](https://github.com/89luca89) in [#297](https://github.com/89luca89/distrobox/pull/297)

init: move zypper recommends after the basic packages install, make OpenSUSE containers creation faster

install: add --next flag to install latest commit from git

stop: update misleading comment by [@misobarisic](https://github.com/misobarisic) in [#307](https://github.com/89luca89/distrobox/pull/307)

uninstall: interactive rm won't work when executed throught pipe

docs: update compatibility list

Confirm support for:
Redhat UBI 9
Redhat UBI 9-init
Redhat UBI 9-minimal
AlmaLinux 8-minimal
AlmaLinux 9-minimal
AlmaLinux 9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
