### PR TITLE
flam3, qosmic: enable on darwin

### DIFF
--- a/pkgs/applications/graphics/qosmic/default.nix
+++ b/pkgs/applications/graphics/qosmic/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation
+{ stdenv
 , fetchFromGitHub
 , fetchpatch
 , qmake
@@ -13,7 +13,7 @@
 , lib
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qosmic";
   version = "1.6.0";
 
@@ -42,6 +42,13 @@ mkDerivation rec {
     })
   ];
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace qosmic.pro \
+      --replace "/share" "/Applications/qosmic.app/Contents/Resources" \
+      --replace "/qosmic/scripts" "/scripts" \
+      --replace "install_icons install_desktop" ""
+  '';
+
   nativeBuildInputs = [ qmake wrapQtAppsHook pkg-config ];
 
   buildInputs = [
@@ -55,16 +62,19 @@ mkDerivation rec {
 
   qmakeFlags = [
     # Use pkg-config to correctly locate library paths
-    "-config" "link_pkgconfig"
+    "CONFIG+=link_pkgconfig"
   ];
+
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv qosmic.app $out/Applications
+  '';
 
   meta = with lib; {
     description = "A cosmic recursive flame fractal editor";
     homepage = "https://github.com/bitsed/qosmic";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.raboof ];
-    # It might be possible to make it work on OSX,
-    # but this has not been tested.
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/graphics/flam3/default.nix
+++ b/pkgs/tools/graphics/flam3/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes
Enable on darwin.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
