### PR TITLE
qremotecontrol-server: 2.4.1 -> unstable-2014-11-05, use Qt5 

### DIFF
--- a/pkgs/servers/misc/qremotecontrol-server/0001-fix-qt5-build-include-QDataStream.patch
+++ b/pkgs/servers/misc/qremotecontrol-server/0001-fix-qt5-build-include-QDataStream.patch
@@ -1,0 +1,26 @@
+From 922d3dd36ac72b29ea21c4c728a922b43b19400e Mon Sep 17 00:00:00 2001
+From: Francesco Gazzetta <fgaz@fgaz.me>
+Date: Tue, 14 Jun 2022 17:55:43 +0200
+Subject: [PATCH] Another Qt5 fix
+
+---
+ qtsingleapplication/qtlocalpeer.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/qtsingleapplication/qtlocalpeer.cpp b/qtsingleapplication/qtlocalpeer.cpp
+index 4a84036..e6ccc72 100644
+--- a/qtsingleapplication/qtlocalpeer.cpp
++++ b/qtsingleapplication/qtlocalpeer.cpp
+@@ -41,6 +41,9 @@
+ 
+ #include "qtlocalpeer.h"
+ #include <QCoreApplication>
++#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
++#include <QDataStream>
++#endif
+ #include <QTime>
+ 
+ #if defined(Q_OS_WIN)
+-- 
+2.36.0
+

--- a/pkgs/servers/misc/qremotecontrol-server/default.nix
+++ b/pkgs/servers/misc/qremotecontrol-server/default.nix
@@ -1,24 +1,35 @@
 { lib
 , stdenv
 , fetchgit
-, qmake4Hook
-, qt4
+, qmake
+, wrapQtAppsHook
+, qtbase
 , xorg
 }:
 
 stdenv.mkDerivation rec {
   pname = "qremotecontrol-server";
-  version = "2.4.2";
+  version = "unstable-2014-11-05"; # basically 2.4.2 + qt5
 
-  # There is no 2.4.2 release tarball, but there is a git tag
   src = fetchgit {
     url = "https://git.code.sf.net/p/qrc/gitcode";
-    rev = version;
-    sha256 = "sha256-i3X575SbrWV8kWWHAhXvKl5aSKFZm0VyrJOiL7eYrCo=";
+    rev = "8f1c55eac10ac8af974c3c20157d90ef57f7308a";
+    sha256 = "sha256-AfFScec5/emG/f+yc5Zn37USIEWzGP/sBifE6Kx8d0E=";
   };
 
-  nativeBuildInputs = [ qmake4Hook ];
-  buildInputs = [ qt4 xorg.libXtst ];
+  patches = [
+    ./0001-fix-qt5-build-include-QDataStream.patch
+  ];
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    xorg.libXtst
+  ];
 
   postPatch = ''
     substituteInPlace QRemoteControl-Server.pro \
@@ -29,8 +40,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = with maintainers; [ fgaz ];
-    homepage = "https://qremote.org/";
-    downloadPage = "https://qremote.org/download.php#Download";
+    homepage = "https://sourceforge.net/projects/qrc/";
     description = "Remote control your desktop from your mobile";
     longDescription = ''
       With QRemoteControl installed on your desktop you can easily control
@@ -46,4 +56,3 @@ stdenv.mkDerivation rec {
     '';
   };
 }
-

--- a/pkgs/servers/misc/qremotecontrol-server/default.nix
+++ b/pkgs/servers/misc/qremotecontrol-server/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv
-, fetchurl
+{ lib
+, stdenv
+, fetchgit
 , qmake4Hook
 , qt4
 , xorg
@@ -7,11 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qremotecontrol-server";
-  version = "2.4.1";
+  version = "2.4.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/qrc/${version}/qremotecontrol-${version}.tar.bz2";
-    sha256 = "07hzc9959a56b49jgmcv8ry8b9sppklvqs9kns3qjj3v9d22nbrp";
+  # There is no 2.4.2 release tarball, but there is a git tag
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/qrc/gitcode";
+    rev = version;
+    sha256 = "sha256-i3X575SbrWV8kWWHAhXvKl5aSKFZm0VyrJOiL7eYrCo=";
   };
 
   nativeBuildInputs = [ qmake4Hook ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22962,7 +22962,7 @@ with pkgs;
 
   qpid-cpp = callPackage ../servers/amqp/qpid-cpp { };
 
-  qremotecontrol-server = callPackage ../servers/misc/qremotecontrol-server { };
+  qremotecontrol-server = libsForQt5.callPackage ../servers/misc/qremotecontrol-server { };
 
   rabbitmq-server = callPackage ../servers/amqp/rabbitmq-server {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon Cocoa;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Qt4 is going to be removed: https://github.com/NixOS/nixpkgs/pull/174634

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
