### PR TITLE
Add TensorRT packages

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/extension.nix
+++ b/pkgs/development/libraries/science/math/cudnn/extension.nix
@@ -85,7 +85,7 @@ final: prev: let
       rec {
         fileVersion = "10.2";
         fullVersion = "8.3.2.44";
-        hash = "sha256-mKh4TpKGLyABjSDCgbMNSgzZUfk2lPZDPM9K6cUCumo=";
+        hash = "sha256-1vVu+cqM+PketzIQumw9ykm6REbBZhv6/lXB7EC2aaw=";
         url = "${urlPrefix}/v${majorMinorPatch fullVersion}/local_installers/${fileVersion}/cudnn-linux-x86_64-${fullVersion}_cuda${fileVersion}-archive.tar.xz";
         supportedCudaVersions = [ "10.2" ];
       }

--- a/pkgs/development/libraries/science/math/tensorrt/8.nix
+++ b/pkgs/development/libraries/science/math/tensorrt/8.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, requireFile
+, autoPatchelfHook
+, autoAddOpenGLRunpathHook
+, cudaVersion
+, cudatoolkit
+, cudnn
+}:
+
+assert lib.assertMsg (lib.strings.versionAtLeast cudaVersion "11.0")
+  "This version of TensorRT requires at least CUDA 11.0 (current version is ${cudaVersion})";
+assert lib.assertMsg (lib.strings.versionAtLeast cudnn.version "8.3")
+  "This version of TensorRT requires at least cuDNN 8.3 (current version is ${cudnn.version})";
+
+stdenv.mkDerivation rec {
+  pname = "cudatoolkit-${cudatoolkit.majorVersion}-tensorrt";
+  version = "8.4.0.6";
+  src = requireFile rec {
+    name = "TensorRT-${version}.Linux.x86_64-gnu.cuda-11.6.cudnn8.3.tar.gz";
+    sha256 = "sha256-DNgHHXF/G4cK2nnOWImrPXAkOcNW6Wy+8j0LRpAH/LQ=";
+    message = ''
+      To use the TensorRT derivation, you must join the NVIDIA Developer Program
+      and download the ${version} Linux x86_64 TAR package from
+      ${meta.homepage}.
+
+      Once you have downloaded the file, add it to the store with the following
+      command, and try building this derivation again.
+
+      $ nix-store --add-fixed sha256 ${name}
+    '';
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    autoAddOpenGLRunpathHook
+  ];
+
+  # Used by autoPatchelfHook
+  buildInputs = [
+    cudatoolkit.cc.cc.lib # libstdc++
+    cudatoolkit
+    cudnn
+  ];
+
+  sourceRoot = "TensorRT-${version}";
+
+  installPhase = ''
+    install --directory "$dev" "$out"
+    mv include "$dev"
+    mv targets/x86_64-linux-gnu/lib "$out"
+    install -D --target-directory="$out/bin" targets/x86_64-linux-gnu/bin/trtexec
+  '';
+
+  # Tell autoPatchelf about runtime dependencies.
+  # (postFixup phase is run before autoPatchelfHook.)
+  postFixup =
+    let
+      mostOfVersion = builtins.concatStringsSep "."
+        (lib.take 3 (lib.versions.splitVersion version));
+    in
+    ''
+      echo 'Patching RPATH of libnvinfer libs'
+      patchelf --debug --add-needed libnvinfer.so \
+        "$out/lib/libnvinfer.so.${mostOfVersion}" \
+        "$out/lib/libnvinfer_plugin.so.${mostOfVersion}" \
+        "$out/lib/libnvinfer_builder_resource.so.${mostOfVersion}"
+    '';
+
+  meta = with lib; {
+    description = "TensorRT: a high-performance deep learning interface";
+    homepage = "https://developer.nvidia.com/tensorrt";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ aidalgol ];
+  };
+}

