### PR TITLE
python310Packages.ocrmypdf: 13.4.7 -> 13.5.0

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "13.4.7";
+  version = "13.5.0";
 
   src = fetchFromGitHub {
     owner = "ocrmypdf";
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-jCfMCjh8MdH5K76iyJCgtkgPtpxnCxlXlzttTIzINPk=";
+    hash = "sha256-jGVqH2z8NRnQcm4hv4OufCm26o6Qr8/mBRIScvcUpkE=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/ocrmypdf/paths.patch
+++ b/pkgs/development/python-modules/ocrmypdf/paths.patch
@@ -1,20 +1,20 @@
 diff --git a/src/ocrmypdf/_exec/ghostscript.py b/src/ocrmypdf/_exec/ghostscript.py
-index 1146cc5f..43f3915c 100644
+index 4da65483..af750249 100644
 --- a/src/ocrmypdf/_exec/ghostscript.py
 +++ b/src/ocrmypdf/_exec/ghostscript.py
-@@ -40,15 +40,7 @@ For details see:
+@@ -35,15 +35,7 @@ log = logging.getLogger(__name__)
  # Most reliable what to get the bitness of Python interpreter, according to Python docs
- _is_64bit = sys.maxsize > 2 ** 32
+ _IS_64BIT = sys.maxsize > 2**32
  
--_gswin = None
+-_GSWIN = None
 -if os.name == 'nt':
--    if _is_64bit:
--        _gswin = 'gswin64c'
+-    if _IS_64BIT:
+-        _GSWIN = 'gswin64c'
 -    else:
--        _gswin = 'gswin32c'
+-        _GSWIN = 'gswin32c'
 -
--GS = _gswin if _gswin else 'gs'
--del _gswin
+-GS = _GSWIN if _GSWIN else 'gs'
+-del _GSWIN
 +GS = '@gs@'
  
  
@@ -73,10 +73,10 @@ index ca8a4542..d0544174 100644
              '--skip-if-larger',
              '--quality',
 diff --git a/src/ocrmypdf/_exec/tesseract.py b/src/ocrmypdf/_exec/tesseract.py
-index a3688f65..61f54465 100644
+index 01177cac..665f1145 100644
 --- a/src/ocrmypdf/_exec/tesseract.py
 +++ b/src/ocrmypdf/_exec/tesseract.py
-@@ -75,7 +75,7 @@ class TesseractVersion(StrictVersion):
+@@ -114,7 +114,7 @@ class TesseractVersion(Version):
  
  
  def version() -> str:
@@ -85,7 +85,7 @@ index a3688f65..61f54465 100644
  
  
  def has_user_words():
-@@ -97,7 +97,7 @@ def get_languages():
+@@ -141,7 +141,7 @@ def get_languages():
          msg += output
          return msg
  
@@ -94,7 +94,7 @@ index a3688f65..61f54465 100644
      try:
          proc = run(
              args_tess,
-@@ -119,7 +119,7 @@ def get_languages():
+@@ -163,7 +163,7 @@ def get_languages():
  
  
  def tess_base_args(langs: List[str], engine_mode: Optional[int]) -> List[str]:
@@ -104,10 +104,10 @@ index a3688f65..61f54465 100644
          args.extend(['-l', '+'.join(langs)])
      if engine_mode is not None:
 diff --git a/src/ocrmypdf/_exec/unpaper.py b/src/ocrmypdf/_exec/unpaper.py
-index aec365c2..cc5cb7e4 100644
+index 479959ef..cc15fdec 100644
 --- a/src/ocrmypdf/_exec/unpaper.py
 +++ b/src/ocrmypdf/_exec/unpaper.py
-@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
+@@ -69,7 +69,7 @@ class UnpaperImageTooLargeError(Exception):
  
  
  def version() -> str:
@@ -115,13 +115,13 @@ index aec365c2..cc5cb7e4 100644
 +    return get_version('@unpaper@')
  
  
- def _setup_unpaper_io(tmpdir: Path, input_file: Path) -> Tuple[Path, Path]:
-@@ -71,7 +71,7 @@ def _setup_unpaper_io(tmpdir: Path, input_file: Path) -> Tuple[Path, Path]:
- def run(
+ SUFFIXES = {'1': '.pbm', 'L': '.pgm', 'RGB': '.ppm'}
+@@ -123,7 +123,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[Tuple[Path, Path, Path]]:
+ def run_unpaper(
      input_file: Path, output_file: Path, *, dpi: DecFloat, mode_args: List[str]
  ) -> None:
 -    args_unpaper = ['unpaper', '-v', '--dpi', str(round(dpi, 6))] + mode_args
 +    args_unpaper = ['@unpaper@', '-v', '--dpi', str(round(dpi, 6))] + mode_args
  
-     with TemporaryDirectory() as tmpdir:
-         input_pnm, output_pnm = _setup_unpaper_io(Path(tmpdir), input_file)
+     with _setup_unpaper_io(input_file) as (input_pnm, output_pnm, tmpdir):
+         # To prevent any shenanigans from accepting arbitrary parameters in


### PR DESCRIPTION

###### Description of changes
https://github.com/ocrmypdf/OCRmyPDF/blob/v13.5.0/docs/release_notes.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
