### PR TITLE
tiscamera: fix build, binaries and udev rules

### DIFF
--- a/pkgs/os-specific/linux/tiscamera/0001-Remove-wrong-volatile-usage-with-g_once_init_enter.patch
+++ b/pkgs/os-specific/linux/tiscamera/0001-Remove-wrong-volatile-usage-with-g_once_init_enter.patch
@@ -1,0 +1,27 @@
+From d0c20ee4f76aedfbade27f0764f53b2f761c52e8 Mon Sep 17 00:00:00 2001
+From: Raymond Gauthier <jraygauthier@gmail.com>
+Date: Wed, 15 Jun 2022 11:37:21 -0400
+Subject: [PATCH] Remove wrong volatile usage with g_once_init_enter
+
+This fixes the following compiler error we get with gcc 11:
+'__atomic_load' must not be a pointer to a 'volatile' type.
+---
+ src/gstreamer-1.0/gstmetatcamstatistics.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gstreamer-1.0/gstmetatcamstatistics.cpp b/src/gstreamer-1.0/gstmetatcamstatistics.cpp
+index 33637238..55575674 100644
+--- a/src/gstreamer-1.0/gstmetatcamstatistics.cpp
++++ b/src/gstreamer-1.0/gstmetatcamstatistics.cpp
+@@ -19,7 +19,7 @@
+ 
+ GType tcam_statistics_meta_api_get_type (void)
+ {
+-    static volatile GType type;
++    static GType type;
+     static const gchar* tags[] = {"id", "val", NULL};
+ 
+     if (g_once_init_enter(&type))
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/tiscamera/default.nix
+++ b/pkgs/os-specific/linux/tiscamera/default.nix
@@ -3,10 +3,12 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
+, runtimeShell
 , pcre
 , tinyxml
 , libusb1
 , libzip
+, zstd
 , glib
 , gobject-introspection
 , gst_all_1
@@ -18,7 +20,11 @@
 , libuuid
 , wrapGAppsHook
 , catch2
+, withGui ? true
+, libsForQt5
 }:
+
+with lib;
 
 stdenv.mkDerivation rec {
   pname = "tiscamera";
@@ -33,6 +39,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     cp ${catch2}/include/catch2/catch.hpp external/catch/catch.hpp
+
+    substituteInPlace ./data/udev/80-theimagingsource-cameras.rules.in \
+      --replace "/bin/sh" "${runtimeShell}/bin/sh" \
+      --replace "typically /usr/bin/" "" \
+      --replace "typically /usr/share/theimagingsource/tiscamera/uvc-extension/" ""
   '';
 
   nativeBuildInputs = [
@@ -40,6 +51,8 @@ stdenv.mkDerivation rec {
     pkg-config
     python3Packages.wrapPython
     wrapGAppsHook
+  ] ++ optionals withGui [
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -47,22 +60,35 @@ stdenv.mkDerivation rec {
     tinyxml
     libusb1
     libzip
+    zstd
     glib
     gobject-introspection
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
     libwebcam
     libunwind
     elfutils
     orc
     libuuid
     python3Packages.python
+  ] ++ optionals withGui [
+    python3Packages.pyqt5
+    libsForQt5.qtbase
+  ];
+
+  pythonPath = [
+    python3Packages.pygobject3
+  ] ++ optionals withGui [
     python3Packages.pyqt5
   ];
 
-  pythonPath = with python3Packages; [ pyqt5 pygobject3 ];
-
   propagatedBuildInputs = pythonPath;
+
+  patches = [
+    ./0001-Remove-wrong-volatile-usage-with-g_once_init_enter.patch
+  ];
 
   cmakeFlags = [
     "-DBUILD_ARAVIS=OFF" # For GigE support. Won't need it as our camera is usb.
@@ -71,6 +97,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_V4L2=ON"
     "-DBUILD_LIBUSB=ON"
     "-DBUILD_TESTS=ON"
+    "-DTCAM_BUILD_WITH_GUI=${if withGui then "ON" else "OFF"}"
     "-DTCAM_INSTALL_UDEV=${placeholder "out"}/lib/udev/rules.d"
     "-DTCAM_INSTALL_UVCDYNCTRL=${placeholder "out"}/share/uvcdynctrl/data/199e"
     "-DTCAM_INSTALL_GST_1_0=${placeholder "out"}/lib/gstreamer-1.0"
@@ -90,11 +117,24 @@ stdenv.mkDerivation rec {
   # gstreamer tests requires, besides gst-plugins-bad, plugins installed by this expression.
   checkPhase = "ctest --force-new-ctest-process -E gstreamer";
 
+  # wrapGAppsHook: make sure we add ourselves to the introspection
+  # and gstreamer paths.
+  GI_TYPELIB_PATH = "${placeholder "out"}/lib/girepository-1.0";
+  GST_PLUGIN_SYSTEM_PATH_1_0 = "${placeholder "out"}/lib/gstreamer-1.0";
+
+  QT_PLUGIN_PATH = optionalString withGui "${libsForQt5.qtbase.bin}/${libsForQt5.qtbase.qtPluginPrefix}";
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    gappsWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
   postFixup = ''
     wrapPythonPrograms "$out $pythonPath"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "The Linux sources and UVC firmwares for The Imaging Source cameras";
     homepage = "https://github.com/TheImagingSource/tiscamera";
     license = with licenses; [ asl20 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20889,7 +20889,7 @@ with pkgs;
 
   tinyxml-2 = callPackage ../development/libraries/tinyxml-2 { };
 
-  tiscamera = callPackage ../os-specific/linux/tiscamera { stdenv = gcc10StdenvCompat; };
+  tiscamera = callPackage ../os-specific/linux/tiscamera { };
 
   tivodecode = callPackage ../applications/video/tivodecode { };
 


### PR DESCRIPTION
 -  Patche the source code so that it builds with gcc11.
    This avoid runtime issues loading C++ gstreamer plugins
    requiring more recent libc++std.
 -  Patch udev rules
 -  Add our own out as GST plugin path and GI plugin path
 -  Fix 'tcam-capture' qt gui
 -  Add a `withGui` flag to opt out of gui build / support.
 -  Add missing `libzstd` which resulted in build time warnings.

###### Description of changes

Was no longer working. Currently have an opportunity to experiment with a actual tis camera again, so made sure this package still was functional.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
