### PR TITLE
vde2: 2.3.2 -> 2.3.3

### DIFF
--- a/pkgs/tools/networking/vde2/default.nix
+++ b/pkgs/tools/networking/vde2/default.nix
@@ -1,22 +1,17 @@
-{ lib, stdenv, fetchurl, fetchpatch, openssl, libpcap, python2, withPython ? false }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, libpcap, wolfssl }:
 
 stdenv.mkDerivation rec {
   pname = "vde2";
-  version = "2.3.2";
+  version = "2.3.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/vde/vde2/${version}/vde2-${version}.tar.gz";
-    sha256 = "14xga0ib6p1wrv3hkl4sa89yzjxv7f1vfqaxsch87j6scdm59pr2";
+  src = fetchFromGitHub {
+    owner = "virtualsquare";
+    repo = "vde-2";
+    rev = "v${version}";
+    sha256 = "sha256-Yf6QB7j5lYld2XtqhYspK4037lTtimoFc7nCavCP+mU=";
   };
 
-  patches = [
-    # Fix build with openssl 1.1.0
-    (fetchpatch {
-      name = "vde_cryptcab-compile-against-openssl-1.1.0.patch";
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b11be49997fa94b603e366064690b7cc6bce61/trunk/vde_cryptcab-compile-against-openssl-1.1.0.patch";
-      sha256 = "07z1yabwigq35mkwzqa934n7vjnjlqz5xfzq8cfj87lgyjjp00qi";
-    })
-  ] ++ lib.optional stdenv.hostPlatform.isMusl [
+  patches = lib.optional stdenv.hostPlatform.isMusl [
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/vde2/musl-build-fix.patch?id=ddee2f86a48e087867d4a2c12849b2e3baccc238";
       sha256 = "0b5382v541bkxhqylilcy34bh83ag96g71f39m070jzvi84kx8af";
@@ -27,19 +22,9 @@ stdenv.mkDerivation rec {
     MACOSX_DEPLOYMENT_TARGET=10.16
   '';
 
-  configureFlags = lib.optional (!withPython) "--disable-python";
+  nativeBuildInputs = [ autoreconfHook ];
 
-  buildInputs = [ openssl libpcap ]
-    ++ lib.optional withPython python2;
-
-  hardeningDisable = [ "format" ];
-
-  # Disable parallel build as it fails as:
-  #   make: *** No rule to make target '../../src/lib/libvdemgmt.la',
-  #    needed by 'libvdesnmp.la'.  Stop.
-  # Next release should address it with
-  #     https://github.com/virtualsquare/vde-2/commit/7dd9ed46d5dca125ca45d679ac9f3acbfb0f9300.patch
-  enableParallelBuilding = false;
+  buildInputs = [ libpcap wolfssl ];
 
   meta = with lib; {
     homepage = "https://github.com/virtualsquare/vde-2";


### PR DESCRIPTION
https://github.com/virtualsquare/vde-2/releases/tag/v2.3.3

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
