### PR TITLE
xxHash: add pkg-config file fix, clean up a bit

### DIFF
--- a/pkgs/development/libraries/xxHash/default.nix
+++ b/pkgs/development/libraries/xxHash/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, fetchurl
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -16,13 +16,21 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2WoYCO6QRHWrbGP2mK04/sLNTyQLOuL3urVktilAwMA=";
   };
 
+  # CMake build fixes
   patches = [
     # Merged in https://github.com/Cyan4973/xxHash/pull/649
     # Should be present in next release
-    (fetchurl {
-      name = "cmakeinstallfix.patch";
+    (fetchpatch {
+      name = "cmake-install-fix";
       url = "https://github.com/Cyan4973/xxHash/commit/636f966ecc713c84ddd3b7ccfde2bfb2cc7492a0.patch";
-      hash = "sha256-fj+5V5mDhFgWGvrG1E4fEekL4eh7as0ouVvY4wnIHjs=";
+      sha256 = "sha256-B1PZ/0BXlOrSiPvgCPLvI/sjQvnR0n5PQHOO38LOij0=";
+    })
+
+    # Submitted at https://github.com/Cyan4973/xxHash/pull/723
+    (fetchpatch {
+      name = "cmake-pkgconfig-fix";
+      url = "https://github.com/Cyan4973/xxHash/commit/5db353bbd05ee5eb1f90afc08d10da9416154e55.patch";
+      sha256 = "sha256-dElgSu9DVo2hY6TTVHLTtt0zkXmQV3nc9i/KbrDkK8s=";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

Add a patch to fix the pkg-config file generated by the new cmake-based build. Fixes tdesktop and friends. No nixpkgs-review because this is a lot, but tdesktop builds fine.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
