### PR TITLE
nixos/fontconfig: remove binding "same" from default fonts alias

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -89,7 +89,7 @@ let
   defaultFontsConf =
     let genDefault = fonts: name:
       optionalString (fonts != []) ''
-        <alias binding="same">
+        <alias>
           <family>${name}</family>
           <prefer>
           ${concatStringsSep ""


### PR DESCRIPTION
###### Description of changes
Is hard to overwrite default font from user config while system uses "same" binding. Forcing user bind "strong" to take priority.

`As far as I can tell, the "same" binding is meant to be a substitution rule: if you want to make, say, "DjvU Sns" actually use "DejaVu Sans".  It does not feel right to use it for the generic sans, sans-serif, and monospace families.`

As discussed here: https://lists.sr.ht/~protesilaos/dotfiles/%3C87h75k1s0z.fsf%40nadanix.com%3E
