### PR TITLE
discord: add openasar option

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -1,4 +1,4 @@
-{ pname, version, src, meta, stdenv, binaryName, desktopName, undmg }:
+{ pname, version, src, openasar, meta, stdenv, binaryName, desktopName, lib, undmg }:
 
 stdenv.mkDerivation {
   inherit pname version src meta;
@@ -8,7 +8,15 @@ stdenv.mkDerivation {
   sourceRoot = ".";
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/Applications
     cp -r "${desktopName}.app" $out/Applications
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.strings.optionalString (openasar != null) ''
+    cp -f ${openasar} $out/Applications/${desktopName}.app/Contents/Resources/app.asar
   '';
 }

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,6 +1,5 @@
-{ branch ? "stable", pkgs, lib, stdenv, withOpenASAR ? false }:
+{ branch ? "stable", callPackage, fetchurl, lib, stdenv, withOpenASAR ? false }:
 let
-  inherit (pkgs) callPackage fetchurl;
   versions = if stdenv.isLinux then {
     stable = "0.0.18";
     ptb = "0.0.29";

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,4 +1,4 @@
-{ branch ? "stable", pkgs, lib, stdenv }:
+{ branch ? "stable", pkgs, lib, stdenv, withOpenASAR ? false }:
 let
   inherit (pkgs) callPackage fetchurl;
   versions = if stdenv.isLinux then {
@@ -61,8 +61,11 @@ let
       ++ lib.optionals (branch == "ptb") [ "aarch64-darwin" ];
   };
   package = if stdenv.isLinux then ./linux.nix else ./darwin.nix;
+
+  openasar = if withOpenASAR then callPackage ./openasar.nix { } else null;
+
   packages = (builtins.mapAttrs
-    (_: value: callPackage package (value // { inherit src version; meta = meta // { mainProgram = value.binaryName; }; }))
+    (_: value: callPackage package (value // { inherit src version openasar; meta = meta // { mainProgram = value.binaryName; }; }))
     {
       stable = rec {
         pname = "discord";

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -1,4 +1,4 @@
-{ pname, version, src, meta, binaryName, desktopName, autoPatchelfHook
+{ pname, version, src, openasar, meta, binaryName, desktopName, autoPatchelfHook
 , makeDesktopItem, lib, stdenv, wrapGAppsHook, makeShellWrapper, alsa-lib, at-spi2-atk
 , at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk-pixbuf
 , glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid, libX11
@@ -72,6 +72,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/{bin,opt/${binaryName},share/pixmaps,share/icons/hicolor/256x256/apps}
     mv * $out/opt/${binaryName}
 
@@ -95,6 +97,12 @@ stdenv.mkDerivation rec {
     ln -s $out/opt/${binaryName}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
 
     ln -s "${desktopItem}/share/applications" $out/share/
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.strings.optionalString (openasar != null) ''
+    cp -f ${openasar} $out/opt/${binaryName}/resources/app.asar
   '';
 
   desktopItem = makeDesktopItem {

--- a/pkgs/applications/networking/instant-messengers/discord/openasar.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/openasar.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, nodejs, bash, nodePackages }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2022-06-10";
+  pname = "openasar";
+
+  src = fetchFromGitHub {
+    owner = "GooseMod";
+    repo = "OpenAsar";
+    rev = "c6f2f5eb7827fea14cb4c54345af8ff6858c633a";
+    sha256 = "m6e/WKGgkR8vjKcHSNdWE25MmDQM1Z3kgB24OJgbw/w=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    bash scripts/injectPolyfills.sh
+    substituteInPlace src/index.js --replace 'nightly' '${version}'
+    ${nodejs}/bin/node scripts/strip.js
+    ${nodePackages.asar}/bin/asar pack src app.asar
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install app.asar $out
+
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Open-source alternative of Discord desktop's \"app.asar\".";
+    homepage = "https://openasar.dev";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pedrohlc ];
+    platforms = nodejs.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35212,19 +35212,16 @@ with pkgs;
 
   mpvc = callPackage ../applications/misc/mpvc { };
 
-  discord = import ../applications/networking/instant-messengers/discord {
+  discord = callPackage ../applications/networking/instant-messengers/discord {
     branch = "stable";
-    inherit pkgs lib stdenv;
   };
 
-  discord-ptb = import ../applications/networking/instant-messengers/discord {
+  discord-ptb = callPackage ../applications/networking/instant-messengers/discord {
     branch = "ptb";
-    inherit pkgs lib stdenv;
   };
 
-  discord-canary = import ../applications/networking/instant-messengers/discord {
+  discord-canary = callPackage ../applications/networking/instant-messengers/discord {
     branch = "canary";
-    inherit pkgs lib stdenv;
   };
 
   golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah {};


### PR DESCRIPTION
###### Description of changes

![Demo](https://user-images.githubusercontent.com/1368952/174908630-dac1dda9-2b0f-43f6-b73a-18e1c46e846c.png)

The features are described in [the project's README](https://github.com/GooseMod/OpenAsar). It's also interesting to read [its FAQ](https://github.com/GooseMod/OpenAsar/blob/main/faq.md).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
