### PR TITLE
osv-detector: init at 0.6.0

### DIFF
--- a/pkgs/tools/security/osv-detector/default.nix
+++ b/pkgs/tools/security/osv-detector/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, osv-detector
+, testers
+}:
+
+buildGoModule rec {
+  pname = "osv-detector";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "G-Rath";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Y/9q4ZJ4vxDitqrM4hGe49iqLYk4ebhTs4jrD7P8fdw=";
+  };
+
+  vendorSha256 = "sha256-KAxpDQIRrLZIOvfW8wf0CV4Fj6l3W6nNZNCH3ZE6yJc=";
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X main.version=${version}"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = osv-detector;
+    command = "osv-detector -version";
+    version = "osv-detector ${version} (unknown, commit none)";
+  };
+
+  meta = with lib; {
+    description = "Auditing tool for detecting vulnerabilities";
+    homepage = "https://github.com/G-Rath/osv-detector";
+    changelog = "https://github.com/G-Rath/osv-detector/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4139,6 +4139,8 @@ with pkgs;
 
   ossutil = callPackage ../tools/admin/ossutil {};
 
+  osv-detector = callPackage ../tools/security/osv-detector {};
+
   pastel = callPackage ../applications/misc/pastel {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes
Auditing tool for detecting vulnerabilities

https://github.com/G-Rath/osv-detector

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
