### PR TITLE
checksec: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -1,39 +1,59 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, file, findutils
-, binutils-unwrapped, glibc, coreutils, sysctl, openssl
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, file
+, findutils
+, binutils-unwrapped
+, glibc
+, coreutils
+, sysctl
+, openssl
 }:
 
 stdenv.mkDerivation rec {
   pname = "checksec";
-  version = "2.5.0";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "slimm609";
     repo = "checksec.sh";
     rev = version;
-    sha256 = "sha256-GxWXocz+GCEssRrIQP6E9hjVIhVh2EmZrefELxQlV1Q=";
+    hash = "sha256-BWtchWXukIDSLJkFX8M/NZBvfi7vUE2j4yFfS0KEZDo=";
   };
 
-  patches = [ ./0001-attempt-to-modprobe-config-before-checking-kernel.patch ];
-  nativeBuildInputs = [ makeWrapper ];
+  patches = [
+    ./0001-attempt-to-modprobe-config-before-checking-kernel.patch
+  ];
 
-  installPhase = let
-    path = lib.makeBinPath [
-      findutils file binutils-unwrapped sysctl openssl
-    ];
-  in ''
-    mkdir -p $out/bin
-    install checksec $out/bin
-    substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6
-    substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
-    wrapProgram $out/bin/checksec \
-      --prefix PATH : ${path}
-  '';
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase =
+    let
+      path = lib.makeBinPath [
+        findutils
+        file
+        binutils-unwrapped
+        sysctl
+        openssl
+      ];
+    in
+    ''
+      mkdir -p $out/bin
+      install checksec $out/bin
+      substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6
+      substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
+      wrapProgram $out/bin/checksec \
+        --prefix PATH : ${path}
+    '';
 
   meta = with lib; {
-    description = "A tool for checking security bits on executables";
-    homepage    = "https://www.trapkit.de/tools/checksec/";
-    license     = licenses.bsd3;
-    platforms   = platforms.linux;
+    description = "Tool for checking security bits on executables";
+    homepage = "https://www.trapkit.de/tools/checksec/";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ thoughtpolice globin ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/slimm609/checksec.sh/releases/tag/2.6.0

- Run `nixpkgs-fmt`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
