### PR TITLE
crlfsuite: init at 2.0

### DIFF
--- a/pkgs/tools/security/crlfsuite/default.nix
+++ b/pkgs/tools/security/crlfsuite/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "crlfsuite";
+  version = "2.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "Nefcore";
+    repo = "CRLFsuite";
+    rev = "v${version}";
+    sha256 = "sha256-V/EaOtGDPJQAMu9akOtZN5LKLFd3EQkjn79q7ubV0Mc=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    colorama
+    requests
+  ];
+
+  # No tests present
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "crlfsuite"
+  ];
+
+  meta = with lib; {
+    description = "CRLF injection (HTTP Response Splitting) scanner";
+    homepage = "https://github.com/Nefcore/CRLFsuite";
+    license = licenses.mit;
+    maintainers = with maintainers; [ c0bw3b fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4682,6 +4682,8 @@ with pkgs;
 
   cmt = callPackage ../applications/audio/cmt {};
 
+  crlfsuite = callPackage ../tools/security/crlfsuite {};
+
   crlfuzz = callPackage ../tools/security/crlfuzz {};
 
   hedgedoc = callPackage ../servers/web-apps/hedgedoc { };


### PR DESCRIPTION
###### Description of changes
CRLF injection (HTTP Response Splitting) scanner

https://github.com/Nefcore/CRLFsuite

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
