### PR TITLE
nomad: remove dependency on Nvidia

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/1.2.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.2.nix
@@ -1,11 +1,9 @@
 { callPackage
 , buildGoModule
-, nvidia_x11
-, nvidiaGpuSupport
 }:
 
 callPackage ./generic.nix {
-  inherit buildGoModule nvidia_x11 nvidiaGpuSupport;
+  inherit buildGoModule;
   version = "1.2.8";
   sha256 = "11yn8g9wsdb35q97wn5vy93kgbn5462k0a33wxlfdz14i5h00yj8";
   vendorSha256 = "06wyfnlm37qjvd1pwzygflfpcp9p52f61wgi6pb9l7hnqy2ph6j5";

--- a/pkgs/applications/networking/cluster/nomad/1.3.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.3.nix
@@ -1,11 +1,9 @@
 { callPackage
 , buildGoModule
-, nvidia_x11
-, nvidiaGpuSupport
 }:
 
 callPackage ./generic.nix {
-  inherit buildGoModule nvidia_x11 nvidiaGpuSupport;
+  inherit buildGoModule;
   version = "1.3.1";
   sha256 = "03ckhqh5xznvhbk380ka0g9w9hrvsi389h5maw68f3g3acx68jm7";
   vendorSha256 = "08k5dxaq4r2q0km6y9mc14haski6l7hmhmzn5wjb961hwf5hkfgh";

--- a/pkgs/applications/networking/cluster/nomad/generic.nix
+++ b/pkgs/applications/networking/cluster/nomad/generic.nix
@@ -4,9 +4,6 @@
 , version
 , sha256
 , vendorSha256
-, nvidiaGpuSupport
-, patchelf
-, nvidia_x11
 , nixosTests
 }:
 
@@ -25,22 +22,10 @@ buildGoModule rec {
 
   inherit vendorSha256;
 
-  nativeBuildInputs = lib.optionals nvidiaGpuSupport [
-    patchelf
-  ];
-
   # ui:
   #  Nomad release commits include the compiled version of the UI, but the file
   #  is only included if we build with the ui tag.
-  tags = [ "ui" ] ++ lib.optional (!nvidiaGpuSupport) "nonvidia";
-
-  # The dependency on NVML isn't explicit. We have to make it so otherwise the
-  # binary will not know where to look for the relevant symbols.
-  postFixup = lib.optionalString nvidiaGpuSupport ''
-    for bin in $out/bin/*; do
-      patchelf --add-needed "${nvidia_x11}/lib/libnvidia-ml.so" "$bin"
-    done
-  '';
+  tags = [ "ui" ];
 
   passthru.tests.nomad = nixosTests.nomad;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8727,11 +8727,9 @@ with pkgs;
   # https://github.com/hashicorp/nomad/blob/master/contributing/golang.md
   nomad_1_2 = callPackage ../applications/networking/cluster/nomad/1.2.nix {
     buildGoModule = buildGo117Module;
-    inherit (linuxPackages);
   };
   nomad_1_3 = callPackage ../applications/networking/cluster/nomad/1.3.nix {
     buildGoModule = buildGo117Module;
-    inherit (linuxPackages);
   };
 
   nomad-autoscaler = callPackage ../applications/networking/cluster/nomad-autoscaler { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8727,13 +8727,11 @@ with pkgs;
   # https://github.com/hashicorp/nomad/blob/master/contributing/golang.md
   nomad_1_2 = callPackage ../applications/networking/cluster/nomad/1.2.nix {
     buildGoModule = buildGo117Module;
-    inherit (linuxPackages) nvidia_x11;
-    nvidiaGpuSupport = config.cudaSupport or false;
+    inherit (linuxPackages);
   };
   nomad_1_3 = callPackage ../applications/networking/cluster/nomad/1.3.nix {
     buildGoModule = buildGo117Module;
-    inherit (linuxPackages) nvidia_x11;
-    nvidiaGpuSupport = config.cudaSupport or false;
+    inherit (linuxPackages);
   };
 
   nomad-autoscaler = callPackage ../applications/networking/cluster/nomad-autoscaler { };


### PR DESCRIPTION
###### Description of changes

Nomad 1.2.0 [externalized]( https://github.com/hashicorp/nomad/blob/main/CHANGELOG.md#120-november-15-2021) the Nvidia device driver out of the main codebase and into a separate [plugin](https://github.com/hashicorp/nomad-device-nvidia), so there is no need to load the Nvidia libraries anymore when building Nomad itself.

I'm getting started with Nix, so let me know if there's anything I did wrong :slightly_smiling_face: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
