### PR TITLE
fpc: 3.2.0 -> 3.2.2

### DIFF
--- a/pkgs/development/compilers/fpc/binary.nix
+++ b/pkgs/development/compilers/fpc/binary.nix
@@ -2,23 +2,23 @@
 
 stdenv.mkDerivation rec {
   pname = "fpc-binary";
-  version = "3.2.0";
+  version = "3.2.2";
 
   src =
     if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
         url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}.i386-linux.tar";
-        sha256 = "0y0510b2fbxbqz28967xx8b023k6q9fv5yclfrc1yc9mg8fyn411";
+        sha256 = "f62980ac0b2861221f79fdbff67836aa6912a4256d4192cfa4dfa0ac5b419958";
       }
     else if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
-        url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}-x86_64-linux.tar";
-        sha256 = "0gfbwjvjqlx0562ayyl08khagslrws758al2yhbi4bz5rzk554ni";
+        url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}.x86_64-linux.tar";
+        sha256 = "5adac308a5534b6a76446d8311fc340747cbb7edeaacfe6b651493ff3fe31e83";
       }
     else if stdenv.hostPlatform.system == "aarch64-linux" then
       fetchurl {
         url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}.aarch64-linux.tar";
-        sha256 = "1h481ngg3m8nlsg9mw7rr1bn2c4sj4wzqny9bxyq3xvcral12r71";
+        sha256 = "b39470f9b6b5b82f50fc8680a5da37d2834f2129c65c24c5628a80894d565451";
       }
     else throw "Not supported on ${stdenv.hostPlatform.system}.";
 

--- a/pkgs/development/compilers/fpc/default.nix
+++ b/pkgs/development/compilers/fpc/default.nix
@@ -3,12 +3,12 @@
 let startFPC = import ./binary.nix { inherit stdenv fetchurl; }; in
 
 stdenv.mkDerivation rec {
-  version = "3.2.0";
+  version = "3.2.2";
   pname = "fpc";
 
   src = fetchurl {
     url = "mirror://sourceforge/freepascal/fpcbuild-${version}.tar.gz";
-    sha256 = "0f38glyn3ffmqww432snhx2b8wyrq0yj1njkp4zh56lqrvm19fgr";
+    sha256 = "85ef993043bb83f999e2212f1bca766eb71f6f973d362e2290475dbaaf50161f";
   };
 
   buildInputs = [ startFPC gawk ];

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -9,7 +9,7 @@
 #  1. the build date is embedded in the binary through `$I %DATE%` - we should dump that
 
 let
-  version = "2.0.12";
+  version = "2.2.2-0";
 
   # as of 2.0.10 a suffix is being added. That may or may not disappear and then
   # come back, so just leave this here.
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${majorMinorPatch version}/lazarus-${version}.tar.gz";
-    sha256 = "sha256-umzvf4I6LSgWYimYLvySYDnUIxPEDiL+DGd2wT0AFbI=";
+    sha256 = "a9832004cffec8aca69de87290441d54772bf95d5d04372249d5a5491fb674c4";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/fpc/mark-paths.patch
+++ b/pkgs/development/compilers/fpc/mark-paths.patch
@@ -19,16 +19,16 @@ index a7398fb9..8e46fec0 100644
  {$else powerpc64}
        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib;=/usr/lib;=/usr/X11R6/lib',true);
  {$endif powerpc64}
-@@ -164,7 +164,7 @@ begin
-       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/i386-linux-gnu',true);
+@@ -165,7 +165,7 @@ begin
  {$endif i386}
  {$ifdef aarch64}
+       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib64',true);
 -      LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/aarch64-linux-gnu',true);
 +      LibrarySearchPath.AddLibraryPath(sysrootpath,'=@syslibpath@',true);
  {$endif aarch64}
  {$ifdef powerpc}
        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/powerpc-linux-gnu',true);
-@@ -185,53 +185,53 @@ begin
+@@ -186,53 +186,53 @@ begin
  end;
  
  {$ifdef m68k}
@@ -95,7 +95,7 @@ index a7398fb9..8e46fec0 100644
  {$endif sparc64}
  
  
-@@ -266,9 +266,9 @@ begin
+@@ -267,9 +267,9 @@ begin
        libctype:=uclibc;
      end
  {$ifdef i386}


### PR DESCRIPTION
fpc: 3.2.0 -> 3.2.2
lazarus: 2.0.12 -> 2.2.2-0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
