### PR TITLE
pythonPackages.adafruit-nrfutil: init at 0.5.3.post17

### DIFF
--- a/pkgs/development/python-modules/adafruit-nrfutil/default.nix
+++ b/pkgs/development/python-modules/adafruit-nrfutil/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pythonOlder
+, pyserial
+, click
+, ecdsa
+, behave
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "adafruit-nrfutil";
+  version = "0.5.3.post17";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "adafruit";
+    repo = "Adafruit_nRF52_nrfutil";
+    rev = version;
+    sha256 = "sha256-mHHKOQE9AGBX8RAyaPOy+JS3fTs98+AFdq9qsVy7go4=";
+  };
+
+  patches = [
+    # Pull a patch which fixes the tests, but is not yet released in a new version:
+    # https://github.com/adafruit/Adafruit_nRF52_nrfutil/pull/38
+    (fetchpatch {
+      name = "fix-tests.patch";
+      url = "https://github.com/adafruit/Adafruit_nRF52_nrfutil/commit/e5fbcc8ee5958041db38c04139ba686bf7d1b845.patch";
+      sha256 = "sha256-0tbJldGtYcDdUzA3wZRv0lenXVn6dqV016U9nMpQ6/w=";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    pyserial
+    click
+    ecdsa
+  ];
+
+  checkInputs = [
+    behave
+    nose
+  ];
+
+  preCheck = ''
+    mkdir test-reports
+  '';
+
+  pythonImportsCheck = [
+    "nordicsemi"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/adafruit/Adafruit_nRF52_nrfutil";
+    description = "Modified version of Nordic's nrfutil 0.5.x for use with the Adafruit Feather nRF52";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ stargate01 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -171,6 +171,8 @@ in {
 
   adafruit-io = callPackage ../development/python-modules/adafruit-io { };
 
+  adafruit-nrfutil = callPackage ../development/python-modules/adafruit-nrfutil { };
+
   adafruit-platformdetect = callPackage ../development/python-modules/adafruit-platformdetect { };
 
   adafruit-pureio = callPackage ../development/python-modules/adafruit-pureio { };


### PR DESCRIPTION
###### Description of changes

This PR adds the Python 3 adafruit-nrfutil package from PyPi. See https://github.com/adafruit/Adafruit_nRF52_nrfutil .

Depends on: https://github.com/adafruit/Adafruit_nRF52_nrfutil/pull/38 ~~(and a successive new version)~~. Required for the tests to pass under recent Python and `ecdsa` versions. Before that PR is merged and a new version is tagged, this PR will be a draft.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
