### PR TITLE
talosctl: 1.0.6 -> 1.1.0

### DIFF
--- a/pkgs/applications/networking/cluster/talosctl/default.nix
+++ b/pkgs/applications/networking/cluster/talosctl/default.nix
@@ -1,42 +1,21 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
-let
-  # look for GO_LDFLAGS getting set in the Makefile
-  version = "1.0.6";
-  sha256 = "sha256-4cUaQWqVndp06eFgqInOMMGITbTdZO5BOqXW2XEpuWU=";
-  vendorSha256 = "sha256-7q35d+jbIDe7fAy6nL5FWdSovBb/f64HYLHGL+zE6bI=";
-  pkgsVersion = "v1.0.0-25-gcf9709e";
-  extrasVersion = "v1.0.0-4-g05b0920";
-in
+{ lib, stdenv, buildGoModule, fetchFromGitHub, installShellFiles }:
+
 buildGoModule rec {
   pname = "talosctl";
-  inherit version vendorSha256;
-  # nixpkgs-update: no auto update
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "siderolabs";
     repo = "talos";
     rev = "v${version}";
-    inherit sha256;
+    sha256 = "sha256-52WzQ5LWgIX/XBJPNvWV0tAPnw1AiINDL/7D3UYvvn4=";
   };
 
-  ldflags =
-    let
-      versionPkg = "github.com/talos-systems/talos/pkg/version"; # VERSION_PKG
-      imagesPkgs = "github.com/talos-systems/talos/pkg/images"; # IMAGES_PKGS
-      mgmtHelpersPkg = "github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"; #MGMT_HELPERS_PKG
-    in
-    [
-      "-X ${versionPkg}.Name=Client"
-      "-X ${versionPkg}.SHA=${src.rev}" # should be the hash, but as we build from tags, this needs to do
-      "-X ${versionPkg}.Tag=${src.rev}"
-      "-X ${versionPkg}.PkgsVersion=${pkgsVersion}" # PKGS
-      "-X ${versionPkg}.ExtrasVersion=${extrasVersion}" # EXTRAS
-      "-X ${imagesPkgs}.Username=siderolabs" # USERNAME
-      "-X ${imagesPkgs}.Registry=ghcr.io" # REGISTRY
-      "-X ${mgmtHelpersPkg}.ArtifactsPath=_out" # ARTIFACTS
-      "-s"
-      "-w"
-    ];
+  vendorSha256 = "sha256-iluI4UGw5cZ70wmC9jDiGttvxZ7xFyqcL9IZX4ubJqs=";
+
+  ldflags = [ "-s" "-w" ];
+
+  GOWORK = "off";
 
   subPackages = [ "cmd/talosctl" ];
 
@@ -56,5 +35,8 @@ buildGoModule rec {
     homepage = "https://www.talos.dev/";
     license = licenses.mpl20;
     maintainers = with maintainers; [ flokli ];
+    # requires >= 10.14 SDK https://github.com/NixOS/nixpkgs/issues/101229
+    # Undefined symbols for architecture x86_64: "_SecTrustEvaluateWithError"
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30046,7 +30046,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  talosctl = callPackage ../applications/networking/cluster/talosctl { };
+  talosctl = callPackage ../applications/networking/cluster/talosctl {
+    buildGoModule = buildGo118Module;
+  };
 
   talentedhack = callPackage ../applications/audio/talentedhack { };
 


### PR DESCRIPTION
> https://github.com/siderolabs/talos/commit/b315ed95327a9b7cfb1f83a9da02e96bafecbb1d
> Generate separate file for each variable and assign them during go build using go:embed instead of using ldflags -X.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
