### PR TITLE
mattermost: Refactoring and upgrades

### DIFF
--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -46,6 +46,5 @@ buildGo118Module rec {
     homepage = "https://www.mattermost.org";
     license = with licenses; [ agpl3 asl20 ];
     maintainers = with maintainers; [ fpletz ryantm numinit kranzes ];
-    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -7,18 +7,18 @@
 
 buildGo118Module rec {
   pname = "mattermost";
-  version = "7.0.0";
+  version = "7.0.1";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost-server";
     rev = "v${version}";
-    sha256 = "sha256-0sjVlN+YZDhIXxch4DUkvBGDS0KUdGFflT87z1/udd4=";
+    sha256 = "sha256-oxZaOOV5pkK9HAi/AQ+MLZgfwvF6d/ArzYrXzUQGTDA=";
   };
 
   webapp = fetchurl {
     url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-    sha256 = "sha256-O2bJsj2YjeaRfqPrehgwn8bNHaYwqcrcU1htCYurPlw=";
+    sha256 = "sha256-NWVDPDqdx7mdWCr/qBi8HsUsCJbT63x37UZGecHsZr4=";
   };
 
   vendorSha256 = "sha256-0sKuk0klxeep8J96RntDP9DHsVM4vrOmsKXiaWurVis=";

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,101 +1,51 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, buildGoPackage, buildEnv
+{ lib
+, buildGo118Module
+, fetchFromGitHub
+, fetchurl
+, nixosTests
+}:
 
-# The suffix for the Mattermost version.
-, versionSuffix ? "nixpkgs"
+buildGo118Module rec {
+  pname = "mattermost";
+  version = "7.0.0";
 
-# The constant build date.
-, buildDate ? "1970-01-01"
-
-# Set to true to set the build hash to the Nix store path.
-, storePathAsBuildHash ? false }:
-
-let
-  version = "6.3.6";
-
-  goPackagePath = "github.com/mattermost/mattermost-server";
-
-  mattermost-server-build = buildGoPackage rec {
-    pname = "mattermost-server";
-    inherit version goPackagePath;
-
-    src = fetchFromGitHub {
-      owner = "mattermost";
-      repo = "mattermost-server";
-      rev = "v${version}";
-      sha256 = "905zxMucDTxxrLoh5ZoAExW4eFmi+xa98aI3EpJZ2Og=";
-    };
-
-    ldflags = [
-      "-s" "-w"
-      "-X ${goPackagePath}/model.BuildNumber=${version}${lib.optionalString (versionSuffix != null) "-${versionSuffix}"}"
-      "-X ${goPackagePath}/model.BuildDate=${buildDate}"
-      "-X ${goPackagePath}/model.BuildEnterpriseReady=false"
-    ];
+  src = fetchFromGitHub {
+    owner = "mattermost";
+    repo = "mattermost-server";
+    rev = "v${version}";
+    sha256 = "sha256-0sjVlN+YZDhIXxch4DUkvBGDS0KUdGFflT87z1/udd4=";
   };
 
-  mattermost-server = if storePathAsBuildHash then mattermost-server-build.overrideAttrs (orig: {
-    buildPhase = ''
-      origGo="$(type -p go)"
-
-      # Override the Go binary to set the build hash in -ldflags to $out.
-      # Technically this is more accurate than a Git hash!
-      # nixpkgs does not appear to support environment variables in ldflags
-      # for go packages, so we have to rewrite -ldflags before calling go.
-      go() {
-        local args=()
-        local ldflags="-X ${goPackagePath}/model.BuildHash=$out"
-        local found=0
-        for arg in "$@"; do
-          if [[ "$arg" == -ldflags=* ]] && [ $found -eq 0 ]; then
-            arg="-ldflags=''${ldflags} ''${arg#-ldflags=}"
-            found=1
-          fi
-          args+=("$arg")
-        done
-        "$origGo" "''${args[@]}"
-      }
-
-      ${orig.buildPhase}
-    '';
-  }) else mattermost-server-build;
-
-  mattermost-webapp = stdenv.mkDerivation {
-    pname = "mattermost-webapp";
-    inherit version;
-
-    src = fetchurl {
-      url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-      sha256 = "JDsCDZEtbeBTYuzOSwrxFNRKXy+9KXirjaCz6ODP5uw=";
-    };
-
-    installPhase = ''
-      mkdir -p $out
-      tar --strip 1 --directory $out -xf $src \
-        mattermost/client \
-        mattermost/i18n \
-        mattermost/fonts \
-        mattermost/templates \
-        mattermost/config
-
-      # For some reason a bunch of these files are +x...
-      find $out -type f -exec chmod -x {} \;
-    '';
+  webapp = fetchurl {
+    url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
+    sha256 = "sha256-O2bJsj2YjeaRfqPrehgwn8bNHaYwqcrcU1htCYurPlw=";
   };
 
-in
-  buildEnv {
-    name = "mattermost-${version}";
-    paths = [ mattermost-server mattermost-webapp ];
+  vendorSha256 = "sha256-0sKuk0klxeep8J96RntDP9DHsVM4vrOmsKXiaWurVis=";
 
-    meta = with lib; {
-      description = "Open-source, self-hosted Slack-alternative";
-      homepage = "https://www.mattermost.org";
-      sourceProvenance = with sourceTypes; [
-        fromSource
-        binaryNativeCode  # mattermost-webapp
-      ];
-      license = with licenses; [ agpl3 asl20 ];
-      maintainers = with maintainers; [ fpletz ryantm numinit ];
-      platforms = platforms.unix;
-    };
-  }
+  subPackages = [ "cmd/mattermost" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/mattermost/mattermost-server/v6/model.Version=${version}"
+  ];
+
+  postInstall = ''
+    tar --strip 1 --directory $out -xf $webapp \
+      mattermost/{client,i18n,fonts,templates,config}
+
+    # For some reason a bunch of these files are executable
+    find $out/{client,i18n,fonts,templates,config} -type f -exec chmod -x {} \;
+  '';
+
+  passthru.tests.mattermost = nixosTests.mattermost;
+
+  meta = with lib; {
+    description = "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle";
+    homepage = "https://www.mattermost.org";
+    license = with licenses; [ agpl3 asl20 ];
+    maintainers = with maintainers; [ fpletz ryantm numinit kranzes ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/misc/mmctl/default.nix
+++ b/pkgs/tools/misc/mmctl/default.nix
@@ -1,24 +1,33 @@
-{ lib, fetchFromGitHub, buildGoModule }:
+{ lib
+, fetchFromGitHub
+, buildGoModule
+}:
+
 buildGoModule rec {
   pname = "mmctl";
-  version = "6.4.2";
+  version = "7.0.0";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mmctl";
     rev = "v${version}";
-    sha256 = "sha256-FlqkY4LvAW9Cibs+3UkMDWA+uc62wMh13BllWuxjVZU=";
+    sha256 = "sha256-X9IvuH3LrysqcL0JZIchE9n51w7eQTFE2NWUTXMnRYs=";
   };
 
   vendorSha256 = null;
 
   checkPhase = "make test";
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/mattermost/mmctl/v6/commands.Version=${version}"
+  ];
+
   meta = with lib; {
     description = "A remote CLI tool for Mattermost";
     homepage = "https://github.com/mattermost/mmctl";
     license = licenses.asl20;
     maintainers = with maintainers; [ ppom ];
-    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/misc/mmctl/default.nix
+++ b/pkgs/tools/misc/mmctl/default.nix
@@ -5,13 +5,13 @@
 
 buildGoModule rec {
   pname = "mmctl";
-  version = "7.0.0";
+  version = "7.0.1";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mmctl";
     rev = "v${version}";
-    sha256 = "sha256-X9IvuH3LrysqcL0JZIchE9n51w7eQTFE2NWUTXMnRYs=";
+    sha256 = "sha256-xNj8aM3hpcvxwXCdFCfkXDBagIdCjcjWLGNp43KsV10=";
   };
 
   vendorSha256 = null;


### PR DESCRIPTION
###### Description of changes
I migrated the `mattermost` package from buildGoPackage to buildGoModule which is now the standard. 
The package expression has not been worked on (excluding updates) in about 5 years. 
- [mattermost: 6.3.6 -> 7.0.0](https://github.com/NixOS/nixpkgs/pull/178389/commits/21738df66b20c274118395cd63460097b0a3e8fd)
- [mattermost: 7.0.0 -> 7.0.1](https://github.com/NixOS/nixpkgs/pull/178389/commits/c750d488035c9dc234523f3b5e62575cb784124c)
- [mmctl: 6.4.2 -> 7.0.0](https://github.com/NixOS/nixpkgs/pull/178389/commits/ad439443f11aeeff9a63171b604bd8dc6d78321d)
- [mmctl: 7.0.0 -> 7.0.1](https://github.com/NixOS/nixpkgs/pull/178389/commits/09724b15170081415c1559dc4508584b4de61b42)

Closes #167281

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
