### PR TITLE
headless: Don't use deprecated vesa.

### DIFF
--- a/nixos/modules/profiles/headless.nix
+++ b/nixos/modules/profiles/headless.nix
@@ -6,8 +6,6 @@
 with lib;
 
 {
-  boot.vesa = false;
-
   # Don't start a tty on the serial consoles.
   systemd.services."serial-getty@ttyS0".enable = lib.mkDefault false;
   systemd.services."serial-getty@hvc0".enable = false;
@@ -15,7 +13,7 @@ with lib;
   systemd.services."autovt@".enable = false;
 
   # Since we can't manually respond to a panic, just reboot.
-  boot.kernelParams = [ "panic=1" "boot.panic_on_fail" ];
+  boot.kernelParams = [ "panic=1" "boot.panic_on_fail" "vga=0x317" "nomodeset" ];
 
   # Don't allow emergency mode, because we don't have a console.
   systemd.enableEmergencyMode = false;


### PR DESCRIPTION
###### Description of changes

This option is deprecated as per https://github.com/NixOS/nixpkgs/pull/76481. So I applied recommendation.

###### Things done
I didn't test since the value was already to false. The recommendation was merged so it seem safe to apply.