### PR TITLE
vscode-extensions.ms-vscode.cpptools: 1.9.1 -> 1.11.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix
+++ b/pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix
@@ -1,6 +1,9 @@
-{ publisher, name, version, sha256 ? "" }:
+{ publisher, name, version, arch ? "", sha256 ? "" }:
+let
+  archurl = (if arch == "" then "" else "?targetPlatform=${arch}");
+in
 {
-  url = "https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${name}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
+  url = "https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${name}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage${archurl}";
   sha256 = sha256;
   # The `*.vsix` file is in the end a simple zip file. Change the extension
   # so that existing `unzip` hooks takes care of the unpacking.


### PR DESCRIPTION
###### Description of changes

This PR was forked from #151228, it inherits some changes such as the removal of `mono`, and the automatic wrapping of the debugger. Based on the work by @vlaci .

- Update the `ms-vscode.cpptools` Visual Studio Code extension to version `1.11.0`
- Use the standard `buildVscodeMarketplaceExtension` download and unpacking functionality
- Download binary extension for the correct architecture
- Fix debugging using `OpenDebugAD7`

Related issues:
- Closes #166797
- https://discourse.nixos.org/t/vscode-cpptools-opendebugad7-is-broken-in-nixpkgs/17581

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
