### PR TITLE
treewide: start cleaning up maintainer-list

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9371,10 +9371,6 @@
     githubId = 20391;
     name = "Nahum Shalman";
   };
-  nslqqq = {
-    email = "nslqqq@gmail.com";
-    name = "Nikita Mikhailov";
-  };
   nthorne = {
     email = "notrupertthorne@gmail.com";
     github = "nthorne";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1627,10 +1627,6 @@
     githubId = 30630233;
     name = "Timo Triebensky";
   };
-  bjg = {
-    email = "bjg@gnu.org";
-    name = "Brian Gough";
-  };
   bjornfor = {
     email = "bjorn.forsman@gmail.com";
     github = "bjornfor";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9064,10 +9064,6 @@
     githubId = 6391776;
     name = "Nikita Voloboev";
   };
-  nfjinjing = {
-    email = "nfjinjing@gmail.com";
-    name = "Jinjing Wang";
-  };
   ngiger = {
     email = "niklaus.giger@member.fsf.org";
     github = "ngiger";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8883,12 +8883,6 @@
     githubId = 220262;
     name = "Ion Mudreac";
   };
-  muflax = {
-    email = "mail@muflax.com";
-    github = "muflax";
-    githubId = 69918;
-    name = "Stefan Dorn";
-  };
   multun = {
     email = "victor.collod@epita.fr";
     github = "multun";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9421,10 +9421,6 @@
     githubId = 7249506;
     name = "oida";
   };
-  okasu = {
-    email = "oka.sux@gmail.com";
-    name = "Okasu";
-  };
   olcai = {
     email = "dev@timan.info";
     github = "olcai";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8733,10 +8733,6 @@
     githubId = 839693;
     name = "Ingolf Wanger";
   };
-  msackman = {
-    email = "matthew@wellquite.org";
-    name = "Matthew Sackman";
-  };
   mschneider = {
     email = "markus.schneider.sic+nix@gmail.com";
     name = "Markus Schneider";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -578,10 +578,6 @@
     githubId = 11599075;
     name = "Pierre-Louis Braun";
   };
-  all = {
-    email = "nix-commits@lists.science.uu.nl";
-    name = "Nix Committers";
-  };
   allonsy = {
     email = "linuxbash8@gmail.com";
     github = "allonsy";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7110,19 +7110,6 @@
     githubId = 621759;
     name = "Lassulus";
   };
-  lattfein = {
-    email = "lattfein@gmail.com";
-    # Their GitHub account was deleted.
-    #
-    # See: https://github.com/NixOS/nixpkgs/pull/69007 where this
-    # was added but is now owned by a ghost.
-    #
-    # Possibly the username lattfein (currently github ID 56827487) is
-    # owned by the same person, but we should confirm before adding
-    # the GitHub name or ID back.
-    # github = "lattfein";
-    name = "Koki Yasuno";
-  };
   layus = {
     email = "layus.on@gmail.com";
     github = "layus";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1342,10 +1342,6 @@
     githubId = 35324;
     name = "Badi' Abdul-Wahid";
   };
-  balajisivaraman = {
-    email = "sivaraman.balaji@gmail.com";
-    name = "Balaji Sivaraman";
-  };
   balodja = {
     email = "balodja@gmail.com";
     github = "balodja";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9901,13 +9901,6 @@
     githubId = 152312;
     name = "Periklis Tsirakidis";
   };
-  petabyteboy = {
-    email = "milan@petabyte.dev";
-    matrix = "@milan:petabyte.dev";
-    github = "petabyteboy";
-    githubId = 3250809;
-    name = "Milan Pässler";
-  };
   petercommand = {
     email = "petercommand@gmail.com";
     github = "petercommand";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9105,6 +9105,7 @@
   nessdoor = {
     name = "Tomas Antonio Lopez";
     email = "entropy.overseer@protonmail.com";
+    github = "nessdoor";
     githubId = 25993494;
   };
   netcrns = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7641,10 +7641,6 @@
     githubId = 39707188;
     name = "Lynn Dong";
   };
-  lyt = {
-    email = "wheatdoge@gmail.com";
-    name = "Tim Liou";
-  };
   m00wl = {
     name = "Moritz Lumme";
     email = "moritz.lumme@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11285,10 +11285,6 @@
     githubId = 5104601;
     name = "schnusch";
   };
-  schristo = {
-    email = "schristopher@konputa.com";
-    name = "Scott Christopher";
-  };
   sciencentistguy = {
     email = "jamie@quigley.xyz";
     name = "Jamie Quigley";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5100,10 +5100,6 @@
     github = "hiljusti";
     githubId = 17605298;
   };
-  hinton = {
-    email = "t@larkery.com";
-    name = "Tom Hinton";
-  };
   hirenashah = {
     email = "hiren@hiren.io";
     github = "hirenashah";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2162,10 +2162,6 @@
     githubId = 89596;
     name = "Florian Friesdorf";
   };
-  chattered = {
-    email = "me@philscotted.com";
-    name = "Phil Scott";
-  };
   chekoopa = {
     email = "chekoopa@mail.ru";
     github = "chekoopa";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13493,10 +13493,6 @@
     github = "wdavidw";
     githubId = 46896;
   };
-  wedens = {
-    email = "kirill.wedens@gmail.com";
-    name = "wedens";
-  };
   WeebSorceress = {
     name = "WeebSorceress";
     email = "hello@weebsorceress.anonaddy.me";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13613,10 +13613,6 @@
     githubId = 5185341;
     name = "Will Cohen";
   };
-  winden = {
-    email = "windenntw@gmail.com";
-    name = "Antonio Vargas Gonzalez";
-  };
   winpat = {
     email = "patrickwinter@posteo.ch";
     github = "winpat";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3900,10 +3900,6 @@
     githubId = 2544204;
     name = "Erik Skytthe";
   };
-  Esteth = {
-    email = "adam.copp@gmail.com";
-    name = "Adam Copp";
-  };
   ethancedwards8 = {
     email = "ethan@ethancedwards.com";
     github = "ethancedwards8";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13559,6 +13559,8 @@
   };
   vq = {
     email = "vq@erq.se";
+    github = "vq";
+    githubId = 230381;
     name = "Daniel Nilsson";
   };
   vrinek = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6768,10 +6768,6 @@
     github = "kjeremy";
     githubId = 4325700;
   };
-  kkallio = {
-    email = "tierpluspluslists@gmail.com";
-    name = "Karn Kallio";
-  };
   klden = {
     name = "Kenzyme Le";
     email = "kl@kenzymele.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6614,6 +6614,8 @@
   };
   karolchmist = {
     email = "info+nix@chmist.com";
+    github = "karolchmist";
+    githubId = 1927188;
     name = "karolchmist";
   };
   kayhide = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7511,10 +7511,6 @@
     githubId = 1597330;
     name = "Leonardo Romor";
   };
-  lrworth = {
-    email = "luke@worth.id.au";
-    name = "Luke Worth";
-  };
   lschuermann = {
     email = "leon.git@is.currently.online";
     matrix = "@leons:is.currently.online";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6116,10 +6116,6 @@
     githubId = 336631;
     name = "Joel Moberg";
   };
-  joelteon = {
-    email = "me@joelt.io";
-    name = "Joel Taylor";
-  };
   joepie91 = {
     email = "admin@cryto.net";
     matrix = "@joepie91:pixie.town";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7665,10 +7665,6 @@
     githubId = 3044438;
     name = "Lucas Savva";
   };
-  m3tti = {
-    email = "mathaeus.peter.sander@gmail.com";
-    name = "Mathaeus Sander";
-  };
   ma27 = {
     email = "maximilian@mbosch.me";
     matrix = "@ma27:nicht-so.sexy";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11728,10 +11728,6 @@
     githubId = 158321;
     name = "Stewart Mackenzie";
   };
-  sjourdois = {
-    email = "sjourdois@gmail.com";
-    name = "Stéphane ‘kwisatz’ Jourdois";
-  };
   skeidel = {
     email = "svenkeidel@gmail.com";
     github = "svenkeidel";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13607,10 +13607,6 @@
     githubId = 20464732;
     name = "Willi Butz";
   };
-  willtim = {
-    email = "tim.williams.public@gmail.com";
-    name = "Tim Philip Williams";
-  };
   willcohen = {
     email = "willcohen@users.noreply.github.com";
     github = "willcohen";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8733,10 +8733,6 @@
     githubId = 839693;
     name = "Ingolf Wanger";
   };
-  mschneider = {
-    email = "markus.schneider.sic+nix@gmail.com";
-    name = "Markus Schneider";
-  };
   mschristiansen = {
     email = "mikkel@rheosystems.com";
     github = "mschristiansen";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10477,10 +10477,6 @@
     githubId = 25647735;
     name = "Victor Freire";
   };
-  ravloony = {
-    email = "ravloony@gmail.com";
-    name = "Tom Macdonald";
-  };
   rawkode = {
     email = "david.andrew.mckay@gmail.com";
     github = "rawkode";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8941,10 +8941,6 @@
       fingerprint = "7A10 AB8E 0BEC 566B 090C  9BE3 D812 6E55 9CE7 C35D";
     }];
   };
-  Nate-Devv = {
-    email = "natedevv@gmail.com";
-    name = "Nathan Moore";
-  };
   nathanruiz = {
     email = "nathanruiz@protonmail.com";
     github = "nathanruiz";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8239,10 +8239,6 @@
     githubId = 6412377;
     name = "Samuel Ruprecht";
   };
-  metabar = {
-    email = "softs@metabarcoding.org";
-    name = "Celine Mercier";
-  };
   kira-bruneau = {
     email = "kira.bruneau@pm.me";
     name = "Kira Bruneau";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8358,10 +8358,6 @@
     githubId = 5378535;
     name = "Milo Gertjejansen";
   };
-  miltador = {
-    email = "miltador@yandex.ua";
-    name = "Vasiliy Solovey";
-  };
   mimame = {
     email = "miguel.madrid.mencia@gmail.com";
     github = "mimame";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4483,12 +4483,6 @@
     githubId = 893115;
     name = "Mateusz Kowalczyk";
   };
-  fuwa = {
-    email = "echowss@gmail.com";
-    github = "fuwa0529";
-    githubId = 40521440;
-    name = "Haruka Akiyama";
-  };
   fuzen = {
     email = "me@fuzen.cafe";
     github = "Fuzen-py";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2791,12 +2791,6 @@
     githubId = 24708079;
     name = "Dan Eads";
   };
-  danharaj = {
-    email = "dan@obsidian.systems";
-    github = "danharaj";
-    githubId = 23366017;
-    name = "Dan Haraj";
-  };
   danielbarter = {
     email = "danielbarter@gmail.com";
     github = "danielbarter";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7844,10 +7844,6 @@
     githubId = 26470037;
     name = "Markus Kowalewski";
   };
-  markWot = {
-    email = "markus@wotringer.de";
-    name = "Markus Wotringer";
-  };
   marijanp = {
     name = "Marijan Petričević";
     email = "marijan.petricevic94@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2860,10 +2860,6 @@
     githubId = 7589338;
     name = "Daniel Șerbănescu";
   };
-  dasuxullebt = {
-    email = "christoph.senjak@googlemail.com";
-    name = "Christoph-Simon Senjak";
-  };
   datafoo = {
     email = "34766150+datafoo@users.noreply.github.com";
     github = "datafoo";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10029,10 +10029,6 @@
       fingerprint = "D03B 218C AE77 1F77 D7F9  20D9 823A 6154 4264 08D3";
     }];
   };
-  piotr = {
-    email = "ppietrasa@gmail.com";
-    name = "Piotr Pietraszkiewicz";
-  };
   pjbarnoy = {
     email = "pjbarnoy@gmail.com";
     github = "pjbarnoy";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11750,10 +11750,6 @@
     githubId = 266500;
     name = "Sven Keidel";
   };
-  skrzyp = {
-    email = "jot.skrzyp@gmail.com";
-    name = "Jakub Skrzypnik";
-  };
   skykanin = {
     email = "skykanin@users.noreply.github.com";
     github = "skykanin";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7703,6 +7703,7 @@
   };
   lux = {
     email = "lux@lux.name";
+    github = "luxferresum";
     githubId = 1208273;
     matrix = "@lux:ontheblueplanet.com";
     name = "Lux";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3748,12 +3748,6 @@
     githubId = 1365692;
     name = "Will Fancher";
   };
-  elyhaka = {
-    email = "elyhaka@protonmail.com";
-    github = "Elyhaka";
-    githubId = 57923898;
-    name = "Elyhaka";
-  };
   emmabastas = {
     email = "emma.bastas@protonmail.com";
     matrix = "@emmabastas:matrix.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13541,12 +13541,6 @@
     githubId = 5604643;
     name = "Mikhail Volkhov";
   };
-  volth = {
-    email = "jaroslavas@volth.com";
-    github = "volth";
-    githubId = 508305;
-    name = "Jaroslavas Pocepko";
-  };
   vonfry = {
     email = "nixos@vonfry.name";
     github = "Vonfry";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5579,6 +5579,8 @@
   };
   ivan-tkatchev = {
     email = "tkatchev@gmail.com";
+    github = "ivan-tkatchev";
+    githubId = 650601;
     name = "Ivan Tkatchev";
   };
   ivanbrennan = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1670,12 +1670,6 @@
     githubId = 37907;
     name = "Julian Stecklina";
   };
-  bloomvdomino = {
-    name = "Laura Fäßler";
-    email = "0x@ytex.de";
-    github = "bloomvdomino";
-    githubId = 33204710;
-  };
   bluescreen303 = {
     email = "mathijs@bluescreen303.nl";
     github = "bluescreen303";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4435,10 +4435,6 @@
     githubId = 36706276;
     name = "Fufezan Mihai";
   };
-  funfunctor = {
-    email = "eocallaghan@alterapraxis.com";
-    name = "Edward O'Callaghan";
-  };
   fusion809 = {
     email = "brentonhorne77@gmail.com";
     github = "fusion809";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3796,10 +3796,6 @@
     githubId = 5085029;
     name = "Emanuele Peruffo";
   };
