### PR TITLE
nixos/tests/fcitx: disable

### DIFF
--- a/nixos/tests/fcitx/default.nix
+++ b/nixos/tests/fcitx/default.nix
@@ -5,6 +5,7 @@ import ../make-test-python.nix (
     # copy_from_host works only for store paths
     rec {
         name = "fcitx";
+        meta.broken = true; # takes hours to time out since October 2021
         nodes.machine =
         {
           pkgs,


### PR DESCRIPTION
It never worked on 21.11 and still does not:
https://hydra.nixos.org/job/nixos/release-21.11/nixos.tests.fcitx.x86_64-linux/all
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.fcitx.x86_64-linux/all
and it frequently makes big channels wait (same on aarch64-linux).