### PR TITLE
pipewire-pulse: Do not try to execute pactl(1)

### DIFF
--- a/nixos/modules/services/desktops/pipewire/daemon/pipewire-pulse.conf.json
+++ b/nixos/modules/services/desktops/pipewire/daemon/pipewire-pulse.conf.json
@@ -33,10 +33,6 @@
     }
   ],
   "context.exec": [
-    {
-      "path": "pactl",
-      "args": "load-module module-always-sink"
-    }
   ],
   "stream.properties": {},
   "pulse.properties": {


### PR DESCRIPTION
The program is not in pipewire-pulse.service's PATH, so it always fails
to execute it.

I have no clue as to why this would be needed or wanted, but sound just
works with pipewire (and KDE/Plasma) on NixOS.

Noticed by looking at `journalctl -p 0..4`:
```
Jun 14 17:16:39 <hostname> pipewire-pulse[9091]: pw.conf: execvp error 'pactl': No such file or directory
```

@jtojnar @Kranzes @jansol