-  epitrochoid = {
-    email = "mpcervin@uncg.edu";
-    name = "Mabry Cervin";
-  };
   equirosa = {
     email = "eduardo@eduardoquiros.com";
     github = "equirosa";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6461,10 +6461,6 @@
     githubId = 46386452;
     name = "Jeroen Wijenbergh";
   };
-  jwilberding = {
-    email = "jwilberding@afiniate.com";
-    name = "Jordan Wilberding";
-  };
   jwoudenberg = {
     email = "nixpkgs@jasperwoudenberg.com";
     github = "jwoudenberg";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8239,12 +8239,6 @@
     githubId = 1788114;
     name = "Meghea Iulian";
   };
-  mehandes = {
-    email = "niewskici@gmail.com";
-    github = "mehandes";
-    githubId = 32581276;
-    name = "Matt Deming";
-  };
   meisternu = {
     email = "meister@krutt.org";
     github = "meisternu";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3363,10 +3363,6 @@
     githubId = 6199462;
     name = "Dmytro Rets";
   };
-  drewkett = {
-    email = "burkett.andrew@gmail.com";
-    name = "Andrew Burkett";
-  };
   drewrisinger = {
     email = "drisinger+nixpkgs@gmail.com";
     github = "drewrisinger";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4453,10 +4453,6 @@
     githubId = 17859309;
     name = "Fuzen";
   };
-  fuzzy-id = {
-    email = "hacking+nixos@babibo.de";
-    name = "Thomas Bach";
-  };
   fxfactorial = {
     email = "edgar.factorial@gmail.com";
     github = "fxfactorial";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13000,10 +13000,6 @@
     githubId = 15064765;
     name = "tshaynik";
   };
-  tstrobel = {
-    email = "4ZKTUB6TEP74PYJOPWIR013S2AV29YUBW5F9ZH2F4D5UMJUJ6S@hash.domains";
-    name = "Thomas Strobel";
-  };
   ttuegel = {
     email = "ttuegel@mailbox.org";
     github = "ttuegel";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14028,10 +14028,6 @@
     githubId = 1557253;
     name = "Lennart Eichhorn";
   };
-  zef = {
-    email = "zef@zef.me";
-    name = "Zef Hemel";
-  };
   zeratax = {
     email = "mail@zera.tax";
     github = "zeratax";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3020,6 +3020,8 @@
   };
   delta = {
     email = "d4delta@outlook.fr";
+    github = "D4Delta";
+    githubId = 12224254;
     name = "Delta";
   };
   deltadelta = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -207,7 +207,7 @@
   };
   abigailbuccaneer = {
     email = "abigailbuccaneer@gmail.com";
-    github = "abigailbuccaneer";
+    github = "AbigailBuccaneer";
     githubId = 908758;
     name = "Abigail Bunyan";
   };
@@ -329,7 +329,7 @@
   };
   aethelz = {
     email = "aethelz@protonmail.com";
-    github = "aethelz";
+    github = "eugenezastrogin";
     githubId = 10677343;
     name = "Eugene";
   };
@@ -523,7 +523,7 @@
   alexnortung = {
     name = "alexnortung";
     email = "alex_nortung@live.dk";
-    github = "alexnortung";
+    github = "Alexnortung";
     githubId = 1552267;
   };
   alexshpilkin = {
@@ -556,7 +556,7 @@
   };
   alibabzo = {
     email = "alistair.bill@gmail.com";
-    github = "alibabzo";
+    github = "alistairbill";
     githubId = 2822871;
     name = "Alistair Bill";
   };
@@ -617,7 +617,7 @@
   };
   alva = {
     email = "alva@skogen.is";
-    github = "fjallarefur";
+    github = "illfygli";
     githubId = 42881386;
     name = "Alva";
     keys = [{
@@ -641,7 +641,7 @@
   };
   amar1729 = {
     email = "amar.paul16@gmail.com";
-    github = "amar1729";
+    github = "Amar1729";
     githubId = 15623522;
     name = "Amar Paul";
   };
@@ -707,7 +707,7 @@
   };
   amorsillo = {
     email = "andrew.morsillo@gmail.com";
-    github = "AndrewMorsillo";
+    github = "evelant";
     githubId = 858965;
     name = "Andrew Morsillo";
   };
@@ -1035,13 +1035,13 @@
   };
   arnoutkroeze = {
     email = "nixpkgs@arnoutkroeze.nl";
-    github = "arnoutkroeze";
+    github = "ArnoutKroeze";
     githubId = 37151054;
     name = "Arnout Kroeze";
   };
   arobyn = {
     email = "shados@shados.net";
-    github = "shados";
+    github = "Shados";
     githubId = 338268;
     name = "Alexei Robyn";
   };
@@ -1174,7 +1174,7 @@
   };
   atnnn = {
     email = "etienne@atnnn.com";
-    github = "atnnn";
+    github = "AtnNn";
     githubId = 706854;
     name = "Etienne Laurin";
   };
@@ -1216,7 +1216,7 @@
   };
   avaq = {
     email = "nixpkgs@account.avaq.it";
-    github = "avaq";
+    github = "Avaq";
     githubId = 1217745;
     name = "Aldwin Vlasblom";
   };
@@ -1274,7 +1274,7 @@
   artturin = {
     email = "artturin@artturin.com";
     matrix = "@artturin:matrix.org";
-    github = "artturin";
+    github = "Artturin";
     githubId = 56650223;
     name = "Artturi N";
   };
@@ -1290,7 +1290,7 @@
   };
   ayazhafiz = {
     email = "ayaz.hafiz.1@gmail.com";
-    github = "ayazhafiz";
+    github = "hafiz";
     githubId = 262763;
     name = "Ayaz Hafiz";
   };
@@ -1370,7 +1370,7 @@
   };
   bandresen = {
     email = "bandresen@gmail.com";
-    github = "bandresen";
+    github = "bennyandresen";
     githubId = 80325;
     name = "Benjamin Andresen";
   };
@@ -1782,7 +1782,7 @@
   };
   brainrape = {
     email = "martonboros@gmail.com";
-    github = "brainrape";
+    github = "brainrake";
     githubId = 302429;
     name = "Marton Boros";
   };
@@ -1904,7 +1904,7 @@
   };
   builditluc = {
     email = "builditluc@icloud.com";
-    github = "builditluc";
+    github = "Builditluc";
     githubId = 37375448;
     name = "Buildit";
   };
@@ -1991,7 +1991,7 @@
   };
   cameronnemo = {
     email = "cnemo@tutanota.com";
-    github = "cameronnemo";
+    github = "CameronNemo";
     githubId = 3212452;
     name = "Cameron Nemo";
   };
@@ -2263,7 +2263,7 @@
   };
   chrisjefferson = {
     email = "chris@bubblescope.net";
-    github = "chrisjefferson";
+    github = "ChrisJefferson";
     githubId = 811527;
     name = "Christopher Jefferson";
   };
@@ -2343,7 +2343,7 @@
   };
   citadelcore = {
     email = "alex@arctarus.co.uk";
-    github = "citadelcore";
+    github = "CitadelCore";
     githubId = 5567402;
     name = "Alex Zero";
     keys = [{
@@ -2432,7 +2432,7 @@
   };
   cmcdragonkai = {
     email = "roger.qiu@matrix.ai";
-    github = "cmcdragonkai";
+    github = "CMCDragonkai";
     githubId = 640797;
     name = "Roger Qiu";
   };
@@ -2560,7 +2560,7 @@
   congee = {
     email = "changshengwu@pm.me";
     matrix = "@congeec:matrix.org";
-    github = "congee";
+    github = "Congee";
     name = "Changsheng Wu";
     githubId = 2083950;
   };
@@ -2632,7 +2632,7 @@
   };
   creator54 = {
     email = "hi.creator54@gmail.com";
-    github = "creator54";
+    github = "Creator54";
     githubId = 34543609;
     name = "creator54";
   };
@@ -2982,7 +2982,7 @@
   dearrude = {
     name = "Ebrahim Nejati";
     email = "dearrude@tfwno.gf";
-    github = "dearrude";
+    github = "DearRude";
     githubId = 30749142;
     keys = [{
       fingerprint = "4E35 F2E5 2132 D654 E815  A672 DB2C BC24 2868 6000";
@@ -3162,7 +3162,7 @@
   };
   diegolelis = {
     email = "diego.o.lelis@gmail.com";
-    github = "diegolelis";
+    github = "DiegoLelis";
     githubId = 8404455;
     name = "Diego Lelis";
   };
@@ -3174,7 +3174,7 @@
   };
   diffumist = {
     email = "git@diffumist.me";
-    github = "diffumist";
+    github = "Diffumist";
     githubId = 32810399;
     name = "Diffumist";
   };
@@ -3216,7 +3216,7 @@
   };
   dizfer = {
     email = "david@izquierdofernandez.com";
-    github = "dizfer";
+    github = "DIzFer";
     githubId = 8852888;
     name = "David Izquierdo";
   };
@@ -3490,7 +3490,7 @@
   };
   e-user = {
     email = "nixos@sodosopa.io";
-    github = "e-user";
+    github = "outergod";
     githubId = 93086;
     name = "Alexander Kahl";
   };
@@ -3578,7 +3578,7 @@
   };
   emantor = {
     email = "rouven+nixos@czerwinskis.de";
-    github = "emantor";
+    github = "Emantor";
     githubId = 934284;
     name = "Rouven Czerwinski";
   };
@@ -3663,7 +3663,7 @@
   ekleog = {
     email = "leo@gaspard.io";
     matrix = "@leo:gaspard.ninja";
-    github = "ekleog";
+    github = "Ekleog";
     githubId = 411447;
     name = "Leo Gaspard";
   };
@@ -3879,7 +3879,7 @@
   ericson2314 = {
     email = "John.Ericson@Obsidian.Systems";
     matrix = "@ericson2314:matrix.org";
-    github = "ericson2314";
+    github = "Ericson2314";
     githubId = 1055245;
     name = "John Ericson";
   };
@@ -3918,7 +3918,7 @@
   };
   ersin = {
     email = "me@ersinakinci.com";
-    github = "earksiinni";
+    github = "DesertDevErsin";
     githubId = 5427394;
     name = "Ersin Akinci";
   };
@@ -4043,7 +4043,7 @@
   };
   exfalso = {
     email = "0slemi0@gmail.com";
-    github = "exfalso";
+    github = "exFalso";
     githubId = 1042674;
     name = "Andras Slemmer";
   };
@@ -4169,7 +4169,7 @@
   };
   fedx-sudo = {
     email = "fedx-sudo@pm.me";
-    github = "Fedx-sudo";
+    github = "FedX-sudo";
     githubId = 66258975;
     name = "Fedx sudo";
     matrix = "fedx:matrix.org";
@@ -4348,13 +4348,13 @@
   };
   forkk = {
     email = "forkk@forkk.net";
-    github = "forkk";
+    github = "Forkk";
     githubId = 1300078;
     name = "Andrew Okin";
   };
   fornever = {
     email = "friedrich@fornever.me";
-    github = "fornever";
+    github = "ForNeVeR";
     githubId = 92793;
     name = "Friedrich von Never";
   };
@@ -4389,13 +4389,13 @@
   };
   freax13 = {
     email = "erbse.13@gmx.de";
-    github = "freax13";
+    github = "Freax13";
     githubId = 14952658;
     name = "Tom Dohrmann";
   };
   fredeb = {
     email = "im@fredeb.dev";
-    github = "fredeeb";
+    github = "FredeEB";
     githubId = 7551358;
     name = "Frede Emil";
   };
@@ -4413,7 +4413,7 @@
   };
   fridh = {
     email = "fridh@fridh.nl";
-    github = "fridh";
+    github = "FRidh";
     githubId = 2129135;
     name = "Frederik Rietdijk";
   };
@@ -4483,7 +4483,7 @@
   };
   fuuzetsu = {
     email = "fuuzetsu@fuuzetsu.co.uk";
-    github = "fuuzetsu";
+    github = "Fuuzetsu";
     githubId = 893115;
     name = "Mateusz Kowalczyk";
   };
@@ -4495,7 +4495,7 @@
   };
   fuzen = {
     email = "me@fuzen.cafe";
-    github = "fuzen-py";
+    github = "Fuzen-py";
     githubId = 17859309;
     name = "Fuzen";
   };
@@ -4517,7 +4517,7 @@
   };
   Gabriel439 = {
     email = "Gabriel439@gmail.com";
-    github = "Gabriel439";
+    github = "Gabriella439";
     githubId = 1313787;
     name = "Gabriel Gonzalez";
   };
@@ -4544,7 +4544,7 @@
   };
   galagora = {
     email = "lightningstrikeiv@gmail.com";
-    github = "galagora";
+    github = "Galagora";
     githubId = 45048741;
     name = "Alwanga Oyango";
   };
@@ -4635,7 +4635,7 @@
   ggpeti = {
     email = "ggpeti@gmail.com";
     matrix = "@ggpeti:ggpeti.com";
-    github = "ggpeti";
+    github = "ggPeti";
     githubId = 3217744;
     name = "Peter Ferenczy";
   };
@@ -4689,7 +4689,7 @@
   };
   glenns = {
     email = "glenn.searby@gmail.com";
-    github = "glenns";
+    github = "GlennS";
     githubId = 615606;
     name = "Glenn Searby";
   };
