### PR TITLE
Three small improvements to ocamlPackages

### DIFF
--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
-  buildInputs = [ topkg ];
-  propagatedBuildInputs = [ cmdliner seq stdlib-shims ];
+  buildInputs = [ cmdliner topkg ];
+  propagatedBuildInputs = [ seq stdlib-shims ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/ocaml-r/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-r/default.nix
@@ -37,6 +37,8 @@ buildDunePackage rec {
   checkInputs = [ alcotest ];
 
   meta = {
+    # This has been broken by the update to R 4.2.0 (#171597)
+    broken = true;
     description = "OCaml bindings for the R interpreter";
     inherit (src.meta) homepage;
     license = lib.licenses.gpl3;

--- a/pkgs/development/ocaml-modules/parmap/default.nix
+++ b/pkgs/development/ocaml-modules/parmap/default.nix
@@ -10,13 +10,12 @@ buildDunePackage rec {
   };
 
   minimalOCamlVersion = "4.03";
-  useDune2 = true;
 
   buildInputs = [
     dune-configurator
   ];
 
-  doCheck = true;
+  doCheck = false; # prevent running slow benchmarks
 
   meta = with lib; {
     description = "Library for multicore parallel programming";


### PR DESCRIPTION
###### Description of changes

Three minor unrelated changes:
  - disable tests in `parmap`: those tests are more benchmarks and are very costly to run
  - there is no need to propagate the `cmdliner` input to `fmt`, and it becomes annoying when there are two versions of `cmdliner` around (as currently in `nixpkgs`)
  - `ocaml-r` has been broken since the last update of R and there is no easy fix in sight.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

