### PR TITLE
deadbeefPlugins.musical-spectrum: init at unstable-2020-07-01

### DIFF
--- a/pkgs/applications/audio/deadbeef/plugins/musical-spectrum.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/musical-spectrum.nix
@@ -1,0 +1,42 @@
+{ deadbeef
+, fetchFromGitHub
+, fftw
+, glib
+, gtk3
+, lib
+, pkg-config
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deadbeef-musical-spectrum-plugin";
+  version = "unstable-2020-07-01";
+
+  src = fetchFromGitHub {
+    owner = "cboxdoerfer";
+    repo = "ddb_musical_spectrum";
+    rev = "a97fd4e1168509911ab43ba32d815b5489000a06";
+    sha256 = "0p33wyqi27y0q1mvjv5nn6l3vvqlg6b8yd6k2l07bax670bl0q3g";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ deadbeef fftw glib gtk3 ];
+  makeFlags = [ "gtk3" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/deadbeef
+    install -v -c -m 644 gtk3/ddb_vis_musical_spectrum_GTK3.so $out/lib/deadbeef/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Musical spectrum plugin for the DeaDBeeF music player";
+    homepage = "https://github.com/cboxdoerfer/ddb_musical_spectrum";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ddelabru ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25921,6 +25921,7 @@ with pkgs;
     headerbar-gtk3 = callPackage ../applications/audio/deadbeef/plugins/headerbar-gtk3.nix { };
     lyricbar = callPackage ../applications/audio/deadbeef/plugins/lyricbar.nix { };
     mpris2 = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
+    musical-spectrum = callPackage ../applications/audio/deadbeef/plugins/musical-spectrum.nix { };
     statusnotifier = callPackage ../applications/audio/deadbeef/plugins/statusnotifier.nix { };
   };
 


### PR DESCRIPTION
###### Description of changes

This DeaDBeeF plugin provides an old-school "musical spectrum" that shows the live levels of frequencies corresponding to different musical notes. I packaged it up because I wanted to spend some time in 2004. :smile_cat:

I opted to include only the gtk3 version of the plugin in this derivation because that seems to be the norm for other DeaDBeeF plugins in nixpkgs.

Tested on NixOS 22.05 by building a custom deadbeef-with-plugins derivation:

![Screenshot_2022-06-19_21-44-51](https://user-images.githubusercontent.com/39909293/174517894-78bb6a19-98be-452e-96d8-83ee2d116cf2.png)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
