### PR TITLE
umoria: fix savefile persistence (#178136); refactor and extend

### DIFF
--- a/pkgs/games/umoria/default.nix
+++ b/pkgs/games/umoria/default.nix
@@ -38,24 +38,22 @@ gcc9Stdenv.mkDerivation rec {
 
     RUNDIR=\$(mktemp -d)
 
-    cleanup() {
-      rm -rf \$RUNDIR
-    }
-
-    trap cleanup EXIT
+    # Print the directory, so users have access to dumps, and let the system
+    # take care of cleaning up temp files.
+    echo "Running umoria in \$RUNDIR"
 
     cd \$RUNDIR
-    mkdir data
-
-    for i in $out/data/*; do
-      ln -s \$i "data/\$(basename \$i)"
-    done
+    ln -sn $out/data \$RUNDIR/data
 
     mkdir -p ${savesDir}
     [[ ! -f ${savesDir}/scores.dat ]] && touch ${savesDir}/scores.dat
     ln -s ${savesDir}/scores.dat scores.dat
 
-    $out/.umoria-unwrapped ${savesDir}/game.sav
+    if [ \$# -eq 0 ]; then
+       $out/.umoria-unwrapped ${savesDir}/game.sav
+    else
+       $out/.umoria-unwrapped "\$@"
+    fi
     EOF
 
     chmod +x $out/bin/umoria
@@ -74,7 +72,7 @@ gcc9Stdenv.mkDerivation rec {
     '';
     platforms = platforms.unix;
     badPlatforms = [ "aarch64-darwin" ];
-    maintainers = [ maintainers.aciceri ];
+    maintainers = with maintainers; [ aciceri kenran ];
     license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/games/umoria/default.nix
+++ b/pkgs/games/umoria/default.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  savesDir = "~/.umoria/";
+  savesDir = "~/.umoria";
 in
 gcc9Stdenv.mkDerivation rec {
   pname = "umoria";
@@ -55,7 +55,7 @@ gcc9Stdenv.mkDerivation rec {
     [[ ! -f ${savesDir}/scores.dat ]] && touch ${savesDir}/scores.dat
     ln -s ${savesDir}/scores.dat scores.dat
 
-    $out/.umoria-unwrapped
+    $out/.umoria-unwrapped ${savesDir}/game.sav
     EOF
 
     chmod +x $out/bin/umoria


### PR DESCRIPTION
###### Description of changes

Part 1 (fixes #178136):
It was impossible to continue a saved character before, as the `cleanup` function would remove the whole temporary `RUNDIR`, including the actual save file.

`umoria` allows passing a custom save file location, which now points to the already-used data directory `~/.umoria`.

Part 2:
- Simplify some symlinking
- Don't remove the temporary run directory: `umoria` allows for dumping character info, which would be in there and inaccessible after saving the game otherwise.  The system takes care of cleaning up the temporary directory anyway.
- Allow passing arguments to the wrapped executable, for instance to customize different save directories/files, maniupulate game seeds, checking out highscores, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
