### PR TITLE
woodpecker-{agent,cli,server}: init at 0.15.3

### DIFF
--- a/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
@@ -1,29 +1,17 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, callPackage, fetchFromGitHub }:
 let
-  inherit (import ./common.nix { inherit lib fetchFromGitHub; })
-    meta
-    version
-    src
-    ;
+  common = callPackage ./common.nix { };
 in
 buildGoModule {
   pname = "woodpecker-agent";
-  inherit version src;
+  inherit (common) version src ldflags postBuild;
   vendorSha256 = null;
 
   subPackages = "cmd/agent";
 
-  CGO_ENABLED = false;
+  CGO_ENABLED = 0;
 
-  ldflags = [
-    "-s"
-    "-w"
-    ''-extldflags "-static"''
-    "-X github.com/woodpecker-ci/woodpecker/version.Version=${version}"
-  ];
-
-  meta = meta // {
+  meta = common.meta // {
     description = "Woodpecker Continuous Integration agent";
-    mainProgram = "agent";
   };
 }

--- a/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+let
+  inherit (import ./common.nix { inherit lib fetchFromGitHub; })
+    meta
+    version
+    src
+    ;
+in
+buildGoModule {
+  pname = "woodpecker-agent";
+  inherit version src;
+  vendorSha256 = null;
+
+  subPackages = "cmd/agent";
+
+  CGO_ENABLED = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    ''-extldflags "-static"''
+    "-X github.com/woodpecker-ci/woodpecker/version.Version=${version}"
+  ];
+
+  meta = meta // {
+    description = "Woodpecker Continuous Integration agent";
+    mainProgram = "agent";
+  };
+}

--- a/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
@@ -1,29 +1,17 @@
-{ lib, buildGoModule, fetchFromGitHub, mkYarnPackage }:
+{ lib, buildGoModule, callPackage, fetchFromGitHub }:
 let
-  inherit (import ./common.nix { inherit lib fetchFromGitHub; })
-    meta
-    version
-    src
-    ;
+  common = callPackage ./common.nix { };
 in
 buildGoModule {
   pname = "woodpecker-cli";
-  inherit version src;
+  inherit (common) version src ldflags postBuild;
   vendorSha256 = null;
 
   subPackages = "cmd/cli";
 
-  CGO_ENABLED = false;
+  CGO_ENABLED = 0;
 
-  ldflags = [
-    "-s"
-    "-w"
-    ''-extldflags "-static"''
-    "-X github.com/woodpecker-ci/woodpecker/version.Version=${version}"
-  ];
-
-  meta = meta // {
+  meta = common.meta // {
     description = "Command line client for the Woodpecker Continuous Integration server";
-    mainProgram = "cli";
   };
 }

