### PR TITLE
makeDBusConf: reduce build closure

### DIFF
--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -20,12 +20,12 @@ runCommand "dbus-1"
     allowSubstitutes = false;
 
     nativeBuildInputs = [
-      libxslt
+      libxslt.bin
       findXMLCatalogs
     ];
 
     buildInputs = [
-      dbus
+      dbus.out
     ];
   }
   ''


### PR DESCRIPTION
\*buildInputs take .dev outputs by default, but we don't need it here.
The extra dependency (introduced by commit d1720612814) was breaking
tests like nixosTests.containers-imperative and nixosTests.installer.*
https://hydra.nixos.org/eval/1767666#tabs-still-fail