### PR TITLE
nixos/generic-extlinux-compatible: don't copy to same fs

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -10,9 +10,9 @@ let
   timeoutStr = if blCfg.timeout == null then "-1" else toString blCfg.timeout;
 
   # The builder used to write during system activation
-  builder = import ./extlinux-conf-builder.nix { inherit pkgs; };
+  builder = import ./extlinux-conf-builder.nix { inherit pkgs cfg; };
   # The builder exposed in populateCmd, which runs on the build architecture
-  populateBuilder = import ./extlinux-conf-builder.nix { pkgs = pkgs.buildPackages; };
+  populateBuilder = import ./extlinux-conf-builder.nix { pkgs = pkgs.buildPackages; inherit cfg; };
 in
 {
   options = {
@@ -65,6 +65,24 @@ in
         '';
       };
 
+      copyKernels = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to copy the necessary boot files into /boot, so
+          /nix/store is not needed by the boot loader. This is done
+          automatically if /boot is on a different partition than /.
+        '';
+      };
+
+      storePath = mkOption {
+        default = "/nix/store";
+        type = types.str;
+        description = ''
+          Path to the Nix store when looking for kernels at boot.
+          Only makes sense when copyKernels is false.
+        '';
+      };
     };
   };
 

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
@@ -1,8 +1,9 @@
-{ pkgs }:
+{ pkgs, cfg }:
 
 pkgs.substituteAll {
   src = ./extlinux-conf-builder.sh;
   isExecutable = true;
   path = [pkgs.coreutils pkgs.gnused pkgs.gnugrep];
   inherit (pkgs) bash;
+  inherit (cfg) copyKernels storePath;
 }

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -37,9 +37,7 @@ done
 
 [ "$timeout" = "" -o "$default" = "" ] && usage
 
-if [[ -n "@copyKernels@" ]]; then
-    mkdir -p $target/nixos
-fi
+mkdir -p $target/nixos
 mkdir -p $target/extlinux
 
 # Convert a path to a file in the Nix store such as
@@ -55,7 +53,7 @@ declare -A filesCopied
 copyToKernelsDir() {
     local src=$(readlink -f "$1")
     # Don't copy if on same filesystem, just point to the original.
-    if [[ -z "@copyKernels@" && $(stat -f -c %i $src) = $(stat -f -c %i $target/) ]]; then
+    if [[ -z "@copyKernels@" && $(stat -f -c %i $src) = $(stat -f -c %i $target/nixos) ]]; then
         # Replace /nix/store with storePath
         echo "${src/#\/nix\/store/@storePath@}"
         return

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -52,7 +52,13 @@ declare -A filesCopied
 
 copyToKernelsDir() {
     local src=$(readlink -f "$1")
-    local dst="$target/nixos/$(cleanName $src)"
+    # Don't copy if on same filesystem, just point to the original.
+    if [[ $(stat -f -c %i $src) = $(stat -f -c %i $target/nixos) ]]; then
+        echo "$src"
+        return
+    fi
+    local reldst="nixos/$(cleanName $src)"
+    local dst="$target/$reldst"
     # Don't copy the file if $dst already exists.  This means that we
     # have to create $dst atomically to prevent partially copied
     # kernels or initrd if this script is ever interrupted.
@@ -62,7 +68,8 @@ copyToKernelsDir() {
         mv $dstTmp $dst
     fi
     filesCopied[$dst]=1
-    result=$dst
+    # Relative path from $target/extlinux/extlinux.conf
+    echo "../$reldst"
 }
 
 # Copy its kernel, initrd and dtbs to $target/nixos, and echo out an
@@ -75,11 +82,11 @@ addEntry() {
         return
     fi
 
-    copyToKernelsDir "$path/kernel"; kernel=$result
-    copyToKernelsDir "$path/initrd"; initrd=$result
+    kernel=$(copyToKernelsDir "$path/kernel")
+    initrd=$(copyToKernelsDir "$path/initrd")
     dtbDir=$(readlink -m "$path/dtbs")
     if [ -e "$dtbDir" ]; then
-        copyToKernelsDir "$dtbDir"; dtbs=$result
+        dtbs=$(copyToKernelsDir "$dtbDir")
     fi
 
     timestampEpoch=$(stat -L -c '%Z' $path)
@@ -95,8 +102,8 @@ addEntry() {
     else
         echo "  MENU LABEL NixOS - Configuration $tag ($timestamp - $nixosLabel)"
     fi
-    echo "  LINUX ../nixos/$(basename $kernel)"
-    echo "  INITRD ../nixos/$(basename $initrd)"
+    echo "  LINUX $kernel"
+    echo "  INITRD $initrd"
     echo "  APPEND init=$path/init $extraParams"
 
     if [ -n "$noDeviceTree" ]; then
@@ -106,9 +113,9 @@ addEntry() {
     if [ -d "$dtbDir" ]; then
         # if a dtbName was specified explicitly, use that, else use FDTDIR
         if [ -n "$dtbName" ]; then
-            echo "  FDT ../nixos/$(basename $dtbs)/${dtbName}"
+            echo "  FDT $dtbs/$dtbName"
         else
-            echo "  FDTDIR ../nixos/$(basename $dtbs)"
+            echo "  FDTDIR $dtbs"
         fi
     else
         if [ -n "$dtbName" ]; then

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -1,4 +1,4 @@
-#! @bash@/bin/sh -e
+#! @bash@/bin/bash -e
 
 shopt -s nullglob
 
@@ -37,7 +37,9 @@ done
 
 [ "$timeout" = "" -o "$default" = "" ] && usage
 
-mkdir -p $target/nixos
+if [[ -n "@copyKernels@" ]]; then
+    mkdir -p $target/nixos
+fi
 mkdir -p $target/extlinux
 
 # Convert a path to a file in the Nix store such as
@@ -53,8 +55,9 @@ declare -A filesCopied
 copyToKernelsDir() {
     local src=$(readlink -f "$1")
     # Don't copy if on same filesystem, just point to the original.
-    if [[ $(stat -f -c %i $src) = $(stat -f -c %i $target/nixos) ]]; then
-        echo "$src"
+    if [[ -z "@copyKernels@" && $(stat -f -c %i $src) = $(stat -f -c %i $target/) ]]; then
+        # Replace /nix/store with storePath
+        echo "${src/#\/nix\/store/@storePath@}"
         return
     fi
     local reldst="nixos/$(cleanName $src)"


### PR DESCRIPTION
###### Description of changes

I'm running nixos on a small arm sbc with u-boot, using the extlinux-conf builder. My root fs is ext4, filling the entire emmc. In this configuration, I noticed that my kernel and initrd would get copied to `/boot`, even though they're on the same fs and could be read directly by u-boot. This isn't a huge deal, but is somewhat undesirable, especially when using a small soldered-on emmc, as it creates some extra wear.

I've been running with this change for a while and thought I should contribute it upstream. Several other bootloader configurators (e.g. grub) already offer this option (controlled by a `copyKernels` setting). If it's not appropriate to detect automatically and I should add an equivalent setting, let me know.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

