### PR TITLE
ffmpeg-full: add cuda features, jellyfin-ffmpeg: fix CUDA tonemap

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -49,8 +49,11 @@
 , alsa-lib ? null # Alsa in/output support
 #, avisynth ? null # Support for reading AviSynth scripts
 , bzip2 ? null
+, clang ? null
 , celt ? null # CELT decoder
 #, crystalhd ? null # Broadcom CrystalHD hardware acceleration
+, cuda ? !stdenv.isDarwin && !stdenv.isAarch64 # Dynamically linked CUDA
+, cuda-llvm ? !stdenv.isDarwin && !stdenv.isAarch64 # LLVM-based CUDA compilation
 , dav1d ? null # AV1 decoder (focused on speed and correctness)
 #, decklinkExtlib ? false, blackmagic-design-desktop-video ? null # Blackmagic Design DeckLink I/O support
 , fdkaacExtlib ? false, fdk_aac ? null # Fraunhofer FDK AAC de/encoder
@@ -327,6 +330,8 @@ stdenv.mkDerivation rec {
     #(enableFeature avisynth "avisynth")
     (enableFeature (bzip2 != null) "bzlib")
     (enableFeature (celt != null) "libcelt")
+    (enableFeature cuda "cuda")
+    (enableFeature (clang != null && cuda-llvm) "cuda-llvm")
     #(enableFeature crystalhd "crystalhd")
     (enableFeature (dav1d != null) "libdav1d")
     #(enableFeature decklinkExtlib "decklink")
@@ -447,6 +452,7 @@ stdenv.mkDerivation rec {
     ++ optionals isLinux [ alsa-lib libraw1394 libv4l vulkan-loader glslang ]
     ++ optional (isLinux && !isAarch64 && libmfx != null) libmfx
     ++ optional (nvdec || nvenc) nv-codec-headers
+    ++ optional cuda-llvm clang
     ++ optionals stdenv.isDarwin [ Cocoa CoreServices CoreAudio AVFoundation
                                    MediaToolbox VideoDecodeAcceleration
                                    libiconv ];

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -17,6 +17,10 @@
     sha256 = "sha256-jMd7tEEfiHqTp4q8c6EvbjL0KyJ6ucj4ZNrKOJLJ1Mc=";
   };
 
+  configureFlags = old.configureFlags ++ [
+    "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
+  ];
+
   postPatch = ''
     for file in $(cat debian/patches/series); do
       patch -p1 < debian/patches/$file


### PR DESCRIPTION
###### Description of changes

This enables the `cuda`, `cuda-llvm` features in `ffmpeg-full`. IANAL, but I think there should be no licensing issues, as in this case FFmpeg only uses cuda headers, and uses the dynamic `libcuda` from the drivers (as per `postFixup`). Please point out otherwise if needed.

I've included a `jellyfin-ffmpeg` change which adds a CUDA-related flag [per upstream request](https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1159060073). Please notify me if this needs to be a separate commit/PR.

For `jellyfin-ffmpeg` to build, this currently hard-depends on https://github.com/NixOS/nixpkgs/pull/178276 . I will rebase and mark this ready when the mentioned PR is merged.

Manual testing: Jellyfin (`nixpkgs-unstable`), GTX 1060, Nvidia 515.48.07).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