--- a/pkgs/development/libraries/science/math/tensorrt/extension.nix
+++ b/pkgs/development/libraries/science/math/tensorrt/extension.nix
@@ -1,0 +1,63 @@
+final: prev: let
+
+  inherit (final) callPackage;
+  inherit (prev) cudatoolkit cudaVersion lib pkgs;
+
+  ### TensorRT
+
+  buildTensorRTPackage = args:
+    callPackage ./generic.nix { } args;
+
+  toUnderscore = str: lib.replaceStrings ["."] ["_"] str;
+
+  majorMinorPatch = str: lib.concatStringsSep "." (lib.take 3 (lib.splitVersion str));
+
+  tensorRTPackages = with lib; let
+    # Check whether a file is supported for our cuda version
+    isSupported = fileData: elem cudaVersion fileData.supportedCudaVersions;
+    # Return the first file that is supported. In practice there should only ever be one anyway.
+    supportedFile = files: findFirst isSupported null files;
+    # Supported versions with versions as keys and file as value
+    supportedVersions = filterAttrs (version: file: file !=null ) (mapAttrs (version: files: supportedFile files) tensorRTVersions);
+    # Compute versioned attribute name to be used in this package set
+    computeName = version: "tensorrt_${toUnderscore version}";
+    # Add all supported builds as attributes
+    allBuilds = mapAttrs' (version: file: nameValuePair (computeName version) (buildTensorRTPackage (removeAttrs file ["fileVersionCuda"]))) supportedVersions;
+    # Set the default attributes, e.g. tensorrt = tensorrt_8_4;
+    defaultBuild = { "tensorrt" = allBuilds.${computeName tensorRTDefaultVersion}; };
+  in allBuilds // defaultBuild;
+
+  tensorRTVersions = {
+    "8.4.0" = [
+      rec {
+        fileVersionCuda = "11.6";
+        fileVersionCudnn = "8.3";
+        fullVersion = "8.4.0.6";
+        sha256 = "sha256-DNgHHXF/G4cK2nnOWImrPXAkOcNW6Wy+8j0LRpAH/LQ=";
+        tarball = "TensorRT-${fullVersion}.Linux.x86_64-gnu.cuda-${fileVersionCuda}.cudnn${fileVersionCudnn}.tar.gz";
+        supportedCudaVersions = [ "11.0" "11.1" "11.2" "11.3" "11.4" "11.5" "11.6" ];
+      }
+      rec {
+        fileVersionCuda = "10.2";
+        fileVersionCudnn = "8.3";
+        fullVersion = "8.4.0.6";
+        sha256 = "sha256-aCzH0ZI6BrJ0v+e5Bnm7b8mNltA7NNuIa8qRKzAQv+I=";
+        tarball = "TensorRT-${fullVersion}.Linux.x86_64-gnu.cuda-${fileVersionCuda}.cudnn${fileVersionCudnn}.tar.gz";
+        supportedCudaVersions = [ "10.2" ];
+      }
+    ];
+  };
+
+  # Default attributes
+  tensorRTDefaultVersion = {
+    "10.2" = "8.4.0";
+    "11.0" = "8.4.0";
+    "11.1" = "8.4.0";
+    "11.2" = "8.4.0";
+    "11.3" = "8.4.0";
+    "11.4" = "8.4.0";
+    "11.5" = "8.4.0";
+    "11.6" = "8.4.0";
+  }.${cudaVersion};
+
+in tensorRTPackages

--- a/pkgs/development/libraries/science/math/tensorrt/generic.nix
+++ b/pkgs/development/libraries/science/math/tensorrt/generic.nix
@@ -8,20 +8,25 @@
 , cudnn
 }:
 
