### PR TITLE
nixos/nfs: clean-up and RFC42 compliance

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -47,6 +47,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `isPowerPC` predicate, found on `platform` attrsets (`hostPlatform`, `buildPlatform`, `targetPlatform`, etc) has been removed in order to reduce confusion.  The predicate was was defined such that it matches only the 32-bit big-endian members of the POWER/PowerPC family, despite having a name which would imply a broader set of systems.  If you were using this predicate, you can replace `foo.isPowerPC` with `(with foo; isPower && is32bit && isBigEndian)`.
 
+- `services.nfs` has been migrated to follow the RFC42 way of handling options through `services.nfs.settings`.
+
 - PHP 7.4 is no longer supported due to upstream not supporting this
   version for the entire lifecycle of the 22.11 release.
 

--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -1,113 +1,106 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    optionalAttrs optionalString recursiveUpdate
+    mkEnableOption mkOption mkIf types mkRenamedOptionModule mkRemovedOptionModule;
 
   cfg = config.services.nfs.server;
 
   exports = pkgs.writeText "exports" cfg.exports;
 
+  format = pkgs.formats.ini { };
+
+  libDir = "/var/lib/nfs";
+
 in
 
 {
   imports = [
+    (mkRemovedOptionModule [ "services" "nfs" "server" "extraNfsdConfig" ] "RFC42 compliant settings in services.nfs.server.settings")
     (mkRenamedOptionModule [ "services" "nfs" "lockdPort" ] [ "services" "nfs" "server" "lockdPort" ])
     (mkRenamedOptionModule [ "services" "nfs" "statdPort" ] [ "services" "nfs" "server" "statdPort" ])
   ];
 
   ###### interface
 
-  options = {
+  options.services.nfs.server = {
+    enable = mkEnableOption "the kernel's NFS server";
 
-    services.nfs = {
+    settings = mkOption {
+      type = format.type;
+      default = { };
+      description = ''
+        Extra configuration options for /etc/nfs.conf.
 
-      server = {
-        enable = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether to enable the kernel's NFS server.
-          '';
-        };
-
-        extraNfsdConfig = mkOption {
-          type = types.str;
-          default = "";
-          description = ''
-            Extra configuration options for the [nfsd] section of /etc/nfs.conf.
-          '';
-        };
-
-        exports = mkOption {
-          type = types.lines;
-          default = "";
-          description = ''
-            Contents of the /etc/exports file.  See
-            <citerefentry><refentrytitle>exports</refentrytitle>
-            <manvolnum>5</manvolnum></citerefentry> for the format.
-          '';
-        };
-
-        hostName = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = ''
-            Hostname or address on which NFS requests will be accepted.
-            Default is all.  See the <option>-H</option> option in
-            <citerefentry><refentrytitle>nfsd</refentrytitle>
-            <manvolnum>8</manvolnum></citerefentry>.
-          '';
-        };
-
-        nproc = mkOption {
-          type = types.int;
-          default = 8;
-          description = ''
-            Number of NFS server threads.  Defaults to the recommended value of 8.
-          '';
-        };
-
-        createMountPoints = mkOption {
-          type = types.bool;
-          default = false;
-          description = "Whether to create the mount points in the exports file at startup time.";
-        };
-
-        mountdPort = mkOption {
-          type = types.nullOr types.int;
-          default = null;
-          example = 4002;
-          description = ''
-            Use fixed port for rpc.mountd, useful if server is behind firewall.
-          '';
-        };
-
-        lockdPort = mkOption {
-          type = types.nullOr types.int;
-          default = null;
-          example = 4001;
-          description = ''
-            Use a fixed port for the NFS lock manager kernel module
-            (<literal>lockd/nlockmgr</literal>).  This is useful if the
-            NFS server is behind a firewall.
-          '';
-        };
-
-        statdPort = mkOption {
-          type = types.nullOr types.int;
-          default = null;
-          example = 4000;
-          description = ''
-            Use a fixed port for <command>rpc.statd</command>. This is
-            useful if the NFS server is behind a firewall.
-          '';
-        };
-
-      };
-
+        See <citerefentry><refentrytitle>nfs.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+      '';
     };
 
+    exports = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Contents of the /etc/exports file.  See
+        <citerefentry><refentrytitle>exports</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for the format.
+      '';
+    };
+
+    hostName = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Hostname or address on which NFS requests will be accepted.
+        Default is all.  See the <option>-H</option> option in
+        <citerefentry><refentrytitle>nfsd</refentrytitle>
+        <manvolnum>8</manvolnum></citerefentry>.
+      '';
+    };
+
+    nproc = mkOption {
+      type = types.int;
+      default = 8;
+      description = ''
+        Number of NFS server threads.  Defaults to the recommended value of 8.
+      '';
+    };
+
+    createMountPoints = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to create the mount points in the exports file at startup time.";
+    };
+
+    mountdPort = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 4002;
+      description = ''
+        Use fixed port for rpc.mountd, useful if server is behind firewall.
+      '';
+    };
+
+    lockdPort = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 4001;
+      description = ''
+        Use a fixed port for the NFS lock manager kernel module
+        (<literal>lockd/nlockmgr</literal>).  This is useful if the
+        NFS server is behind a firewall.
+      '';
+    };
+
+    statdPort = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 4000;
+      description = ''
+        Use a fixed port for <command>rpc.statd</command>. This is
+        useful if the NFS server is behind a firewall.
+      '';
+    };
   };
 
 
