### PR TITLE
vimPlugins: use lua derivation if it exists

### DIFF
--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -7,9 +7,7 @@
 }:
 let
   # sanitizeDerivationName
-  normalizeName = name:
-    (lib.concatMapStrings (s: if lib.isList s then "-" else s))
-      ((builtins.split "[.]") name);
+  normalizeName = lib.replaceStrings [ "." ] [ "-" ];
 in
 
 rec {

--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, buildVimPluginFrom2Nix
+, buildLuarocksPackage
+, lua51Packages
+, toVimPlugin
+}:
+let
+  # sanitizeDerivationName
+  normalizeName = name:
+    (lib.concatMapStrings (s: if lib.isList s then "-" else s))
+      ((builtins.split "[.]") name);
+in
+
+rec {
+  # function to create vim plugin from lua packages that are already packaged in
+  # luaPackages
+  buildNeovimPluginFrom2Nix = attrs@{
+    # the lua attribute name that matches this vim plugin. Both should be equal
+    # in the majority of cases but we make it possible to have different attribute names
+    luaAttr ? (normalizeName attrs.pname)
+    , ...
+  }:
+    let
+      hasMatch = builtins.hasAttr luaAttr lua51Packages;
+      drv = lua51Packages.${luaAttr};
+      luaDrv = lua51Packages.lib.overrideLuarocks drv (drv: {
+        extraConfig = ''
+          -- to create a flat hierarchy
+          lua_modules_path = "lua"
+        '';
+      });
+      finalDrv = toVimPlugin (luaDrv.overrideAttrs(oa: {
+          nativeBuildInputs = oa.nativeBuildInputs or [] ++ [
+            lua51Packages.luarocksMoveDataFolder
+          ];
+        }));
+
+    in
+      finalDrv;
+}

--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -10,19 +10,17 @@ let
   normalizeName = lib.replaceStrings [ "." ] [ "-" ];
 in
 
