### PR TITLE
geoserver: init at 2.21.0

### DIFF
--- a/pkgs/servers/geospatial/geoserver/default.nix
+++ b/pkgs/servers/geospatial/geoserver/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchurl, unzip, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "geoserver";
+  version = "2.21.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/geoserver/GeoServer/${version}/geoserver-${version}-bin.zip";
+    sha256 = "sha256-UCr22Ffhnux6eA0w5qoaf5Hvuypsl/FGpK+emi8G0Mc=";
+  };
+
+  sourceRoot = ".";
+  nativeBuildInputs = [ unzip makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/geoserver
+    cp -r . $out/share/geoserver
+    rm -fr $out/share/geoserver/bin/*.bat
+
+    makeWrapper $out/share/geoserver/bin/startup.sh $out/bin/geoserver-startup \
+      --set JAVA_HOME "${jre}" \
+      --set GEOSERVER_HOME "$out/share/geoserver"
+    makeWrapper $out/share/geoserver/bin/shutdown.sh $out/bin/geoserver-shutdown \
+      --set JAVA_HOME "${jre}" \
+      --set GEOSERVER_HOME "$out/share/geoserver"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Open source server for sharing geospatial data";
+    homepage = "https://geoserver.org/";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7748,14 +7748,6 @@ with pkgs;
 
   mani = callPackage ../development/tools/mani { };
 
-  mapcache = callPackage ../servers/geospatial/mapcache { };
-
-  mapserver = callPackage ../servers/geospatial/mapserver { };
-
-  martin = callPackage ../servers/geospatial/martin {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
-
   mask = callPackage ../development/tools/mask { };
 
   mathpix-snipping-tool = callPackage ../tools/misc/mathpix-snipping-tool { };
@@ -10964,8 +10956,6 @@ with pkgs;
 
   tidy-viewer = callPackage ../tools/text/tidy-viewer { };
 
-  tile38 = callPackage ../servers/geospatial/tile38 { };
-
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };
 
   tiledb = callPackage ../development/libraries/tiledb { };
@@ -11579,8 +11569,6 @@ with pkgs;
   rcm = callPackage ../tools/misc/rcm {};
 
   td = callPackage ../tools/misc/td { };
-
-  tegola = callPackage ../servers/geospatial/tegola {};
 
   tftp-hpa = callPackage ../tools/networking/tftp-hpa {};
 
@@ -13198,10 +13186,6 @@ with pkgs;
   remarkable-toolchain = callPackage ../development/tools/misc/remarkable/remarkable-toolchain { };
 
   remarkable2-toolchain = callPackage ../development/tools/misc/remarkable/remarkable2-toolchain { };
-
-  t-rex = callPackage ../servers/geospatial/t-rex {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
 
   tacacsplus = callPackage ../servers/tacacsplus { };
 
@@ -22090,8 +22074,6 @@ with pkgs;
 
   mattermost-desktop = callPackage ../applications/networking/instant-messengers/mattermost-desktop { };
 
-  mbtileserver = callPackage ../servers/geospatial/mbtileserver { };
-
   memcached = callPackage ../servers/memcached {};
 
   meteor = callPackage ../servers/meteor { };
@@ -22333,10 +22315,6 @@ with pkgs;
   tomcat_connectors = callPackage ../servers/http/apache-modules/tomcat-connectors { };
 
   tomcat-native = callPackage ../servers/http/tomcat/tomcat-native.nix { };
-
-  pg_featureserv = callPackage ../servers/geospatial/pg_featureserv { };
-
-  pg_tileserv = callPackage ../servers/geospatial/pg_tileserv { };
 
   pies = callPackage ../servers/pies { };
 
@@ -22929,6 +22907,30 @@ with pkgs;
   zabbix = zabbix50;
 
   zipkin = callPackage ../servers/monitoring/zipkin { };
+
+  ### SERVERS / GEOSPATIAL
+
+  mapcache = callPackage ../servers/geospatial/mapcache { };
+
+  mapserver = callPackage ../servers/geospatial/mapserver { };
+
+  martin = callPackage ../servers/geospatial/martin {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
+  mbtileserver = callPackage ../servers/geospatial/mbtileserver { };
+
+  pg_featureserv = callPackage ../servers/geospatial/pg_featureserv { };
+
+  pg_tileserv = callPackage ../servers/geospatial/pg_tileserv { };
+
+  t-rex = callPackage ../servers/geospatial/t-rex {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
+  tegola = callPackage ../servers/geospatial/tegola { };
+
+  tile38 = callPackage ../servers/geospatial/tile38 { };
 
   ### OS-SPECIFIC
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22910,6 +22910,8 @@ with pkgs;
 
   ### SERVERS / GEOSPATIAL
 
+  geoserver = callPackage ../servers/geospatial/geoserver { };
+
   mapcache = callPackage ../servers/geospatial/mapcache { };
 
   mapserver = callPackage ../servers/geospatial/mapserver { };


### PR DESCRIPTION
###### Description of changes

> **[GeoServer](https://github.com/geoserver/geoserver)** is the reference implementation of the Open Geospatial Consortium (OGC) Web Feature Service (WFS) and Web Coverage Service (WCS) standards, as well as a high performance certified compliant Web Map Service (WMS), compliant Catalog Service for the Web (CSW) and implementing Web Processing Service (WPS). GeoServer forms a core component of the Geospatial Web.

[![Packaging status](https://repology.org/badge/tiny-repos/geoserver.svg)](https://repology.org/project/geoserver/versions)

Try it out:
* `mkdir -p data_dir`
* `GEOSERVER_DATA_DIR=$PWD/data_dir result/bin/geoserver-startup`
* Go to http://localhost:8080/geoserver (admin:geoserver)
* Read more: https://docs.geoserver.org/latest/en/user/index.html

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
