### PR TITLE
wxGTK30-gtk2,wxGTK30-gtk3: add missing buildInput on Darwin

### DIFF
--- a/pkgs/applications/emulators/bochs/default.nix
+++ b/pkgs/applications/emulators/bochs/default.nix
@@ -130,6 +130,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }
 # TODO: a better way to organize the options

--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -7,6 +7,8 @@
 , pango
 , pkg-config
 , wxGTK
+# darwin deps
+, Cocoa
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +30,7 @@ stdenv.mkDerivation rec {
     libexif
     pango
     wxGTK
-  ];
+  ] ++ lib.optional stdenv.isDarwin Cocoa;
 
   meta = with lib; {
     homepage = "http://wxsvg.sourceforge.net/";
@@ -37,9 +39,8 @@ stdenv.mkDerivation rec {
       wxSVG is C++ library to create, manipulate and render Scalable Vector
       Graphics (SVG) files with the wxWidgets toolkit.
     '';
-    license = with licenses; gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
-    platforms = wxGTK.meta.platforms;
-    broken = stdenv.isDarwin;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTorres ];
+    inherit (wxGTK.meta) platforms;
   };
 }

--- a/pkgs/development/libraries/wxwidgets/wxGTK30.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK30.nix
@@ -18,6 +18,7 @@
 , withGtk2 ? true
 , withWebKit ? false, webkitgtk
 , AGL
+, AVFoundation
 , Carbon
 , Cocoa
 , Kernel
@@ -57,6 +58,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional withMesa libGLU
   ++ lib.optional withWebKit webkitgtk
   ++ lib.optionals stdenv.isDarwin [
+    AVFoundation
     Carbon
     Cocoa
     Kernel
@@ -130,7 +132,6 @@ stdenv.mkDerivation rec {
     license = licenses.wxWindows;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux ++ platforms.darwin;
-    badPlatforms = [ "x86_64-darwin" ];
   };
 
   passthru = {

--- a/pkgs/tools/networking/p2p/amule/default.nix
+++ b/pkgs/tools/networking/p2p/amule/default.nix
@@ -80,6 +80,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     # cmake fails: Cannot specify link libraries for target "wxWidgets::ADV" which is not built by this project.
-    broken = enableDaemon;
+    broken = enableDaemon || stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35053,6 +35053,8 @@ with pkgs;
 
   wxsqliteplus = callPackage ../development/libraries/wxsqliteplus {
     wxGTK = wxGTK30;
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+    inherit (darwin.stubs) setfile;
   };
 
   x11idle = callPackage ../tools/misc/x11idle {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21231,6 +21231,7 @@ with pkgs;
 
   wxSVG = callPackage ../development/libraries/wxSVG {
     wxGTK = wxGTK30-gtk3;
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
   wtk = callPackage ../development/libraries/wtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21212,7 +21212,7 @@ with pkgs;
   wxGTK30 = callPackage ../development/libraries/wxwidgets/wxGTK30.nix {
     withGtk2 = true;
     inherit (darwin.stubs) setfile;
-    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+    inherit (darwin.apple_sdk.frameworks) AGL AVFoundation Carbon Cocoa Kernel QTKit;
   };
   wxGTK30-gtk2 = wxGTK30.override { withGtk2 = true; };
   wxGTK30-gtk3 = wxGTK30.override { withGtk2 = false; };


### PR DESCRIPTION
###### Description of changes

Add `AVFoundation` to `buildInputs` to get package building on Darwin, and fix packages that depend on `wxGTK30-gtk{2,3}` or mark then as broken if fix isn't obvious.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
