### PR TITLE
python310Packages.growattserver: 1.2.0 -> 1.2.2

### DIFF
--- a/pkgs/development/python-modules/growattserver/default.nix
+++ b/pkgs/development/python-modules/growattserver/default.nix
@@ -7,31 +7,28 @@
 
 buildPythonPackage rec {
   pname = "growattserver";
-  version = "1.2.0";
-  disabled = pythonOlder "3.6";
+  version = "1.2.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "indykoning";
     repo = "PyPi_GrowattServer";
     rev = version;
-    sha256 = "0v9clmz4qg6krmbsbfsrhsan824y2mqvwxsxb0fzfgaszxwkpm30";
+    hash = "sha256-dS5Ng89aYzfegdFlyt1eo7vhva2ME77pQV2hkd/iNq8=";
   };
 
   propagatedBuildInputs = [
     requests
   ];
 
-  postPatch = ''
-    # https://github.com/indykoning/PyPi_GrowattServer/issues/2
-    substituteInPlace setup.py \
-      --replace "tag = os.environ['LATEST_TAG']" "" \
-      --replace "version=tag," 'version="${version}",'
-  '';
-
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "growattServer" ];
+  pythonImportsCheck = [
+    "growattServer"
+  ];
 
   meta = with lib; {
     description = "Python package to retrieve information from Growatt units";


### PR DESCRIPTION
###### Description of changes
https://github.com/indykoning/PyPi_GrowattServer/releases/tag/1.2.2
https://github.com/indykoning/PyPi_GrowattServer/releases/tag/1.2.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
