### PR TITLE
Improve caching for multiLayered docker builds

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -952,13 +952,21 @@ rec {
           # when the number of layers equals:
           #      maxLayers-1, maxLayers, and maxLayers+1, 0
           store_layers="$(
-            paths |
-              jq -sR '
-                rtrimstr("\n") | split("\n")
-                  | (.[:$maxLayers-1] | map([.])) + [ .[$maxLayers-1:] ]
+            if [[ $availableLayers -eq 1 ]]; then
+              paths |
+                jq -sR '
+                  rtrimstr("\n") | split("\n")
+                  | (.[:0] | map([.])) + [ .[0:] ]
                   | map(select(length > 0))
-              ' \
-                --argjson maxLayers "$availableLayers"
+                '
+            else
+              paths |
+                jq -sR --argjson maxLayers $availableLayers '
+                  rtrimstr("\n") | split("\n")
+                  | (.[:$maxLayers-2] | map([.])) + [ .[$maxLayers-2:-1] ] + [ [.[-1]] ]
+                  | map(select(length > 0))
+                '
+            fi
           )"
 
           cat ${baseJson} | jq '


### PR DESCRIPTION
###### Description of changes

The bottom layer of a multiLayered build will often be the actual binary we are building, which is what changes from commit to commit when a repository is changed. Other layers are placed higher on the list because they have more dependency points on the scoring system. This means that the most frequently changing layer (the application binary) ends up being lumped in with a bunch of other dependencies if we have more than 125 layers in the container, which is pretty inefficient when pushing new containers.

This change re-prioritizes the final item on the list by putting it in its own layer, improving docker layer efficiency substantially.

Example script I used to prove out this change:
```
paths() {                            
            cat paths.json  
         }   
                                    
for availableLayers in 1 2 3 4 5         
do                             
  echo "Testing with $availableLayers number of layers:"  
  store_layers_original="$(                                                
              paths |                                                      
                  jq -sR --argjson maxLayers $availableLayers '            
                  rtrimstr("\n") | split("\n")                             
                    | (.[:$maxLayers-1] | map([.])) + [ .[$maxLayers-1:] ]  
                    | map(select(length > 0))  
                '  
            )"  
  echo "Original output"  
  echo $store_layers_original | jq  
                                               
  store_layers="$(                                                                                                      
              if [[ $availableLayers -eq 1 ]]; then
                  paths |    
                      jq -sR '                                       
                      rtrimstr("\n") | split("\n")  
                        | (.[:0] | map([.])) + [ .[0:] ]                                        
                        | map(select(length > 0))  
                    '  
              else      
                  paths |                                                                                               
                      jq -sR --argjson maxLayers $availableLayers '                                                     
                      rtrimstr("\n") | split("\n")                                        
                        | (.[:$maxLayers-2] | map([.])) + [ .[$maxLayers-2:-1] ] + [ [.[-1]] ]   
                        | map(select(length > 0))   
                    '  
              fi      
            )"                                                                                                          
  echo "Revised output, prioritizing the final layer on its own."   
  echo $store_layers | jq                                                                                               
  echo " "  
  echo " "  
done                      
```
I also wrote a paths.json file to disk with these contents:
```
first                                         
second      
third                                                                                                                   
fourth
``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

