### PR TITLE
routersploit: init at unstable-2021-02-06

### DIFF
--- a/pkgs/development/python-modules/threat9-test-bed/default.nix
+++ b/pkgs/development/python-modules/threat9-test-bed/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, click
+, faker
+, fetchFromGitHub
+, flask
+, gunicorn
+, pyopenssl
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "threat9-test-bed";
+  version = "0.6.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "threat9";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-0YSjMf2gDdrvkDaT77iwfCkiDDXKHnZyI8d7JmBSuCg=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    click
+    faker
+    flask
+    gunicorn
+    pyopenssl
+    requests
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "threat9_test_bed"
+  ];
+
+  disabledTests = [
+    # Assertion issue with the response codes
+    "test_http_service_mock"
+    "tests_http_service_mock"
+    "test_http_service_mock_random_port"
+  ];
+
+  meta = with lib; {
+    description = "Module for adding unittests.mock as view functions";
+    homepage = "https://github.com/threat9/threat9-test-bed";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/routersploit/default.nix
+++ b/pkgs/tools/security/routersploit/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "routersploit";
+  version = "unstable-2021-02-06";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "threat9";
+    repo = pname;
+    rev = "3fd394637f5566c4cf6369eecae08c4d27f93cda";
+    hash = "sha256-IET0vL0VVP9ZNn75hKdTCiEmOZRHHYICykhzW2g3LEg=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    future
+    paramiko
+    pycryptodome
+    pysnmp
+    requests
+    setuptools
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest-xdist
+    pytestCheckHook
+    threat9-test-bed
+  ];
+
+  postInstall = ''
+    mv $out/bin/rsf.py $out/bin/rsf
+  '';
+
+  pythonImportsCheck = [
+    "routersploit"
+  ];
+
+  pytestFlagsArray = [
+    "-n"
+    "$NIX_BUILD_CORES"
+    # Run the same tests as upstream does in the first round
+    "tests/core/"
+    "tests/test_exploit_scenarios.py"
+    "tests/test_module_info.py"
+  ];
+
+  meta = with lib; {
+    description = "Exploitation Framework for Embedded Devices";
+    homepage = "https://github.com/threat9/routersploit";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4320,6 +4320,8 @@ with pkgs;
 
   roundcubePlugins = dontRecurseIntoAttrs (callPackage ../servers/roundcube/plugins { });
 
+  routersploit = callPackage ../tools/security/routersploit { };
+
   routinator = callPackage ../servers/routinator {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10462,6 +10462,8 @@ in {
 
   threadpoolctl = callPackage ../development/python-modules/threadpoolctl { };
 
+  threat9-test-bed = callPackage ../development/python-modules/threat9-test-bed { };
+
   three-merge = callPackage ../development/python-modules/three-merge { };
 
   thrift = callPackage ../development/python-modules/thrift { };


### PR DESCRIPTION
###### Description of changes
Exploitation Framework for Embedded Devices

https://github.com/threat9/routersploit

Related to #81418 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
