### PR TITLE
gollum: 5.2.3 -> 5.3.0

### DIFF
--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -47,7 +47,7 @@ in
     user-icons = mkOption {
       type = types.nullOr (types.enum [ "gravatar" "identicon" ]);
       default = null;
-      description = "User icons for history view";
+      description = "Enable specific user icons for history view";
     };
 
     emoji = mkOption {

--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -68,6 +68,12 @@ in
       description = "Disable editing pages";
     };
 
+    local-time = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Use the browser's local timezone instead of the server's for displaying dates.";
+    };
+
     branch = mkOption {
       type = types.str;
       default = "master";
@@ -123,6 +129,7 @@ in
             ${optionalString cfg.emoji "--emoji"} \
             ${optionalString cfg.h1-title "--h1-title"} \
             ${optionalString cfg.no-edit "--no-edit"} \
+            ${optionalString cfg.local-time "--local-time"} \
             ${optionalString (cfg.allowUploads != null) "--allow-uploads ${cfg.allowUploads}"} \
             ${optionalString (cfg.user-icons != null) "--user-icons ${cfg.user-icons}"} \
             ${cfg.stateDir}

--- a/pkgs/applications/misc/gollum/Gemfile.lock
+++ b/pkgs/applications/misc/gollum/Gemfile.lock
@@ -13,13 +13,15 @@ GEM
     gemojione (4.3.3)
       json
     github-markup (4.0.1)
-    gollum (5.2.3)
+    gollum (5.3.0)
       gemojione (~> 4.1)
       gollum-lib (~> 5.1)
+      i18n (~> 1.8)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.1.0)
-      mustache-sinatra (~> 1.0)
+      mustache-sinatra (>= 1.0.1, < 2)
       octicons (~> 12.0)
+      rdoc (~> 6)
       rss (~> 0.2.9)
       sass (~> 3.5)
       sinatra (~> 2.0)
@@ -30,7 +32,7 @@ GEM
       uglifier (~> 4.2)
       useragent (~> 0.16.2)
       webrick (~> 1.7)
-    gollum-lib (5.1.3)
+    gollum-lib (5.2)
       gemojione (~> 4.1)
       github-markup (~> 4.0)
       gollum-rugged_adapter (~> 1.0)
@@ -43,6 +45,8 @@ GEM
       mime-types (~> 1.15)
       rugged (~> 1.1.0)
     htmlentities (4.3.4)
+    i18n (1.10.0)
+      concurrent-ruby (~> 1.0)
     json (2.6.2)
     kramdown (2.4.0)
       rexml
@@ -66,15 +70,19 @@ GEM
       nokogiri (>= 1.6.3.1)
     org-ruby (0.9.12)
       rubypants (~> 0.2)
+    psych (4.0.4)
+      stringio
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rdoc (6.4.0)
+      psych (>= 4.0.0)
     rexml (3.2.5)
-    rouge (3.28.0)
+    rouge (3.29.0)
     rss (0.2.9)
       rexml
     ruby2_keywords (0.0.5)
@@ -101,6 +109,7 @@ GEM
       rack (> 1, < 3)
     sprockets-helpers (1.4.0)
       sprockets (>= 2.2)
+    stringio (3.0.2)
     therubyrhino (2.1.2)
       therubyrhino_jar (>= 1.7.4, < 1.7.9)
     therubyrhino_jar (1.7.8)
@@ -111,7 +120,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.1)
+    unf_ext (0.0.8.2)
     useragent (0.16.10)
     webrick (1.7.0)
     wikicloth (0.8.3)
@@ -133,4 +142,4 @@ DEPENDENCIES
   wikicloth
 
 BUNDLED WITH
-   2.2.33
+   2.3.9

