### PR TITLE
segger-jlink: init at 7.66

### DIFF
--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -14,60 +14,60 @@ let
   supported = {
     x86_64-linux = {
       name = "x86_64";
-      sha256 = "0cmd9ny6mslj9260scply573gbmn6k5r9wyxmcbjb14k4b3sldic";
+      sha256 = "90aa7e4f5eae6e60fd41978111b3ff124ba0269562d0d0ec3110d3cb4bb51fe2";
     };
     i686-linux = {
       name = "i386";
-      sha256 = "1jjh5a8y17ma369s9k0xlyr8i10v2r1kxmv0i9v4cix5dnjyq0pp";
+      sha256 = "18aea42cd17591cada78af7cba0f94a9d851e9d29995b6c8e1e7033d0af35d1c";
     };
     aarch64-linux = {
       name = "arm64";
-      sha256 = "0p3gjv36a82xyps20drm7h0vm0jmz5gd930ynwr3iy46md41hgyv";
+      sha256 = "db410c1df80748827b4e25ff3abceee29e28305a0a7e30e4e39bb5c7e32f1aa2";
     };
     armv7l-linux = {
       name = "arm";
-      sha256 = "0z9q3mqhfwb341mk5p1d3vp6mfwffcdk68968jy1qr2ga2s34wpb";
+      sha256 = "abcdaf44aeb2ad4e769709ec4fe971e259b23d297a98f58199c7bdf26db82e84";
     };
   };
 
   platform = supported.${system} or (throw "unsupported platform ${system}");
 
-  version = "750";
+  version = "766";
 
   url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
-
-  assert !acceptLicense -> throw ''
-    Use of the "SEGGER JLink Software and Documentation pack" requires the
-    acceptance of the following licenses:
-
-      - SEGGER Downloads Terms of Use [1]
-      - SEGGER Software Licensing [2]
-
-    You can express acceptance by setting acceptLicense to true in your
-    configuration. Note that this is not a free license so it requires allowing
-    unfree licenses as well.
-
-    configuration.nix:
-      nixpkgs.config.allowUnfree = true;
-      nixpkgs.config.segger-jlink.acceptLicense = true;
-
-    config.nix:
-      allowUnfree = true;
-      segger-jlink.acceptLicense = true;
-
-    [1]: ${url}
-    [2]: https://www.segger.com/purchase/licensing/
-  '';
 
 in stdenv.mkDerivation {
   pname = "segger-jlink";
   inherit version;
 
-  src = fetchurl {
-    inherit url;
-    inherit (platform) sha256;
-    curlOpts = "--data accept_license_agreement=accepted";
-  };
+  src =
+    assert !acceptLicense -> throw ''
+      Use of the "SEGGER JLink Software and Documentation pack" requires the
+      acceptance of the following licenses:
+
+        - SEGGER Downloads Terms of Use [1]
+        - SEGGER Software Licensing [2]
+
+      You can express acceptance by setting acceptLicense to true in your
+      configuration. Note that this is not a free license so it requires allowing
+      unfree licenses as well.
+
+      configuration.nix:
+        nixpkgs.config.allowUnfree = true;
+        nixpkgs.config.segger-jlink.acceptLicense = true;
+
+      config.nix:
+        allowUnfree = true;
+        segger-jlink.acceptLicense = true;
+
+      [1]: ${url}
+      [2]: https://www.segger.com/purchase/licensing/
+    '';
+      fetchurl {
+        inherit url;
+        inherit (platform) sha256;
+        curlOpts = "--data accept_license_agreement=accepted";
+      };
 
   # Currently blocked by patchelf bug
   # https://github.com/NixOS/patchelf/pull/275
@@ -131,6 +131,6 @@ in stdenv.mkDerivation {
     homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
     license = licenses.unfree;
     platforms = attrNames supported;
-    maintainers = with maintainers; [ FlorianFranzen reardencode ];
+    maintainers = with maintainers; [ FlorianFranzen ];
   };
 }

