### PR TITLE
tiscamera: 0.13.1 -> 1.0.0

### DIFF
--- a/pkgs/os-specific/linux/tiscamera/0001-cmake-find-aravis-fix-pkg-cfg-include-dirs.patch
+++ b/pkgs/os-specific/linux/tiscamera/0001-cmake-find-aravis-fix-pkg-cfg-include-dirs.patch
@@ -1,0 +1,25 @@
+From 90b540bd135de2587352719b14c385b20aa572be Mon Sep 17 00:00:00 2001
+From: Raymond Gauthier <jraygauthier@gmail.com>
+Date: Wed, 15 Jun 2022 16:09:58 -0400
+Subject: [PATCH] cmake-find-aravis: fix pkg cfg include dirs
+
+---
+ cmake/modules/FindAravis.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/modules/FindAravis.cmake b/cmake/modules/FindAravis.cmake
+index 5dab5431..811302b9 100644
+--- a/cmake/modules/FindAravis.cmake
++++ b/cmake/modules/FindAravis.cmake
+@@ -20,7 +20,7 @@ find_path(aravis_INCLUDE_DIR
+ 	arv.h
+ 	PATHS
+ 	${aravis_PKGCONF_INCLUDE_DIRS}
+-	${aravis0_6_PKGCONF_INCLUDE_DIRS}
++	${aravis0_8_PKGCONF_INCLUDE_DIRS}
+ 	/usr/local/include
+ 	# /usr/local/include/aravis-0.4
+ 	/usr/local/include/aravis-0.8
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/tiscamera/0001-tcamconvert-tcamsrc-add-missing-include-lib-dirs.patch
+++ b/pkgs/os-specific/linux/tiscamera/0001-tcamconvert-tcamsrc-add-missing-include-lib-dirs.patch
@@ -1,0 +1,70 @@
+From 5e7146e176cb1b01b47d16a66763469dccd87f25 Mon Sep 17 00:00:00 2001
+From: Raymond Gauthier <jraygauthier@gmail.com>
+Date: Thu, 9 Jun 2022 19:45:30 -0400
+Subject: [PATCH] tcamconvert&tcamsrc: add missing include/lib dirs
+
+These were building libraries with dependencies on gstreamer-video
+and gstreamer-base but weren't adding the proper include and
+lib directories which resulted in build failure on systems
+where video and base aren't installed in the same location
+as gstreamer itself (e.g: nix, nixos).
+---
+ src/gstreamer-1.0/tcamconvert/CMakeLists.txt |  2 ++
+ src/gstreamer-1.0/tcamsrc/CMakeLists.txt     | 11 +++++++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/src/gstreamer-1.0/tcamconvert/CMakeLists.txt b/src/gstreamer-1.0/tcamconvert/CMakeLists.txt
+index 30563c38..066cb5d7 100644
+--- a/src/gstreamer-1.0/tcamconvert/CMakeLists.txt
++++ b/src/gstreamer-1.0/tcamconvert/CMakeLists.txt
+@@ -28,6 +28,8 @@ add_library(tcamconvert SHARED
+ target_include_directories(tcamconvert
+   PRIVATE
+   ${GSTREAMER_INCLUDE_DIRS}
++  ${GSTREAMER_BASE_INCLUDE_DIRS}
++  ${GSTREAMER_VIDEO_INCLUDE_DIRS}
+   )
+ 
+ set_project_warnings(tcamconvert)
+diff --git a/src/gstreamer-1.0/tcamsrc/CMakeLists.txt b/src/gstreamer-1.0/tcamsrc/CMakeLists.txt
+index 3bc7ed97..ed5be37f 100644
+--- a/src/gstreamer-1.0/tcamsrc/CMakeLists.txt
++++ b/src/gstreamer-1.0/tcamsrc/CMakeLists.txt
+@@ -21,12 +21,15 @@ add_library(gsttcamstatistics SHARED
+ target_include_directories(gsttcamstatistics
+   PRIVATE
+   ${GSTREAMER_INCLUDE_DIRS}
++  ${GSTREAMER_BASE_INCLUDE_DIRS}
++  ${GSTREAMER_VIDEO_INCLUDE_DIRS}
+   )
+ 
+ target_link_libraries( gsttcamstatistics
+   PRIVATE
+   ${GSTREAMER_LIBRARIES}
+   ${GSTREAMER_BASE_LIBRARIES}
++  ${GSTREAMER_VIDEO_LIBRARIES}
+   )
+ 
+ 
+@@ -53,10 +56,18 @@ add_library(gsttcamsrc SHARED
+ 	tcambind.cpp
+     )
+ 
++  target_include_directories(gsttcamsrc
++    PRIVATE
++    ${GSTREAMER_INCLUDE_DIRS}
++    ${GSTREAMER_BASE_INCLUDE_DIRS}
++    ${GSTREAMER_VIDEO_INCLUDE_DIRS}
++    )
++
+   target_link_libraries( gsttcamsrc
+     PRIVATE
+ 	${GSTREAMER_LIBRARIES}
+ 	${GSTREAMER_BASE_LIBRARIES}
++    ${GSTREAMER_VIDEO_LIBRARIES}
+ 
+ 	tcamgstbase
+ 	tcam::gst-helper
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/tiscamera/0001-udev-rules-fix-install-location.patch
+++ b/pkgs/os-specific/linux/tiscamera/0001-udev-rules-fix-install-location.patch
@@ -1,0 +1,25 @@
+From fdbc0b74812b9afd663226715375b5688e5408b5 Mon Sep 17 00:00:00 2001
+From: Raymond Gauthier <jraygauthier@gmail.com>
+Date: Thu, 9 Jun 2022 20:23:02 -0400
+Subject: [PATCH] udev/rules: fix install location
+
+---
+ CMakeInstall.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeInstall.cmake b/CMakeInstall.cmake
+index 4773091f..962c9b09 100644
+--- a/CMakeInstall.cmake
++++ b/CMakeInstall.cmake
+@@ -92,7 +92,7 @@ else()
+ 
+   else()
+ 
+-    set(TCAM_INSTALL_UDEV "${CMAKE_INSTALL_PREFIX}/udev/rules.d" CACHE PATH "udev rules installation path" FORCE)
++    set(TCAM_INSTALL_UDEV "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE PATH "udev rules installation path" FORCE)
+     set(TCAM_INSTALL_SYSTEMD "${CMAKE_INSTALL_PREFIX}/lib/systemd/system/" CACHE PATH "systemd unit installation path" FORCE)
+ 
+     set(TCAM_INSTALL_PKGCONFIG "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig" CACHE PATH "pkgconfig installation path" FORCE)
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/tiscamera/default.nix
+++ b/pkgs/os-specific/linux/tiscamera/default.nix
@@ -3,82 +3,111 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
-, pcre
-, tinyxml
+, runtimeShell
+, catch2
+, elfutils
+, libselinux
+, libsepol
+, libunwind
 , libusb1
+, libuuid
 , libzip
+, orc
+, pcre
+, zstd
 , glib
 , gobject-introspection
 , gst_all_1
-, libwebcam
-, libunwind
-, elfutils
-, orc
-, python3Packages
-, libuuid
 , wrapGAppsHook
-, catch2
+, withDoc ? true
+, sphinx
+, graphviz
+, withAravis ? true
+, aravis
+, meson
+, withAravisUsbVision ? withAravis
+, withGui ? true
+, qt5
 }:
 
 stdenv.mkDerivation rec {
   pname = "tiscamera";
-  version = "0.13.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "TheImagingSource";
     repo = pname;
     rev = "v-${pname}-${version}";
-    sha256 = "0hpy9yhc4mn6w8gvzwif703smmcys0j2jqbz2xfghqxcyb0ykplj";
+    sha256 = "0msz33wvqrji11kszdswcvljqnjflmjpk0aqzmsv6i855y8xn6cd";
   };
+
+  patches = [
+    ./0001-tcamconvert-tcamsrc-add-missing-include-lib-dirs.patch
+    ./0001-udev-rules-fix-install-location.patch
+    ./0001-cmake-find-aravis-fix-pkg-cfg-include-dirs.patch
+  ];
 
   postPatch = ''
     cp ${catch2}/include/catch2/catch.hpp external/catch/catch.hpp
+
+    substituteInPlace ./data/udev/80-theimagingsource-cameras.rules.in \
+      --replace "/bin/sh" "${runtimeShell}/bin/sh" \
+      --replace "typically /usr/bin/" "" \
+      --replace "typically /usr/share/theimagingsource/tiscamera/uvc-extension/" ""
   '';
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    python3Packages.wrapPython
     wrapGAppsHook
+  ] ++ lib.optionals withDoc [
+    sphinx
+    graphviz
+  ] ++ lib.optionals withAravis [
+    meson
+  ] ++ lib.optionals withGui [
+    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    pcre
-    tinyxml
+    elfutils
+    libselinux
+    libsepol
+    libunwind
     libusb1
+    libuuid
     libzip
+    orc
+    pcre
+    zstd
     glib
     gobject-introspection
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
-    libwebcam
-    libunwind
-    elfutils
-    orc
-    libuuid
-    python3Packages.python
-    python3Packages.pyqt5
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+  ] ++ lib.optionals withAravis [
+    aravis
+  ] ++ lib.optionals withGui [
+    qt5.qtbase
   ];
 
-  pythonPath = with python3Packages; [ pyqt5 pygobject3 ];
-
-  propagatedBuildInputs = pythonPath;
+  hardeningDisable = [ "format" ];
 
   cmakeFlags = [
-    "-DBUILD_ARAVIS=OFF" # For GigE support. Won't need it as our camera is usb.
-    "-DBUILD_GST_1_0=ON"
-    "-DBUILD_TOOLS=ON"
-    "-DBUILD_V4L2=ON"
-    "-DBUILD_LIBUSB=ON"
-    "-DBUILD_TESTS=ON"
-    "-DTCAM_INSTALL_UDEV=${placeholder "out"}/lib/udev/rules.d"
-    "-DTCAM_INSTALL_UVCDYNCTRL=${placeholder "out"}/share/uvcdynctrl/data/199e"
-    "-DTCAM_INSTALL_GST_1_0=${placeholder "out"}/lib/gstreamer-1.0"
-    "-DTCAM_INSTALL_GIR=${placeholder "out"}/share/gir-1.0"
-    "-DTCAM_INSTALL_TYPELIB=${placeholder "out"}/lib/girepository-1.0"
-    "-DTCAM_INSTALL_SYSTEMD=${placeholder "out"}/etc/systemd/system"
-    "-DTCAM_INSTALL_PYTHON3_MODULES=${placeholder "out"}/lib/${python3Packages.python.libPrefix}/site-packages"
-    "-DGSTREAMER_1.0_INCLUDEDIR=${placeholder "out"}/include/gstreamer-1.0"
+    "-DTCAM_BUILD_GST_1_0=ON"
+    "-DTCAM_BUILD_TOOLS=ON"
+    "-DTCAM_BUILD_V4L2=ON"
+    "-DTCAM_BUILD_LIBUSB=ON"
+    "-DTCAM_BUILD_TESTS=ON"
+    "-DTCAM_BUILD_ARAVIS=${if withAravis then "ON" else "OFF"}"
+    "-DTCAM_BUILD_DOCUMENTATION=${if withDoc then "ON" else "OFF"}"
+    "-DTCAM_BUILD_WITH_GUI=${if withGui then "ON" else "OFF"}"
+    "-DTCAM_DOWNLOAD_MESON=OFF"
+    "-DTCAM_INTERNAL_ARAVIS=OFF"
+    "-DTCAM_ARAVIS_USB_VISION=${if withAravis && withAravisUsbVision then "ON" else "OFF"}"
+    "-DTCAM_INSTALL_FORCE_PREFIX=ON"
     # There are gobject introspection commands launched as part of the build. Those have a runtime
     # dependency on `libtcam` (which itself is built as part of this build). In order to allow
     # that, we set the dynamic linker's path to point on the build time location of the library.
@@ -90,8 +119,17 @@ stdenv.mkDerivation rec {
   # gstreamer tests requires, besides gst-plugins-bad, plugins installed by this expression.
   checkPhase = "ctest --force-new-ctest-process -E gstreamer";
 
-  postFixup = ''
-    wrapPythonPrograms "$out $pythonPath"
+  # wrapGAppsHook: make sure we add ourselves to the introspection
+  # and gstreamer paths.
+  GI_TYPELIB_PATH = "${placeholder "out"}/lib/girepository-1.0";
+  GST_PLUGIN_SYSTEM_PATH_1_0 = "${placeholder "out"}/lib/gstreamer-1.0";
+
+  QT_PLUGIN_PATH = lib.optionalString withGui "${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}";
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    gappsWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20962,7 +20962,7 @@ with pkgs;
 
   tinyxml-2 = callPackage ../development/libraries/tinyxml-2 { };
 
-  tiscamera = callPackage ../os-specific/linux/tiscamera { stdenv = gcc10StdenvCompat; };
+  tiscamera = callPackage ../os-specific/linux/tiscamera { };
 
   tivodecode = callPackage ../applications/video/tivodecode { };
 


### PR DESCRIPTION
###### Description of changes

Package was broken. A new version was available. Currently have an opportunity to experiment with a actual tis camera again, so made sure to update the package testing that it is functional.

Also, as requested, added support for Aravis.

Also added support for building documentation.

Also added support for *not* building gui.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
