### PR TITLE
nixos/security/wrappers: use an assertion for the existence check

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -202,15 +202,21 @@ in
   ###### implementation
   config = {
 
-    assertions = lib.mapAttrsToList
-      (name: opts:
+    assertions = lib.concatLists (lib.mapAttrsToList
+      (name: opts: [
         { assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
           message = ''
             The security.wrappers.${name} wrapper is not valid:
                 setuid/setgid and capabilities are mutually exclusive.
           '';
         }
-      ) wrappers;
+        { assertion = lib.pathHasContext (toString opts.source) -> lib.pathExists opts.source;
+          message = ''
+            The security.wrappers.${name} wrapper is not valid:
+                the source store path '${opts.source}' does not exist.
+          '';
+        }
+      ]) wrappers);
 
     security.wrappers =
       let
@@ -273,33 +279,5 @@ in
             ln --symbolic "$wrapperDir" "${wrapperDir}"
           fi
         '';
-
-    ###### wrappers consistency checks
-    system.extraDependencies = lib.singleton (pkgs.runCommandLocal
-      "ensure-all-wrappers-paths-exist" { }
-      ''
-        # make sure we produce output
-        mkdir -p $out
-
-        echo -n "Checking that Nix store paths of all wrapped programs exist... "
-
-        declare -A wrappers
-        ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v:
-          "wrappers['${n}']='${v.source}'") wrappers)}
-
-        for name in "''${!wrappers[@]}"; do
-          path="''${wrappers[$name]}"
-          if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
-            test -t 1 && echo -ne '\033[1;31m'
-            echo "FAIL"
-            echo "The path $path does not exist!"
-            echo 'Please, check the value of `security.wrappers."'$name'".source`.'
-            test -t 1 && echo -ne '\033[0m'
-            exit 1
-          fi
-        done
-
-        echo "OK"
-      '');
   };
 }


### PR DESCRIPTION
A simpler implementation of 7d8b303e3fd76ccf58cfe26348e889def3663546 that uses an assertion instead of a derivation.

`pathHasContext` seems a bit better than `hasPrefix storeDir` because it avoids a string comparison, and catches nonsense like `"foo${pkgs.hello}bar"`.

Tested success and failure.