@@ -115,61 +108,61 @@ in
 
   config = mkIf cfg.enable {
 
-    services.nfs.extraConfig = ''
-      [nfsd]
-      threads=${toString cfg.nproc}
-      ${optionalString (cfg.hostName != null) "host=${cfg.hostName}"}
-      ${cfg.extraNfsdConfig}
+    services = {
+      nfs.settings = recursiveUpdate
+        {
+          nfsd = { threads = cfg.nproc; }
+            // optionalAttrs (cfg.hostName != null) { host = cfg.hostName; };
+          mountd = { }
+            // optionalAttrs (cfg.mountdPort != null) { port = cfg.mountdPort; };
+          statd = { }
+            // optionalAttrs (cfg.statdPort != null) { port = cfg.statdPort; };
+          lockd = { }
+            // optionalAttrs (cfg.lockdPort != null) {
+            port = cfg.lockdPort;
+            udp-port = cfg.lockdPort;
+          };
+        }
+        cfg.settings;
 
-      [mountd]
-      ${optionalString (cfg.mountdPort != null) "port=${toString cfg.mountdPort}"}
-
-      [statd]
-      ${optionalString (cfg.statdPort != null) "port=${toString cfg.statdPort}"}
-
-      [lockd]
-      ${optionalString (cfg.lockdPort != null) ''
-        port=${toString cfg.lockdPort}
-        udp-port=${toString cfg.lockdPort}
-      ''}
-    '';
-
-    services.rpcbind.enable = true;
+      rpcbind.enable = true;
+    };
 
     boot.supportedFilesystems = [ "nfs" ]; # needed for statd and idmapd
 
     environment.etc.exports.source = exports;
 
-    systemd.services.nfs-server =
-      { enable = true;
-        wantedBy = [ "multi-user.target" ];
+    systemd = {
+      services = {
+        nfs-server = {
+          enable = true;
+          wantedBy = [ "multi-user.target" ];
+        };
 
-        preStart =
-          ''
-            mkdir -p /var/lib/nfs/v4recovery
+        nfs-mountd = {
+          enable = true;
+          restartTriggers = [ exports ];
+
+          preStart = optionalString cfg.createMountPoints ''
+            # create export directories:
+            # skip comments, take first col which may either be a quoted
+            # "foo bar" or just foo (-> man export)
+            sed '/^#.*/d;s/^"\([^"]*\)".*/\1/;t;s/[ ].*//' ${exports} \
+            | xargs -d '\n' mkdir -p
           '';
+        };
+
+        nfsdcld.serviceConfig = {
+          Type = "exec";
+          ExecStart = [ "" "${pkgs.nfs-utils}/bin/nfsdcld --foreground" ];
+        };
       };
 
-    systemd.services.nfs-mountd =
-      { enable = true;
-        restartTriggers = [ exports ];
-
-        preStart =
-          ''
-            mkdir -p /var/lib/nfs
-
-            ${optionalString cfg.createMountPoints
-              ''
-                # create export directories:
-                # skip comments, take first col which may either be a quoted
-                # "foo bar" or just foo (-> man export)
-                sed '/^#.*/d;s/^"\([^"]*\)".*/\1/;t;s/[ ].*//' ${exports} \
-                | xargs -d '\n' mkdir -p
-              ''
-            }
-          '';
-      };
-
+      tmpfiles.rules = [
+        "d ${libDir}            0755 - - - -"
+        "d ${libDir}/nfsdcld    0775 root nogroup - -"
+        "d ${libDir}/v4recovery 0755 - - - -"
+      ];
+    };
   };
