### PR TITLE
sil / sil-q: clean up and add tests

### DIFF
--- a/pkgs/games/sil-q/default.nix
+++ b/pkgs/games/sil-q/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, writeScript, makeWrapper, ncurses, libX11 }:
+{ pkgs, lib, stdenv, fetchFromGitHub, writeScript, makeWrapper, ncurses, libX11 }:
 
 let
   setup = writeScript "setup" ''
@@ -46,6 +46,13 @@ in stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    saveDirCreation = pkgs.runCommand "save-dir-creation" {} ''
+      HOME=$(pwd) ${lib.getExe pkgs.sil-q} --help
+      test -d .sil && touch $out
+    '';
+  };
 
   meta = {
     description = "A roguelike game set in the First Age of Middle-earth";

--- a/pkgs/games/sil/default.nix
+++ b/pkgs/games/sil/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchzip, ncurses, libX11, libXaw, libXt, libXext, libXmu, makeWrapper, writeScript, ... }:
+{ pkgs, lib, stdenv, fetchzip, ncurses, libX11, libXaw, libXt, libXext, libXmu
+, makeWrapper, writeScript }:
+
 let
   setup = writeScript "setup" ''
     mkdir -p "$ANGBAND_PATH"
@@ -15,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchzip {
     url = "http://www.amirrorclear.net/flowers/game/sil/Sil-130-src.zip";
     sha256 = "1amp2mr3fxascra0k76sdsvikjh8g76nqh46kka9379zd35lfq8w";
-    stripRoot=false;
+    stripRoot = false;
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -25,7 +27,7 @@ stdenv.mkDerivation rec {
 
   makefile = "Makefile.std";
 
-  prePatch = ''
+  postPatch = ''
     # Allow usage of ANGBAND_PATH
     substituteInPlace config.h --replace "#define FIXED_PATHS" ""
   '';
@@ -41,30 +43,42 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-fcommon";
 
   installPhase = ''
-    # the makefile doesn't have a sensible install target, so we hav to do it ourselves
+    runHook preInstall
+
+    # the makefile doesn't have a sensible install target, so we have to do it ourselves
     mkdir -p $out/bin
     cp sil $out/bin/sil
-    # Wrap the program to set a user-local ANGBAND_PATH, and run the setup script to copy files into place
+
+    # Wrap the program to set a user-local ANGBAND_PATH, and run the setup script to copy files into place.
     # We could just use the options for a user-local save and scores dir, but it tried to write to the
     # lib directory anyway, so we might as well give everyone a copy
     wrapProgram $out/bin/sil \
-      --run "set -u" \
       --run "export ANGBAND_PATH=\$HOME/.sil" \
       --run "${setup} ${src}/Sil/lib"
+
+    runHook postInstall
   '';
 
+  passthru.tests = {
+    saveDirCreation = pkgs.runCommand "save-dir-creation" {} ''
+      HOME=$(pwd) ${lib.getExe pkgs.sil} --help
+      test -d .sil && touch $out
+    '';
+  };
+
   meta = {
-    description = "A rouge-like game set in the first age of Middle-earth";
+    description = "A rogue-like game set in the First Age of Middle-earth";
     longDescription = ''
-      A game of adventure set in the first age of Middle-earth, when the world still
-      rang with elven song and gleamed with dwarven mail.
+      A game of adventure set in the First Age of Middle-earth, when the world still
+      rang with Elven song and gleamed with Dwarven mail.
 
       Walk the dark halls of Angband.  Slay creatures black and fell.  Wrest a shining
       Silmaril from Morgoth’s iron crown.
     '';
     homepage = "http://www.amirrorclear.net/flowers/game/sil/index.html";
     license = lib.licenses.gpl2;
-    maintainers = [ lib.maintainers.michaelpj ];
+    maintainers = with lib.maintainers; [ michaelpj kenran ];
     platforms = lib.platforms.linux;
+    mainProgram = "sil";
   };
 }


### PR DESCRIPTION
###### Description of changes

Sil:
- Add `meta.mainProgram` to be able to use `nix run`
- Fix some typos and misformatting
- Test creation of the save directory in `passthru.tests`
- Run `preInstall` and `postInstall` hooks
- Change `prePatch` to `postPatch` (as in a suggestion I received when adding `sil-q`)
- Include myself as maintainer

Sil-Q:
- Test creation of the save directory in `passthru.tests` (same test as above, as they use the same mechanism to create the save directory)

I wasn't sure whether to squash, so I kept the commits separate per package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
