### PR TITLE
_1password: 2.3.1 -> 2.4.1

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -12,12 +12,12 @@ let
     if extension == "zip" then fetchzip args else fetchurl args;
 
   pname = "1password-cli";
-  version = "2.3.1";
+  version = "2.4.1";
   sources = rec {
-    aarch64-linux = fetch "linux_arm64" "sha256-MikzcVqlhVSKzr1ttOCAg4p57sjsalSuwcqBhVUr5Ng=" "zip";
-    i686-linux = fetch "linux_386" "sha256-ElOhd3n38xAPtVePjQb8qMUCCAWqEfBKlX9Vuz5/Zns=" "zip";
-    x86_64-linux = fetch "linux_amd64" "sha256-r8yl9dDiiIQBooePrq/dGw2RU9tJXmeblx+qk3qq5Ys=" "zip";
-    aarch64-darwin = fetch "apple_universal" "sha256-sXdYInNBOEW/zIEPjhKbFOMxZdrMlE8pOwhmXLUJgsk=" "pkg";
+    aarch64-linux = fetch "linux_arm64" "sha256-ANRYE1BoezrcDxZrQYp/OPdtn4J+FmC/PLSIP5Amm18=" "zip";
+    i686-linux = fetch "linux_386" "sha256-w3anr76uj/Z+ilZ+LUGOB1CoKkvxcD+v8c8lVADPwRY=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-axZ+XDIMJlAicnYTIXgcaoT+Zcg6xvHlchl/ng7V9GY=" "zip";
+    aarch64-darwin = fetch "apple_universal" "sha256-/DnrQ4fwbc2ELtsEClvzA9kTrse3pMgGLbhiKZ3gphA=" "pkg";
     x86_64-darwin = aarch64-darwin;
   };
   platforms = builtins.attrNames sources;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://app-updates.agilebits.com/product_history/CLI2#v2040101
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
