### PR TITLE
notepad-next: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/applications/editors/notepad-next/default.nix
+++ b/pkgs/applications/editors/notepad-next/default.nix
@@ -1,30 +1,31 @@
-{ mkDerivation, lib, fetchFromGitHub, qmake, libsForQt5, stdenv }:
+{ mkDerivation, lib, fetchFromGitHub, qmake, qttools, qtx11extras, stdenv }:
 
 mkDerivation rec {
   pname = "notepad-next";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "dail8859";
     repo = "NotepadNext";
     rev = "v${version}";
-    sha256 = "sha256-J7Ngt6YtAAZsza2lN0d1lX3T8gNJHp60sCwwaLMGBHQ=";
+    sha256 = "sha256-LyUV85wW6FGlkV0qSIfkLMHpXXj1qvRnGZuYy8ASwZ8=";
     # External dependencies - https://github.com/dail8859/NotepadNext/issues/135
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ qmake libsForQt5.qt5.qttools ];
-  qmakeFlags = [ "src/NotepadNext.pro" ];
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtx11extras ];
 
-  # References
-  #  https://github.com/dail8859/NotepadNext/blob/master/doc/Building.md
-  #  https://github.com/dail8859/NotepadNext/pull/124
+  qmakeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "src/NotepadNext.pro"
+  ];
+
   postPatch = ''
-    substituteInPlace ./src/NotepadNext/NotepadNext.pro --replace /usr $out
+    substituteInPlace src/i18n.pri \
+      --replace 'EXTRA_TRANSLATIONS = \' "" \
+      --replace '$$[QT_INSTALL_TRANSLATIONS]/qt_zh_CN.qm' ""
   '';
-
-  # Upstream suggestion: https://github.com/dail8859/NotepadNext/issues/135
-  CXXFLAGS = "-std=gnu++1z";
 
   meta = with lib; {
     homepage = "https://github.com/dail8859/NotepadNext";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
