### PR TITLE
trillian-im: init at 6.3.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7776,6 +7776,12 @@
     githubId = 31056089;
     name = "Tom Ho";
   };
+  majiir = {
+    email = "majiir@nabaal.net";
+    github = "Majiir";
+    githubId = 963511;
+    name = "Majiir Paktu";
+  };
   makefu = {
     email = "makefu@syntax-fehler.de";
     github = "makefu";

--- a/pkgs/applications/networking/instant-messengers/trillian-im/default.nix
+++ b/pkgs/applications/networking/instant-messengers/trillian-im/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, atkmm
+, cairo
+, cairomm
+, gtk3
+, gtkmm3
+, libnotify
+, libsecret
+, pangomm
+, xorg
+, libpulseaudio
+, librsvg
+, libzip
+, openssl
+, webkitgtk
+, libappindicator-gtk3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "trillian-im";
+  version = "6.3.0.1";
+
+  src = fetchurl {
+    url = "https://www.trillian.im/get/linux/6.3/trillian_${version}_amd64.deb";
+    sha256 = "42e3466ee236ac2644907059f0961eba3a6ed6b6156afb2c57f54ebe6065ac6f";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    atkmm
+    cairo
+    cairomm
+    gtk3
+    gtkmm3
+    libnotify
+    libsecret
+    pangomm
+    xorg.libXScrnSaver
+    libpulseaudio
+    librsvg
+    libzip
+    openssl
+    webkitgtk
+    libappindicator-gtk3
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rm -rf $out/usr
+
+    rm $out/bin/trillian
+    ln -s "$out/share/trillian/trillian" "$out/bin/trillian"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Modern instant messaging for home and work that prioritizes chat interoperability and security";
+    homepage = "https://www.trillian.im/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ majiir ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30313,6 +30313,8 @@ with pkgs;
 
   tribler = callPackage ../applications/networking/p2p/tribler { };
 
+  trillian-im = callPackage ../applications/networking/instant-messengers/trillian-im { };
+
   trojita = libsForQt5.callPackage ../applications/networking/mailreaders/trojita { };
 
   ttyper = callPackage ../applications/misc/ttyper { };


### PR DESCRIPTION
###### Description of changes

> [**Trillian**](https://www.trillian.im/) is modern and secure instant messaging for people, business and healthcare

Trillian is a non-free IM client. I followed the guidance in [this post](https://unix.stackexchange.com/a/523174) to get this working. Tested on a NixOS 22.05 VM.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
