### PR TITLE
pyside2: 5.15.2 -> 5.15.5

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -14,6 +14,7 @@
 , pycrypto
 , pynacl
 , pyside2
+, pysocks
 , pytestCheckHook
 , qrcode
 , qt5
@@ -132,6 +133,7 @@ rec {
       pyside2
       psutil
       qrcode
+      pysocks
     ];
 
     nativeBuildInputs = [ qt5.wrapQtAppsHook ];

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pyside2";
-  version = "5.15.2";
+  version = "5.15.5";
 
   src = fetchurl {
     url = "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${version}-src/pyside-setup-opensource-src-${version}.tar.xz";
-    sha256 = "060ljj1nzyp4zfz2vasbv2i7gs5rfkkjwxxbisd0fdw01d5m01mk";
+    sha256 = "0cwvw6695215498rsbm2xzkwaxdr3w7zfvy4kc62c01k6pxs881r";
   };
 
   patches = [

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation {
     license = with licenses; [ gpl2 lgpl21 ];
     homepage = "https://wiki.qt.io/Qt_for_Python";
     maintainers = with maintainers; [ gebner ];
-    broken = stdenv.isDarwin || python.isPy310;
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26753,7 +26753,7 @@ with pkgs;
   fragments = callPackage ../applications/networking/p2p/fragments { };
 
   freecad = libsForQt5.callPackage ../applications/graphics/freecad {
-    boost = python3Packages.boost169;
+    boost = python3Packages.boost;
     inherit (python3Packages)
       GitPython
       matplotlib

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1354,11 +1354,6 @@ in {
     enablePython = true;
   });
 
-  boost169 = toPythonModule (pkgs.boost169.override {
-    inherit (self) python numpy;
-    enablePython = true;
-  });
-
   boschshcpy = callPackage ../development/python-modules/boschshcpy { };
 
   boost-histogram = callPackage ../development/python-modules/boost-histogram {


### PR DESCRIPTION
###### Description of changes

Package update.


Currenty, this breaks python310Packages.tumpa, python39Packages.tumpa and freecad. There is already an update for freecad (#178259), which would get unblocked by this PR providing a newer version of pyside2.
I removed the python3Packages.boost169 attribute, because only freecad used it and boost compilation failed in Boost.Python with the new Python 3.10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
    <details>
      <summary>3 packages failed to build:</summary>
      <ul>
        <li>freecad</li>
        <li>python310Packages.tumpa</li>
        <li>python39Packages.tumpa</li>
      </ul>
    </details>
    <details>
      <summary>20 packages built:</summary>
      <ul>
        <li>conan</li>
        <li>cutter</li>
        <li>expliot</li>
        <li>hydrus</li>
        <li>napari (python310Packages.napari)</li>
        <li>onionshare-gui</li>
        <li>patray</li>
        <li>python310Packages.magicgui</li>
        <li>python310Packages.napari-npe2</li>
        <li>python310Packages.pyside2</li>
        <li>python310Packages.pyside2-tools</li>
        <li>python310Packages.shiboken2</li>
        <li>python39Packages.magicgui</li>
        <li>python39Packages.napari</li>
        <li>python39Packages.napari-npe2</li>
        <li>python39Packages.pyside2</li>
        <li>python39Packages.pyside2-tools</li>
        <li>python39Packages.shiboken2</li>
        <li>sl1-to-photon</li>
        <li>syncplay</li>
      </ul>
    </details>
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).