### PR TITLE
lib: add a short alias for cartesianProductOfSets

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -301,6 +301,8 @@ rec {
       ) listOfAttrs
     ) [{}] (attrNames attrsOfLists);
 
+  /* Alias for `cartesianProductOfSets`. */
+  X = cartesianProductOfSets;
 
   /* Utility function that creates a {name, value} pair as expected by
      builtins.listToAttrs.


### PR DESCRIPTION
###### Description of changes

This function can be very handy, but it's a mouthful to type. Not sure if we have an official policy on function aliasing in nixpkgs, but I thought I'd at least suggest it.

The `X` is in lieu of [⨯](https://en.wikipedia.org/w/index.php?title=Glossary_of_mathematical_symbols&diff=1094124914&oldid=1094118861#Arithmetic_operators)