### PR TITLE
libopenmpt-modplug: init at 0.8.9.0-openmpt1

### DIFF
--- a/pkgs/development/libraries/audio/libopenmpt-modplug/default.nix
+++ b/pkgs/development/libraries/audio/libopenmpt-modplug/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, lib
+, fetchurl
+, autoreconfHook
+, pkg-config
+, libopenmpt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libopenmpt-modplug";
+  version = "0.8.9.0-openmpt1";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchurl {
+    url = "https://lib.openmpt.org/files/libopenmpt-modplug/libopenmpt-modplug-${version}.tar.gz";
+    sha256 = "sha256-7M4aDuz9sLWCTKuJwnDc5ZWWKVosF8KwQyFez018T/c=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libopenmpt
+  ];
+
+  configureFlags = [
+    "--enable-libmodplug"
+  ];
+
+  meta = with lib; {
+    description = "A libmodplug emulation layer based on libopenmpt";
+    homepage = "https://lib.openmpt.org/libopenmpt/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28918,6 +28918,8 @@ with pkgs;
 
   libopenmpt = callPackage ../development/libraries/audio/libopenmpt { };
 
+  libopenmpt-modplug = callPackage ../development/libraries/audio/libopenmpt-modplug { };
+
   openrazer-daemon = with python3Packages; toPythonApplication openrazer-daemon;
 
   opusfile = callPackage ../applications/audio/opusfile { };


### PR DESCRIPTION
###### Description of changes

This is a libmodplug emulation layer based on libopenmpt.

https://lib.openmpt.org/libopenmpt/

> libopenmpt also provides a compatibility layer implementing the libmodplug interface on top of libopenmpt in the **libopenmpt-modplug** package.

It's not a fully featured replacement but it can work for some projects. I tested `moc` via `nix-build -E 'with import ./. { }; moc.override { libmodplug = libopenmpt-modplug; }'` and it was capable of playing modfiles.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
