### PR TITLE
gphotos-sync: 2.14.2 -> 3.04

### DIFF
--- a/pkgs/development/python-modules/types-pyyaml/default.nix
+++ b/pkgs/development/python-modules/types-pyyaml/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-pyyaml";
+  version = "6.0.8";
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "types-PyYAML";
+    inherit version;
+    sha256 = "0f349hmw597f2gcja445fsrlnfzb0dj7fy62g8wcbydlgcvmsjfr";
+  };
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "yaml-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for PyYAML";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dnr ];
+  };
+}

--- a/pkgs/tools/backup/gphotos-sync/default.nix
+++ b/pkgs/tools/backup/gphotos-sync/default.nix
@@ -1,54 +1,80 @@
 { lib
 , fetchFromGitHub
-, python3Packages
+, fetchpatch
+, python3
 , ffmpeg
 }:
-
-python3Packages.buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      google-auth-oauthlib = super.google-auth-oauthlib.overridePythonAttrs (oldAttrs: rec {
+        version = "0.5.2b1";
+        src = fetchFromGitHub {
+          owner = "gilesknap";
+          repo = "google-auth-library-python-oauthlib";
+          rev = "v${version}";
+          hash = "sha256-o4Jakm/JgLszumrSoTTnU+nc79Ei70abjpmn614qGyc=";
+        };
+      });
+    };
+  };
+in
+py.pkgs.buildPythonApplication rec {
   pname = "gphotos-sync";
-  version = "2.14.2";
+  version = "3.04";
+  format = "pyproject";
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   src = fetchFromGitHub {
     owner = "gilesknap";
     repo = "gphotos-sync";
     rev = version;
-    sha256 = "0cfmbrdy6w18hb623rjn0a4hnn3n63jw2jlmgn4a2k1sjqhpx3bf";
+    sha256 = "0mnlnqmlh3n1b6fjwpx2byl1z41vgghjb95598kz5gvdi95iirrs";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  patches = [
+    ./skip-network-tests.patch
+  ];
+
+  propagatedBuildInputs = with py.pkgs; [
     appdirs
     attrs
     exif
+    google-auth-oauthlib
     psutil
     pyyaml
     requests-oauthlib
+    types-pyyaml
+    types-requests
   ];
+
+  postPatch = ''
+    # this is a patched release that we include via packageOverrides above
+    substituteInPlace setup.cfg \
+      --replace " @ https://github.com/gilesknap/google-auth-library-python-oauthlib/archive/refs/tags/v0.5.2b1.zip" ""
+  '';
 
   buildInputs = [
     ffmpeg
   ];
 
-  checkInputs = with python3Packages; [
-    pytestCheckHook
+  checkInputs = with py.pkgs; [
     mock
+    pytestCheckHook
+    setuptools-scm
   ];
 
-  checkPhase = ''
+  preCheck = ''
     export HOME=$(mktemp -d)
-
-    # patch to skip all tests that do network access
-    cat >>test/test_setup.py <<EOF
-    import pytest, requests
-    requests.Session.__init__ = lambda *args, **kwargs: pytest.skip("no network access")
-    EOF
-
-    pytestCheckPhase
+    substituteInPlace setup.cfg \
+      --replace "--cov=gphotos_sync --cov-report term --cov-report xml:cov.xml" ""
   '';
 
   meta = with lib; {
     description = "Google Photos and Albums backup with Google Photos Library API";
     homepage = "https://github.com/gilesknap/gphotos-sync";
-    license = licenses.mit;
+    license = licenses.asl20;
     maintainers = with maintainers; [ dnr ];
   };
 }

--- a/pkgs/tools/backup/gphotos-sync/skip-network-tests.patch
+++ b/pkgs/tools/backup/gphotos-sync/skip-network-tests.patch
@@ -1,0 +1,21 @@
+diff --git a/tests/test_setup.py b/tests/test_setup.py
+index 085b110..ea4a7d2 100644
+--- a/tests/test_setup.py
++++ b/tests/test_setup.py
+@@ -45,7 +45,8 @@ class SetupDbAndCredentials:
+         return self
+ 
+     def __exit__(self, exc_type=None, exc_value=None, traceback=None):
+-        self.gp.google_photos_down.close()
++        if hasattr(self.gp, 'google_photos_down'):
++            self.gp.google_photos_down.close()
+ 
+     def test_setup(self, test_name, args=None, trash_db=False, trash_files=False):
+         self.root = Path("/tmp/gpTests/{}".format(test_name))
+@@ -76,3 +77,6 @@ class SetupDbAndCredentials:
+ 
+     def test_done(self):
+         self.gp.data_store.store()
++
++import pytest, requests
++requests.Session.__init__ = lambda *args, **kwargs: pytest.skip("no network access")

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10728,6 +10728,8 @@ in {
 
   types-pytz = callPackage ../development/python-modules/types-pytz { };
 
+  types-pyyaml = callPackage ../development/python-modules/types-pyyaml { };
+
   types-redis = callPackage ../development/python-modules/types-redis { };
 
   types-requests = callPackage ../development/python-modules/types-requests { };


### PR DESCRIPTION
###### Description of changes

The gphotos-sync project is active again and released a large update. The most important change was switching away from an OAuth method that's been deprecated by Google, which would prevent new users from setting it up for their account. See https://github.com/gilesknap/gphotos-sync/releases for more details.

Also adds `python3Packages.types-pyyaml` which is a new dependency.

###### Things done

I tested the new oauth flow on my account (though with an old client secret).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - package tests still pass, although many try to access the network and have to be disabled
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

