### PR TITLE
cve-bin-tool: 3.0 -> 3.1.1

### DIFF
--- a/pkgs/tools/security/cve-bin-tool/default.nix
+++ b/pkgs/tools/security/cve-bin-tool/default.nix
@@ -33,7 +33,7 @@ buildPythonApplication rec {
     owner = "intel";
     repo = "cve-bin-tool";
     rev = "v${version}";
-    sha256 = "sha256:0nz3ax3ldnrzk8694x0p743g5h2zply29ljpn21llbc7ca27zdv9";
+    sha256 = "0nz3ax3ldnrzk8694x0p743g5h2zply29ljpn21llbc7ca27zdv9";
   };
 
   # Wants to open a sqlite database, access the internet, etc

--- a/pkgs/tools/security/cve-bin-tool/default.nix
+++ b/pkgs/tools/security/cve-bin-tool/default.nix
@@ -3,10 +3,6 @@
 , fetchFromGitHub
 , jsonschema
 , plotly
-, pytest
-, pytest-xdist
-, pytest-cov
-, pytest-asyncio
 , beautifulsoup4
 , pyyaml
 , isort
@@ -25,16 +21,19 @@
 , cchardet
 , pillow
 , pytestCheckHook
+, xmlschema
+, setuptools
+, packaging
 }:
 buildPythonApplication rec {
   pname = "cve-bin-tool";
-  version = "3.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "cve-bin-tool";
     rev = "v${version}";
-    sha256 = "1fmdnlhi03fdr4d4n7ydf6m0gx0cl77n3db8ldbs3m9zryblhzpr";
+    sha256 = "sha256:0nz3ax3ldnrzk8694x0p743g5h2zply29ljpn21llbc7ca27zdv9";
   };
 
   # Wants to open a sqlite database, access the internet, etc
@@ -43,10 +42,6 @@ buildPythonApplication rec {
   propagatedBuildInputs = [
     jsonschema
     plotly
-    pytest
-    pytest-xdist
-    pytest-cov
-    pytest-asyncio
     beautifulsoup4
     pyyaml
     isort
@@ -65,6 +60,9 @@ buildPythonApplication rec {
     cchardet
     # needed by brotlipy
     pillow
+    setuptools
+    xmlschema
+    packaging
   ];
 
   checkInputs = [
@@ -75,10 +73,15 @@ buildPythonApplication rec {
     "cve_bin_tool"
   ];
 
+  # required until https://github.com/intel/cve-bin-tool/pull/1665 is merged
+  postPatch = ''
+    sed '/^pytest/d' -i requirements.txt
+  '';
+
   meta = with lib; {
     description = "CVE Binary Checker Tool";
     homepage = "https://github.com/intel/cve-bin-tool";
-    license = licenses.gpl3Only;
+    license = licenses.gpl3Plus;
     maintainers = teams.determinatesystems.members;
   };
 }


### PR DESCRIPTION
###### Description of changes

`cve-bin-tool` is currently broken, I fixed it and took the opportunity to update it to latest version while here. I switched to Pypi sources because it has a newer version than we can find in the git repository releases.

**Error message**
```
Traceback (most recent call last):
  File "/nix/store/60a58mqgrf4d6nd5ibi8hv3h3sm2g9gh-cve-bin-tool-3.0/bin/.cve-bin-tool-wrapped", line 6, in <module>
    from cve_bin_tool.cli import main
  File "/nix/store/60a58mqgrf4d6nd5ibi8hv3h3sm2g9gh-cve-bin-tool-3.0/lib/python3.9/site-packages/cve_bin_tool/cli.py", line 24, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

This PR was sponsored by [Tweag](https://tweag.io)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
