### PR TITLE
discord-sh: init at unstable-2022-05-19

### DIFF
--- a/pkgs/tools/networking/discord-sh/default.nix
+++ b/pkgs/tools/networking/discord-sh/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, curl, jq, coreutils }:
+
+stdenvNoCC.mkDerivation {
+  pname = "discord-sh";
+  version = "unstable-2022-05-19";
+
+  src = fetchFromGitHub {
+    owner = "ChaoticWeg";
+    repo = "discord.sh";
+    rev = "6aaea548f88eb48b7adeef824fbddac1c4749447";
+    sha256 = "sha256-RoPhn/Ot4ID1nEbZEz1bd2iq8g7mU2e7kwNRvZOD/pc=";
+  };
+
+  # ignore Makefile by disabling buildPhase. Upstream Makefile tries to download
+  # binaries from the internet for linting
+  dontBuild = true;
+
+  # discord.sh looks for the .webhook file in the source code directory, which
+  # isn't mutable on Nix
+  postPatch = ''
+    substituteInPlace discord.sh \
+      --replace 'thisdir="$(cd "$(dirname "$(readlink -f "''${BASH_SOURCE[0]}")")" && pwd)"' 'thisdir="$(pwd)"'
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preCheck
+    $out/bin/discord.sh --help
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 discord.sh $out/bin/discord.sh
+    wrapProgram $out/bin/discord.sh \
+      --set PATH "${lib.makeBinPath [ curl jq coreutils ]}"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Write-only command-line Discord webhook integration written in 100% Bash script";
+    homepage = "https://github.com/ChaoticWeg/discord.sh";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17089,6 +17089,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };
 
+  discord-sh = callPackage ../tools/networking/discord-sh { };
+
   dlib = callPackage ../development/libraries/dlib { };
 
   doctest = callPackage ../development/libraries/doctest { };


### PR DESCRIPTION
###### Description of changes

Adds [discord.sh](https://github.com/ChaoticWeg/discord.sh) as a package.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
