### PR TITLE
omnisharp-roslyn-mono: init at 1.37.17

### DIFF
--- a/pkgs/development/tools/omnisharp-roslyn-mono/create-deps.sh
+++ b/pkgs/development/tools/omnisharp-roslyn-mono/create-deps.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=../../../../.. -i bash -p msbuild dotnet-sdk_5 jq xmlstarlet curl
+set -euo pipefail
+
+cat << EOL
+{ fetchurl }: [
+EOL
+
+tmpdir="$(mktemp -d -p "$(pwd)")" # must be under source root
+trap 'rm -rf "$tmpdir"' EXIT
+
+mapfile -t repos < <(
+    xmlstarlet sel -t -v 'configuration/packageSources/add/@value' -n NuGet.Config |
+        while IFS= read index
+        do
+            curl --compressed -fsL "$index" | \
+                jq -r '.resources[] | select(."@type" == "PackageBaseAddress/3.0.0")."@id"'
+        done
+    )
+
+msbuild -t:restore -p:Configuration=Release -p:RestorePackagesPath="$tmpdir" \
+        -p:RestoreNoCache=true -p:RestoreForce=true \
+        src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj >&2
+
+cd "$tmpdir"
+for package in *
+do
+    cd "$package"
+    for version in *
+    do
+        found=false
+        for repo in "${repos[@]}"
+        do
+            url="$repo$package/$version/$package.$version.nupkg"
+            if curl -fsL "$url" -o /dev/null
+            then
+                found=true
+                break
+            fi
+        done
+
+        if ! $found
+        then
+            echo "couldn't find $package $version" >&2
+            exit 1
+        fi
+
+        sha256=$(nix-prefetch-url "$url" 2>/dev/null)
+        cat << EOL
+  {
+    pname = "$package";
+    version = "$version";
+    src = fetchurl {
+      url = "$url";
+      sha256 = "$sha256";
+    };
+  }
+EOL
+    done
+    cd ..
+done
+cd ..
+
+cat << EOL
+]
+EOL

