### PR TITLE
gnatboot: 4.1 -> 11.2.0-4

### DIFF
--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, autoPatchelfHook, fetchzip, lzma, ncurses5, readline, gmp, mpfr
+{ stdenv, lib, autoPatchelfHook, fetchzip, xz, ncurses5, readline, gmp, mpfr
 , expat, libipt, zlib, dejagnu, sourceHighlight, python3, elfutils, guile, glibc
 }:
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
   };
 
-  NativeBuildInputs = [
+  nativeBuildInputs = [
     autoPatchelfHook
     dejagnu
     elfutils
@@ -20,12 +20,12 @@ stdenv.mkDerivation rec {
     gmp
     guile
     libipt
-    lzma
     mpfr
     ncurses5
     python3
     readline
     sourceHighlight
+    xz
     zlib
   ];
 

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -5,10 +5,9 @@
 stdenv.mkDerivation rec {
   pname = "gnatboot";
   version = "11.2.0-4";
+
   src = fetchzip {
-    url =
-      "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-"
-      + version + "/gnat-x86_64-linux-" + version + ".tar.gz";
+    url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-${version}/gnat-x86_64-linux-${version}.tar.gz";
     hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
   };
 

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
-    cp -var * $out/
+    cp -ar * $out/
   '';
 
   passthru = {

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -1,55 +1,106 @@
-{ lib, stdenv, fetchurl }:
+{ stdenv, lib, autoPatchelfHook, fetchzip, lzma, ncurses5, readline, gmp, mpfr
+, expat, libipt, zlib, dejagnu, sourceHighlight, python3, elfutils, guile, glibc
+}:
 
-if stdenv.hostPlatform != stdenv.targetPlatform
-then builtins.throw "gnatboot can't cross-compile"
-else
+stdenv.mkDerivation rec {
+  pname = "gnatboot";
+  version = "11.2.0-4";
+  src = fetchzip {
+    url =
+      "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-"
+      + version + "/gnat-x86_64-linux-" + version + ".tar.gz";
+    hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
+  };
 
-stdenv.mkDerivation {
-  pname = "gentoo-gnatboot";
-  version = "4.1";
+  nativeBuildInputs = [
+    autoPatchelfHook
+    lzma
+    ncurses5
+    readline
+    gmp
+    mpfr
+    expat
+    libipt
+    zlib
+    dejagnu
+    sourceHighlight
+    python3
+    elfutils
+    guile
+    glibc
+  ];
 
-  src = if stdenv.hostPlatform.system == "i686-linux" then
-    fetchurl {
-      url = "mirror://gentoo/distfiles/gnatboot-4.1-i386.tar.bz2";
-      sha256 = "0665zk71598204bf521vw68i5y6ccqarq9fcxsqp7ccgycb4lysr";
-    }
-  else if stdenv.hostPlatform.system == "x86_64-linux" then
-    fetchurl {
-      url = "mirror://gentoo/distfiles/gnatboot-4.1-amd64.tar.bz2";
-      sha256 = "1li4d52lmbnfs6llcshlbqyik2q2q4bvpir0f7n38nagp0h6j0d4";
-    }
-  else
-    throw "Platform not supported";
+  propagatedNativeBuildInputs = [
+    autoPatchelfHook
+    lzma
+    ncurses5
+    readline
+    gmp
+    mpfr
+    expat
+    libipt
+    zlib
+    dejagnu
+    sourceHighlight
+    python3
+    elfutils
+    guile
+    glibc
+  ];
 
-  dontStrip = 1;
+  buildInputs = [
+    autoPatchelfHook
+    lzma
+    ncurses5
+    readline
+    gmp
+    mpfr
+    expat
+    libipt
+    zlib
+    dejagnu
+    sourceHighlight
+    python3
+    elfutils
+    guile
+    glibc
+  ];
+
+  propagatedBuildInputs = [
+    autoPatchelfHook
+    lzma
+    ncurses5
+    readline
+    gmp
+    mpfr
+    expat
+    libipt
+    zlib
+    dejagnu
+    sourceHighlight
+    python3
+    elfutils
+    guile
+    glibc
+  ];
 
   installPhase = ''
     mkdir -p $out
-    cp -R * $out
-
-    set +e
-    for a in $out/bin/* ; do
-      patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-        --set-rpath $(cat $NIX_CC/nix-support/orig-libc)/lib:$(cat $NIX_CC/nix-support/orig-cc)/lib64:$(cat $NIX_CC/nix-support/orig-cc)/lib $a
-    done
-    set -e
-
-    mv $out/bin/gnatgcc_2wrap $out/bin/gnatgcc
-    ln -s $out/bin/gnatgcc $out/bin/gcc
+    cp -var * $out/
   '';
 
   passthru = {
-    langC = true; # TRICK for gcc-wrapper to wrap it
+    langC = true;
     langCC = false;
     langFortran = false;
     langAda = true;
   };
 
   meta = with lib; {
-    homepage = "https://gentoo.org";
-    license = licenses.gpl3Plus;
-    maintainers = [ maintainers.lucus16 ];
-
+    description = "GNAT, the GNU Ada Translator";
+    homepage = "https://www.gnu.org/software/gnat";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ethindp ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
   };
 
-  propagatedNativeBuildInputs = [
+  NativeBuildInputs = [
     autoPatchelfHook
     dejagnu
     elfutils

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -11,76 +11,22 @@ stdenv.mkDerivation rec {
     hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
   };
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    lzma
-    ncurses5
-    readline
-    gmp
-    mpfr
-    expat
-    libipt
-    zlib
-    dejagnu
-    sourceHighlight
-    python3
-    elfutils
-    guile
-    glibc
-  ];
-
   propagatedNativeBuildInputs = [
     autoPatchelfHook
-    lzma
-    ncurses5
-    readline
-    gmp
-    mpfr
-    expat
-    libipt
-    zlib
     dejagnu
-    sourceHighlight
-    python3
     elfutils
-    guile
-    glibc
-  ];
-
-  buildInputs = [
-    autoPatchelfHook
-    lzma
-    ncurses5
-    readline
-    gmp
-    mpfr
     expat
-    libipt
-    zlib
-    dejagnu
-    sourceHighlight
-    python3
-    elfutils
-    guile
     glibc
-  ];
-
-  propagatedBuildInputs = [
-    autoPatchelfHook
-    lzma
-    ncurses5
-    readline
     gmp
-    mpfr
-    expat
-    libipt
-    zlib
-    dejagnu
-    sourceHighlight
-    python3
-    elfutils
     guile
-    glibc
+    libipt
+    lzma
+    mpfr
+    ncurses5
+    python3
+    readline
+    sourceHighlight
+    zlib
   ];
 
   installPhase = ''

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -101,6 +101,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/gnat";
     license = licenses.gpl3;
     maintainers = with maintainers; [ ethindp ];
-    platforms = platforms.linux;
+    platforms = with platforms; [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    langC = true;
+    langC = true; # TRICK for gcc-wrapper to wrap it
     langCC = false;
     langFortran = false;
     langAda = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12945,7 +12945,7 @@ with pkgs;
     inherit (gnome2) libart_lgpl;
   });
 
-  gnat = gnat11;
+  gnat = gnat12;
 
   gnat6 = wrapCC (gcc6.cc.override {
     name = "gnat";
@@ -12976,7 +12976,7 @@ with pkgs;
     gnatboot =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnat6
+      then buildPackages.gnatboot
       else buildPackages.gnat9;
   });
 
@@ -12992,7 +12992,7 @@ with pkgs;
     gnatboot =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnat6
+      then buildPackages.gnatboot
       else buildPackages.gnat10;
   });
 
@@ -13008,7 +13008,7 @@ with pkgs;
     gnatboot =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnat6
+      then buildPackages.gnatboot
       else buildPackages.gnat11;
   });
 
@@ -13024,7 +13024,7 @@ with pkgs;
     gnatboot =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnat6
+      then buildPackages.gnatboot
       else buildPackages.gnat12;
   });
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR does a couple things:

* All gnat builds now use the gnatboot package instead of a previous gnat version.
* The "gnat" package has been changed to reference "gnat12".
* The gnatboot package now uses prebuilt binaries provided by the [Alire project](https://github.com/alire-project/gnat-fsf-builds).

Notes:

1. GNAT 6 and 9 do not build successfully. Build failures will continue to occur; this should, however, be resolvable if someone really needs these old versions.
2. As of now, the gnatboot package uses x86-64-specific binaries. No other architectures are supported. Cross-compilation is possible, but will need to be bootstrapped from an x86-64 system.
3. The aforementioned repository does contain cross-compilers for other architectures; however, these are x86-64-specific, so it seemed redundant to include them, as we can simply reproduce them in nixpkgs automatically.

Suggestions:

Due to the continuing build failures with GCC versions before 10.x.x, I suggest that we simply remove GCC versions older than 10.x.x. In particular, removal of GNAT 6 and 9 is strongly encouraged, as it is very unlikely that anyone
will actually need to use these very old versions of Gnat.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
