### PR TITLE
Update aws-sam-cli, aws-sam-translator, and awscli2

### DIFF
--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -5,6 +5,7 @@
 , jsonschema
 , mock
 , parameterized
+, pytest-env
 , pytestCheckHook
 , pythonOlder
 , pyyaml
@@ -13,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "aws-sam-translator";
-  version = "1.42.0";
+  version = "1.46.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -22,7 +23,7 @@ buildPythonPackage rec {
     owner = "aws";
     repo = "serverless-application-model";
     rev = "v${version}";
-    sha256 = "sha256-pjcRsmxPL4lbgDopW+wKQRkRcqebLPTd95JTL8PiWtc=";
+    sha256 = "sha256-SLGxpRbTuK+Lxww45dfHIMwwxV5vhlnYyG4WqG45aNg=";
   };
 
   propagatedBuildInputs = [
@@ -41,6 +42,7 @@ buildPythonPackage rec {
   checkInputs = [
     mock
     parameterized
+    pytest-env
     pytestCheckHook
     pyyaml
   ];

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -5,11 +5,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "1.37.0";
+  version = "1.52.0";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    hash = "sha256-XE3g2mKwAiaJvi0ShVScnCKrmz7ujaQgOeFXuYwtP4g=";
+    hash = "sha256-ldr0X+I5+Nfb+WBDOe0m202WOuccGUI5HFL3fpbBNPo=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -36,15 +36,23 @@ python3.pkgs.buildPythonApplication rec {
     wrapProgram $out/bin/sam --set  SAM_CLI_TELEMETRY 0
   '';
 
+  patches = [
+    # Click 8.1 removed `get_terminal_size`, recommending
+    # `shutil.get_terminal_size` instead.
+    # (https://github.com/pallets/click/pull/2130)
+    ./support-click-8-1.patch
+  ];
+
   # fix over-restrictive version bounds
   postPatch = ''
     substituteInPlace requirements/base.txt \
       --replace "aws_lambda_builders==" "aws-lambda-builders #" \
-      --replace "click~=7.1" "click~=8.0" \
+      --replace "click~=7.1" "click~=8.1" \
       --replace "dateparser~=1.0" "dateparser>=0.7" \
       --replace "docker~=4.2.0" "docker>=4.2.0" \
       --replace "Flask~=1.1.2" "Flask~=2.0" \
       --replace "jmespath~=0.10.0" "jmespath" \
+      --replace "MarkupSafe==2.0.1" "MarkupSafe #" \
       --replace "PyYAML~=5.3" "PyYAML #" \
       --replace "regex==" "regex #" \
       --replace "requests==" "requests #" \

--- a/pkgs/development/tools/aws-sam-cli/support-click-8-1.patch
+++ b/pkgs/development/tools/aws-sam-cli/support-click-8-1.patch
@@ -1,0 +1,21 @@
+diff --git a/samcli/commands/_utils/table_print.py b/samcli/commands/_utils/table_print.py
+index de63af29..a9d0f2fe 100644
+--- a/samcli/commands/_utils/table_print.py
++++ b/samcli/commands/_utils/table_print.py
+@@ -7,6 +7,7 @@ from functools import wraps
+ from typing import Sized
+ 
+ import click
++import shutil
+ 
+ MIN_OFFSET = 20
+ 
+@@ -30,7 +31,7 @@ def pprint_column_names(
+ 
+     def pprint_wrap(func):
+         # Calculate terminal width, number of columns in the table
+-        width, _ = click.get_terminal_size()
++        width, _ = shutil.get_terminal_size()
+         # For UX purposes, set a minimum width for the table to be usable
+         # and usable_width keeps margins in mind.
+         width = max(width, min_width)

--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -29,7 +29,7 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.7.8"; # N.B: if you change this, check if overrides are still up-to-date
+  version = "2.7.9"; # N.B: if you change this, check if overrides are still up-to-date
 
   src = fetchFromGitHub {
     owner = "aws";
@@ -67,6 +67,7 @@ with py.pkgs; buildPythonApplication rec {
   postPatch = ''
     substituteInPlace setup.cfg \
       --replace "colorama>=0.2.5,<0.4.4" "colorama" \
+      --replace "cryptography>=3.3.2,<37.0.0" "cryptography" \
       --replace "docutils>=0.10,<0.16" "docutils" \
       --replace "ruamel.yaml>=0.15.0,<0.16.0" "ruamel.yaml" \
       --replace "wcwidth<0.2.0" "wcwidth" \


### PR DESCRIPTION
###### Description of changes

- Relaxes python dependency bounds in `awscli2` to allow for current packages in nixpkgs ([cryptography changelog](https://cryptography.io/en/latest/changelog/#v37-0-0))
- Updates awscli2 to 2.7.9 ([changelog](https://github.com/aws/aws-cli/blob/2.7.9/CHANGELOG.rst))
- Updates aws-sam-translator to 1.46.0 ([changelog](https://github.com/aws/serverless-application-model/releases))
- Updates aws-sam-cli to 1.52.0 ([changelog](https://github.com/aws/aws-sam-cli/releases)); this depends on the updated version of aws-sam-translator.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
