### PR TITLE
ocamlPackages.ocaml-migrate-parsetree-2: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
@@ -4,8 +4,6 @@ buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
    version = "2.4.0";
 
-   useDune2 = true;
-
    minimalOCamlVersion = "4.02";
 
    src = fetchurl {

--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
@@ -2,15 +2,15 @@
 
 buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
-   version = "2.3.0";
+   version = "2.4.0";
 
    useDune2 = true;
 
    minimalOCamlVersion = "4.02";
 
    src = fetchurl {
-     url = "https://github.com/ocaml-ppx/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-     sha256 = "sha256:02mzh1rcvc2xpq4iz01z7kvzsgxns3774ggxi96f147i8yr2d08h";
+     url = "https://github.com/ocaml-ppx/${pname}/releases/download/${version}/${pname}-${version}.tbz";
+     sha256 = "sha256-7EnEUtwzemIFVqtoK/AZi/UBglULUC2PsjClkSYKpqQ=";
    };
 
    meta = {


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/tag/2.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