@@ -4756,7 +4756,7 @@
   govanify = {
     name = "Gauvain 'GovanifY' Roussel-Tarbouriech";
     email = "gauvain@govanify.com";
-    github = "govanify";
+    github = "GovanifY";
     githubId = 6375438;
     keys = [{
       fingerprint = "5214 2D39 A7CE F8FA 872B  CA7F DE62 E1E2 A614 5556";
@@ -4945,7 +4945,7 @@
   };
   hanemile = {
     email = "mail@emile.space";
-    github = "hanemile";
+    github = "HanEmile";
     githubId = 22756350;
     name = "Emile Hansmaennel";
   };
@@ -4957,7 +4957,7 @@
   };
   HaoZeke = {
     email = "r95g10@gmail.com";
-    github = "haozeke";
+    github = "HaoZeke";
     githubId = 4336207;
     name = "Rohit Goswami";
     keys = [{
@@ -5000,7 +5000,7 @@
   };
   havvy = {
     email = "ryan.havvy@gmail.com";
-    github = "havvy";
+    github = "Havvy";
     githubId = 731722;
     name = "Ryan Scheel";
   };
@@ -5052,7 +5052,7 @@
   };
   heel = {
     email = "parizhskiy@gmail.com";
-    github = "heel";
+    github = "HeeL";
     githubId = 287769;
     name = "Sergii Paryzhskyi";
   };
@@ -5179,7 +5179,7 @@
   hleboulanger = {
     email = "hleboulanger@protonmail.com";
     name = "Harold Leboulanger";
-    github = "thbkrhsw";
+    github = "thbkrshw";
     githubId = 33122;
   };
   hlolli = {
@@ -5190,7 +5190,7 @@
   };
   hugoreeves = {
     email = "hugo@hugoreeves.com";
-    github = "hugoreeves";
+    github = "HugoReeves";
     githubId = 20039091;
     name = "Hugo Reeves";
     keys = [{
@@ -5236,7 +5236,7 @@
   hoverbear = {
     email = "operator+nix@hoverbear.org";
     matrix = "@hoverbear:matrix.org";
-    github = "hoverbear";
+    github = "Hoverbear";
     githubId = 130903;
     name = "Ana Hobden";
   };
@@ -5333,7 +5333,7 @@
   iammrinal0 = {
     email = "nixpkgs@mrinalpurohit.in";
     matrix = "@iammrinal0:nixos.dev";
-    github = "iammrinal0";
+    github = "iAmMrinal0";
     githubId = 890062;
     name = "Mrinal";
   };
@@ -5470,7 +5470,7 @@
   };
   imgabe = {
     email = "gabrielpmonte@hotmail.com";
-    github = "imgabe";
+    github = "ImGabe";
     githubId = 24387926;
     name = "Gabriel Pereira";
   };
@@ -5546,7 +5546,7 @@
   isgy = {
     name = "isgy";
     email = "isgy@teiyg.com";
-    github = "isgy";
+    github = "tgys";
     githubId = 13622947;
     keys = [{
       fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293";
@@ -5625,7 +5625,7 @@
   };
   izorkin = {
     email = "Izorkin@gmail.com";
-    github = "izorkin";
+    github = "Izorkin";
     githubId = 26877687;
     name = "Yurii Izorkin";
   };
@@ -5833,7 +5833,7 @@
   };
   jdanek = {
     email = "jdanek@redhat.com";
-    github = "jdanekrh";
+    github = "jirkadanek";
     githubId = 17877663;
     keys = [{
       fingerprint = "D4A6 F051 AD58 2E7C BCED  5439 6927 5CAD F15D 872E";
@@ -5884,7 +5884,7 @@
   };
   jefflabonte = {
     email = "grimsleepless@protonmail.com";
-    github = "jefflabonte";
+    github = "JeffLabonte";
     githubId = 9425955;
     name = "Jean-François Labonté";
   };
@@ -5908,7 +5908,7 @@
   };
   jeschli = {
     email = "jeschli@gmail.com";
-    github = "Jeschli";
+    github = "0mbi";
     githubId = 10786794;
     name = "Markus Hihn";
   };
@@ -6136,7 +6136,7 @@
   };
   joelancaster = {
     email = "joe.a.lancas@gmail.com";
-    github = "joelancaster";
+    github = "JoeLancaster";
     githubId = 16760945;
     name = "Joe Lancaster";
   };
@@ -6183,7 +6183,7 @@
   };
   johnazoidberg = {
     email = "git@danielschaefer.me";
-    github = "johnazoidberg";
+    github = "JohnAZoidberg";
     githubId = 5307138;
     name = "Daniel Schäfer";
   };
@@ -6195,7 +6195,7 @@
   };
   johnmh = {
     email = "johnmh@openblox.org";
-    github = "johnmh";
+    github = "JohnMH";
     githubId = 2576152;
     name = "John M. Harris, Jr.";
   };
@@ -6548,7 +6548,7 @@
   kaction = {
     name = "Dmitry Bogatov";
     email = "KAction@disroot.org";
-    github = "kaction";
+    github = "KAction";
     githubId = 44864956;
     keys = [{
       fingerprint = "3F87 0A7C A7B4 3731 2F13  6083 749F D4DF A2E9 4236";
@@ -6556,7 +6556,7 @@
   };
   kaiha = {
     email = "kai.harries@gmail.com";
-    github = "kaiha";
+    github = "KaiHa";
     githubId = 6544084;
     name = "Kai Harries";
   };
@@ -6658,7 +6658,7 @@
   };
   kentjames = {
     email = "jameschristopherkent@gmail.com";
-    github = "kentjames";
+    github = "KentJames";
     githubId = 2029444;
     name = "James Kent";
   };
@@ -6702,7 +6702,7 @@
   };
   kho-dialga = {
     email = "ivandashenyou@gmail.com";
-    github = "kho-dialga";
+    github = "Kho-Dialga";
     githubId = 55767703;
     name = "Iván Brito";
   };
@@ -6850,7 +6850,7 @@
     email = "me@kloenk.dev";
     matrix = "@kloenk:petabyte.dev";
     name = "Finn Behrens";
-    github = "kloenk";
+    github = "Kloenk";
     githubId = 12898828;
     keys = [{
       fingerprint = "6881 5A95 D715 D429 659B  48A4 B924 45CF C954 6F9D";
@@ -6943,7 +6943,7 @@
   };
   kovirobi = {
     email = "kovirobi@gmail.com";
-    github = "kovirobi";
+    github = "KoviRobi";
     githubId = 1903418;
     name = "Kovacsics Robert";
   };
@@ -6997,7 +6997,7 @@
   };
   kristian-brucaj = {
     email = "kbrucaj@gmail.com";
-    github = "kristian-brucaj";
+    github = "Kristian-Brucaj";
     githubId = 8893110;
     name = "Kristian Brucaj";
   };
@@ -7051,7 +7051,7 @@
   };
   kyleondy = {
     email = "kyle@ondy.org";
-    github = "kyleondy";
+    github = "KyleOndy";
     githubId = 1640900;
     name = "Kyle Ondy";
     keys = [{
@@ -7226,7 +7226,7 @@
   };
   leemachin = {
     email = "me@mrl.ee";
-    github = "leemachin";
+    github = "leemeichin";
     githubId = 736291;
     name = "Lee Machin";
   };
@@ -7249,7 +7249,7 @@
   leixb = {
     email = "abone9999+nixpkgs@gmail.com";
     matrix = "@leix_b:matrix.org";
-    github = "LeixB";
+    github = "Leixb";
     githubId = 17183803;
     name = "Aleix Boné";
     keys = [{
@@ -7480,7 +7480,7 @@
   };
   lnl7 = {
     email = "daiderd@gmail.com";
-    github = "lnl7";
+    github = "LnL7";
     githubId = 689294;
     name = "Daiderd Jordan";
   };
@@ -7544,7 +7544,7 @@
   };
   louisdk1 = {
     email = "louis@louis.dk";
-    github = "louisdk1";
+    github = "LouisDK1";
     githubId = 4969294;
     name = "Louis Tim Larsen";
   };
@@ -7723,7 +7723,7 @@
   };
   lynty = {
     email = "ltdong93+nix@gmail.com";
-    github = "lynty";
+    github = "Lynty";
     githubId = 39707188;
     name = "Lynn Dong";
   };
@@ -7750,7 +7750,7 @@
   ma27 = {
     email = "maximilian@mbosch.me";
     matrix = "@ma27:nicht-so.sexy";
-    github = "ma27";
+    github = "Ma27";
     githubId = 6025220;
     name = "Maximilian Bosch";
   };
@@ -7866,7 +7866,7 @@
   };
   marcweber = {
     email = "marco-oweber@gmx.de";
-    github = "marcweber";
+    github = "MarcWeber";
     githubId = 34086;
     name = "Marc Weber";
   };
@@ -7975,7 +7975,7 @@
   };
   mathnerd314 = {
     email = "mathnerd314.gph+hs@gmail.com";
-    github = "mathnerd314";
+    github = "Mathnerd314";
     githubId = 322214;
     name = "Mathnerd314";
   };
@@ -8258,7 +8258,7 @@
   };
   melkor333 = {
     email = "samuel@ton-kunst.ch";
-    github = "melkor333";
+    github = "Melkor333";
     githubId = 6412377;
     name = "Samuel Ruprecht";
   };
@@ -8335,7 +8335,7 @@
   mic92 = {
     email = "joerg@thalheim.io";
     matrix = "@mic92:nixos.dev";
-    github = "mic92";
+    github = "Mic92";
     githubId = 96200;
     name = "Jörg Thalheim";
     keys = [{
@@ -8436,7 +8436,7 @@
   };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
-    github = "milesbreslin";
+    github = "MilesBreslin";
     githubId = 38543128;
     name = "Miles Breslin";
   };
@@ -8513,7 +8513,7 @@
   };
   misterio77 = {
     email = "eu@misterio.me";
-    github = "misterio77";
+    github = "Misterio77";
     githubId = 5727578;
     matrix = "@misterio:matrix.org";
     name = "Gabriel Fontes";
@@ -8602,7 +8602,7 @@
   };
   mmesch = {
     email = "mmesch@noreply.github.com";
-    github = "mmesch";
+    github = "MMesch";
     githubId = 2597803;
     name = "Matthias Meschede";
   };
@@ -8678,7 +8678,7 @@
   };
   moredread = {
     email = "code@apb.name";
-    github = "moredread";
+    github = "Moredread";
     githubId = 100848;
     name = "André-Patrick Bubel";
     keys = [{
@@ -8705,13 +8705,13 @@
   };
   mothsart = {
     email = "jerem.ferry@gmail.com";
-    github = "mothsart";
+    github = "mothsART";
     githubId = 10601196;
     name = "Jérémie Ferry";
   };
   mounium = {
     email = "muoniurn@gmail.com";
-    github = "mounium";
+    github = "Mounium";
     githubId = 20026143;
     name = "Katona László";
   };
@@ -8937,7 +8937,7 @@
   };
   myrl = {
     email = "myrl.0xf@gmail.com";
-    github = "myrl";
+    github = "Myrl";
     githubId = 9636071;
     name = "Myrl Hex";
   };
@@ -8949,7 +8949,7 @@
   };
   nadrieril = {
     email = "nadrieril@gmail.com";
-    github = "nadrieril";
+    github = "Nadrieril";
     githubId = 6783654;
     name = "Nadrieril Feneanar";
   };
@@ -9090,7 +9090,7 @@
   };
   nequissimus = {
     email = "tim@nequissimus.com";
-    github = "nequissimus";
+    github = "NeQuissimus";
     githubId = 628342;
     name = "Tim Steinbach";
   };
@@ -9187,7 +9187,7 @@
   };
   nickhu = {
     email = "me@nickhu.co.uk";
-    github = "nickhu";
+    github = "NickHu";
     githubId = 450276;
     name = "Nick Hu";
   };
@@ -9245,7 +9245,7 @@
   ninjatrappeur = {
     email = "felix@alternativebit.fr";
     matrix = "@ninjatrappeur:matrix.org";
-    github = "ninjatrappeur";
+    github = "NinjaTrappeur";
     githubId = 1219785;
     name = "Félix Baylac-Jacqué";
   };
@@ -9281,7 +9281,7 @@
   };
   nkpvk = {
     email = "niko.pavlinek@gmail.com";
-    github = "nkpvk";
+    github = "npavlinek";
     githubId = 16385648;
     name = "Niko Pavlinek";
   };
@@ -9376,7 +9376,7 @@
   };
   notthemessiah = {
     email = "brian.cohen.88@gmail.com";
-    github = "notthemessiah";
+    github = "NOTtheMessiah";
     githubId = 2946283;
     name = "Brian Cohen";
   };
@@ -9574,7 +9574,7 @@
   };
   omnipotententity = {
     email = "omnipotententity@gmail.com";
-    github = "omnipotententity";
+    github = "OmnipotentEntity";
     githubId = 1538622;
     name = "Michael Reilly";
   };
@@ -9640,7 +9640,7 @@
   };
   oro = {
     email = "marco@orovecchia.at";
-    github = "oro";
+    github = "Oro";
     githubId = 357005;
     name = "Marco Orovecchia";
   };
@@ -9703,7 +9703,7 @@
   };
   pablovsky = {
     email = "dealberapablo07@gmail.com";
-    github = "pablo1107";
+    github = "Pablo1107";
     githubId = 17091659;
     name = "Pablo Andres Dealbera";
   };
@@ -9753,7 +9753,7 @@
   };
   panaeon = {
     email = "vitalii.voloshyn@gmail.com";
-    github = "panaeon";
+    github = "PanAeon";
     githubId = 686076;
     name = "Vitalii Voloshyn";
   };
@@ -9772,7 +9772,7 @@
   papojari = {
     email = "papojari-git.ovoid@aleeas.com";
     matrix = "@papojari:artemislena.eu";
-    github = "papojari";
+    github = "auroraanna";
     githubId = 81317317;
     name = "papojari";
   };
@@ -9784,7 +9784,7 @@
   };
   parasrah = {
     email = "nixos@parasrah.com";
-    github = "parasrah";
+    github = "Parasrah";
     githubId = 14935550;
     name = "Brad Pfannmuller";
   };
@@ -9835,7 +9835,7 @@
   };
   payas = {
     email = "relekarpayas@gmail.com";
-    github = "payasrelekar";
+    github = "bhankas";
     githubId = 24254289;
     name = "Payas Relekar";
   };
