### PR TITLE
way-displays: init at 1.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11858,6 +11858,12 @@
     github = "simarra";
     githubId = 14372987;
   };
+  simoneruffini = {
+    email = "simone.ruffini@tutanota.com";
+    github = "simoneruffini";
+    githubId = 50401154;
+    name = "Simone Ruffini";
+  };
   simonchatts = {
     email = "code@chatts.net";
     github = "simonchatts";

--- a/pkgs/tools/wayland/way-displays/default.nix
+++ b/pkgs/tools/wayland/way-displays/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, wayland
+, libinput
+, libyamlcpp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "way-displays";
+  version = "1.5.3";
+
+  src = fetchFromGitHub {
+    owner = "alex-courtis";
+    repo = "way-displays";
+    rev = "${version}";
+    sha256 = "sha256-5A0qZRpWw3Deo9cGqGULpQMoPCVh85cWE/wJ5XSbVJk=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/cfg.cpp --replace "\"/etc" "\"$out/etc"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland
+  ];
+
+  buildInputs = [
+    wayland
+    libyamlcpp
+    libinput
+  ];
+
+  makeFlags = [ "DESTDIR=$(out) PREFIX= PREFIX_ETC="];
+
+  meta = with lib; {
+    homepage = "https://github.com/alex-courtis/way-displays";
+    description = "Auto Manage Your Wayland Displays";
+    license = licenses.mit;
+    maintainers = with maintainers; [ simoneruffini ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3133,6 +3133,8 @@ with pkgs;
 
   wayland-proxy-virtwl = callPackage ../tools/wayland/wayland-proxy-virtwl { };
 
+  way-displays = callPackage ../tools/wayland/way-displays { };
+
   wev = callPackage ../tools/wayland/wev { };
 
   wdomirror = callPackage ../tools/wayland/wdomirror { };


### PR DESCRIPTION
###### Description of changes

Added a new package: [way-displays](https://github.com/alex-courtis/way-displays/) an application to manage display configurations for wayland compositors based on wlroots.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
