### PR TITLE
Submodule refactor

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -113,10 +113,6 @@ rec {
                   args ? {}
                 , # This would be remove in the future, Prefer _module.check option instead.
                   check ? true
-                  # Internal variable to avoid `_key` collisions regardless
-                  # of `extendModules`. Used in `submoduleWith`.
-                  # Test case: lib/tests/modules, "168767"
-                , extensionOffset ? 0
                 }:
     let
       withWarnings = x:
@@ -345,17 +341,15 @@ rec {
         modules ? [],
         specialArgs ? {},
         prefix ? [],
-        extensionOffset ? length modules,
         }:
           evalModules (evalModulesArgs // {
             modules = regularModules ++ modules;
             specialArgs = evalModulesArgs.specialArgs or {} // specialArgs;
             prefix = extendArgs.prefix or evalModulesArgs.prefix or [];
-            inherit extensionOffset;
           });
 
       type = lib.types.submoduleWith {
-        inherit modules specialArgs extensionOffset;
+        inherit modules specialArgs;
       };
 
       result = withWarnings {

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -194,6 +194,10 @@ checkConfigOutput '^"submodule"$' options.submodule.type.description ./declare-s
 ## Paths should be allowed as values and work as expected
 checkConfigOutput '^true$' config.submodule.enable ./declare-submoduleWith-path.nix
 
+# Check the file location information is propagated into submodules
+checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix
+
+
 # Check that disabledModules works recursively and correctly
 checkConfigOutput '^true$' config.enable ./disable-recursive/main.nix
 checkConfigOutput '^true$' config.enable ./disable-recursive/{main.nix,disable-foo.nix}

--- a/lib/tests/modules/submoduleFiles.nix
+++ b/lib/tests/modules/submoduleFiles.nix
@@ -1,0 +1,21 @@
+{ lib, ... }: {
+  options.submodule = lib.mkOption {
+    default = {};
+    type = lib.types.submoduleWith {
+      modules = [ ({ options, ... }: {
+        options.value = lib.mkOption {};
+
+        options.internalFiles = lib.mkOption {
+          default = options.value.files;
+        };
+      })];
+    };
+  };
+
+  imports = [
+    {
+      _file = "the-file.nix";
+      submodule.value = 10;
+    }
+  ];
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -580,19 +580,10 @@ rec {
       let
         inherit (lib.modules) evalModules;
 
-        shorthandToModule = if shorthandOnlyDefinesConfig == false
-          then value: value
-          else value: { config = value; };
-
         allModules = defs: imap1 (n: { value, file }:
-          if isFunction value
-          then setFunctionArgs
-                (args: lib.modules.unifyModuleSyntax file "${toString file}-${toString (n + extensionOffset)}" (value args))
-                (functionArgs value)
-          else if isAttrs value
-          then
-            lib.modules.unifyModuleSyntax file "${toString file}-${toString (n + extensionOffset)}" (shorthandToModule value)
-          else value
+          if isAttrs value && shorthandOnlyDefinesConfig
+          then { _file = file; config = value; }
+          else { _file = file; imports = [ value ]; }
         ) defs;
 
         base = evalModules {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -580,7 +580,7 @@ rec {
       let
         inherit (lib.modules) evalModules;
 
-        allModules = defs: imap1 (n: { value, file }:
+        allModules = defs: map ({ value, file }:
           if isAttrs value && shorthandOnlyDefinesConfig
           then { _file = file; config = value; }
           else { _file = file; imports = [ value ]; }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -571,11 +571,6 @@ rec {
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false
       , description ? null
-
-        # Internal variable to avoid `_key` collisions regardless
-        # of `extendModules`. Wired through by `evalModules`.
-        # Test case: lib/tests/modules, "168767"
-      , extensionOffset ? 0
       }@attrs:
       let
         inherit (lib.modules) evalModules;
@@ -623,7 +618,6 @@ rec {
           (base.extendModules {
             modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
             prefix = loc;
-            extensionOffset = extensionOffset + length defs;
           }).config;
         emptyValue = { value = {}; };
         getSubOptions = prefix: (base.extendModules


### PR DESCRIPTION
###### Description of changes

Rebase of #108833 + suggestion.

TODO
 - [x] check ofborg performance report
 - [x] remove unused extension offset

Resolves #108833 
Closes #177157 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
