### PR TITLE
metrics job: schedule on a dedicated machine again

### DIFF
--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -4,8 +4,7 @@ with pkgs;
 
 runCommand "nixpkgs-metrics"
   { nativeBuildInputs = with pkgs.lib; map getBin [ nix time jq ];
-    # see https://github.com/NixOS/nixpkgs/issues/52436
-    #requiredSystemFeatures = [ "benchmark" ]; # dedicated `t2a` machine, by @vcunat
+    requiredSystemFeatures = [ "benchmark" ]; # dedicated `t2a` machine, by @vcunat
   }
   ''
     export NIX_STORE_DIR=$TMPDIR/store


### PR DESCRIPTION
Reverts NixOS/nixpkgs#172837

I set up the new machine yesterday, and it seems OK.  16G RAM and expandable, Skylake-S.