### PR TITLE
dnsmonster: init at 0.9.3

### DIFF
--- a/pkgs/tools/networking/dnsmonster/default.nix
+++ b/pkgs/tools/networking/dnsmonster/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, libpcap
+}:
+
+buildGoModule rec {
+  pname = "dnsmonster";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "mosajjal";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-1tYC76g3GOqMaosAYYXOrOKTdW7muPTaeeLzGUsjogE=";
+  };
+
+  vendorSha256 = "sha256-2gWifzBjAx+c/if6ZZQ/s73oPPTY9eJfHYL4F/058h0=";
+
+  buildInputs = [
+    libpcap
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/mosajjal/dnsmonster/util.releaseVersion=${version}"
+  ];
+
+  meta = with lib; {
+    description = "Passive DNS Capture and Monitoring Toolkit";
+    homepage = "https://github.com/mosajjal/dnsmonster";
+    changelog = "https://github.com/mosajjal/dnsmonster/releases/tag/v${version}";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ fab ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5221,6 +5221,8 @@ with pkgs;
 
   dnsmon-go = callPackage ../tools/networking/dnsmon-go { };
 
+  dnsmonster = callPackage ../tools/networking/dnsmonster { };
+
   dnspeep = callPackage ../tools/security/dnspeep { };
 
   dnsproxy = callPackage ../tools/networking/dnsproxy { };


### PR DESCRIPTION
###### Description of changes
Passive DNS Capture and Monitoring Toolkit

https://github.com/mosajjal/dnsmonster

Related to #81418 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
