### PR TITLE
 tree-sitter: init tree-sitter-{go-work,rego,sql}, update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -69,6 +69,7 @@
   tree-sitter-query = lib.importJSON ./tree-sitter-query.json;
   tree-sitter-r = lib.importJSON ./tree-sitter-r.json;
   tree-sitter-regex = lib.importJSON ./tree-sitter-regex.json;
+  tree-sitter-rego = lib.importJSON ./tree-sitter-rego.json;
   tree-sitter-rst = lib.importJSON ./tree-sitter-rst.json;
   tree-sitter-ruby = lib.importJSON ./tree-sitter-ruby.json;
   tree-sitter-rust = lib.importJSON ./tree-sitter-rust.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -30,6 +30,7 @@
   tree-sitter-glimmer = lib.importJSON ./tree-sitter-glimmer.json;
   tree-sitter-glsl = lib.importJSON ./tree-sitter-glsl.json;
   tree-sitter-go = lib.importJSON ./tree-sitter-go.json;
+  tree-sitter-gowork = lib.importJSON ./tree-sitter-gowork.json;
   tree-sitter-godot-resource = lib.importJSON ./tree-sitter-godot-resource.json;
   tree-sitter-gomod = lib.importJSON ./tree-sitter-gomod.json;
   tree-sitter-graphql = lib.importJSON ./tree-sitter-graphql.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -77,6 +77,7 @@
   tree-sitter-scheme = lib.importJSON ./tree-sitter-scheme.json;
   tree-sitter-scss = lib.importJSON ./tree-sitter-scss.json;
   tree-sitter-sparql = lib.importJSON ./tree-sitter-sparql.json;
+  tree-sitter-sql = lib.importJSON ./tree-sitter-sql.json;
   tree-sitter-supercollider = lib.importJSON ./tree-sitter-supercollider.json;
   tree-sitter-surface = lib.importJSON ./tree-sitter-surface.json;
   tree-sitter-svelte = lib.importJSON ./tree-sitter-svelte.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-clojure",