@@ -10024,7 +10024,7 @@
   };
   pierrer = {
     email = "pierrer@pi3r.be";
-    github = "pierrer";
+    github = "PierreR";
     githubId = 93115;
     name = "Pierre Radermecker";
   };
@@ -10082,7 +10082,7 @@
   };
   pkmx = {
     email = "pkmx.tw@gmail.com";
-    github = "pkmx";
+    github = "PkmX";
     githubId = 610615;
     name = "Chih-Mao Chen";
   };
@@ -10166,7 +10166,7 @@
   };
   pneumaticat = {
     email = "kevin@potatofrom.space";
-    github = "pneumaticat";
+    github = "kliu128";
     githubId = 11365056;
     name = "Kevin Liu";
   };
@@ -10235,7 +10235,7 @@
   };
   pombeirp = {
     email = "nix@endgr.33mail.com";
-    github = "PombeirP";
+    github = "pedropombeiro";
     githubId = 138074;
     name = "Pedro Pombeiro";
   };
@@ -10324,7 +10324,7 @@
   };
   progval = {
     email = "progval+nix@progval.net";
-    github = "ProgVal";
+    github = "progval";
     githubId = 406946;
     name = "Valentin Lorentz";
   };
@@ -10443,7 +10443,7 @@
   };
   peelz = {
     email = "peelz.dev+nixpkgs@gmail.com";
-    github = "louistakepillz";
+    github = "notpeelz";
     githubId = 920910;
     name = "peelz";
   };
@@ -10473,7 +10473,7 @@
   };
   queezle = {
     email = "git@queezle.net";
-    github = "qzle";
+    github = "queezle42";
     githubId = 1024891;
     name = "Jens Nolte";
   };
@@ -10545,13 +10545,13 @@
   ralith = {
     email = "ben.e.saunders@gmail.com";
     matrix = "@ralith:ralith.com";
-    github = "ralith";
+    github = "Ralith";
     githubId = 104558;
     name = "Benjamin Saunders";
   };
   ramkromberg = {
     email = "ramkromberg@mail.com";
-    github = "ramkromberg";
+    github = "RamKromberg";
     githubId = 14829269;
     name = "Ram Kromberg";
   };
@@ -10597,7 +10597,7 @@
   };
   razvan = {
     email = "razvan.panda@gmail.com";
-    github = "razvan-panda";
+    github = "razvan-flavius-panda";
     githubId = 1758708;
     name = "Răzvan Flavius Panda";
   };
@@ -10685,7 +10685,7 @@
   };
   regnat = {
     email = "regnat@regnat.ovh";
-    github = "regnat";
+    github = "thufschmitt";
     githubId = 7226587;
     name = "Théophane Hufschmitt";
   };
@@ -10784,7 +10784,7 @@
   };
   rhoriguchi = {
     email = "ryan.horiguchi@gmail.com";
-    github = "rhoriguchi ";
+    github = "rhoriguchi";
     githubId = 6047658;
     name = "Ryan Horiguchi";
   };
@@ -11005,7 +11005,7 @@
   };
   ronanmacf = {
     email = "macfhlar@tcd.ie";
-    github = "ronanmacf";
+    github = "RonanMacF";
     githubId = 25930627;
     name = "Ronan Mac Fhlannchadha";
   };
@@ -11202,7 +11202,7 @@
   };
   rytone = {
     email = "max@ryt.one";
-    github = "rytone";
+    github = "rastertail";
     githubId = 8082305;
     name = "Maxwell Beck";
     keys = [{
@@ -11423,7 +11423,7 @@
   scoder12 = {
     name = "Spencer Pogorzelski";
     email = "34356756+Scoder12@users.noreply.github.com";
-    github = "scoder12";
+    github = "Scoder12";
     githubId = 34356756;
   };
   scolobb = {
@@ -11441,7 +11441,7 @@
   Scriptkiddi = {
     email = "nixos@scriptkiddi.de";
     matrix = "@fritz.otlinghaus:helsinki-systems.de";
-    github = "scriptkiddi";
+    github = "Scriptkiddi";
     githubId = 3598650;
     name = "Fritz Otlinghaus";
   };
@@ -11490,7 +11490,7 @@
   };
   sebtm = {
     email = "mail@sebastian-sellmeier.de";
-    github = "sebtm";
+    github = "SebTM";
     githubId = 17243347;
     name = "Sebastian Sellmeier";
   };
@@ -11562,7 +11562,7 @@
   };
   sfrijters = {
     email = "sfrijters@gmail.com";
-    github = "sfrijters";
+    github = "SFrijters";
     githubId = 918365;
     name = "Stefan Frijters";
   };
@@ -11619,13 +11619,13 @@
   };
   shawndellysse = {
     email = "sdellysse@gmail.com";
-    github = "shawndellysse";
+    github = "sdellysse";
     githubId = 293035;
     name = "Shawn Dellysse";
   };
   shawn8901 = {
     email = "shawn8901@googlemail.com";
-    github = "shawn8901";
+    github = "Shawn8901";
     githubId = 12239057;
     name = "Shawn8901";
   };
@@ -11755,7 +11755,7 @@
   simarra = {
     name = "simarra";
     email = "loic.martel@protonmail.com";
-    github = "simarra";
+    github = "Simarra";
     githubId = 14372987;
   };
   simoneruffini = {
@@ -11806,7 +11806,7 @@
   };
   sirseruju = {
     email = "sir.seruju@yandex.ru";
-    github = "sirseruju";
+    github = "SirSeruju";
     githubId = 74881555;
     name = "Fofanov Sergey";
   };
@@ -11875,7 +11875,7 @@
   };
   smakarov = {
     email = "setser200018@gmail.com";
-    github = "setser";
+    github = "SeTSeR";
     githubId = 12733495;
     name = "Sergey Makarov";
     keys = [{
@@ -11918,7 +11918,7 @@
   };
   sna = {
     email = "abouzahra.9@wright.edu";
-    github = "s-na";
+    github = "S-NA";
     githubId = 20214715;
     name = "S. Nordin Abouzahra";
   };
@@ -11948,7 +11948,7 @@
   };
   sohalt = {
     email = "nixos@sohalt.net";
-    github = "sohalt";
+    github = "Sohalt";
     githubId = 2157287;
     name = "sohalt";
   };
@@ -12062,7 +12062,7 @@
   };
   srgom = {
     email = "srgom@users.noreply.github.com";
-    github = "srgom";
+    github = "SRGOM";
     githubId = 8103619;
     name = "SRGOM";
   };
@@ -12081,14 +12081,14 @@
   };
   sstef = {
     email = "stephane@nix.frozenid.net";
-    github = "fkstef";
+    github = "haskelious";
     githubId = 8668915;
     name = "Stephane Schitter";
   };
   staccato = {
     name = "staccato";
     email = "moveq@riseup.net";
-    github = "staccato";
+    github = "braaandon";
     githubId = 86573128;
   };
   stackshadow = {
@@ -12191,13 +12191,13 @@
   };
   stevebob = {
     email = "stephen@sherra.tt";
-    github = "stevebob";
+    github = "gridbugs";
     githubId = 417118;
     name = "Stephen Sherratt";
   };
   steveej = {
     email = "mail@stefanjunker.de";
-    github = "steveej";
+    github = "steveeJ";
     githubId = 1181362;
     name = "Stefan Junker";
   };
@@ -12404,7 +12404,7 @@
   };
   szczyp = {
     email = "qb@szczyp.com";
-    github = "szczyp";
+    github = "Szczyp";
     githubId = 203195;
     name = "Szczyp";
   };
@@ -12557,7 +12557,7 @@
   };
   tchekda = {
     email = "contact@tchekda.fr";
-    github = "tchekda";
+    github = "Tchekda";
     githubId = 23559888;
     keys = [{
       fingerprint = "44CE A8DD 3B31 49CD 6246  9D8F D0A0 07ED A4EA DA0F";
@@ -12729,7 +12729,7 @@
     name = "The Hedgehog";
     email = "hedgehog@mrhedgehog.xyz";
     matrix = "@mrhedgehog:jupiterbroadcasting.com";
-    github = "ModdedGamers";
+    github = "theHedgehog0";
     githubId = 35778371;
     keys = [{
       fingerprint = "38A0 29B0 4A7E 4C13 A4BB  86C8 7D51 0786 6B1C 6752";
@@ -12749,7 +12749,7 @@
   };
   thesola10 = {
     email = "me@thesola.io";
-    github = "thesola10";
+    github = "Thesola10";
     githubId = 7287268;
     keys = [{
       fingerprint = "1D05 13A6 1AC4 0D8D C6D6  5F2C 8924 5619 BEBB 95BA";
@@ -12994,7 +12994,7 @@
   };
   tomsmeets = {
     email = "tom.tsmeets@gmail.com";
-    github = "tomsmeets";
+    github = "TomSmeets";
     githubId = 6740669;
     name = "Tom Smeets";
   };
@@ -13038,7 +13038,7 @@
   };
   travisdavis-ops = {
     email = "travisdavismedia@gmail.com";
-    github = "travisdavis-ops";
+    github = "TravisDavis-ops";
     githubId = 52011418;
     name = "Travis Davis";
   };
@@ -13159,7 +13159,7 @@
   };
   tvorog = {
     email = "marszaripov@gmail.com";
-    github = "tvorog";
+    github = "TvoroG";
     githubId = 1325161;
     name = "Marsel Zaripov";
   };
@@ -13319,7 +13319,7 @@
   valodim = {
     email = "look@my.amazin.horse";
     matrix = "@Valodim:stratum0.org";
-    github = "valodim";
+    github = "Valodim";
     githubId = 27813;
     name = "Vincent Breitmoser";
   };
@@ -13569,7 +13569,7 @@
   };
   vskilet = {
     email = "victor@sene.ovh";
-    github = "vskilet";
+    github = "Vskilet";
     githubId = 7677567;
     name = "Victor SENE";
   };
@@ -13703,7 +13703,7 @@
   };
   willibutz = {
     email = "willibutz@posteo.de";
-    github = "willibutz";
+    github = "WilliButz";
     githubId = 20464732;
     name = "Willi Butz";
   };
@@ -13801,7 +13801,7 @@
   };
   wolfangaukang = {
     email = "clone.gleeful135+nixpkgs@anonaddy.me";
-    github = "wolfangaukang";
+    github = "WolfangAukang";
     githubId = 8378365;
     name = "P. R. d. O.";
   };
@@ -13868,7 +13868,7 @@
   };
   wyvie = {
     email = "elijahrum@gmail.com";
-    github = "wyvie";
+    github = "alicerum";
     githubId = 3992240;
     name = "Elijah Rum";
   };
@@ -13942,7 +13942,7 @@
   };
   xnwdd = {
     email = "nwdd+nixos@no.team";
-    github = "xnwdd";
+    github = "xNWDD";
     githubId = 3028542;
     name = "Guillermo NWDD";
   };
@@ -13973,7 +13973,7 @@
   xyenon = {
     name = "XYenon";
     email = "i@xyenon.bid";
-    github = "xyenon";
+    github = "XYenon";
     githubId = 20698483;
   };
   xzfc = {
@@ -14058,7 +14058,7 @@
   yorickvp = {
     email = "yorickvanpelt@gmail.com";
     matrix = "@yorickvp:matrix.org";
-    github = "yorickvp";
+    github = "yorickvP";
     githubId = 647076;
     name = "Yorick van Pelt";
   };
@@ -14195,7 +14195,7 @@
   };
   zauberpony = {
     email = "elmar@athmer.org";
-    github = "zauberpony";
+    github = "elmarx";
     githubId = 250877;
     name = "Elmar Athmer";
   };
