### PR TITLE
kodi.packages.urllib3: 1.26.8+matrix.1 -> 1.26.9+matrix.1

### DIFF
--- a/pkgs/applications/video/kodi/addons/urllib3/default.nix
+++ b/pkgs/applications/video/kodi/addons/urllib3/default.nix
@@ -1,23 +1,20 @@
-{ lib, buildKodiAddon, fetchFromGitHub, addonUpdateScript }:
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
 
 buildKodiAddon rec {
   pname = "urllib3";
   namespace = "script.module.urllib3";
-  version = "1.26.8+matrix.1";
+  version = "1.26.9+matrix.1";
 
-  # temporarily fetching from a PR because of CVE-2021-33503
-  # see https://github.com/xbmc/repo-scripts/pull/2193 for details
-  src = fetchFromGitHub {
-    owner = "xbmc";
-    repo = "repo-scripts";
-    rev = "f0bfacab4732e33c5669bedd1a86319fa9e38338";
-    sha256 = "sha256-UEMLrIvuuPARGHMsz6dOZrOuHIYVSpi0gBy2lK1Y2sk=";
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "w2HXepAHLE4NAWTXOQgY3ifr3mlI/QYF6KAKqpAmO/g=";
   };
-
-  sourceRoot = "source/script.module.urllib3";
 
   passthru = {
     pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.urllib3";
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

upstream fixed the CVE so we don't need to patch this ourselves anymore - cleanup from https://github.com/NixOS/nixpkgs/pull/176391

ping @dotlambda who really took care of things for this CVE :heart:

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
