### PR TITLE
infra-arcana: init at 21.0.1

### DIFF
--- a/pkgs/games/infra-arcana/default.nix
+++ b/pkgs/games/infra-arcana/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, makeWrapper
+, SDL2
+, SDL2_image
+, SDL2_mixer
+}:
+
+stdenv.mkDerivation rec {
+  pname = "infra-arcana";
+  version = "21.0.1";
+
+  src = fetchFromGitLab {
+    owner = "martin-tornqvist";
+    repo = "ia";
+    rev = "v${version}";
+    sha256 = "sha256-E2ssxdYa27qRk5cCmM7A5VqXGExwXHblR34y+rOUBRI=";
+  };
+
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = [ SDL2 SDL2_image SDL2_mixer ];
+
+  # Some parts of the game don't compile with glibc 2.34. As soon as
+  # this is fixed upstream we can switch to the default build flags.
+  buildFlags = [ "ia" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{opt/ia,bin}
+
+    # Remove build artifacts
+    rm -rf CMake* cmake* compile_commands.json CTest* Makefile
+    cp -ra * $out/opt/ia
+
+    # Uses relative paths when looking for assets
+    wrapProgram $out/opt/ia/ia --run "cd $out/opt/ia"
+    ln -s $out/opt/ia/ia $out/bin/infra-arcana
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://sites.google.com/site/infraarcana";
+    description = "A Lovecraftian single-player roguelike game";
+    longDescription = ''
+      Infra Arcana is a Roguelike set in the early 20th century. The goal is to
+      explore the lair of a dreaded cult called The Church of Starry Wisdom.
+
+      Buried deep beneath their hallowed grounds lies an artifact called The
+      Shining Trapezohedron - a window to all secrets of the universe. Your
+      ultimate goal is to unearth this artifact.
+    '';
+    platforms = platforms.linux;
+    maintainers = [ maintainers.kenran ];
+    license = licenses.agpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31961,6 +31961,8 @@ with pkgs;
 
   icbm3d = callPackage ../games/icbm3d { };
 
+  infra-arcana = callPackage ../games/infra-arcana { };
+
   ingen = callPackage ../applications/audio/ingen { };
 
   ideogram = callPackage ../applications/graphics/ideogram { };


### PR DESCRIPTION
###### Description of changes

Add the Lovecraft-inspired roguelike game [Infra Arcana](https://sites.google.com/site/infraarcana/home) in its latest released version 21.0.1.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
