### PR TITLE
pcsx2: 1.7.2731 -> 1.7.3113

### DIFF
--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -32,14 +32,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pcsx2";
-  version = "1.7.2731";
+  version = "1.7.3113";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
     fetchSubmodules = true;
     rev = "v${version}";
-    hash = "sha256-b3cK3ly9J44YMy/cNprlDCSsu8+DrlhRSLXv5xMouWo=";
+    hash = "sha256-0s0scHPzS81qGZY4Rc5DXuA1d3UR2hvnOtFv5sB2nYs=";
   };
 
   cmakeFlags = [
@@ -78,12 +78,11 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  # Wayland doesn't seem to work right now (crashes when booting a game).
-  # Try removing `--prefix GDK_BACKEND : x11` on the next update.
-  # (This may be solved when the project finshes migrating to Qt)
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+      # Wayland doesn't work right now (crashes when booting a game).
+      # Will be solved with Qt migration.
       --prefix GDK_BACKEND : x11
     )
   '';


### PR DESCRIPTION
###### Description of changes
~NOTE: This PR is not meant to be reviewed now. Right now the application doesn't launch, and even if it did, the new Qt6 interface is in a state that upstream doesn't recommend to use yet. This draft is meant to be revisited later, and so that I can put in some notes.~

Upgrades PCSX2 to the latest upstream version ~and switches to the new Qt6 interface, since the old wxWidgets interface is going to be deprecated.
It also cleanups dependencies, adding all the ones that CMakeLists can detect on the system (thanks to the new flag that PCSX2 added, `USE_SYSTEM_LIBS`). This meant that I had to add `rapidyaml`, since it wasn't packaged before. I added it a bit haphazardly, since [there should be also some Python stuff in there](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rapidyaml-git) (that PCSX2 doesn't need).
Submodules still need to be fetched. Not all of them are needed, but `fetchSubmodules` is either true or false (according to the AUR, the needed ones are 3rdparty/libchdr/libchdr 3rdparty/gtest 3rdparty/cubeb/cubeb 3rdparty/imgui 3rdparty/glslang/glslang 3rdparty/vulkan-headers 3rdparty/fmt/fmt)~.
Should the license still be `licenses.free`?

~Right now, the application doesn't launch, until this is merged: https://github.com/PCSX2/pcsx2/pull/6131.
It seems that the `PACKAGE_MODE` flag might be removed?~

Don't know about #104850 without migrating to Qt.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
