### PR TITLE
graphwar: init at 1.0.0

### DIFF
--- a/pkgs/games/graphwar/default.nix
+++ b/pkgs/games/graphwar/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, copyDesktopItems
+, jdk
+, makeDesktopItem
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "graphwar";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "catabriga";
+    repo = "graphwar";
+    rev = version;
+    sha256 = "sha256-t3Y576dXWp2Mj6OSQN5cm9FuNBWNqKq6xxkVRbjIBgE=";
+  };
+
+  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
+  buildInputs = [ jdk ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p out/
+    javac -d out/ -sourcepath src/ -classpath out/ -encoding utf8 src/**/*.java
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/
+    mv out $out/lib/graphwar
+    cp -r rsc $out/lib/graphwar/rsc
+
+    makeWrapper ${jdk}/bin/java $out/bin/graphwar \
+      --add-flags "-classpath $out/lib/graphwar Graphwar.Graphwar"
+    makeWrapper ${jdk}/bin/java $out/bin/graphwar-roomserver \
+      --add-flags "-classpath $out/lib/graphwar RoomServer.RoomServer"
+    makeWrapper ${jdk}/bin/java $out/bin/graphwar-globalserver \
+      --add-flags "-classpath $out/lib/graphwar GlobalServer.GlobalServer"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "graphwar";
+      exec = "graphwar";
+      desktopName = "Graphwar";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = with lib; {
+    homepage = "http://www.graphwar.com/";
+    description = "An artillery game in which you must hit your enemies using mathematical functions";
+    license = licenses.gpl3Plus;
+    platforms = jdk.meta.platforms;
+    maintainers = with maintainers; [ yrd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31976,6 +31976,8 @@ with pkgs;
     wine = wineWowPackages.unstable;
   };
 
+  graphwar = callPackage ../games/graphwar { };
+
   gtetrinet = callPackage ../games/gtetrinet {
     inherit (gnome2) GConf libgnome libgnomeui;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This packages [Graphwar](http://www.graphwar.com/), a game about hitting opponents using mathematical formulas.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
