### PR TITLE
treewide: reduce maintenance workload for ma27

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -162,7 +162,7 @@ let
           with on-the-fly code analysis, error prevention and
           automated refactorings for PHP and JavaScript code.
         '';
-        maintainers = with maintainers; [ schristo ma27 ];
+        maintainers = with maintainers; [ schristo ];
       };
     });
 

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -133,7 +133,7 @@ in
       # those contributions were copied from Vim (identified in the commit logs
       # by the vim-patch token). See LICENSE for details."
       license = with licenses; [ asl20 vim ];
-      maintainers = with maintainers; [ manveru rvolosatovs ma27 ];
+      maintainers = with maintainers; [ manveru rvolosatovs ];
       platforms   = platforms.unix;
     };
   }

--- a/pkgs/applications/misc/dmenu/wayland.nix
+++ b/pkgs/applications/misc/dmenu/wayland.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     description = "dmenu for wayland-compositors";
     homepage = "https://github.com/nyyManni/dmenu-wayland";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -90,6 +90,6 @@ stdenv.mkDerivation rec {
     changelog   = "https://github.com/swaywm/sway/releases/tag/${version}";
     license     = licenses.mit;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ primeos synthetica ma27 ];
+    maintainers = with maintainers; [ primeos synthetica ];
   };
 }

--- a/pkgs/applications/window-managers/sway/lock-fancy.nix
+++ b/pkgs/applications/window-managers/sway/lock-fancy.nix
@@ -46,6 +46,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://github.com/Big-B/swaylock-fancy";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/mobile/adb-sync/default.nix
+++ b/pkgs/development/mobile/adb-sync/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     license = licenses.asl20;
     platforms = platforms.unix;
     hydraPlatforms = [];
-    maintainers = with maintainers; [ scolobb ma27 ];
+    maintainers = with maintainers; [ scolobb ];
   };
 }

--- a/pkgs/development/python-modules/face_recognition/default.nix
+++ b/pkgs/development/python-modules/face_recognition/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   meta = with lib; {
     license = licenses.mit;
     homepage = "https://github.com/ageitgey/face_recognition";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
     description = "The world's simplest facial recognition api for Python and the command line";
   };
 }

--- a/pkgs/development/python-modules/face_recognition_models/default.nix
+++ b/pkgs/development/python-modules/face_recognition_models/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/ageitgey/face_recognition_models";
     license = licenses.cc0;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
     description = "Trained models for the face_recognition python library";
   };
 }

--- a/pkgs/development/python-modules/pytesseract/default.nix
+++ b/pkgs/development/python-modules/pytesseract/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/pytesseract/";
     license = licenses.asl20;
     description = "A Python wrapper for Google Tesseract";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/rust/cargo-make/default.nix
+++ b/pkgs/development/tools/rust/cargo-make/default.nix
@@ -37,6 +37,6 @@ rustPlatform.buildRustPackage rec {
     description = "A Rust task runner and build tool";
     homepage = "https://github.com/sagiegurari/cargo-make";
     license = licenses.asl20;
-    maintainers = with maintainers; [ xrelkd ma27 ];
+    maintainers = with maintainers; [ xrelkd ];
   };
 }

--- a/pkgs/development/tools/wasm-bindgen-cli/default.nix
+++ b/pkgs/development/tools/wasm-bindgen-cli/default.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://rustwasm.github.io/docs/wasm-bindgen/";
     license = with licenses; [ asl20 /* or */ mit ];
     description = "Facilitating high-level interactions between wasm modules and JavaScript";
-    maintainers = with maintainers; [ ma27 nitsky rizary ];
+    maintainers = with maintainers; [ nitsky rizary ];
     mainProgram = "wasm-bindgen";
   };
 }

--- a/pkgs/servers/documize-community/default.nix
+++ b/pkgs/servers/documize-community/default.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Open source Confluence alternative for internal & external docs built with Golang + EmberJS";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ ma27 elseym ];
+    maintainers = with maintainers; [ elseym ];
     mainProgram = "documize";
     homepage = "https://www.documize.com/";
   };

--- a/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
     inherit (src.meta) homepage;
     description = "A dnsmasq exporter for Prometheus";
     license = licenses.asl20;
-    maintainers = with maintainers; [ willibutz globin ma27 ];
+    maintainers = with maintainers; [ willibutz globin ];
   };
 }

--- a/pkgs/servers/web-apps/hedgedoc/default.nix
+++ b/pkgs/servers/web-apps/hedgedoc/default.nix
@@ -116,7 +116,7 @@ mkYarnPackage rec {
     description = "Realtime collaborative markdown notes on all platforms";
     license = licenses.agpl3;
     homepage = "https://hedgedoc.org";
-    maintainers = with maintainers; [ willibutz ma27 globin ];
+    maintainers = with maintainers; [ willibutz globin ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -125,7 +125,7 @@ python3Packages.buildPythonApplication rec {
     '';
     homepage = "https://diffoscope.org/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ dezgeg ma27 danielfullmer ];
+    maintainers = with maintainers; [ dezgeg danielfullmer ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/docker-ls/default.nix
+++ b/pkgs/tools/misc/docker-ls/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     '';
 
     homepage = "https://github.com/mayflower/docker-ls";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
     platforms = docker.meta.platforms;
     license = licenses.mit;
   };

--- a/pkgs/tools/misc/termtosvg/default.nix
+++ b/pkgs/tools/misc/termtosvg/default.nix
@@ -15,6 +15,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://nbedos.github.io/termtosvg/";
     description = "Record terminal sessions as SVG animations";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
       it however you like.
     '';
     license = licenses.publicDomain;
-    maintainers = with maintainers; [ bluescreen303 fpletz ma27 ];
+    maintainers = with maintainers; [ bluescreen303 fpletz ];
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/networking/bandwhich/default.nix
+++ b/pkgs/tools/networking/bandwhich/default.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://github.com/imsnif/bandwhich";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ma27 SuperSandro2000 ];
+    maintainers = with maintainers; [ Br1ght0ne SuperSandro2000 ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION

###### Description of changes
Note: I DO NOT resign from nixpkgs, not at all!

However, I like a clean notification inbox and I get a lot of stuff for
packages where I'm only an end-user or don't use them anymore and thus
can't help out that much.

So please consider it a measure to reduce the mental load for me when
going through my notifications ;-)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
