### PR TITLE
regpg: init at 1.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -78,6 +78,13 @@
       fingerprint = "2536 9E86 1AA5 9EB7 4C47  B138 6510 870A 77F4 9A99";
     }];
   };
+  _0xC45 = {
+    email = "jason@0xc45.com";
+    name = "Jason Vigil";
+    github = "0xC45";
+    githubId = 56617252;
+    matrix = "@oxc45:matrix.org";
+  };
   _1000101 = {
     email = "b1000101@pm.me";
     github = "1000101";

--- a/pkgs/tools/security/regpg/default.nix
+++ b/pkgs/tools/security/regpg/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, gnupg
+, perl
+}:
+
+let
+  perlEnv = perl.withPackages (p: with p; [ TextMarkdown ]);
+in
+stdenv.mkDerivation rec {
+  pname = "regpg";
+  version = "1.11";
+
+  src = fetchFromGitHub {
+    owner = "fanf2";
+    repo = "regpg";
+    rev = "regpg-${version}";
+    sha256 = "2ea99950804078190e1cc2a76d4740e3fdd5395a9043db3f3fe86bf2477d3a7d";
+  };
+
+  nativeBuildInputs = [ makeWrapper perlEnv ];
+
+  postPatch = ''
+    patchShebangs ./util/insert-here.pl ./util/markdown.pl
+    substituteInPlace ./Makefile \
+      --replace 'util/insert-here.pl' 'perl util/insert-here.pl'
+    substituteInPlace ./Makefile \
+      --replace 'util/markdown.pl' 'perl util/markdown.pl'
+    substituteInPlace util/insert-here.pl \
+      --replace 'qx(git describe)' '"regpg-${version}"'
+  '';
+
+  dontConfigure = true;
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  postFixup = ''
+    patchShebangs $out/bin/regpg
+    wrapProgram $out/bin/regpg --prefix PATH ":" \
+      "${lib.makeBinPath [ gnupg ]}"
+  '';
+
+  meta = with lib; {
+    description = "GPG wrapper utility for storing secrets in VCS";
+    homepage = "https://dotat.at/prog/regpg";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ _0xC45 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9977,6 +9977,8 @@ with pkgs;
 
   reftools = callPackage ../development/tools/reftools { };
 
+  regpg = callPackage ../tools/security/regpg { };
+
   remote-touchpad = callPackage ../tools/inputmethods/remote-touchpad { };
 
   reposurgeon = callPackage ../applications/version-management/reposurgeon { };


### PR DESCRIPTION
###### Description of changes

Add new package "regpg": https://dotat.at/prog/regpg/

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