-assert lib.assertMsg (lib.strings.versionAtLeast cudaVersion "11.0")
-  "This version of TensorRT requires at least CUDA 11.0 (current version is ${cudaVersion})";
-assert lib.assertMsg (lib.strings.versionAtLeast cudnn.version "8.3")
-  "This version of TensorRT requires at least cuDNN 8.3 (current version is ${cudnn.version})";
+{ fullVersion
+, fileVersionCudnn
+, tarball
+, sha256
+, supportedCudaVersions ? [ ]
+}:
+
+assert lib.assertMsg (lib.strings.versionAtLeast cudnn.version fileVersionCudnn)
+  "This version of TensorRT requires at least cuDNN ${fileVersionCudnn} (current version is ${cudnn.version})";
 
 stdenv.mkDerivation rec {
   pname = "cudatoolkit-${cudatoolkit.majorVersion}-tensorrt";
-  version = "8.4.0.6";
+  version = fullVersion;
   src = requireFile rec {
-    name = "TensorRT-${version}.Linux.x86_64-gnu.cuda-11.6.cudnn8.3.tar.gz";
-    sha256 = "sha256-DNgHHXF/G4cK2nnOWImrPXAkOcNW6Wy+8j0LRpAH/LQ=";
+    name = tarball;
+    inherit sha256;
     message = ''
-      To use the TensorRT derivation, you must join the NVIDIA Developer Program
-      and download the ${version} Linux x86_64 TAR package from
+      To use the TensorRT derivation, you must join the NVIDIA Developer Program and
+      download the ${version} Linux x86_64 TAR package for CUDA ${cudaVersion} from
       ${meta.homepage}.
 
       Once you have downloaded the file, add it to the store with the following
@@ -70,6 +75,12 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with lib; {
+    # Check that the cudatoolkit version satisfies our min/max constraints (both
+    # inclusive). We mark the package as broken if it fails to satisfies the
+    # official version constraints (as recorded in default.nix). In some cases
+    # you _may_ be able to smudge version constraints, just know that you're
+    # embarking into unknown and unsupported territory when doing so.
+    broken = !(elem cudaVersion supportedCudaVersions);
     description = "TensorRT: a high-performance deep learning interface";
     homepage = "https://developer.nvidia.com/tensorrt";
     license = licenses.unfree;

--- a/pkgs/development/python-modules/tensorrt/default.nix
+++ b/pkgs/development/python-modules/tensorrt/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, python
+, buildPythonPackage
+, autoPatchelfHook
+, unzip
+, cudaPackages
+}:
+
+let
+  pyVersion = "${lib.versions.major python.version}${lib.versions.minor python.version}";
+in
+buildPythonPackage rec {
+  pname = "tensorrt";
+  version = cudaPackages.tensorrt.version;
+
+  src = cudaPackages.tensorrt.src;
+
+  format = "wheel";
+  # We unpack the wheel ourselves because of the odd packaging.
+  dontUseWheelUnpack = true;
+
+  nativeBuildInputs = [
+    unzip
+    autoPatchelfHook
+    cudaPackages.autoAddOpenGLRunpathHook
+  ];
+
+  preUnpack = ''
+    mkdir -p dist
+    tar --strip-components=2 -xf "$src" --directory=dist \
+      "TensorRT-${version}/python/tensorrt-${version}-cp${pyVersion}-none-linux_x86_64.whl"
+  '';
+
+  sourceRoot = ".";
+
+  buildInputs = [
+    cudaPackages.cudnn
+    cudaPackages.tensorrt
+  ];
+
+  pythonCheckImports = [
+    "tensorrt"
+  ];
+
+  meta = with lib; {
+    description = "Python bindings for TensorRT, a high-performance deep learning interface";
+    homepage = "https://developer.nvidia.com/tensorrt";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ aidalgol ];
+  };
+}

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -43,16 +43,6 @@ let
     };
   in { inherit cutensor; };
 
-  tensorrtExtension = final: prev: let
-    ### Tensorrt
-
-    inherit (final) cudaMajorMinorVersion cudaMajorVersion;
-
-    # TODO: Add derivations for TensorRT versions that support older CUDA versions.
-
-    tensorrt = final.callPackage ../development/libraries/science/math/tensorrt/8.nix { };
-  in { inherit tensorrt; };
-
   extraPackagesExtension = final: prev: {
 
     nccl = final.callPackage ../development/libraries/science/math/nccl { };
@@ -74,10 +64,10 @@ let
     (import ../development/compilers/cudatoolkit/redist/extension.nix)
     (import ../development/compilers/cudatoolkit/redist/overrides.nix)
     (import ../development/libraries/science/math/cudnn/extension.nix)
+    (import ../development/libraries/science/math/tensorrt/extension.nix)
     (import ../test/cuda/cuda-samples/extension.nix)
     (import ../test/cuda/cuda-library-samples/extension.nix)
     cutensorExtension
-  ] ++ (lib.optional (lib.strings.versionAtLeast cudaVersion "11.0") tensorrtExtension));
-  # We only package the current version of TensorRT, which requires CUDA 11.
+  ]);
 
 in (scope.overrideScope' composedExtension)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10384,6 +10384,8 @@ in {
 
   tensorly = callPackage ../development/python-modules/tensorly { };
 
+  tensorrt = callPackage ../development/python-modules/tensorrt { };
+
   tellduslive = callPackage ../development/python-modules/tellduslive { };
 
   termcolor = callPackage ../development/python-modules/termcolor { };


### PR DESCRIPTION
###### Description of changes

Add derivations for TensorRT, a high-performance deep learning interface SDK from NVIDIA, which is at this point non-redistributable.  Uses different upstream tarballs depending on the current CUDA version, similar to the cudnn derivations.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
