### PR TITLE
lib/modules: add `attrArgName`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -113,6 +113,7 @@ rec {
                   args ? {}
                 , # This would be remove in the future, Prefer _module.check option instead.
                   check ? true
+                , attrArgName ? "name"
                 }:
     let
       withWarnings = x:
@@ -341,15 +342,17 @@ rec {
         modules ? [],
         specialArgs ? {},
         prefix ? [],
+        attrArgName ? "name",
         }:
           evalModules (evalModulesArgs // {
             modules = regularModules ++ modules;
             specialArgs = evalModulesArgs.specialArgs or {} // specialArgs;
             prefix = extendArgs.prefix or evalModulesArgs.prefix or [];
+            inherit attrArgName;
           });
 
       type = lib.types.submoduleWith {
-        inherit modules specialArgs;
+        inherit modules specialArgs attrArgName;
       };
 
       result = withWarnings {

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -337,6 +337,8 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # because of an `extendModules` bug, issue 168767.
 checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
 
+checkConfigOutput '^"foo=qux,bar=xyz"$' config.result ./nested-extendModules-with-name.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/nested-extendModules-with-name.nix
+++ b/lib/tests/modules/nested-extendModules-with-name.nix
@@ -1,0 +1,33 @@
+{ config, extendModules, lib, ... }:
+let
+  inherit (lib) mkOption types;
+  inherit (types) attrsOf submodule;
+in
+{
+  options = {
+    withKey = mkOption {
+      type = attrsOf (
+        submodule ({ name, ... }: {
+          options.value = mkOption {
+            type = attrsOf (
+              (extendModules {
+                attrArgName = name;
+              }).type
+            );
+          };
+        })
+      );
+    };
+    res = mkOption {
+      type = types.str;
+    };
+    result = mkOption {
+      default = config.withKey.foo.value.qux.withKey.bar.value.xyz.res;
+    };
+  };
+  config = {
+    withKey.foo.value.qux.withKey.bar.value.xyz = { foo, bar, lib, config, ... }: {
+      res = "foo=" + foo + ",bar=" + bar;
+    };
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -570,6 +570,7 @@ rec {
       { modules
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false
+      , attrArgName ? "name"
       , description ? null
       }@attrs:
       let
@@ -599,7 +600,7 @@ rec {
             # &gt; and &lt; wouldn't be encoded correctly so the encoded values
             # would be used, and use of `<` and `>` would break the XML document.
             # It shouldn't cause an issue since this is cosmetic for the manual.
-            _module.args.name = lib.mkOptionDefault "‹name›";
+            _module.args.${attrArgName} = lib.mkOptionDefault "‹name›";
           }] ++ modules;
         };
 
@@ -616,7 +617,7 @@ rec {
         check = x: isAttrs x || isFunction x || path.check x;
         merge = loc: defs:
           (base.extendModules {
-            modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
+            modules = [ { _module.args.${attrArgName} = last loc; } ] ++ allModules defs;
             prefix = loc;
           }).config;
         emptyValue = { value = {}; };


### PR DESCRIPTION
###### Description of changes

Make the `name` module parameter configurable, so that `extendModules`/`moduleType` can be reused as a submodule type more than once, and so that the parameter can be domain-specific.

Closes #177564.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
