### PR TITLE
jellyfin-ffmpeg: 5.0.1-5 -> 5.0.1-6, bump nv-codec-headers to v11

### DIFF
--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,6 +1,14 @@
-{ ffmpeg_5, ffmpeg-full, fetchFromGitHub, lib }:
+{ ffmpeg_5
+, ffmpeg-full
+, nv-codec-headers-11
+, fetchFromGitHub
+, lib
+}:
 
-(ffmpeg-full.override { ffmpeg = ffmpeg_5; }).overrideAttrs (old: rec {
+(ffmpeg-full.override {
+  ffmpeg = ffmpeg_5;
+  nv-codec-headers = nv-codec-headers-11;
+}).overrideAttrs (old: rec {
   pname = "jellyfin-ffmpeg";
   version = "5.0.1-5";
 

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,22 +1,20 @@
-{ ffmpeg_5
-, ffmpeg-full
+{ ffmpeg_5-full
 , nv-codec-headers-11
 , fetchFromGitHub
 , lib
 }:
 
-(ffmpeg-full.override {
-  ffmpeg = ffmpeg_5;
+(ffmpeg_5-full.override {
   nv-codec-headers = nv-codec-headers-11;
 }).overrideAttrs (old: rec {
   pname = "jellyfin-ffmpeg";
-  version = "5.0.1-5";
+  version = "5.0.1-7";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-ffmpeg";
     rev = "v${version}";
-    sha256 = "sha256-rFzBAniw2vQGFn2GDlz6NiB/Ow2EZlE3Lu+ceYTStkM=";
+    sha256 = "sha256-jMd7tEEfiHqTp4q8c6EvbjL0KyJ6ucj4ZNrKOJLJ1Mc=";
   };
 
   postPatch = ''
@@ -26,8 +24,6 @@
 
     ${old.postPatch or ""}
   '';
-
-  doCheck = false; # https://github.com/jellyfin/jellyfin-ffmpeg/issues/79
 
   meta = with lib; {
     description = "${old.meta.description} (Jellyfin fork)";


### PR DESCRIPTION
###### Description of changes

[Per upstream request](https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1159060073), this bumps the version of `nv-codec-headers` that `jellyfin-ffmpeg` uses from the default of v9, to v11.

This fixes basic NVENC encoding in Jellyfin 10.8.0 (the core issue described by https://github.com/jellyfin/jellyfin/issues/7944).

Manual testing: Jellyfin (`nixpkgs-unstable`), GTX 1060, Nvidia 515.48.07).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).