### PR TITLE
psutil: 5.9.0 -> 5.9.1

### DIFF
--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "psutil";
-  version = "5.9.0";
+  version = "5.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25";
+    sha256 = "sha256-V/GBm12elc37DIgailt9VC7Qt8Ui1XVwaoC+3ISMiVQ=";
   };
 
   # We have many test failures on various parts of the package:


### PR DESCRIPTION
###### Description of changes

Release notes:

5.9.1
=====

2022-05-20

**Enhancements**

- 1053_: drop Python 2.6 support.  (patches by Matthieu Darbois and Hugo van
  Kemenade)
- 2050_, [Linux]: increase ``read(2)`` buffer size from 1k to 32k when reading
  ``/proc`` pseudo files line by line. This should help having more consistent
  results.
- 2057_, [OpenBSD]: add support for `cpu_freq()`_.
- 2107_, [Linux]: `Process.memory_full_info()`_ (reporting process USS/PSS/Swap
  memory) now reads ``/proc/pid/smaps_rollup`` instead of ``/proc/pids/smaps``,
  which makes it 5 times faster.

**Bug fixes**

- 2048_: ``AttributeError`` is raised if ``psutil.Error`` class is raised
  manually and passed through ``str``.
- 2049_, [Linux]: `cpu_freq()`_ erroneously returns ``curr`` value in GHz while
  ``min`` and ``max`` are in MHz.
- 2050_, [Linux]: `virtual_memory()`_ may raise ``ValueError`` if running in a
  LCX container.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - It built a *ton* of stuff, failed the first couple times due to running out of disk space, then I *think* it succeeded? I'm really not sure what happened
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [X] **ALSO** tested by building `s-tui` before and after `psutil` update. Before it reports CPU frequency in GHz labeled as MHz, after it reports in MHz labeled as MHz.
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
