### PR TITLE
makePkgconfigItem: init new function to generate pc files

### DIFF
--- a/pkgs/build-support/make-pkgconfigitem/default.nix
+++ b/pkgs/build-support/make-pkgconfigitem/default.nix
@@ -1,0 +1,69 @@
+{ lib, writeTextFile, buildPackages }:
+
+# See https://people.freedesktop.org/~dbn/pkg-config-guide.html#concepts
+{ name # The name of the pc file
+  # keywords
+  # provide a default description for convenience. it's not important but still required by pkg-config.
+, description ? "A pkg-config file for ${name}"
+, url ? ""
+, version ? ""
+, requires ? [ ]
+, requiresPrivate ? [ ]
+, conflicts ? [ ]
+, cflags ? [ ]
+, libs ? [ ]
+, libsPrivate ? [ ]
+, variables ? { }
+}:
+
+let
+  # only 'out' has to be changed, otherwise it would be replaced by the out of the writeTextFile
+  placeholderToSubstVar = builtins.replaceStrings [ "${placeholder "out"}" ] [ "@out@" ];
+
+  replacePlaceholderAndListToString = x:
+    if builtins.isList x
+    then placeholderToSubstVar (builtins.concatStringsSep " " x)
+    else placeholderToSubstVar x;
+
+  keywordsSection =
+    let
+      mustBeAList = attr: attrName: lib.throwIfNot (lib.isList attr) "'${attrName}' must be a list" attr;
+    in
+    {
+      "Name" = name;
+      "Description" = description;
+      "URL" = url;
+      "Version" = version;
+      "Requires" = mustBeAList requires "requires";
+      "Requires.private" = mustBeAList requiresPrivate "requiresPrivate";
+      "Conflicts" = mustBeAList conflicts "conflicts";
+      "Cflags" = mustBeAList cflags "cflags";
+      "Libs" = mustBeAList libs "libs";
+      "Libs.private" = mustBeAList libsPrivate "libsPrivate";
+    };
+
+  renderVariable = name: value:
+    lib.optionalString (value != "" && value != [ ]) "${name}=${replacePlaceholderAndListToString value}";
+  renderKeyword = name: value:
+    lib.optionalString (value != "" && value != [ ]) "${name}: ${replacePlaceholderAndListToString value}";
+
+  renderSomething = renderFunc: attrs:
+    lib.pipe attrs [
+      (lib.mapAttrsToList renderFunc)
+      (builtins.filter (v: v != ""))
+      (builtins.concatStringsSep "\n")
+      (section: ''${section}
+      '')
+    ];
+
+  variablesSectionRendered = renderSomething renderVariable variables;
+  keywordsSectionRendered = renderSomething renderKeyword keywordsSection;
+
+  content = [ variablesSectionRendered keywordsSectionRendered ];
+in
+writeTextFile {
+  name = "${name}.pc";
+  destination = "/lib/pkgconfig/${name}.pc";
+  text = builtins.concatStringsSep "\n" content;
+  checkPhase = ''${buildPackages.pkg-config}/bin/pkg-config --validate "$target"'';
+}

--- a/pkgs/build-support/setup-hooks/copy-pkgconfig-items.sh
+++ b/pkgs/build-support/setup-hooks/copy-pkgconfig-items.sh
@@ -1,0 +1,46 @@
+# shellcheck shell=bash
+
+# Setup hook that installs specified pkgconfig items.
+#
+# Example usage in a derivation:
+#
+#   { …, makePkgconfigItem, copyPkgconfigItems, … }:
+#
+#   let pkgconfigItem = makePkgconfigItem { … }; in
+#   stdenv.mkDerivation {
+#     …
+#     nativeBuildInputs = [ copyPkgconfigItems ];
+#
+#     pkgconfigItems =  [ pkgconfigItem ];
+#     …
+#   }
+#
+# This hook will copy files which are either given by full path
+# or all '*.pc' files placed inside the 'lib/pkgconfig'
+# folder of each `pkgconfigItems` argument.
+
+postInstallHooks+=(copyPkgconfigItems)
+
+copyPkgconfigItems() {
+    if [ "${dontCopyPkgconfigItems-}" = 1 ]; then return; fi
+
+    if [ -z "$pkgconfigItems" ]; then
+        return
+    fi
+
+    pkgconfigdir="${!outputDev}/lib/pkgconfig"
+    for pkgconfigItem in $pkgconfigItems; do
+        if [[ -f "$pkgconfigItem" ]]; then
+            substituteAllInPlace "$pkgconfigItem"
+            echo "Copying '$pkgconfigItem' into '${pkgconfigdir}'"
+            install -D -m 444 -t "${pkgconfigdir}" "$pkgconfigItem"
+            substituteAllInPlace "${pkgconfigdir}"/*
+        else
+            for f in "$pkgconfigItem"/lib/pkgconfig/*.pc; do
+                echo "Copying '$f' into '${pkgconfigdir}'"
+                install -D -m 444 -t "${pkgconfigdir}" "$f"
+                substituteAllInPlace "${pkgconfigdir}"/*
+            done
+        fi
+    done
+}

--- a/pkgs/development/libraries/stb/default.nix
+++ b/pkgs/development/libraries/stb/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, copyPkgconfigItems, makePkgconfigItem }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "stb";
   version = "unstable-2021-09-10";
 
@@ -11,11 +11,28 @@ stdenv.mkDerivation {
     sha256 = "0qq35cd747lll4s7bmnxb3pqvyp2hgcr9kyf758fax9lx76iwjhr";
   };
 
+  nativeBuildInputs = [ copyPkgconfigItems ];
+
+  pkgconfigItems = [
+    (makePkgconfigItem rec {
+      name = "stb";
+      version = "1";
+      cflags = [ "-I${variables.includedir}/stb" ];
+      variables = rec {
+        prefix = "${placeholder "out"}";
+        includedir = "${prefix}/include";
+      };
+      inherit (meta) description;
+    })
+  ];
+
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/include/stb
     cp *.h $out/include/stb/
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -826,6 +826,10 @@ with pkgs;
 
   makeDesktopItem = callPackage ../build-support/make-desktopitem { };
 
+  copyPkgconfigItems = makeSetupHook { } ../build-support/setup-hooks/copy-pkgconfig-items.sh;
+
+  makePkgconfigItem = callPackage ../build-support/make-pkgconfigitem { };
+
   makeDarwinBundle = callPackage ../build-support/make-darwin-bundle { };
 
   makeAutostartItem = callPackage ../build-support/make-startupitem { };


### PR DESCRIPTION
some packages like blas and lapack make pc files manually

base copied from makeDesktopItem

https://people.freedesktop.org/~dbn/pkg-config-guide.html

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
