### PR TITLE
ffcast: fix cross-compilation

### DIFF
--- a/pkgs/tools/X11/ffcast/default.nix
+++ b/pkgs/tools/X11/ffcast/default.nix
@@ -1,30 +1,40 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, perl, libX11 }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, makeWrapper, perl
+, ffmpeg, imagemagick, xdpyinfo, xprop, xrectsel, xwininfo
+}:
 
 stdenv.mkDerivation rec {
   pname = "ffcast";
   version = "2.5.0";
 
   src = fetchFromGitHub {
-    owner = "lolilolicon";
+    owner = "ropery";
     repo = "FFcast";
     rev = version;
     sha256 = "047y32bixhc8ksr98vwpgd0k1xxgsv2vs0n3kc2xdac4krc9454h";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ perl libX11 ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper perl /*for pod2man*/ ];
 
   configureFlags = [ "--disable-xrectsel" ];
 
-  postBuild = ''
-    make install
+  postInstall = let
+    binPath = lib.makeBinPath [
+      ffmpeg
+      imagemagick
+      xdpyinfo
+      xprop
+      xrectsel
+      xwininfo
+    ];
+  in ''
+    wrapProgram $out/bin/ffcast --prefix PATH : ${binPath}
   '';
 
   meta = with lib; {
     description = "Run commands on rectangular screen regions";
-    homepage = "https://github.com/lolilolicon/FFcast";
-    license = licenses.gpl3;
-    maintainers = [ maintainers.guyonvarch ];
+    homepage = "https://github.com/ropery/FFcast";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sikmir ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/X11/xrectsel/default.nix
+++ b/pkgs/tools/X11/xrectsel/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.3.2";
 
   src = fetchFromGitHub {
-    owner = "lolilolicon";
+    owner = "ropery";
     repo = "xrectsel";
     rev = version;
     sha256 = "0prl4ky3xzch6xcb673mcixk998d40ngim5dqc5374b1ls2r6n7l";
@@ -14,15 +14,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libX11 ];
 
-  postBuild = ''
-    make install
-  '';
-
   meta = with lib; {
     description = "Print the geometry of a rectangular screen region";
-    homepage = "https://github.com/lolilolicon/xrectsel";
-    license = licenses.gpl3;
-    maintainers = [ maintainers.guyonvarch ];
+    homepage = "https://github.com/ropery/xrectsel";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sikmir ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes
* Fix cross-compilation
* Update download url
* Fix wrapping
* Fix license

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