@@ -14218,7 +14218,7 @@
   };
   zeratax = {
     email = "mail@zera.tax";
-    github = "ZerataX";
+    github = "zeratax";
     githubId = 5024958;
     name = "Jona Abdinghoff";
     keys = [{
@@ -14342,7 +14342,7 @@
   };
   rakesh4g = {
     email = "rakeshgupta4u@gmail.com";
-    github = "rakesh4g";
+    github = "Rakesh4G";
     githubId = 50867187;
     name = "Rakesh Gupta";
   };
@@ -14372,7 +14372,7 @@
   };
   matthewcroughan = {
     email = "matt@croughan.sh";
-    github = "matthewcroughan";
+    github = "MatthewCroughan";
     githubId = 26458780;
     name = "Matthew Croughan";
   };
@@ -14538,7 +14538,7 @@
     name = "Josh Hoffer";
     email = "jhoffer@sansorgan.es";
     matrix = "@princemachiavelli:matrix.org";
-    github = "princemachiavelli";
+    github = "Princemachiavelli";
     githubId = 2730968;
     keys = [{
       fingerprint = "DD54 130B ABEC B65C 1F6B  2A38 8312 4F97 A318 EA18";

--- a/maintainers/scripts/fix-maintainers.pl
+++ b/maintainers/scripts/fix-maintainers.pl
@@ -1,0 +1,52 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i perl -p perl -p perlPackages.LWP -p perlPackages.LWPProtocolHttps -p perlPackages.LWPUserAgent -p perlPackages.JSON -p perlPackages.PathTiny
+use LWP::UserAgent;
+use JSON;
+use Path::Tiny;
+use strict;
+use warnings;
+
+my $maintainers_list_nix = "../maintainer-list.nix";
+my $maintainers_json = from_json(`nix-instantiate --json --eval --expr 'builtins.fromJSON (builtins.toJSON (import $maintainers_list_nix))'`);
+
+STDOUT->autoflush(1);
+
+my $ua = LWP::UserAgent->new();
+
+keys %$maintainers_json; # reset the internal iterator so a prior each() doesn't affect the loop
+while(my($k, $v) = each %$maintainers_json) {
+    my $current_user = %$v{'github'};
+    if (!defined $current_user) {
+        print "$k has no github handle\n";
+        next;
+    }
+    my $github_id = %$v{'githubId'};
+    if (!defined $github_id) {
+        print "$k has no githubId\n";
+        next;
+    }
+    my $url = 'https://api.github.com/user/' . $github_id;
+    my $resp = $ua->get(
+        $url,
+        "Authorization" => "Token $ENV{GH_TOKEN}"
+    );
+
+    if ($resp->header("X-RateLimit-Remaining") == 0) {
+        my $ratelimit_reset = $resp->header("X-RateLimit-Reset");
+        print "Request limit exceeded, waiting until " . scalar localtime $ratelimit_reset . "\n";
+        sleep($ratelimit_reset - time() + 5);
+    }
+    if ($resp->code != 200) {
+        print $current_user . " likely deleted their github account\n";
+        next;
+    }
+    my $resp_json = from_json($resp->content);
+    my $api_user = %$resp_json{"login"};
+    if ($current_user ne $api_user) {
+        print $current_user . " is now known on github as " . $api_user . ". Editing maintainer-list.nix…\n";
+        my $file = path($maintainers_list_nix);
+        my $data = $file->slurp_utf8;
+        $data =~ s/github = "$current_user";$/github = "$api_user";/m;
+        $file->spew_utf8($data);
+    }
+}

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -325,7 +325,6 @@ with lib.maintainers; {
   jitsi = {
     members = [
       cleeyv
-      petabyteboy
       ryantm
       yuka
     ];

--- a/nixos/modules/hardware/raid/hpsa.nix
+++ b/nixos/modules/hardware/raid/hpsa.nix
@@ -40,7 +40,7 @@ let
       homepage = "https://downloads.linux.hpe.com/SDR/downloads/MCP/Ubuntu/pool/non-free/";
       license = licenses.unfreeRedistributable;
       platforms = [ "x86_64-linux" ];
-      maintainers = with maintainers; [ volth ];
+      maintainers = with maintainers; [ ];
     };
   };
 in {

--- a/nixos/tests/xrdp.nix
+++ b/nixos/tests/xrdp.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "xrdp";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ volth ];
+    maintainers = [ ];
   };
 
   nodes = {

--- a/pkgs/applications/audio/gbsplay/default.nix
+++ b/pkgs/applications/audio/gbsplay/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     description = "Gameboy sound player";
     license = licenses.gpl1;
     platforms = [ "i686-linux" "x86_64-linux" ];
-    maintainers = with maintainers; [ dasuxullebt ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     description = "A free, minimal, hardcore audio tool for DJs, live performers and electronic musicians";
     homepage = "https://giadamusic.com/";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/audio/mpdevil/default.nix
+++ b/pkgs/applications/audio/mpdevil/default.nix
@@ -48,6 +48,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/SoongNoonien/mpdevil";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bloomvdomino ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/audio/muso/default.nix
+++ b/pkgs/applications/audio/muso/default.nix
@@ -33,6 +33,6 @@ rustPlatform.buildRustPackage rec {
     description = "An automatic music sorter (based on ID3 tags)";
     homepage = "https://github.com/quebin31/muso";
     license = with licenses; [ gpl3Plus ];
-    maintainers = with maintainers; [ bloomvdomino ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/blockchains/wownero/default.nix
+++ b/pkgs/applications/blockchains/wownero/default.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://wownero.org/";
     license     = licenses.bsd3;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ fuwa ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/editors/fte/default.nix
+++ b/pkgs/applications/editors/fte/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "A free text editor for developers";
     homepage = "http://fte.sourceforge.net/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -94,7 +94,7 @@ let
           The new IDE extends the IntelliJ platform with the coding assistance
           and tool integrations specific for the Go language
         '';
-        maintainers = [ maintainers.miltador ];
+        maintainers = [ ];
       };
     }).overrideAttrs (attrs: {
       postFixup = (attrs.postFixup or "") + lib.optionalString stdenv.isLinux ''
@@ -206,7 +206,7 @@ let
           apps, services and libraries, Unity games, ASP.NET and
           ASP.NET Core web applications.
         '';
-        maintainers = [ maintainers.miltador ];
+        maintainers = [ ];
       };
     }).overrideAttrs (attrs: {
       postPatch = lib.optionalString (!stdenv.isDarwin) (attrs.postPatch + ''

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -162,7 +162,7 @@ let
           with on-the-fly code analysis, error prevention and
           automated refactorings for PHP and JavaScript code.
         '';
-        maintainers = with maintainers; [ schristo ];
+        maintainers = with maintainers; [ ];
       };
     });
 

--- a/pkgs/applications/editors/rednotebook/default.nix
+++ b/pkgs/applications/editors/rednotebook/default.nix
@@ -39,6 +39,6 @@ buildPythonApplication rec {
     changelog = "https://github.com/jendrikseipp/rednotebook/blob/v${version}/CHANGELOG.md";
     description = "A modern journal that includes a calendar navigation, customizable templates, export functionality and word clouds";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ orivej tstrobel ];
+    maintainers = with maintainers; [ orivej ];
   };
 }

--- a/pkgs/applications/file-managers/mucommander/default.nix
+++ b/pkgs/applications/file-managers/mucommander/default.nix
@@ -80,7 +80,7 @@ in stdenv.mkDerivation {
     homepage = "http://www.mucommander.com/";
     description = "Cross-platform file manager";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/ahodesuka/ahoviewer";
     description = "A GTK2 image viewer, manga reader, and booru browser";
-    maintainers = with maintainers; [ skrzyp xzfc ];
+    maintainers = with maintainers; [ xzfc ];
     license = licenses.mit;
     # Unintentionally not working on Darwin:
     # https://github.com/ahodesuka/ahoviewer/issues/62

--- a/pkgs/applications/misc/bibletime/default.nix
+++ b/pkgs/applications/misc/bibletime/default.nix
@@ -59,6 +59,6 @@ mkDerivation rec {
     homepage = "http://www.bibletime.info/";
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.piotr ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -100,7 +100,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://usebottles.com/";
     downloadPage = "https://github.com/bottlesdevs/Bottles/releases";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ bloomvdomino psydvl shamilton ];
+    maintainers = with maintainers; [ psydvl shamilton ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -51,7 +51,7 @@ mkDerivation rec {
     homepage = "https://hluk.github.io/CopyQ";
     description = "Clipboard Manager with Advanced Features";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ willtim artturin ];
+    maintainers = with maintainers; [ artturin ];
     # NOTE: CopyQ supports windows and osx, but I cannot test these.
     # OSX build requires QT5.
     platforms = platforms.linux;

--- a/pkgs/applications/misc/diffpdf/default.nix
+++ b/pkgs/applications/misc/diffpdf/default.nix
@@ -52,7 +52,7 @@ mkDerivation rec {
     homepage = "http://www.qtrac.eu/diffpdfc.html";
     description = "Tool for diffing pdf files visually or textually";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ tstrobel ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     description = "Linux port of FAR Manager v2, a program for managing files and archives in Windows operating systems";
     homepage = "https://github.com/elfmz/far2l";
     license = licenses.gpl2Plus; # NOTE: might change in far2l repo soon, check next time
-    maintainers = with maintainers; [ volth hypersw ];
+    maintainers = with maintainers; [ hypersw ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -183,7 +183,7 @@ in stdenv.mkDerivation rec {
 
     homepage = "http://wb.mysql.com/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.kkallio ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/tdrop/default.nix
+++ b/pkgs/applications/misc/tdrop/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/noctuid/tdrop";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wedens ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/misc/tipp10/default.nix
+++ b/pkgs/applications/misc/tipp10/default.nix
@@ -19,7 +19,7 @@ mkDerivation rec {
     description = "Learn and train typing with the ten-finger system";
     homepage = "https://gitlab.com/tipp10/tipp10";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/tpmmanager/default.nix
+++ b/pkgs/applications/misc/tpmmanager/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     homepage = "https://projects.sirrix.com/trac/tpmmanager";
     description = "Tool for managing the TPM";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ tstrobel ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/applications/misc/wofi/default.nix
+++ b/pkgs/applications/misc/wofi/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     description = "A launcher/menu program for wlroots based wayland compositors such as sway";
     homepage = "https://hg.sr.ht/~scoopta/wofi";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ elyhaka ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/applications/networking/browsers/captive-browser/default.nix
+++ b/pkgs/applications/networking/browsers/captive-browser/default.nix
@@ -16,6 +16,6 @@ buildGoPackage rec {
     description = "Dedicated Chrome instance to log into captive portals without messing with DNS settings";
     homepage = "https://blog.filippo.io/captive-browser";
     license = licenses.mit;
-    maintainers = with maintainers; [ volth ma27 ];
+    maintainers = with maintainers; [ ma27 ];
   };
 }

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -78,7 +78,7 @@ let
           so delivering a highly-availabile service on top of a cluster of
           computers, each of which may be prone to failures.
         '';
-        maintainers = with maintainers; [ volth illustris ];
+        maintainers = with maintainers; [ illustris ];
         platforms = attrNames sha256;
       };
     };

--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://davmail.sourceforge.net/";
     description = "A Java application which presents a Microsoft Exchange server as local CALDAV, IMAP and SMTP servers";
-    maintainers = [ maintainers.hinton ];
+    maintainers = [ ];
     platforms = platforms.all;
     license = licenses.gpl2Plus;
   };

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -40,7 +40,7 @@ let
       description = "Low-latency, high quality voice chat software";
       homepage = "https://mumble.info";
       license = licenses.bsd3;
-      maintainers = with maintainers; [ petabyteboy infinisil felixsinger ];
+      maintainers = with maintainers; [ infinisil felixsinger ];
       platforms = platforms.linux;
     };
   });

--- a/pkgs/applications/networking/p2p/tixati/default.nix
+++ b/pkgs/applications/networking/p2p/tixati/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/networking/p2p/vuze/default.nix
+++ b/pkgs/applications/networking/p2p/vuze/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.vuze.com";
     license = licenses.unfree;
     platforms = platforms.all;
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -100,6 +100,6 @@ mkDerivation rec {
     license = licenses.unfree;
     description = "Desktop sharing application, providing remote support and online meetings";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ jagajaga dasuxullebt jraygauthier ];
+    maintainers = with maintainers; [ jagajaga jraygauthier ];
   };
 }

--- a/pkgs/applications/networking/remote/xrdp/default.nix
+++ b/pkgs/applications/networking/remote/xrdp/default.nix
@@ -98,7 +98,7 @@ let
       description = "An open source RDP server";
       homepage = "https://github.com/neutrinolabs/xrdp";
       license = licenses.asl20;
-      maintainers = [ maintainers.volth ];
+      maintainers = [ ];
       platforms = platforms.linux;
     };
   };

--- a/pkgs/applications/networking/station/default.nix
+++ b/pkgs/applications/networking/station/default.nix
@@ -36,6 +36,6 @@ in appimageTools.wrapType2 rec {
     homepage = "https://getstation.com";
     license = licenses.mit;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ lattfein ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/office/ib/controller/default.nix
+++ b/pkgs/applications/office/ib/controller/default.nix
@@ -158,7 +158,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ib-controller/ib-controller";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/office/ib/tws/default.nix
+++ b/pkgs/applications/office/ib/tws/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.interactivebrokers.com";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/office/moneyplex/default.nix
+++ b/pkgs/applications/office/moneyplex/default.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Moneyplex online banking software";
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     platforms = platforms.linux;
     license = licenses.unfree;

--- a/pkgs/applications/science/biology/diamond/default.nix
+++ b/pkgs/applications/science/biology/diamond/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
       fullName = "University of Tuebingen, Benjamin Buchfink";
       url = "https://raw.githubusercontent.com/bbuchfink/diamond/master/src/COPYING";
     };
-    maintainers = [ maintainers.metabar ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/science/biology/ecopcr/default.nix
+++ b/pkgs/applications/science/biology/ecopcr/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://git.metabarcoding.org/obitools/ecopcr/wikis/home";
     license = licenses.cecill20;
-    maintainers = [ maintainers.metabar ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     description = "Icarus Verilog compiler";
     homepage    = "http://iverilog.icarus.com/";  # https does not work
     license     = with licenses; [ gpl2Plus lgpl21Plus ];
-    maintainers = with maintainers; [ winden thoughtpolice ];
+    maintainers = with maintainers; [ thoughtpolice ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/applications/science/machine-learning/sc2-headless/default.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/default.nix
@@ -57,6 +57,6 @@ in stdenv.mkDerivation rec {
       url = "https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html";
       free = false;
     };
-    maintainers = with lib.maintainers; [ danharaj ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/virtualization/driver/win-pvdrivers/default.nix
+++ b/pkgs/applications/virtualization/driver/win-pvdrivers/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Xen Subproject: Windows PV Driver";
     homepage = "http://xenproject.org/downloads/windows-pv-drivers.html";
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     license = licenses.bsd3;
   };

--- a/pkgs/applications/virtualization/driver/win-qemu/default.nix
+++ b/pkgs/applications/virtualization/driver/win-qemu/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Windows QEMU Drivers";
     homepage = "https://fedoraproject.org/wiki/Windows_Virtio_Drivers";
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms = platforms.linux;
     license = licenses.gpl2;
   };

--- a/pkgs/applications/virtualization/driver/win-signed-gplpv-drivers/default.nix
+++ b/pkgs/applications/virtualization/driver/win-signed-gplpv-drivers/default.nix
@@ -39,9 +39,9 @@ stdenv.mkDerivation {
       Certificate obtained from the VeriSign CA.
     '';
     homepage = "http://wiki.univention.de/index.php?title=Installing-signed-GPLPV-drivers";
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     platforms = platforms.linux;
     license = licenses.gpl2;
   };
-}
+  }

