### PR TITLE
etebase-server: 0.8.3 -> 0.9.1

### DIFF
--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -1,16 +1,17 @@
 { lib, fetchFromGitHub, buildPythonPackage, aioredis, aiofiles, django_3
-, fastapi, msgpack, pynacl, typing-extensions }:
+, fastapi, msgpack, pynacl, typing-extensions
+, withLdap ? true, ldap }:
 
 buildPythonPackage rec {
   pname = "etebase-server";
-  version = "0.8.3";
+  version = "0.9.1";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "etesync";
     repo = "server";
     rev = "v${version}";
-    sha256 = "sha256-rPs34uzb5veiOw74SACLrDm4Io0CYH9EL9IuV38CkPY=";
+    sha256 = "sha256-mYXy0N7ohNk3K2XNB6JvULF6lhL5dV8yBvooR6RuV1E=";
   };
 
   patches = [ ./secret.patch ];
@@ -23,7 +24,7 @@ buildPythonPackage rec {
     msgpack
     pynacl
     typing-extensions
-  ];
+  ] ++ lib.optional withLdap ldap;
 
   installPhase = ''
     mkdir -p $out/bin $out/lib


### PR DESCRIPTION
###### Description of changes
Update etebase-server to latest release:
https://github.com/etesync/server/blob/master/ChangeLog.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
