### PR TITLE
Fix CHM format support in Calibre

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -16,7 +16,6 @@
 , hunspell
 , hyphen
 , unrarSupport ? false
-, chmlib
 , python3Packages
 , libusb1
 , libmtp
@@ -66,7 +65,6 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config qmake removeReferencesTo wrapGAppsHook ];
 
   buildInputs = [
-    chmlib
     fontconfig
     hunspell
     hyphen
@@ -102,6 +100,7 @@ mkDerivation rec {
       msgpack
       netifaces
       pillow
+      pychm
       pyqt-builder
       pyqt5
       python

--- a/pkgs/development/python-modules/pychm/default.nix
+++ b/pkgs/development/python-modules/pychm/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, chmlib
+}:
+
+buildPythonPackage rec {
+  pname = "pychm";
+  version = "0.8.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wpn9ijlsmrpyiwg3drmgz4dms1i1i347adgqw37bkrh3vn6yq16";
+  };
+
+  buildInputs = [ chmlib ];
+
+  pythonImportsCheck = [ "chm" ];
+
+  meta = with lib; {
+    description = "Library to manipulate Microsoft HTML Help (CHM) files";
+    homepage = "https://github.com/dottedmag/pychm";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ alexshpilkin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7084,6 +7084,8 @@ in {
 
   pychef = callPackage ../development/python-modules/pychef { };
 
+  pychm = callPackage ../development/python-modules/pychm { };
+
   PyChromecast = callPackage ../development/python-modules/pychromecast { };
 
   pyclimacell = callPackage ../development/python-modules/pyclimacell { };


### PR DESCRIPTION
###### Description of changes

The `calibre` package mistakenly included a dependency on the (native) library `chmlib`, whereas in reality Calibre uses a Python wrapper for it, called `pychm` (and imported in Python code as `chm`), which was not previously packaged in Nixpkgs. That wrapper is declared to be in maintenance mode by its developer, but Calibre’s CHM support depends on it unconditionally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