--- a/pkgs/development/tools/omnisharp-roslyn-mono/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn-mono/default.nix
@@ -1,0 +1,119 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, mono6
+, msbuild
+, dotnetCorePackages
+, makeWrapper
+, unzip
+, writeText
+}:
+
+let
+
+  dotnet-sdk = dotnetCorePackages.sdk_5_0;
+
+  deps = map
+    (package: stdenv.mkDerivation (with package; {
+      inherit pname version src;
+
+      buildInputs = [ unzip ];
+      unpackPhase = ''
+        unzip $src
+        chmod -R u+r .
+        function traverseRename () {
+          for e in *
+          do
+            t="$(echo "$e" | sed -e "s/%20/\ /g" -e "s/%2B/+/g")"
+            [ "$t" != "$e" ] && mv -vn "$e" "$t"
+            if [ -d "$t" ]
+            then
+              cd "$t"
+              traverseRename
+              cd ..
+            fi
+          done
+        }
+
+        traverseRename
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        package=$out/lib/dotnet/${pname}/${version}
+        mkdir -p $package
+        cp -r . $package
+        echo "{}" > $package/.nupkg.metadata
+
+        runHook postInstall
+      '';
+
+      dontFixup = true;
+    }))
+    (import ./deps.nix { inherit fetchurl; });
+
+  nuget-config = writeText "NuGet.Config" ''
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <packageSources>
+        <clear />
+      </packageSources>
+      <fallbackPackageFolders>
+        ${lib.concatStringsSep "\n" (map (package: "<add key=\"${package}\" value=\"${package}/lib/dotnet\"/>") deps)}
+      </fallbackPackageFolders>
+    </configuration>
+  '';
+
+in
+stdenv.mkDerivation rec {
+
+  pname = "omnisharp-roslyn-mono";
+  version = "1.37.17";
+
+  src = fetchFromGitHub {
+    owner = "OmniSharp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-HqZtpRLlw6gwgVq0mW+kNRW8YRJ0niEfOGkUUVBbERA=";
+  };
+
+  nativeBuildInputs = [ makeWrapper msbuild ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    HOME=$(pwd)/fake-home msbuild -r \
+      -p:Configuration=Release \
+      -p:RestoreConfigFile=${nuget-config} \
+      src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r bin/Release/OmniSharp.Stdio.Driver/net472 $out/src
+    cp bin/Release/OmniSharp.Host/net472/SQLitePCLRaw* $out/src
+    mkdir $out/src/.msbuild
+    ln -s ${msbuild}/lib/mono/xbuild/* $out/src/.msbuild/
+    rm $out/src/.msbuild/Current
+    mkdir $out/src/.msbuild/Current
+    ln -s ${msbuild}/lib/mono/xbuild/Current/* $out/src/.msbuild/Current/
+    ln -s ${msbuild}/lib/mono/msbuild/Current/bin $out/src/.msbuild/Current/Bin
+
+    makeWrapper ${mono6}/bin/mono $out/bin/omnisharp \
+      --suffix PATH : ${dotnet-sdk}/bin \
+      --add-flags "$out/src/OmniSharp.exe"
+  '';
+
+  meta = with lib; {
+    description = "OmniSharp based on roslyn workspaces (mono version)";
+    homepage = "https://github.com/OmniSharp/omnisharp-roslyn";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ elizagamedev ];
+  };
+
+}

--- a/pkgs/development/tools/omnisharp-roslyn-mono/deps.nix
+++ b/pkgs/development/tools/omnisharp-roslyn-mono/deps.nix
@@ -1,0 +1,2202 @@
+{ fetchurl }: [
+  {
+    pname = "cake.scripting.abstractions";
+    version = "0.6.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/cake.scripting.abstractions/0.6.4/cake.scripting.abstractions.0.6.4.nupkg";
+      sha256 = "14fcixlj2xazf6cb46gw8jgbsz89c6s8fnhvppxs8q12pygmkx0l";
+    };
+  }
+  {
+    pname = "cake.scripting.transport";
+    version = "0.6.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/cake.scripting.transport/0.6.4/cake.scripting.transport.0.6.4.nupkg";
+      sha256 = "08cwj572mvmlagj5jry11j2l2fqc6yl4sw0szvql4ard9cx7j51n";
+    };
+  }
+  {
+    pname = "dotnet.script.dependencymodel";
+    version = "1.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/dotnet.script.dependencymodel/1.1.0/dotnet.script.dependencymodel.1.1.0.nupkg";
+      sha256 = "0ly1jwvzndrhgvrwy7kagabyca40j8w9p5jvvfj4wlpffvxq44xl";
+    };
+  }
+  {
+    pname = "dotnet.script.dependencymodel.nuget";
+    version = "1.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/dotnet.script.dependencymodel.nuget/1.1.0/dotnet.script.dependencymodel.nuget.1.1.0.nupkg";
+      sha256 = "1kvjrm28jlfmcsy5fna8hy814chbcsc39ka12h8mgpdvjkr93njr";
+    };
+  }
+  {
+    pname = "humanizer.core";
+    version = "2.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/humanizer.core/2.2.0/humanizer.core.2.2.0.nupkg";
+      sha256 = "08mzg65y9d3zvq16rsmpapcdan71ggq2mpks6k777h3wlm2sh3p5";
+    };
+  }
+  {
+    pname = "icsharpcode.decompiler";
+    version = "7.1.0.6543";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/icsharpcode.decompiler/7.1.0.6543/icsharpcode.decompiler.7.1.0.6543.nupkg";
+      sha256 = "1xrajs5dcd7aqsg9ibhdcy39yrd8737kknkmqf907n7fqs2jxr46";
+    };
+  }
+  {
+    pname = "mcmaster.extensions.commandlineutils";
+    version = "3.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/mcmaster.extensions.commandlineutils/3.1.0/mcmaster.extensions.commandlineutils.3.1.0.nupkg";
+      sha256 = "075n1mfsxwz514r94l8i3ax0wp43c3xb4f9w25a96h6xxnj0k2hd";
+    };
+  }
+  {
+    pname = "mediatr";
+    version = "8.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/mediatr/8.1.0/mediatr.8.1.0.nupkg";
+      sha256 = "0cqx7yfh998xhsfk5pr6229lcjcs1jxxyqz7dwskc9jddl6a2akp";
+    };
+  }
+  {
+    pname = "microsoft.aspnetcore.app.ref";
+    version = "3.1.10";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.ref/3.1.10/microsoft.aspnetcore.app.ref.3.1.10.nupkg";
+      sha256 = "0xn4zh7shvijqlr03fqsmps6gz856isd9bg9rk4z2c4599ggal77";
+    };
+  }
+  {
+    pname = "microsoft.bcl.asyncinterfaces";
+    version = "1.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/1.1.0/microsoft.bcl.asyncinterfaces.1.1.0.nupkg";
+      sha256 = "1dq5yw7cy6s42193yl4iqscfw5vzkjkgv0zyy32scr4jza6ni1a1";
+    };
+  }
+  {
+    pname = "microsoft.bcl.asyncinterfaces";
+    version = "1.1.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/1.1.1/microsoft.bcl.asyncinterfaces.1.1.1.nupkg";
+      sha256 = "0a1ahssqds2ympr7s4xcxv5y8jgxs7ahd6ah6fbgglj4rki1f1vw";
+    };
+  }
+  {
+    pname = "microsoft.bcl.asyncinterfaces";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/5.0.0/microsoft.bcl.asyncinterfaces.5.0.0.nupkg";
+      sha256 = "0cp5jbax2mf6xr3dqiljzlwi05fv6n9a35z337s92jcljiq674kf";
+    };
+  }
+  {
+    pname = "microsoft.build";
+    version = "16.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build/16.10.0/microsoft.build.16.10.0.nupkg";
+      sha256 = "1ran3fp016wvj8d2ahv0cmwhm6hjjh64w82s7cy52s7qffrgjk46";
+    };
+  }
+  {
+    pname = "microsoft.build.framework";
+    version = "16.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.framework/16.10.0/microsoft.build.framework.16.10.0.nupkg";
+      sha256 = "17a8qxgq0jzxpjannhxkcg0941b64yb7z0yq75gz6hsq9ln3agja";
+    };
+  }
+  {
+    pname = "microsoft.build.locator";
+    version = "1.4.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.locator/1.4.1/microsoft.build.locator.1.4.1.nupkg";
+      sha256 = "0j119rri7a401rca67cxdyrn3rprzdl1b2wrblqc23xsff1xvlrx";
+    };
+  }
+  {
+    pname = "microsoft.build.tasks.core";
+    version = "16.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.tasks.core/16.10.0/microsoft.build.tasks.core.16.10.0.nupkg";
+      sha256 = "0yc3p4bksxmbq1n8wfqgn6b6x9ccyzq229f0mn08z4jfima3cnxg";
+    };
+  }
+  {
+    pname = "microsoft.build.tasks.git";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.tasks.git/1.0.0/microsoft.build.tasks.git.1.0.0.nupkg";
+      sha256 = "0avwja8vk56f2kr2pmrqx3h60bnwbs7ds062lhvhcxv87m5yfqnj";
+    };
+  }
+  {
+    pname = "microsoft.build.utilities.core";
+    version = "16.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.utilities.core/16.10.0/microsoft.build.utilities.core.16.10.0.nupkg";
+      sha256 = "1rh3gzrz8mmzilvs33cxngv0a805nb47s615rvj4xk5igm384w14";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.analyzers";
+    version = "3.3.2";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.2/microsoft.codeanalysis.analyzers.3.3.2.nupkg";
+      sha256 = "162vb5894zxps0cf5n9gc08an7gwybzz87allx3lsszvllr9ldx4";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.analyzerutilities";
+    version = "3.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzerutilities/3.3.0/microsoft.codeanalysis.analyzerutilities.3.3.0.nupkg";
+      sha256 = "0b2xy6m3l1y6j2xc97cg5llia169jv4nszrrrqclh505gpw6qccz";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.common";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.common/4.0.0-6.21526.21/microsoft.codeanalysis.common.4.0.0-6.21526.21.nupkg";
+      sha256 = "0sv5hxadf9pbclssc9kq2cnvfkrnb0f2f4gmqhp2cy4xkr9fjn92";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.csharp";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp/4.0.0-6.21526.21/microsoft.codeanalysis.csharp.4.0.0-6.21526.21.nupkg";
+      sha256 = "0cgp6rjw0lj3hr19sg5xvb5g29amrnng6y23rzcv5knw7a6zavs7";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.csharp.features";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.features/4.0.0-6.21526.21/microsoft.codeanalysis.csharp.features.4.0.0-6.21526.21.nupkg";
+      sha256 = "1a8xhrc4g2xlhmangcj0hv9872fw3zv1bcq52b54vczm6aym39pj";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.csharp.scripting";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.scripting/4.0.0-6.21526.21/microsoft.codeanalysis.csharp.scripting.4.0.0-6.21526.21.nupkg";
+      sha256 = "1mlf75v2nabfi9hwx9q2d14mcxlz3n8gdkczpyvvyfh3f72pl4x3";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.csharp.workspaces";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.workspaces/4.0.0-6.21526.21/microsoft.codeanalysis.csharp.workspaces.4.0.0-6.21526.21.nupkg";
+      sha256 = "04r6crnqml1c8mabsfrjzxc6bq6ndc9wwqwy8zsal80gwa54yj3v";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.externalaccess.omnisharp";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.externalaccess.omnisharp/4.0.0-6.21526.21/microsoft.codeanalysis.externalaccess.omnisharp.4.0.0-6.21526.21.nupkg";
+      sha256 = "1f7wp5829wz8nrafqwlr74p3xgw86591cl2d9dnhs8cp9p6y5ah9";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.externalaccess.omnisharp.csharp";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.externalaccess.omnisharp.csharp/4.0.0-6.21526.21/microsoft.codeanalysis.externalaccess.omnisharp.csharp.4.0.0-6.21526.21.nupkg";
+      sha256 = "1mc9h0svsqdrmr8bk1zgvjn1awc06mwhsp34q8grcb6n1w641hsp";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.features";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.features/4.0.0-6.21526.21/microsoft.codeanalysis.features.4.0.0-6.21526.21.nupkg";
+      sha256 = "0bg93pzv89v0s74mn52ng4cz2ys2bk8z96b3ml06r9wa3piz08la";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.scripting.common";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.scripting.common/4.0.0-6.21526.21/microsoft.codeanalysis.scripting.common.4.0.0-6.21526.21.nupkg";
+      sha256 = "0s5h10zj2qyfs0a09agdba06vc09pcq2wamr7pf8dx415vkjswyj";
+    };
+  }
+  {
+    pname = "microsoft.codeanalysis.workspaces.common";
+    version = "4.0.0-6.21526.21";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.workspaces.common/4.0.0-6.21526.21/microsoft.codeanalysis.workspaces.common.4.0.0-6.21526.21.nupkg";
+      sha256 = "0kp2l72zpfydfqv5cm8wqvk86wpgh946j8sw9hvhm3xwzflchl7b";
+    };
+  }
+  {
+    pname = "microsoft.csharp";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.csharp/4.3.0/microsoft.csharp.4.3.0.nupkg";
+      sha256 = "0gw297dgkh0al1zxvgvncqs0j15lsna9l1wpqas4rflmys440xvb";
+    };
+  }
+  {
+    pname = "microsoft.diasymreader";
+    version = "1.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.diasymreader/1.3.0/microsoft.diasymreader.1.3.0.nupkg";
+      sha256 = "1nswah83z3pfibaqmjd8y96fgnkrak8005qqinc8nqs5mpkf5pfb";
+    };
+  }
+  {
+    pname = "microsoft.dotnet.platformabstractions";
+    version = "3.1.6";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.dotnet.platformabstractions/3.1.6/microsoft.dotnet.platformabstractions.3.1.6.nupkg";
+      sha256 = "0b9myd7gqbpaw9pkd2bx45jhik9mwj0f1ss57sk2cxmag2lkdws5";
+    };
+  }
+  {
+    pname = "microsoft.extensions.caching.abstractions";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/5.0.0/microsoft.extensions.caching.abstractions.5.0.0.nupkg";
+      sha256 = "0j83zapqhgqb4v5f6kn891km095pfhvsqha357a86ccclmv2czvb";
+    };
+  }
+  {
+    pname = "microsoft.extensions.caching.memory";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/5.0.0/microsoft.extensions.caching.memory.5.0.0.nupkg";
+      sha256 = "0l8spndl3kvccjlay202msm31iy5iig0i9ddbsdy92wbcjr97lca";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/2.0.0/microsoft.extensions.configuration.2.0.0.nupkg";
+      sha256 = "0yssxq9di5h6xw2cayp5hj3l9b2p0jw9wcjz73rwk4586spac9s9";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/5.0.0/microsoft.extensions.configuration.5.0.0.nupkg";
+      sha256 = "01m9vzlq0vg0lhckj2dimwq42niwny8g3lm13c9a401hlyg90z1p";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.abstractions";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/2.0.0/microsoft.extensions.configuration.abstractions.2.0.0.nupkg";
+      sha256 = "1ilz2yrgg9rbjyhn6a5zh9pr51nmh11z7sixb4p7vivgydj9gxwf";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.abstractions";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/5.0.0/microsoft.extensions.configuration.abstractions.5.0.0.nupkg";
+      sha256 = "0fqxkc9pjxkqylsdf26s9q21ciyk56h1w33pz3v1v4wcv8yv1v6k";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.binder";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/2.0.0/microsoft.extensions.configuration.binder.2.0.0.nupkg";
+      sha256 = "1prvdbma6r18n5agbhhabv6g357p1j70gq4m9g0vs859kf44nrgc";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.binder";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/5.0.0/microsoft.extensions.configuration.binder.5.0.0.nupkg";
+      sha256 = "0sld0bh2k5kss32i3nf8mwqkjagmw0d1cdfmxm87ckiicwm413a0";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.commandline";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.commandline/5.0.0/microsoft.extensions.configuration.commandline.5.0.0.nupkg";
+      sha256 = "084hnz5l0vr15ay23rksqipslqnz3pp30w9hsirpx1iqdm5688mc";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.environmentvariables";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.environmentvariables/5.0.0/microsoft.extensions.configuration.environmentvariables.5.0.0.nupkg";
+      sha256 = "03gvckj10ljk1mir9g8cf3cajsnihhvmh8z8341gkr9h5653qkv0";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.fileextensions";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.fileextensions/5.0.0/microsoft.extensions.configuration.fileextensions.5.0.0.nupkg";
+      sha256 = "1wq229r3xcmm9wh9sqdpvmfv4qpbp2zms9x6xk7g7sbb8h32hnz3";
+    };
+  }
+  {
+    pname = "microsoft.extensions.configuration.json";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.json/5.0.0/microsoft.extensions.configuration.json.5.0.0.nupkg";
+      sha256 = "0hq5i483bjbvprp1la9l3si82x1ydxbvkpfc7r3s7zgxg957fyp9";
+    };
+  }
+  {
+    pname = "microsoft.extensions.dependencyinjection";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/2.0.0/microsoft.extensions.dependencyinjection.2.0.0.nupkg";
+      sha256 = "018izzgykaqcliwarijapgki9kp2c560qv8qsxdjywr7byws5apq";
+    };
+  }
+  {
+    pname = "microsoft.extensions.dependencyinjection";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/5.0.0/microsoft.extensions.dependencyinjection.5.0.0.nupkg";
+      sha256 = "15sdwcyzz0qlybwbdq854bn3jk6kx7awx28gs864c4shhbqkppj4";
+    };
+  }
+  {
+    pname = "microsoft.extensions.dependencyinjection.abstractions";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/2.0.0/microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg";
+      sha256 = "1pwrfh9b72k9rq6mb2jab5qhhi225d5rjalzkapiayggmygc8nhz";
+    };
+  }
+  {
+    pname = "microsoft.extensions.dependencyinjection.abstractions";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/5.0.0/microsoft.extensions.dependencyinjection.abstractions.5.0.0.nupkg";
+      sha256 = "17cz6s80va0ch0a6nqa1wbbbp3p8sqxb96lj4qcw67ivkp2yxiyj";
+    };
+  }
+  {
+    pname = "microsoft.extensions.dependencymodel";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/5.0.0/microsoft.extensions.dependencymodel.5.0.0.nupkg";
+      sha256 = "1mma1zxi0b40972cwfvkj9y0w9r7vjbi74784jzcb22pric00k5x";
+    };
+  }
+  {
+    pname = "microsoft.extensions.fileproviders.abstractions";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.abstractions/5.0.0/microsoft.extensions.fileproviders.abstractions.5.0.0.nupkg";
+      sha256 = "01ahgd0b2z2zycrr2lcsq2cl59fn04bh51hdwdp9dcsdkpvnasj1";
+    };
+  }
+  {
+    pname = "microsoft.extensions.fileproviders.physical";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.physical/5.0.0/microsoft.extensions.fileproviders.physical.5.0.0.nupkg";
+      sha256 = "00vii8148a6pk12l9jl0rhjp7apil5q5qcy7v1smnv17lj4p8szd";
+    };
+  }
+  {
+    pname = "microsoft.extensions.filesystemglobbing";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.filesystemglobbing/5.0.0/microsoft.extensions.filesystemglobbing.5.0.0.nupkg";
+      sha256 = "0lm6n9vbyjh0l17qcc2y9qwn1cns3dyjmkvbxjp0g9sll32kjpmb";
+    };
+  }
+  {
+    pname = "microsoft.extensions.logging";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/2.0.0/microsoft.extensions.logging.2.0.0.nupkg";
+      sha256 = "1jkwjcq1ld9znz1haazk8ili2g4pzfdp6i7r7rki4hg3jcadn386";
+    };
+  }
+  {
+    pname = "microsoft.extensions.logging";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/5.0.0/microsoft.extensions.logging.5.0.0.nupkg";
+      sha256 = "1qa1l18q2jh9azya8gv1p8anzcdirjzd9dxxisb4911i9m1648i3";
+    };
+  }
+  {
+    pname = "microsoft.extensions.logging.abstractions";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/2.0.0/microsoft.extensions.logging.abstractions.2.0.0.nupkg";
+      sha256 = "1x5isi71z02khikzvm7vaschb006pqqrsv86ky1x08a4hir4s43h";
+    };
+  }
+  {
+    pname = "microsoft.extensions.logging.abstractions";
+    version = "2.1.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/2.1.1/microsoft.extensions.logging.abstractions.2.1.1.nupkg";
+      sha256 = "1sgpwj0sa0ac7m5fnkb482mnch8fsv8hfbvk53c6lyh47s1xhdjg";
+    };
+  }
+  {
+    pname = "microsoft.extensions.logging.abstractions";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/5.0.0/microsoft.extensions.logging.abstractions.5.0.0.nupkg";
+      sha256 = "1yza38675dbv1qqnnhqm23alv2bbaqxp0pb7zinjmw8j2mr5r6wc";
+    };
+  }
+  {
+    pname = "microsoft.extensions.logging.configuration";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.configuration/5.0.0/microsoft.extensions.logging.configuration.5.0.0.nupkg";
+      sha256 = "1kmjax24w0ph362jr64rr6f8pyn6ayq39k502q9yrgr7zgrv65pa";
+    };
+  }
+  {
+    pname = "microsoft.extensions.logging.console";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.console/5.0.0/microsoft.extensions.logging.console.5.0.0.nupkg";
+      sha256 = "162akclrhk5r62fza8yr30p5824inwmrpq2s510c3a64v76v9cqz";
+    };
+  }
+  {
+    pname = "microsoft.extensions.options";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/2.0.0/microsoft.extensions.options.2.0.0.nupkg";
+      sha256 = "0g4zadlg73f507krilhaaa7h0jdga216syrzjlyf5fdk25gxmjqh";
+    };
+  }
+  {
+    pname = "microsoft.extensions.options";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/5.0.0/microsoft.extensions.options.5.0.0.nupkg";
+      sha256 = "1rdmgpg770x8qwaaa6ryc27zh93p697fcyvn5vkxp0wimlhqkbay";
+    };
+  }
+  {
+    pname = "microsoft.extensions.options.configurationextensions";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options.configurationextensions/2.0.0/microsoft.extensions.options.configurationextensions.2.0.0.nupkg";
+      sha256 = "1isc3rjbzz60f7wbmgcwslx5d10hm5hisnk7v54vfi2bz7132gll";
+    };
+  }
+  {
+    pname = "microsoft.extensions.options.configurationextensions";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options.configurationextensions/5.0.0/microsoft.extensions.options.configurationextensions.5.0.0.nupkg";
+      sha256 = "1085yrfgc70am43v8i5rxh14kal3bhdd5q85vgny5qp7y1rw0xyw";
+    };
+  }
+  {
+    pname = "microsoft.extensions.primitives";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/2.0.0/microsoft.extensions.primitives.2.0.0.nupkg";
+      sha256 = "1xppr5jbny04slyjgngxjdm0maxdh47vq481ps944d7jrfs0p3mb";
+    };
+  }
+  {
+    pname = "microsoft.extensions.primitives";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/5.0.0/microsoft.extensions.primitives.5.0.0.nupkg";
+      sha256 = "0swqcknyh87ns82w539z1mvy804pfwhgzs97cr3nwqk6g5s42gd6";
+    };
+  }
+  {
+    pname = "microsoft.netcore.app.ref";
+    version = "3.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.ref/3.1.0/microsoft.netcore.app.ref.3.1.0.nupkg";
+      sha256 = "08svsiilx9spvjamcnjswv0dlpdrgryhr3asdz7cvnl914gjzq4y";
+    };
+  }
+  {
+    pname = "microsoft.netcore.platforms";
+    version = "1.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.0.1/microsoft.netcore.platforms.1.0.1.nupkg";
+      sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
+    };
+  }
+  {
+    pname = "microsoft.netcore.platforms";
+    version = "1.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg";
+      sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
+    };
+  }
+  {
+    pname = "microsoft.netcore.platforms";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.0.0/microsoft.netcore.platforms.2.0.0.nupkg";
+      sha256 = "1fk2fk2639i7nzy58m9dvpdnzql4vb8yl8vr19r2fp8lmj9w2jr0";
+    };
+  }
+  {
+    pname = "microsoft.netcore.platforms";
+    version = "2.1.2";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.1.2/microsoft.netcore.platforms.2.1.2.nupkg";
+      sha256 = "1507hnpr9my3z4w1r6xk5n0s1j3y6a2c2cnynj76za7cphxi1141";
+    };
+  }
+  {
+    pname = "microsoft.netcore.platforms";
+    version = "3.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/3.1.0/microsoft.netcore.platforms.3.1.0.nupkg";
+      sha256 = "1gc1x8f95wk8yhgznkwsg80adk1lc65v9n5rx4yaa4bc5dva0z3j";
+    };
+  }
+  {
+    pname = "microsoft.netcore.targets";
+    version = "1.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg";
+      sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
+    };
+  }
+  {
+    pname = "microsoft.netcore.targets";
+    version = "1.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg";
+      sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
+    };
+  }
+  {
+    pname = "microsoft.netframework.referenceassemblies";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netframework.referenceassemblies/1.0.0/microsoft.netframework.referenceassemblies.1.0.0.nupkg";
+      sha256 = "0na724xhvqm63vq9y18fl9jw9q2v99bdwr353378s5fsi11qzxp9";
+    };
+  }
+  {
+    pname = "microsoft.netframework.referenceassemblies.net472";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netframework.referenceassemblies.net472/1.0.0/microsoft.netframework.referenceassemblies.net472.1.0.0.nupkg";
+      sha256 = "1bqinq2nxnpqxziypg1sqy3ly0nymxxjpn8fwkn3rl4vl6gdg3rc";
+    };
+  }
+  {
+    pname = "microsoft.net.stringtools";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.net.stringtools/1.0.0/microsoft.net.stringtools.1.0.0.nupkg";
+      sha256 = "06yakiyzgss399giivfx6xdrnfxqfsvy5fzm90scjanvandv0sdj";
+    };
+  }
+  {
+    pname = "microsoft.sourcelink.common";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.sourcelink.common/1.0.0/microsoft.sourcelink.common.1.0.0.nupkg";
+      sha256 = "1zxkpx01zdv17c39iiy8fx25ran89n14qwddh1f140v1s4dn8z9c";
+    };
+  }
+  {
+    pname = "microsoft.sourcelink.github";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.sourcelink.github/1.0.0/microsoft.sourcelink.github.1.0.0.nupkg";
+      sha256 = "029ixyaqn48cjza87m5qf0g1ynyhlm6irgbx1n09src9g666yhpd";
+    };
+  }
+  {
+    pname = "microsoft.testplatform.objectmodel";
+    version = "16.9.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.testplatform.objectmodel/16.9.4/microsoft.testplatform.objectmodel.16.9.4.nupkg";
+      sha256 = "1jizkbrnm4pv60zch29ki7gj8m7j5whk141x9cwx4kwsd6cfzwi6";
+    };
+  }
+  {
+    pname = "microsoft.testplatform.translationlayer";
+    version = "16.9.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.testplatform.translationlayer/16.9.4/microsoft.testplatform.translationlayer.16.9.4.nupkg";
+      sha256 = "0y5w2zflvq06jim2i6d49qi45ix0b8vlyf024w29n5g1lb570qf0";
+    };
+  }
+  {
+    pname = "microsoft.visualstudio.sdk.embedinteroptypes";
+    version = "15.0.12";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.sdk.embedinteroptypes/15.0.12/microsoft.visualstudio.sdk.embedinteroptypes.15.0.12.nupkg";
+      sha256 = "083pva0a0xxvqqrjv75if25wr3rq034wgjhbax74zhzdb665nzsw";
+    };
+  }
+  {
+    pname = "microsoft.visualstudio.setup.configuration.interop";
+    version = "1.14.114";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.setup.configuration.interop/1.14.114/microsoft.visualstudio.setup.configuration.interop.1.14.114.nupkg";
+      sha256 = "062mqkmjf4k6zm3wi9ih0lzypfsnv82lgh88r35fj66akihn86gv";
+    };
+  }
+  {
+    pname = "microsoft.visualstudio.setup.configuration.interop";
+    version = "1.16.30";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.setup.configuration.interop/1.16.30/microsoft.visualstudio.setup.configuration.interop.1.16.30.nupkg";
+      sha256 = "14022lx03vdcqlvbbdmbsxg5pqfx1rfq2jywxlyaz9v68cvsb0g4";
+    };
+  }
+  {
+    pname = "microsoft.visualstudio.threading";
+    version = "16.7.56";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.threading/16.7.56/microsoft.visualstudio.threading.16.7.56.nupkg";
+      sha256 = "13x0xrsjxd86clf9cjjwmpzlyp8pkrf13riya7igs8zy93zw2qap";
+    };
+  }
+  {
+    pname = "microsoft.visualstudio.threading.analyzers";
+    version = "16.7.56";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.threading.analyzers/16.7.56/microsoft.visualstudio.threading.analyzers.16.7.56.nupkg";
+      sha256 = "04v9df0k7bsc0rzgkw4mnvi43pdrh42vk6xdcwn9m6im33m0nnz2";
+    };
+  }
+  {
+    pname = "microsoft.visualstudio.validation";
+    version = "15.5.31";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.validation/15.5.31/microsoft.visualstudio.validation.15.5.31.nupkg";
+      sha256 = "1ah99rn922qa0sd2k3h64m324f2r32pw8cn4cfihgvwx4qdrpmgw";
+    };
+  }
+  {
+    pname = "microsoft.win32.primitives";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg";
+      sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+    };
+  }
+  {
+    pname = "microsoft.win32.registry";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/4.3.0/microsoft.win32.registry.4.3.0.nupkg";
+      sha256 = "1gxyzxam8163vk1kb6xzxjj4iwspjsz9zhgn1w9rjzciphaz0ig7";
+    };
+  }
+  {
+    pname = "microsoft.win32.registry";
+    version = "4.6.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/4.6.0/microsoft.win32.registry.4.6.0.nupkg";
+      sha256 = "0i4y782yrqqyx85pg597m20gm0v126w0j9ddk5z7xb3crx4z9f2s";
+    };
+  }
+  {
+    pname = "microsoft.win32.systemevents";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.7.0/microsoft.win32.systemevents.4.7.0.nupkg";
+      sha256 = "0pjll2a62hc576hd4wgyasva0lp733yllmk54n37svz5ac7nfz0q";
+    };
+  }
+  {
+    pname = "nerdbank.streams";
+    version = "2.6.81";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nerdbank.streams/2.6.81/nerdbank.streams.2.6.81.nupkg";
+      sha256 = "06wihcaga8537ibh0mkj28m720m6vzkqk562zkynhca85nd236yi";
+    };
+  }
+  {
+    pname = "netstandard.library";
+    version = "1.6.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/netstandard.library/1.6.1/netstandard.library.1.6.1.nupkg";
+      sha256 = "1z70wvsx2d847a2cjfii7b83pjfs34q05gb037fdjikv5kbagml8";
+    };
+  }
+  {
+    pname = "netstandard.library";
+    version = "2.0.3";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/netstandard.library/2.0.3/netstandard.library.2.0.3.nupkg";
+      sha256 = "1fn9fxppfcg4jgypp2pmrpr6awl3qz1xmnri0cygpkwvyx27df1y";
+    };
+  }
+  {
+    pname = "newtonsoft.json";
+    version = "11.0.2";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/11.0.2/newtonsoft.json.11.0.2.nupkg";
+      sha256 = "1784xi44f4k8v1fr696hsccmwpy94bz7kixxqlri98zhcxn406b2";
+    };
+  }
+  {
+    pname = "newtonsoft.json";
+    version = "12.0.3";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg";
+      sha256 = "17dzl305d835mzign8r15vkmav2hq8l6g7942dfjpnzr17wwl89x";
+    };
+  }
+  {
+    pname = "newtonsoft.json";
+    version = "9.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/9.0.1/newtonsoft.json.9.0.1.nupkg";
+      sha256 = "0mcy0i7pnfpqm4pcaiyzzji4g0c8i3a5gjz28rrr28110np8304r";
+    };
+  }
+  {
+    pname = "nuget.common";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.common/5.10.0/nuget.common.5.10.0.nupkg";
+      sha256 = "0qy6blgppgvxpfcricmvva3qzddk18dza5vy851jrbqshvf9g7kx";
+    };
+  }
+  {
+    pname = "nuget.common";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.common/5.2.0/nuget.common.5.2.0.nupkg";
+      sha256 = "14y7axpmdl9fg8jfc42gxpcq9wj8k3vzc07npmgjnzqlp5xjyyac";
+    };
+  }
+  {
+    pname = "nuget.configuration";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.configuration/5.10.0/nuget.configuration.5.10.0.nupkg";
+      sha256 = "0xb1n94lrwa6k83i9xcsq68202086p2gj74gzlbhlvb8c2pw6lbb";
+    };
+  }
+  {
+    pname = "nuget.configuration";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.configuration/5.2.0/nuget.configuration.5.2.0.nupkg";
+      sha256 = "0b4dkym3vnj7qldnqqq6h6ry0gkql5c2ps5wy72b8s4fc3dmnvf1";
+    };
+  }
+  {
+    pname = "nuget.dependencyresolver.core";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.dependencyresolver.core/5.10.0/nuget.dependencyresolver.core.5.10.0.nupkg";
+      sha256 = "0dhhclm281ihpfsjzxw34l6zlw49nwzyjiynkmsbcj9icfkp3y4r";
+    };
+  }
+  {
+    pname = "nuget.dependencyresolver.core";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.dependencyresolver.core/5.2.0/nuget.dependencyresolver.core.5.2.0.nupkg";
+      sha256 = "156yjfsk9pzqviiwy69lxfqf61yyj4hn4vdgfcbqvw4d567i150r";
+    };
+  }
+  {
+    pname = "nuget.frameworks";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.frameworks/5.0.0/nuget.frameworks.5.0.0.nupkg";
+      sha256 = "18ijvmj13cwjdrrm52c8fpq021531zaz4mj4b4zapxaqzzxf2qjr";
+    };
+  }
+  {
+    pname = "nuget.frameworks";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.frameworks/5.10.0/nuget.frameworks.5.10.0.nupkg";
+      sha256 = "0gb6n8rg2jpjp52icgpb3wjdfs3qllh5vbcz8hbcix3l7dncy3v2";
+    };
+  }
+  {
+    pname = "nuget.frameworks";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.frameworks/5.2.0/nuget.frameworks.5.2.0.nupkg";
+      sha256 = "1fh4rp26m77jq5dyln68wz9qm217la9vv21amis2qvcy6gknk2wp";
+    };
+  }
+  {
+    pname = "nuget.librarymodel";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.librarymodel/5.10.0/nuget.librarymodel.5.10.0.nupkg";
+      sha256 = "0b6mmq2mqfr06ypc772dmcd8bz55gkyfrgn0j3nrgkcdww4fzf9q";
+    };
+  }
+  {
+    pname = "nuget.librarymodel";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.librarymodel/5.2.0/nuget.librarymodel.5.2.0.nupkg";
+      sha256 = "0vxd0y7rzzxvmxji9bzp95p2rx48303r3nqrlhmhhfc4z5fxjlqk";
+    };
+  }
+  {
+    pname = "nuget.packaging";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.packaging/5.10.0/nuget.packaging.5.10.0.nupkg";
+      sha256 = "11g0v061axhp0nisclq5cm2mc92d69z92giz9l40ih478c5nishw";
+    };
+  }
+  {
+    pname = "nuget.packaging";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.packaging/5.2.0/nuget.packaging.5.2.0.nupkg";
+      sha256 = "14frrbdkka9jd6g52bv4lbqnpckw09yynr08f9kfgbc3j8pklqqb";
+    };
+  }
+  {
+    pname = "nuget.packaging.core";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.packaging.core/5.10.0/nuget.packaging.core.5.10.0.nupkg";
+      sha256 = "1frxwwl583qwsj84rjgvd7il6icgxzxxps6yng75qx8ppf99dsr6";
+    };
+  }
+  {
+    pname = "nuget.projectmodel";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.projectmodel/5.10.0/nuget.projectmodel.5.10.0.nupkg";
+      sha256 = "1cqg319n986wciskrqsfawfhqp1d7a7i2qjd0qplpckyw8msng2i";
+    };
+  }
+  {
+    pname = "nuget.projectmodel";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.projectmodel/5.2.0/nuget.projectmodel.5.2.0.nupkg";
+      sha256 = "1j23jk2zql52v2nqgi0k6d7z63pjjzrvw8y1s38zpf0sn7lzdr0h";
+    };
+  }
+  {
+    pname = "nuget.protocol";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.protocol/5.10.0/nuget.protocol.5.10.0.nupkg";
+      sha256 = "0cs9qp169zx6g2w5bzrlhxv0q1i8mb8dxlb2nkiq7pkvah86rxkc";
+    };
+  }
+  {
+    pname = "nuget.protocol";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.protocol/5.2.0/nuget.protocol.5.2.0.nupkg";
+      sha256 = "1vlrrlcy7p2sf23wqax8mfhplnzppd73xqlr2g83ya056w0yf2rd";
+    };
+  }
+  {
+    pname = "nuget.versioning";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.versioning/5.10.0/nuget.versioning.5.10.0.nupkg";
+      sha256 = "10vvw6vjpx0c26rlxh7dnpyp4prahn25717ccd8bzkjmyzhm90cs";
+    };
+  }
+  {
+    pname = "nuget.versioning";
+    version = "5.2.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.versioning/5.2.0/nuget.versioning.5.2.0.nupkg";
+      sha256 = "08ay8bhddj9yiq6h9lk814l65fpx5gh1iprkl7pcp78g57a6k45k";
+    };
+  }
+  {
+    pname = "omnisharp.extensions.jsonrpc";
+    version = "0.19.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/omnisharp.extensions.jsonrpc/0.19.0/omnisharp.extensions.jsonrpc.0.19.0.nupkg";
+      sha256 = "0m9lw21iz90ayl35f24ir3vbiydf4sjqw590qqgwknykpzsi1ai2";
+    };
+  }
+  {
+    pname = "omnisharp.extensions.jsonrpc.generators";
+    version = "0.19.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/omnisharp.extensions.jsonrpc.generators/0.19.0/omnisharp.extensions.jsonrpc.generators.0.19.0.nupkg";
+      sha256 = "17akjdh9dnyxr01lnlsa41ca52psqnny8j3wxz904zs15pz932ln";
+    };
+  }
+  {
+    pname = "omnisharp.extensions.languageprotocol";
+    version = "0.19.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/omnisharp.extensions.languageprotocol/0.19.0/omnisharp.extensions.languageprotocol.0.19.0.nupkg";
+      sha256 = "06d4wakdaj42c9qnlhdyqrjnm97azp4hrvfg70f96ldl765y9vrf";
+    };
+  }
+  {
+    pname = "omnisharp.extensions.languageserver";
+    version = "0.19.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/omnisharp.extensions.languageserver/0.19.0/omnisharp.extensions.languageserver.0.19.0.nupkg";
+      sha256 = "0k1z3zchl1d82fj0ha63i54g5j046iaz8vb3cyxpjb6kp7zah28v";
+    };
+  }
+  {
+    pname = "omnisharp.extensions.languageserver.shared";
+    version = "0.19.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/omnisharp.extensions.languageserver.shared/0.19.0/omnisharp.extensions.languageserver.shared.0.19.0.nupkg";
+      sha256 = "0s3h9v5p043ip27g9jcvd0np9q3hn2pfv6gn539m45yb5d74a6i5";
+    };
+  }
+  {
+    pname = "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
+    };
+  }
+  {
+    pname = "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
+    };
+  }
+  {
+    pname = "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
+    };
+  }
+  {
+    pname = "runtime.native.system";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg";
+      sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
+    };
+  }
+  {
+    pname = "runtime.native.system.io.compression";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.native.system.io.compression/4.3.0/runtime.native.system.io.compression.4.3.0.nupkg";
+      sha256 = "1vvivbqsk6y4hzcid27pqpm5bsi6sc50hvqwbcx8aap5ifrxfs8d";
+    };
+  }
+  {
+    pname = "runtime.native.system.net.http";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg";
+      sha256 = "1n6rgz5132lcibbch1qlf0g9jk60r0kqv087hxc0lisy50zpm7kk";
+    };
+  }
+  {
+    pname = "runtime.native.system.security.cryptography.apple";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg";
+      sha256 = "1b61p6gw1m02cc1ry996fl49liiwky6181dzr873g9ds92zl326q";
+    };
+  }
+  {
+    pname = "runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.0/runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
+    };
+  }
+  {
+    pname = "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
+    };
+  }
+  {
+    pname = "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
+    };
+  }
+  {
+    pname = "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg";
+      sha256 = "10yc8jdrwgcl44b4g93f1ds76b176bajd3zqi2faf5rvh1vy9smi";
+    };
+  }
+  {
+    pname = "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
+    };
+  }
+  {
+    pname = "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
+    };
+  }
+  {
+    pname = "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
+    };
+  }
+  {
+    pname = "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
+    };
+  }
+  {
+    pname = "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
+    };
+  }
+  {
+    pname = "sqlitepclraw.bundle_green";
+    version = "2.0.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.bundle_green/2.0.4/sqlitepclraw.bundle_green.2.0.4.nupkg";
+      sha256 = "1197ynpm4fl6il9vi0mi1s1pmw3rk3j0a05kwrxpqlfgp7iwhc22";
+    };
+  }
+  {
+    pname = "sqlitepclraw.core";
+    version = "2.0.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.core/2.0.4/sqlitepclraw.core.2.0.4.nupkg";
+      sha256 = "0lb5vwfl1hd24xzzdaj2p4k2hv2k0i3mgdri6fjj0ssb37mcyir1";
+    };
+  }
+  {
+    pname = "sqlitepclraw.lib.e_sqlite3";
+    version = "2.0.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.lib.e_sqlite3/2.0.4/sqlitepclraw.lib.e_sqlite3.2.0.4.nupkg";
+      sha256 = "0kmx1w5qllmwxldr8338qxwmpfzc6g2lmyrah7wfaxd3mvfzky5c";
+    };
+  }
+  {
+    pname = "sqlitepclraw.provider.dynamic_cdecl";
+    version = "2.0.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.provider.dynamic_cdecl/2.0.4/sqlitepclraw.provider.dynamic_cdecl.2.0.4.nupkg";
+      sha256 = "084r98kilpm0q1aw41idq8slncpd7cz65g0m1wr0p8d12x8z5g6j";
+    };
+  }
+  {
+    pname = "sqlitepclraw.provider.e_sqlite3";
+    version = "2.0.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.provider.e_sqlite3/2.0.4/sqlitepclraw.provider.e_sqlite3.2.0.4.nupkg";
+      sha256 = "1vm8w8xvqi11sihdz5s6y4w7ghq4pp5f2ksixdhlbycvs6m4h7i7";
+    };
+  }
+  {
+    pname = "system.appcontext";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.appcontext/4.3.0/system.appcontext.4.3.0.nupkg";
+      sha256 = "1649qvy3dar900z3g817h17nl8jp4ka5vcfmsr05kh0fshn7j3ya";
+    };
+  }
+  {
+    pname = "system.buffers";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg";
+      sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
+    };
+  }
+  {
+    pname = "system.buffers";
+    version = "4.4.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.buffers/4.4.0/system.buffers.4.4.0.nupkg";
+      sha256 = "183f8063w8zqn99pv0ni0nnwh7fgx46qzxamwnans55hhs2l0g19";
+    };
+  }
+  {
+    pname = "system.buffers";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.buffers/4.5.0/system.buffers.4.5.0.nupkg";
+      sha256 = "1ywfqn4md6g3iilpxjn5dsr0f5lx6z0yvhqp4pgjcamygg73cz2c";
+    };
+  }
+  {
+    pname = "system.buffers";
+    version = "4.5.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.buffers/4.5.1/system.buffers.4.5.1.nupkg";
+      sha256 = "04kb1mdrlcixj9zh1xdi5as0k0qi8byr5mi3p3jcxx72qz93s2y3";
+    };
+  }
+  {
+    pname = "system.codedom";
+    version = "4.4.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.codedom/4.4.0/system.codedom.4.4.0.nupkg";
+      sha256 = "1zgbafm5p380r50ap5iddp11kzhr9khrf2pnai6k593wjar74p1g";
+    };
+  }
+  {
+    pname = "system.collections";
+    version = "4.0.11";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.collections/4.0.11/system.collections.4.0.11.nupkg";
+      sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
+    };
+  }
+  {
+    pname = "system.collections";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg";
+      sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
+    };
+  }
+  {
+    pname = "system.collections.concurrent";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg";
+      sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
+    };
+  }
+  {
+    pname = "system.collections.immutable";
+    version = "1.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg";
+      sha256 = "1d5gjn5afnrf461jlxzawcvihz195gayqpcfbv6dd7pxa9ialn06";
+    };
+  }
+  {
+    pname = "system.collections.immutable";
+    version = "1.7.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.7.1/system.collections.immutable.1.7.1.nupkg";
+      sha256 = "1nh4nlxfc7lbnbl86wwk1a3jwl6myz5j6hvgh5sp4krim9901hsq";
+    };
+  }
+  {
+    pname = "system.collections.immutable";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/5.0.0/system.collections.immutable.5.0.0.nupkg";
+      sha256 = "1kvcllagxz2q92g81zkz81djkn2lid25ayjfgjalncyc68i15p0r";
+    };
+  }
+  {
+    pname = "system.componentmodel.composition";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.componentmodel.composition/4.5.0/system.componentmodel.composition.4.5.0.nupkg";
+      sha256 = "196ihd17in5idnxq5l5xvpa1fhqamnihjg3mcmv1k4n8bjrrj5y7";
+    };
+  }
+  {
+    pname = "system.composition";
+    version = "1.0.31";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.composition/1.0.31/system.composition.1.0.31.nupkg";
+      sha256 = "0aa27jz73qb0xm6dyxv22qhfrmyyqjyn2dvvsd9asi82lcdh9i61";
+    };
+  }
+  {
+    pname = "system.composition.attributedmodel";
+    version = "1.0.31";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.composition.attributedmodel/1.0.31/system.composition.attributedmodel.1.0.31.nupkg";
+      sha256 = "1ipyb86hvw754kmk47vjmzyilvj5hymg9nqabz70sbgsz1fygrdv";
+    };
+  }
+  {
+    pname = "system.composition.convention";
+    version = "1.0.31";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.composition.convention/1.0.31/system.composition.convention.1.0.31.nupkg";
+      sha256 = "00gqcdrql7vhynxh4xq0s9j5nw27kghmn2n773v7lhzjh3ash18r";
+    };
+  }
+  {
+    pname = "system.composition.hosting";
+    version = "1.0.31";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.composition.hosting/1.0.31/system.composition.hosting.1.0.31.nupkg";
+      sha256 = "1f1bnk3j7ndx9r7zpzibmrhw78clys1pspl20j2dhnmkiwhl23vy";
+    };
+  }
+  {
+    pname = "system.composition.runtime";
+    version = "1.0.31";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.composition.runtime/1.0.31/system.composition.runtime.1.0.31.nupkg";
+      sha256 = "1shfybfzsn4g6aim4pggb5ha31g0fz2kkk0519c4vj6m166g39ws";
+    };
+  }
+  {
+    pname = "system.composition.typedparts";
+    version = "1.0.31";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.composition.typedparts/1.0.31/system.composition.typedparts.1.0.31.nupkg";
+      sha256 = "1m4j19zx50lbbdx1xxbgpsd1dai2r3kzkyapw47kdvkb89qjkl63";
+    };
+  }
+  {
+    pname = "system.configuration.configurationmanager";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.configuration.configurationmanager/4.7.0/system.configuration.configurationmanager.4.7.0.nupkg";
+      sha256 = "0pav0n21ghf2ax6fiwjbng29f27wkb4a2ddma0cqx04s97yyk25d";
+    };
+  }
+  {
+    pname = "system.console";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.console/4.3.0/system.console.4.3.0.nupkg";
+      sha256 = "1flr7a9x920mr5cjsqmsy9wgnv3lvd0h1g521pdr1lkb2qycy7ay";
+    };
+  }
+  {
+    pname = "system.diagnostics.debug";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg";
+      sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
+    };
+  }
+  {
+    pname = "system.diagnostics.diagnosticsource";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg";
+      sha256 = "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq";
+    };
+  }
+  {
+    pname = "system.diagnostics.diagnosticsource";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/5.0.0/system.diagnostics.diagnosticsource.5.0.0.nupkg";
+      sha256 = "0phd2qizshjvglhzws1jd0cq4m54gscz4ychzr3x6wbgl4vvfrga";
+    };
+  }
+  {
+    pname = "system.diagnostics.tools";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tools/4.3.0/system.diagnostics.tools.4.3.0.nupkg";
+      sha256 = "0in3pic3s2ddyibi8cvgl102zmvp9r9mchh82ns9f0ms4basylw1";
+    };
+  }
+  {
+    pname = "system.diagnostics.tracing";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg";
+      sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+    };
+  }
+  {
+    pname = "system.drawing.common";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.7.0/system.drawing.common.4.7.0.nupkg";
+      sha256 = "0yfw7cpl54mgfcylvlpvrl0c8r1b0zca6p7r3rcwkvqy23xqcyhg";
+    };
+  }
+  {
+    pname = "system.formats.asn1";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.formats.asn1/5.0.0/system.formats.asn1.5.0.0.nupkg";
+      sha256 = "1axc8z0839yvqi2cb63l73l6d9j6wd20lsbdymwddz9hvrsgfwpn";
+    };
+  }
+  {
+    pname = "system.globalization";
+    version = "4.0.11";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.globalization/4.0.11/system.globalization.4.0.11.nupkg";
+      sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
+    };
+  }
+  {
+    pname = "system.globalization";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg";
+      sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
+    };
+  }
+  {
+    pname = "system.globalization.calendars";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg";
+      sha256 = "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq";
+    };
+  }
+  {
+    pname = "system.globalization.extensions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg";
+      sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
+    };
+  }
+  {
+    pname = "system.io";
+    version = "4.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io/4.1.0/system.io.4.1.0.nupkg";
+      sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+    };
+  }
+  {
+    pname = "system.io";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg";
+      sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+    };
+  }
+  {
+    pname = "system.io.compression";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io.compression/4.3.0/system.io.compression.4.3.0.nupkg";
+      sha256 = "084zc82yi6yllgda0zkgl2ys48sypiswbiwrv7irb3r0ai1fp4vz";
+    };
+  }
+  {
+    pname = "system.io.compression.zipfile";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.4.3.0.nupkg";
+      sha256 = "1yxy5pq4dnsm9hlkg9ysh5f6bf3fahqqb6p8668ndy5c0lk7w2ar";
+    };
+  }
+  {
+    pname = "system.io.filesystem";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg";
+      sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+    };
+  }
+  {
+    pname = "system.io.filesystem.primitives";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg";
+      sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
+    };
+  }
+  {
+    pname = "system.io.pipelines";
+    version = "4.7.3";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/4.7.3/system.io.pipelines.4.7.3.nupkg";
+      sha256 = "0djp59x56klidi04xx8p5jc1nchv5zvd1d59diphqxwvgny3aawy";
+    };
+  }
+  {
+    pname = "system.io.pipelines";
+    version = "5.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/5.0.1/system.io.pipelines.5.0.1.nupkg";
+      sha256 = "1zvfcd2l1d5qxifsqd0cjyv57nr61a9ac2ca5jinyqmj32wgjd6v";
+    };
+  }
+  {
+    pname = "system.linq";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg";
+      sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
+    };
+  }
+  {
+    pname = "system.linq.expressions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.linq.expressions/4.3.0/system.linq.expressions.4.3.0.nupkg";
+      sha256 = "0ky2nrcvh70rqq88m9a5yqabsl4fyd17bpr63iy2mbivjs2nyypv";
+    };
+  }
+  {
+    pname = "system.memory";
+    version = "4.5.3";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg";
+      sha256 = "0naqahm3wljxb5a911d37mwjqjdxv9l0b49p5dmfyijvni2ppy8a";
+    };
+  }
+  {
+    pname = "system.memory";
+    version = "4.5.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.4/system.memory.4.5.4.nupkg";
+      sha256 = "14gbbs22mcxwggn0fcfs1b062521azb9fbb7c113x0mq6dzq9h6y";
+    };
+  }
+  {
+    pname = "system.net.http";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.0/system.net.http.4.3.0.nupkg";
+      sha256 = "1i4gc757xqrzflbk7kc5ksn20kwwfjhw9w7pgdkn19y3cgnl302j";
+    };
+  }
+  {
+    pname = "system.net.primitives";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg";
+      sha256 = "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii";
+    };
+  }
+  {
+    pname = "system.net.sockets";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.net.sockets/4.3.0/system.net.sockets.4.3.0.nupkg";
+      sha256 = "1ssa65k6chcgi6mfmzrznvqaxk8jp0gvl77xhf1hbzakjnpxspla";
+    };
+  }
+  {
+    pname = "system.net.websockets";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.net.websockets/4.3.0/system.net.websockets.4.3.0.nupkg";
+      sha256 = "1gfj800078kggcgl0xyl00a6y5k4wwh2k2qm69rjy22wbmq7fy4p";
+    };
+  }
+  {
+    pname = "system.numerics.vectors";
+    version = "4.4.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.4.0/system.numerics.vectors.4.4.0.nupkg";
+      sha256 = "0rdvma399070b0i46c4qq1h2yvjj3k013sqzkilz4bz5cwmx1rba";
+    };
+  }
+  {
+    pname = "system.numerics.vectors";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.5.0/system.numerics.vectors.4.5.0.nupkg";
+      sha256 = "1kzrj37yzawf1b19jq0253rcs8hsq1l2q8g69d7ipnhzb0h97m59";
+    };
+  }
+  {
+    pname = "system.objectmodel";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.objectmodel/4.3.0/system.objectmodel.4.3.0.nupkg";
+      sha256 = "191p63zy5rpqx7dnrb3h7prvgixmk168fhvvkkvhlazncf8r3nc2";
+    };
+  }
+  {
+    pname = "system.reactive";
+    version = "4.4.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reactive/4.4.1/system.reactive.4.4.1.nupkg";
+      sha256 = "0gx8jh3hny2y5kijz5k9pxiqw481d013787c04zlhps21ygklw4a";
+    };
+  }
+  {
+    pname = "system.reflection";
+    version = "4.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection/4.1.0/system.reflection.4.1.0.nupkg";
+      sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+    };
+  }
+  {
+    pname = "system.reflection";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg";
+      sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+    };
+  }
+  {
+    pname = "system.reflection.dispatchproxy";
+    version = "4.5.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.dispatchproxy/4.5.1/system.reflection.dispatchproxy.4.5.1.nupkg";
+      sha256 = "0cdnl4i9mfk7kx2ylglayqwqw7kl5k1xr8siaxch45hfyc2cpds8";
+    };
+  }
+  {
+    pname = "system.reflection.emit";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.3.0/system.reflection.emit.4.3.0.nupkg";
+      sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
+    };
+  }
+  {
+    pname = "system.reflection.emit.ilgeneration";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.ilgeneration/4.3.0/system.reflection.emit.ilgeneration.4.3.0.nupkg";
+      sha256 = "0w1n67glpv8241vnpz1kl14sy7zlnw414aqwj4hcx5nd86f6994q";
+    };
+  }
+  {
+    pname = "system.reflection.emit.lightweight";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.lightweight/4.3.0/system.reflection.emit.lightweight.4.3.0.nupkg";
+      sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
+    };
+  }
+  {
+    pname = "system.reflection.extensions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.extensions/4.3.0/system.reflection.extensions.4.3.0.nupkg";
+      sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
+    };
+  }
+  {
+    pname = "system.reflection.metadata";
+    version = "1.6.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/1.6.0/system.reflection.metadata.1.6.0.nupkg";
+      sha256 = "1wdbavrrkajy7qbdblpbpbalbdl48q3h34cchz24gvdgyrlf15r4";
+    };
+  }
+  {
+    pname = "system.reflection.metadata";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/5.0.0/system.reflection.metadata.5.0.0.nupkg";
+      sha256 = "17qsl5nanlqk9iz0l5wijdn6ka632fs1m1fvx18dfgswm258r3ss";
+    };
+  }
+  {
+    pname = "system.reflection.primitives";
+    version = "4.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.0.1/system.reflection.primitives.4.0.1.nupkg";
+      sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
+    };
+  }
+  {
+    pname = "system.reflection.primitives";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg";
+      sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
+    };
+  }
+  {
+    pname = "system.reflection.typeextensions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.reflection.typeextensions/4.3.0/system.reflection.typeextensions.4.3.0.nupkg";
+      sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
+    };
+  }
+  {
+    pname = "system.resources.extensions";
+    version = "4.6.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.resources.extensions/4.6.0/system.resources.extensions.4.6.0.nupkg";
+      sha256 = "0inch9jgchgmsg3xjivbhh9mpin40mhdd8dgf4i1p3g42i0hzc0j";
+    };
+  }
+  {
+    pname = "system.resources.resourcemanager";
+    version = "4.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.4.0.1.nupkg";
+      sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
+    };
+  }
+  {
+    pname = "system.resources.resourcemanager";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg";
+      sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
+    };
+  }
+  {
+    pname = "system.runtime";
+    version = "4.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg";
+      sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+    };
+  }
+  {
+    pname = "system.runtime";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg";
+      sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
+    };
+  }
+  {
+    pname = "system.runtime.compilerservices.unsafe";
+    version = "4.4.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.4.0/system.runtime.compilerservices.unsafe.4.4.0.nupkg";
+      sha256 = "0a6ahgi5b148sl5qyfpyw383p3cb4yrkm802k29fsi4mxkiwir29";
+    };
+  }
+  {
+    pname = "system.runtime.compilerservices.unsafe";
+    version = "4.5.2";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.4.5.2.nupkg";
+      sha256 = "1vz4275fjij8inf31np78hw50al8nqkngk04p3xv5n4fcmf1grgi";
+    };
+  }
+  {
+    pname = "system.runtime.compilerservices.unsafe";
+    version = "4.5.3";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.3/system.runtime.compilerservices.unsafe.4.5.3.nupkg";
+      sha256 = "1afi6s2r1mh1kygbjmfba6l4f87pi5sg13p4a48idqafli94qxln";
+    };
+  }
+  {
+    pname = "system.runtime.compilerservices.unsafe";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.7.0/system.runtime.compilerservices.unsafe.4.7.0.nupkg";
+      sha256 = "16r6sn4czfjk8qhnz7bnqlyiaaszr0ihinb7mq9zzr1wba257r54";
+    };
+  }
+  {
+    pname = "system.runtime.compilerservices.unsafe";
+    version = "4.7.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.7.1/system.runtime.compilerservices.unsafe.4.7.1.nupkg";
+      sha256 = "119br3pd85lq8zcgh4f60jzmv1g976q1kdgi3hvqdlhfbw6siz2j";
+    };
+  }
+  {
+    pname = "system.runtime.compilerservices.unsafe";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/5.0.0/system.runtime.compilerservices.unsafe.5.0.0.nupkg";
+      sha256 = "02k25ivn50dmqx5jn8hawwmz24yf0454fjd823qk6lygj9513q4x";
+    };
+  }
+  {
+    pname = "system.runtime.extensions";
+    version = "4.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.1.0/system.runtime.extensions.4.1.0.nupkg";
+      sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
+    };
+  }
+  {
+    pname = "system.runtime.extensions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg";
+      sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
+    };
+  }
+  {
+    pname = "system.runtime.handles";
+    version = "4.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.0.1/system.runtime.handles.4.0.1.nupkg";
+      sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
+    };
+  }
+  {
+    pname = "system.runtime.handles";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg";
+      sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
+    };
+  }
+  {
+    pname = "system.runtime.interopservices";
+    version = "4.1.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.1.0/system.runtime.interopservices.4.1.0.nupkg";
+      sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
+    };
+  }
+  {
+    pname = "system.runtime.interopservices";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg";
+      sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+    };
+  }
+  {
+    pname = "system.runtime.interopservices.runtimeinformation";
+    version = "4.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.runtimeinformation/4.0.0/system.runtime.interopservices.runtimeinformation.4.0.0.nupkg";
+      sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
+    };
+  }
+  {
+    pname = "system.runtime.interopservices.runtimeinformation";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.4.3.0.nupkg";
+      sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
+    };
+  }
+  {
+    pname = "system.runtime.interopservices.windowsruntime";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.windowsruntime/4.3.0/system.runtime.interopservices.windowsruntime.4.3.0.nupkg";
+      sha256 = "0bpsy91yqm2ryp5y9li8p6yh4yrxcvg9zvm569ifw25rpy67bgp9";
+    };
+  }
+  {
+    pname = "system.runtime.numerics";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg";
+      sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
+    };
+  }
+  {
+    pname = "system.security.accesscontrol";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/4.5.0/system.security.accesscontrol.4.5.0.nupkg";
+      sha256 = "1wvwanz33fzzbnd2jalar0p0z3x0ba53vzx1kazlskp7pwyhlnq0";
+    };
+  }
+  {
+    pname = "system.security.accesscontrol";
+    version = "4.6.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/4.6.0/system.security.accesscontrol.4.6.0.nupkg";
+      sha256 = "1wl1dyghi0qhpap1vgfhg2ybdyyhy9vc2a7dpm1xb30vfgmlkjmf";
+    };
+  }
+  {
+    pname = "system.security.accesscontrol";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/4.7.0/system.security.accesscontrol.4.7.0.nupkg";
+      sha256 = "0n0k0w44flkd8j0xw7g3g3vhw7dijfm51f75xkm1qxnbh4y45mpz";
+    };
+  }
+  {
+    pname = "system.security.cryptography.algorithms";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg";
+      sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
+    };
+  }
+  {
+    pname = "system.security.cryptography.algorithms";
+    version = "4.3.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.1/system.security.cryptography.algorithms.4.3.1.nupkg";
+      sha256 = "1m2wnzg3m3c0s11jg4lshcl2a47d78zri8khc21yrz34jjkbyls2";
+    };
+  }
+  {
+    pname = "system.security.cryptography.cng";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg";
+      sha256 = "1k468aswafdgf56ab6yrn7649kfqx2wm9aslywjam1hdmk5yypmv";
+    };
+  }
+  {
+    pname = "system.security.cryptography.cng";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.7.0/system.security.cryptography.cng.4.7.0.nupkg";
+      sha256 = "00797sqbba8lys486ifxblz9j52m29kidclvmqpk531820k55x9j";
+    };
+  }
+  {
+    pname = "system.security.cryptography.cng";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/5.0.0/system.security.cryptography.cng.5.0.0.nupkg";
+      sha256 = "06hkx2za8jifpslkh491dfwzm5dxrsyxzj5lsc0achb6yzg4zqlw";
+    };
+  }
+  {
+    pname = "system.security.cryptography.csp";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg";
+      sha256 = "1x5wcrddf2s3hb8j78cry7yalca4lb5vfnkrysagbn6r9x6xvrx1";
+    };
+  }
+  {
+    pname = "system.security.cryptography.encoding";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg";
+      sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
+    };
+  }
+  {
+    pname = "system.security.cryptography.openssl";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0givpvvj8yc7gv4lhb6s1prq6p2c4147204a0wib89inqzd87gqc";
+    };
+  }
+  {
+    pname = "system.security.cryptography.pkcs";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.pkcs/4.7.0/system.security.cryptography.pkcs.4.7.0.nupkg";
+      sha256 = "1mwvzl5ask8kk0vdgchhqr90nl61kagg47warb7dxrb03cxjd4wm";
+    };
+  }
+  {
+    pname = "system.security.cryptography.pkcs";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.pkcs/5.0.0/system.security.cryptography.pkcs.5.0.0.nupkg";
+      sha256 = "0hb2mndac3xrw3786bsjxjfh19bwnr991qib54k6wsqjhjyyvbwj";
+    };
+  }
+  {
+    pname = "system.security.cryptography.primitives";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg";
+      sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
+    };
+  }
+  {
+    pname = "system.security.cryptography.protecteddata";
+    version = "4.4.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/4.4.0/system.security.cryptography.protecteddata.4.4.0.nupkg";
+      sha256 = "1q8ljvqhasyynp94a1d7jknk946m20lkwy2c3wa8zw2pc517fbj6";
+    };
+  }
+  {
+    pname = "system.security.cryptography.protecteddata";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/4.7.0/system.security.cryptography.protecteddata.4.7.0.nupkg";
+      sha256 = "1s1sh8k10s0apa09c5m2lkavi3ys90y657whg2smb3y8mpkfr5vm";
+    };
+  }
+  {
+    pname = "system.security.cryptography.x509certificates";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg";
+      sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
+    };
+  }
+  {
+    pname = "system.security.cryptography.xml";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.xml/4.7.0/system.security.cryptography.xml.4.7.0.nupkg";
+      sha256 = "08c82yb1nhfqr15rrypc36c7pysp7jymkwnra84w72nd53h3dfgb";
+    };
+  }
+  {
+    pname = "system.security.permissions";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.permissions/4.5.0/system.security.permissions.4.5.0.nupkg";
+      sha256 = "192ww5rm3c9mirxgl1nzyrwd18am3izqls0hzm0fvcdjl5grvbhm";
+    };
+  }
+  {
+    pname = "system.security.permissions";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.permissions/4.7.0/system.security.permissions.4.7.0.nupkg";
+      sha256 = "13f366sj36jwbvld957gk2q64k2xbj48r8b0k9avrri2nlq1fs04";
+    };
+  }
+  {
+    pname = "system.security.principal.windows";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.5.0/system.security.principal.windows.4.5.0.nupkg";
+      sha256 = "0rmj89wsl5yzwh0kqjgx45vzf694v9p92r4x4q6yxldk1cv1hi86";
+    };
+  }
+  {
+    pname = "system.security.principal.windows";
+    version = "4.6.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.6.0/system.security.principal.windows.4.6.0.nupkg";
+      sha256 = "1jmfzfz1n8hp63s5lja5xxpzkinbp6g59l3km9h8avjiisdrg5wm";
+    };
+  }
+  {
+    pname = "system.security.principal.windows";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.7.0/system.security.principal.windows.4.7.0.nupkg";
+      sha256 = "1a56ls5a9sr3ya0nr086sdpa9qv0abv31dd6fp27maqa9zclqq5d";
+    };
+  }
+  {
+    pname = "system.text.encoding";
+    version = "4.0.11";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.0.11/system.text.encoding.4.0.11.nupkg";
+      sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+    };
+  }
+  {
+    pname = "system.text.encoding";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg";
+      sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+    };
+  }
+  {
+    pname = "system.text.encoding.codepages";
+    version = "4.0.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/4.0.1/system.text.encoding.codepages.4.0.1.nupkg";
+      sha256 = "00wpm3b9y0k996rm9whxprngm8l500ajmzgy2ip9pgwk0icp06y3";
+    };
+  }
+  {
+    pname = "system.text.encoding.codepages";
+    version = "4.5.1";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/4.5.1/system.text.encoding.codepages.4.5.1.nupkg";
+      sha256 = "1z21qyfs6sg76rp68qdx0c9iy57naan89pg7p6i3qpj8kyzn921w";
+    };
+  }
+  {
+    pname = "system.text.encoding.extensions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg";
+      sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
+    };
+  }
+  {
+    pname = "system.text.encodings.web";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.encodings.web/4.7.0/system.text.encodings.web.4.7.0.nupkg";
+      sha256 = "0sd3bihfar5rwm6nib4lhyys306nkm02qvk6p6sgzmnlfmma2wn3";
+    };
+  }
+  {
+    pname = "system.text.encodings.web";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.encodings.web/5.0.0/system.text.encodings.web.5.0.0.nupkg";
+      sha256 = "144pgy65jc3bkar7d4fg1c0rq6qmkx68gj9k1ldk97558w22v1r1";
+    };
+  }
+  {
+    pname = "system.text.json";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.json/4.7.0/system.text.json.4.7.0.nupkg";
+      sha256 = "0fp3xrysccm5dkaac4yb51d793vywxks978kkl5x4db9gw29rfdr";
+    };
+  }
+  {
+    pname = "system.text.json";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.json/5.0.0/system.text.json.5.0.0.nupkg";
+      sha256 = "1gpgl18z6qrgmqrikgh99xkjwzb1didrjp77bch7nrlra21gr4ks";
+    };
+  }
+  {
+    pname = "system.text.regularexpressions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.text.regularexpressions/4.3.0/system.text.regularexpressions.4.3.0.nupkg";
+      sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
+    };
+  }
+  {
+    pname = "system.threading";
+    version = "4.0.11";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading/4.0.11/system.threading.4.0.11.nupkg";
+      sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
+    };
+  }
+  {
+    pname = "system.threading";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg";
+      sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
+    };
+  }
+  {
+    pname = "system.threading.tasks";
+    version = "4.0.11";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.0.11/system.threading.tasks.4.0.11.nupkg";
+      sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+    };
+  }
+  {
+    pname = "system.threading.tasks";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg";
+      sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
+    };
+  }
+  {
+    pname = "system.threading.tasks.dataflow";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.dataflow/5.0.0/system.threading.tasks.dataflow.5.0.0.nupkg";
+      sha256 = "028fimgwn5j9fv6m547c975a8b90d9qcnb89k5crjyspsnjcqbhy";
+    };
+  }
+  {
+    pname = "system.threading.tasks.extensions";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.4.3.0.nupkg";
+      sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
+    };
+  }
+  {
+    pname = "system.threading.tasks.extensions";
+    version = "4.5.2";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.2/system.threading.tasks.extensions.4.5.2.nupkg";
+      sha256 = "1sh63dz0dymqcwmprp0nadm77b83vmm7lyllpv578c397bslb8hj";
+    };
+  }
+  {
+    pname = "system.threading.tasks.extensions";
+    version = "4.5.3";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.3/system.threading.tasks.extensions.4.5.3.nupkg";
+      sha256 = "0g7r6hm572ax8v28axrdxz1gnsblg6kszq17g51pj14a5rn2af7i";
+    };
+  }
+  {
+    pname = "system.threading.tasks.extensions";
+    version = "4.5.4";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.4.5.4.nupkg";
+      sha256 = "0y6ncasgfcgnjrhynaf0lwpkpkmv4a07sswwkwbwb5h7riisj153";
+    };
+  }
+  {
+    pname = "system.threading.timer";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.threading.timer/4.3.0/system.threading.timer.4.3.0.nupkg";
+      sha256 = "1nx773nsx6z5whv8kaa1wjh037id2f1cxhb69pvgv12hd2b6qs56";
+    };
+  }
+  {
+    pname = "system.valuetuple";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg";
+      sha256 = "00k8ja51d0f9wrq4vv5z2jhq8hy31kac2rg0rv06prylcybzl8cy";
+    };
+  }
+  {
+    pname = "system.windows.extensions";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.windows.extensions/4.7.0/system.windows.extensions.4.7.0.nupkg";
+      sha256 = "11dmyx3j0jafjx5r9mkj1v4w2a4rzrdn8fgwm2d1g7fs1ayqcvy9";
+    };
+  }
+  {
+    pname = "system.xml.readerwriter";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.xml.readerwriter/4.3.0/system.xml.readerwriter.4.3.0.nupkg";
+      sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
+    };
+  }
+  {
+    pname = "system.xml.xdocument";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.xml.xdocument/4.3.0/system.xml.xdocument.4.3.0.nupkg";
+      sha256 = "08h8fm4l77n0nd4i4fk2386y809bfbwqb7ih9d7564ifcxr5ssxd";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35387,6 +35387,8 @@ with pkgs;
 
   omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
 
+  omnisharp-roslyn-mono = callPackage ../development/tools/omnisharp-roslyn-mono { };
+
   wasmtime = callPackage ../development/interpreters/wasmtime {};
 
   wfuzz = with python3Packages; toPythonApplication wfuzz;


### PR DESCRIPTION
-------

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

OmniSharp 1.38 drops support for dotnet 5.0, and consequently, mono.
This is a problem for Unity, which depends on a mono-compatible version
of OmniSharp for LSP.

This package is a slightly updated revision of the omnisharp-roslyn
package definition as it existed for 1.37.X releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->