### PR TITLE
atomic-operator: init at 0.8.5

### DIFF
--- a/pkgs/development/python-modules/pick/default.nix
+++ b/pkgs/development/python-modules/pick/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pick";
+  version = "1.2.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "wong2";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-9y9O6Iqo07Q+aPM6AvyvjAMQzZQOSpal92Qto8p8bzI=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pick"
+  ];
+
+  meta = with lib; {
+    description = "Module to create curses-based interactive selection list in the terminal";
+    homepage = "https://github.com/wong2/pick";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/atomic-operator/default.nix
+++ b/pkgs/tools/security/atomic-operator/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "atomic-operator";
+  version = "0.8.5";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "swimlane";
+    repo = pname;
+    rev = version;
+    hash = "sha256-fO8bvzeMdJVWlhpzdTmJo9mrT6iorsLqr/GPF9gvE70=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    attrs
+    certifi
+    chardet
+    charset-normalizer
+    fire
+    idna
+    paramiko
+    pick
+    pypsrp
+    pyyaml
+    requests
+    urllib3
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "atomic_operator"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_download_of_atomic_red_team_repo"
+    "test_setting_input_arguments"
+    "test_config_parser"
+  ];
+
+  meta = with lib; {
+    description = "Tool to execute Atomic Red Team tests (Atomics)";
+    homepage = "https://www.atomic-operator.com/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -255,6 +255,8 @@ with pkgs;
 
   authz0 = callPackage ../tools/security/authz0 { };
 
+  atomic-operator = callPackage ../tools/security/atomic-operator { };
+
   avro-tools = callPackage ../development/tools/avro-tools { };
 
   bacnet-stack = callPackage ../tools/networking/bacnet-stack {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6473,6 +6473,8 @@ in {
 
   piccata = callPackage ../development/python-modules/piccata { };
 
+  pick = callPackage ../development/python-modules/pick { };
+
   pickleshare = callPackage ../development/python-modules/pickleshare { };
 
   picos = callPackage ../development/python-modules/picos { };


### PR DESCRIPTION
###### Description of changes
Tool to execute Atomic Red Team tests (Atomics)

https://www.atomic-operator.com/

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
