### PR TITLE
pkgs: add ASIX ax99100 out of tree kernel module

### DIFF
--- a/pkgs/os-specific/linux/ax99100/default.nix
+++ b/pkgs/os-specific/linux/ax99100/default.nix
@@ -1,0 +1,29 @@
+{ kernel, stdenv, kmod, lib, fetchzip }:
+stdenv.mkDerivation
+{
+  pname = "ax99100";
+  version = "1.8.0";
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+  src = fetchzip {
+    url = "https://www.asix.com.tw/en/support/download/file/1229";
+    sha256 = "1rbp1m01qr6b3nbr72vpbw89pjh8mddc60im78z2yjd951xkbcjh";
+    extension = "tar.bz2";
+  };
+
+  makeFlags = [ "KDIR='${kernel.dev}/lib/modules/${kernel.modDirVersion}/build'" ];
+
+  installPhase = ''
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/tty/serial
+    cp ax99100.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/tty/serial
+  '';
+
+  meta = {
+    description = "ASIX AX99100 Serial and Parralel Port driver";
+    homepage = "https://www.asix.com.tw/en/product/Interface/PCIe_Bridge/AX99100";
+    # According to the source code in the tarball, the license is gpl2.
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    # currently, the build fails with kernels newer than 5.17
+    broken = lib.versionAtLeast kernel.version "5.18.0";
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -282,6 +282,8 @@ in {
 
     apfs = callPackage ../os-specific/linux/apfs { };
 
+    ax99100 = callPackage ../os-specific/linux/ax99100 {};
+
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bbswitch = callPackage ../os-specific/linux/bbswitch {};


### PR DESCRIPTION
###### Description of changes

This PR adds the linux kernel module for ax99100 based serial and parallel port devices.
The ASIX AX99100 micro chip os a Serail and Parallel Port chip that can be built on top of PCIe 2.0 devices, including 
M.2 

Uncomplete list of devices with an AX99100 serial and parallel port interface:
- https://www.delock.de/produkt/89556/merkmale.html?setLanguage=en
- https://www.delock.de/produkt/95270/merkmale.html?f=s

Homepage: https://www.asix.com.tw/en/product/Interface/PCIe_Bridge/AX99100

###### Things done

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` showed 
```bash
23 packages marked as broken and skipped:
linuxKernel.packages.linux_4_14.ax99100 linuxKernel.packages.linux_4_14_hardened.ax99100 linuxKernel.packages.linux_4_19.ax99100 linuxKernel.packages.linux_4_19_hardened.ax99100 linuxKernel.packages.linux_4_9.ax99100 linuxKernel.packages.linux_5_10.ax99100 linuxKernel.packages.linux_5_10_hardened.ax99100 linuxKernel.packages.linux_5_15.ax99100 linuxKernel.packages.linux_5_15_hardened.ax99100 linuxKernel.packages.linux_5_17.ax99100 linuxKernel.packages.linux_5_17_hardened.ax99100 linuxKernel.packages.linux_5_18.ax99100 linuxKernel.packages.linux_5_18_hardened.ax99100 linuxKernel.packages.linux_5_4.ax99100 linuxKernel.packages.linux_5_4_hardened.ax99100 linuxKernel.packages.linux_hardened.ax99100 linuxKernel.packages.linux_latest_libre.ax99100 linuxKernel.packages.linux_libre.ax99100 linuxKernel.packages.linux_lqx.ax99100 linuxKernel.packages.linux_testing_bcachefs.ax99100 linuxKernel.packages.linux_xanmod.ax99100 linuxKernel.packages.linux_xanmod_latest.ax99100 linuxKernel.packages.linux_zen.ax99100
```
Is this something I need to fix? 
I have built a subset of these derivations and it works.