### PR TITLE
nix-daemon: remove `CURL_CA_BUNDLE` from sevice

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -724,7 +724,6 @@ in
           ++ optionals cfg.distributedBuilds [ pkgs.gzip ];
 
         environment = cfg.envVars
-          // { CURL_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"; }
           // config.networking.proxy.envVars;
 
         unitConfig.RequiresMountsFor = "/nix/store";


### PR DESCRIPTION
###### Description of changes

This was set [over six years ago](https://github.com/NixOS/nixpkgs/commit/bfebc7342e42ebe7a57c9e21b11ab19579189bfd#diff-2cb0ed310b9b4492829c804417671afe93631ed1ae5a0fcb0f3441c3399dc1ecR168) and it doesn't seem to be needed.

I upgraded my `nixos-unstable` install just a few days ago and started getting ssl failures from the Nix daemon. Removing this line is the only thing that solved it.

Unless somebody has a good argument for why this is still needed I think it should be fine to remove.