--- a/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub, mkYarnPackage }:
+let
+  inherit (import ./common.nix { inherit lib fetchFromGitHub; })
+    meta
+    version
+    src
+    ;
+in
+buildGoModule {
+  pname = "woodpecker-cli";
+  inherit version src;
+  vendorSha256 = null;
+
+  subPackages = "cmd/cli";
+
+  CGO_ENABLED = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    ''-extldflags "-static"''
+    "-X github.com/woodpecker-ci/woodpecker/version.Version=${version}"
+  ];
+
+  meta = meta // {
+    description = "Command line client for the Woodpecker Continuous Integration server";
+    mainProgram = "cli";
+  };
+}

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,0 +1,17 @@
+{ lib, fetchFromGitHub }:
+rec {
+  version = "0.15.3";
+
+  src = fetchFromGitHub {
+    owner = "woodpecker-ci";
+    repo = "woodpecker";
+    rev = "v${version}";
+    sha256 = "sha256-HOOH3H2SXLcT2oW/xL80TO+ZSI+Haulnznpb4hlCQow=";
+  };
+
+  meta = with lib; {
+    homepage = "https://woodpecker-ci.org/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -9,6 +9,22 @@ rec {
     sha256 = "sha256-HOOH3H2SXLcT2oW/xL80TO+ZSI+Haulnznpb4hlCQow=";
   };
 
+  yarnSha256 = "sha256-x9g0vSoexfknqLejgcNIigmkFnqYsmhcQNTOStcj68o=";
+
+  postBuild = ''
+    cd $GOPATH/bin
+    for f in *; do
+      mv -- "$f" "woodpecker-$f"
+    done
+    cd -
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/woodpecker-ci/woodpecker/version.Version=${version}"
+  ];
+
   meta = with lib; {
     homepage = "https://woodpecker-ci.org/";
     license = licenses.asl20;

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,15 +1,18 @@
 { lib, fetchFromGitHub }:
-rec {
+let
   version = "0.15.3";
+  srcSha256 = "sha256-HOOH3H2SXLcT2oW/xL80TO+ZSI+Haulnznpb4hlCQow=";
+  yarnSha256 = "sha256-x9g0vSoexfknqLejgcNIigmkFnqYsmhcQNTOStcj68o=";
+in
+{
+  inherit version yarnSha256;
 
   src = fetchFromGitHub {
     owner = "woodpecker-ci";
     repo = "woodpecker";
     rev = "v${version}";
-    sha256 = "sha256-HOOH3H2SXLcT2oW/xL80TO+ZSI+Haulnznpb4hlCQow=";
+    sha256 = srcSha256;
   };
-
-  yarnSha256 = "sha256-x9g0vSoexfknqLejgcNIigmkFnqYsmhcQNTOStcj68o=";
 
   postBuild = ''
     cd $GOPATH/bin

--- a/pkgs/development/tools/continuous-integration/woodpecker/frontend.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/frontend.nix
@@ -1,0 +1,40 @@
+{ lib, callPackage, fetchFromGitHub, fetchYarnDeps, mkYarnPackage }:
+let
+  common = callPackage ./common.nix { };
+in
+mkYarnPackage {
+  pname = "woodpecker-frontend";
+  inherit (common) version;
+
+  src = "${common.src}/web";
+
+  packageJSON = ./woodpecker-package.json;
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${common.src}/web/yarn.lock";
+    sha256 = common.yarnSha256;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -R deps/woodpecker-ci/dist $out
+    echo "${common.version}" > "$out/version"
+
+    runHook postInstall
+  '';
+
+  # Do not attempt generating a tarball for woodpecker-frontend again.
+  doDist = false;
+
+  meta = common.meta // {
+    description = "Woodpecker Continuous Integration server frontend";
+  };
+}

--- a/pkgs/development/tools/continuous-integration/woodpecker/server.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/server.nix
@@ -17,6 +17,8 @@ buildGoModule {
 
   passthru = {
     inherit woodpecker-frontend;
+
+    updateScript = ./update.sh;
   };
 
   meta = common.meta // {

--- a/pkgs/development/tools/continuous-integration/woodpecker/server.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/server.nix
@@ -1,0 +1,59 @@
+{ lib, buildGoModule, fetchFromGitHub, mkYarnPackage, glibc }:
+let
+  inherit (import ./common.nix { inherit lib fetchFromGitHub; })
+    meta
+    version
+    src
+    ;
+
+  frontend = mkYarnPackage {
+    pname = "woodpecker-frontend";
+    inherit version;
+
+    src = "${src}/web";
+
+    packageJSON = "${src}/web/package.json";
+    yarnLock = "${src}/web/yarn.lock";
+
+    buildPhase = ''
+      yarn build
+    '';
+
+    distPhase = "true";
+  };
+in
+buildGoModule {
+  pname = "woodpecker-server";
+  inherit version src;
+  vendorSha256 = null;
+
+  subPackages = "cmd/server";
+
+  buildInputs = [
+    glibc.static
+  ];
+
+  CGO_ENABLED = true;
+
+  # FIXME: what about stdenv.hostPlatform.isMusl
+  cflags = [
+    "-I${lib.getDev glibc}/include"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    ''-extldflags "-static"''
+    "-X github.com/woodpecker-ci/woodpecker/version.Version=${version}"
+    "-L ${lib.getLib glibc}/lib"
+  ];
+
+  postPatch = ''
+    cp -r ${frontend}/libexec/woodpecker-ci/deps/woodpecker-ci/dist web/dist
+  '';
+
+  meta = meta // {
+    description = "Woodpecker Continuous Integration server";
+    mainProgram = "server";
+  };
+}

--- a/pkgs/development/tools/continuous-integration/woodpecker/server.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/server.nix
@@ -15,6 +15,10 @@ buildGoModule {
 
   CGO_ENABLED = 1;
 
+  passthru = {
+    inherit woodpecker-frontend;
+  };
+
   meta = common.meta // {
     description = "Woodpecker Continuous Integration server";
   };

--- a/pkgs/development/tools/continuous-integration/woodpecker/update.sh
+++ b/pkgs/development/tools/continuous-integration/woodpecker/update.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix wget prefetch-yarn-deps nix-prefetch-github jq
+
+# shellcheck shell=bash
+
+if [ -n "$GITHUB_TOKEN" ]; then
+    TOKEN_ARGS=(--header "Authorization: token $GITHUB_TOKEN")
+fi
+
+if [[ $# -gt 1 || $1 == -* ]]; then
+    echo "Regenerates packaging data for the woodpecker packages."
+    echo "Usage: $0 [git release tag]"
+    exit 1
+fi
+
+set -x
+
+cd "$(dirname "$0")"
+version="$1"
+
+set -euo pipefail
+
+if [ -z "$version" ]; then
+    version="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/woodpecker-ci/woodpecker/releases?per_page=1" | jq -r '.[0].tag_name')"
+fi
+
+# strip leading "v"
+version="${version#v}"
+
+# Woodpecker repository
+src_hash=$(nix-prefetch-github woodpecker-ci woodpecker --rev "v${version}" | jq -r .sha256)
+
+# Front-end dependencies
+woodpecker_src="https://raw.githubusercontent.com/woodpecker-ci/woodpecker/v$version"
+wget "${TOKEN_ARGS[@]}" "$woodpecker_src/web/package.json" -O woodpecker-package.json
+
+web_tmpdir=$(mktemp -d)
+trap 'rm -rf "$web_tmpdir"' EXIT
+pushd "$web_tmpdir"
+wget "${TOKEN_ARGS[@]}" "$woodpecker_src/web/yarn.lock"
+yarn_hash=$(prefetch-yarn-deps yarn.lock)
+popd
+
+# Use friendlier hashes
+src_hash=$(nix hash to-sri --type sha256 "$src_hash")
+yarn_hash=$(nix hash to-sri --type sha256 "$yarn_hash")
+
+sed -i -E -e "s#version = \".*\"#version = \"$version\"#" common.nix
+sed -i -E -e "s#srcSha256 = \".*\"#srcSha256 = \"$src_hash\"#" common.nix
+sed -i -E -e "s#yarnSha256 = \".*\"#yarnSha256 = \"$yarn_hash\"#" common.nix

--- a/pkgs/development/tools/continuous-integration/woodpecker/woodpecker-package.json
+++ b/pkgs/development/tools/continuous-integration/woodpecker/woodpecker-package.json
@@ -1,0 +1,63 @@
+{
+  "name": "woodpecker-ci",
+  "author": "Woodpecker CI",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=14"
+  },
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "lint": "eslint --max-warnings 0 --ext .js,.ts,.vue,.json .",
+    "formatcheck": "prettier -c .",
+    "format:fix": "prettier --write .",
+    "typecheck": "vue-tsc --noEmit",
+    "test": "echo 'No tests configured' && exit 0"
+  },
+  "dependencies": {
+    "@kyvg/vue3-notification": "2.3.4",
+    "@meforma/vue-toaster": "1.2.2",
+    "ansi-to-html": "0.7.2",
+    "dayjs": "1.10.7",
+    "floating-vue": "2.0.0-beta.5",
+    "fuse.js": "6.4.6",
+    "humanize-duration": "3.27.0",
+    "javascript-time-ago": "2.3.10",
+    "node-emoji": "1.11.0",
+    "pinia": "2.0.0",
+    "vue": "v3.2.20",
+    "vue-router": "4.0.10"
+  },
+  "devDependencies": {
+    "@iconify/json": "1.1.421",
+    "@types/humanize-duration": "3.27.0",
+    "@types/javascript-time-ago": "2.0.3",
+    "@types/node": "16.11.6",
+    "@types/node-emoji": "1.8.1",
+    "@typescript-eslint/eslint-plugin": "5.6.0",
+    "@typescript-eslint/parser": "5.6.0",
+    "@vitejs/plugin-vue": "1.9.4",
+    "@vue/compiler-sfc": "3.2.20",
+    "eslint": "7.32.0",
+    "eslint-config-airbnb-base": "15.0.0",
+    "eslint-config-airbnb-typescript": "16.1.0",
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-import": "2.25.3",
+    "eslint-plugin-prettier": "4.0.0",
+    "eslint-plugin-promise": "5.1.1",
+    "eslint-plugin-simple-import-sort": "7.0.0",
+    "eslint-plugin-vue": "7.18.0",
+    "eslint-plugin-vue-scoped-css": "1.3.0",
+    "prettier": "2.4.1",
+    "typescript": "4.4.4",
+    "unplugin-icons": "0.12.17",
+    "unplugin-vue-components": "0.17.0",
+    "vite": "2.6.13",
+    "vite-plugin-windicss": "1.4.12",
+    "vite-svg-loader": "3.0.0",
+    "vue-tsc": "0.28.10",
+    "windicss": "3.2.0"
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11497,6 +11497,8 @@ with pkgs;
 
   woodpecker-server = callPackage ../development/tools/continuous-integration/woodpecker/server.nix { };
 
+  woodpecker-frontend = callPackage ../development/tools/continuous-integration/woodpecker/frontend.nix { };
+
   woof = callPackage ../tools/misc/woof { };
 
   wootility = callPackage ../tools/misc/wootility {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11491,6 +11491,12 @@ with pkgs;
 
   woff2 = callPackage ../development/web/woff2 { };
 
+  woodpecker-agent = callPackage ../development/tools/continuous-integration/woodpecker/agent.nix { };
+
+  woodpecker-cli = callPackage ../development/tools/continuous-integration/woodpecker/cli.nix { };
+
+  woodpecker-server = callPackage ../development/tools/continuous-integration/woodpecker/server.nix { };
+
   woof = callPackage ../tools/misc/woof { };
 
   wootility = callPackage ../tools/misc/wootility {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11495,9 +11495,9 @@ with pkgs;
 
   woodpecker-cli = callPackage ../development/tools/continuous-integration/woodpecker/cli.nix { };
 
-  woodpecker-server = callPackage ../development/tools/continuous-integration/woodpecker/server.nix { };
-
-  woodpecker-frontend = callPackage ../development/tools/continuous-integration/woodpecker/frontend.nix { };
+  woodpecker-server = callPackage ../development/tools/continuous-integration/woodpecker/server.nix {
+    woodpecker-frontend = callPackage ../development/tools/continuous-integration/woodpecker/frontend.nix { };
+  };
 
   woof = callPackage ../tools/misc/woof { };
 


### PR DESCRIPTION
###### Description of changes

Supersedes #169470.
Closes #178332.

Some notes :

* [x] We probably want to prefix the different binaries with `woodpecker-`, instead of just `cli`, `agent`, and `server`.
* [x] Address/remove the FIXME about `musl`.
* [x] Perhaps add an update script.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).