### PR TITLE
monocypher: init at 3.1.3

### DIFF
--- a/pkgs/development/libraries/monocypher/default.nix
+++ b/pkgs/development/libraries/monocypher/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  pname = "monocypher";
+  version = "3.1.3";
+
+  src = fetchurl {
+    url = "https://monocypher.org/download/monocypher-${version}.tar.gz";
+    hash = "sha256-tEK1d98o+MNsqgHZrpARtd2ccX2UvlIBaKBONtf1AW4=";
+  };
+
+  patches = [
+    # Fix cross-compilation
+    (fetchpatch {
+      url = "https://github.com/LoupVaillant/Monocypher/commit/376715e1c0ebb375e50dfa757bc89486c9a7b404.patch";
+      hash = "sha256-tuwSUaU4w+jkaj10ChMgUmOQmoKYnv5JgJ1og8EXxFk=";
+    })
+  ];
+
+  makeFlags = [ "AR:=$(AR)" "CC:=$(CC)" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Boring crypto that simply works";
+    homepage = "https://monocypher.org";
+    license = with licenses; [ bsd2 cc0 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28315,6 +28315,8 @@ with pkgs;
     mopidy-youtube
     mopidy-ytmusic;
 
+  monocypher = callPackage ../development/libraries/monocypher { };
+
   motif = callPackage ../development/libraries/motif { };
 
   mousai = callPackage ../applications/audio/mousai { };


### PR DESCRIPTION
###### Description of changes
[**Monocypher**](https://monocypher.org/) is an easy-to-use crypto library.

[![Packaging status](https://repology.org/badge/tiny-repos/monocypher.svg)](https://repology.org/project/monocypher/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
