### PR TITLE
linuxPackages.rtw88: 2022-05-08 to 2022-06-03

### DIFF
--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw88";
-  version = "unstable-2022-05-08";
+  version = "unstable-2022-06-03";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw88";
-    rev = "dbcc43c31a4576f90e1e468d3a85c2dfdb25ec42";
-    hash = "sha256-IDHolspYtwjV5r5WArWl1g4zgKLvPd4ydKKH/aE5NSg=";
+    rev = "03da251c76ea1005b42625825c39181e12d75693";
+    sha256 = "0l5ysp4x5wzrn48sfjv3rciqhq5ldcmk86b9x6j9775zjj7yw8hw";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
###### Description of changes

```
[Merge pull request](https://github.com/lwfinger/rtw88/commit/03da251c76ea1005b42625825c39181e12d75693) https://github.com/lwfinger/rtw88/pull/87 [from Lollixzc/patch-1](https://github.com/lwfinger/rtw88/commit/03da251c76ea1005b42625825c39181e12d75693) 

@[lwfinger](https://github.com/lwfinger/rtw88/commits?author=lwfinger)
lwfinger committed 12 days ago
  
[Updating supported kernel version](https://github.com/lwfinger/rtw88/commit/fb982976cce1607e104e38be808eaa6351afadf8) 

@[Lollixzc](https://github.com/lwfinger/rtw88/commits?author=Lollixzc)
Lollixzc committed 12 days ago
  
Commits on May 30, 2022
[rtw88: Fix builds for kernel 5.19](https://github.com/lwfinger/rtw88/commit/2f8beba2420df8cbf06f53f1b98d35e59b0a9277) 

@[lwfinger](https://github.com/lwfinger/rtw88/commits?author=lwfinger)
lwfinger committed 16 days ago
 
Commits on May 24, 2022
[rtw88: Fix Sparse warning for rtw8821c_hw_spec](https://github.com/lwfinger/rtw88/commit/dbcc43c31a4576f90e1e468d3a85c2dfdb25ec42) 

@[lwfinger](https://github.com/lwfinger/rtw88/commits?author=lwfinger)
lwfinger committed 22 days ago
 
[rtw88: Fix Sparse warning for rtw8723d_hw_spec](https://github.com/lwfinger/rtw88/commit/9a0526b18b073b1f3a47db85ae3e36839c4b1c42) 

@[lwfinger](https://github.com/lwfinger/rtw88/commits?author=lwfinger)
lwfinger committed 22 days ago
 
[rtw88: Fix Sparse warning for rtw8822c_hw_spec](https://github.com/lwfinger/rtw88/commit/84c7e906545affa3a81b42d1b0667c2515af1330) 

@[lwfinger](https://github.com/lwfinger/rtw88/commits?author=lwfinger)
lwfinger committed 22 days ago
 
[rtw88: Fix sparse warning for rtw8822b_hw_spec](https://github.com/lwfinger/rtw88/commit/57a45d64f862c9213f21eba2791854ae17eb737d) 

@[lwfinger](https://github.com/lwfinger/rtw88/commits?author=lwfinger)
lwfinger committed 22 days ago
```


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_9.rtlwifi_new</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_14.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_4_14_hardened.rtlwifi_new</li>
  </ul>
</details>
<details>
  <summary>20 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_4_19_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_10.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_10_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_15.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_hardened.rtlwifi_new (linuxKernel.packages.linux_5_15_hardened.rtlwifi_new)</li>
    <li>linuxKernel.packages.linux_5_17.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_17_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_18.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_18_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_4.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_4_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_latest_libre.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_libre.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_lqx.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_testing_bcachefs.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_xanmod.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_xanmod_latest.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_zen.rtlwifi_new</li>
    <li>rtw88-firmware</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
