### PR TITLE
angband: add a nixos test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -37,6 +37,7 @@ in {
   airsonic = handleTest ./airsonic.nix {};
   allTerminfo = handleTest ./all-terminfo.nix {};
   amazon-init-shell = handleTest ./amazon-init-shell.nix {};
+  angband = handleTest ./angband.nix {};
   apfs = handleTest ./apfs.nix {};
   apparmor = handleTest ./apparmor.nix {};
   atd = handleTest ./atd.nix {};

--- a/nixos/tests/angband.nix
+++ b/nixos/tests/angband.nix
@@ -1,0 +1,41 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+{
+  name = "angband";
+  meta = { maintainers = with lib.maintainers; [ kenran ]; };
+
+  nodes.machine = { pkgs, ... }: {
+    imports = [ ./common/x11.nix ];
+    environment.systemPackages =
+      [ pkgs.angband pkgs.xterm pkgs.source-code-pro ];
+  };
+
+  enableOCR = true;
+
+  testScript = let angbandSdl2 = pkgs.angband.override { enableSdl2 = true; };
+  in ''
+    machine.start()
+    machine.wait_for_x()
+
+    # xterm instance from which we launch the game
+    machine.succeed("DISPLAY=:0 xterm -fa 'Source Code Pro' -fs 13 -fullscreen >&2 &")
+    machine.sleep(2)
+
+    with subtest("Can run Angband with GCU frontend"):
+        machine.send_chars("angband -mgcu\n")
+        # Angband has started
+        machine.wait_for_text("Initialization complete")
+        machine.screenshot("gcu_angband")
+
+        machine.send_chars("x")
+        machine.sleep(1)
+        machine.send_key("ctrl-x")
+
+    machine.sleep(2)
+
+    with subtest("Can run Angband with SDL2 frontend"):
+        machine.send_chars("${lib.getExe angbandSdl2} -g -msdl2\n")
+        machine.wait_for_window("Angband")
+        machine.screenshot("sdl2_angband")
+  '';
+})

--- a/pkgs/games/angband/default.nix
+++ b/pkgs/games/angband/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, ncurses5
+{ lib, stdenv, nixosTests, fetchFromGitHub, autoreconfHook, ncurses5
 , enableSdl2 ? false, SDL2, SDL2_image, SDL2_sound, SDL2_mixer, SDL2_ttf
 }:
 
@@ -28,10 +28,14 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "bindir=$(out)/bin" ];
 
+  passthru.tests = {
+    runAngband = nixosTests.angband;
+  };
+
   meta = with lib; {
     homepage = "https://angband.github.io/angband";
     description = "A single-player roguelike dungeon exploration game";
-    maintainers = [ ];
+    maintainers = with maintainers; [ kenran ];
     license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Description of changes

Adds a NixOS test for Angband, and links it to `pkgs.angband`. The test checks whether console Angband initializes correctly, as well as the newly added SDL2 variant. Also adds me to its list of maintainers.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
