### PR TITLE
prusa-slicer: fix boost 1.79 incompatibility

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -1,8 +1,39 @@
-{ stdenv, lib, fetchFromGitHub, cmake, copyDesktopItems, makeDesktopItem
-, pkg-config, wrapGAppsHook, boost, cereal, cgal_5, curl, dbus, eigen, expat
-, glew, glib, gmp, gtest, gtk3, hicolor-icon-theme, ilmbase, libpng, mpfr, nlopt
-, openvdb, pcre, qhull, systemd, tbb, wxGTK31-gtk3, xorg, fetchpatch
-, wxGTK31-gtk3-override ? null }:
+{ stdenv
+, lib
+, binutils
+, fetchFromGitHub
+, cmake
+, copyDesktopItems
+, makeDesktopItem
+, pkg-config
+, wrapGAppsHook
+, boost
+, cereal
+, cgal_5
+, curl
+, dbus
+, eigen
+, expat
+, glew
+, glib
+, gmp
+, gtest
+, gtk3
+, hicolor-icon-theme
+, ilmbase
+, libpng
+, mpfr
+, nlopt
+, openvdb
+, pcre
+, qhull
+, systemd
+, tbb
+, wxGTK31-gtk3
+, xorg
+, fetchpatch
+, wxGTK31-gtk3-override ? null
+}:
 let
   wxGTK31-gtk3-prusa = wxGTK31-gtk3.overrideAttrs (old: rec {
     pname = "wxwidgets-prusa3d-patched";
@@ -16,7 +47,8 @@ let
     };
   });
   wxGTK31-gtk3-override' = if wxGTK31-gtk3-override == null then wxGTK31-gtk3-prusa else wxGTK31-gtk3-override;
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "prusa-slicer";
   version = "2.4.2";
 
@@ -28,6 +60,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    binutils
     boost
     cereal
     cgal_5
@@ -57,6 +90,16 @@ in stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://github.com/prusa3d/PrusaSlicer/commit/76f4d6fa98bda633694b30a6e16d58665a634680.patch";
       sha256 = "1r806ycp704ckwzgrw1940hh1l6fpz0k1ww3p37jdk6mygv53nv6";
+    })
+    # Fix compile error with boost 1.79. See https://github.com/prusa3d/PrusaSlicer/issues/8238
+    # Can be removed with the next version update
+    (fetchpatch {
+      url = "https://github.com/prusa3d/PrusaSlicer/commit/408e56f0390f20aaf793e0aa0c70c4d9544401d4.patch";
+      sha256 = "sha256-vzEPjLE3Yy5szawPn2Yp3i7MceWewpdnLUPVu9+H3W8=";
+    })
+    (fetchpatch {
+      url = "https://github.com/prusa3d/PrusaSlicer/commit/926ae0471800abd1e5335e251a5934570eb8f6ff.patch";
+      sha256 = "sha256-tAEgubeGGKFWY7r7p/6pmI2HXUGKi2TM1X5ILVZVT20=";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

Since the update of boost to 1.79, prusa-slicer will not compile anymore. This has been fixed by upstream und the patches are now included here.

Also add binutils, because g++ doesn't seem to find `as` otherwise and run nixfmt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
