### PR TITLE
wpsoffice: 11.1.0.9615 -> 11.1.0.11664

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -1,157 +1,68 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , mkDerivation
 , fetchurl
 , dpkg
 , wrapGAppsHook
 , wrapQtAppsHook
+, autoPatchelfHook
 , alsa-lib
-, atk
-, bzip2
-, cairo
-, cups
-, dbus
-, expat
-, ffmpeg
-, fontconfig
-, freetype
-, gdk-pixbuf
-, glib
-, gperftools
-, gtk2-x11
-, libpng12
 , libtool
-, libuuid
-, libxml2
-, xz
 , nspr
-, nss
-, openssl
-, pango
-, qt4
-, qtbase
-, sqlite
-, unixODBC
+, mesa
+, libtiff
+, cups
 , xorg
-, zlib
-, steam
+, steam-run
 , makeWrapper
+, useChineseVersion ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "wpsoffice";
-  version = "11.1.0.9615";
+  version = "11.1.0.11664";
 
-  src = fetchurl {
-    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/9615/wps-office_11.1.0.9615.XA_amd64.deb";
-    sha256 = "0dpd4njpizclllps3qagipycfws935rhj9k5gmdhjfgsk0ns188w";
+  src = if useChineseVersion then fetchurl {
+    url = "https://wps-linux-personal.wpscdn.cn/wps/download/ep/Linux2019/${lib.last (lib.splitString "." version)}/wps-office_${version}_amd64.deb";
+    sha256 = "sha256-D2LhxBMHmQjVExa/63DHdws0V+EmOSlJzGq91jbuJHs=";
+  } else fetchurl {
+    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/${lib.last (lib.splitString "." version)}/wps-office_${version}.XA_amd64.deb";
+    sha256 = "sha256-9qZGqs4nsB9mWCJTi2x+vWmMF0sEoUYgEzLI//hijfU=";
   };
+
   unpackCmd = "dpkg -x $src .";
   sourceRoot = ".";
 
-  postUnpack = lib.optionalString (version == "11.1.0.9505") ''
-    # distribution is missing libjsapiservice.so, so we should not let
+  postUnpack = ''
+    # distribution is missing libkappessframework.so, so we should not let
     # autoPatchelfHook fail on the following dead libraries
-    rm opt/kingsoft/wps-office/office6/{libjsetapi.so,libjswppapi.so,libjswpsapi.so}
+    rm -r opt/kingsoft/wps-office/office6/addons/pdfbatchcompression
+
+    # Remove the following libraries because they depend on qt4
+    rm -r opt/kingsoft/wps-office/office6/{librpcetapi.so,librpcwpsapi.so,librpcwppapi.so,libavdevice.so.58.10.100,libmediacoder.so}
+    rm -r opt/kingsoft/wps-office/office6/addons/wppcapturer/libwppcapturer.so
+    rm -r opt/kingsoft/wps-office/office6/addons/wppencoder/libwppencoder.so
   '';
 
-  nativeBuildInputs = [ dpkg wrapGAppsHook wrapQtAppsHook makeWrapper ];
+  nativeBuildInputs = [ dpkg wrapGAppsHook wrapQtAppsHook makeWrapper autoPatchelfHook ];
 
-  meta = with lib; {
-    description = "Office suite, formerly Kingsoft Office";
-    homepage = "https://www.wps.com/";
-    platforms = [ "x86_64-linux" ];
-    hydraPlatforms = [];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ mlatus th0rgal ];
-  };
-
-  buildInputs = with xorg; [
+  buildInputs = [
     alsa-lib
-    atk
-    bzip2
-    cairo
-    dbus.lib
-    expat
-    ffmpeg
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gperftools
-    gtk2-x11
-    libICE
-    libSM
-    libX11
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    libpng12
+    xorg.libXdamage
+    xorg.libXtst
     libtool
-    libuuid
-    libxcb
-    libxml2
-    xz
     nspr
-    nss
-    openssl
-    pango
-    qt4
-    qtbase
-    sqlite
-    unixODBC
-    zlib
+    mesa
+    libtiff
     cups.lib
   ];
 
-  dontPatchELF = true;
-
-  # wpsoffice uses `/build` in its own build system making nix things there
-  # references to nix own build directory
-  noAuditTmpdir = true;
-
-  unvendoredLibraries = [
-    # Have to use parts of the vendored qt4
-    #"Qt"
-    "SDL2"
-    "bz2"
-    "avcodec"
-    "avdevice"
-    "avformat"
-    "avutil"
-    "swresample"
-    "swscale"
-    "jpeg"
-    "png"
-    # File saving breaks unless we are using vendored llvmPackages_8.libcxx
-    #"c++"
-    "ssl" "crypto"
-    "nspr"
-    "nss"
-    "odbc"
-    "tcmalloc" # gperftools
-  ];
-
-  installPhase = let
-    steam-run = (steam.override {
-      extraPkgs = p: buildInputs;
-    }).run;
-  in ''
+  installPhase = ''
+    runHook preInstall
     prefix=$out/opt/kingsoft/wps-office
     mkdir -p $out
     cp -r opt $out
     cp -r usr/* $out
-    for lib in $unvendoredLibraries; do
-      rm -v "$prefix/office6/lib$lib"*.so{,.*}
-    done
     for i in wps wpp et wpspdf; do
       substituteInPlace $out/bin/$i \
         --replace /opt/kingsoft/wps-office $prefix
@@ -160,17 +71,18 @@ stdenv.mkDerivation rec {
       substituteInPlace $i \
         --replace /usr/bin $out/bin
     done
-
     for i in wps wpp et wpspdf; do
       mv $out/bin/$i $out/bin/.$i-orig
       makeWrapper ${steam-run}/bin/steam-run $out/bin/$i \
         --add-flags $out/bin/.$i-orig \
         --argv0 $i
     done
+    runHook postInstall
   '';
 
   dontWrapQtApps = true;
   dontWrapGApps = true;
+
   postFixup = ''
     for f in "$out"/bin/*; do
       echo "Wrapping $f"
@@ -179,4 +91,13 @@ stdenv.mkDerivation rec {
         "''${qtWrapperArgs[@]}"
     done
   '';
+
+  meta = with lib; {
+    description = "Office suite, formerly Kingsoft Office";
+    homepage = "https://www.wps.com";
+    platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [ ];
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ mlatus th0rgal rewine ];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31740,7 +31740,10 @@ with pkgs;
 
   worldengine-cli = python3Packages.worldengine;
 
-  wpsoffice = libsForQt5.callPackage ../applications/office/wpsoffice {};
+  wpsoffice = libsForQt5.callPackage ../applications/office/wpsoffice { };
+  wpsoffice-cn = libsForQt5.callPackage ../applications/office/wpsoffice {
+    useChineseVersion = true;
+  };
 
   wrapFirefox = callPackage ../applications/networking/browsers/firefox/wrapper.nix { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
