### PR TITLE
rapidfuzz-cpp: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/libraries/catch2/3.nix
+++ b/pkgs/development/libraries/catch2/3.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "catch2";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "catchorg";
+    repo = "Catch2";
+    rev = "v${version}";
+    hash = "sha256-GcMkAgSfQnWs8wQeQD4ZMxJZED8V7FWBU04qMCutlPo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DCATCH_DEVELOPMENT_BUILD=ON"
+    "-DCATCH_BUILD_TESTING=${if doCheck then "ON" else "OFF"}"
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    python3
+  ];
+
+  meta = {
+    description = "Modern, C++-native, test framework for unit-tests";
+    homepage = "https://github.com/catchorg/Catch2";
+    changelog = "https://github.com/catchorg/Catch2/blob/${src.rev}/docs/release-notes.md";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [ dotlambda ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/jarowinkler-cpp/default.nix
+++ b/pkgs/development/libraries/jarowinkler-cpp/default.nix
@@ -2,18 +2,18 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, catch2
+, catch2_3
 }:
 
 stdenv.mkDerivation rec {
   pname = "jarowinkler-cpp";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "maxbachmann";
     repo = "jarowinkler-cpp";
     rev = "v${version}";
-    hash = "sha256-6dIyCyoPs/2wHyGqlE+NC0pwz5ggS5edhN4Jbltx0jg=";
+    hash = "sha256-3/x0fyaDJTouBKbif0ALgMzht6HMEGHNw8g8zQlUcNk=";
   };
 
   nativeBuildInputs = [
@@ -21,15 +21,14 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = lib.optionals doCheck [
-    "-DRAPIDFUZZ_BUILD_TESTING=ON"
+    "-DJARO_WINKLER_BUILD_TESTING=ON"
   ];
 
   checkInputs = [
-    catch2
+    catch2_3
   ];
 
-  # uses unreleased Catch2 version 3
-  doCheck = false;
+  doCheck = true;
 
   meta = {
     description = "Fast Jaro and Jaro-Winkler distance";

--- a/pkgs/development/libraries/rapidfuzz-cpp/default.nix
+++ b/pkgs/development/libraries/rapidfuzz-cpp/default.nix
@@ -2,19 +2,28 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, catch2
+, catch2_3
 }:
 
 stdenv.mkDerivation rec {
   pname = "rapidfuzz-cpp";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "maxbachmann";
     repo = "rapidfuzz-cpp";
     rev = "v${version}";
-    hash = "sha256-331iW0nu5MlxuKNTgMkRSASnglxn+hEWBhRMnw0lY2Y=";
+    hash = "sha256-Tf7nEMXiem21cvQHPnYnCvOOLg0KBBnNQDaYIcHcm2g=";
   };
+
+  patches = lib.optionals doCheck [
+    ./dont-fetch-project-options.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace test/CMakeLists.txt \
+      --replace WARNINGS_AS_ERRORS ""
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -25,11 +34,10 @@ stdenv.mkDerivation rec {
   ];
 
   checkInputs = [
-    catch2
+    catch2_3
   ];
 
-  # uses unreleased Catch2 version 3
-  doCheck = false;
+  doCheck = true;
 
   meta = {
     description = "Rapid fuzzy string matching in C++ using the Levenshtein Distance";

--- a/pkgs/development/libraries/rapidfuzz-cpp/dont-fetch-project-options.patch
+++ b/pkgs/development/libraries/rapidfuzz-cpp/dont-fetch-project-options.patch
@@ -1,0 +1,58 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 5ba4464..ad72319 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -12,39 +12,10 @@ else()
+     FetchContent_MakeAvailable(Catch2)
+ endif()
+ 
+-# include aminya & jason turner's C++ best practices recommended cmake project utilities
+-include(FetchContent)
+-FetchContent_Declare(_project_options URL https://github.com/aminya/project_options/archive/refs/tags/v0.20.0.zip)
+-FetchContent_MakeAvailable(_project_options)
+-include(${_project_options_SOURCE_DIR}/Index.cmake)
+-
+-project_options(
+-        # ENABLE_CACHE
+-        # ENABLE_CONAN
+-        WARNINGS_AS_ERRORS
+-        # ENABLE_CPPCHECK
+-        # ENABLE_CLANG_TIDY
+-        # ENABLE_INCLUDE_WHAT_YOU_USE
+-        # ENABLE_COVERAGE
+-        # ENABLE_PCH
+-        # PCH_HEADERS <Eigen/Dense> <fmt/core.h> <vector> <utility> <string> <string_view>
+-        # ENABLE_DOXYGEN
+-        # ENABLE_IPO
+-        # ENABLE_USER_LINKER
+-        # ENABLE_BUILD_WITH_TIME_TRACE
+-        # ENABLE_UNITY
+-        # ENABLE_SANITIZER_ADDRESS
+-        # ENABLE_SANITIZER_LEAK
+-        # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
+-        # ENABLE_SANITIZER_THREAD
+-        # ENABLE_SANITIZER_MEMORY
+-        # CLANG_WARNINGS "-Weverything"
+-)
+-
+ function(rapidfuzz_add_test test)
+     add_executable(test_${test} tests-${test}.cpp)
+     target_link_libraries(test_${test} ${PROJECT_NAME})
+-    target_link_libraries(test_${test} Catch2::Catch2WithMain project_warnings)
++    target_link_libraries(test_${test} Catch2::Catch2WithMain)
+     add_test(NAME ${test} COMMAND test_${test})
+ endfunction()
+ 
+diff --git a/test/distance/CMakeLists.txt b/test/distance/CMakeLists.txt
+index 2a70054..7a43c88 100644
+--- a/test/distance/CMakeLists.txt
++++ b/test/distance/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ function(rapidfuzz_add_test test)
+     add_executable(test_${test} tests-${test}.cpp)
+     target_link_libraries(test_${test} ${PROJECT_NAME})
+-    target_link_libraries(test_${test} Catch2::Catch2WithMain project_warnings)
++    target_link_libraries(test_${test} Catch2::Catch2WithMain)
+     add_test(NAME ${test} COMMAND test_${test})
+ endfunction()
+ 

--- a/pkgs/development/python-modules/rapidfuzz/default.nix
+++ b/pkgs/development/python-modules/rapidfuzz/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , cmake
 , cython_3
+, ninja
 , rapidfuzz-capi
 , scikit-build
 , jarowinkler
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     cmake
     cython_3
+    ninja
     rapidfuzz-capi
     scikit-build
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2951,6 +2951,8 @@ with pkgs;
 
   catch2 = callPackage ../development/libraries/catch2 { };
 
+  catch2_3 = callPackage ../development/libraries/catch2/3.nix { };
+
   catdoc = callPackage ../tools/text/catdoc { };
 
   catdocx = callPackage ../tools/text/catdocx { };


### PR DESCRIPTION
###### Description of changes
https://github.com/maxbachmann/rapidfuzz-cpp/releases/tag/v1.0.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @yuuyins 