### PR TITLE
[22.05] liblouis: apply patch for CVE-2022-26981

### DIFF
--- a/pkgs/development/libraries/liblouis/default.nix
+++ b/pkgs/development/libraries/liblouis/default.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/liblouis/liblouis/commit/528f38938e9f539a251d9de92ad1c1b90401c4d0.patch";
       sha256 = "0hlhqsvd5wflg70bd7bmssnchk8znzbr93in0zpspzbyap6xz112";
     })
+    (fetchpatch {
+      name = "CVE-2022-26981.patch";
+      url = "https://github.com/liblouis/liblouis/commit/73751be7a5617bfff4a735ae095203a2d3ec50ef.patch";
+      sha256 = "sha256-PvGG62QHVslrClZP903AYCBof6jDzNe4L8eFU8X0vF4=";
+    })
   ];
 
   outputs = [ "out" "dev" "man" "info" "doc" ];


### PR DESCRIPTION
Fixes: CVE-2022-26981

Refs:
https://github.com/liblouis/liblouis/pull/1185
https://github.com/advisories/GHSA-xrp8-mw8v-p6mq
https://nvd.nist.gov/vuln/detail/CVE-2022-26981

###### Things done

- [x] Built on x86_64-linux
- [x] Tested that the reproducer works
- [ ] TODO: verify that this really fixes the issue, since it didn't actually crash before the patch 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).