### PR TITLE
python3Packages.wandb: 0.12.17 -> 0.12.18

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -25,6 +25,7 @@
 , pytestCheckHook
 , python-dateutil
 , pythonOlder
+, pytorch
 , pyyaml
 , requests
 , scikit-learn
@@ -38,7 +39,7 @@
 
 buildPythonPackage rec {
   pname = "wandb";
-  version = "0.12.17";
+  version = "0.12.18";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -47,7 +48,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = "client";
     rev = "v${version}";
-    hash = "sha256-hY01cql/j3ieL1zJoPOM/QZiF0X/ivekFRfX+TvZhyM=";
+    hash = "sha256-9++CFoC8p3cACPyjRbb6i8MdJp8iD9GUh0uHpTiufdg=";
   };
 
   patches = [
@@ -93,12 +94,15 @@ buildPythonPackage rec {
     pytest-mock
     pytest-xdist
     pytestCheckHook
+    pytorch
     scikit-learn
     tqdm
   ];
 
   disabledTestPaths = [
     # Tests that try to get chatty over sockets or spin up servers, not possible in the nix build environment.
+    "tests/integrations/test_keras.py"
+    "tests/integrations/test_torch.py"
     "tests/test_cli.py"
     "tests/test_data_types.py"
     "tests/test_file_stream.py"
@@ -111,6 +115,7 @@ buildPythonPackage rec {
     "tests/test_metric_full.py"
     "tests/test_metric_internal.py"
     "tests/test_mode_disabled.py"
+    "tests/test_model_workflows.py"
     "tests/test_mp_full.py"
     "tests/test_public_api.py"
     "tests/test_redir.py"
@@ -119,14 +124,18 @@ buildPythonPackage rec {
     "tests/test_start_method.py"
     "tests/test_tb_watcher.py"
     "tests/test_telemetry_full.py"
+    "tests/test_util.py"
     "tests/wandb_agent_test.py"
     "tests/wandb_artifacts_test.py"
     "tests/wandb_integration_test.py"
     "tests/wandb_run_test.py"
     "tests/wandb_settings_test.py"
     "tests/wandb_sweep_test.py"
+    "tests/wandb_tensorflow_test.py"
     "tests/wandb_verify_test.py"
-    "tests/test_model_workflows.py"
+
+    # Requires metaflow, which is not yet packaged.
+    "tests/integrations/test_metaflow.py"
 
     # Fails and borks the pytest runner as well.
     "tests/wandb_test.py"


### PR DESCRIPTION
###### Description of changes
Upgrade the wandb python package to the latest version. Test requirements changed in this release: pytorch is now a test dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
