### PR TITLE
firefox: Improve detecting signing requirements

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -97,12 +97,15 @@ let
 
       nameArray = builtins.map(a: a.name) (if usesNixExtensions then nixExtensions else []);
 
+      requiresSigning = browser ? MOZ_REQUIRE_SIGNING
+                     -> toString browser.MOZ_REQUIRE_SIGNING != "";
+
       # Check that every extension has a unqiue .name attribute
       # and an extid attribute
       extensions = if nameArray != (lib.unique nameArray) then
         throw "Firefox addon name needs to be unique"
-      else if ! (lib.hasSuffix "esr" browser.name) then
-        throw "Nix addons are only supported in Firefox ESR"
+      else if requiresSigning && !lib.hasSuffix "esr" browser.name then
+        throw "Nix addons are only supported without signature enforcement (eg. Firefox ESR)"
       else builtins.map (a:
         if ! (builtins.hasAttr "extid" a) then
         throw "nixExtensions has an invalid entry. Missing extid attribute. Please use fetchfirefoxaddon"


### PR DESCRIPTION
Firefox 61 started to enforce signatures for add-ons and since commit d031843a1eee244172570c64c9e238641563e68e, we get an evaluation error that recommends the user to switch to Firefox ESR.

This isn't an option for everyone and as I also pointed out in the [pull request](https://github.com/NixOS/nixpkgs/pull/133504) introducing the above commit, I've been building Firefox like this:

```nix
let
  firefoxNoSigning = firefox-unwrapped.overrideAttrs (lib.const {
    MOZ_REQUIRE_SIGNING = false;
  });
in wrapFirefox firefoxNoSigning {
  nixExtensions = ...;
}
```

However, this only works after manually modifying `nixpkgs` (or copy & paste `wrapper.nix` elsewhere) every time I want to have a new Firefox version. Of course, this gets annoying and tedious after a while, so this motivated me to properly fix this to not only check for an ESR version but also check the value of `MOZ_REQUIRE_SIGNING`.

Note that I'm using `toString` here to check for the value because there are several ways (`false`, `null`, `""`, ...) to set the environment variable to an empty string and `toString` makes sure that it really is the desired behaviour. I specifically checked the Firefox source and also tested this with multiple values and only building with `MOZ_REQUIRE_SIGNING` set to an empty string seems to work (no `0`, `false` or other variants).

Additionally, there is another method to allow unsigned add-ons, which is by using the [`--with-unsigned-addon-scopes` configure option](https://bugs.archlinux.org/task/63075). Unfortunately, this does not work with `nixExtensions` because we don't have (or want) a central directory where those add-ons reside.

Since `nixExtensions` disallows manually installing add-ons, setting `MOZ_REQUIRE_SIGNING` to `false` is safe in this case.

Cc: @Luis-Hebendanz