### PR TITLE
nixos/security: enable pam_mount when cryptHomeLuks is set

### DIFF
--- a/nixos/modules/security/pam_mount.nix
+++ b/nixos/modules/security/pam_mount.nix
@@ -14,6 +14,7 @@ let
   '';
 
   anyPamMount = any (attrByPath ["pamMount"] false) (attrValues config.security.pam.services);
+  anyHomeLuks = any (user: ! isNull user.cryptHomeLuks) (attrValues config.users.users);
 in
 
 {
@@ -128,7 +129,7 @@ in
 
   };
 
-  config = mkIf (cfg.enable || anyPamMount) {
+  config = mkIf (cfg.enable || anyPamMount || anyHomeLuks) {
 
     environment.systemPackages = [ pkgs.pam_mount ];
     environment.etc."security/pam_mount.conf.xml" = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -110,6 +110,7 @@ in {
   cri-o = handleTestOn ["x86_64-linux"] ./cri-o.nix {};
   custom-ca = handleTest ./custom-ca.nix {};
   croc = handleTest ./croc.nix {};
+  crypthomeluks = handleTest ./crypthomeluks.nix {};
   deluge = handleTest ./deluge.nix {};
   dendrite = handleTest ./matrix/dendrite.nix {};
   dex-oidc = handleTest ./dex-oidc.nix {};

--- a/nixos/tests/crypthomeluks.nix
+++ b/nixos/tests/crypthomeluks.nix
@@ -1,0 +1,26 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+let
+  cryptHomeLuksPath = "/dev/mapper/alice-home-encrypted";
+  pamMountConfPath = "/etc/security/pam_mount.conf.xml";
+in
+{
+  name = "crypthomeluks";
+  nodes = {
+    machineWithCryptHomeLuks = { ... }:
+    {
+      users.users.alice = { isNormalUser = true; cryptHomeLuks = cryptHomeLuksPath; };
+    };
+    machineWithoutCryptHomeLuks = { ... }:
+    {
+      users.users.alice = { isNormalUser = true; };
+    };
+  };
+
+  testScript = ''
+      machineWithCryptHomeLuks.wait_for_unit("default.target")
+      machineWithCryptHomeLuks.succeed("grep '<volume [^>]*path=\"${cryptHomeLuksPath}\"' ${pamMountConfPath}")
+      machineWithoutCryptHomeLuks.wait_for_unit("default.target")
+      machineWithoutCryptHomeLuks.fail("test -f ${pamMountConfPath}")
+  '';
+})

--- a/pkgs/os-specific/linux/pam_mount/default.nix
+++ b/pkgs/os-specific/linux/pam_mount/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, util-linux }:
+{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, util-linux, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "pam_mount";
@@ -42,5 +42,9 @@ stdenv.mkDerivation rec {
     license = with licenses; [ gpl2 gpl3 lgpl21 lgpl3 ];
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
+  };
+
+  passthru.tests = {
+    cryptHomeLuks = nixosTests.crypthomeluks;
   };
 }


### PR DESCRIPTION
###### Description of changes

Automatically enable `pam_mount`, when `cryptHomeLuks` is set for a user.

Rational: When `users.users.<username>.cryptHomeLuks` is set on its own without
setting `security.pam.mount.enable` to `true`, the given LUKS device is not
mounted on login. But the brief description of the option `cryptHomeLuks`
suggests to the user, its going to be mounted and mentions nothing of further
configuration steps to be taken.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
