### PR TITLE
qt6: 6.3.0 -> 6.3.1

### DIFF
--- a/pkgs/development/libraries/qt-6/fetch.sh
+++ b/pkgs/development/libraries/qt-6/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/6.3/6.3.0/submodules/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/6.3/6.3.1/submodules/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -57,7 +57,6 @@
 , ffmpeg
 , lib
 , stdenv
-, fetchpatch
 , glib
 , libxml2
 , libxslt
@@ -92,16 +91,6 @@ qtModule rec {
   # ninja builds some components with -Wno-format,
   # which cannot be set at the same time as -Wformat-security
   hardeningDisable = [ "format" ];
-
-  patches = [
-    # drop UCHAR_TYPE override to fix build with system ICU
-    (fetchpatch {
-      url = "https://code.qt.io/cgit/qt/qtwebengine-chromium.git/patch/?id=75f0f4eb";
-      stripLen = 1;
-      extraPrefix = "src/3rdparty/";
-      sha256 = "sha256-3aMcVXJg+v+UbsSO27g6MA6/uVkWUxyQsMD1EzlzXDs=";
-    })
-  ];
 
   postPatch = ''
     # Patch Chromium build tools

--- a/pkgs/development/libraries/qt-6/srcs.nix
+++ b/pkgs/development/libraries/qt-6/srcs.nix
@@ -1,262 +1,262 @@
 # DO NOT EDIT! This file is generated automatically.
-# Command: ./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-6/6.3
+# Command: ./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-6
 { fetchurl, mirror }:
 
 {
   qt3d = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qt3d-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1qadnm2i2cgzigzq2wl0id5wzmc1p6zls4mrg1w8hd5d1lw65rvl";
-      name = "qt3d-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qt3d-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1zpdafqm82hd2bijw20hi1ng81xwihsn9mm7n5ns4gr5zdnvc6cr";
+      name = "qt3d-everywhere-src-6.3.1.tar.xz";
     };
   };
   qt5compat = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qt5compat-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0gkis7504qdpavimkx33zl9082r4rfa2v4iba4a943f5h3krn69b";
