### PR TITLE
poac: init at 0.4.1

### DIFF
--- a/pkgs/development/tools/poac/default.nix
+++ b/pkgs/development/tools/poac/default.nix
@@ -1,0 +1,123 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, cpm-cmake
+, git
+, cacert
+, boost179
+, fmt_8
+, icu
+, libarchive
+, libgit2
+, lz4
+, ninja
+, openssl_3
+, spdlog
+}:
+
+let
+  git2Cpp = fetchFromGitHub {
+    owner = "ken-matsui";
+    repo = "git2-cpp";
+    rev = "v0.1.0-alpha.1";
+    sha256 = "sha256-Ub0wrBK5oMfWGv+kpq/W1PN3yzpcfg+XWRFF/lV9VCY=";
+  };
+
+  glob = fetchFromGitHub {
+    owner = "p-ranav";
+    repo = "glob";
+    rev = "v0.0.1";
+    sha256 = "sha256-2y+a7YFBiYX8wbwCCWw1Cm+SFoXGB3ZxLPi/QdZhcdw=";
+  };
+
+  packageProjectCMake = fetchFromGitHub {
+    owner = "TheLartians";
+    repo = "PackageProject.cmake";
+    rev = "v1.3";
+    sha256 = "sha256-ZktftDrPo+JhBt0XKJekv0cyxIagvcgMcXZOBd4RtKs=";
+  };
+
+  mitamaCppResult = fetchFromGitHub {
+    owner = "LoliGothick";
+    repo = "mitama-cpp-result";
+    rev = "v9.3.0";
+    sha256 = "sha256-CWYVPpmPIZZTsqXKh+Ft3SlQ4C9yjUof1mJ8Acn5kmM=";
+  };
+
+  structopt = fetchFromGitHub {
+    owner = "p-ranav";
+    repo = "structopt";
+    rev = "e9722d3c2b52cf751ebc1911b93d9649c4e365cc";
+    sha256 = "sha256-jIfKUyY2QQ2/donywwlz65PY8u7xODGoG6SlNtUhwkg=";
+  };
+
+  toml11 = fetchFromGitHub {
+    owner = "ToruNiina";
+    repo = "toml11";
+    rev = "9086b1114f39a8fb10d08ca704771c2f9f247d02";
+    sha256 = "sha256-fHUElHO4ckNQq7Q88GdbHGxfaAvWoWtGB0eD9y2MnLo=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "poac";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "poacpm";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-jXYPeI/rVuTr7OYV5sMgNr+U1OfN0XZtun6mihtlErY=";
+  };
+
+  preConfigure = ''
+    mkdir -p ${placeholder "out"}/share/cpm
+    cp ${cpm-cmake}/share/cpm/CPM.cmake ${placeholder "out"}/share/cpm/CPM_0.35.1.cmake
+  '';
+
+  cmakeFlags = [
+    "-DCPM_USE_LOCAL_PACKAGES=ON"
+    "-DCPM_SOURCE_CACHE=${placeholder "out"}/share"
+    "-DFETCHCONTENT_SOURCE_DIR_FMT=${fmt_8}"
+    "-DFETCHCONTENT_SOURCE_DIR_GIT2-CPP=${git2Cpp}"
+    "-DFETCHCONTENT_SOURCE_DIR_GLOB=${glob}"
+    "-DFETCHCONTENT_SOURCE_DIR_PACKAGEPROJECT.CMAKE=${packageProjectCMake}"
+    "-DFETCHCONTENT_SOURCE_DIR_MITAMA-CPP-RESULT=${mitamaCppResult}"
+    "-DFETCHCONTENT_SOURCE_DIR_NINJA=${ninja.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_STRUCTOPT=${structopt}"
+    "-DFETCHCONTENT_SOURCE_DIR_TOML11=${toml11}"
+  ];
+
+  nativeBuildInputs = [ cmake git cacert ];
+  buildInputs = [
+    (if stdenv.isDarwin
+      then boost179
+      else (boost179.override { enableShared = false; enableStatic = true; }))
+    fmt_8
+    git2Cpp
+    glob
+    packageProjectCMake
+    mitamaCppResult
+    ninja
+    structopt
+    toml11
+    icu
+    libarchive
+    libgit2
+    lz4
+    openssl_3
+    spdlog
+  ];
+
+  meta = with lib; {
+    homepage = "https://poac.pm";
+    description = "Package Manager for C++";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ken-matsui ];
+    platforms = platforms.unix;
+    # https://github.com/NixOS/nixpkgs/pull/189712#issuecomment-1237791234
+    broken = (stdenv.isLinux && stdenv.isAarch64)
+    # error: excess elements in scalar initializer on std::aligned_alloc
+          || (stdenv.isDarwin && stdenv.isx86_64);
+  };
+}

--- a/pkgs/development/tools/poac/default.nix
+++ b/pkgs/development/tools/poac/default.nix
@@ -90,9 +90,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake git cacert ];
   buildInputs = [
-    (if stdenv.isDarwin
-      then boost179
-      else (boost179.override { enableShared = false; enableStatic = true; }))
+    (boost179.override {
+      enableShared = stdenv.isDarwin;
+      enableStatic = !stdenv.isDarwin;
+    })
     fmt_8
     git2Cpp
     glob

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9735,6 +9735,10 @@ with pkgs;
 
   po4a = perlPackages.Po4a;
 
+  poac = callPackage ../development/tools/poac {
+    inherit (llvmPackages_14) stdenv;
+  };
+
   podiff = callPackage ../tools/text/podiff { };
 
   podman = callPackage ../applications/virtualization/podman/wrapper.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
