### PR TITLE
envoy: 1.21.1 -> 1.21.4

### DIFF
--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -23,8 +23,8 @@ let
     # However, the version string is more useful for end-users.
     # These are contained in a attrset of their own to make it obvious that
     # people should update both.
-    version = "1.21.1";
-    rev = "af50070ee60866874b0a9383daf9364e884ded22";
+    version = "1.21.4";
+    rev = "782ba5e5ab9476770378ec9f1901803e0d38ac41";
   };
 in
 buildBazelPackage rec {
@@ -35,7 +35,7 @@ buildBazelPackage rec {
     owner = "envoyproxy";
     repo = "envoy";
     inherit (srcVer) rev;
-    hash = "sha256:11mm72zmb479ss585jzqzhklyyqmdadnvr91ghzvjxc0j2a1hrr4";
+    hash = "sha256-SthKDMQs5yNU0iouAPVsDeCPKcsBXmO9ebDwu58UQRs=";
 
     postFetch = ''
       chmod -R +w $out
@@ -85,8 +85,8 @@ buildBazelPackage rec {
 
   fetchAttrs = {
     sha256 = {
-      x86_64-linux = "sha256-23Z6SbKnbah/NCrdMrXhrNFFASd/8xRH3fSyIE++heA=";
-      aarch64-linux = "sha256-dMOu0HYUIUJ+XEtctjaZZ1jGGQq+cHbay8+KwR5XqP0=";
+      x86_64-linux = "sha256-/SA+WFHcMjk6iLwuEmuBIzy3pMhw7TThIEx292dv6IE=";
+      aarch64-linux = "sha256-0XdeirdIP7+nKy8zZbr2uHN2RZ4ZFOJt9i/+Ow1s/W4=";
     }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;


### PR DESCRIPTION
###### Description of changes

### Incompatible Behavior Changes
_Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required_

### Minor Behavior Changes
_Changes that may cause incompatibilities for some users, but should not for most_

* [1.21.2](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.2) cryptomb: remove RSA PKCS1 v1.5 padding support.
* [1.21.2](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.2) perf: ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
* [1.21.3](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.3)/[1.21.4](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/current) tls: if both [match_subject_alt_names](https://www.envoyproxy.io/docs/envoy/v1.21.4/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-certificatevalidationcontext-match-subject-alt-names) and [match_typed_subject_alt_names](https://www.envoyproxy.io/docs/envoy/v1.21.4/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-certificatevalidationcontext-match-typed-subject-alt-names) are specified, the former (deprecated) field is ignored. Previously, setting both fields would result in an error.

### Bug Fixes
_Changes expected to improve the state of the world and are unlikely to have negative effects_

* [1.21.3](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.3) decompression: fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max inflation payload size is now limited. This change can be reverted via the envoy.reloadable_features.enable_compression_bomb_protection runtime flag.
* [1.21.3](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.3) health_check: fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
* [1.21.3](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.3) oauth: fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing access in the presence of any access token attached to the request.
* [1.21.3](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.3) oauth: fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in newer versions and corrupts memory on earlier versions.
* [1.21.3](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/v1.21.3) router: fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an Envoy-generated local reply.
* [1.21.4](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/current) docker: update Docker images (distroless -> d65ac1a) to resolve CVE issues in container packages.

### Removed Config or Runtime
_Normally occurs at the end of the [deprecation period](https://www.envoyproxy.io/docs/envoy/v1.21.4/version_history/version_history#deprecated)_

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