-
 }

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -1,19 +1,20 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    any optionalAttrs
+    mkDefault mkIf mkMerge mkOption literalExpression types;
 
   inInitrd = any (fs: fs == "nfs") config.boot.initrd.supportedFilesystems;
 
-  nfsStateDir = "/var/lib/nfs";
+  libDir = "/var/lib/nfs";
 
-  rpcMountpoint = "${nfsStateDir}/rpc_pipefs";
+  rpcMountpoint = "${libDir}/rpc_pipefs";
 
-  format = pkgs.formats.ini {};
+  format = pkgs.formats.ini { };
 
   idmapdConfFile = format.generate "idmapd.conf" cfg.idmapd.settings;
-  nfsConfFile = pkgs.writeText "nfs.conf" cfg.extraConfig;
+  nfsConfFile = format.generate "nfs.conf" cfg.settings;
   requestKeyConfFile = pkgs.writeText "request-key.conf" ''
     create id_resolver * * ${pkgs.nfs-utils}/bin/nfsidmap -t 600 %k %d
   '';
@@ -25,34 +26,33 @@ in
 {
   ###### interface
 
-  options = {
-    services.nfs = {
-      idmapd.settings = mkOption {
-        type = format.type;
-        default = {};
-        description = ''
-          libnfsidmap configuration. Refer to
-          <link xlink:href="https://linux.die.net/man/5/idmapd.conf"/>
-          for details.
-        '';
-        example = literalExpression ''
-          {
-            Translation = {
-              GSS-Methods = "static,nsswitch";
-            };
-            Static = {
-              "root/hostname.domain.com@REALM.COM" = "root";
-            };
-          }
-        '';
-      };
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = ''
-          Extra nfs-utils configuration.
-        '';
-      };
+  options.services.nfs = {
+    idmapd.settings = mkOption {
+      type = format.type;
+      default = { };
+      description = ''
+        libnfsidmap configuration. Refer to
+        <link xlink:href="https://linux.die.net/man/5/idmapd.conf"/>
+        for details.
+      '';
+      example = literalExpression ''
+        {
+          Translation = {
+            GSS-Methods = "static,nsswitch";
+          };
+          Static = {
+            "root/hostname.domain.com@REALM.COM" = "root";
+          };
+        }
+      '';
+    };
+
+    settings = mkOption rec {
+      type = format.type;
+      default = { };
+      description = ''
+        Extra configuration options for /etc/nfs.conf.
+      '';
     };
   };
 
@@ -60,76 +60,81 @@ in
 
   config = mkIf (any (fs: fs == "nfs" || fs == "nfs4") config.boot.supportedFilesystems) {
 
-    services.rpcbind.enable = true;
-
-    services.nfs.idmapd.settings = {
-      General = mkMerge [
-        { Pipefs-Directory = rpcMountpoint; }
-        (mkIf (config.networking.domain != null) { Domain = config.networking.domain; })
-      ];
-      Mapping = {
-        Nobody-User = "nobody";
-        Nobody-Group = "nogroup";
+    services = {
+      nfs.idmapd.settings = {
+        General = {
+          Pipefs-Directory = rpcMountpoint;
+        }
+        // optionalAttrs (config.networking.domain != null) { Domain = config.networking.domain; };
+        Mapping = {
+          Nobody-User = "nobody";
+          Nobody-Group = "nogroup";
+        };
+        Translation = {
+          Method = "nsswitch";
+        };
       };
-      Translation = {
-        Method = "nsswitch";
-      };
+      rpcbind.enable = true;
     };
 
     system.fsPackages = [ pkgs.nfs-utils ];
 
     boot.initrd.kernelModules = mkIf inInitrd [ "nfs" ];
 
-    systemd.packages = [ pkgs.nfs-utils ];
-
-    environment.systemPackages = [ pkgs.keyutils ];
-
-    environment.etc = {
-      "idmapd.conf".source = idmapdConfFile;
-      "nfs.conf".source = nfsConfFile;
-      "request-key.conf".source = requestKeyConfFile;
+    environment = {
+      etc = {
+        "idmapd.conf".source = idmapdConfFile;
+        "nfs.conf".source = nfsConfFile;
+        "request-key.conf".source = requestKeyConfFile;
+      };
+      systemPackages = [ pkgs.keyutils ];
     };
 
-    systemd.services.nfs-blkmap =
-      { restartTriggers = [ nfsConfFile ];
+    systemd = {
+      packages = [ pkgs.nfs-utils ];
+
+      services = {
+        nfs-blkmap = {
+          restartTriggers = [ nfsConfFile ];
+        };
+
+        nfs-idmapd = {
+          restartTriggers = [ idmapdConfFile ];
+        };
+
+        nfs-mountd = {
+          restartTriggers = [ nfsConfFile ];
+          enable = mkDefault false;
+        };
+
+        nfs-server = {
+          restartTriggers = [ nfsConfFile ];
+          enable = mkDefault false;
+        };
+
+        auth-rpcgss-module = {
+          unitConfig.ConditionPathExists = [ "" "/etc/krb5.keytab" ];
+        };
+
+        rpc-gssd = {
+          restartTriggers = [ nfsConfFile ];
+          unitConfig.ConditionPathExists = [ "" "/etc/krb5.keytab" ];
+        };
+
+        rpc-statd = {
+          restartTriggers = [ nfsConfFile ];
+        };
       };
 
-    systemd.targets.nfs-client =
-      { wantedBy = [ "multi-user.target" "remote-fs.target" ];
+      targets.nfs-client = {
+        wantedBy = [ "multi-user.target" "remote-fs.target" ];
       };
 
-    systemd.services.nfs-idmapd =
-      { restartTriggers = [ idmapdConfFile ];
-      };
-
-    systemd.services.nfs-mountd =
-      { restartTriggers = [ nfsConfFile ];
-        enable = mkDefault false;
-      };
-
-    systemd.services.nfs-server =
-      { restartTriggers = [ nfsConfFile ];
-        enable = mkDefault false;
-      };
-
-    systemd.services.auth-rpcgss-module =
-      {
-        unitConfig.ConditionPathExists = [ "" "/etc/krb5.keytab" ];
-      };
-
-    systemd.services.rpc-gssd =
-      { restartTriggers = [ nfsConfFile ];
-        unitConfig.ConditionPathExists = [ "" "/etc/krb5.keytab" ];
-      };
-
-    systemd.services.rpc-statd =
-      { restartTriggers = [ nfsConfFile ];
-
-        preStart =
-          ''
-            mkdir -p /var/lib/nfs/{sm,sm.bak}
-          '';
-      };
-
+      tmpfiles.rules = [
+        "d ${libDir}/sm     0700 nobody root - -"
+        "d ${libDir}/sm.bak 0700 nobody root - -"
+        "d ${rpcMountpoint}      0555 - - - -"
+      ];
+    };
   };
 }


### PR DESCRIPTION
###### Description of changes

- RFC42 compliance to avoid having to deal with a wall of text and
  support setting all settings in /etc/nfs.conf
- migrate from preScript to tmpfiles for directory creation and
  settings permissions
- avoid running daemons in double-fork mode if possible

There are no functionality changes or changes to permissions/users as
that will come later.

Should have done this for 22.05 as I've been running it for ages.

NixOS tests pass as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
