### PR TITLE
treewide/misc: add `sourceType` `binaryNativeCode` for more packages

### DIFF
--- a/pkgs/misc/cups/drivers/brgenml1lpr/default.nix
+++ b/pkgs/misc/cups/drivers/brgenml1lpr/default.nix
@@ -87,6 +87,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Brother BrGenML1 LPR driver";
     homepage = "http://www.brother.com";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = lib.platforms.linux;
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [ jraygauthier ];

--- a/pkgs/misc/cups/drivers/brother/dcp9020cdw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/dcp9020cdw/default.nix
@@ -58,6 +58,7 @@ rec {
     meta = with lib; {
       homepage = "http://www.brother.com/";
       description = "Brother ${model} printer driver";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
       license = licenses.unfree;
       platforms = platforms.linux;
       downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_eu&os=128";
@@ -90,6 +91,7 @@ rec {
     meta = with lib; {
       homepage = "http://www.brother.com/";
       description = "Brother ${model} printer CUPS wrapper driver";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
       license = licenses.unfree;
       platforms = platforms.linux;
       downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_eu&os=128";

--- a/pkgs/misc/cups/drivers/brother/mfcl3770cdw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcl3770cdw/default.nix
@@ -48,6 +48,7 @@ in rec {
     meta = {
       description = "Brother ${lib.strings.toUpper model} driver";
       homepage = "http://www.brother.com/";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
       platforms = [ "x86_64-linux" "i686-linux" ];
       maintainers = [ lib.maintainers.steveej ];
@@ -80,6 +81,7 @@ in rec {
     meta = {
       description = "Brother ${lib.strings.toUpper model} CUPS wrapper driver";
       homepage = "http://www.brother.com/";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.gpl2;
       platforms = [ "x86_64-linux" "i686-linux" ];
       maintainers = [ lib.maintainers.steveej ];

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -209,6 +209,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "CUPS Linux drivers for Canon printers";
     homepage = "http://www.canon.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [
       # please consider maintaining if you are updating this package

--- a/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
@@ -103,6 +103,10 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Canon InkJet printer drivers for the iP5400, MP520, MP210, MP140, iP3500, and MP610 series.  (MP520 drivers also work for MX700.)";
     homepage = "http://support-asia.canon-asia.com/content/EN/0100084101.html";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jerith666 ];

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
@@ -145,6 +145,10 @@ in stdenv.mkDerivation {
   meta = with lib; {
     description = "Canon InkJet printer drivers for the MG2400 MG2500 MG3500 MG5500 MG6400 MG6500 MG7100 and P200 series";
     homepage = "https://www.canon-europe.com/support/consumer_products/products/fax__multifunctionals/inkjet/pixma_mg_series/pixma_mg5550.aspx?type=drivers&driverdetailid=tcm:13-1094072";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ chpatrick ];

--- a/pkgs/misc/cups/drivers/fxlinuxprint/default.nix
+++ b/pkgs/misc/cups/drivers/fxlinuxprint/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
       DocuPrint 3205 d/3208 d/3505 d/3508 d/4405 d/4408 d
     '';
     homepage = "https://onlinesupport.fujixerox.com";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ delan ];
     platforms = platforms.linux;

--- a/pkgs/misc/cups/drivers/hl1110/default.nix
+++ b/pkgs/misc/cups/drivers/hl1110/default.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://www.brother.com/";
     description = "Brother HL1110 printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     downloadPage = "http://support.brother.com/g/b/downloadlist.aspx?c=eu_ot&lang=en&prod=hl1110_us_eu_as&os=128#SelectLanguageType-561_0_1";

--- a/pkgs/misc/cups/drivers/hl1210w/default.nix
+++ b/pkgs/misc/cups/drivers/hl1210w/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://www.brother.com/";
     description = "Brother HL1210W printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=nz&lang=en&prod=hl1210w_eu_as&os=128";

--- a/pkgs/misc/cups/drivers/hl3140cw/default.nix
+++ b/pkgs/misc/cups/drivers/hl3140cw/default.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://www.brother.com/";
     description = "Brother hl3140cw printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=eu_ot&lang=en&prod=hl3140cw_us_eu&os=128";

--- a/pkgs/misc/cups/drivers/hll2340dw/default.nix
+++ b/pkgs/misc/cups/drivers/hll2340dw/default.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "http://www.brother.com/";
     description = "Brother hl-l2340dw printer driver";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = platforms.linux;
     downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=es&prod=hll2340dw_us_eu_as&os=128&flang=English";

--- a/pkgs/misc/cups/drivers/hll2350dw/default.nix
+++ b/pkgs/misc/cups/drivers/hll2350dw/default.nix
@@ -86,6 +86,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.brother.com/";
     description = "Brother HL-L2350DW printer driver";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = builtins.map (arch: "${arch}-linux") arches;
     downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us_ot&lang=en&prod=hll2350dw_us_eu_as&os=128";

--- a/pkgs/misc/cups/drivers/hll2390dw-cups/default.nix
+++ b/pkgs/misc/cups/drivers/hll2390dw-cups/default.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.brother.com/";
     description = "Brother HL-L2390DW combined print driver";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     downloadPage = "http://support.brother.com/g/b/downloadlist.aspx?c=us_ot&lang=en&prod=hll2390dw_us&os=128";

--- a/pkgs/misc/cups/drivers/kyocera/default.nix
+++ b/pkgs/misc/cups/drivers/kyocera/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "CUPS drivers for several Kyocera FS-{1020,1025,1040,1060,1120,1125} printers";
     homepage = "https://www.kyoceradocumentsolutions.ru/index/service_support/download_center.false.driver.FS1040._.EN.html#";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = [ maintainers.vanzef ];
     platforms = platforms.linux;

--- a/pkgs/misc/cups/drivers/kyodialog3/default.nix
+++ b/pkgs/misc/cups/drivers/kyodialog3/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "CUPS drivers for several Kyocera printers";
     homepage = "https://www.kyoceradocumentsolutions.com";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = [ maintainers.steveej ];
     platforms = platforms.linux;

--- a/pkgs/misc/cups/drivers/mfc9140cdncupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfc9140cdncupswrapper/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Brother MFC-9140CDN CUPS wrapper driver";
     homepage = "http://www.brother.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/misc/cups/drivers/mfc9140cdnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfc9140cdnlpr/default.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Brother MFC-9140CDN LPR printer driver";
     homepage = "http://www.brother.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ hexa ];
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/misc/cups/drivers/mfcj470dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj470dwlpr/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.brother.com/";
     description = "Brother MFC-J470DW LPR driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     downloadPage = "http://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj470dw_us_eu_as&os=128";

--- a/pkgs/misc/cups/drivers/mfcj6510dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj6510dwlpr/default.nix
@@ -82,6 +82,7 @@ stdenv.mkDerivation rec {
     description  = "Brother MFC-J6510DW LPR driver";
     downloadPage = "http://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj6510dw_all&os=128";
     homepage     = "http://www.brother.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license      = with licenses; unfree;
     maintainers  = with maintainers; [ ramkromberg ];
     platforms    = with platforms; linux;

--- a/pkgs/misc/cups/drivers/mfcl2700dnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2700dnlpr/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Brother MFC-L2700DN LPR driver";
     homepage = "http://www.brother.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.tv ];
     platforms = [ "i686-linux" ];

--- a/pkgs/misc/cups/drivers/mfcl2720dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2720dwlpr/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Brother MFC-L2720DW lpr driver";
     homepage = "http://www.brother.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = [ lib.maintainers.xeji ];

--- a/pkgs/misc/cups/drivers/mfcl2740dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2740dwlpr/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Brother MFC-L2740DW lpr driver";
     homepage = "http://www.brother.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = [ lib.maintainers.Enzime ];

--- a/pkgs/misc/cups/drivers/mfcl2750dw/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2750dw/default.nix
@@ -86,6 +86,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.brother.com/";
     description = "Brother MFC-L2750DW printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = builtins.map (arch: "${arch}-linux") arches;
     maintainers = [ maintainers.lovesegfault ];

--- a/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Brother MFC-L8690CDW LPR printer driver";
     homepage = "http://www.brother.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.fuzzy-id ];
     platforms = [ "i686-linux" ];

--- a/pkgs/misc/cups/drivers/samsung/1.00.36/default.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.36/default.nix
@@ -106,6 +106,7 @@ in stdenv.mkDerivation rec {
     description = "Unified Linux Driver for Samsung printers and scanners";
     homepage = "http://www.bchemnet.com/suldr";
     downloadPage = "http://www.bchemnet.com/suldr/driver/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
 
     # Tested on linux-x86_64. Might work on linux-i386.

--- a/pkgs/misc/cups/drivers/samsung/1.00.37.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.37.nix
@@ -89,6 +89,7 @@ in stdenv.mkDerivation rec {
     description = "Unified Linux Driver for Samsung printers and scanners";
     homepage = "http://www.bchemnet.com/suldr";
     downloadPage = "http://www.bchemnet.com/suldr/driver/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
 
     # Tested on linux-x86_64. Might work on linux-i386.

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -75,6 +75,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Samsung's Linux printing drivers; includes binaries without source code";
     homepage = "http://www.samsung.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ joko ];

--- a/pkgs/misc/drivers/epson-alc1100/default.nix
+++ b/pkgs/misc/drivers/epson-alc1100/default.nix
@@ -63,6 +63,7 @@ in
           };
       '';
 
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
       license = with licenses; [ mit eapl ];
       maintainers = [ maintainers.eperuffo ];
       platforms = platforms.linux;

--- a/pkgs/misc/drivers/pantum-driver/default.nix
+++ b/pkgs/misc/drivers/pantum-driver/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Pantum universal driver";
     homepage = "https://global.pantum.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" ];
   };

--- a/pkgs/misc/drivers/pentablet-driver/default.nix
+++ b/pkgs/misc/drivers/pentablet-driver/default.nix
@@ -31,6 +31,7 @@ mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.xp-pen.com/download-46.html";
     description = "Driver for XP-PEN Pentablet drawing tablets";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ ivar ];

--- a/pkgs/misc/drivers/sundtek/default.nix
+++ b/pkgs/misc/drivers/sundtek/default.nix
@@ -45,6 +45,7 @@ in
     meta = {
       description = "Sundtek MediaTV driver";
       maintainers = [ maintainers.simonvandel ];
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       platforms = platforms.unix;
       license = licenses.unfree;
       homepage = "https://support.sundtek.com/index.php/topic,1573.0.html";


### PR DESCRIPTION
###### Description of changes

For packages missed in #177212.

See also #176823, #178057,  #178059

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
