### PR TITLE
iwgtk: 0.4 -> 0.6

### DIFF
--- a/pkgs/tools/networking/iwgtk/default.nix
+++ b/pkgs/tools/networking/iwgtk/default.nix
@@ -1,21 +1,21 @@
-{ fetchFromGitHub, gtk3, lib, pkg-config, stdenv }:
+{ fetchFromGitHub, gtk4, lib, pkg-config, stdenv }:
 
 stdenv.mkDerivation rec {
   pname = "iwgtk";
-  version = "0.4";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "j-lentz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "129h7vq9b1r9a5c79hk8d06bj8lgzrnhq55x54hqri9c471jjh0s";
+    sha256 = "pIN8ry9b2pt8wegeQt4sKPAdkYiw9/Am0sSuBY1+OVs=";
   };
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ gtk3 ];
+  buildInputs = [ gtk4 ];
 
-  makeFlags = [ "prefix=$(out)" ];
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=''" ];
 
   meta = with lib; {
     description = "Lightweight, graphical wifi management utility for Linux";


### PR DESCRIPTION
https://github.com/J-Lentz/iwgtk/releases/tag/v0.6

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
