### PR TITLE
perccli, storcli: init proprietary HW RAID configuration tools

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9863,6 +9863,12 @@
     githubId = 1788628;
     name = "pandaman";
   };
+  panicgh = {
+    email = "nbenes.gh@xandea.de";
+    github = "panicgh";
+    githubId = 79252025;
+    name = "Nicolas Benes";
+  };
   paperdigits = {
     email = "mica@silentumbrella.com";
     github = "paperdigits";

--- a/pkgs/tools/misc/perccli/default.nix
+++ b/pkgs/tools/misc/perccli/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, rpmextract
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "perccli";
+  version = "7.1910.00";
+
+  src = fetchurl {
+    url = "https://dl.dell.com/FOLDER07815522M/1/PERCCLI_${version}_A12_Linux.tar.gz";
+    sha256 = "sha256-Gt/kr5schR/IzFmnhXO57gjZpOJ9NSnPX/Sj7zo8Qjk=";
+    # Dell seems to block "uncommon" user-agents, such as Nixpkgs's custom one.
+    # Sending no user-agent at all seems to be fine though.
+    curlOptsList = [ "--user-agent" "" ];
+  };
+
+  nativeBuildInputs = [ rpmextract ];
+
+  buildCommand = ''
+    tar xf $src
+    rpmextract PERCCLI_*_Linux/perccli-*.noarch.rpm
+    install -D ./opt/MegaRAID/perccli/perccli64 $out/bin/perccli64
+    ln -s perccli64 $out/bin/perccli
+
+    # Not needed because the binary is statically linked
+    #eval fixupPhase
+  '';
+
+  meta = with lib; {
+    description = "Perccli Support for PERC RAID controllers";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ panicgh ];
+    platforms = with platforms; intersectLists x86_64 linux;
+  };
+}

--- a/pkgs/tools/misc/storcli/default.nix
+++ b/pkgs/tools/misc/storcli/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, rpmextract
+, unzip
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "storcli";
+  version = "7.2106.00";
+
+  src = fetchurl {
+    url = "https://docs.broadcom.com/docs-and-downloads/raid-controllers/raid-controllers-common-files/00${version}00.0000_Unified_StorCLI.zip";
+    sha256 = "sha256-sRMpNXCdcysliVQwRE/1yAeU/cp+y0f2F8BPiWyotxQ=";
+  };
+
+  nativeBuildInputs = [ rpmextract unzip ];
+
+  buildCommand = ''
+    unzip $src
+    rpmextract Unified_storcli_all_os/Linux/storcli-*.noarch.rpm
+    install -D ./opt/MegaRAID/storcli/storcli64 $out/bin/storcli64
+    ln -s storcli64 $out/bin/storcli
+
+    # Not needed because the binary is statically linked
+    #eval fixupPhase
+  '';
+
+  meta = with lib; {
+    description = "Storage Command Line Tool";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ panicgh ];
+    platforms = with platforms; intersectLists x86_64 linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9531,6 +9531,8 @@ with pkgs;
 
   pell = callPackage ../applications/misc/pell { };
 
+  perccli = callPackage ../tools/misc/perccli { };
+
   perceptualdiff = callPackage ../tools/graphics/perceptualdiff { };
 
   percona-xtrabackup = percona-xtrabackup_8_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10831,6 +10831,8 @@ with pkgs;
 
   stm32loader = with python3Packages; toPythonApplication stm32loader;
 
+  storcli = callPackage ../tools/misc/storcli { };
+
   stremio = qt5.callPackage ../applications/video/stremio { };
 
   sunwait = callPackage ../applications/misc/sunwait { };


### PR DESCRIPTION
###### Description of changes

Proprietary RAID controller management/configuration tools, usually for server HW RAID.

Nixpkgs already contains a package for [megacli](/pkgs/tools/misc/megacli/default.nix), which stuck at a version from 2014 (see [this search](https://www.broadcom.com/support/download-search?dk=megacli) and then unfold "Management Software and Tools"). I am not a storage expert, but MegaCLI seems to have been succeeded by StorCLI, which has slightly different CLI syntax. [This manual](https://docs.broadcom.com/doc/12352476), for example, has a section on "MegaCLI Commands to StorCLI Command Conversion".

If this is correct, maybe the megacli pkg should be removed (delete Nix files and add alias suggesting to use storcli?). I could add this to this PR.

Backport to 22.05 would be nice, but is not a must.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
