### PR TITLE
texlive.combined.basic-scheme: fix $PATH of wrapped scripts

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -180,7 +180,7 @@ in (buildEnv {
       echo -n "Wrapping '$link'"
       rm "$link"
       makeWrapper "$target" "$link" \
-        --prefix PATH : "$out/bin:${perl}/bin" \
+        --prefix PATH : "${gnused}/bin:${gnugrep}/bin:${coreutils}/bin:$out/bin:${perl}/bin" \
         --prefix PERL5LIB : "$PERL5LIB" \
         --set-default TEXMFCNF "$TEXMFCNF"
 

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -4,7 +4,7 @@
 */
 { stdenv, lib, fetchurl, runCommand, writeText, buildEnv
 , callPackage, ghostscriptX, harfbuzz
-, makeWrapper, python3, ruby, perl
+, makeWrapper, python3, ruby, perl, gnused, gnugrep, coreutils
 , useFixedHashes ? true
 , recurseIntoAttrs
 }:
@@ -23,7 +23,7 @@ let
   # function for creating a working environment from a set of TL packages
   combine = import ./combine.nix {
     inherit bin combinePkgs buildEnv lib makeWrapper writeText
-      stdenv python3 ruby perl;
+      stdenv python3 ruby perl gnused gnugrep coreutils;
     ghostscript = ghostscriptX; # could be without X, probably, but we use X above
   };
 


### PR DESCRIPTION
Fix missing sed, grep and coreutils in $PATH. Closes: #150620

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
