### PR TITLE
dnsrecon: 1.0.0 -> 1.1.1

### DIFF
--- a/pkgs/tools/security/dnsrecon/default.nix
+++ b/pkgs/tools/security/dnsrecon/default.nix
@@ -5,14 +5,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dnsrecon";
-  version = "1.1.0";
+  version = "1.1.1";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "darkoperator";
     repo = pname;
     rev = version;
-    hash = "sha256-O6MdSaCxrprsxffeVKciIjSkdMXsT4riOvNCM4iZfn0=";
+    hash = "sha256-zbFtaEklkfLkrqJAPptOqDTdWGbCE+3ZO79t68iqLIU=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/security/dnsrecon/default.nix
+++ b/pkgs/tools/security/dnsrecon/default.nix
@@ -5,38 +5,34 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dnsrecon";
-  version = "1.0.0";
-  format = "other";
+  version = "1.1.0";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "darkoperator";
     repo = pname;
     rev = version;
-    sha256 = "sha256-VRO5ugr/+iZh+hh3tVs/JNAr7GXao/HK43O3FlkbcSM=";
+    hash = "sha256-O6MdSaCxrprsxffeVKciIjSkdMXsT4riOvNCM4iZfn0=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
     dnspython
     netaddr
     lxml
+    setuptools
   ];
 
-  postPatch = ''
-    substituteInPlace dnsrecon.py \
-      --replace "namelist.txt" "../share/namelist.txt"
+  preFixup = ''
+    # Install wordlists, etc.
+    install -vD namelist.txt subdomains-*.txt snoop.txt -t $out/share/wordlists
   '';
 
-  installPhase = ''
-    runHook preInstall
+  # Tests require access to /etc/resolv.conf
+  doCheck = false;
 
-    install -vD dnsrecon.py $out/bin/dnsrecon
-    install -vD namelist.txt subdomains-*.txt -t $out/share
-    install -vd $out/${python3.sitePackages}/
-    cp -R lib tools msf_plugin $out/${python3.sitePackages}
-
-    runHook postInstall
-  '';
-
+  pythonImportsCheck = [
+    "dnsrecon"
+  ];
 
   meta = with lib; {
     description = "DNS Enumeration script";


### PR DESCRIPTION
###### Description of changes
https://github.com/darkoperator/dnsrecon/releases/tag/1.1.1
https://github.com/darkoperator/dnsrecon/releases/tag/1.1.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
