### PR TITLE
hpccm: init at 22.5.0

### DIFF
--- a/pkgs/development/python-modules/archspec/default.nix
+++ b/pkgs/development/python-modules/archspec/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, click
+, six
+, pytestCheckHook
+, jsonschema
+}:
+
+buildPythonPackage rec {
+  pname = "archspec";
+  version = "0.1.4";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-ScigEpYNArveqi5tlqiA7LwsVs2RkjT+GChxhSy/ndw=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+  propagatedBuildInputs = [ click six ];
+  checkInputs = [ pytestCheckHook jsonschema ];
+
+  pythonImportsCheck = [ "archspec" ];
+
+  meta = with lib; {
+    description = "A library for detecting, labeling, and reasoning about microarchitectures";
+    homepage = "https://archspec.readthedocs.io/en/latest/";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/development/python-modules/hpccm/default.nix
+++ b/pkgs/development/python-modules/hpccm/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, six
+, archspec
+, pytestCheckHook
+, pytest-xdist
+}:
+
+buildPythonPackage rec {
+  pname = "hpccm";
+  version = "22.5.0";
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "hpc-container-maker";
+    rev = "v${version}";
+    sha256 = "sha256-zR5+X9BKaUvLPQ05FnfU817esgxVqP8n+wfdWy20BN4=";
+  };
+
+  propagatedBuildInputs = [ six archspec ];
+  checkInputs = [ pytestCheckHook pytest-xdist ];
+
+  disabledTests = [
+    # tests require git
+    "test_commit"
+    "test_tag"
+  ];
+
+  pythonImportsCheck = [ "hpccm" ];
+
+  meta = with lib; {
+    description = "HPC Container Maker";
+    homepage = "https://github.com/NVIDIA/hpc-container-maker";
+    license = licenses.asl20;
+    platforms = platforms.x86;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6996,6 +6996,8 @@ with pkgs;
 
   hotspot = libsForQt5.callPackage ../development/tools/analysis/hotspot { };
 
+  hpccm = with python3Packages; toPythonApplication hpccm;
+
   hping = callPackage ../tools/networking/hping { };
 
   hqplayer-desktop = libsForQt5.callPackage ../applications/audio/hqplayer-desktop { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4011,6 +4011,8 @@ in {
 
   hpack = callPackage ../development/python-modules/hpack { };
 
+  hpccm = callPackage ../development/python-modules/hpccm { };
+
   hsaudiotag3k = callPackage ../development/python-modules/hsaudiotag3k { };
 
   hsluv = callPackage ../development/python-modules/hsluv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -617,6 +617,8 @@ in {
 
   archinfo = callPackage ../development/python-modules/archinfo { };
 
+  archspec = callPackage ../development/python-modules/archspec { };
+
   area = callPackage ../development/python-modules/area { };
 
   arelle = callPackage ../development/python-modules/arelle {


### PR DESCRIPTION
###### Description of changes

HPC Container Maker is an application that helps create Nvidia compatible docker (and singularity) containers.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>hpccm</li>
    <li>python310Packages.archspec</li>
    <li>python39Packages.archspec</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
