### PR TITLE
HentaiAtHome: use default JDK with ZGC support

### DIFF
--- a/pkgs/applications/misc/HentaiAtHome/default.nix
+++ b/pkgs/applications/misc/HentaiAtHome/default.nix
@@ -1,24 +1,43 @@
-{ buildGraalvmNativeImage, fetchzip, graalvm17-ce, lib }:
-
-buildGraalvmNativeImage rec {
+{ buildPackages
+, buildPlatform
+, fetchzip
+, javaOpts ? "-XX:+UseZGC"
+, jdk
+, jre_headless
+, lib
+, makeWrapper
+, stdenvNoCC
+,
+}:
+stdenvNoCC.mkDerivation rec {
   pname = "HentaiAtHome";
   version = "1.6.1";
+
   src = fetchzip {
-    url = "https://repo.e-hentai.org/hath/HentaiAtHome_${version}.zip";
+    url = "https://repo.e-hentai.org/hath/HentaiAtHome_${version}_src.zip";
     hash =
-      "sha512-nGGCuVovj4NJGrihKKYXnh0Ic9YD36o7r6wv9zSivZn22zm8lBYVXP85LnOw2z9DiJARivOctQGl48YFD7vxOQ==";
+      "sha512-j+B0kx6fjUibI3MjVJ5PVTq9xxtSOTTY/XizAJKjeNkpExJF9DIV4VCwf+sfLlg+7W4UBosnyb8hZNNoidRBKA==";
     stripRoot = false;
   };
 
-  jar = "${src}/HentaiAtHome.jar";
-  dontUnpack = true;
+  nativeBuildInputs = [ jdk makeWrapper ];
 
-  graalvmDrv = graalvm17-ce;
-  extraNativeImageBuildArgs = [
-    "--enable-url-protocols=http,https"
-    "--install-exit-handlers"
-    "--no-fallback"
-  ];
+  LANG = "en_US.UTF-8";
+  LOCALE_ARCHIVE = lib.optionalString (buildPlatform.libc == "glibc")
+    "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+
+  buildPhase = ''
+    make all
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    cp build/HentaiAtHome.jar $out/share/java
+
+    mkdir -p $out/bin
+    makeWrapper ${jre_headless}/bin/java $out/bin/HentaiAtHome \
+      --add-flags "${javaOpts} -jar $out/share/java/HentaiAtHome.jar"
+  '';
 
   doInstallCheck = true;
   installCheckPhase = ''
@@ -27,11 +46,12 @@ buildGraalvmNativeImage rec {
     popd
   '';
 
+  strictDeps = true;
+
   meta = with lib; {
     homepage = "https://ehwiki.org/wiki/Hentai@Home";
     description =
       "Hentai@Home is an open-source P2P gallery distribution system which reduces the load on the E-Hentai Galleries";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     maintainers = with maintainers; [ terrorjack ];
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This patch uses default JDK for building/running HentaiAtHome, and enables ZGC by default. The default Serial GC shipped with GraalVM Community proves to be suboptimal for long-running servers. With this change, my server quality rises above 8000 according to Hentai@Home dashboard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
