### PR TITLE
js8call: init at 2.2.0

### DIFF
--- a/pkgs/applications/radio/js8call/cmake.patch
+++ b/pkgs/applications/radio/js8call/cmake.patch
@@ -1,0 +1,69 @@
+diff --git a/CMake/Modules/Findhamlib.cmake b/CMake/Modules/Findhamlib.cmake
+index 1590f05..e797851 100644
+--- a/CMake/Modules/Findhamlib.cmake
++++ b/CMake/Modules/Findhamlib.cmake
+@@ -47,7 +47,7 @@ if (NOT PC_HAMLIB_FOUND)
+ 
+   # libusb-1.0 has no pkg-config file on Windows so we have to find it
+   # ourselves
+-  find_library (LIBUSB NAMES usb-1.0 PATH_SUFFIXES MinGW32/dll)
++  find_library (LIBUSB NAMES libusb-1.0 usb-1.0 PATH_SUFFIXES MinGW32/dll)
+   if (LIBUSB)
+     set (hamlib_EXTRA_LIBRARIES ${LIBUSB} ${hamlib_EXTRA_LIBRARIES})
+     get_filename_component (hamlib_libusb_path ${LIBUSB} PATH)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 75b80b3..7c04265 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -558,7 +558,6 @@ find_package (FFTW3 COMPONENTS double single threads REQUIRED)
+ #
+ # libhamlib setup
+ #
+-set (hamlib_STATIC 1)
+ find_package (hamlib 3 REQUIRED)
+ find_program (RIGCTL_EXE rigctl)
+ find_program (RIGCTLD_EXE rigctld)
+@@ -576,6 +576,7 @@ message (STATUS "hamlib_LIBRARY_DIRS: ${hamlib_LIBRARY_DIRS}")
+ find_package (Qt5Widgets 5 REQUIRED)
+ find_package (Qt5Multimedia 5 REQUIRED)
+ find_package (Qt5PrintSupport 5 REQUIRED)
++find_package (Qt5SerialPort 5 REQUIRED)
+ 
+ if (WIN32)
+   add_definitions (-DQT_NEEDS_QTMAIN)
+@@ -849,7 +850,7 @@ target_link_libraries (qcp Qt5::Widgets Qt5::PrintSupport)
+ add_library (wsjt_qt STATIC ${wsjt_qt_CXXSRCS} ${wsjt_qt_GENUISRCS} ${GENAXSRCS})
+ # set wsjtx_udp exports to static variants
+ target_compile_definitions (wsjt_qt PUBLIC UDP_STATIC_DEFINE)
+-target_link_libraries (wsjt_qt qcp Qt5::Widgets Qt5::Network)
++target_link_libraries (wsjt_qt qcp Qt5::Widgets Qt5::Network Qt5::SerialPort)
+ target_include_directories (wsjt_qt BEFORE PRIVATE ${hamlib_INCLUDE_DIRS})
+ if (WIN32)
+   target_link_libraries (wsjt_qt Qt5::AxContainer Qt5::AxBase)
+@@ -959,7 +960,6 @@ else ()
+       )
+   endif ()
+ endif ()
+-qt5_use_modules (js8call SerialPort) # not sure why the interface link library syntax above doesn't work
+ 
+ # if (UNIX)
+ #   if (NOT WSJT_SKIP_MANPAGES)
+@@ -1292,3 +1292,5 @@ configure_file ("${PROJECT_SOURCE_DIR}/CMakeCPackOptions.cmake.in"
+ set (CPACK_PROJECT_CONFIG_FILE "${PROJECT_BINARY_DIR}/CMakeCPackOptions.cmake")
+ 
+ include (CPack)
++
++add_definitions (-DJS8_USE_HAMLIB_THREE)
+diff --git a/Configuration.cpp b/Configuration.cpp
+index 8258f97..63a29bb 100644
+--- a/Configuration.cpp
++++ b/Configuration.cpp
+@@ -160,7 +160,7 @@
+ #include <QFont>
+ #include <QFontDialog>
+ #include <QColorDialog>
+-#include <QSerialPortInfo>
++#include <QtSerialPort/QSerialPortInfo>
+ #include <QScopedPointer>
+ #include <QDateTimeEdit>
+ #include <QProcess>

--- a/pkgs/applications/radio/js8call/default.nix
+++ b/pkgs/applications/radio/js8call/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromBitbucket
+, wrapQtAppsHook
+, pkg-config
+, hamlib
+, libusb1
+, cmake
+, gfortran
+, fftw
+, fftwFloat
+, qtbase
+, qtmultimedia
+, qtserialport
+}:
+
+stdenv.mkDerivation rec {
+  pname = "js8call";
+  version = "2.2.0";
+
+  src = fetchFromBitbucket {
+    owner = "widefido";
+    repo = pname;
+    rev = "v${version}-ga";
+    sha256 = "sha256-mFPhiAAibCiAkLrysAmIQalVCGd9ips2lqbAsowYprY=";
+  };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    gfortran
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    hamlib
+    libusb1
+    fftw
+    fftwFloat
+    qtbase
+    qtmultimedia
+    qtserialport
+  ];
+
+  prePatch = ''
+    substituteInPlace CMakeLists.txt \
+        --replace "/usr/share/applications" "$out/share/applications" \
+        --replace "/usr/share/pixmaps" "$out/share/pixmaps" \
+        --replace "/usr/bin/" "$out/bin"
+  '';
+
+  patches = [ ./cmake.patch ];
+
+  meta = with lib; {
+    description = "Weak-signal keyboard messaging for amateur radio";
+    longDescription = ''
+      JS8Call is software using the JS8 Digital Mode providing weak signal
+      keyboard to keyboard messaging to Amateur Radio Operators.
+    '';
+    homepage = "http://js8call.com/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ melling ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27640,6 +27640,8 @@ with pkgs;
 
   josm = callPackage ../applications/misc/josm { };
 
+  js8call = qt5.callPackage ../applications/radio/js8call { };
+
   jwm = callPackage ../applications/window-managers/jwm { };
 
   jwm-settings-manager = callPackage ../applications/window-managers/jwm/jwm-settings-manager.nix { };


### PR DESCRIPTION
###### Description of changes

Packages [js8call](http://js8call.com/), a weak signal keyboard to keyboard messaging mode for amateur radio.

Requested in #142790

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
