### PR TITLE
buildDhallUrl: Respect proxy environment variables

### DIFF
--- a/pkgs/development/interpreters/dhall/build-dhall-url.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-url.nix
@@ -76,7 +76,8 @@ let
    sourceFile = "source.dhall";
 
 in
-  runCommand name { } (''
+  runCommand name { impureEnvVars = lib.fetchers.proxyImpureEnvVars; }
+ (''
     set -eu
 
     mkdir -p ${cacheDhall} $out/${cacheDhall}


### PR DESCRIPTION
###### Description of changes

`buildDhallUrl` is a fixed output derivation, which means
that we can (and should) inherit impure proxy-related
environment variables for fetching URLs.

The motivation for this change is:

https://discourse.dhall-lang.org/t/cant-build-a-nixified-dhall-package-in-a-sandbox-depending-on-the-environment/

… where a `buildDhallUrl` derivation was failing in a restricted
networking environment due to not inheriting proxy-related
settings.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).