### PR TITLE
cudatext: 1.165.2 → 1.166.2

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.165.2";
+  version = "1.166.2";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-eNpU7PpzyL2KHPL6cPmxZw/49VALjCWUdavV6Ex1IQI=";
+    sha256 = "sha256-kJ1UpVff6FS/gk3Ecz+GEDFYeu2CmXG5ehFEawk+/yg=";
   };
 
   postPatch = ''
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
 
   buildPhase = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: dep: ''
-    cp -r --no-preserve=mode ${dep} ${name}
+    ln -s ${dep} ${name}
   '') deps) + ''
     lazbuild --lazarusdir=${lazarus}/share/lazarus --pcp=./lazarus --ws=${widgetset} \
       bgrabitmap/bgrabitmap/bgrabitmappack.lpk \
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -Dm755 app/cudatext $out/bin/cudatext
+    install -Dm755 app/cudatext -t $out/bin
 
     install -dm755 $out/share/cudatext
     cp -r app/{data,py,settings_default} $out/share/cudatext

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -1,23 +1,23 @@
 {
   "EncConv": {
     "owner": "Alexey-T",
-    "rev": "2022.04.18",
-    "sha256": "sha256-UV07a9qNzd0JQWCq/eD0K9fA7kxAKj5OP7dOpECo8xw="
+    "rev": "2022.06.19",
+    "sha256": "sha256-M00rHH3dG6Vx6MEALxRNlnLLfX/rRI+rdTS7riOhgeg="
   },
   "ATBinHex-Lazarus": {
     "owner": "Alexey-T",
-    "rev": "2022.04.16",
-    "sha256": "sha256-7ye73KSpoPvvxBNwBC3uloufFE+448RDyNScumk1ViE="
+    "rev": "2022.06.14",
+    "sha256": "sha256-3QhARraYURW5uCf2f4MZfUbxdbsg9h7BlXUxKcz4jwA="
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2022.05.06",
-    "sha256": "sha256-mYZ3mgtUpQ8sry5WmdluHca/CR7RqR9GRrxIoeZFLes="
+    "rev": "2022.06.19",
+    "sha256": "sha256-4pkwgg2U6NAGv+fVFKIli2Qe3fyDMiliFLJSgsh1hsQ="
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2022.06.01",
-    "sha256": "sha256-dilFwvtD8OLLq7QOPWSG3FeBM12Yy4ztM+CedJQAAaU="
+    "rev": "2022.06.14",
+    "sha256": "sha256-rS4hO4jm9k6raspPzX7z7HF8cdTqcwcD2DDRvQFQjLk="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
@@ -26,13 +26,13 @@
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2022.05.06",
-    "sha256": "sha256-ppm8Wuxhi5N3Er0f0h9d+v2spwEMr7ksf9tz4vI42+M="
+    "rev": "2022.06.14",
+    "sha256": "sha256-P21Tb/hhQvXvT3LhM3lw4B0joQ2cFxsOXjljKaut6OM="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
-    "rev": "2022.05.23",
-    "sha256": "sha256-/PqEx2Z1TVjnxfeWR9qBZUNzdqDBttuLmSBzIEPe1MY="
+    "rev": "2022.06.14",
+    "sha256": "sha256-Kcl3y5SN9DKUDL3ozjMrlsObsMVtGuU5iWrpLoMbPz4="
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",
@@ -51,7 +51,7 @@
   },
   "bgrabitmap": {
     "owner": "bgrabitmap",
-    "rev": "v11.4",
-    "sha256": "sha256-jZL8lzjua033E76IL0HIk/fihC73ifCb4LqMni7vvb0="
+    "rev": "v11.5",
+    "sha256": "sha256-Pevh+yhtN3oSSvbQfnO7SM6UHBVe0sSpbK8ss98XqcU="
   }
 }

--- a/pkgs/applications/editors/cudatext/update.sh
+++ b/pkgs/applications/editors/cudatext/update.sh
@@ -4,7 +4,17 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+nixpkgs="$(git rev-parse --show-toplevel)"
+
+oldVersion=$(nix-instantiate --eval -E "(import \"$nixpkgs\" { config = {}; overlays = []; }).cudatext.version" | tr -d '"')
 version=$(curl -s https://api.github.com/repos/Alexey-T/CudaText/releases/latest | jq -r '.tag_name')
+
+if [[ $version == $oldVersion ]]; then
+  echo "Already at latest version $version"
+  exit 0
+fi
+echo "New version: $version"
+
 url="https://github.com/Alexey-T/CudaText/archive/refs/tags/${version}.tar.gz"
 hash=$(nix-prefetch-url --quiet --unpack --type sha256 $url)
 sriHash=$(nix hash to-sri --type sha256 $hash)


### PR DESCRIPTION
###### Description of changes
* [Changelog](https://cudatext.github.io/history.txt)
* Fix update script (avoid deps only updates, ##176172)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
