### PR TITLE
buildDhallUrl: fix impure proxy variable passing

### DIFF
--- a/pkgs/development/interpreters/dhall/build-dhall-url.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-url.nix
@@ -59,6 +59,7 @@ let
         outputHash = hash;
         name = baseNameOf url;
         nativeBuildInputs = [ cacert ];
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars;
       }
       ''
         echo "${url} ${dhallHash}" > in-dhall-file
@@ -76,7 +77,7 @@ let
    sourceFile = "source.dhall";
 
 in
-  runCommand name { impureEnvVars = lib.fetchers.proxyImpureEnvVars; }
+  runCommand name { }
  (''
     set -eu
 


### PR DESCRIPTION
###### Description of changes

#177891 tried fixing a problem with `buildDhallUrl` in environments where proxy variables are necessary for internet access to work.  The `impureEnvVars` should be set in `downloadEncodedFile` instead of the final `runCommand`, as the former is an FOD, the latter isn't.

The actual problem was still happening after #177891 but is a bit tricky to reproduce. I've created a repository with instructions and confirmed that this change fixes it. [This is the repo.](https://github.com/kenranunderscore/nix-dhall-sandbox-repro)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