-      name = "qt5compat-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qt5compat-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1zbcaswpl79ixcxzj85qzjq73962s4c7316pibwfrskqswmwcgm4";
+      name = "qt5compat-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtactiveqt-everywhere-src-6.3.0.tar.xz";
-      sha256 = "01sziyhzmvqn1flw6y73aszqll1yijxxc7hyzkd269zbmpm42l4c";
-      name = "qtactiveqt-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtactiveqt-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0axygqjqny6vjwmc5swn80xrcs97bcjwgxsg81f35srxpn9lxdb4";
+      name = "qtactiveqt-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtbase = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtbase-everywhere-src-6.3.0.tar.xz";
-      sha256 = "168g39xiasriwpny9rf4alx3k8gnkffqjqm1n2rr5xsp6gjalrdq";
-      name = "qtbase-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtbase-everywhere-src-6.3.1.tar.xz";
+      sha256 = "00sfya41ihqb0zwg6wf1kiy02iymj6mk584hhk2c4s94khfl4r0a";
+      name = "qtbase-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtcharts = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtcharts-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1k9ngvl94xd5xr34ycwvchvzih037yvfzvdf625cik21yv2n49v7";
-      name = "qtcharts-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtcharts-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1xvwsabyfln3sih9764xknl2s3w4w069k210kgbh94bj50iwqc7k";
+      name = "qtcharts-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtconnectivity-everywhere-src-6.3.0.tar.xz";
-      sha256 = "06p6n23y2a6nca0rzdli6zl7m2i42h2pm28092zb4vd578p17xwq";
-      name = "qtconnectivity-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtconnectivity-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1c4mnrl7fa8j8fmv5zbqak48nylhxpib7vmsbmmbqqcw19qy8p5j";
+      name = "qtconnectivity-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtdatavis3d-everywhere-src-6.3.0.tar.xz";
-      sha256 = "138dkvarvh45j4524y1piw0dm2j16s3lk5pazbggi3xjnbrjwl89";
-      name = "qtdatavis3d-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtdatavis3d-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1wm8iigpml84zfkw3mb2kll0imszc2y19hkcfwq1wbr9w24xda43";
+      name = "qtdatavis3d-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtdeclarative-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0dxa9j8cxfd86nqpvxvzxd1jdlw8h0xxqvsiv9jlyb9bvhlv156j";
-      name = "qtdeclarative-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtdeclarative-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1s268fha3650dn1lqxf8jfa07wxpw09f6p7rjyiwq3w24d0nkrq3";
+      name = "qtdeclarative-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtdoc = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtdoc-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0r9giv6xpg6zhghrrv4chlk1cimmiw93cj6rdf4rkf2g3qmgv6d8";
-      name = "qtdoc-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtdoc-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1qvhv2b9c6mz7r3sdx0l81a2jr9qri17y1y8k3d6qh488fxqrk32";
+      name = "qtdoc-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtimageformats = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtimageformats-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1vxbjdfy1zya4pgcl4483912aw7ip0d768xmnrz2md3mxlbhsp82";
-      name = "qtimageformats-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtimageformats-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0br1vqgx0hcc2nx32xviic94mvj6fbagrnzskdr7zdmvvyw140xd";
+      name = "qtimageformats-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtlanguageserver = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtlanguageserver-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1apfkq5grxkx69d8x7gmj19klr3jypsz1csw6r00q7hf0vvxiakh";
-      name = "qtlanguageserver-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtlanguageserver-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1g2azb4mdzh5zp7xc57g8l2a8wfi44wfjm6js88q4mmchyj4f4br";
+      name = "qtlanguageserver-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtlottie = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtlottie-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1svxz5ndljhrn52vyyr1yziar63ksjz78mvaxfhjgdd5pc5mgnrr";
-      name = "qtlottie-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtlottie-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1x8wmc6gwmxk92zjcsrbhrbqbfvnk7302ggghld5wk8jk5lsf2vl";
+      name = "qtlottie-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtmultimedia-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0gpylyrjkks27y5bfaxqs7idj0wyscpn1kh51i4ahx19z1zj8l6h";
-      name = "qtmultimedia-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtmultimedia-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0dkk3lmzi2fs13cnj8q1lpcs6gghj219826gkwnzyd6nmlm280vy";
+      name = "qtmultimedia-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtnetworkauth-everywhere-src-6.3.0.tar.xz";
-      sha256 = "17q6v4d2qglw88gd2i9m4cvvacpfsw6a544g0ch8a0hr56a9hfi0";
-      name = "qtnetworkauth-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtnetworkauth-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0apvsb2ip1m3kw8vi9spvf6f6q72ys8vr40rpyysi7shsjwm83yn";
+      name = "qtnetworkauth-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtpositioning = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtpositioning-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0vi3123pa9pc4xqh6rgxwz40xvvl4w0x09fn6kdld8s5nbv51vg9";
-      name = "qtpositioning-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtpositioning-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0v78wamvdw02kf9rq7m5v24q2g6jmgq4ch0fnfa014p1r978wy06";
+      name = "qtpositioning-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtquick3d = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtquick3d-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0zijxf33v5b2hrwppp4gr1i1dscdxqjjcb8a48c4ny0zxv8mpl0a";
-      name = "qtquick3d-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtquick3d-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0mhj0r6081bjkq3fsr1vh43zn587v9m20mdpnc979h5q8zp6d9rg";
+      name = "qtquick3d-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtquicktimeline = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtquicktimeline-everywhere-src-6.3.0.tar.xz";
-      sha256 = "06hwygywqc6kqs2ss8ng6ymjs3m72r51x2lzppjnpz4y2lqskw4z";
-      name = "qtquicktimeline-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtquicktimeline-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1gpb51d8r707sr0dnvbz65d4zwisfdw40s10kximaxwfrvq3r8aq";
+      name = "qtquicktimeline-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtremoteobjects-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0v2ax6xynv13z1dqnklnvfxxdhh9fallrjdmqpkmkydgy163zckm";
-      name = "qtremoteobjects-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtremoteobjects-everywhere-src-6.3.1.tar.xz";
+      sha256 = "19jcxxxj3q8vnf9cbgrp3q1pvgwsln8n16nk1gg822f6265h6vga";
+      name = "qtremoteobjects-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtscxml = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtscxml-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1w3hi9c5v0lji59pkk0dhaq3xly9skf3jsm93gxj0y9nmkbdpc09";
-      name = "qtscxml-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtscxml-everywhere-src-6.3.1.tar.xz";
+      sha256 = "06c6dwwx3z26k9ff6nqagg70lws4l1c6drz1yi4z1lb3c56ibg01";
+      name = "qtscxml-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtsensors = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtsensors-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0j4ppqn8m04hfqrzrmp80fmwpr474arcycf58jypm17fnlrwfmy7";
-      name = "qtsensors-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtsensors-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1k301lgbiw3fiyryfr18k0dq89ls4xgs4n2pffs456msxmchn92b";
+      name = "qtsensors-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtserialbus = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtserialbus-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1mi76sxh21wj1b1myqrzaaspf1iwa4bxr342p1b6krrnrf4ckxnj";
-      name = "qtserialbus-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtserialbus-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1lkqv3r66fiddxbg0fv9w6l83adz3y8zq6i4pmd0hnxs0ivkz580";
+      name = "qtserialbus-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtserialport = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtserialport-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0kxnblyk8bw02bdjsnjbblczg0dvj7ys95bpr2w49h4cshs6kggf";
-      name = "qtserialport-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtserialport-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0vk17cjj9jpdkgd8qwb1x0lijg0p2jxdzx4d67hd57brcl7didjf";
+      name = "qtserialport-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtshadertools = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtshadertools-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0v5xmyc9d3vacvdm2zpancqqmsvaz0635cba2aym9hipkndrb62l";
-      name = "qtshadertools-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtshadertools-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0nj35s2z5n438q7nqf6bnj3slwz2am3169ck1ixwqa0mjrv73dsr";
+      name = "qtshadertools-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtsvg = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtsvg-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1qxhilxbk7wgnah7qlfcr5gsn19626dp6dc260wh8r1zgr6m0r1i";
-      name = "qtsvg-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtsvg-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1xvxz2jfpr1al85rhwss7ji5vkxa812d0b888hry5f7pwqcg86bv";
+      name = "qtsvg-everywhere-src-6.3.1.tar.xz";
     };
   };
   qttools = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qttools-everywhere-src-6.3.0.tar.xz";
