### PR TITLE
xanmod-kernels: add TT variant as dev

### DIFF
--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -7,7 +7,7 @@ let
     hash = "sha256-MeH9RUPDiuN22eAZ18v+N3aIT18dQ3FnTkcQV0MjB4k=";
   };
 
-  stableTTVariant = {
+  devVariant = {
     version = "5.15.47";
     suffix = "xanmod1-tt";
     hash = "sha256-/0cfH59Oe62cF92tNNXfKKFnPztY4hjiVbvCth59HJU=";
@@ -89,6 +89,6 @@ let
 in
 {
   stable = xanmodKernelFor stableVariant;
-  stableTT = xanmodKernelFor stableTTVariant;
+  dev = xanmodKernelFor devVariant;
   edge = xanmodKernelFor edgeVariant;
 }

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -8,9 +8,9 @@ let
   };
 
   ttVariant = {
-    version = "5.15.47";
+    version = "5.15.54";
     suffix = "xanmod1-tt";
-    hash = "sha256-/0cfH59Oe62cF92tNNXfKKFnPztY4hjiVbvCth59HJU=";
+    hash = "sha256-4ck9PAFuIt/TxA/U+moGlVfCudJnzSuAw7ooFG3OJis=";
   };
 
   edgeVariant = {

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -7,7 +7,7 @@ let
     hash = "sha256-B7WPFY9SnqL3nwNxxXPjxdRAYMT8H5OpwQsZIRm5aD0=";
   };
 
-  devVariant = {
+  ttVariant = {
     version = "5.15.47";
     suffix = "xanmod1-tt";
     hash = "sha256-/0cfH59Oe62cF92tNNXfKKFnPztY4hjiVbvCth59HJU=";
@@ -86,6 +86,6 @@ let
 in
 {
   stable = xanmodKernelFor stableVariant;
-  dev = xanmodKernelFor devVariant;
+  tt = xanmodKernelFor ttVariant;
   edge = xanmodKernelFor edgeVariant;
 }

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -2,9 +2,9 @@
 
 let
   stableVariant = {
-    version = "5.15.43";
+    version = "5.15.47";
     suffix = "xanmod1";
-    hash = "sha256-MeH9RUPDiuN22eAZ18v+N3aIT18dQ3FnTkcQV0MjB4k=";
+    hash = "sha256-B7WPFY9SnqL3nwNxxXPjxdRAYMT8H5OpwQsZIRm5aD0=";
   };
 
   devVariant = {
@@ -14,9 +14,9 @@ let
   };
 
   edgeVariant = {
-    version = "5.18.1";
+    version = "5.18.4";
     suffix = "xanmod1";
-    hash = "sha256-dqvB4F2S7cklSJ7XTUNvWVKTsZGLevOXME5lvhmfyis=";
+    hash = "sha256-giVzl7r/1Ce824wEoW61yeBcmQmlkVuPtqGQR80ORZY=";
   };
 
   xanmodKernelFor = { version, suffix, hash }: buildLinux (args // rec {
@@ -44,9 +44,6 @@ let
 
         # AMD P-state driver
         X86_AMD_PSTATE = yes;
-
-        # Linux RNG framework
-        LRNG = whenOlder "5.18" yes;
 
         # Paragon's NTFS3 driver
         NTFS3_FS = module;

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -7,6 +7,12 @@ let
     hash = "sha256-MeH9RUPDiuN22eAZ18v+N3aIT18dQ3FnTkcQV0MjB4k=";
   };
 
+  stableTTVariant = {
+    version = "5.15.47";
+    suffix = "xanmod1-tt";
+    hash = "sha256-/0cfH59Oe62cF92tNNXfKKFnPztY4hjiVbvCth59HJU=";
+  };
+
   edgeVariant = {
     version = "5.18.1";
     suffix = "xanmod1";
@@ -83,5 +89,6 @@ let
 in
 {
   stable = xanmodKernelFor stableVariant;
+  stableTT = xanmodKernelFor stableTTVariant;
   edge = xanmodKernelFor edgeVariant;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23420,6 +23420,8 @@ with pkgs;
   # XanMod kernel
   linuxPackages_xanmod = linuxKernel.packages.linux_xanmod;
   linux_xanmod = linuxKernel.kernels.linux_xanmod;
+  linuxPackages_xanmod_tt = linuxKernel.packages.linux_xanmod_tt;
+  linux_xanmod_tt = linuxKernel.kernels.linux_xanmod_tt;
   linuxPackages_xanmod_latest = linuxKernel.packages.linux_xanmod_latest;
   linux_xanmod_latest = linuxKernel.kernels.linux_xanmod_latest;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23420,8 +23420,8 @@ with pkgs;
   # XanMod kernel
   linuxPackages_xanmod = linuxKernel.packages.linux_xanmod;
   linux_xanmod = linuxKernel.kernels.linux_xanmod;
-  linuxPackages_xanmod_dev = linuxKernel.packages.linux_xanmod_dev;
-  linux_xanmod_dev = linuxKernel.kernels.linux_xanmod_dev;
+  linuxPackages_xanmod_tt = linuxKernel.packages.linux_xanmod_tt;
+  linux_xanmod_tt = linuxKernel.kernels.linux_xanmod_tt;
   linuxPackages_xanmod_latest = linuxKernel.packages.linux_xanmod_latest;
   linux_xanmod_latest = linuxKernel.kernels.linux_xanmod_latest;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23420,8 +23420,8 @@ with pkgs;
   # XanMod kernel
   linuxPackages_xanmod = linuxKernel.packages.linux_xanmod;
   linux_xanmod = linuxKernel.kernels.linux_xanmod;
-  linuxPackages_xanmod_tt = linuxKernel.packages.linux_xanmod_tt;
-  linux_xanmod_tt = linuxKernel.kernels.linux_xanmod_tt;
+  linuxPackages_xanmod_dev = linuxKernel.packages.linux_xanmod_dev;
+  linux_xanmod_dev = linuxKernel.kernels.linux_xanmod_dev;
   linuxPackages_xanmod_latest = linuxKernel.packages.linux_xanmod_latest;
   linux_xanmod_latest = linuxKernel.kernels.linux_xanmod_latest;
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -225,12 +225,12 @@ in {
       ];
     }).stable;
 
-    linux_xanmod_tt = (xanmodKernels {
+    linux_xanmod_dev = (xanmodKernels {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
-    }).stableTT;
+    }).dev;
 
     linux_xanmod_latest = (xanmodKernels {
       kernelPatches = [
@@ -568,7 +568,7 @@ in {
     linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
     linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
     linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
-    linux_xanmod_tt = recurseIntoAttrs (packagesFor kernels.linux_xanmod_tt);
+    linux_xanmod_dev = recurseIntoAttrs (packagesFor kernels.linux_xanmod_dev);
     linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
 
     hardkernel_4_14 = recurseIntoAttrs (packagesFor kernels.linux_hardkernel_4_14);

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -225,12 +225,12 @@ in {
       ];
     }).stable;
 
-    linux_xanmod_dev = (xanmodKernels {
+    linux_xanmod_tt = (xanmodKernels {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
-    }).dev;
+    }).tt;
 
     linux_xanmod_latest = (xanmodKernels {
       kernelPatches = [
@@ -568,7 +568,7 @@ in {
     linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
     linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
     linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
-    linux_xanmod_dev = recurseIntoAttrs (packagesFor kernels.linux_xanmod_dev);
+    linux_xanmod_tt = recurseIntoAttrs (packagesFor kernels.linux_xanmod_tt);
     linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
 
     hardkernel_4_14 = recurseIntoAttrs (packagesFor kernels.linux_hardkernel_4_14);

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -225,6 +225,13 @@ in {
       ];
     }).stable;
 
+    linux_xanmod_tt = (xanmodKernels {
+      kernelPatches = [
+        kernelPatches.bridge_stp_helper
+        kernelPatches.request_key_helper
+      ];
+    }).stableTT;
+
     linux_xanmod_latest = (xanmodKernels {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
@@ -561,6 +568,7 @@ in {
     linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
     linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
     linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
+    linux_xanmod_tt = recurseIntoAttrs (packagesFor kernels.linux_xanmod_tt);
     linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
 
     hardkernel_4_14 = recurseIntoAttrs (packagesFor kernels.linux_hardkernel_4_14);


### PR DESCRIPTION
###### Description of changes

the xanmod-tt kernel used to be the default but was removed in #165257. this PR adds back the xanmod1-tt stable variant as linux_xanmod_dev, leaving the default linux_xanmod kernel to the base stable variant. note that the TT scheduler patches have not been made available for the edge variant upstream so we can't add a matching linux_xanmod_latest_dev variant.

alternatives considered:
* just use overrides to set the TT variant: this patched version is published as a separate release so this can't be easily overridden by users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
