### PR TITLE
clickgen: allow building on Python 3.10+

### DIFF
--- a/pkgs/development/python-modules/clickgen/default.nix
+++ b/pkgs/development/python-modules/clickgen/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildPythonPackage
 , pythonOlder
-, pythonAtLeast
 , fetchFromGitHub
 , pillow
 , libX11
@@ -17,7 +16,7 @@ buildPythonPackage rec {
   version = "1.2.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.8" || pythonAtLeast "3.10";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "ful1e5";


### PR DESCRIPTION
###### Description of changes

Allow clickgen to be built on newer Python interpreters

The code gets tested on Python 3.8-3.10 ([see here](https://github.com/ful1e5/clickgen/blob/v1.2.0/.github/workflows/app-ci.yml#L21)), so there doesn't seem to be a reason to disallow building on Python 3.10. I can update the PR to just bump the upper Python version limit instead, if you feel keeping the upper limit is necessary

Fixes `bibata-cursors` and `clickgen` packages, which were giving eval errors after the recent staging cycle making Python 3.10 default (and therefore `python3Packages` is `python310.pkgs` -- ref #175805)

cc: @WolfangAukang (for #172436 which added this restriction)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>bibata-cursors</li>
    <li>bibata-extra-cursors</li>
    <li>clickgen (python310Packages.clickgen)</li>
  </ul>
</details>