### PR TITLE
unvanquished: fix sdl event overflow

### DIFF
--- a/pkgs/games/unvanquished/default.nix
+++ b/pkgs/games/unvanquished/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchzip
 , fetchFromGitHub
+, fetchpatch
 , SDL2
 , buildFHSUserEnv
 , cmake
@@ -138,6 +139,24 @@ in stdenv.mkDerivation rec {
     cp -r ${unvanquished-binary-deps}/* daemon/external_deps/linux64-${binary-deps-version}/
     chmod +w -R daemon/external_deps/linux64-${binary-deps-version}/
   '';
+
+  patches = [
+    (fetchpatch {
+      name = "fix-sdl-eventqueue-part1.patch";
+      url = "https://github.com/DaemonEngine/Daemon/commit/3a978c485f2a7e02c0bc5aeed2c7c4378026cb33.patch";
+      sha256 = "sha256-wVDscGf5zOOmivItNK913l0cfNFR6RpApewrxbmfG8s=";
+      stripLen = 1;
+      extraPrefix = "daemon/";
+    })
+    (fetchpatch {
+      name = "fix-sdl-eventqueue-part2.patch";
+      url = "https://github.com/DaemonEngine/Daemon/commit/54f98909c8871a57efb40263b215b81f22010b22.patch";
+      sha256 = "sha256-9qlyJnUEyZgFaclpXthKHm3qq+cW4E4LMOpLukcwBCU=";
+      stripLen = 1;
+      extraPrefix = "daemon/";
+      excludes = [ "*/CMakeLists.txt" ];
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Fixes https://github.com/DaemonEngine/Daemon/issues/600

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (the only supported platform)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).