### PR TITLE
treewide: rename "withX" option to "x11Support"

### DIFF
--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -3,7 +3,7 @@
 , libX11, libXext, libXinerama, libXi, libXrender, libXrandr, libXtst
 , pkg-config, glib, gdk-pixbuf-xlib, gtk3, gtkmm3, iproute2, dbus, systemd, which
 , libdrm, udev, util-linux
-, withX ? true
+, x11Support ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config ];
   buildInputs = [ fuse3 glib icu libdnet libdrm libmspack libtirpc openssl pam procps rpcsvc-proto udev xercesc ]
-      ++ lib.optionals withX [ gdk-pixbuf-xlib gtk3 gtkmm3 libX11 libXext libXinerama libXi libXrender libXrandr libXtst ];
+      ++ lib.optionals x11Support [ gdk-pixbuf-xlib gtk3 gtkmm3 libX11 libXext libXinerama libXi libXrender libXrandr libXtst ];
 
   postPatch = ''
      sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' Makefile.am
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     "--without-xmlsecurity"
     "--with-udev-rules-dir=${placeholder "out"}/lib/udev/rules.d"
     "--with-fuse=fuse3"
-  ] ++ lib.optional (!withX) "--without-x";
+  ] ++ lib.optional (!x11Support) "--without-x";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libAfterImage/default.nix
+++ b/pkgs/development/libraries/libAfterImage/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, autoreconfHook, giflib, libjpeg, libpng, libX11, zlib
 , static ? stdenv.hostPlatform.isStatic
-, withX ? !stdenv.isDarwin }:
+, x11Support ? !stdenv.isDarwin }:
 
 stdenv.mkDerivation {
   pname = "libAfterImage";
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
   patchFlags = [ "-p0" ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ giflib libjpeg libpng zlib ] ++ lib.optional withX libX11;
+  buildInputs = [ giflib libjpeg libpng zlib ] ++ lib.optional x11Support libX11;
 
   preConfigure = ''
     rm -rf {libjpeg,libpng,libungif,zlib}/
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
     "--disable-mmx-optimization"
     "--${if static then "enable" else "disable"}-staticlibs"
     "--${if !static then "enable" else "disable"}-sharedlibs"
-  ] ++ lib.optional withX "--with-x";
+  ] ++ lib.optional x11Support "--with-x";
 
   meta = with lib; {
     homepage = "http://www.afterstep.org/afterimage/";

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -17,7 +17,7 @@
 
 assert libX11 != null -> (fontconfig != null && gnused != null && coreutils != null);
 let
-  withX = libX11 != null && !aquaterm && !stdenv.isDarwin;
+  x11Support = libX11 != null && !aquaterm && !stdenv.isDarwin;
 in
 (if withQt then mkDerivation else stdenv.mkDerivation) rec {
   pname = "gnuplot";
@@ -35,7 +35,7 @@ in
     ++ lib.optional withTeXLive (texlive.combine { inherit (texlive) scheme-small; })
     ++ lib.optional withLua lua
     ++ lib.optional withCaca libcaca
-    ++ lib.optionals withX [ libX11 libXpm libXt libXaw ]
+    ++ lib.optionals x11Support [ libX11 libXpm libXt libXaw ]
     ++ lib.optionals withQt [ qtbase qtsvg ]
     ++ lib.optional withWxGTK wxGTK;
 
@@ -45,14 +45,14 @@ in
   '';
 
   configureFlags = [
-    (if withX then "--with-x" else "--without-x")
+    (if x11Support then "--with-x" else "--without-x")
     (if withQt then "--with-qt=qt5" else "--without-qt")
     (if aquaterm then "--with-aquaterm" else "--without-aquaterm")
   ] ++ lib.optional withCaca "--with-caca";
 
   CXXFLAGS = lib.optionalString (stdenv.isDarwin && withQt) "-std=c++11";
 
-  postInstall = lib.optionalString withX ''
+  postInstall = lib.optionalString x11Support ''
     wrapProgram $out/bin/gnuplot \
        --prefix PATH : '${gnused}/bin' \
        --prefix PATH : '${coreutils}/bin' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23562,7 +23562,7 @@ with pkgs;
   ocf-resource-agents = callPackage ../os-specific/linux/ocf-resource-agents { };
 
   open-vm-tools = callPackage ../applications/virtualization/open-vm-tools { };
-  open-vm-tools-headless = open-vm-tools.override { withX = false; };
+  open-vm-tools-headless = open-vm-tools.override { x11Support = false; };
 
   air = callPackage ../development/tools/air { };
 
@@ -26099,7 +26099,7 @@ with pkgs;
   };
 
   emacs28-nox = lowPrio (emacs28.override {
-    withX = false;
+    x11Support = false;
     withNS = false;
     withGTK2 = false;
     withGTK3 = false;


### PR DESCRIPTION
Some packages used "withX" option to enable or disable support for x11, but
most were using x11Support. This commit makes them all uniform.

This is no-rebuild commit.
