### PR TITLE
git-cola: 3.12.0 -> 4.0.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,21 +1,21 @@
 { lib, fetchFromGitHub, python3Packages, gettext, git, qt5 }:
 
 let
-  inherit (python3Packages) buildPythonApplication pyqt5 sip_4 pyinotify;
+  inherit (python3Packages) buildPythonApplication pyqt5 sip_4 pyinotify qtpy;
 
 in buildPythonApplication rec {
   pname = "git-cola";
-  version = "3.12.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "git-cola";
     repo = "git-cola";
     rev = "v${version}";
-    sha256 = "1f8jpfa916nszj431cmp41bxj2m76k2n8qnscqgxrc0k3pnnp3wc";
+    hash = "sha256-xCGXPGZa4K9f37kZRerfUY+Y7atRdqld5rxj0VYdziU=";
   };
 
   buildInputs = [ git gettext ];
-  propagatedBuildInputs = [ pyqt5 sip_4 pyinotify ];
+  propagatedBuildInputs = [ pyqt5 sip_4 pyinotify qtpy ];
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

Update to the latest upstream release 4.0.1.

- [Release on GitHub](https://github.com/git-cola/git-cola/releases/tag/v4.0.1)
- [Compare changes on GitHub](https://github.com/git-cola/git-cola/compare/v3.12.0...v4.0.1)


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).