--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -1,0 +1,136 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, qt4
+, udev
+, system
+, config
+, acceptLicense ? config.segger-jlink.acceptLicense or false
+}:
+
+let
+  supported = {
+    x86_64-linux = {
+      name = "x86_64";
+      sha256 = "19gh6hlpq4dm3ji9wdf9n435zimybvgkzshdww25j9bdm0dl0595";
+    };
+    i686-linux = {
+      name = "i386";
+      sha256 = "1f0iik519panf3649nxszzh61vss927k7zgr4yx1lj991ba6rjdq";
+    };
+    aarch64-linux = {
+      name = "arm64";
+      sha256 = "0gyka0w7xiphp22vkszkx8bvm46k3pnsxmpg0mzi580gpwh3ay1q";
+    };
+    armv7l-linux = {
+      name = "arm";
+      sha256 = "0ws8l85fl4slvx6d4q779f24ppdwm901kbdbksjl66zn25wz8g33";
+    };
+  };
+
+  platform = supported.${system} or (throw "unsupported platform ${system}");
+
+  version = "720";
+
+  url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
+
+  throwLicense = throw ''
+    Use of the "SEGGER JLink Software and Documentation pack" requires the
+    acceptance of the following licenses:
+
+      - SEGGER Downloads Terms of Use [1]
+      - SEGGER Software Licensing [2]
+
+    You can express acceptance by setting acceptLicense to true in your
+    configuration. Note that this is not a free license so it requires allowing
+    unfree licenses as well.
+
+    configuration.nix:
+      nixpkgs.config.allowUnfree = true;
+      nixpkgs.config.segger-jlink.acceptLicense = true;
+
+    config.nix:
+      allowUnfree = true;
+      segger-jlink.acceptLicense = true;
+
+    [1]: ${url}
+    [2]: https://www.segger.com/purchase/licensing/
+  '';
+
+in stdenv.mkDerivation {
+  pname = "segger-jlink";
+  inherit version;
+
+  src = assert !acceptLicense -> throwLicense; fetchurl {
+    inherit url;
+    inherit (platform) sha256;
+    curlOpts = "--data accept_license_agreement=accepted";
+  };
+
+  # Currently blocked by patchelf bug
+  # https://github.com/NixOS/patchelf/pull/275
+  #runtimeDependencies = [ udev ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ qt4 udev ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    # Install all files to JLink first
+    mkdir -p $out/JLink
+    cp -r * $out/JLink
+
+    # Symlink all binaries into bin
+    mkdir -p $out/bin
+    for prog in $out/JLink/J*; do
+      if test -L $prog; then
+        mv $prog $out/bin
+      else
+        ln -s $prog $out/bin
+      fi
+    done
+
+    # Remove included Qt4
+    rm $out/JLink/libQt*
+
+    ${lib.optionalString (system == "x86_64-linux") ''
+      # Remove 32-bit libs on 64-bit x86 systems
+      rm -r $out/JLink/{x86,lib*_x86.so*}
+    ''}
+
+    ${lib.optionalString (system == "aarch64-linux") ''
+      # Remove 32-bit libs on 64-bit ARM systems
+      rm -r $out/JLink/{arm,lib*_arm.so*}
+    ''}
+
+    # Symlink all libraries into lib
+    mkdir -p $out/lib
+    ln -s $out/JLink/*.so* $out/lib
+
+    # Move docs and examples
+    mkdir -p $out/share
+    mv $out/JLink/Doc $out/share/docs
+    mv $out/JLink/Samples $out/share/examples
+
+    # Move udev rule
+    mkdir -p $out/lib/udev/rules.d
+    mv $out/JLink/99-jlink.rules $out/lib/udev/rules.d/
+  '';
+
+  preFixup = ''
+    # Workaround to setting runtime dependecy
+    patchelf --add-needed libudev.so.1 $out/JLink/libjlinkarm.so
+  '';
+
+  meta = with lib; {
+    description = "J-Link Software and Documentation pack";
+    homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+    license = licenses.unfree;
+    platforms = attrNames supported;
+    maintainers = with maintainers; [ FlorianFranzen reardencode ];
+  };
+}

--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -36,7 +36,7 @@ let
 
   url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
 
-  throwLicense = throw ''
+  assert !acceptLicense -> throw ''
     Use of the "SEGGER JLink Software and Documentation pack" requires the
     acceptance of the following licenses:
 
@@ -63,7 +63,7 @@ in stdenv.mkDerivation {
   pname = "segger-jlink";
   inherit version;
 
-  src = assert !acceptLicense -> throwLicense; fetchurl {
+  src = fetchurl {
     inherit url;
     inherit (platform) sha256;
     curlOpts = "--data accept_license_agreement=accepted";

--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -14,25 +14,25 @@ let
   supported = {
     x86_64-linux = {
       name = "x86_64";
-      sha256 = "19gh6hlpq4dm3ji9wdf9n435zimybvgkzshdww25j9bdm0dl0595";
+      sha256 = "0cmd9ny6mslj9260scply573gbmn6k5r9wyxmcbjb14k4b3sldic";
     };
     i686-linux = {
       name = "i386";
-      sha256 = "1f0iik519panf3649nxszzh61vss927k7zgr4yx1lj991ba6rjdq";
+      sha256 = "1jjh5a8y17ma369s9k0xlyr8i10v2r1kxmv0i9v4cix5dnjyq0pp";
     };
     aarch64-linux = {
       name = "arm64";
-      sha256 = "0gyka0w7xiphp22vkszkx8bvm46k3pnsxmpg0mzi580gpwh3ay1q";
+      sha256 = "0p3gjv36a82xyps20drm7h0vm0jmz5gd930ynwr3iy46md41hgyv";
     };
     armv7l-linux = {
       name = "arm";
-      sha256 = "0ws8l85fl4slvx6d4q779f24ppdwm901kbdbksjl66zn25wz8g33";
+      sha256 = "0z9q3mqhfwb341mk5p1d3vp6mfwffcdk68968jy1qr2ga2s34wpb";
     };
   };
 
   platform = supported.${system} or (throw "unsupported platform ${system}");
 
-  version = "720";
+  version = "750";
 
   url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16297,6 +16297,8 @@ with pkgs;
 
   scss-lint = callPackage ../development/tools/scss-lint { };
 
+  segger-jlink = callPackage ../development/tools/misc/segger-jlink { };
+
   segger-ozone = callPackage ../development/tools/misc/segger-ozone { };
 
   selene = callPackage ../development/tools/selene {


### PR DESCRIPTION
###### Description of changes

This PR continues the stale / abandoned #121601 , and fixes the syntax error regarding the license file.

Based on the work by @FlorianFranzen and @reardencode .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
