### PR TITLE
ocamlPackages.ke: 0.4 → 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/ke/default.nix
+++ b/pkgs/development/ocaml-modules/ke/default.nix
@@ -5,21 +5,19 @@
 
 buildDunePackage rec {
   pname = "ke";
-  version = "0.4";
-
-  useDune2 = true;
+  version = "0.6";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ke/releases/download/v${version}/ke-v${version}.tbz";
-    sha256 = "13c9xy60vmq29mnwpg3h3zgl6gjbjfwbx1s0crfc6xwvark0zxnx";
+    url = "https://github.com/mirage/ke/releases/download/v${version}/ke-${version}.tbz";
+    sha256 = "sha256-YSFyB+IgCwSxd1lzZhD/kggmmmR/hUy1rnLNrA1nIwU=";
   };
 
-  propagatedBuildInputs = [ bigarray-compat fmt ];
+  propagatedBuildInputs = [ fmt ];
 
   checkInputs = [ alcotest bigstringaf ];
   doCheck = true;
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.08";
 
   meta = {
     description = "Fast implementation of queue in OCaml";


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://github.com/mirage/ke/blob/v0.6/CHANGES.md#v06-2022-04-07-paris-france

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
