### PR TITLE
kdepim-runtime: use XOAUTH2 SASL plugin from libkgapi

### DIFF
--- a/pkgs/applications/kde/kdepim-runtime/default.nix
+++ b/pkgs/applications/kde/kdepim-runtime/default.nix
@@ -24,6 +24,6 @@ mkDerivation {
     qca-qt5 qtkeychain qtnetworkauth qtspeech qtxmlpatterns
   ];
   qtWrapperArgs = [
-    "--prefix SASL_PATH : ${cyrus_sasl}/lib/sasl2:${libkgapi}/lib/sasl2"
+    "--prefix SASL_PATH : ${lib.makeSearchPath "lib/sasl2" [ cyrus_sasl libkgapi ]}"
   ];
 }

--- a/pkgs/applications/kde/kdepim-runtime/default.nix
+++ b/pkgs/applications/kde/kdepim-runtime/default.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules, kdoctools,
   shared-mime-info,
   akonadi, akonadi-calendar, akonadi-contacts, akonadi-mime, akonadi-notes,
-  kholidays, kcalutils, kcontacts, kdav, kidentitymanagement,
+  cyrus_sasl, kholidays, kcalutils, kcontacts, kdav, kidentitymanagement,
   kimap, kldap, kmailtransport, kmbox, kmime, knotifications, knotifyconfig,
   pimcommon, libkgapi, libsecret,
   qca-qt5, qtkeychain, qtnetworkauth, qtspeech, qtwebengine, qtxmlpatterns,
@@ -22,5 +22,8 @@ mkDerivation {
     kldap kmailtransport kmbox kmime knotifications knotifyconfig qtwebengine
     pimcommon libkgapi libsecret
     qca-qt5 qtkeychain qtnetworkauth qtspeech qtxmlpatterns
+  ];
+  qtWrapperArgs = [
+    "--prefix SASL_PATH : ${cyrus_sasl}/lib/sasl2:${libkgapi}/lib/sasl2"
   ];
 }


### PR DESCRIPTION
###### Description of changes

Some mail servers like Gmail [use SASL XOAUTH2 mechanism][1] to authenticate clients with OAuth token instead of password. Unfortunately, Cyrus SASL does not have authentication plugin for this mechanism out of the box, so clients that use this library and want to authenticate at such mail servers should bring their own plugin for XOAUTH2. KMail (or KDE PIM in general) have such plugin as [part of LibKGAPI][2], and on FHS systems LibKGAPI puts its plugin right next to other Cyrus SASL plugins, so it can be picked up by library automatically. In NixOS, this plugin end up in other directory, which has no references to it, so `akonadi_imap_resource` fails with next error message when tries to authenticate at such mail servers:

    org.kde.pim.kimap: sasl_client_start failed with: -4 "SASL(-4): no mechanism available: No worthy mechs found"

In result, no mail is fetched (progress bar in KMail is stuck at 0%), and user after reading logs is left wondering why no worthy mechs were found.

This commit sets `SASL_PATH` environment variable, so Cyrus SASL can find both its own plugins and one provided by LibKGAPI. With this change, KMail can successfully fetch mail from Gmail.

This fix is based on discussion in #108480 about means for merging SASL plugins folders from different packages. I think setting `SASL_PATH` is the most straightforward way of doing this in Nix, but maybe it should be automated somehow, like it is done with `XDG_DATA_DIRS` in `wrapQtAppsHook`. However, I do not know easy way to do so in non-breaking manner, so lets leave it to package maintainers for now.

[1]: https://developers.google.com/gmail/imap/xoauth2-protocol#the_sasl_xoauth2_mechanism
[2]: https://github.com/KDE/libkgapi/tree/master/src/saslplugin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
      _NB: `nixpkgs-review` tries to build packages that are marked as broken. All non-broken packages build successfully with this changes._
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
