### PR TITLE
snipe-it: 6.0.2 -> 6.0.4

### DIFF
--- a/pkgs/servers/web-apps/snipe-it/default.nix
+++ b/pkgs/servers/web-apps/snipe-it/default.nix
@@ -18,13 +18,13 @@ let
 
 in package.override rec {
   pname = "snipe-it";
-  version = "6.0.2";
+  version = "6.0.4";
 
   src = fetchFromGitHub {
     owner = "snipe";
     repo = pname;
     rev = "v${version}";
-    sha256 = "174s2h3whim98d9h8l4qr3vpk199zfxgwyys3d3gblpx1m5mr07k";
+    sha256 = "06h8rnk8q85f0z0a1q0j010kzs4z2k5sxvi06avk7ndpkrisv4wz";
   };
 
   meta = with lib; {

--- a/pkgs/servers/web-apps/snipe-it/update.sh
+++ b/pkgs/servers/web-apps/snipe-it/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p nix curl jq nix-update
+#! nix-shell -I nixpkgs=../../../.. -i bash -p nix curl jq nix-update
 
 # check if composer2nix is installed
 if ! command -v composer2nix &> /dev/null; then
@@ -7,7 +7,7 @@ if ! command -v composer2nix &> /dev/null; then
   exit 1
 fi
 
-CURRENT_VERSION=$(nix eval --raw '(with import ../../../.. {}; snipe-it.version)')
+CURRENT_VERSION=$(nix eval -f ../../../.. --raw snipe-it.version)
 TARGET_VERSION_REMOTE=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} https://api.github.com/repos/snipe/snipe-it/releases/latest | jq -r ".tag_name")
 TARGET_VERSION=${TARGET_VERSION_REMOTE:1}
 SNIPE_IT=https://github.com/snipe/snipe-it/raw/$TARGET_VERSION_REMOTE


### PR DESCRIPTION
###### Description of changes
https://github.com/snipe/snipe-it/releases/tag/v6.0.4
https://github.com/snipe/snipe-it/releases/tag/v6.0.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