-  "rev": "879f0e726295807d917d576fcf9e1e432c4c20fc",
-  "date": "2022-04-11T22:46:47+09:00",
-  "path": "/nix/store/19bcj8f61w958njvksnqzm5r5s8szzz2-tree-sitter-clojure",
-  "sha256": "16g7s819gjgdc4wlp7rnvyv5i5dqa1yawxs8l4ggnz8n8acqza9n",
+  "rev": "e57c569ae332ca365da623712ae1f50f84daeae2",
+  "date": "2022-06-03T17:55:54+09:00",
+  "path": "/nix/store/fx58zcfxr983yczijs6cgdfa3158bl0s-tree-sitter-clojure",
+  "sha256": "0hq8rv4s0gzbfv3qj4gsrm87baiy6k1hyfbhbbpwbrcpd8jl7gdn",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elm-tooling/tree-sitter-elm",
-  "rev": "5128296ba8542853d59e6b7c8dfe3d1fb9a637ea",
-  "date": "2022-02-04T13:10:25+01:00",
-  "path": "/nix/store/8brpvn8y88x3f3dsbgqql57kp9bygj3w-tree-sitter-elm",
-  "sha256": "10hbi4vyj4hjixqswdcbvzl60prldczz29mlp02if61wvwiwvqrw",
+  "rev": "a9a8efad446f78db3989d7ed8517987daf510c83",
+  "date": "2022-06-07T23:23:33+02:00",
+  "path": "/nix/store/rqmldb72cml0qm7p8kpjlj064f5miprc-tree-sitter-elm",
+  "sha256": "11d9lrybhqi85lxr7gf8s4zxgbclnjiwn0w1mga3lsh9nnf50a4a",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/omertuc/tree-sitter-go-work",
+  "rev": "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2",
+  "date": "2021-12-18T20:13:22+01:00",
+  "path": "/nix/store/7a4raw2gi4xgbg858cs0davbplj7m8rq-tree-sitter-gowork",
+  "sha256": "1kzrs4rpby3b0h87rbr02k55k3mmkmdy7rvl11q95b3ym0smmyqb",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "1b54c3f39436bbded6593ac9e0103f9115bbbd2e",
-  "date": "2022-05-19T19:09:09+02:00",
-  "path": "/nix/store/d9825wx3mjjj76pcbbz4pd6fz5h0c2ag-tree-sitter-haskell",
-  "sha256": "11brbizaw5m77hrmg6i5s437y4f1xgvfvjddfy1n39zpyf5x6nad",
+  "rev": "ca0a13f1acb60cf32e74cced3cb623b6c70fa77c",
+  "date": "2022-06-06T23:15:37+02:00",
+  "path": "/nix/store/dmq8mc361rkhrpa5s06h1z9k8khkvi78-tree-sitter-haskell",
+  "sha256": "1r3mfnj1f6p2cqriay22jjfggrmyywimidzmzw8h5q84flngdg2s",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MichaHoffmann/tree-sitter-hcl",
-  "rev": "3cb7fc28247efbcb2973b97e71c78838ad98a583",
-  "date": "2021-09-20T21:50:41+02:00",
-  "path": "/nix/store/rgd0p162smlfn90ggyq3y6y4q9sgybwh-tree-sitter-hcl",
-  "sha256": "0hg7w3hsvxjwz1rb1izknn46msm4mkjx2cnq603lzn7i9mb1pbyr",
+  "rev": "4ff21306a71269c4ac814769b90b0ecf3194d21d",
+  "date": "2022-06-02T20:13:06+02:00",
+  "path": "/nix/store/jsn5dixjqqvwagcgwgjdr91igic2r42w-tree-sitter-hcl",
+  "sha256": "1gvpl6kw83ywwd64ssz5xs4idc8ip2jmiz2mfy9xlkjbl9nfngci",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-heex",
-  "rev": "57e46b4b002d5fb5c1f2706fe42380e544ecab5f",
-  "date": "2022-04-17T10:39:01-07:00",
-  "path": "/nix/store/afmvzkh237ikn0b9fw51crzhyk4ys1d2-tree-sitter-heex",
-  "sha256": "0gfxqph5j3n3dlpnyw85lrwhgjh4zm7mdrnf0qyv0f2basayfabm",
+  "rev": "4d8d646bba27ec11bbf76ea37410a604d2e18bfc",
+  "date": "2022-06-09T17:09:44-05:00",
+  "path": "/nix/store/hcn9zl21asz1h6h2abqjpcc37sr56s6s-tree-sitter-heex",
+  "sha256": "0s38g23npq4k2yfwijmp14wmk7klhlycr4jl9a1hnh8qqihxjbj1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-latex",
-  "rev": "104a5dea952d5f00150afd6a8436e6cad95ef718",
-  "date": "2022-06-01T18:13:32+00:00",
-  "path": "/nix/store/7y5r30ylv51rqn3d8wk088ni7k58nzpm-tree-sitter-latex",
-  "sha256": "0b78hpp76hkpjd38zjfc2z98ipnazk2aza83k4r754gj8yshhsqx",
+  "rev": "9cbe0c6be9455b6d3be19f51daef6d08732abab1",
+  "date": "2022-06-05T08:50:52+02:00",
+  "path": "/nix/store/63i0iskmn862l0rm8gdkgs1bsxxpxw54-tree-sitter-latex",
+  "sha256": "1ahij4lwg59xvzy2jn8i4rpp6bjz8pl7sqwn6a3rwal3d2x89b3d",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "fdbef3621b62e098d7c9a34669cbe8a8bd807bf2",
-  "date": "2022-06-01T15:02:43+02:00",
-  "path": "/nix/store/rq8rljxmmnii1w2bw3n7224vmwnm0j1n-tree-sitter-php",
-  "sha256": "1bsdls8icmh6wnyhdibmxxignmdx3wh0bkcrwcwc7mc0xac5r4z2",
+  "rev": "866e4a155739a1374da5247b876e70f8639005f6",
+  "date": "2022-06-06T09:18:54+02:00",
+  "path": "/nix/store/23f9s4z321mnjnqfxjdj75rkcvwv2xpa-tree-sitter-php",
+  "sha256": "11nagsvq2jsinrhsfpnylz1lkp6hiw3jndshnjvzvkjmmpavm1gr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/victorhqc/tree-sitter-prisma",
-  "rev": "0ac307e4be0409d4327082ddc737ed432a49dfc3",
-  "date": "2022-04-20T10:52:00+02:00",
-  "path": "/nix/store/24vp6k2ijg832c95hx2x0j8x4i6pxffz-tree-sitter-prisma",
-  "sha256": "13rcwlkxv9dns7mgxrb34vzhq32c854bna6gsyczvs6vishm6i9l",
+  "rev": "17a59236ac25413b81b1613ea6ba5d8d52d7cd6c",
+  "date": "2022-06-11T23:04:44+02:00",
+  "path": "/nix/store/qdkwinjdy495z59wvxhifk8caksndswj-tree-sitter-prisma",
+  "sha256": "1pw9mi6hhvww4i7gf7snl893b3hwnfwp18rhbcsf7z52cr78mmqi",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/FallenAngel97/tree-sitter-rego",
+  "rev": "6bf5f8878bef2fb760508bff1ce0262a31925018",
+  "date": "2022-04-23T19:59:01+03:00",
+  "path": "/nix/store/gnbksy85s2z7b8c02im8liaa1d7g07my-tree-sitter-rego",
+  "sha256": "1ly2lhk4mfqmsg3pzv21ikzsxaz39bah3sgd3lcbaiqd0zzgbzks",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "8599058ef292e82203a1b23d10734dcbaf4d1b5c",
-  "date": "2022-05-09T16:17:13-07:00",
-  "path": "/nix/store/q802q124fq79wwr6m4xfcdmgw6fzjigw-tree-sitter-scala",
-  "sha256": "0i6qkgyv722jwma2rs0nf02jzl5dvml5m1whb7580qnza95x7py1",
+  "rev": "140c96cf398693189d4e50f76d19ddfcd8a018f8",
+  "date": "2022-06-06T08:54:55+02:00",
+  "path": "/nix/store/a1pi2xyaq2jjllbkj44xhi5cp0vnlnm4-tree-sitter-scala",
+  "sha256": "1hfx696x5pfww6zsfv36wkmxld14f02krmx55fy5rgzlz1m3xgja",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "1448396b310486e7d15e5e056713457cb0413bc2",
-  "date": "2022-05-17T11:34:51+08:00",
-  "path": "/nix/store/bhwsjp4salwmfq5cyvr0dd3al5s9xhsl-tree-sitter-scheme",
-  "sha256": "1m9pzlzrmphx6162dq2nxry30wpjbsi1zhl4asjvmc0zy4r3427f",
+  "rev": "5bb5b2de83d548243fbcc77e76224882ffb4ce68",
+  "date": "2022-06-07T22:14:20+08:00",
+  "path": "/nix/store/jy8z2s9zmgxm8ziv39cqkkia52mq7mbx-tree-sitter-scheme",
+  "sha256": "1cdbzmgkz3f1zbhgps9q1zvy1hnwwj5rlr5fp4jbvbnwp13pd04a",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/m-novikov/tree-sitter-sql",
+  "rev": "2ec2fedbb38d09737e2a1cdd207f6416dc1cb109",
+  "date": "2022-06-11T22:57:56+02:00",
+  "path": "/nix/store/zzx4b5cnsrrdzkb5rbmx5d8vzbyr0rbi-tree-sitter-sql",
+  "sha256": "0dcpdshymyszsr1dflsr3j6ynrnrq0g4qdxqcz7d0anpwh3xw4cs",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "8e9dba7bd7cf089838a036a98be94db53ba2d0a9",
-  "date": "2022-04-13T09:44:02-07:00",
-  "path": "/nix/store/188d0ki07nhmihrl2b868vmb9rd4hf4q-tree-sitter-typescript",
-  "sha256": "010nnihmaw1a1l9mzjd1nmrb0z6j2h3pr872dzpdq7ajg0j3j1wl",
+  "rev": "1b3ba31c7538825b05815f4f5bffcca6394edc63",
+  "date": "2022-06-02T09:10:56-07:00",
+  "path": "/nix/store/g3q8azmyclcdns0ihwl5im46qlsfxbfj-tree-sitter-typescript",
+  "sha256": "1iw6823zh2m95gjmly34j49ixga07fhax7z6g2q6px06gj4fm5df",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -178,6 +178,10 @@ let
       orga = "camdencheek";
       repo = "tree-sitter-go-mod";
     };
+    "tree-sitter-gowork" = {
+      orga = "omertuc";
+      repo = "tree-sitter-go-work";
+    };
     "tree-sitter-graphql" = {
       orga = "bkegley";
       repo = "tree-sitter-graphql";

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -134,6 +134,10 @@ let
       orga = "Himujjal";
       repo = "tree-sitter-svelte";
     };
+    "tree-sitter-sql" = {
+      orga = "m-novikov";
+      repo = "tree-sitter-sql";
+    };
     "tree-sitter-vim" = {
       orga = "vigoux";
       repo = "tree-sitter-viml";

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -122,6 +122,10 @@ let
       orga = "MDeiml";
       repo = "tree-sitter-markdown";
     };
+    "tree-sitter-rego" = {
+      orga = "FallenAngel97";
+      repo = "tree-sitter-rego";
+    };
     "tree-sitter-rst" = {
       orga = "stsewd";
       repo = "tree-sitter-rst";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
