### PR TITLE
image_optim: add oxipng, fix optional workers

### DIFF
--- a/pkgs/applications/graphics/image_optim/Gemfile.lock
+++ b/pkgs/applications/graphics/image_optim/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    exifr (1.3.9)
+    exifr (1.3.10)
     fspath (3.1.2)
-    image_optim (0.31.1)
+    image_optim (0.31.3)
       exifr (~> 1.2, >= 1.2.2)
       fspath (~> 3.0)
       image_size (>= 1.5, < 4)
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
-    image_size (3.0.2)
+    image_size (3.2.0)
     in_threads (1.6.0)
     progress (3.6.0)
 
@@ -20,4 +20,4 @@ DEPENDENCIES
   image_optim
 
 BUNDLED WITH
-   2.3.9
+   2.4.6

--- a/pkgs/applications/graphics/image_optim/default.nix
+++ b/pkgs/applications/graphics/image_optim/default.nix
@@ -1,9 +1,10 @@
 { lib, bundlerApp, bundlerUpdateScript, makeWrapper,
   withPngcrush ? true,       pngcrush,
-  withPngout ? true,         pngout,
+  withPngout ? false,        pngout, # disabled by default because it's unfree
   withAdvpng ? true,         advancecomp,
   withOptipng ? true,        optipng,
   withPngquant ? true,       pngquant,
+  withOxipng ? true,         oxipng,
   withJhead ? true,          jhead,
   withJpegoptim ? true,      jpegoptim,
   withJpegrecompress ? true, jpeg-archive,
@@ -15,18 +16,31 @@
 with lib;
 
 let
-  optionalDepsPath = []
-    ++ optional withPngcrush pngcrush
+  optionalDepsPath = optional withPngcrush pngcrush
     ++ optional withPngout pngout
     ++ optional withAdvpng advancecomp
     ++ optional withOptipng optipng
     ++ optional withPngquant pngquant
+    ++ optional withOxipng oxipng
     ++ optional withJhead jhead
     ++ optional withJpegoptim jpegoptim
     ++ optional withJpegrecompress jpeg-archive
     ++ optional withJpegtran libjpeg
     ++ optional withGifsicle gifsicle
     ++ optional withSvgo svgo;
+
+  disabledWorkersFlags = optional (!withPngcrush) "--no-pngcrush"
+    ++ optional (!withPngout) "--no-pngout"
+    ++ optional (!withAdvpng) "--no-advpng"
+    ++ optional (!withOptipng) "--no-optipng"
+    ++ optional (!withPngquant) "--no-pngquant"
+    ++ optional (!withOxipng) "--no-oxipng"
+    ++ optional (!withJhead) "--no-jhead"
+    ++ optional (!withJpegoptim) "--no-jpegoptim"
+    ++ optional (!withJpegrecompress) "--no-jpegrecompress"
+    ++ optional (!withJpegtran) "--no-jpegtran"
+    ++ optional (!withGifsicle) "--no-gifsicle"
+    ++ optional (!withSvgo) "--no-svgo";
 in
 
 bundlerApp {
@@ -39,16 +53,23 @@ bundlerApp {
 
   postBuild = ''
     wrapProgram $out/bin/image_optim \
-      --prefix PATH : ${lib.escapeShellArg (makeBinPath optionalDepsPath)}
+      --prefix PATH : ${lib.escapeShellArg (makeBinPath optionalDepsPath)} \
+      --add-flags "${lib.concatStringsSep " " disabledWorkersFlags}"
   '';
 
   passthru.updateScript = bundlerUpdateScript "image_optim";
 
   meta = with lib; {
-    description = "Command line tool and ruby interface to optimize (lossless compress, optionally lossy) jpeg, png, gif and svg images using external utilities (advpng, gifsicle, jhead, jpeg-recompress, jpegoptim, jpegrescan, jpegtran, optipng, pngcrush, pngout, pngquant, svgo)";
-    homepage    = "https://github.com/toy/image_optim";
-    license     = licenses.mit;
+    description = "Optimize images using multiple utilities";
+    longDescription = ''
+      Command line tool and ruby interface to optimize (lossless compress,
+      optionally lossy) jpeg, png, gif and svg images using external utilities
+      (advpng, gifsicle, jhead, jpeg-recompress, jpegoptim, jpegrescan,
+      jpegtran, optipng, oxipng, pngcrush, pngout, pngquant, svgo)
+    '';
+    homepage = "https://github.com/toy/image_optim";
+    license = licenses.mit;
     maintainers = with maintainers; [ srghma nicknovitski ];
-    platforms   = platforms.all;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/graphics/image_optim/gemset.nix
+++ b/pkgs/applications/graphics/image_optim/gemset.nix
@@ -4,10 +4,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0mylhwmh6n4xihxr9s3zj0lc286f5maxbqd4dgk3paqnd7afz88s";
+      sha256 = "08fmmswa9fwymwsa2gzlm856ak3y9kjxdzm4zdrcrfyxs2p8yqwc";
       type = "gem";
     };
-    version = "1.3.9";
+    version = "1.3.10";
   };
   fspath = {
     groups = ["default"];
@@ -25,20 +25,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1l3n59w1cbvfg2srfa14g3jdqwbkf7l86g4qrgfz3qps7zi0drg7";
+      sha256 = "02iw1plldayr1l8bdw2gshq0h083h0fxwji1m1nfhzikz917c07p";
       type = "gem";
     };
-    version = "0.31.1";
+    version = "0.31.3";
   };
   image_size = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "033k72f8n28psm89wv1qwsrnqyzz57ihyivyi442wha6vr9iyjz3";
+      sha256 = "10slvvyam8gkdjzlhb3wb21hp46ay18miyh1advwvyny660rmdsb";
       type = "gem";
     };
-    version = "3.0.2";
+    version = "3.2.0";
   };
   in_threads = {
     groups = ["default"];


### PR DESCRIPTION
###### Description of changes

Support for [oxipng](https://github.com/shssoichiro/oxipng) was added with [version 0.31.0](https://github.com/toy/image_optim/blob/master/CHANGELOG.markdown#v0310-2021-10-03). So we add `oxipng` as an optional dependency.

If some optional workers are disabled `image_optim` fails with an error message like:
```
Bin resolving errors:
pngout worker: `pngout` not found; please provide proper binary or disable this worker (--no-pngout argument or `:pngout => false` through options)
```
To fix the problem the flag `--no-program` is added while wrapping if the worker `program` is disabled.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
