### PR TITLE
rkdeveloptool: unstable-2021-02-03 -> unstable-2021-04-08

### DIFF
--- a/pkgs/misc/rkdeveloptool/default.nix
+++ b/pkgs/misc/rkdeveloptool/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "rkdeveloptool";
-  version = "unstable-2021-02-03";
+  version = "unstable-2021-04-08";
 
   src = fetchFromGitHub {
     owner = "rockchip-linux";
     repo = "rkdeveloptool";
-    rev = "e607a5d6ad3f6af66d3daf3f6370e6dc9763a20d";
-    sha256 = "08m0yfds5rpr5l0s75ynfarq3hrv94l3aadld17cz5gqapqcfs2n";
+    rev = "46bb4c073624226c3f05b37b9ecc50bbcf543f5a";
+    sha256 = "eIFzyoY6l3pdfCN0uS16hbVp0qzdG3MtcS1jnDX1Yk0=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   buildInputs = [ libusb1 ];
 
   # main.cpp:1568:36: error: '%s' directive output may be truncated writing up to 557 bytes into a region of size 5
-  CPPFLAGS = "-Wno-error=format-truncation";
+  CPPFLAGS = lib.optionals stdenv.cc.isGNU [ "-Wno-error=format-truncation" ];
 
   meta = with lib; {
     homepage = "https://github.com/rockchip-linux/rkdeveloptool";


### PR DESCRIPTION
###### Description of changes
update version
fix build on darwin
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
