### PR TITLE
graalvmXX-ce: use a patched version of zlib

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/default.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, Foundation }:
+{ callPackage, fetchpatch, zlib, Foundation }:
 /*
   Add new graal versions and products here and then see update.nix on how to
   generate the sources.
@@ -7,6 +7,15 @@
 let
   mkGraal = opts: callPackage (import ./mkGraal.nix opts) {
     inherit Foundation;
+    # remove this once zlib 1.2.13 is released
+    zlib = zlib.overrideAttrs (oldAttrs: {
+      patches = (oldAttrs.patches or [ ]) ++ [
+        (fetchpatch {
+          url = "https://github.com/madler/zlib/commit/ec3df00224d4b396e2ac6586ab5d25f673caa4c2.patch";
+          sha256 = "sha256-jSa3OCigBdpWFDllCWC2rgE9GxCNR0yjsc+bpwPDBEA=";
+        })
+      ];
+    });
   };
 
   /*


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The previous releases of zlib were not sensitive to incorrect CRC inputs with bits set above the low 32. Some programs were depended on this behavior, including GraalVM. So this commit backports a patch from `zlib` develop that brings back the old behavior. This will probably be included in the next release of zlib.

Before:

```
$ rm -rf ~/.babashka
$ bb -e "(babashka.pods/load-pod 'clj-kondo/clj-kondo \"2022.05.31\")"
Downloading pod clj-kondo/clj-kondo (2022.05.31)
----- Error --------------------------------------------------------------------
Type:     java.util.zip.ZipException
Message:  invalid entry CRC (expected 0x269cdf2c but got 0x13b86fd8)
Location: <expr>:1:1

----- Context ------------------------------------------------------------------
1: (babashka.pods/load-pod 'clj-kondo/clj-kondo "2022.05.31")
   ^--- invalid entry CRC (expected 0x269cdf2c but got 0x13b86fd8)

----- Stack trace --------------------------------------------------------------
babashka.pods.impl.resolver/unzip             - <built-in>
babashka.pods.impl.resolver/resolve/fn--30674 - <built-in>
clojure.core/mapv/fn--8535                    - <built-in>
clojure.core.protocols/fn--8244               - <built-in>
clojure.core.protocols/fn--8204/G--8199--8213 - <built-in>
... (run with --debug to see elided elements)
babashka.pods.sci/load-pod/fn--30887          - <built-in>
babashka.pods.sci/load-pod                    - <built-in>
clojure.core/apply                            - <built-in>
babashka.impl.pods/load-pod                   - <built-in>
user                                          - <expr>:1:1
```

After:

```
$ rm -rf ~/.babashka
$ ./result/bin/bb -e "(babashka.pods/load-pod 'clj-kondo/clj-kondo \"2022.05.31\")"
Downloading pod clj-kondo/clj-kondo (2022.05.31)
Successfully installed pod clj-kondo/clj-kondo (2022.05.31)
```

The issue should affect other programs using GraalVM, but this was the
test that I had at hand.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
