### PR TITLE
lib/systems: make riscv{32,64}-embedded soft-float by default

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -131,11 +131,25 @@ rec {
   riscv64-embedded = {
     config = "riscv64-none-elf";
     libc = "newlib";
+    # Compile a soft-float libgcc.a (intrinsics). This does not
+    # restrict the buildPackages.gcc to rv32i targets, but defines the
+    # default target arch and ABI.
+    gcc = {
+      arch = "rv32i";
+      abi = "ilp32";
+    };
   };
 
   riscv32-embedded = {
     config = "riscv32-none-elf";
     libc = "newlib";
+    # Compile a soft-float libgcc.a (intrinsics). This does not
+    # restrict the buildPackages.gcc to rv32i targets, but defines the
+    # default target arch and ABI.
+    gcc = {
+      arch = "rv32i";
+      abi = "ilp32";
+    };
   };
 
   mmix = {


### PR DESCRIPTION
###### Description of changes

By default, the target configuration `riscv{32,64}-none-elf` builds a GCC with a hard-float `libgcc.a`. Many RISC-V embedded implementations do not feature hard float support, so using the compiler shipped through `pkgCross.riscv{32,64}-embedded.buildPackages.gcc` will not work for them. Building a new target with the proper options requires two compilations of GCC, due to the way Nix builds the compiler (target GCC -> libc with target GCC -> target GCC with built libc), which is not exactly a cheap operation.

Instead, it appears to make more sense to follow the approach of other architectures (e.g. arm-embedded) and default to soft-float, eventually providing an explicit hard-float target as well.

What makes this issue worse with RISC-V is that a given compiler theoretically supports multiple different target architectures specified through the `-march` flag. The compiler with hard-float intrinsics will happily compile a soft-float target, and is able to link as long as no hard-float objects (e.g. intrinsics) are included. However, changing from a target with multiplication support (`rv32imc`) to one without (`rv32i`) now requires linking against `muldi3.o` and `div.o` of `libgcc.a`, which are hard-float modules, despite this change not introducing any floating point arithmetic per se:

```
  LD        build/rv32i/rv32i.0x00080060.0x40008000.elf
/nix/store/j98mn0mvm4fxg5bia7hf47d6bbd5ws1r-riscv32-none-elf-binutils-2.38/bin/riscv32-none-elf-ld: /nix/store/457pgk7c91w462lawn43lzvf5rlxk4q1-riscv32-none-elf-stage-final-gcc-debug-11.3.0/lib/gcc/riscv32-none-elf/11.3.0/libgcc.a(muldi3.o): can't link double-float modules with soft-float modules
/nix/store/j98mn0mvm4fxg5bia7hf47d6bbd5ws1r-riscv32-none-elf-binutils-2.38/bin/riscv32-none-elf-ld: failed to merge target specific data of file /nix/store/457pgk7c91w462lawn43lzvf5rlxk4q1-riscv32-none-elf-stage-final-gcc-debug-11.3.0/lib/gcc/riscv32-none-elf/11.3.0/libgcc.a(muldi3.o)
/nix/store/j98mn0mvm4fxg5bia7hf47d6bbd5ws1r-riscv32-none-elf-binutils-2.38/bin/riscv32-none-elf-ld: /nix/store/457pgk7c91w462lawn43lzvf5rlxk4q1-riscv32-none-elf-stage-final-gcc-debug-11.3.0/lib/gcc/riscv32-none-elf/11.3.0/libgcc.a(div.o): can't link double-float modules with soft-float modules
/nix/store/j98mn0mvm4fxg5bia7hf47d6bbd5ws1r-riscv32-none-elf-binutils-2.38/bin/riscv32-none-elf-ld: failed to merge target specific data of file /nix/store/457pgk7c91w462lawn43lzvf5rlxk4q1-riscv32-none-elf-stage-final-gcc-debug-11.3.0/lib/gcc/riscv32-none-elf/11.3.0/libgcc.a(div.o)
collect2: error: ld returned 1 exit status
make: *** [../../AppMakefile.mk:269: build/rv32i/rv32i.0x00080060.0x40008000.elf] Error 1
```

I'm currently facing this issue within https://github.com/tock/libtock-c. I would prefer to avoid having users build GCC twice before they can produce binaries.

Alternatively we could look into shipping a multilib-GCC by default for this target, which would then support soft-/hard-float and intrinsics optimized for multiple different `-march` (e.g. `rv32i`, `rv32imc`, `rv32imac`, ...). I don't know what's the preferred/best approach here and looking for feedback. According to my findings, this change does not influence binaries built for architectures where some instrinsics are backed by hardware instructions (meaning a `libgcc.a` built for `rv32i` without hardware multiplication does not cause binaries linked for `rv32imc` with hardware multiplication to use the software multiplication implementation), so the tradeoff of this change would really only be using soft-float for intrinsics (`libgcc.a`) by default, even if the target potentially has hard-float.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Thanks to @alyssais for helping me debug this!

@NixOS/exotic-platform-maintainers 