### PR TITLE
vscode-extensions.ms-python.python: pull upstream fix for -fno-common…

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/python/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/python/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, vscode-utils, extractNuGet
+{ lib, stdenv, fetchurl, fetchpatch, vscode-utils, extractNuGet
 , icu, curl, openssl, liburcu, lttng-ust, autoPatchelfHook
 , python3, musl
 , pythonUseFixed ? false       # When `true`, the python default setting will be fixed to specified.
@@ -28,6 +28,17 @@ let
       url = "https://lttng.org/files/lttng-ust/lttng-ust-${version}.tar.bz2";
       sha256 = "0ddwk0nl28bkv2xb78gz16a2bvlpfbjmzwfbgwf5p1cq46dyvy86";
     };
+    patches = (oldAttrs.patches or []) ++ [
+      # Pull upstream fix for -fno-common toolchain. Without it build fails on
+      # upstream gcc-10 as:
+      #   ld: libustsnprintf.a(libustsnprintf_la-core.o):snprintf/core.c:23: multiple definition of
+      #     `ust_loglevel'; ustctl.o:liblttng-ust-ctl/ustctl.c:80: first defined here
+      (fetchpatch {
+        name = "fno-common.patch";
+        url = "https://github.com/lttng/lttng-ust/commit/21a934df4c683e73e0a66a9afca33573fcf9d789.patch";
+        sha256 = "122lw9rdmr80gmz7814235ibqs47c6pzvg0ryh01805x0cymx74z";
+      })
+    ];
   });
 
   pythonDefaultsTo = if pythonUseFixed then "${python3}/bin/python" else "python";


### PR DESCRIPTION
… toolchains

Without the change lttng-ust dependency fails the build on upstream
gcc-10 as:

    ld: libustsnprintf.a(libustsnprintf_la-core.o):snprintf/core.c:23: multiple definition of
      `ust_loglevel'; ustctl.o:liblttng-ust-ctl/ustctl.c:80: first defined here

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
