### PR TITLE
sil-q: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6684,6 +6684,13 @@
       fingerprint = "932F 3E8E 1C0F 4A98 95D7  B8B8 B0CA A28A 0295 8308";
     }];
   };
+  kenran = {
+    email = "johannes.maier@mailbox.org";
+    github = "kenranunderscore";
+    githubId = 5188977;
+    matrix = "@kenran_:matrix.org";
+    name = "Johannes Maier";
+  };
   kentjames = {
     email = "jameschristopherkent@gmail.com";
     github = "kentjames";

--- a/pkgs/games/sil-q/default.nix
+++ b/pkgs/games/sil-q/default.nix
@@ -1,0 +1,66 @@
+{ lib, stdenv, fetchFromGitHub, writeScript, makeWrapper, ncurses, libX11 }:
+
+let
+  setup = writeScript "setup" ''
+    mkdir -p "$ANGBAND_PATH"
+    # copy all the data files into place
+    cp -ar $1/* "$ANGBAND_PATH"
+    # the copied files need to be writable
+    chmod +w -R "$ANGBAND_PATH"
+  '';
+in stdenv.mkDerivation rec {
+  pname = "sil-q";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "sil-quirk";
+    repo = "sil-q";
+    rev = "v${version}";
+    sha256 = "sha256-v/sWhPWF9cCKD8N0RHpwzChMM1t9G2yrMDmi1cZxdOs=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ ncurses libX11 ];
+
+  # Makefile(s) and config are not top-level
+  sourceRoot = "source/src";
+
+  postPatch = ''
+    # allow usage of ANGBAND_PATH
+    substituteInPlace config.h --replace "#define FIXED_PATHS" ""
+
+    # change Makefile.std for ncurses according to its own comment
+    substituteInPlace Makefile.std --replace "-lcurses" "-lncurses"
+  '';
+
+  makefile = "Makefile.std";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp sil $out/bin/sil-q
+    wrapProgram $out/bin/sil-q \
+      --run "export ANGBAND_PATH=\$HOME/.sil" \
+      --run "${setup} ${src}/lib"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A roguelike game set in the First Age of Middle-earth";
+    longDescription = ''
+      A game of adventure set in the First Age of Middle-earth, when the world still
+      rang with Elven song and gleamed with Dwarven mail.
+
+      Walk the dark halls of Angband.  Slay creatures black and fell.  Wrest a shining
+      Silmaril from Morgoth’s iron crown.
+
+      A fork of Sil that's still actively developed.
+    '';
+    homepage = "https://github.com/sil-quirk/sil-q";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.kenran ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32308,6 +32308,8 @@ with pkgs;
 
   sil = callPackage ../games/sil { };
 
+  sil-q = callPackage ../games/sil-q { };
+
   simutrans = callPackage ../games/simutrans { };
   # get binaries without data built by Hydra
   simutrans_binaries = lowPrio simutrans.binaries;


### PR DESCRIPTION
###### Description of changes

Adds the [Sil-Q](https://github.com/sil-quirk/sil-q) game, with support for the `ncurses` and `X11` frontends. Sil-Q is the "continuation" of Sil (which is already packaged but no longer actively developed).

The Nix expression takes some things from Sil's and is thus quite similar. One thing I don't know yet is whether I need the `NIX_CFLAGS_COMPILE = "-fcommon"` bit, too. It seems to be relevant to #110571.

This also adds me as a maintainer as a separate commit as per the manual.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
