### PR TITLE
hollywood: init at 1.22

### DIFF
--- a/pkgs/applications/misc/hollywood/default.nix
+++ b/pkgs/applications/misc/hollywood/default.nix
@@ -1,0 +1,94 @@
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, lib
+, coreutils
+, apg
+, atop
+, bmon
+, cmatrix
+, pygments
+, moreutils
+, util-linux
+, jp2a
+, man
+, mplayer
+, openssh
+, tree
+, mlocate
+, findutils
+, ccze
+, ncurses
+, python3
+, wget
+, libcaca
+, newsboat
+, rsstail
+, w3m
+, ticker
+, tmux
+}:
+
+stdenv.mkDerivation {
+  pname = "hollywood";
+  version = "1.22";
+
+  src = fetchFromGitHub {
+    owner = "dustinkirkland";
+    repo = "hollywood";
+    rev = "35275a68c37bbc39d8b2b0e4664a0c2f5451e5f6";
+    sha256 = "sha256-faIm1uXERvIDZ6SK6uarVkWGNJskAroHgq5Cg7nUZc4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [ ./nixos-paths.patch ];
+  postPatch = ''
+    rm lib/hollywood/speedometer
+    rm bin/wallstreet
+    rm -r lib/wallstreet
+  '';
+
+  dontBuild = true;
+
+  installPhase =
+    let pathDeps = [
+      tmux
+      coreutils
+      ncurses
+      jp2a
+      mlocate
+      apg
+      atop
+      bmon
+      cmatrix
+      pygments
+      moreutils
+      util-linux
+      jp2a
+      man
+      mplayer
+      openssh
+      tree
+      findutils
+      ccze
+    ];
+    in ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r bin $out/bin
+      cp -r lib $out/lib
+      cp -r share $out/share
+      wrapProgram $out/bin/hollywood --prefix PATH : ${lib.makeBinPath pathDeps}
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Fill your console with Hollywood melodrama technobabble";
+    homepage = "https://a.hollywood.computer/";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.anselmschueler ];
+  };
+}

--- a/pkgs/applications/misc/hollywood/nixos-paths.patch
+++ b/pkgs/applications/misc/hollywood/nixos-paths.patch
@@ -1,0 +1,67 @@
+diff --git a/bin/hollywood b/bin/hollywood
+index 6f1ee68..09bc4ea 100755
+--- a/bin/hollywood
++++ b/bin/hollywood
+@@ -74,7 +74,7 @@ if [ -z "$TMUX" ]; then
+ 	else
+ 		tmux_launcher=tmux
+ 	fi
+-	$tmux_launcher new-session -d -s $PKG "/bin/bash"
++	$tmux_launcher new-session -d -s $PKG "/usr/bin/env bash"
+ 	$tmux_launcher send-keys -t $PKG "$0 $1"
+ 	$tmux_launcher send-keys -t $PKG Enter
+ 	exec $tmux_launcher attach-session -t $PKG
+diff --git a/lib/hollywood/code b/lib/hollywood/code
+index 532ce73..3448447 100755
+--- a/lib/hollywood/code
++++ b/lib/hollywood/code
+@@ -19,7 +19,7 @@ command -v view >/dev/null 2>&1 || exit 1
+ 
+ trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" INT
+ while true; do
+-	FILES=$(locate -l 4096 "/usr/*.java" "/usr/*.c" "/usr/*.cpp" 2>/dev/null | sort -R)
++	FILES=$(locate -l 4096 "/usr/*.java" "/run/current-system/sw/*.java" "/usr/*.c" "/run/current-system/sw/*.c" "/usr/*.cpp" "/run/current-system/sw/*.cpp" 2>/dev/null | sort -R)
+ 	for f in $FILES; do
+ 		[ -r "$f" ] || continue
+ 		[ -s "$f" ] || continue
+diff --git a/lib/hollywood/hexdump b/lib/hollywood/hexdump
+index f2fb0bd..db059f5 100755
+--- a/lib/hollywood/hexdump
++++ b/lib/hollywood/hexdump
+@@ -19,8 +19,8 @@ command -v ccze >/dev/null 2>&1 || exit 1
+ 
+ trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" INT
+ while true; do
+-	for f in $(ls /usr/bin/ | sort -R); do
+-		head -c 4096 "/usr/bin/$f" | hexdump -C | ccze -A -c default=green -c dir="bold green"
++	for f in $(find /usr/bin/ /run/current-system/sw/bin/ | sort -R); do
++		head -c 4096 "$f" | hexdump -C | ccze -A -c default=green -c dir="bold green"
+ 		sleep 0.7
+ 	done
+ done
+diff --git a/lib/hollywood/jp2a b/lib/hollywood/jp2a
+index e87b950..6541f80 100755
+--- a/lib/hollywood/jp2a
++++ b/lib/hollywood/jp2a
+@@ -19,7 +19,7 @@ command -v jp2a >/dev/null 2>&1 || exit 1
+ 
+ trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" INT
+ while true; do
+-	FILES=$(locate -l 4096 "/usr/*jpg" 2>/dev/null | sort -R)
++	FILES=$(locate -l 4096 "/usr/*jpg" "/run/current-system/sw/*jpg" 2>/dev/null | sort -R)
+ 	for f in $FILES; do
+ 		[ -r "$f" ] || continue
+ 		[ -s "$f" ] || continue
+diff --git a/lib/hollywood/man b/lib/hollywood/man
+index 2d42513..f4d8bbb 100755
+--- a/lib/hollywood/man
++++ b/lib/hollywood/man
+@@ -19,7 +19,7 @@ command -v ccze >/dev/null 2>&1 || exit 1
+ 
+ trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" INT
+ while true; do
+-	FILES=$(ls /usr/share/man/man1/ | sort -R | sed "s/\.1\.gz.*$//" | head -n 4096)
++	FILES=$(ls /usr/share/man/man1/ /run/current-system/sw/share/man/man1/ | sort -R | sed "s/\.1\.gz.*$//" | head -n 4096)
+ 	for f in $FILES; do
+ 		man "$f" | ccze -A
+ 		sleep 0.2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27011,6 +27011,10 @@ with pkgs;
     gtk = gtk3;
   };
 
+  hollywood = callPackage ../applications/misc/hollywood {
+    inherit (python3Packages) pygments;
+  };
+
   hors = callPackage ../development/tools/hors {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

Added Hollywood, a tool for creating hollywood-esque technobabble nonsense terminal content.

`wallstreet` has been omitted as it does not currently function, not even on Ubuntu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
