### PR TITLE
cc-wrapper: fix typo in shell script

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -160,7 +160,7 @@ if [ "$dontLink" != 1 ]; then
 fi
 
 if [[ -e @out@/nix-support/add-local-cc-cflags-before.sh ]]; then
-    source @out@/nix-support/add-local-cflags-before.sh
+    source @out@/nix-support/add-local-cc-cflags-before.sh
 fi
 
 # As a very special hack, if the arguments are just `-v', then don't


### PR DESCRIPTION
Noticed this bug when was trying to bootstrap m4 on darwin. That fixes

	line 163: no such file or directory error

That does not solve all problems staging has on darwin.