--- a/pkgs/applications/virtualization/driver/win-spice/default.nix
+++ b/pkgs/applications/virtualization/driver/win-spice/default.nix
@@ -72,8 +72,8 @@ stdenv.mkDerivation  {
     description = "Windows SPICE Drivers";
     homepage = "https://www.spice-space.org/";
     license = [ licenses.asl20 ]; # See https://github.com/vrozenfe/qxl-dod
+    maintainers = [ ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = [ maintainers.tstrobel ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/virtualization/driver/win-virtio/default.nix
+++ b/pkgs/applications/virtualization/driver/win-virtio/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     description = "Windows VirtIO Drivers";
     homepage = "https://fedoraproject.org/wiki/Windows_Virtio_Drivers";
     license = [ licenses.bsd3 ];
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/virtualization/qboot/default.nix
+++ b/pkgs/applications/virtualization/qboot/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     description = "A simple x86 firmware for booting Linux";
     homepage = "https://github.com/bonzini/qboot";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ tstrobel ];
+    maintainers = with lib.maintainers; [ ];
     platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/applications/virtualization/seabios/default.nix
+++ b/pkgs/applications/virtualization/seabios/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.seabios.org";
     license = licenses.lgpl3;
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/virtualization/virt-top/default.nix
+++ b/pkgs/applications/virtualization/virt-top/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "A top-like utility for showing stats of virtualized domains";
     homepage = "https://people.redhat.com/~rjones/virt-top/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -252,7 +252,7 @@ stdenv.mkDerivation (rec {
                     + "\nIncludes:\n"
                     + withXenfiles (name: x: "* ${name}: ${x.meta.description or "(No description)"}.");
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ eelco tstrobel oxij ];
+    maintainers = with lib.maintainers; [ eelco oxij ];
     license = lib.licenses.gpl2;
     # https://xenbits.xen.org/docs/unstable/support-matrix.html
     knownVulnerabilities = lib.optionals (lib.versionOlder version "4.13") [

--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A tiling window manager based on binary space partitioning";
     homepage = "https://github.com/baskerville/bspwm";
-    maintainers = with maintainers; [ meisternu epitrochoid ];
+    maintainers = with maintainers; [ meisternu ];
     license = licenses.bsd2;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/window-managers/kbdd/default.nix
+++ b/pkgs/applications/window-managers/kbdd/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/qnikst/kbdd";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.wedens ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/window-managers/leftwm/default.nix
+++ b/pkgs/applications/window-managers/leftwm/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/leftwm/leftwm";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ mschneider ];
+    maintainers = with maintainers; [ ];
     changelog = "https://github.com/leftwm/leftwm/blob/${version}/CHANGELOG";
   };
 }

--- a/pkgs/build-support/templaterpm/default.nix
+++ b/pkgs/build-support/templaterpm/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Create templates of nix expressions from RPM .spec files";
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     hydraPlatforms = [];
   };

--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -19,6 +19,6 @@ in fetchzip {
 
     license = licenses.free;
     platforms = platforms.all;
-    maintainers = with maintainers; [ volth emily ];
+    maintainers = with maintainers; [ emily ];
   };
 }

--- a/pkgs/data/fonts/gohufont/default.nix
+++ b/pkgs/data/fonts/gohufont/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation rec {
     '';
     homepage    = "https://font.gohu.org/";
     license     = licenses.wtfpl;
-    maintainers = with maintainers; [ epitrochoid rnhmjoj ];
+    maintainers = with maintainers; [ rnhmjoj ];
   };
 }

--- a/pkgs/data/fonts/liberastika/default.nix
+++ b/pkgs/data/fonts/liberastika/default.nix
@@ -26,6 +26,6 @@ in fetchzip rec {
     license = licenses.gpl2;
     platforms = platforms.all;
     hydraPlatforms = [];
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/data/fonts/libertine/default.nix
+++ b/pkgs/data/fonts/libertine/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Linux Libertine Fonts";
     homepage = "http://linuxlibertine.sf.net";
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
     license = licenses.ofl;
   };
 }

--- a/pkgs/data/fonts/meslo-lg/default.nix
+++ b/pkgs/data/fonts/meslo-lg/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "A customized version of Apple’s Menlo-Regular font";
     homepage = "https://github.com/andreberg/Meslo-Font/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ balajisivaraman ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; all;
   };
 }

--- a/pkgs/data/fonts/terminus-font-ttf/default.nix
+++ b/pkgs/data/fonts/terminus-font-ttf/default.nix
@@ -28,6 +28,6 @@ in fetchzip {
     '';
     homepage = "https://files.ax86.net/terminus-ttf";
     license = licenses.ofl;
-    maintainers = with maintainers; [ okasu ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/data/fonts/ttf-envy-code-r/default.nix
+++ b/pkgs/data/fonts/ttf-envy-code-r/default.nix
@@ -20,6 +20,6 @@ in fetchzip {
     homepage = "https://damieng.com/blog/tag/envy-code-r";
     description = "Free scalable coding font by DamienG";
     license = licenses.unfree;
-    maintainers = [ maintainers.lyt ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/data/icons/flat-remix-icon-theme/default.nix
+++ b/pkgs/data/icons/flat-remix-icon-theme/default.nix
@@ -39,6 +39,6 @@ stdenvNoCC.mkDerivation rec  {
     license = with licenses; [ gpl3Only ];
     # breeze-icons and pantheon.elementary-icon-theme dependencies are restricted to linux
     platforms = platforms.linux;
-    maintainers = with maintainers; [ mschneider ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/data/icons/kora-icon-theme/default.nix
+++ b/pkgs/data/icons/kora-icon-theme/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec  {
     homepage = "https://github.com/bikass/kora";
     license = with licenses; [ gpl3Only ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bloomvdomino ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/data/themes/pop-gtk/default.nix
+++ b/pkgs/data/themes/pop-gtk/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/pop-os/gtk-theme";
     license = with licenses; [ gpl3 lgpl21 cc-by-sa-40 ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ elyhaka ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/desktops/enlightenment/econnman/default.nix
+++ b/pkgs/desktops/enlightenment/econnman/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     homepage = "https://enlightenment.org/";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ matejc tstrobel ftrvxmtrx ] ++ teams.enlightenment.members;
+    maintainers = with lib.maintainers; [ matejc ftrvxmtrx ] ++ teams.enlightenment.members;
   };
 }

--- a/pkgs/desktops/enlightenment/efl/default.nix
+++ b/pkgs/desktops/enlightenment/efl/default.nix
@@ -208,6 +208,6 @@ stdenv.mkDerivation rec {
     homepage = "https://enlightenment.org/";
     license = with licenses; [ bsd2 lgpl2Only licenses.zlib ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx ] ++ teams.enlightenment.members;
+    maintainers = with maintainers; [ matejc ftrvxmtrx ] ++ teams.enlightenment.members;
   };
 }

--- a/pkgs/desktops/enlightenment/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/enlightenment/default.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.enlightenment.org";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx ] ++ teams.enlightenment.members;
+    maintainers = with maintainers; [ matejc ftrvxmtrx ] ++ teams.enlightenment.members;
   };
 }

--- a/pkgs/desktops/enlightenment/terminology/default.nix
+++ b/pkgs/desktops/enlightenment/terminology/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.enlightenment.org/about-terminology";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx ] ++ teams.enlightenment.members;
+    maintainers = with maintainers; [ matejc ftrvxmtrx ] ++ teams.enlightenment.members;
   };
 }

--- a/pkgs/desktops/lxde/core/lxappearance/default.nix
+++ b/pkgs/desktops/lxde/core/lxappearance/default.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://lxde.org/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ hinton romildo ];
+    maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/desktops/xfce/art/xfwm4-themes/default.nix
+++ b/pkgs/desktops/xfce/art/xfwm4-themes/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "Themes for Xfce";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ volth ] ++ teams.xfce.members;
+    maintainers = with maintainers; [ ] ++ teams.xfce.members;
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "Plugin which integrates titlebar and window controls into the xfce4-panel";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ volth ] ++ teams.xfce.members;
+    maintainers = with maintainers; [ ] ++ teams.xfce.members;
     # Does not build with vala 0.48 or later
     # libxfce4panel-2.0.vapi:92.3-92.41: error: overriding method `Xfce.PanelPlugin.remote_event' is incompatible
     # with base method `bool Xfce.PanelPluginProvider.remote_event (string, GLib.Value, uint)': too few parameters.

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     description = "Xfce plugins which allows to put the maximized window title and buttons on the panel";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ volth ] ++ teams.xfce.members;
+    maintainers = with maintainers; [ ] ++ teams.xfce.members;
   };
 }

--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Clozure Common Lisp";
     homepage    = "https://ccl.clozure.com/";
-    maintainers = with maintainers; [ raskin muflax tohl ];
+    maintainers = with maintainers; [ raskin tohl ];
     platforms   = attrNames options;
     # assembler failures during build, x86_64-darwin broken since 2020-10-14
     broken      = (stdenv.isDarwin && stdenv.isx86_64);

--- a/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
@@ -321,7 +321,6 @@ let
       license = with licenses; [ upl gpl2Classpath bsd3 ];
       maintainers = with maintainers; [
         bandresen
-        volth
         hlolli
         glittershark
         babariviere

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -26,7 +26,7 @@ openjdk11.overrideAttrs (oldAttrs: rec {
     '';
     homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
     inherit (openjdk11.meta) license platforms mainProgram;
-    maintainers = with maintainers; [ edwtjo petabyteboy ];
+    maintainers = with maintainers; [ edwtjo ];
   };
   passthru = oldAttrs.passthru // {
     home = "${jetbrains.jdk}/lib/openjdk";

--- a/pkgs/development/compilers/opa/default.nix
+++ b/pkgs/development/compilers/opa/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://opalang.org/";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.kkallio ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/development/compilers/pakcs/default.nix
+++ b/pkgs/development/compilers/pakcs/default.nix
@@ -94,7 +94,7 @@ in stdenv.mkDerivation {
       with dynamic web pages, prototyping embedded systems).
     '';
 
-    maintainers = with maintainers; [ kkallio ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -150,7 +150,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://racket-lang.org/";
     license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ kkallio henrytill vrthra ];
+    maintainers = with maintainers; [ henrytill vrthra ];
     platforms = [ "x86_64-darwin" "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/interpreters/racket/racket_7_9.nix
+++ b/pkgs/development/interpreters/racket/racket_7_9.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://racket-lang.org/";
     license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ kkallio henrytill vrthra ];
+    maintainers = with maintainers; [ henrytill vrthra ];
     platforms = [ "x86_64-darwin" "x86_64-linux" "aarch64-linux" ];
     broken = stdenv.isDarwin; # No support yet for setting FFI lookup path
   };

--- a/pkgs/development/libraries/SDL_gfx/default.nix
+++ b/pkgs/development/libraries/SDL_gfx/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "https://sourceforge.net/projects/sdlgfx/";
     license = licenses.zlib;
 
-    maintainers = with maintainers; [ bjg ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/glpk/default.nix
+++ b/pkgs/development/libraries/glpk/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/glpk/";
     license = licenses.gpl3Plus;
 
-    maintainers = with maintainers; [ bjg ] ++ teams.sage.members;
+    maintainers = with maintainers; [ ] ++ teams.sage.members;
     mainProgram = "glpsol";
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/gss/";
     description = "Generic Security Service";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ bjg ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     description = "Set of VAAPI GStreamer Plug-ins";
     homepage = "https://gstreamer.freedesktop.org";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/half/default.nix
+++ b/pkgs/development/libraries/half/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "C++ library for half precision floating point arithmetics";
     platforms = platforms.all;
     license = licenses.mit;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libHX/default.nix
+++ b/pkgs/development/libraries/libHX/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       and functions commonly needed, such as maps, deques, linked lists, string formatting
       and autoresizing, option and config file parsing, type checking casts and more.
       '';
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms = platforms.linux;
     license = with licenses; [ gpl3 lgpl21Plus wtfpl ];
   };

--- a/pkgs/development/libraries/libbladeRF/default.nix
+++ b/pkgs/development/libraries/libbladeRF/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://nuand.com/libbladeRF-doc";
     description = "Supporting library of the BladeRF SDR opensource hardware";
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ funfunctor ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libpam-wrapper/default.nix
+++ b/pkgs/development/libraries/libpam-wrapper/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Wrapper for testing PAM modules";
     homepage = "https://cwrap.org/pam_wrapper.html";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.elyhaka ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/neardal/default.nix
+++ b/pkgs/development/libraries/neardal/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     description = "C APIs to exchange datas with the NFC daemon 'Neard'";
     license = licenses.lgpl2;
     homepage = "https://01.org/linux-nfc";
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/sword/default.nix
+++ b/pkgs/development/libraries/sword/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       texts in around 100 languages.
     '';
     license = licenses.gpl2;
-    maintainers = with maintainers; [ piotr AndersonTorres ];
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/development/libraries/ubus/default.nix
+++ b/pkgs/development/libraries/ubus/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation {
     homepage = "https://git.openwrt.org/?p=project/ubus.git;a=summary";
     license = licenses.lgpl21Only;
     platforms = platforms.all;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/uci/default.nix
+++ b/pkgs/development/libraries/uci/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation {
     homepage = "https://git.openwrt.org/?p=project/uci.git;a=summary";
     license = licenses.lgpl21Only;
     platforms = platforms.all;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/vo-amrwbenc/default.nix
+++ b/pkgs/development/libraries/vo-amrwbenc/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec{
     homepage = "https://sourceforge.net/projects/opencore-amr/";
     description = "VisualOn Adaptive Multi Rate Wideband (AMR-WB) encoder";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.Esteth ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -20,7 +20,7 @@ buildDunePackage rec {
     description = "Syntax for cross-language type definitions";
     homepage = "https://github.com/mjambon/atd";
     license = licenses.mit;
-    maintainers = with maintainers; [ aij jwilberding ];
+    maintainers = with maintainers; [ aij ];
     mainProgram = "atdcat";
   };
 }

--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     inherit (ocaml.meta) platforms;
     description = "Benchmark running times of code";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ volth ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/ocaml-modules/curses/default.nix
+++ b/pkgs/development/ocaml-modules/curses/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mbacarella/curses";
     license = licenses.lgpl21Plus;
     changelog = "https://github.com/mbacarella/curses/raw/${version}/CHANGES";
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/merlin-extend/default.nix
+++ b/pkgs/development/ocaml-modules/merlin-extend/default.nix
@@ -19,6 +19,6 @@ buildDunePackage rec {
     homepage = "https://github.com/let-def/merlin-extend";
     description = "SDK to extend Merlin";
     license = licenses.mit;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -27,7 +27,7 @@ buildDunePackage rec {
     description = "OCaml Bindings to gettext";
     homepage = "https://github.com/gildor478/ocaml-gettext";
     license = licenses.lgpl21;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
     mainProgram = "ocaml-gettext";
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "OCaml bindings for libvirt";
     homepage = "https://libvirt.org/ocaml/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -21,6 +21,6 @@ buildDunePackage rec {
       downloadPage = "https://github.com/backtracking/ocamlgraph";
       description = "Graph library for OCaml";
       license = licenses.gpl2Oss;
-      maintainers = with maintainers; [ kkallio ];
+      maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -19,6 +19,6 @@ buildDunePackage rec {
     homepage = "https://github.com/let-def/ppx_tools_versioned";
     description = "Tools for authors of syntactic tools (such as ppx rewriters)";
     license = licenses.gpl2;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/ocaml-modules/ptmap/default.nix
+++ b/pkgs/development/ocaml-modules/ptmap/default.nix
@@ -25,6 +25,6 @@ buildDunePackage rec {
     homepage = "https://www.lri.fr/~filliatr/software.en.html";
     description = "Maps over integers implemented as Patricia trees";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ volth ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation ({
     inherit (ocaml.meta) platforms;
     description = ''Ropes ("heavyweight strings") in OCaml'';
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ volth ];
+    maintainers = with lib.maintainers; [ ];
   };
 } // param.extra)

--- a/pkgs/development/python-modules/absl-py/default.nix
+++ b/pkgs/development/python-modules/absl-py/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     description = "Abseil Python Common Libraries";
     homepage = "https://github.com/abseil/abseil-py";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ danharaj ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/adblock/default.nix
+++ b/pkgs/development/python-modules/adblock/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python wrapper for Brave's adblocking library";
     homepage = "https://github.com/ArniDagur/python-adblock/";
-    maintainers = with maintainers; [ petabyteboy dotlambda ];
+    maintainers = with maintainers; [ dotlambda ];
     license = with licenses; [ asl20 /* or */ mit ];
   };
 }

--- a/pkgs/development/python-modules/django-cacheops/default.nix
+++ b/pkgs/development/python-modules/django-cacheops/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "A slick ORM cache with automatic granular event-driven invalidation for Django";
     homepage = "https://github.com/Suor/django-cacheops";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/et_xmlfile/default.nix
+++ b/pkgs/development/python-modules/et_xmlfile/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://pypi.python.org/pypi/et_xmlfile";
     license = licenses.mit;
-    maintainers = with maintainers; [ sjourdois ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
       syntax. Then the template is passed data to render the final document.
       an optional sandboxed environment.
     '';
-    maintainers = with maintainers; [ pierron sjourdois ];
+    maintainers = with maintainers; [ pierron ];
   };
 }

--- a/pkgs/development/python-modules/linode/default.nix
+++ b/pkgs/development/python-modules/linode/default.nix
@@ -19,7 +19,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ghickman/linode";
     description = "A thin python wrapper around Linode's API";
     license = licenses.mit;
-    maintainers = with maintainers; [ nslqqq ];
+    maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/development/python-modules/lxml/default.nix
+++ b/pkgs/development/python-modules/lxml/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
     description = "Pythonic binding for the libxml2 and libxslt libraries";
     homepage = "https://lxml.de";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jonringer sjourdois ];
+    maintainers = with maintainers; [ jonringer ];
   };
 }

