### PR TITLE
arcanist: 20220425 -> 20220517

### DIFF
--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -25,16 +25,19 @@ let makeArcWrapper = toolset: ''
 in
 stdenv.mkDerivation {
   pname = "arcanist";
-  version = "20220425";
+  version = "20220517";
 
   src = fetchFromGitHub {
     owner = "phacility";
     repo = "arcanist";
-    rev = "da206314cf59f71334b187283e18823bddc16ddd";
-    sha256 = "sha256-6VVUjFMwPQvk22Ni1YUSgks4ZM0j1JP+71VnYKD8onM=";
+    rev = "85c953ebe4a6fef332158fd757d97c5a58682d3a";
+    sha256 = "0x847fw74mzrbhzpgc4iqgvs6dsf4svwfa707dsbxi78fn2lxbl7";
   };
 
-  patches = [ ./dont-require-python3-in-path.patch ];
+  patches = [
+    ./dont-require-python3-in-path.patch
+    ./shellcomplete-strlen-null.patch
+  ];
 
   buildInputs = [ php python3 ];
 

--- a/pkgs/development/tools/misc/arcanist/shellcomplete-strlen-null.patch
+++ b/pkgs/development/tools/misc/arcanist/shellcomplete-strlen-null.patch
@@ -1,0 +1,13 @@
+diff --git a/src/toolset/workflow/ArcanistShellCompleteWorkflow.php b/src/toolset/workflow/ArcanistShellCompleteWorkflow.php
+index 9c2fcf9a..307231c8 100644
+--- a/src/toolset/workflow/ArcanistShellCompleteWorkflow.php
++++ b/src/toolset/workflow/ArcanistShellCompleteWorkflow.php
+@@ -92,7 +92,7 @@ EOTEXT
+     $argv = $this->getArgument('argv');
+ 
+     $is_generate = $this->getArgument('generate');
+-    $is_shell = (bool)strlen($this->getArgument('shell'));
++    $is_shell = phutil_nonempty_string($this->getArgument('shell'));
+     $is_current = $this->getArgument('current');
+ 
+     if ($argv) {


### PR DESCRIPTION
The patch will make its way upstream eventually (probably), but the phabricator maintainer is currently rejecting all contributions, so for the moment we'll have to just fix it locally.

###### Description of changes
- revision bump for some php 8.1 fixes
- one extra php 8.1 fix in a local patch

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).