### PR TITLE
crystfel-scripts: init at 0.10.1

### DIFF
--- a/pkgs/applications/science/physics/crystfel/attributes.nix
+++ b/pkgs/applications/science/physics/crystfel/attributes.nix
@@ -1,0 +1,10 @@
+{ fetchurl }:
+rec {
+  crystfel-pname = "crystfel";
+  crystfel-version = "0.10.1";
+
+  crystfel-src = fetchurl {
+    url = "https://www.desy.de/~twhite/${crystfel-pname}/${crystfel-pname}-${crystfel-version}.tar.gz";
+    sha256 = "0i9d5ggalic7alj97dxjdys7010kxhm2cb4lwakvigl023j8ms79";
+  };
+}

--- a/pkgs/applications/science/physics/crystfel/core.nix
+++ b/pkgs/applications/science/physics/crystfel/core.nix
@@ -36,6 +36,8 @@
 }:
 
 let
+  attributes = import ./attributes.nix { inherit fetchurl; };
+
   libccp4 = stdenv.mkDerivation rec {
     pname = "libccp4";
     version = "6.5.1";
@@ -160,12 +162,9 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  pname = "crystfel";
-  version = "0.10.1";
-  src = fetchurl {
-    url = "https://www.desy.de/~twhite/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "0i9d5ggalic7alj97dxjdys7010kxhm2cb4lwakvigl023j8ms79";
-  };
+  pname = attributes.crystfel-pname;
+  version = attributes.crystfel-version;
+  src = attributes.crystfel-src;
   nativeBuildInputs = [ meson pkg-config ninja flex bison doxygen opencl-headers ]
     ++ lib.optionals withGui [ wrapGAppsHook ];
   buildInputs = [
@@ -181,6 +180,7 @@ stdenv.mkDerivation rec {
     mosflm
     pinkIndexer
     xgandalf
+    makeWrapper
   ] ++ lib.optionals withGui [ gtk3 gdk-pixbuf ]
   ++ lib.optionals stdenv.isDarwin [
     argp-standalone

--- a/pkgs/applications/science/physics/crystfel/scripts.nix
+++ b/pkgs/applications/science/physics/crystfel/scripts.nix
@@ -1,0 +1,134 @@
+{ stdenv, python3Packages, fetchurl, perl, gnuplot, R, gnugrep, coreutils, crystfel-headless, perlPackages, symlinkJoin }:
+let attributes = import ./attributes.nix { inherit fetchurl; };
+in
+rec {
+  gnuplot-scripts = stdenv.mkDerivation {
+    name = "crystfel-gnuplot-scripts";
+    version = attributes.crystfel-version;
+    src = attributes.crystfel-src;
+    buildInputs = [ gnuplot ];
+    postPatch = ''
+      sed -ie 's#gnuplot#${gnuplot}/bin/gnuplot#' scripts/fg-graph
+      sed -i -e 's#gnuplot#${gnuplot}/bin/gnuplot#' -e 's#grep#${gnugrep}/bin/grep#' -e 's#paste#${coreutils}/bin/paste#'  scripts/plot-radius-resolution
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      cp scripts/*gp $out/
+      cp scripts/fg-graph $out/bin
+      cp scripts/plot-radius-resolution $out/bin
+    '';
+  };
+  r-scripts = stdenv.mkDerivation {
+    name = "crystfel-r-scripts";
+    version = attributes.crystfel-version;
+    src = attributes.crystfel-src;
+    buildInputs = [ R ];
+    installPhase = ''
+      mkdir -p $out/bin
+      cp scripts/*.R $out/
+    '';
+  };
+  perl-scripts = stdenv.mkDerivation {
+    name = "crystfel-perl-scripts";
+    version = attributes.crystfel-version;
+    src = attributes.crystfel-src;
+    buildInputs = [ perl ];
+    installPhase = ''
+      mkdir -p $out/bin
+      cp scripts/alternate-stream $out/bin
+      cp scripts/cif2hkl $out/bin
+      cp scripts/eV-to-A $out/bin
+      cp scripts/split-indexed $out/bin
+      cp scripts/find-filename $out/bin
+      cp scripts/hkl2hkl $out/bin
+      cp scripts/indexed-filenames $out/bin
+    '';
+  };
+  stream_grep = perlPackages.buildPerlPackage {
+    pname = "crystfel-stream-grep";
+    version = attributes.crystfel-version;
+    src = attributes.crystfel-src;
+    propagatedBuildInputs = with perlPackages; [ GetoptLongDescriptive Switch ];
+    outputs = [ "out" "dev" ]; # no "devdoc"
+    preConfigure = ''
+      cp ${./stream_grep_Makefile_PL} Makefile.PL;
+    '';
+  };
+  python-scripts = python3Packages.buildPythonApplication rec {
+    name = "crystfel-python-scripts";
+    version = attributes.crystfel-version;
+    src = attributes.crystfel-src;
+
+    postUnpack =
+      let setupPy = builtins.toFile "setup.py" ''
+        from distutils.core import setup
+
+        setup(
+          name="crystfel-scripts",
+          version="1.0",
+          scripts=[
+            "scripts/detector-shift",
+            "scripts/ave-peak-resolution",
+            "scripts/ave-resolution",
+            "scripts/clean-stream.py",
+            "scripts/crystal-frame-number",
+            "scripts/display-hdf5",
+            "scripts/find-multiples",
+            "scripts/find-pairs",
+            "scripts/gaincal-to-saturation-map",
+            "scripts/eiger-badmap",
+            "scripts/euxfel-train-analysis",
+            "scripts/sum-hdf5-files",
+            "scripts/sum-peaks",
+            "scripts/transfer-geom",
+            "scripts/truncate-stream",
+            "scripts/turbo-index-lsf",
+            "scripts/Rsplit_surface.py",
+            "scripts/add-beam-params",
+            "scripts/plot-pr",
+            "scripts/plot-pr-contourmap",
+            "scripts/make-csplit",
+            "scripts/move-entire-detector",
+            "scripts/split-by-mask",
+            "scripts/stream2sol.py",
+            "scripts/peak-intensity",
+            "scripts/peakogram-stream",
+            "scripts/extract-geom"
+          ]
+        )
+      '';
+      in "cp ${setupPy} crystfel-${attributes.crystfel-version}/setup.py";
+
+    propagatedBuildInputs = [ python3Packages.numpy python3Packages.matplotlib python3Packages.h5py ];
+  };
+  combination-scripts = stdenv.mkDerivation {
+    name = "crystfel-combination-scripts";
+    version = attributes.crystfel-version;
+    src = attributes.crystfel-src;
+
+    postPatch = ''
+      sed -i\
+        -e 's#python clean-stream.py#${python-scripts}/bin/clean-stream.py#'\
+        -e 's#./alternate-stream#${perl-scripts}/bin/alternate-stream#'\
+        -e 's#process_hkl#${crystfel-headless}/bin/process_hkl#'\
+        -e 's#compare_hkl#${crystfel-headless}/bin/compare_hkl#'\
+        -e 's#python Rsplit_surface.py#${python-scripts}/bin/Rsplit_surface.py#'\
+        scripts/Rsplit_surface
+      sed -i\
+        -e 's#render_hkl#${crystfel-headless}/bin/render_hkl#'\
+        scripts/zone-axes
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp scripts/Rsplit_surface $out/bin/
+      cp scripts/zone-axes $out/bin/
+    '';
+
+  };
+  all-scripts = symlinkJoin {
+    name = "crystfel-scripts";
+
+    paths = [ python-scripts perl-scripts combination-scripts stream_grep r-scripts gnuplot-scripts ];
+  };
+}

--- a/pkgs/applications/science/physics/crystfel/stream_grep_Makefile_PL
+++ b/pkgs/applications/science/physics/crystfel/stream_grep_Makefile_PL
@@ -1,0 +1,6 @@
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME              => "CrystFEL::StreamGrep",
+    EXE_FILES      => ["scripts/stream_grep"],
+);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1920,9 +1920,11 @@ with pkgs;
 
   checkip = callPackage ../tools/networking/checkip { };
 
-  crystfel = callPackage ../applications/science/physics/crystfel { };
+  crystfel = callPackage ../applications/science/physics/crystfel/core.nix { };
 
-  crystfel-headless = callPackage ../applications/science/physics/crystfel { withGui = false; };
+  crystfel-headless = callPackage ../applications/science/physics/crystfel/core.nix { withGui = false; };
+
+  crystfel-scripts = (callPackage ../applications/science/physics/crystfel/scripts.nix { }).all-scripts;
 
   ec2-api-tools = callPackage ../tools/virtualization/ec2-api-tools { };
 


### PR DESCRIPTION
###### Description of changes

The CrystFEL program (already in nixpkgs) comes with some optional helper scripts for various crystallography tasks. These scripts use Python, R, gnuplot and Perl. I wrote a derivation packaging all scripts, and expose those as a separate package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).