### PR TITLE
linuxPackages.rtl8188eus-aircrack: fix build for newer kernels

### DIFF
--- a/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, bc }:
 
 stdenv.mkDerivation {
   pname = "rtl8188eus-aircrack";
@@ -7,14 +7,26 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "aircrack-ng";
     repo = "rtl8188eus";
-    rev = "6146193406b62e942d13d4d43580ed94ac70c218";
-    sha256 = "sha256-85STELbFB7QmTaM8GvJNlWvAg6KPAXeYRiMb4cGA6RY=";
+    rev = "0958f294f90b49d6bad4972b14f90676e5d858d3";
+    hash = "sha256-dkCcwvOLxqU1IZ/OXTp67akjWgsaH1Cq4N8d9slMRI8=";
   };
 
+  patches = [
+    # Support for kernel version 5.17+
+    (fetchpatch {
+      url = "https://github.com/aircrack-ng/rtl8188eus/commit/a56696c733b134f21cf81084e55b88f46acc1ec2.patch";
+      hash = "sha256-Nky358ymOpYDRDXaemFpSHSQFY1hQBX+BdDIBoGoOck=";
+    })
+
+    # Removed 'extern' from inline function declarations
+    (fetchpatch {
+      url = "https://github.com/aircrack-ng/rtl8188eus/commit/0f1905259ec9b85fd1453be3abd322ff543e12bc.patch";
+      hash = "sha256-cQQmytNth2QY577P7kxqpaw4Id+RfZIgWVgvCN0fQxI=";
+    })
+  ];
+
   nativeBuildInputs = [ bc ];
-
   buildInputs = kernel.moduleBuildDependencies;
-
   hardeningDisable = [ "pic" ];
 
   prePatch = ''
@@ -36,6 +48,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/aircrack-ng/rtl8188eus";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ fortuneteller2k ];
-    broken = kernel.kernelAtLeast "5.15" || kernel.isHardened;
+    broken = kernel.isHardened;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
