### PR TITLE
{asusctl, nixos/asusd}: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11416,6 +11416,12 @@
     githubId = 695473;
     name = "Sascha Grunert";
   };
+  sauricat = {
+    email = "linshu1729@protonmail.com";
+    github = "sauricat";
+    githubId = 3533655;
+    name = "Shu Lin";
+  };
   sauyon = {
     email = "s@uyon.co";
     github = "sauyon";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -431,6 +431,7 @@
   ./services/games/terraria.nix
   ./services/hardware/acpid.nix
   ./services/hardware/actkbd.nix
+  ./services/hardware/asusd.nix
   ./services/hardware/auto-cpufreq.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/bolt.nix

--- a/nixos/modules/services/hardware/asusd.nix
+++ b/nixos/modules/services/hardware/asusd.nix
@@ -1,0 +1,52 @@
+# asusd daemon.
+
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.asusd;
+in
+{
+  options = {
+    services.asusd = {
+      enable = lib.mkEnableOption "ASUS Notebook Control";
+      ledmodesFile = lib.mkOption {
+        type = lib.types.str;
+        default = "${pkgs.asusctl}/etc/asusd/asusd-ledmodes.toml";
+        defaultText = "\${pkgs.asusctl}/etc/asusd/asusd-ledmodes.toml";
+        description = "The ledmodes settings to be used by asusd";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.asusd = {
+      description = "ASUS Notebook Control";
+      before = [ "multi-user.target" ];
+      startLimitIntervalSec = 200;
+      startLimitBurst = 2;
+      environment."IS_SERVICE" = "1";
+      serviceConfig = {
+        ExecStart = "${pkgs.asusctl}/bin/asusd";
+        Restart = "on-failure";
+        RestartSec = 1;
+        Type = "dbus";
+        BusName = "org.asuslinux.Daemon";
+        SELinuxContext = "system_u:system_r:unconfined_t:s0";
+      };
+    };
+    systemd.user.services.asus-notify = {
+      description = "ASUS Notifications";
+      wantedBy = [ "default.target" ];
+      startLimitIntervalSec = 200;
+      startLimitBurst = 2;
+      serviceConfig = {
+        ExecStart = "${pkgs.asusctl}/bin/asus-notify";
+        Restart = "always";
+        RestartSec = 1;
+      };
+    };
+    services.dbus.packages = [ pkgs.asusctl ];
+    environment.etc."asusd/asusd-ledmodes.toml".source = cfg.ledmodesFile;
+  };
+
+  meta.maintainers = with lib.maintainers; [ sauricat ];
+}

--- a/pkgs/tools/system/asusctl/default.nix
+++ b/pkgs/tools/system/asusctl/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitLab
+, fetchpatch
+, rustPlatform
+, pkg-config
+, udev
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "asusctl";
+  version = "git-3cd6eb";
+  src = fetchFromGitLab {
+    owner = "asus-linux";
+    repo = pname;
+    rev = "3cd6eb13a95992db9a0c7d1d5dc441ab292205c7";
+    sha256 = "sha256-sA/ZbqPsctMd5sCjWd0i22KCA/TqSMMVAEVKWFlZyWM=";
+  };
+  cargoHash = "sha256-LbzULOU6osoK52KUMyNHMbAgqaOYDk2z1UhZ8PCR28U=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ udev ];
+
+  postInstall = ''
+    make install INSTALL_PROGRAM=true DESTDIR=$out prefix=
+  '';
+
+  meta = {
+    description = "Control utility for ASUS ROG";
+    longDescription = ''
+      asusd is a utility for Linux to control many aspects of various ASUS
+      laptops but can also be used with non-asus laptops with reduced features.
+    '';
+    homepage = "https://asus-linux.org";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ sauricat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -233,6 +233,8 @@ with pkgs;
 
   astrolog = callPackage ../applications/science/astronomy/astrolog { };
 
+  asusctl = callPackage ../tools/system/asusctl { };
+
   atkinson-hyperlegible = callPackage ../data/fonts/atkinson-hyperlegible { };
 
   atuin = callPackage ../tools/misc/atuin {


### PR DESCRIPTION
###### Description of changes

The `asusctl` is a system control tool mainly for ASUS laptops. I packed it and added a service option for its daemon `asusd`. 

For more details please see the [project homepage](https://gitlab.com/asus-linux/asusctl).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
