### PR TITLE
boost: use jfrog mirror instead of bintray

### DIFF
--- a/pkgs/development/libraries/boost/1.72.nix
+++ b/pkgs/development/libraries/boost/1.72.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     urls = [
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
-      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
     # SHA256 from http://www.boost.org/users/history/version_1_72_0.html
     sha256 = "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722";

--- a/pkgs/development/libraries/boost/1.73.nix
+++ b/pkgs/development/libraries/boost/1.73.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     urls = [
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
-      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
     # SHA256 from http://www.boost.org/users/history/version_1_73_0.html
     sha256 = "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402";

--- a/pkgs/development/libraries/boost/1.74.nix
+++ b/pkgs/development/libraries/boost/1.74.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     urls = [
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
-      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
     # SHA256 from http://www.boost.org/users/history/version_1_74_0.html
     sha256 = "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1";

--- a/pkgs/development/libraries/boost/1.75.nix
+++ b/pkgs/development/libraries/boost/1.75.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     urls = [
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
-      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
     # SHA256 from http://www.boost.org/users/history/version_1_75_0.html
     sha256 = "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb";

--- a/pkgs/development/libraries/boost/1.77.nix
+++ b/pkgs/development/libraries/boost/1.77.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     urls = [
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
-      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
     # SHA256 from http://www.boost.org/users/history/version_1_77_0.html
     sha256 = "sha256-/J+F/AMOIzFCkIJBr3qEbmBjCqc4jeml+vsfOiaECFQ=";

--- a/pkgs/development/libraries/boost/1.78.nix
+++ b/pkgs/development/libraries/boost/1.78.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     urls = [
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
-      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
     # SHA256 from http://www.boost.org/users/history/version_1_78_0.html
     sha256 = "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc";

--- a/pkgs/development/libraries/boost/1.79.nix
+++ b/pkgs/development/libraries/boost/1.79.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     urls = [
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
-      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
     # SHA256 from http://www.boost.org/users/history/version_1_79_0.html
     sha256 = "475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39";


### PR DESCRIPTION

###### Description of changes


See https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html and https://github.com/NixOS/nixpkgs/issues/111896 for more info


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