-rec {
   # function to create vim plugin from lua packages that are already packaged in
   # luaPackages
-  buildNeovimPluginFrom2Nix = attrs@{
+  {
     # the lua attribute name that matches this vim plugin. Both should be equal
     # in the majority of cases but we make it possible to have different attribute names
     luaAttr ? (normalizeName attrs.pname)
     , ...
-  }:
+  }@attrs:
     let
-      hasMatch = builtins.hasAttr luaAttr lua51Packages;
-      drv = lua51Packages.${luaAttr};
-      luaDrv = lua51Packages.lib.overrideLuarocks drv (drv: {
+      originalLuaDrv = lua51Packages.${luaAttr};
+      luaDrv = lua51Packages.lib.overrideLuarocks originalLuaDrv (drv: {
         extraConfig = ''
           -- to create a flat hierarchy
           lua_modules_path = "lua"
@@ -33,7 +31,5 @@ rec {
             lua51Packages.luarocksMoveDataFolder
           ];
         }));
-
     in
-      finalDrv;
-}
+      finalDrv

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -187,8 +187,8 @@ in
   inherit makeNeovimConfig;
   inherit legacyWrapper;
 
-  inherit (callPackage ./build-neovim-plugin.nix {
+  buildNeovimPluginFrom2Nix = callPackage ./build-neovim-plugin.nix {
     inherit (vimUtils) buildVimPluginFrom2Nix toVimPlugin;
     inherit buildLuarocksPackage;
-  }) buildNeovimPluginFrom2Nix;
+  };
 }

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -1,4 +1,6 @@
 { lib
+, buildLuarocksPackage
+, callPackage
 , vimUtils
 , nodejs
 , neovim-unwrapped
@@ -184,4 +186,9 @@ in
 {
   inherit makeNeovimConfig;
   inherit legacyWrapper;
+
+  inherit (callPackage ./build-neovim-plugin.nix {
+    inherit (vimUtils) buildVimPluginFrom2Nix toVimPlugin;
+    inherit buildLuarocksPackage;
+  }) buildNeovimPluginFrom2Nix;
 }

--- a/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
+++ b/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
@@ -4,6 +4,7 @@
 , vimCommandCheckHook
 , vimGenDocHook
 , neovimRequireCheckHook
+, toVimPlugin
 }:
 
 rec {
@@ -23,11 +24,6 @@ rec {
     let drv = stdenv.mkDerivation (attrs // {
       name = namePrefix + name;
 
-      # dont move the doc folder since vim expects it
-      forceShare= [ "man" "info" ];
-
-      nativeBuildInputs = attrs.nativeBuildInputs or []
-      ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ vimCommandCheckHook vimGenDocHook ];
       inherit unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
 
       installPhase = ''
@@ -40,9 +36,9 @@ rec {
         runHook postInstall
       '';
     });
-    in  drv.overrideAttrs(oa: {
+    in toVimPlugin(drv.overrideAttrs(oa: {
       rtp = "${drv}";
-    });
+    }));
 
   buildVimPluginFrom2Nix = attrs: buildVimPlugin ({
     # vim plugins may override this

--- a/pkgs/applications/editors/vim/plugins/default.nix
+++ b/pkgs/applications/editors/vim/plugins/default.nix
@@ -11,8 +11,7 @@ let
 
   inherit (lib) extends;
 
-  initialPackages = self: {
-  };
+  initialPackages = self: { };
 
   plugins = callPackage ./generated.nix {
     inherit buildVimPluginFrom2Nix;

--- a/pkgs/applications/editors/vim/plugins/default.nix
+++ b/pkgs/applications/editors/vim/plugins/default.nix
@@ -1,5 +1,8 @@
 # TODO check that no license information gets lost
-{ callPackage, config, lib, vimUtils, vim, darwin, llvmPackages, luaPackages }:
+{ callPackage, config, lib, vimUtils, vim, darwin, llvmPackages
+, neovimUtils
+, luaPackages
+}:
 
 let
 
@@ -9,23 +12,11 @@ let
   inherit (lib) extends;
 
   initialPackages = self: {
-    # Convert derivation to a vim plugin.
-    toVimPlugin = drv:
-      drv.overrideAttrs(oldAttrs: {
-
-        nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [
-          vimGenDocHook
-          vimCommandCheckHook
-        ];
-        passthru = (oldAttrs.passthru or {}) // {
-          vimPlugin = true;
-        };
-      });
   };
 
   plugins = callPackage ./generated.nix {
     inherit buildVimPluginFrom2Nix;
-    inherit (vimUtils) buildNeovimPluginFrom2Nix;
+    inherit (neovimUtils) buildNeovimPluginFrom2Nix;
   };
 
   # TL;DR

--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -2527,7 +2527,7 @@ final: prev:
     meta.homepage = "https://github.com/nvim-lua/diagnostic-nvim/";
   };
 
-  diffview-nvim = buildNeovimPluginFrom2Nix {
+  diffview-nvim = buildVimPluginFrom2Nix {
     pname = "diffview.nvim";
     version = "2022-06-09";
     src = fetchFromGitHub {
@@ -3154,7 +3154,7 @@ final: prev:
     meta.homepage = "https://github.com/ruifm/gitlinker.nvim/";
   };
 
-  gitsigns-nvim = buildNeovimPluginFrom2Nix {
+  gitsigns-nvim = buildVimPluginFrom2Nix {
     pname = "gitsigns.nvim";
     version = "2022-05-26";
     src = fetchFromGitHub {
@@ -4282,7 +4282,7 @@ final: prev:
     meta.homepage = "https://github.com/iamcco/markdown-preview.nvim/";
   };
 
-  marks-nvim = buildNeovimPluginFrom2Nix {
+  marks-nvim = buildVimPluginFrom2Nix {
     pname = "marks.nvim";
     version = "2022-05-13";
     src = fetchFromGitHub {
@@ -5110,7 +5110,7 @@ final: prev:
     meta.homepage = "https://github.com/RRethy/nvim-base16/";
   };
 
-  nvim-biscuits = buildNeovimPluginFrom2Nix {
+  nvim-biscuits = buildVimPluginFrom2Nix {
     pname = "nvim-biscuits";
     version = "2022-05-31";
     src = fetchFromGitHub {

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -564,7 +564,7 @@ rec {
   toVimPlugin = drv:
     drv.overrideAttrs(oldAttrs: {
       # dont move the "doc" folder since vim expects it
-      forceShare= [ "man" "info" ];
+      forceShare = [ "man" "info" ];
 
       nativeBuildInputs = oldAttrs.nativeBuildInputs or []
       ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [

--- a/pkgs/development/interpreters/lua-5/hooks/default.nix
+++ b/pkgs/development/interpreters/lua-5/hooks/default.nix
@@ -29,4 +29,12 @@ in {
       name = "luarocks-check-hook";
       deps = [ luarocks ];
     } ./luarocks-check-hook.sh) {};
+
+  # luarocks installs data in a non-overridable location. Until a proper luarocks patch,
+  # we move the files around ourselves
+  luarocksMoveDataFolder = callPackage ({ }:
+    makeSetupHook {
+      name = "luarocks-move-rock";
+      deps = [ ];
+    } ./luarocks-move-data.sh) {};
 }

--- a/pkgs/development/interpreters/lua-5/hooks/luarocks-move-data.sh
+++ b/pkgs/development/interpreters/lua-5/hooks/luarocks-move-data.sh
@@ -1,0 +1,15 @@
+# luarocks installs data in a non-overridable location. Until a proper luarocks patch,
+# we move the files around ourselves
+echo "Sourcing luarocks-move-data-hook.sh"
+
+luarocksMoveDataHook () {
+    echo "Executing luarocksMoveDataHook"
+    if [ -d "$out/$rocksSubdir" ]; then
+        cp -rfv "$out/$rocksSubdir/$pname/$version/." "$out"
+    fi
+
+    echo "Finished executing luarocksMoveDataHook"
+}
+
+echo "Using luarocksMoveDataHook"
+preDistPhases+=" luarocksMoveDataHook"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30430,7 +30430,9 @@ with pkgs;
     lua = luajit;
   };
 
-  neovimUtils = callPackage ../applications/editors/neovim/utils.nix { };
+  neovimUtils = callPackage ../applications/editors/neovim/utils.nix {
+    inherit (lua51Packages) buildLuarocksPackage;
+  };
   neovim = wrapNeovim neovim-unwrapped { };
 
   neovim-qt-unwrapped = libsForQt5.callPackage ../applications/editors/neovim/neovim-qt.nix { };

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -50,7 +50,7 @@ in
   getLuaCPath = drv: getPath drv luaLib.luaCPathList;
 
   inherit (callPackage ../development/interpreters/lua-5/hooks { inherit (args) lib;})
-    luarocksCheckHook lua-setup-hook;
+    luarocksMoveDataFolder luarocksCheckHook lua-setup-hook;
 
   inherit lua callPackage;
   inherit buildLuaPackage buildLuarocksPackage buildLuaApplication;


### PR DESCRIPTION
Neovim plugins are now more often than not written in lua.
One advantage of the lua ecosystem over vim's is the existence of
luarocks and the rockspec format, which allows to specify a package
dependencies formally.
I would like more neovim plugins to have a formal description,
"rockspec" being the current candidate.
This MR allows to use nix lua packages as neovim plugins, so as to enjoy
every benefit that rockspecs bring:
- dependdency discovery
- ability to run test suite
- luarocks versioning
- rockspec metadata

the vim update.py script will check if an attribute with the vim plugin
pname exists in lua51Packages. If it does, it uses
buildNeovimPluginFrom2Nix on it, which modifies the luarocks config to
do an almost flat install (luarocks will install the package in the lua
folder instead of share/5.1/lua etc).
It also calls toVimPlugin on it to get all the vim plugin niceties.

The list of packages that could benefit from this is available at
https://luarocks.org/labels/neovim
but I hope it grows.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
