### PR TITLE
blueprint-compiler: 2022-05-27 -> 0.2.0

### DIFF
--- a/pkgs/development/compilers/blueprint/default.nix
+++ b/pkgs/development/compilers/blueprint/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "blueprint-compiler";
-  version = "unstable-2022-05-27";
+  version = "0.2.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jwestman";
     repo = pname;
-    rev = "cebd9ecadc53790cd547392899589dd5de0ac552";
-    sha256 = "sha256-mNR0ooJSRBIXy2E4avXYEdO1aSST+j41TsVg8+kitwo=";
+    rev = "v${version}";
+    sha256 = "sha256-LXZ6n1oCbPa0taVbUZf52mGECrzXIcF8EaMVJ30rMtc=";
   };
 
   # Requires pythonfuzz, which I've found difficult to package
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    python3.pkgs.wrapPython
   ];
 
   buildInputs = [
@@ -36,10 +35,6 @@ stdenv.mkDerivation rec {
     # So that the compiler can find GIR and .ui files
     gobject-introspection
   ];
-
-  postFixup = ''
-    wrapPythonPrograms
-  '';
 
   meta = with lib; {
     description = "A markup language for GTK user interface files";


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/jwestman/blueprint-compiler/-/releases

- update to 0.2.0
- remove `wrapPython` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