--- a/pkgs/development/python-modules/mpyq/default.nix
+++ b/pkgs/development/python-modules/mpyq/default.nix
@@ -16,6 +16,6 @@ buildPythonPackage rec {
     description = "A Python library for extracting MPQ (MoPaQ) files.";
     homepage = "https://github.com/eagleflo/mpyq";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ danharaj ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "A Python library to read/write Excel 2007 xlsx/xlsm files";
     homepage = "https://openpyxl.readthedocs.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ lihop sjourdois ];
+    maintainers = with lib.maintainers; [ lihop ];
   };
 }

--- a/pkgs/development/python-modules/pixelmatch/default.nix
+++ b/pkgs/development/python-modules/pixelmatch/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     description = "Pixel-level image comparison library";
     homepage = "https://github.com/whtsky/pixelmatch-py";
     license = licenses.isc;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/portpicker/default.nix
+++ b/pkgs/development/python-modules/portpicker/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "Library to choose unique available network ports";
     homepage = "https://github.com/google/python_portpicker";
     license = licenses.asl20;
-    maintainers = with maintainers; [ danharaj ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pygal/default.nix
+++ b/pkgs/development/python-modules/pygal/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "Sexy and simple python charting";
     homepage = "http://www.pygal.org";
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ sjourdois ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pylxd/default.nix
+++ b/pkgs/development/python-modules/pylxd/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     description = "A Python library for interacting with the LXD REST API";
     homepage = "https://pylxd.readthedocs.io/en/latest/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pysc2/default.nix
+++ b/pkgs/development/python-modules/pysc2/default.nix
@@ -58,6 +58,6 @@ buildPythonPackage {
     homepage = "https://github.com/deepmind/pysc2";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ danharaj ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyshark/default.nix
+++ b/pkgs/development/python-modules/pyshark/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     description = "Python wrapper for tshark, allowing Python packet parsing using Wireshark dissectors";
     homepage = "https://github.com/KimiNewt/pyshark/";
     license = licenses.mit;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/DaveMDS/python-efl";
     platforms = platforms.linux;
     license = with licenses; [ gpl3 lgpl3 ];
-    maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx ] ++ teams.enlightenment.members;
+    maintainers = with maintainers; [ matejc ftrvxmtrx ] ++ teams.enlightenment.members;
   };
 }

--- a/pkgs/development/python-modules/queuelib/default.nix
+++ b/pkgs/development/python-modules/queuelib/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     description = "A collection of persistent (disk-based) queues for Python";
     homepage = "https://github.com/scrapy/queuelib";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ drewkett ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/python-modules/s2clientprotocol/default.nix
+++ b/pkgs/development/python-modules/s2clientprotocol/default.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "StarCraft II - client protocol.";
     homepage = "https://github.com/Blizzard/sc2client-proto";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ danharaj ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -135,7 +135,7 @@ buildPythonPackage rec {
     homepage = "https://scrapy.org/";
     changelog = "https://github.com/scrapy/scrapy/raw/${version}/docs/news.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ drewkett marsam ];
+    maintainers = with maintainers; [ marsam ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/toposort/default.nix
+++ b/pkgs/development/python-modules/toposort/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A topological sort algorithm";
     homepage = "https://pypi.python.org/pypi/toposort/";
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     license = licenses.asl20;
   };

--- a/pkgs/development/python-modules/w3lib/default.nix
+++ b/pkgs/development/python-modules/w3lib/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "A library of web-related functions";
     homepage = "https://github.com/scrapy/w3lib";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ drewkett ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python2-modules/jinja2/default.nix
+++ b/pkgs/development/python2-modules/jinja2/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
       Django inspired non-XML syntax but supports inline expressions and
       an optional sandboxed environment.
     '';
-    maintainers = with maintainers; [ pierron sjourdois ];
+    maintainers = with maintainers; [ pierron ];
   };
 }

--- a/pkgs/development/tools/cdecl/default.nix
+++ b/pkgs/development/tools/cdecl/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Translator English -- C/C++ declarations";
     license = lib.licenses.publicDomain;
-    maintainers = with lib.maintainers; [joelteon];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/unused/default.nix
+++ b/pkgs/development/tools/misc/unused/default.nix
@@ -18,6 +18,6 @@ rustPlatform.buildRustPackage rec {
     description = "A tool to identify potentially unused code";
     homepage = "https://unused.codes";
     license = licenses.mit;
-    maintainers = [ maintainers.lrworth ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/nailgun/default.nix
+++ b/pkgs/development/tools/nailgun/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/ocaml/obuild/default.nix
+++ b/pkgs/development/tools/ocaml/obuild/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     platforms = ocaml.meta.platforms or [ ];
     description = "Simple package build system for OCaml";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ volth ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/solarus-quest-editor/default.nix
+++ b/pkgs/development/tools/solarus-quest-editor/default.nix
@@ -35,7 +35,7 @@ mkDerivation rec {
     '';
     homepage = "http://www.solarus-games.org";
     license = licenses.gpl3;
-    maintainers = [ maintainers.Nate-Devv ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/games/angband/default.nix
+++ b/pkgs/games/angband/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://angband.github.io/angband";
     description = "A single-player roguelike dungeon exploration game";
-    maintainers = [ maintainers.chattered ];
+    maintainers = [ ];
     license = licenses.gpl2;
   };
 }

--- a/pkgs/games/crack-attack/default.nix
+++ b/pkgs/games/crack-attack/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nongnu.org/crack-attack/";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.piotr ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/games/egoboo/default.nix
+++ b/pkgs/games/egoboo/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
 
     # I take it out of hydra as it does not work as well as I'd like
-    # maintainers = [ lib.maintainers.bjg ];
+    # maintainers = [ ];
     # platforms = lib.platforms.all;
   };
 }

--- a/pkgs/games/freedink/default.nix
+++ b/pkgs/games/freedink/default.nix
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/freedink/"; # Formerly http://www.freedink.org
     license = lib.licenses.gpl3Plus;
 
-    maintainers = [ lib.maintainers.bjg ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     hydraPlatforms = lib.platforms.linux; # sdl-config times out on darwin
   };

--- a/pkgs/games/keeperrl/default.nix
+++ b/pkgs/games/keeperrl/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     description = "A dungeon management rogue-like";
     homepage = "https://keeperrl.com/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ chattered ];
+    maintainers = with maintainers; [ ];
     # TODO: Add OS X
     platforms = with platforms; [ "i686-linux" "x86_64-linux" ];
   };

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -204,7 +204,7 @@ stdenv.mkDerivation rec {
       binaryBytecode  # deps
     ];
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ fgaz petabyteboy ];
+    maintainers = with maintainers; [ fgaz ];
     platforms = platforms.x86_64;
     # Hash mismatch on darwin:
     # https://github.com/NixOS/nixpkgs/pull/105590#issuecomment-737120293

--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     '';
 
     platforms = platforms.unix;
-    maintainers = with maintainers; [ mikroskeem m3tti ];
+    maintainers = with maintainers; [ mikroskeem ];
     mainProgram = "quake";
   };
 }

--- a/pkgs/games/simutrans/default.nix
+++ b/pkgs/games/simutrans/default.nix
@@ -163,7 +163,7 @@ let
 
       homepage = "http://www.simutrans.com/";
       license = with licenses; [ artistic1 gpl1Plus ];
-      maintainers = with maintainers; [ kkallio vcunat phile314 ];
+      maintainers = with maintainers; [ vcunat phile314 ];
       platforms = with platforms; linux; # TODO: ++ darwin;
     };
   };

--- a/pkgs/games/solarus/default.nix
+++ b/pkgs/games/solarus/default.nix
@@ -35,7 +35,7 @@ mkDerivation rec {
     '';
     homepage = "http://www.solarus-games.org";
     license = licenses.gpl3;
-    maintainers = [ maintainers.Nate-Devv ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     description = "Tales of Maj'eyal (rogue-like game)";
     homepage = "https://te4.org/";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ chattered peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = with platforms; [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -41,7 +41,7 @@ let
     '';
     homepage = "https://www.xonotic.org/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ astsmtl zalakain petabyteboy ];
+    maintainers = with lib.maintainers; [ astsmtl zalakain ];
     platforms = lib.platforms.linux;
   };
 

--- a/pkgs/misc/cups/drivers/mfcl8690cdwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl8690cdwcupswrapper/default.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.brother.com/";
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.fuzzy-id ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.brother.com/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.fuzzy-id ];
+    maintainers = [ ];
     platforms = [ "i686-linux" ];
   };
 }

--- a/pkgs/misc/screensavers/xtrlock-pam/default.nix
+++ b/pkgs/misc/screensavers/xtrlock-pam/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/aanatoly/xtrlock-pam";
     description = "PAM based X11 screen locker";
     license = "unknown";
