### PR TITLE
sx: migrate to resholve.mkDerivation

### DIFF
--- a/pkgs/tools/X11/sx/default.nix
+++ b/pkgs/tools/X11/sx/default.nix
@@ -1,6 +1,13 @@
-{ coreutils, fetchFromGitHub, lib, makeWrapper, stdenv, util-linux, xauth, xorgserver }:
+{ lib
+, bash
+, coreutils
+, fetchFromGitHub
+, resholve
+, xauth
+, xorgserver
+}:
 
-stdenv.mkDerivation rec {
+resholve.mkDerivation rec {
   pname = "sx";
   version = "2.1.7";
 
@@ -11,20 +18,28 @@ stdenv.mkDerivation rec {
     sha256 = "0xv15m30nhcknasqiybj5wwf7l91q4a4jf6xind8x5x00c6br6nl";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
   makeFlags = [ "PREFIX=$(out)" ];
 
-  postInstall = ''
-    wrapProgram $out/bin/sx \
-      --prefix PATH : ${lib.makeBinPath [ coreutils util-linux xorgserver xauth ]}
-  '';
+  solutions = {
+    sx = {
+      scripts = [ "bin/sx" ];
+      interpreter = "${bash}/bin/sh";
+      inputs = [
+        coreutils
+        xauth
+        xorgserver
+      ];
+      execer = [
+        "cannot:${xorgserver}/bin/Xorg"
+      ];
+    };
+  };
 
   meta = with lib; {
     description = "Simple alternative to both xinit and startx for starting a Xorg server";
     homepage = "https://github.com/earnestly/sx";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = with maintainers; [ figsoda thiagokokada ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Migrate `sx` to use `resholve.mkDerivation`. This avoids the usage of `wrapProgram` and also ensure that all dependencies are correctly declared in the script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
