### PR TITLE
nixos/networkd: honor search domains in `.network` configs

### DIFF
--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -95,7 +95,11 @@ in
           DHCP = "yes";
           linkConfig.RequiredForOnline =
             lib.mkDefault config.systemd.network.wait-online.anyInterface;
-          networkConfig.IPv6PrivacyExtensions = "kernel";
+          networkConfig = {
+            IPv6PrivacyExtensions = "kernel";
+          } // optionalAttrs (domains != []) {
+            Domains = concatStringsSep " " domains;
+          };
         };
         networks."99-wireless-client-dhcp" = lib.mkIf cfg.useDHCP {
           # Like above, but this is much more likely to be correct.
@@ -103,7 +107,11 @@ in
           DHCP = "yes";
           linkConfig.RequiredForOnline =
             lib.mkDefault config.systemd.network.wait-online.anyInterface;
-          networkConfig.IPv6PrivacyExtensions = "kernel";
+          networkConfig = {
+            IPv6PrivacyExtensions = "kernel";
+          } // optionalAttrs (domains != []) {
+            Domains = concatStringsSep " " domains;
+          };
           # We also set the route metric to one more than the default
           # of 1024, so that Ethernet is preferred if both are
           # available.
@@ -189,7 +197,11 @@ in
                   TTLPropagate = route.options.ttl-propagate == "enabled";
                 };
             });
-          networkConfig.IPv6PrivacyExtensions = "kernel";
+          networkConfig = {
+            IPv6PrivacyExtensions = "kernel";
+          } // optionalAttrs (i ? domains) {
+            Domains = concatStringsSep " " i.domains;
+          };
           linkConfig = optionalAttrs (i.macAddress != null) {
             MACAddress = i.macAddress;
           } // optionalAttrs (i.mtu != null) {


### PR DESCRIPTION
I'm not 100% confident that this is the right solution, but it does fix my problems so I wanted to submit a PR to iterate on whether this is warranted/whether it needs to be refined.

###### Description of changes

Essentially: while these settings are honored by some of the older networking mechanisms, systemd-networkd loads it up into `networkConfig` but doesn't actively use it. This rectifies that.

`domains` is populated by `config.networking.search`, and `Domains=` is the
right networkd setting per the documentation (excerpt from `systemd.network`
man page):

> the domains without the [~] prefix are called "search domains"

The "broken" state that I observe is that when I have my LAN domain set appropriately:

```nix
{
  networking.search = [ "mydomain.org" ];
}
```

I cannot reach simple single-name hosts on my network. For example, I can `ping -c 1 myhost.mydomain.org` but not `ping -c 1 myhost`. The end result of this change is that the following entry appears in `/etc/systemd/network/99-wireless-client-dhcp.network` and `/etc/systemd/network/99-ethernet-default-dhcp.network` (I'm using the recently-released blanket DHCP support for `systemd-networkd`:

    [Network]
    Domains=mydomain.org

One thing that I'm confused about is that my LAN domain _does_ appear in the `systemd-resolved` configuration - which I'm also using - which, as far as I understand, should make the same thing happen:

```shell
$ cat /etc/systemd/resolved.conf
```
```ini
[Resolve]
<snip>
Domains=mydomain.org
```

...but my single-label hostnames still don't work with that set in resolved.conf. It seems like that _should_ be sufficient, but my observation is that it doesn't function as I'd expect unless it's also set in the relevant `*.network` files. Any ideas are welcome here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
