### PR TITLE
nixos/wireless: replace environmentFile with environmentFiles

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -147,6 +147,16 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>networking.wireless.environmentFile</literal>
+          option is deprecated and replaced with
+          <literal>networking.wireless.environmentFiles</literal>, which
+          allows multiple environment files to be configured.
+          Configurations using the deprecated option will print a
+          warning when rebuilt.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2.
           It is now the upstream version from https://www.memtest.org/,
           as coreboot’s fork is no longer available.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -58,6 +58,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Matrix Synapse now requires entries in the `state_group_edges` table to be unique, in order to prevent accidentally introducing duplicate information (for example, because a database backup was restored multiple times). If your Synapse database already has duplicate rows in this table, this could fail with an error and require manual remediation.
 
+- The `networking.wireless.environmentFile` option is deprecated and replaced with `networking.wireless.environmentFiles`, which allows multiple environment files to be configured.
+  Configurations using the deprecated option will print a warning when rebuilt.
+
 - memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2. It is now the upstream version from https://www.memtest.org/, as coreboot's fork is no longer available.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -109,8 +109,7 @@ let
       path = [ package ];
       serviceConfig.RuntimeDirectory = "wpa_supplicant";
       serviceConfig.RuntimeDirectoryMode = "700";
-      serviceConfig.EnvironmentFile = mkIf (cfg.environmentFile != null)
-        (builtins.toString cfg.environmentFile);
+      serviceConfig.EnvironmentFile = map builtins.toString cfg.environmentFiles;
 
       script =
       ''
@@ -221,9 +220,18 @@ in {
       environmentFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = "/run/secrets/wireless.env";
         description = ''
-          File consisting of lines of the form <literal>varname=value</literal>
+          Deprecated, use
+          <literal>networking.wireless.environmentFiles</literal> instead.
+        '';
+      };
+
+      environmentFiles = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        example = [ "/run/secrets/wireless.env" ];
+        description = ''
+          Files consisting of lines of the form <literal>varname=value</literal>
           to define variables for the wireless configuration.
 
           See section "EnvironmentFile=" in <citerefentry>
@@ -512,6 +520,14 @@ in {
           '';
       }
     ];
+
+    warnings = optional (cfg.environmentFile != null) ''
+      The option networking.wireless.environmentFile is deprecated, please use
+      networking.wireless.environmentFiles instead.
+    '';
+
+    networking.wireless.environmentFiles = mkIf (cfg.environmentFile != null)
+        (singleton cfg.environmentFile);
 
     hardware.wirelessRegulatoryDatabase = true;
 

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -51,12 +51,12 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
       };
 
       # secrets
-      environmentFile = pkgs.writeText "wpa-secrets" ''
+      environmentFiles = lib.singleton (pkgs.writeText "wpa-secrets" ''
         PSK_NIXOS_TEST="reproducibility"
         PSK_VALID="S0m3BadP4ssw0rd";
         # taken from https://github.com/minimaxir/big-list-of-naughty-strings
         PSK_SPECIAL=",./;'[]\-= <>?:\"{}|_+ !@#$%^\&*()`~";
-      '';
+      '');
     };
 
   };


### PR DESCRIPTION
###### Description of changes

This makes it easier to modularize wifi configs, by allowing multiple environment files. Each network can have its own environment file, defined in a separate NixOS module.

I considered adding a `networking.wireless.networks.*.environmentFile` option, but this would be somewhat misleading because the variables in each environment file are global, not available to only a certain network.

The `environmentFile` option is deprecated, with a warning message.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @globin @rnhmjoj