### PR TITLE
haskellPackages: use hnix-store 0.5 for hnix, update maintained packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -238,10 +238,16 @@ self: super: {
   digit = doJailbreak super.digit;
 
   # 2020-06-05: HACK: does not pass own build suite - `dontCheck`
-  hnix = generateOptparseApplicativeCompletion "hnix" (dontCheck super.hnix);
+  # 2022-06-17: Use hnix-store 0.5 until hnix 0.17
+  hnix = generateOptparseApplicativeCompletion "hnix" (dontCheck (
+    super.hnix.override {
+      hnix-store-core = hnix_store_core_0_5_0_0;
+      hnix-store-remote = hnix_store_remote_0_5_0_0.override { hnix-store-core = hnix_store_core_0_5_0_0; };
+    }
+  ));
   # Too strict bounds on algebraic-graphs
   # https://github.com/haskell-nix/hnix-store/issues/180
-  hnix-store-core = doJailbreak super.hnix-store-core;
+  hnix-store-core_0_5_0_0 = doJailbreak super.hnix-store-core_0_5_0_0;
 
   # Fails for non-obvious reasons while attempting to use doctest.
   focuslist = dontCheck super.focuslist;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -240,10 +240,10 @@ self: super: {
   # 2020-06-05: HACK: does not pass own build suite - `dontCheck`
   # 2022-06-17: Use hnix-store 0.5 until hnix 0.17
   hnix = generateOptparseApplicativeCompletion "hnix" (dontCheck (
-    super.hnix.override {
-      hnix-store-core = hnix_store_core_0_5_0_0;
-      hnix-store-remote = hnix_store_remote_0_5_0_0.override { hnix-store-core = hnix_store_core_0_5_0_0; };
-    }
+    super.hnix.overrideScope (hself: hsuper: {
+      hnix-store-core = hself.hnix-store-core_0_5_0_0;
+      hnix-store-remote = hself.hnix-store-remote_0_5_0_0;
+    })
   ));
   # Too strict bounds on algebraic-graphs
   # https://github.com/haskell-nix/hnix-store/issues/180

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -135,6 +135,8 @@ extra-packages:
   - hspec-discover < 2.8                # 2022-04-07: Needed for tasty-hspec 1.1.6
   - bower-json == 1.0.0.1               # 2022-05-21: Needed for spago 0.20.9
   - fourmolu == 0.6.0.0                 # 2022-06-05: Last fourmolu version compatible with hls 1.7/ hls-fourmolu-plugin 1.0.3.0
+  - hnix-store-core == 0.5.0.0          # 2022-06-17: Until hnix 0.17
+  - hnix-store-remote == 0.5.0.0        # 2022-06-17: Until hnix 0.17
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -347,9 +347,16 @@ package-maintainers:
     - lentil
   sorki:
     - cayenne-lpp
+    - blockfrost-client
+    - data-lens-light
     - data-stm32
     - gcodehs
+    - hnix
+    - hnix-store-core
+    - hnix-store-remote
+    - implicit
     - nix-derivation
+    - nix-diff
     - nix-narinfo
     - ttn
     - ttn-client


### PR DESCRIPTION
Should help with broken `hnix` as it is not yet adapted to most recent `hnix-store` (and we still use older `hnix`).

Marking as draft since I'm not able to run `hackage2nix` and test it.

```
$ ./maintainers/scripts/haskell/regenerate-hackage-packages.sh
Starting hackage2nix to regenerate pkgs/development/haskell-modules/hackage-packages.nix ...
error: path '/nix/store/32d1h0bp55v57fwmydgvn5aszh9sa81v-source.drv' is not valid
(use '--show-trace' to show detailed location information)
hackage2nix: user error (Error in $: not enough input)
```