### PR TITLE
python310Packages.cssutils: 2.4.0 -> 2.4.2

### DIFF
--- a/pkgs/development/python-modules/cssutils/default.nix
+++ b/pkgs/development/python-modules/cssutils/default.nix
@@ -6,9 +6,9 @@
 , fetchPypi
 , setuptools
 , setuptools-scm
-, toml
 , importlib-metadata
 , cssselect
+, jaraco-test
 , lxml
 , mock
 , pytestCheckHook
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "cssutils";
-  version = "2.4.0";
+  version = "2.4.2";
 
   disabled = pythonOlder "3.7";
 
@@ -25,13 +25,12 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-LZchCoOwo/4eRGn1/5pkILB4VyA1GIsbq3EDw6NtyJs=";
+    sha256 = "877818bfa9668cc535773f46e6b6a46de28436191211741b3f7b4aaa64d9afbb";
   };
 
   nativeBuildInputs = [
     setuptools
     setuptools-scm
-    toml
   ];
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
@@ -40,6 +39,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     cssselect
+    jaraco-test
     lxml
     mock
     pytestCheckHook

--- a/pkgs/development/python-modules/jaraco-test/default.nix
+++ b/pkgs/development/python-modules/jaraco-test/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, setuptools
+, setuptools-scm
+, toml
+, jaraco_functools
+, jaraco-context
+, more-itertools
+, jaraco_collections
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "jaraco-test";
+  version = "5.1.0";
+
+  disabled = pythonOlder "3.7";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    pname = "jaraco.test";
+    inherit version;
+    sha256 = "04a7503c0c78cd057bd6b5f16ad1e3379b911b619df6694480a564ebc214c0a8";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    toml
+    jaraco_functools
+    jaraco-context
+    more-itertools
+    jaraco_collections
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "jaraco.test" ];
+
+  meta = {
+    description = "Testing support by jaraco";
+    homepage = "https://github.com/jaraco/jaraco.test";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4427,6 +4427,8 @@ in {
 
   jaraco_stream = callPackage ../development/python-modules/jaraco_stream { };
 
+  jaraco-test = callPackage ../development/python-modules/jaraco-test { };
+
   jaraco_text = callPackage ../development/python-modules/jaraco_text { };
 
   jarowinkler = callPackage ../development/python-modules/jarowinkler { };


### PR DESCRIPTION
###### Description of changes
https://github.com/jaraco/cssutils/blob/v2.4.2/CHANGES.rst
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
