### PR TITLE
libaom: propagate libvmaf dev output

### DIFF
--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optionals enableButteraugli [
     libjxl
     libhwy
-  ] ++ lib.optional enableVmaf libvmaf;
+  ];
+  propagatedBuildInputs = lib.optional enableVmaf libvmaf;
 
   preConfigure = ''
     # build uses `git describe` to set the build version


### PR DESCRIPTION
Before the change libaom.dev was missing libvmaf.dev dependency
(because pkgconfig files don't have absolute store paths):

    $ nix path-info -r -f. libaom.dev | unnix
    /<<NIX>>/libunistring-1.0
    /<<NIX>>/libidn2-2.3.2
    /<<NIX>>/glibc-2.35
    /<<NIX>>/gcc-13.0.0-lib
    /<<NIX>>/libvmaf-2.3.1
    /<<NIX>>/libaom-3.3.0
    /<<NIX>>/libaom-3.3.0-bin
    /<<NIX>>/libaom-3.3.0-dev

As a result `gst_all_1.gst-plugins-bad` was failing to build for broken
`aom` depend:

    $ nix build -f. gst_all_1.gst-plugins-bad -L
    ...
    gst-plugins-bad> Package 'libvmaf', required by 'aom', not found

The change propagates dependency explicitly:

    $ nix path-info -r -f. libaom.dev | unnix
    /<<NIX>>/libunistring-1.0
    /<<NIX>>/libidn2-2.3.2
    /<<NIX>>/glibc-2.35
    /<<NIX>>/gcc-13.0.0-lib
    /<<NIX>>/libvmaf-2.3.1
    /<<NIX>>/libaom-3.3.0
    /<<NIX>>/libaom-3.3.0-bin
    /<<NIX>>/libvmaf-2.3.1-dev # <<<-- added
    /<<NIX>>/libaom-3.3.0-dev

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
