### PR TITLE
vim: fix shebangs when cross-compiling

### DIFF
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, callPackage, ncurses, gettext, pkg-config
+{ lib, stdenv, fetchurl, callPackage, ncurses, bash, gawk, gettext, pkg-config
 # default vimrc
 , vimrc ? fetchurl {
     name = "default-vimrc";
@@ -18,8 +18,10 @@ stdenv.mkDerivation {
   inherit (common) version src postPatch hardeningDisable enableParallelBuilding meta;
 
   nativeBuildInputs = [ gettext pkg-config ];
-  buildInputs = [ ncurses ]
+  buildInputs = [ ncurses bash gawk ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ Carbon Cocoa ];
+
+  strictDeps = true;
 
   configureFlags = [
     "--enable-multibyte"
@@ -35,6 +37,13 @@ stdenv.mkDerivation {
     "vim_cv_stat_ignores_slash=yes"
     "vim_cv_memmove_handles_overlap=yes"
   ];
+
+  # which.sh is used to for vim's own shebang patching, so make it find
+  # binaries for the host platform.
+  preConfigure = ''
+    export HOST_PATH
+    substituteInPlace src/which.sh --replace '$PATH' '$HOST_PATH'
+  '';
 
   postInstall = ''
     ln -s $out/bin/vim $out/bin/vi


### PR DESCRIPTION


###### Description of changes

vim does its own shebang patching, which ends up pulling in build platform tools. This PR patches the build system to use `HOST_PATH` instead.

I also enabled `strictDeps` and added additional dependencies needed to make patchShebangs work on some of the other scripts.

This PR brings the cross-compiled package in line with the native one, but even the native build has some unpatched shebang references to python, perl and csh. Additionally, `efm_perl.pl` has a broken shebang (`#! -w`) because vim's build system can't handle not finding perl.

Native shebangs, before and after this PR:
```
result/bin/vimtutor:#!/nix/store/zwjm0gln1vk7x1akpyz0yxjsd1yc46gi-bash-5.1-p16/bin/sh
result/share/vim/vim82/doc/vim2html.pl:#!/usr/bin/env perl
result/share/vim/vim82/macros/less.sh:#!/nix/store/zwjm0gln1vk7x1akpyz0yxjsd1yc46gi-bash-5.1-p16/bin/sh
result/share/vim/vim82/tools/efm_filter.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/demoserver.py:#!/usr/bin/python
result/share/vim/vim82/tools/vim132:#!/bin/csh
result/share/vim/vim82/tools/mve.awk:#!/nix/store/7x07kcbzgjrxi7nzvgpbfaczp6qc7w84-gawk-5.1.1/bin/gawk -f
result/share/vim/vim82/tools/ref:#!/nix/store/zwjm0gln1vk7x1akpyz0yxjsd1yc46gi-bash-5.1-p16/bin/sh
result/share/vim/vim82/tools/vimspell.sh:#!/nix/store/zwjm0gln1vk7x1akpyz0yxjsd1yc46gi-bash-5.1-p16/bin/sh
result/share/vim/vim82/tools/shtags.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/pltags.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/vimm:#!/nix/store/zwjm0gln1vk7x1akpyz0yxjsd1yc46gi-bash-5.1-p16/bin/sh
result/share/vim/vim82/tools/efm_perl.pl:#! -w
```

Cross shebangs, before this PR:
```
result/bin/vimtutor:#!/bin/sh
result/share/vim/vim82/doc/vim2html.pl:#!/usr/bin/env perl
result/share/vim/vim82/macros/less.sh:#!/bin/sh
result/share/vim/vim82/tools/efm_filter.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/demoserver.py:#!/usr/bin/python
result/share/vim/vim82/tools/vim132:#!/bin/csh
result/share/vim/vim82/tools/mve.awk:#!/nix/store/7x07kcbzgjrxi7nzvgpbfaczp6qc7w84-gawk-5.1.1/bin/gawk -f
result/share/vim/vim82/tools/ref:#!/bin/sh
result/share/vim/vim82/tools/vimspell.sh:#!/bin/sh
result/share/vim/vim82/tools/shtags.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/pltags.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/vimm:#!/bin/sh
result/share/vim/vim82/tools/efm_perl.pl:#! -w
```

Cross shebangs, after this PR:
```
result/bin/vimtutor:#!/nix/store/qfxpwp0m5js8sni1pwxla25djrqz2jrq-bash-5.1-p16-armv7l-unknown-linux-gnueabihf/bin/sh
result/share/vim/vim82/doc/vim2html.pl:#!/usr/bin/env perl
result/share/vim/vim82/macros/less.sh:#!/nix/store/qfxpwp0m5js8sni1pwxla25djrqz2jrq-bash-5.1-p16-armv7l-unknown-linux-gnueabihf/bin/sh
result/share/vim/vim82/tools/efm_filter.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/demoserver.py:#!/usr/bin/python
result/share/vim/vim82/tools/vim132:#!/bin/csh
result/share/vim/vim82/tools/mve.awk:#!/nix/store/3rq5g7sg5ah4fh5h7js04pqxpdpfdn41-gawk-armv7l-unknown-linux-gnueabihf-5.1.1/bin/gawk -f
result/share/vim/vim82/tools/ref:#!/nix/store/qfxpwp0m5js8sni1pwxla25djrqz2jrq-bash-5.1-p16-armv7l-unknown-linux-gnueabihf/bin/sh
result/share/vim/vim82/tools/vimspell.sh:#!/nix/store/qfxpwp0m5js8sni1pwxla25djrqz2jrq-bash-5.1-p16-armv7l-unknown-linux-gnueabihf/bin/sh
result/share/vim/vim82/tools/shtags.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/pltags.pl:#!/usr/bin/env perl
result/share/vim/vim82/tools/vimm:#!/nix/store/qfxpwp0m5js8sni1pwxla25djrqz2jrq-bash-5.1-p16-armv7l-unknown-linux-gnueabihf/bin/sh
result/share/vim/vim82/tools/efm_perl.pl:#! -w
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
