### PR TITLE
python310Packages.rpi-gpio2: init at 0.3.0a3

### DIFF
--- a/pkgs/development/python-modules/rpi-gpio2/default.nix
+++ b/pkgs/development/python-modules/rpi-gpio2/default.nix
@@ -1,0 +1,28 @@
+{ lib, libgpiod, buildPythonPackage, fetchurl }:
+
+buildPythonPackage rec {
+  pname = "rpi-gpio2";
+  version = "0.3.0a3";
+
+  # PyPi source does not work for some reason
+  src = fetchurl {
+    url = "https://github.com/underground-software/RPi.GPIO2/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "sha256-AY1AD2Yu66eJUqB4OStZnUeEhmISLVRrTOAcmEHjuOM=";
+  };
+
+  propagatedBuildInputs = [
+    libgpiod
+  ];
+
+  # Disable checks because they need to run on the specific platform
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/underground-software/RPi.GPIO2";
+    description = ''
+      Compatibility layer between RPi.GPIO syntax and libgpiod semantics
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9344,6 +9344,8 @@ in {
 
   rpi-gpio = callPackage ../development/python-modules/rpi-gpio { };
 
+  rpi-gpio2 = callPackage ../development/python-modules/rpi-gpio2 { };
+
   rply = callPackage ../development/python-modules/rply { };
 
   rpm = toPythonModule (pkgs.rpm.override {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
