### PR TITLE
nmap-formatter: 0.3.0 -> 1.0.2

### DIFF
--- a/pkgs/tools/security/nmap-formatter/default.nix
+++ b/pkgs/tools/security/nmap-formatter/default.nix
@@ -5,22 +5,16 @@
 
 buildGoModule rec {
   pname = "nmap-formatter";
-  version = "0.3.0";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "vdjagilev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-tG91Cutk+RCBPv4Rf8CVnZa5Wh8qgsxEL0C6WIoEdsw=";
+    hash = "sha256-ePhm1qwluHhMC0oS/qEHkZv04nAdh2IDSkIW507MLjo=";
   };
 
-  vendorSha256 = "sha256-WXX1b8fPcwIE40w+Kzd7ZuSRXPiYtolRXC/Z8Kc9H2s=";
-
-  postPatch = ''
-    # Fix hard-coded release
-    substituteInPlace cmd/root.go \
-      --replace "0.2.0" "${version}"
-  '';
+  vendorSha256 = "sha256-zkPXjCC+ZdR14O60ZaGFYdEZVxQ5z99HVmLOR10qqfg=";
 
   meta = with lib; {
     description = "Tool that allows you to convert nmap output";


### PR DESCRIPTION
###### Description of changes
https://github.com/vdjagilev/nmap-formatter/releases/tag/v1.0.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
