### PR TITLE
asciinema: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/tools/misc/asciinema/default.nix
+++ b/pkgs/tools/misc/asciinema/default.nix
@@ -1,4 +1,8 @@
-{ lib, python3Packages, fetchFromGitHub, glibcLocales }:
+{ lib
+, python3Packages
+, fetchFromGitHub
+, glibcLocales
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "asciinema";
@@ -9,7 +13,7 @@ python3Packages.buildPythonApplication rec {
     owner = "asciinema";
     repo = "asciinema";
     rev = "v${version}";
-    sha256 = "sha256-ioSNd0Fjk2Fp05lk3HeokIjNYGU0jQEaIDfcFB18mV0=";
+    hash = "sha256-ioSNd0Fjk2Fp05lk3HeokIjNYGU0jQEaIDfcFB18mV0=";
   };
 
   postPatch = ''
@@ -17,16 +21,19 @@ python3Packages.buildPythonApplication rec {
       --replace "python3" "${python3Packages.python}/bin/python"
   '';
 
-  checkInputs = [ glibcLocales python3Packages.nose ];
+  checkInputs = [
+    glibcLocales
+    python3Packages.nose
+  ];
 
   checkPhase = ''
     LC_ALL=en_US.UTF-8 nosetests
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Terminal session recorder and the best companion of asciinema.org";
     homepage = "https://asciinema.org/";
-    license = with lib.licenses; [ gpl3 ];
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ ];
   };
 }
-

--- a/pkgs/tools/misc/asciinema/default.nix
+++ b/pkgs/tools/misc/asciinema/default.nix
@@ -2,14 +2,20 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "asciinema";
-  version = "2.1.0";
+  version = "2.2.0";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "asciinema";
     repo = "asciinema";
     rev = "v${version}";
-    sha256 = "1alcz018jrrpasrmgs8nw775a6pf62xq2xgs54c4mb396prdqy4x";
+    sha256 = "sha256-ioSNd0Fjk2Fp05lk3HeokIjNYGU0jQEaIDfcFB18mV0=";
   };
+
+  postPatch = ''
+    substituteInPlace tests/pty_test.py \
+      --replace "python3" "${python3Packages.python}/bin/python"
+  '';
 
   checkInputs = [ glibcLocales python3Packages.nose ];
 


### PR DESCRIPTION
The project now uses `setup.cfg` instead of `setup.py` therefore we need to set `format = "pyproject";`.

The tests try to find a python binary in `/usr/bin/python3`, so we need to patch them with the correct path.

Release notes: https://github.com/asciinema/asciinema/releases/tag/v2.2.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
