### PR TITLE
irssi: 1.2.3 -> 1.4.1

### DIFF
--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -1,40 +1,57 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config, ncurses, glib, openssl, perl, libintl, libgcrypt, libotr, git }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, glib
+, libgcrypt
+, libintl
+, libotr
+, libtool
+, meson
+, ncurses
+, ninja
+, openssl
+, perl
+, pkg-config
+}:
 
 stdenv.mkDerivation rec {
   pname = "irssi";
-  version = "1.2.3";
-
+  version = "1.4.1";
 
   src = fetchFromGitHub {
-    "owner" = "irssi";
-    "repo" = "irssi";
-    "rev" = "91dc3e4dfa1a9558c5a7fe0ea982cb9df0e2de65";
-    "sha256" = "efnE4vuDd7TnOBxMPduiV0/nez1jVhTjbJ0vzN4ZMcg=";
-    "leaveDotGit" = true;
+    owner = "irssi";
+    repo = "irssi";
+    rev = version;
+    hash = "sha256-HLcIhAZoJfCHoSNQCpoytBR0zmiZd919FcKWCl35G0A=";
   };
 
-  nativeBuildInputs = [ pkg-config autoconf automake libtool git ];
-  buildInputs = [ ncurses glib openssl perl libintl libgcrypt libotr ];
-
-  enableParallelBuilding = true;
-
-  preConfigure = ''
-    NOCONFIGURE=1 ./autogen.sh
-  '';
-
-  configureFlags = [
-    "--with-proxy"
-    "--with-bot"
-    "--with-perl=yes"
-    "--with-otr=yes"
-    "--enable-true-color"
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
   ];
 
-  meta = {
-    homepage    = "https://irssi.org";
-    description = "A terminal based IRC client";
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ lovek323 ];
-    license     = lib.licenses.gpl2Plus;
+  buildInputs = [
+    glib
+    libgcrypt
+    libintl
+    libotr
+    ncurses
+    openssl
+    perl
+  ];
+
+  configureFlags = [
+    "-Dwith-proxy=yes"
+    "-Dwith-bot=yes"
+    "-Dwith-perl=yes"
+  ];
+
+  meta = with lib; {
+    description = "Terminal based IRC client";
+    homepage = "https://irssi.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fab lovek323 ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes
https://irssi.org/NEWS/#news-v1-4-1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
