### PR TITLE
dockerTools: Improve caching for multiLayered docker builds

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -952,14 +952,23 @@ rec {
           # when the number of layers equals:
           #      maxLayers-1, maxLayers, and maxLayers+1, 0
           store_layers="$(
-            paths |
-              jq -sR '
-                rtrimstr("\n") | split("\n")
-                  | (.[:$maxLayers-1] | map([.])) + [ .[$maxLayers-1:] ]
+            if [[ $availableLayers -eq 1 ]]; then
+              paths |
+                jq -sR '
+                  rtrimstr("\n") | split("\n")
+                  | (.[:0] | map([.])) + [ .[0:] ]
                   | map(select(length > 0))
-              ' \
-                --argjson maxLayers "$availableLayers"
+                '
+            else
+              paths |
+                jq -sR --argjson maxLayers $availableLayers '
+                  rtrimstr("\n") | split("\n")
+                  | (.[:$maxLayers-2] | map([.])) + [ .[$maxLayers-2:-1] ] + [ [.[-1]] ]
+                  | map(select(length > 0))
+                '
+            fi
           )"
+
 
           cat ${baseJson} | jq '
             . + {

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -943,8 +943,13 @@ rec {
 
           # Create $maxLayers worth of Docker Layers, one layer per store path
           # unless there are more paths than $maxLayers. In that case, create
-          # $maxLayers-1 for the most popular layers, and smush the remainaing
-          # store paths in to one final layer.
+          # $maxLayers-2 for the most popular store paths, and smush the
+          # remainaing store paths in to the second to last layer. The final
+          # layer is reserved for the least popular store path, which is the
+          # top level derivation. Placing this store path in an independent
+          # layer is a convenient way to ensure that the application binary
+          # can change from commit to commit with minimal impact on other
+          # layers, reducing the upload size when pushing new containers.
           #
           # The following code is fiddly w.r.t. ensuring every layer is
           # created, and that no paths are missed. If you change the


### PR DESCRIPTION
###### Description of changes

The bottom layer of a multiLayered build will often be the actual binary we are building, which is what changes from commit to commit when a repository is changed. Other layers are placed higher on the list because they have more dependency points on the scoring system. This means that the most frequently changing layer (the application binary) ends up being lumped in with a bunch of other dependencies if we have more than 125 layers in the container, which is pretty inefficient when pushing new containers.

This change re-prioritizes the final item on the list by putting it in its own layer, improving docker layer efficiency substantially.

Example script I used to prove out this change:
```
paths() {                            
            cat paths.json  
         }   
                                    
for availableLayers in 1 2 3 4 5         
do                             
  echo "Testing with $availableLayers number of layers:"  
  store_layers_original="$(                                                
              paths |                                                      
                  jq -sR --argjson maxLayers $availableLayers '            
                  rtrimstr("\n") | split("\n")                             
                    | (.[:$maxLayers-1] | map([.])) + [ .[$maxLayers-1:] ]  
                    | map(select(length > 0))  
                '  
            )"  
  echo "Original output"  
  echo $store_layers_original | jq  
                                               
  store_layers="$(                                                                                                      
              if [[ $availableLayers -eq 1 ]]; then
                  paths |    
                      jq -sR '                                       
                      rtrimstr("\n") | split("\n")  
                        | (.[:0] | map([.])) + [ .[0:] ]                                        
                        | map(select(length > 0))  
                    '  
              else      
                  paths |                                                                                               
                      jq -sR --argjson maxLayers $availableLayers '                                                     
                      rtrimstr("\n") | split("\n")                                        
                        | (.[:$maxLayers-2] | map([.])) + [ .[$maxLayers-2:-1] ] + [ [.[-1]] ]   
                        | map(select(length > 0))   
                    '  
              fi      
            )"                                                                                                          
  echo "Revised output, prioritizing the final layer on its own."   
  echo $store_layers | jq                                                                                               
  echo " "  
  echo " "  
done                      
```
I also wrote a paths.json file to disk with these contents:
```
first                                         
second      
third                                                                                                                   
fourth
``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
