### PR TITLE
python3Packages.python-jenkins: remove deprecated unittest2

### DIFF
--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -10,8 +10,8 @@
 , multi_key_dict
 , testscenarios
 , requests
-, unittest2
 , requests-mock
+, stestr
 }:
 
 buildPythonPackage rec {
@@ -33,16 +33,16 @@ buildPythonPackage rec {
   buildInputs = [ mock ];
   propagatedBuildInputs = [ pbr pyyaml setuptools six multi_key_dict requests ];
 
-  checkInputs = [ unittest2 testscenarios requests-mock ];
-  checkPhase = ''
-    unit2
-  '';
+   checkInputs = [ stestr testscenarios requests-mock ];
+   checkPhase = ''
+     stestr run
+   '';
 
   meta = with lib; {
     description = "Python bindings for the remote Jenkins API";
     homepage = "https://pypi.python.org/pypi/python-jenkins";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ gador ];
   };
 
 }


### PR DESCRIPTION
###### Description of changes

Currently, [jenkins-job-builder](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/python-modules/jenkins-job-builder) fails to evaluate, due to its dependency on [python-jenkins](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/python-modules/python-jenkins). This, in turn, fails due to [unittest2](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/python-modules/unittest2), which is deprecated in Pthon 3.10. 

This PR switches from forcing `unittest2` to run the upstream test suite with `stestr`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
