### PR TITLE
kdigger: init at 1.2.0

### DIFF
--- a/pkgs/tools/security/kdigger/default.nix
+++ b/pkgs/tools/security/kdigger/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, fetchpatch
+}:
+
+buildGoModule rec {
+  pname = "kdigger";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "quarkslab";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-j4HIwfRIUpV25DmbQ+9go8aJMEYaFDPxrdr/zGWBeVU=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+  vendorSha256 = "sha256-3vn3MsE/4lBw89wgYgzm0RuJJ5RQTkgS6O74PpfFcUk=";
+
+  patches = [
+    (fetchpatch {
+      name = "simplify-ldflags.patch";
+      url = "https://github.com/quarkslab/kdigger/pull/2.patch";
+      sha256 = "sha256-d/NdoAdnheVgdqr2EF2rNn3gJvbjRZtOKFw2DqWR8TY=";
+    })
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  CGO_ENABLED = 0;
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/quarkslab/kdigger/commands.VERSION=v${version}"
+    "-X github.com/quarkslab/kdigger/commands.BUILDERARCH=${stdenv.hostPlatform.linuxArch}"
+  ];
+
+  preBuild = ''
+    ldflags+=" -X github.com/quarkslab/kdigger/commands.GITCOMMIT=$(cat COMMIT)"
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd kdigger \
+      --bash <($out/bin/kdigger completion bash) \
+      --fish <($out/bin/kdigger completion fish) \
+      --zsh <($out/bin/kdigger completion zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/kdigger --help
+
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/quarkslab/kdigger";
+    changelog = "https://github.com/quarkslab/kdigger/releases/tag/v${version}";
+    description = "An in-pod context discovery tool for Kubernetes penetration testing";
+    longDescription = ''
+      kdigger, short for "Kubernetes digger", is a context discovery tool for
+      Kubernetes penetration testing. This tool is a compilation of various
+      plugins called buckets to facilitate pentesting Kubernetes from inside a
+      pod.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+    # aarch64-linux support progress - https://github.com/quarkslab/kdigger/issues/3
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7469,6 +7469,10 @@ with pkgs;
 
   kdbplus = pkgsi686Linux.callPackage ../applications/misc/kdbplus { };
 
+  kdigger = callPackage ../tools/security/kdigger {
+    buildGoModule = buildGo118Module;
+  };
+
   keepalived = callPackage ../tools/networking/keepalived { };
 
   kexec-tools = callPackage ../os-specific/linux/kexec-tools { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package kdigger for nixpkgs @ 1.2.0

https://github.com/quarkslab/kdigger

Wait to see if x86_64-darwin builds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
