### PR TITLE
vcv-rack: 1.1.6 -> 2.0.6

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -1,50 +1,107 @@
-{ lib, stdenv, makeWrapper, fetchzip, fetchFromGitHub, pkg-config
-, alsa-lib, curl, glew, glfw, gtk2-x11, jansson, libjack2, libXext, libXi
-, libzip, rtaudio, rtmidi, speex, libsamplerate }:
+{ alsa-lib
+, copyDesktopItems
+, curl
+, fetchFromBitbucket
+, fetchFromGitHub
+, fetchzip
+, ghc_filesystem
+, glew
+, glfw
+, gnome
+, gtk3-x11
+, imagemagick
+, jansson
+, jq
+, lib
+, libarchive
+, libicns
+, libjack2
+, libpulseaudio
+, libsamplerate
+, libXext
+, libXi
+, makeDesktopItem
+, makeWrapper
+, pkg-config
+, rtaudio
+, rtmidi
+, speex
+, stdenv
+, wrapGAppsHook
+, zstd
+}:
 
 let
   # The package repo vendors some of the package dependencies as submodules.
-  # Others are downloaded with `make deps`. Due to previous issues with the
-  # `glfw` submodule (see above) and because we can not access the network when
-  # building in a sandbox, we fetch the dependency source manually.
-  pfft-source = fetchzip {
-    url = "https://vcvrack.com/downloads/dep/pffft.zip";
-    sha256 = "084csgqa6f1a270bhybjayrh3mpyi2jimc87qkdgsqcp8ycsx1l1";
+  # Unfortunately, they are not pinned, so we have no guarantee that they
+  # will be stable, and therefore, we can't use them directly. Instead
+  # we'll have to fetch them separately ourselves.
+  pffft-source = fetchFromBitbucket {
+    owner = "jpommier";
+    repo = "pffft";
+    rev = "988259a41d1522047a9420e6265a6ba8289c1654";
+    sha256 = "Oq5N02UNXsbhcPUfjMtD0cgqAZsGx9ke9A+ArrenzGE=";
+  };
+  fuzzysearchdatabase-source = fetchFromBitbucket {
+    owner = "j_norberg";
+    repo = "fuzzysearchdatabase";
+    rev = "fe62479811e503ef3c091f5a859d27bfcf0a44da";
+    sha256 = "zgeUzuuInHPeveBIjlivRGIz+NSb7cW/9hMndxm6qOA=";
   };
   nanovg-source = fetchFromGitHub {
-    owner = "memononen";
+    owner = "VCVRack";
     repo = "nanovg";
-    rev = "1f9c8864fc556a1be4d4bf1d6bfe20cde25734b4";
-    sha256 = "08r15zrr6p1kxigxzxrg5rgya7wwbdx7d078r362qbkmws83wk27";
+    rev = "0bebdb314aff9cfa28fde4744bcb037a2b3fd756";
+    sha256 = "HmQhCE/zIKc3f+Zld229s5i5MWzRrBMF9gYrn8JVQzg=";
   };
   nanosvg-source = fetchFromGitHub {
     owner = "memononen";
     repo = "nanosvg";
-    rev = "25241c5a8f8451d41ab1b02ab2d865b01600d949";
-    sha256 = "114qgfmazsdl53rm4pgqif3gv8msdmfwi91lyc2jfadgzfd83xkg";
+    rev = "ccdb1995134d340a93fb20e3a3d323ccb3838dd0";
+    sha256 = "ymziU0NgGqxPOKHwGm0QyEdK/8jL/QYk5UdIQ3Tn8jw=";
   };
   osdialog-source = fetchFromGitHub {
     owner = "AndrewBelt";
     repo = "osdialog";
-    rev = "e5db5de6444f4b2c4e1390c67b3efd718080c3da";
-    sha256 = "0iqxn1md053nl19hbjk8rqsdcmjwa5l5z0ci4fara77q43rc323i";
+    rev = "21b9dcc2a1bbdacb9b46da477ffd82a4ce9204b9";
+    sha256 = "+4VCBuQvfiuEUdjFu3IB2FwbHFrDJXTb4vcVg6ZFwSM=";
   };
   oui-blendish-source = fetchFromGitHub {
     owner = "AndrewBelt";
     repo = "oui-blendish";
-    rev = "79ec59e6bc7201017fc13a20c6e33380adca1660";
-    sha256 = "17kd0lh2x3x12bxkyhq6z8sg6vxln8m9qirf0basvcsmylr6rb64";
+    rev = "2fc6405883f8451944ed080547d073c8f9f31898";
+    sha256 = "/QZFZuI5kSsEvSfMJlcqB1HiZ9Vcf3vqLqWIMEgxQK8=";
+  };
+  fundamental-source = fetchFromGitHub {
+    owner = "VCVRack";
+    repo = "Fundamental";
+    rev = "533397cdcad5c6401ebd3937d6c1663de2473627"; # tip of branch v2
+    sha256 = "QnwOgrYxiCa/7t/u6F63Ks8C9E8k6T+hia4JZFhp1LI=";
   };
 in
-with lib; stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "VCV-Rack";
-  version = "1.1.6";
+  version = "2.0.6";
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = pname;
+      desktopName = "VCV Rack";
+      genericName = "Eurorack simulator";
+      comment = "Create music by patching together virtual synthesizer modules";
+      exec = "Rack";
+      icon = "Rack";
+      categories = [ "AudioVideo" "AudioVideoEditing" "Audio" ];
+      keywords = [ "music" ];
+    })
+  ];
 
   src = fetchFromGitHub {
     owner = "VCVRack";
     repo = "Rack";
     rev = "v${version}";
-    sha256 = "0ji64prr74qzxf5bx1sw022kbslx9nzll16lmk5in78hbl137b3i";
+    sha256 = "vvGx8tnE7gMiboVUTywIzBB1q/IfiJ8TPnSHvmfHUQg=";
   };
 
   patches = [
@@ -56,46 +113,101 @@ with lib; stdenv.mkDerivation rec {
     # above), we do it here manually
     mkdir -p dep/include
 
-    cp -r ${pfft-source} dep/jpommier-pffft-source
+    cp -r ${pffft-source}/* dep/pffft
+    cp -r ${fuzzysearchdatabase-source}/* dep/fuzzysearchdatabase
     cp -r ${nanovg-source}/* dep/nanovg
     cp -r ${nanosvg-source}/* dep/nanosvg
     cp -r ${osdialog-source}/* dep/osdialog
     cp -r ${oui-blendish-source}/* dep/oui-blendish
 
-    cp dep/jpommier-pffft-source/*.h dep/include
+    cp dep/pffft/*.h dep/include
+    cp dep/fuzzysearchdatabase/src/*.hpp dep/include
     cp dep/nanosvg/**/*.h dep/include
     cp dep/nanovg/src/*.h dep/include
     cp dep/osdialog/*.h dep/include
     cp dep/oui-blendish/*.h dep/include
 
-    substituteInPlace include/audio.hpp --replace "<RtAudio.h>" "<rtaudio/RtAudio.h>"
-    substituteInPlace compile.mk --replace "-march=nocona" ""
+    # Build and dist the Fundamental plugins
+    cp -r ${fundamental-source} plugins/Fundamental/
+    chmod -R +rw plugins/Fundamental # will be used as build dir
+    substituteInPlace plugin.mk --replace ":= all" ":= dist"
+
+    # Fix reference to zenity
+    substituteInPlace dep/osdialog/osdialog_zenity.c \
+      --replace 'zenityBin[] = "zenity"' 'zenityBin[] = "${gnome.zenity}/bin/zenity"'
   '';
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ makeWrapper pkg-config ];
-  buildInputs = [ alsa-lib curl glew glfw gtk2-x11 jansson libjack2 libsamplerate libzip rtaudio rtmidi speex ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    imagemagick
+    jq
+    libicns
+    makeWrapper
+    pkg-config
+    wrapGAppsHook
+  ];
+  buildInputs = [
+    alsa-lib
+    curl
+    ghc_filesystem
+    glew
+    glfw
+    gnome.zenity
+    gtk3-x11
+    jansson
+    libarchive
+    libjack2
+    libpulseaudio
+    libsamplerate
+    rtaudio
+    rtmidi
+    speex
+    zstd
+  ];
 
-  buildFlags = [ "Rack" ];
+  makeFlags = [ "all" "plugins" ];
 
   installPhase = ''
+    runHook preInstall
+
     install -D -m755 -t $out/bin Rack
+    install -D -m755 -t $out/lib libRack.so
 
     mkdir -p $out/share/vcv-rack
-    cp -r res Core.json template.vcv LICENSE* cacert.pem $out/share/vcv-rack
+    cp -r res cacert.pem Core.json template.vcv LICENSE-GPLv3.txt $out/share/vcv-rack
+    cp -r plugins/Fundamental/dist/Fundamental-*.vcvplugin $out/share/vcv-rack/Fundamental.vcvplugin
 
-    # Override the default global resource file directory
-    wrapProgram $out/bin/Rack --add-flags "-s $out/share/vcv-rack"
+    # Extract pngs from the Apple icon image and create
+    # the missing ones from the 1024x1024 image.
+    icns2png --extract icon.icns
+    for size in 16 24 32 48 64 128 256 512 1024; do
+      mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
+      if [ ! -e icon_"$size"x"$size"x32.png ] ; then
+        convert -resize "$size"x"$size" icon_1024x1024x32.png icon_"$size"x"$size"x32.png
+      fi
+      install -Dm644 icon_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/Rack.png
+    done;
+
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+  postFixup = ''
+    # Wrap gApp and override the default global resource file directory
+    wrapProgram $out/bin/Rack \
+        "''${gappsWrapperArgs[@]}" \
+        --add-flags "-s $out/share/vcv-rack"
   '';
 
   meta = with lib; {
     description = "Open-source virtual modular synthesizer";
     homepage = "https://vcvrack.com/";
-    # The source is BSD-3 licensed, some of the art is CC-BY-NC 4.0 or under a
+    # The source is GPL3+ licensed, some of the art is CC-BY-NC 4.0 or under a
     # no-derivatives clause
-    license = with licenses; [ bsd3 cc-by-nc-40 unfreeRedistributable ];
-    maintainers = with maintainers; [ moredread nathyong ];
+    license = with licenses; [ gpl3Plus cc-by-nc-40 unfreeRedistributable ];
+    maintainers = with maintainers; [ nathyong jpotier ddelabru ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/vcv-rack/rack-minimize-vendoring.patch
+++ b/pkgs/applications/audio/vcv-rack/rack-minimize-vendoring.patch
@@ -1,13 +1,12 @@
 diff -ru a/Makefile b/Makefile
---- a/Makefile	1970-01-01 01:00:01.000000000 +0100
-+++ b/Makefile	1970-01-01 01:00:01.000000000 +0100
-@@ -21,8 +21,8 @@
- build/dep/osdialog/osdialog_gtk2.c.o: FLAGS += $(shell pkg-config --cflags gtk+-2.0)
+--- a/Makefile 1970-01-01 01:00:01.000000000 +0100
++++ b/Makefile 1970-01-01 01:00:01.000000000 +0100
+@@ -36,7 +36,7 @@ build/dep/osdialog/osdialog_gtk3.c.o: FLAGS += $(shell pkg-config --cflags gtk+-
  
- 	LDFLAGS += -rdynamic \
--		dep/lib/libGLEW.a dep/lib/libglfw3.a dep/lib/libjansson.a dep/lib/libcurl.a dep/lib/libssl.a dep/lib/libcrypto.a dep/lib/libzip.a dep/lib/libz.a dep/lib/libspeexdsp.a dep/lib/libsamplerate.a dep/lib/librtmidi.a dep/lib/librtaudio.a \
-+		-lGLEW -lglfw -ljansson -lcurl -lssl -lcrypto -lzip -lz -lspeexdsp -lsamplerate -lrtmidi -lrtaudio \
-		-lpthread -lGL -ldl -lX11 -lasound -ljack \
- 		$(shell pkg-config --libs gtk+-2.0)
- 	TARGET := Rack
- endif
+ 	LDFLAGS += -Wl,--whole-archive
+ 	LDFLAGS += -static-libstdc++ -static-libgcc
+-	LDFLAGS += dep/lib/libGLEW.a dep/lib/libglfw3.a dep/lib/libjansson.a dep/lib/libcurl.a dep/lib/libssl.a dep/lib/libcrypto.a dep/lib/libarchive.a dep/lib/libzstd.a dep/lib/libspeexdsp.a dep/lib/libsamplerate.a dep/lib/librtmidi.a dep/lib/librtaudio.a
++	LDFLAGS += -lGLEW -lglfw -ljansson -lcurl -lssl -lcrypto -larchive -lz -lspeexdsp -lsamplerate -lrtmidi -lrtaudio
+ 	LDFLAGS += -Wl,--no-whole-archive
+ 	LDFLAGS += -lpthread -lGL -ldl -lX11 -lasound -ljack -lpulse -lpulse-simple
+ 	LDFLAGS += $(shell pkg-config --libs gtk+-3.0)


### PR DESCRIPTION
###### Description of changes

Update VCV Rack from 1.1.6 to 2.0.6 and add a desktop item. The major version change comes with a significantly different set of dependencies.

This combines two pull requests that had been closed because their developers didn't have the time to work on them: #111042 and #148479. The latter pull request in particular was open for a long time and underwent a lot of changes. VCV Rack 2 has now been the dominant major version of the application for some months and it is growing harder for people to even use VCV Rack 1 because the plugins for it aren't receiving updates, so at this point I would recommend to switch over to this derivation entirely instead of keeping a separate derivation for VCV Rack 1. Personally, I've been using Rack 2 compiled from source on my machine for some time now.

The license of VCV Rack has changed from BSD to GPL3+, and one of the maintainers asked to be removed in #148479.

I dropped some code that forced nix-build to use gcc11 because gcc11 is now the default gcc in nixpkgs.

Long lists (of dependencies etc) were changed to one-item-per-line format for cleaner future commits.

I've been testing this on NIxOS 22.05.

If someone is going to make a derivation for VCV Rack 2 Pro, it will have to be a separate derivation using `requiredFile`. The Pro version has a separate, proprietary/commercial codebase and is distributed in binary form. I won't be doing it because I don't have Pro and don't plan on buying it. (I've bought some plugins that financially support the VCV team instead).

Closes https://github.com/NixOS/nixpkgs/issues/149427

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).