### PR TITLE
mangal: init at version 3.10.0

### DIFF
--- a/pkgs/applications/misc/mangal/default.nix
+++ b/pkgs/applications/misc/mangal/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "mangal";
+  version = "3.10.0";
+
+  src = fetchFromGitHub {
+    owner = "metafates";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rWj9CknWNI6SSh0AwaPpj5TxHQzkAmaAhWW7kze3xiY=";
+  };
+
+  proxyVendor = true;
+  vendorSha256 = "sha256-ZgeG8S78/yS9KfEK1bZ3VlQGmZPBo9TXLQLz8rXOEGo=";
+
+  ldflags = [ "-s" "-w" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    # Mangal creates a config file in the folder ~/.config/mangal and fails if not possible
+    export MANGAL_CONFIG_PATH=`mktemp -d`
+    installShellCompletion --cmd mangal \
+      --bash <($out/bin/mangal completion bash) \
+      --zsh <($out/bin/mangal completion zsh) \
+      --fish <($out/bin/mangal completion fish)
+  '';
+
+  doCheck = false; # test fail because of sandbox
+
+  meta = with lib; {
+    description =
+      "A fancy CLI app written in Go which scrapes, downloads and packs manga into different formats";
+    homepage = "https://github.com/metafates/mangal";
+    license = licenses.mit;
+    maintainers = [ maintainers.bertof ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -723,6 +723,8 @@ with pkgs;
 
   graph-easy = callPackage ../tools/graphics/graph-easy { };
 
+  mangal = callPackage ../applications/misc/mangal { };
+
   graphw00f = callPackage ../tools/security/graphw00f { };
 
   opendrop = python3Packages.callPackage ../tools/networking/opendrop { };


### PR DESCRIPTION
Mangal is a fancy CLI app written in Go which scrapes, downloads and packs manga into different formats.

This pull request adds a derivation for Mangal

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
