### PR TITLE
nixos/networkd: default DHCP network improvements

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8987,7 +8987,7 @@
     githubId = 4323933;
     name = "Naïm Favier";
     keys = [{
-      fingerprint = "51A0 705E 7DD2 3CBC 5EAA  B43E 49B0 7322 580B 7EE2";
+      fingerprint = "F3EB 4BBB 4E71 99BC 299C  D4E9 95AF CE82 1190 8325";
     }];
   };
   nckx = {

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -95,6 +95,7 @@ in
           DHCP = "yes";
           linkConfig.RequiredForOnline =
             lib.mkDefault config.systemd.network.wait-online.anyInterface;
+          networkConfig.IPv6PrivacyExtensions = "kernel";
         };
         networks."99-wireless-client-dhcp" = lib.mkIf cfg.useDHCP {
           # Like above, but this is much more likely to be correct.
@@ -102,6 +103,7 @@ in
           DHCP = "yes";
           linkConfig.RequiredForOnline =
             lib.mkDefault config.systemd.network.wait-online.anyInterface;
+          networkConfig.IPv6PrivacyExtensions = "kernel";
           # We also set the route metric to one more than the default
           # of 1024, so that Ethernet is preferred if both are
           # available.

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -88,20 +88,20 @@ in
           # more likely to result in interfaces being configured to
           # use DHCP when they shouldn't.
 
-          # We set RequiredForOnline to false, because it's fairly
-          # common for such devices to have multiple interfaces and
-          # only one of them to be connected (e.g. a laptop with
-          # ethernet and WiFi interfaces). Maybe one day networkd will
-          # support "any"-style RequiredForOnline...
+          # When wait-online.anyInterface is enabled, RequiredForOnline really
+          # means "sufficient for online", so we can enable it.
+          # Otherwise, don't block the network coming online because of default networks.
           matchConfig.Name = ["en*" "eth*"];
           DHCP = "yes";
-          linkConfig.RequiredForOnline = lib.mkDefault false;
+          linkConfig.RequiredForOnline =
+            lib.mkDefault config.systemd.network.wait-online.anyInterface;
         };
         networks."99-wireless-client-dhcp" = lib.mkIf cfg.useDHCP {
           # Like above, but this is much more likely to be correct.
           matchConfig.WLANInterfaceType = "station";
           DHCP = "yes";
-          linkConfig.RequiredForOnline = lib.mkDefault false;
+          linkConfig.RequiredForOnline =
+            lib.mkDefault config.systemd.network.wait-online.anyInterface;
           # We also set the route metric to one more than the default
           # of 1024, so that Ethernet is preferred if both are
           # available.


### PR DESCRIPTION
When `systemd.network.wait-online.anyInterface` is enabled, `RequiredForOnline` really means "sufficient for online", so enable it.

Also add `IPv6PrivacyExtensions=kernel` to default networks as is done for normal interfaces. Maybe this could go in `genericNetwork`, but I don't know if it makes sense for bridges, bonds etc. and I don't want to break anything.