### PR TITLE
plasma-overdose-kde-theme: init at unstable-2022-05-30

### DIFF
--- a/pkgs/data/themes/plasma-overdose-kde-theme/default.nix
+++ b/pkgs/data/themes/plasma-overdose-kde-theme/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "plasma-overdose-kde-theme";
+  version = "unstable-2022-05-30";
+
+  src = fetchFromGitHub {
+    owner = "Notify-ctrl";
+    repo = "Plasma-Overdose";
+    rev = "d8bf078b4819885d590db27cd1d25d8f4f08fe4c";
+    sha256 = "187f6rlvb2wf5sj3mgr69mfwh9fpqchw4yg6nzv54l98msmxc4h0";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    mv colorschemes $out/share/color-schemes
+    mv plasma $out/share/plasma
+
+    mkdir -p $out/share/aurorae
+    mv aurorae $out/share/aurorae/themes
+
+    mkdir -p $out/share/icons/Plasma-Overdose
+    mv cursors/index.theme $out/share/icons/Plasma-Overdose/cursor.theme
+    mv cursors/cursors $out/share/icons/Plasma-Overdose/cursors
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Cute KDE theme inspired by the game Needy Girl Overdose";
+    homepage = "https://github.com/Notify-ctrl/Plasma-Overdose";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ takagiy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24793,6 +24793,8 @@ with pkgs;
     inherit (plasma5Packages) breeze-icons;
   };
 
+  plasma-overdose-kde-theme = callPackage ../data/themes/plasma-overdose-kde-theme { };
+
   papis = with python3Packages; toPythonApplication papis;
 
   paperlike-go = callPackage ../tools/misc/paperlike-go { };


### PR DESCRIPTION
###### Description of changes

Add a KDE theme https://github.com/Notify-ctrl/Plasma-Overdose.git

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