-      sha256 = "175is0yf74vdxlmcb9nvm86n6m7qj54mhiwkhyi84mwjxa44dsgw";
-      name = "qttools-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qttools-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1h96w4bzkbd80vr7lh6hnypdlmbzc1y52c2zrqzvkgm3587pa4n4";
+      name = "qttools-everywhere-src-6.3.1.tar.xz";
     };
   };
   qttranslations = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qttranslations-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1cs06kiv34zdkicxdjhxydv5rn1ylf4z2f4jl4a9ajm3jbw4xpg4";
-      name = "qttranslations-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qttranslations-everywhere-src-6.3.1.tar.xz";
+      sha256 = "15yvvxw1vngnjlly6cady05ljamg01qiaqn2vh0xkph855gdbgfp";
+      name = "qttranslations-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtvirtualkeyboard-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0wv54zmr9chwx1bds5b2j1436ynq6b5lbv7lbj7sycjlrxdg3al9";
-      name = "qtvirtualkeyboard-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtvirtualkeyboard-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1f62q0gkz21nraaspy1nrg2ygjih5qgq37qns06snnfq0jr8kq2z";
+      name = "qtvirtualkeyboard-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtwayland = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtwayland-everywhere-src-6.3.0.tar.xz";
-      sha256 = "1411l2rc399bj6r36wd8n06a0rpdxkhmr0mashc5kz1zwkv6gdg7";
-      name = "qtwayland-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtwayland-everywhere-src-6.3.1.tar.xz";
+      sha256 = "1w60p1did7awdlzq5k8vnq2ncpskb07cpvz31cbv99bjs6igw53g";
+      name = "qtwayland-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtwebchannel-everywhere-src-6.3.0.tar.xz";
-      sha256 = "03p4ggi9dk11q3zqw29awwxvddgfb3nsrrm58q053y0zlclc9i7b";
-      name = "qtwebchannel-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtwebchannel-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0s16zx3qn3byldvhmsnwijm8rmizk8vpqj7fnwhjg6c67z10m8ma";
+      name = "qtwebchannel-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtwebengine = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtwebengine-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0g899mn6fx9w0mb9dm7y25x3d9gcy8ramwbcpk8pmjqxv1fv8090";
-      name = "qtwebengine-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtwebengine-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0ivfsqd5c0cxsnssj6z37901cf6a47w50zaqgjiysvcm3ar36ymd";
+      name = "qtwebengine-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtwebsockets-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0qb39qnli5wshrnzr9kbdrbddzi2l0y9vg3b1mbdkdv0x6gs0670";
-      name = "qtwebsockets-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtwebsockets-everywhere-src-6.3.1.tar.xz";
+      sha256 = "06hj0pkdzjicmbiinjp1dk1ziz8cb3fgcwy7a0dxxjvzr680v64z";
+      name = "qtwebsockets-everywhere-src-6.3.1.tar.xz";
     };
   };
   qtwebview = {
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.3/6.3.0/submodules/qtwebview-everywhere-src-6.3.0.tar.xz";
-      sha256 = "0mi1fkxz4mags32ld8km4svsnvbai0i81398f435sd1n9ach3gfy";
-      name = "qtwebview-everywhere-src-6.3.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.3/6.3.1/submodules/qtwebview-everywhere-src-6.3.1.tar.xz";
+      sha256 = "0f4hx3rqwg5wqnw37nrhcvi2fxshgfx72xmdc416j4gxhra1i6xl";
+      name = "qtwebview-everywhere-src-6.3.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
**Description of changes**

use latest patch release of qt

https://www.qt.io/blog/qt-6.3.1-released

> 15919c5bda QBuffer: fix writing more than two GiB of data
Fixed silent data truncation when writing more than two GiB at once on
64-bit platforms.

> 4f45c0c5d8 QTextStream: fix streaming of char16_t's
Added op<<(char16_t).

> c00b8652b5 Fix int/qsizetype mismatches in qstring.h
Fixed result truncation mod INT_MAX in fromStdSstring(),
fromStdU16string(), fromStdU32string(), and fromStdWstring().

...

**upstream issues**

patches for jobclient support were sent to ...

* qtwebengine https://bugreports.qt.io/browse/QTBUG-95176
  * probably qt will delegate to chromium
* chromium https://groups.google.com/a/chromium.org/g/chromium-discuss (marked as spam?)
* gn https://groups.google.com/a/chromium.org/g/gn-dev/c/qKtD0TDl00c (marked as spam?)
* devtools-frontend https://groups.google.com/a/chromium.org/g/devtools-reviews/c/TJchABRWq1g (marked as spam?)
* jest-worker https://github.com/facebook/jest/pull/12968

**Child packages**

tdesktop 3.7.3 throws build error &rarr; update to pre-release 3.7.6
tdesktop 3.7.6 throws build error &rarr; update tdesktop.tg_owt ([upstream issue](https://github.com/telegramdesktop/tdesktop/issues/24637))

**Review**

<details>

> $ nixpkgs-review pr 178171
>
> 41 packages updated:
> cutemaze fcitx5-chinese-addons fcitx5-configtool fcitx5-qt fcitx5-qt fcitx5-qt fcitx5-unikey fcitx5-with-addons qt6.qt3d (6.3.0 → 6.3.1) qt6.qt5compat (6.3.0 → 6.3.1) qt6.qtbase (6.3.0 → 6.3.1) qt6.qtcharts (6.3.0 → 6.3.1) qt6.qtconnectivity (6.3.0 → 6.3.1) qt6.qtdatavis3d (6.3.0 → 6.3.1) qt6.qtdeclarative (6.3.0 → 6.3.1) qt6.qtdoc (6.3.0 → 6.3.1) qt6.qtimageformats (6.3.0 → 6.3.1) qt6.qtlanguageserver (6.3.0 → 6.3.1) qt6.qtlottie (6.3.0 → 6.3.1) qt6.qtmultimedia (6.3.0 → 6.3.1) qt6.qtnetworkauth (6.3.0 → 6.3.1) qt6.qtpositioning (6.3.0 → 6.3.1) qt6.qtquick3d (6.3.0 → 6.3.1) qt6.qtquicktimeline (6.3.0 → 6.3.1) qt6.qtremoteobjects (6.3.0 → 6.3.1) qt6.qtscxml (6.3.0 → 6.3.1) qt6.qtsensors (6.3.0 → 6.3.1) qt6.qtserialbus (6.3.0 → 6.3.1) qt6.qtserialport (6.3.0 → 6.3.1) qt6.qtshadertools (6.3.0 → 6.3.1) qt6.qtsvg (6.3.0 → 6.3.1) qt6.qttools (6.3.0 → 6.3.1) qt6.qttranslations (6.3.0 → 6.3.1) qt6.qtvirtualkeyboard (6.3.0 → 6.3.1) qt6.qtwayland (6.3.0 → 6.3.1) qt6.qtwebchannel (6.3.0 → 6.3.1) qt6.qtwebengine (6.3.0 → 6.3.1) qt6.qtwebsockets (6.3.0 → 6.3.1) qt6.qtwebview (6.3.0 → 6.3.1) quazip tdesktop (3.7.3 → 3.7.6)
>
> 2 packages marked as broken and skipped:
> libsForQt512.fcitx5-qt libsForQt514.fcitx5-qt
> 
> 2 packages failed to build:
> qt6.qtwebengine qt6.qtwebview
> 
> 37 packages built:
> cutemaze fcitx5-chinese-addons fcitx5-configtool fcitx5-unikey fcitx5-with-addons libsForQt5.fcitx5-qt qt6.qt3d qt6.qt5compat qt6.qtbase qt6.qtcharts qt6.qtconnectivity qt6.qtdatavis3d qt6.qtdeclarative qt6.qtdoc qt6.qtimageformats qt6.qtlanguageserver qt6.qtlottie qt6.qtmultimedia qt6.qtnetworkauth qt6.qtpositioning qt6.qtquick3d qt6.qtquicktimeline qt6.qtremoteobjects qt6.qtscxml qt6.qtsensors qt6.qtserialbus qt6.qtserialport qt6.qtshadertools qt6.qtsvg qt6.qttools qt6.qttranslations qt6.qtvirtualkeyboard qt6.qtwayland qt6.qtwebchannel qt6.qtwebsockets qt6Packages.quazip tdesktop

</details>

**Things done**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