-    maintainers = with lib.maintainers; [ tstrobel ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
@@ -183,7 +183,7 @@ appleDerivation' stdenv {
   '';
 
   meta = with lib; {
-    maintainers = with maintainers; [ joelteon copumpkin ];
+    maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
     license     = licenses.apsl20;
   };

--- a/pkgs/os-specific/linux/ima-evm-utils/default.nix
+++ b/pkgs/os-specific/linux/ima-evm-utils/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = "https://sourceforge.net/projects/linux-ima/";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ tstrobel ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/os-specific/linux/miraclecast/default.nix
+++ b/pkgs/os-specific/linux/miraclecast/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     description = "Connect external monitors via Wi-Fi";
     homepage    = "https://github.com/albfan/miraclecast";
     license     = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/pam_mount/default.nix
+++ b/pkgs/os-specific/linux/pam_mount/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     description = "PAM module to mount volumes for a user session";
     homepage = "https://pam-mount.sourceforge.net/";
     license = with licenses; [ gpl2 gpl3 lgpl21 lgpl3 ];
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/unscd/default.nix
+++ b/pkgs/os-specific/linux/unscd/default.nix
@@ -71,6 +71,6 @@ stdenv.mkDerivation rec {
     description = "Less buggy replacement for the glibc name service cache daemon";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "Linux kernel vendor specific hardware reset module";
     homepage = "https://github.com/gnif/vendor-reset";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ wedens ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
     broken = kernel.kernelOlder "4.19";
   };

--- a/pkgs/servers/gortr/default.nix
+++ b/pkgs/servers/gortr/default.nix
@@ -17,6 +17,6 @@ buildGoModule rec {
     description = "The RPKI-to-Router server used at Cloudflare";
     homepage = "https://github.com/cloudflare/gortr/";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -118,6 +118,6 @@ stdenv.mkDerivation rec {
     homepage = "https://joinmastodon.org";
     license = licenses.agpl3Plus;
     platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
-    maintainers = with maintainers; [ petabyteboy happy-river erictapen izorkin ];
+    maintainers = with maintainers; [ happy-river erictapen izorkin ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/jitsi-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/jitsi-exporter.nix
@@ -18,6 +18,6 @@ buildGoModule rec {
     description = "Export Jitsi Videobridge metrics to Prometheus";
     homepage = "https://git.xsfx.dev/prometheus/jitsiexporter";
     license = licenses.mit;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/servers/neard/default.nix
+++ b/pkgs/servers/neard/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     description = "Near Field Communication manager";
     homepage = "https://01.org/linux-nfc";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ jtojnar tstrobel ];
+    maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -204,7 +204,7 @@ beamPackages.mixRelease rec {
     description = "ActivityPub microblogging server";
     homepage = "https://git.pleroma.social/pleroma/pleroma";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ petabyteboy ninjatrappeur yuka kloenk ];
+    maintainers = with maintainers; [ ninjatrappeur yuka kloenk ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/rpiplay/default.nix
+++ b/pkgs/servers/rpiplay/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/FD-/RPiPlay";
     description = "An open-source implementation of an AirPlay mirroring server.";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ mschneider ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/shishi/default.nix
+++ b/pkgs/servers/shishi/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://www.gnu.org/software/shishi/";
     description = "An implementation of the Kerberos 5 network security system";
     license     = licenses.gpl3Plus;
-    maintainers = with maintainers; [ bjg lovek323 ];
+    maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/plv8.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8.nix
@@ -80,7 +80,7 @@ let self = stdenv.mkDerivation rec {
   meta = with lib; {
     description = "V8 Engine Javascript Procedural Language add-on for PostgreSQL";
     homepage = "https://plv8.github.io/";
-    maintainers = with maintainers; [ volth marsam ];
+    maintainers = with maintainers; [ marsam ];
     platforms = [ "x86_64-linux" ];
     license = licenses.postgresql;
   };

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     description = "Scales PostgreSQL for time-series data via automatic partitioning across time and space";
     homepage = "https://www.timescale.com/";
     changelog = "https://github.com/timescale/timescaledb/raw/${version}/CHANGELOG.md";
-    maintainers = with maintainers; [ volth marsam ];
+    maintainers = with maintainers; [ marsam ];
     platforms = postgresql.meta.platforms;
     license = licenses.asl20;
     broken = versionOlder postgresql.version "12";

--- a/pkgs/servers/web-apps/restya-board/default.nix
+++ b/pkgs/servers/web-apps/restya-board/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "Web-based kanban board";
     license = licenses.osl3;
     homepage = "https://restya.com";
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/shells/rush/default.nix
+++ b/pkgs/shells/rush/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/rush/";
     license = lib.licenses.gpl3Plus;
 
-    maintainers = [ lib.maintainers.bjg ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -206,6 +206,6 @@ in buildPythonApplication rec {
     description = "Persistent remote applications for X";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ tstrobel offline numinit mvnetbiz ];
+    maintainers = with maintainers; [ offline numinit mvnetbiz ];
   };
 }

--- a/pkgs/tools/X11/xpra/libfakeXinerama.nix
+++ b/pkgs/tools/X11/xpra/libfakeXinerama.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation  rec {
     homepage = "http://xpra.org/";
     description = "fakeXinerama for Xpra";
     platforms = platforms.linux;
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     license = licenses.gpl2;
   };
 }

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -90,6 +90,6 @@ with py.pkgs; buildPythonApplication rec {
     homepage = "https://aws.amazon.com/cli/";
     description = "Unified tool to manage your AWS services";
     license = licenses.asl20;
-    maintainers = with maintainers; [ muflax ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation {
     '';
 
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ muflax ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/backup/zfs-autobackup/default.nix
+++ b/pkgs/tools/backup/zfs-autobackup/default.nix
@@ -28,6 +28,6 @@ pythonPackages.buildPythonApplication rec {
     homepage = "https://github.com/psy0rz/zfs_autobackup";
     description = "ZFS backup, replicationand snapshot tool";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ mschneider ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/bluetooth/bluez-tools/default.nix
+++ b/pkgs/tools/bluetooth/bluez-tools/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Command line bluetooth manager for Bluez5";
     license = licenses.gpl2;
-    maintainers = [ maintainers.dasuxullebt ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/tools/graphics/pngquant/default.nix
+++ b/pkgs/tools/graphics/pngquant/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/kornelski/pngquant/raw/${version}/CHANGELOG";
     platforms = platforms.unix;
     license = with licenses; [ gpl3Plus hpnd bsd2 ];
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/graphics/viu/default.nix
+++ b/pkgs/tools/graphics/viu/default.nix
@@ -20,6 +20,6 @@ rustPlatform.buildRustPackage rec {
     description = "A command-line application to view images from the terminal written in Rust";
     homepage = "https://github.com/atanunq/viu";
     license = licenses.mit;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/misc/claws/default.nix
+++ b/pkgs/tools/misc/claws/default.nix
@@ -18,6 +18,6 @@ buildGoPackage rec {
     description = "Interactive command line client for testing websocket servers";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/misc/coreboot-utils/default.nix
+++ b/pkgs/tools/misc/coreboot-utils/default.nix
@@ -7,7 +7,7 @@ let
     description = "Various coreboot-related tools";
     homepage = "https://www.coreboot.org";
     license = with licenses; [ gpl2Only gpl2Plus ];
-    maintainers = with maintainers; [ petabyteboy felixsinger yuka ];
+    maintainers = with maintainers; [ felixsinger yuka ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/tools/misc/duf/default.nix
+++ b/pkgs/tools/misc/duf/default.nix
@@ -20,6 +20,6 @@ buildGoModule rec {
     description = "Disk Usage/Free Utility";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ petabyteboy penguwin SuperSandro2000 ];
+    maintainers = with maintainers; [ penguwin SuperSandro2000 ];
   };
 }

--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.flashrom.org";
     description = "Utility for reading, writing, erasing and verifying flash ROM chips";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ funfunctor fpletz felixsinger ];
+    maintainers = with maintainers; [ fpletz felixsinger ];
     platforms = platforms.all;
     broken = stdenv.isDarwin; # requires DirectHW
   };

--- a/pkgs/tools/misc/mons/default.nix
+++ b/pkgs/tools/misc/mons/default.nix
@@ -89,7 +89,7 @@ resholve.mkDerivation rec {
     description = "POSIX Shell script to quickly manage 2-monitors display";
     homepage = "https://github.com/Ventto/mons.git";
     license = licenses.mit;
-    maintainers = with maintainers; [ mschneider thiagokokada ];
+    maintainers = with maintainers; [ thiagokokada ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/scanmem/default.nix
+++ b/pkgs/tools/misc/scanmem/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/scanmem/scanmem";
     description = "Memory scanner for finding and poking addresses in executing processes";
-    maintainers = [ maintainers.chattered ];
+    maintainers = [ ];
     platforms = platforms.linux;
     license = licenses.gpl3;
   };

--- a/pkgs/tools/misc/snapper/default.nix
+++ b/pkgs/tools/misc/snapper/default.nix
@@ -63,6 +63,6 @@ stdenv.mkDerivation rec {
     homepage = "http://snapper.io";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ tstrobel markuskowa ];
+    maintainers = with maintainers; [ markuskowa ];
   };
 }

--- a/pkgs/tools/networking/cntlm/default.nix
+++ b/pkgs/tools/networking/cntlm/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     maintainers =
       [
         maintainers.qknight
-        maintainers.markWot
         maintainers.carlosdagos
       ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/tools/networking/dnscrypt-wrapper/default.nix
+++ b/pkgs/tools/networking/dnscrypt-wrapper/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "A tool for adding dnscrypt support to any name resolver";
     homepage = "https://dnscrypt.info/";
     license = licenses.isc;
-    maintainers = with maintainers; [ tstrobel joachifm ];
+    maintainers = with maintainers; [ joachifm ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/freebind/default.nix
+++ b/pkgs/tools/networking/freebind/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/blechschmidt/freebind";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     homepage = "https://haproxy.org";
     changelog = "https://www.haproxy.org/download/${lib.versions.majorMinor version}/src/CHANGELOG";
     license = with licenses; [ gpl2Plus lgpl21Only ];
-    maintainers = with maintainers; [ fuzzy-id ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/networking/miredo/default.nix
+++ b/pkgs/tools/networking/miredo/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "Teredo IPv6 Tunneling Daemon";
     homepage = "https://www.remlab.net/miredo/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.volth ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/ndjbdns/default.nix
+++ b/pkgs/tools/networking/ndjbdns/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     '';
     homepage = "http://pjp.dgplug.org/ndjbdns/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.msackman ];
+    maintainers = [ ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 

--- a/pkgs/tools/networking/netifd/default.nix
+++ b/pkgs/tools/networking/netifd/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation {
     homepage = "https://git.openwrt.org/?p=project/netifd.git;a=summary";
     license = licenses.lgpl21Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/networking/par2cmdline/default.nix
+++ b/pkgs/tools/networking/par2cmdline/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       any kind of file.
     '';
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.muflax ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/networking/reaver-wps-t6x/default.nix
+++ b/pkgs/tools/networking/reaver-wps-t6x/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/t6x/reaver-wps-fork-t6x";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nico202 volth ];
+    maintainers = with maintainers; [ nico202 ];
   };
 }

--- a/pkgs/tools/networking/reaver-wps/default.nix
+++ b/pkgs/tools/networking/reaver-wps/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage = "https://code.google.com/archive/p/reaver-wps/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nico202 volth ];
+    maintainers = with maintainers; [ nico202 ];
   };
 }

--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/shadowsocks/shadowsocks-libev";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.nfjinjing ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/networking/tinyfecvpn/default.nix
+++ b/pkgs/tools/networking/tinyfecvpn/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     description = "A VPN Designed for Lossy Links, with Build-in Forward Error Correction(FEC) Support";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ petabyteboy ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/networking/xnbd/default.nix
+++ b/pkgs/tools/networking/xnbd/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "https://bitbucket.org/hirofuchi/xnbd";
     description = "Yet another NBD (Network Block Device) server program";
     license = lib.licenses.gpl2;
-    maintainers = [ lib.maintainers.volth ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/security/aide/default.nix
+++ b/pkgs/tools/security/aide/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = "https://aide.github.io/";
     description = "A file and directory integrity checker";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/certstrap/default.nix
+++ b/pkgs/tools/security/certstrap/default.nix
@@ -29,6 +29,6 @@ buildGoModule rec {
     homepage = "https://github.com/square/certstrap";
     changelog = "https://github.com/square/certstrap/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -96,6 +96,6 @@ stdenv.mkDerivation rec {
     description = "D-Bus daemon that offers libfprint functionality over the D-Bus interprocess communication bus";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ abbradar elyhaka ];
+    maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/tools/security/mkp224o/default.nix
+++ b/pkgs/tools/security/mkp224o/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage = "http://cathug2kyi4ilneggumrenayhuhsvrgn6qv2y47bgeet42iivkpynqad.onion/";
     license = licenses.cc0;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/security/omapd/default.nix
+++ b/pkgs/tools/security/omapd/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = "https://code.google.com/archive/p/omapd/";
     description = "IF-MAP Server that implements the IF-MAP v1.1 and v2.0 specifications published by the Trusted Computing Group (TCG)";
     license = licenses.gpl3;
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/opencryptoki/default.nix
+++ b/pkgs/tools/security/opencryptoki/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "PKCS#11 implementation for Linux";
     homepage    = "https://github.com/opencryptoki/opencryptoki";
     license     = licenses.cpl10;
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/security/radamsa/default.nix
+++ b/pkgs/tools/security/radamsa/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "A general purpose fuzzer";
     longDescription = "Radamsa is a general purpose data fuzzer. It reads data from given sample files, or standard input if none are given, and outputs modified data. It is usually used to generate malformed data for testing programs.";
     homepage =  "https://gitlab.com/akihe/radamsa";
-    maintainers = [ lib.maintainers.markWot ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/security/sbsigntool/default.nix
+++ b/pkgs/tools/security/sbsigntool/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tools for maintaining UEFI signature databases";
     homepage    = "http://jk.ozlabs.org/docs/sbkeysync-maintaing-uefi-key-databases";
-    maintainers = with maintainers; [ hmenke tstrobel ];
+    maintainers = with maintainers; [ hmenke ];
     platforms   = [ "x86_64-linux" ]; # Broken on i686
     license     = licenses.gpl3;
   };

--- a/pkgs/tools/security/simple-tpm-pk11/default.nix
+++ b/pkgs/tools/security/simple-tpm-pk11/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     '';
     homepage    = "https://github.com/ThomasHabets/simple-tpm-pk11";
     license     = licenses.asl20;
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/security/tpm-luks/default.nix
+++ b/pkgs/tools/security/tpm-luks/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "LUKS key storage in TPM NVRAM";
     homepage = "https://github.com/shpedoikal/tpm-luks/";
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = [ ];
     license = with licenses; [ gpl2Only ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/system/procodile/default.nix
+++ b/pkgs/tools/system/procodile/default.nix
@@ -11,7 +11,7 @@ bundlerApp {
     description = "Run processes in the background (and foreground) on Mac & Linux from a Procfile (for production and/or development environments)";
     homepage    = "https://adam.ac/procodile";
     license     = with licenses; mit;
-    maintainers = with maintainers; [ ravloony manveru nicknovitski ];
+    maintainers = with maintainers; [ manveru nicknovitski ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -81,6 +81,6 @@ pkgs.releaseTools.sourceTarball {
   '';
 
   meta = {
-    maintainers = [ pkgs.lib.maintainers.all ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes
This does a few things:
1. It fixes the github handles and adds a script to do so again
2. It adds github handles and ids to some maintainers that didn't have them for whatever reason
3. It removes a bunch of maintainers, that don't seem to have a github account and don't appear to be active anymore

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).