### PR TITLE
haskell.packages.ghcjs.ghcjs-base: 0.2.0.3 → 0.2.1.0

### DIFF
--- a/pkgs/development/compilers/ghcjs/ghcjs-base.nix
+++ b/pkgs/development/compilers/ghcjs/ghcjs-base.nix
@@ -8,12 +8,14 @@
 }:
 mkDerivation {
   pname = "ghcjs-base";
-  version = "0.2.0.3";
+  version = "0.2.1.0";
+  # This is the release 0.2.1.0, but the hackage release misses test source files,
+  # so lets use github https://github.com/ghcjs/ghcjs-base/issues/132
   src = fetchFromGitHub {
     owner = "ghcjs";
     repo = "ghcjs-base";
-    rev = "85e31beab9beffc3ea91b954b61a5d04e708b8f2";
-    sha256 = "sha256-YDOfi/WZz/602OtbY8wL5jX3X+9oiGL1WhceCraczZU=";
+    rev = "fbaae59b05b020e91783df122249095e168df53f";
+    sha256 = "sha256-x6eCAK1Hne0QkV3Loi9YpxbleNHU593E4AO8cbk2vUc=";
   };
   libraryHaskellDepends = [
     aeson attoparsec base binary bytestring containers deepseq dlist

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -18,6 +18,7 @@ self: super:
   inherit (self.ghc.bootPkgs)
     jailbreak-cabal alex happy gtk2hs-buildtools rehoo hoogle;
 
+  # Test suite fails; https://github.com/ghcjs/ghcjs-base/issues/133
   ghcjs-base = dontCheck (self.callPackage ../compilers/ghcjs/ghcjs-base.nix {
     fetchFromGitHub = pkgs.buildPackages.fetchFromGitHub;
   });
@@ -34,6 +35,9 @@ self: super:
 
   # nodejs crashes during test
   ChasingBottoms = dontCheck super.ChasingBottoms;
+
+  # runs forever
+  text-short = dontCheck super.text-short;
 
   # doctest doesn't work on ghcjs, but sometimes dontCheck doesn't seem to get rid of the dependency
   doctest = pkgs.lib.warn "ignoring dependency on doctest" null;


### PR DESCRIPTION


###### Description of changes

The new upstream release makes it build with aeson-2.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