--- a/pkgs/applications/misc/gollum/gemset.nix
+++ b/pkgs/applications/misc/gollum/gemset.nix
@@ -101,15 +101,15 @@
     version = "4.0.1";
   };
   gollum = {
-    dependencies = ["gemojione" "gollum-lib" "kramdown" "kramdown-parser-gfm" "mustache-sinatra" "octicons" "rss" "sass" "sinatra" "sinatra-contrib" "sprockets" "sprockets-helpers" "therubyrhino" "uglifier" "useragent" "webrick"];
+    dependencies = ["gemojione" "gollum-lib" "i18n" "kramdown" "kramdown-parser-gfm" "mustache-sinatra" "octicons" "rdoc" "rss" "sass" "sinatra" "sinatra-contrib" "sprockets" "sprockets-helpers" "therubyrhino" "uglifier" "useragent" "webrick"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zdpl8rj6r2psigcjavwi57ljriyakh0ydfai9c3q85jzc005bax";
+      sha256 = "1xz7d3xfc536njk0fg4inmzzy350c5bjp237vghrcky8azc6xl7k";
       type = "gem";
     };
-    version = "5.2.3";
+    version = "5.3.0";
   };
   gollum-lib = {
     dependencies = ["gemojione" "github-markup" "gollum-rugged_adapter" "loofah" "nokogiri" "octicons" "rouge" "twitter-text"];
@@ -117,10 +117,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1samwcxjr1z0sy8a87xvp0z4qx0fc2irzx568s6q1yxcba9nqqv2";
+      sha256 = "1acxi4zjdmxlj7hzv9fjqilqngcwjvzhk3khnykdfvnb0l6l4xbs";
       type = "gem";
     };
-    version = "5.1.3";
+    version = "5.2";
   };
   gollum-rugged_adapter = {
     dependencies = ["mime-types" "rugged"];
@@ -142,6 +142,17 @@
       type = "gem";
     };
     version = "4.3.4";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0b2qyvnk4yynlg17ymkq4g5xgr275637fhl1mjh0valw3cb1fhhg";
+      type = "gem";
+    };
+    version = "1.10.0";
   };
   json = {
     groups = ["default"];
@@ -281,6 +292,17 @@
     };
     version = "0.9.12";
   };
+  psych = {
+    dependencies = ["stringio"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0c2lz03mkn43rf2a2xiy8vqgir1dvds0a0fpx7m7my6a21ygryw2";
+      type = "gem";
+    };
+    version = "4.0.4";
+  };
   racc = {
     groups = ["default"];
     platforms = [];
@@ -296,10 +318,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0i5vs0dph9i5jn8dfc6aqd6njcafmb20rwqngrf759c9cvmyff16";
+      sha256 = "1b1qsg0yfargdhmpapp2d3mlxj82wyygs9nj74w0r03diyi8swlc";
       type = "gem";
     };
-    version = "2.2.3";
+    version = "2.2.3.1";
   };
   rack-protection = {
     dependencies = ["rack"];
@@ -333,6 +355,17 @@
     };
     version = "0.10.1";
   };
+  rdoc = {
+    dependencies = ["psych"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bxzcvxvrmb1ngxz0bgz1va4q9c4w8m6gc8lmdhi6gnvaaf98gsy";
+      type = "gem";
+    };
+    version = "6.4.0";
+  };
   RedCloth = {
     groups = ["default"];
     platforms = [];
@@ -358,10 +391,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "080fswzii68wnbsg7pgq55ba7p289sqjlxwp4vch0h32qy1f8v8d";
+      sha256 = "17dhzc9hfzd8x18hfsvn9rsp4jg18wdfsdy3a5p99y5dhfh1321r";
       type = "gem";
     };
-    version = "3.28.0";
+    version = "3.29.0";
   };
   rss = {
     dependencies = ["rexml"];
@@ -470,6 +503,16 @@
     };
     version = "1.4.0";
   };
+  stringio = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jns0x5lbafyqyx7pgzfs6i4ykc7p6zg7gxa6hd82w40n6z9rdvi";
+      type = "gem";
+    };
+    version = "3.0.2";
+  };
   therubyrhino = {
     dependencies = ["therubyrhino_jar"];
     groups = ["default"];
@@ -539,10 +582,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0bf120xbq23zjyf8zi8h1576d71g58srr8rndig0whn10w72vrxz";
+      sha256 = "1yj2nz2l101vr1x9w2k83a0fag1xgnmjwp8w8rw4ik2rwcz65fch";
       type = "gem";
     };
-    version = "0.0.8.1";
+    version = "0.0.8.2";
   };
   useragent = {
     groups = ["default"];

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -294,6 +294,14 @@ in
     propagatedBuildInputs = [ gobject-introspection wrapGAppsHook glib ];
   };
 
+  gollum = attrs: {
+    dontBuild = false;
+    postPatch = ''
+      substituteInPlace bin/gollum \
+        --replace "/usr/bin/env -S ruby" "${ruby}/bin/ruby"
+    '';
+  };
+
   grpc = attrs: {
     nativeBuildInputs = [ pkg-config ] ++ lib.optional stdenv.isDarwin libtool;
     buildInputs = [ openssl ];


### PR DESCRIPTION
###### Description of changes

package `gollum`

* update to v5.3.0

`nixos/gollum`

* add option `local-time` (introduced in gollum v5.3.0)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
