### PR TITLE
cargo-bisect-rustc: 0.6.0 -> 0.6.3

### DIFF
--- a/pkgs/development/tools/rust/cargo-bisect-rustc/default.nix
+++ b/pkgs/development/tools/rust/cargo-bisect-rustc/default.nix
@@ -12,29 +12,30 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-bisect-rustc";
-  version = "0.6.0";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-LEmILWVU6hbh2FmdnQVV1Ob2MQvj+/lCr1hdRoTIOkI=";
+    hash = "sha256-TRcHeA4pOzODyzkQCGkdAWy3Bt2ltrOcpCMDu6n4k3k=";
   };
 
   patches =
     let
-      patchelfPatch = runCommand "0001-dynamically-patchelf-binaries.patch" {
-        CC = stdenv.cc;
-        patchelf = patchelf;
-        libPath = "$ORIGIN/../lib:${lib.makeLibraryPath [ zlib ]}";
-      }
-      ''
-        export dynamicLinker=$(cat $CC/nix-support/dynamic-linker)
-        substitute ${./0001-dynamically-patchelf-binaries.patch} $out \
-          --subst-var patchelf \
-          --subst-var dynamicLinker \
-          --subst-var libPath
-      '';
+      patchelfPatch = runCommand "0001-dynamically-patchelf-binaries.patch"
+        {
+          CC = stdenv.cc;
+          patchelf = patchelf;
+          libPath = "$ORIGIN/../lib:${lib.makeLibraryPath [ zlib ]}";
+        }
+        ''
+          export dynamicLinker=$(cat $CC/nix-support/dynamic-linker)
+          substitute ${./0001-dynamically-patchelf-binaries.patch} $out \
+            --subst-var patchelf \
+            --subst-var dynamicLinker \
+            --subst-var libPath
+        '';
     in
     lib.optionals stdenv.isLinux [ patchelfPatch ];
 
@@ -45,7 +46,7 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  cargoSha256 = "Ls51DQ0yScRhpkuEInCfR45+/WeaUoG935w4BJvwSRk=";
+  cargoSha256 = "sha256-3I5V/JOxxy1+Cwkq9tuHMgHQ0eCfzAViJ4Gl+l8RHlE=";
 
   meta = with lib; {
     description = "Bisects rustc, either nightlies or CI artifacts";


### PR DESCRIPTION
###### Description of changes
Update `cargo-bisect-rustc` to 0.6.3.


###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
