### PR TITLE
nrf-command-line-tools: init at 10.16.0 , segger-jlink: init at 7.66

### DIFF
--- a/pkgs/development/tools/misc/nrf-command-line-tools/default.nix
+++ b/pkgs/development/tools/misc/nrf-command-line-tools/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, udev
+, libusb1
+, segger-jlink
+}:
+
+let
+  supported = {
+    x86_64-linux = {
+      name = "linux-amd64";
+      sha256 = "0e036afa51c83de7824ef75d34e165ed55efc486697b8ff105639644bce988e5";
+    };
+    i686-linux = {
+      name = "linux-i386";
+      sha256 = "ba208559ae1195a0d4342374a0eb79697d31d6b848d180ac906494f17f56623b";
+    };
+    aarch64-linux = {
+      name = "linux-arm64";
+      sha256 = "cffa4b8becdb5545705fd138422c648d809b520b7bc6c77b8b50aa1f79ebe845";
+    };
+    armv7l-linux = {
+      name = "linux-armhf";
+      sha256 = "c58d330152ae1ef588a5ee1d93777e18b341d4f6a2754642b0ddd41821050a3a";
+    };
+  };
+
+  platform = supported.${stdenv.system} or (throw "unsupported platform ${stdenv.system}");
+
+  version = "10.16.0";
+
+  url = "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-${lib.versions.major version}-x-x/${lib.versions.major version}-${lib.versions.minor version}-${lib.versions.patch version}/nrf-command-line-tools-${lib.versions.major version}.${lib.versions.minor version}.${lib.versions.patch version}_${platform.name}.tar.gz";
+
+in stdenv.mkDerivation {
+  pname = "nrf-command-line-tools";
+  inherit version;
+
+  src = fetchurl {
+    inherit url;
+    inherit (platform) sha256;
+  };
+
+  runtimeDependencies = [ segger-jlink ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ udev libusb1 ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf ./python
+    mkdir -p $out
+    cp -r * $out
+
+    chmod +x $out/lib/*
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Nordic Semiconductor nRF Command Line Tools";
+    homepage = "https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools";
+    license = licenses.unfree;
+    platforms = attrNames supported;
+    maintainers = with maintainers; [ stargate01 ];
+  };
+}

--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -1,0 +1,120 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, qt4
+, udev
+, config
+, acceptLicense ? config.segger-jlink.acceptLicense or false
+}:
+
+let
+  supported = {
+    x86_64-linux = {
+      name = "x86_64";
+      sha256 = "90aa7e4f5eae6e60fd41978111b3ff124ba0269562d0d0ec3110d3cb4bb51fe2";
+    };
+    i686-linux = {
+      name = "i386";
+      sha256 = "18aea42cd17591cada78af7cba0f94a9d851e9d29995b6c8e1e7033d0af35d1c";
+    };
+    aarch64-linux = {
+      name = "arm64";
+      sha256 = "db410c1df80748827b4e25ff3abceee29e28305a0a7e30e4e39bb5c7e32f1aa2";
+    };
+    armv7l-linux = {
+      name = "arm";
+      sha256 = "abcdaf44aeb2ad4e769709ec4fe971e259b23d297a98f58199c7bdf26db82e84";
+    };
+  };
+
+  platform = supported.${stdenv.system} or (throw "unsupported platform ${stdenv.system}");
+
+  version = "766";
+
+  url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
+
+in stdenv.mkDerivation {
+  pname = "segger-jlink";
+  inherit version;
+
+  src =
+    assert !acceptLicense -> throw ''
+      Use of the "SEGGER JLink Software and Documentation pack" requires the
+      acceptance of the following licenses:
+
+        - SEGGER Downloads Terms of Use [1]
+        - SEGGER Software Licensing [2]
+
+      You can express acceptance by setting acceptLicense to true in your
+      configuration. Note that this is not a free license so it requires allowing
+      unfree licenses as well.
+
+      configuration.nix:
+        nixpkgs.config.allowUnfree = true;
+        nixpkgs.config.segger-jlink.acceptLicense = true;
+
+      config.nix:
+        allowUnfree = true;
+        segger-jlink.acceptLicense = true;
+
+      [1]: ${url}
+      [2]: https://www.segger.com/purchase/licensing/
+    '';
+      fetchurl {
+        inherit url;
+        inherit (platform) sha256;
+        curlOpts = "--data accept_license_agreement=accepted";
+      };
+
+  # Currently blocked by patchelf bug
+  # https://github.com/NixOS/patchelf/pull/275
+  #runtimeDependencies = [ udev ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ qt4 udev ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install binaries
+    mkdir -p $out/bin
+    mv J* $out/bin
+
+    # Install libraries
+    mkdir -p $out/lib
+    mv libjlinkarm.so* $out/lib
+    # This library is opened via dlopen at runtime
+    for libr in $out/lib/*; do
+      ln -s $libr $out/bin
+    done
+
+    # Install docs and examples
+    mkdir -p $out/share/docs
+    mv Doc/* $out/share/docs
+    mkdir -p $out/share/examples
+    mv Samples/* $out/share/examples
+
+    # Install udev rule
+    mkdir -p $out/lib/udev/rules.d
+    mv 99-jlink.rules $out/lib/udev/rules.d/
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    # Workaround to setting runtime dependecy
+    patchelf --add-needed libudev.so.1 $out/lib/libjlinkarm.so
+  '';
+
+  meta = with lib; {
+    description = "J-Link Software and Documentation pack";
+    homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+    license = licenses.unfree;
+    platforms = attrNames supported;
+    maintainers = with maintainers; [ FlorianFranzen stargate01 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16114,6 +16114,8 @@ with pkgs;
     sdk = true;
   };
 
+  nrf-command-line-tools = callPackage ../development/tools/misc/nrf-command-line-tools { };
+
   nrf5-sdk = callPackage ../development/libraries/nrf5-sdk { };
 
   nrfutil = callPackage ../development/tools/misc/nrfutil { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16357,6 +16357,8 @@ with pkgs;
 
   scss-lint = callPackage ../development/tools/scss-lint { };
 
+  segger-jlink = callPackage ../development/tools/misc/segger-jlink { };
+
   segger-ozone = callPackage ../development/tools/misc/segger-ozone { };
 
   selene = callPackage ../development/tools/selene {


### PR DESCRIPTION
###### Description of changes

This PR adds the Nordic Semiconductor NRF command-line tools (`nrf-command-line-tools`), providing tools like `nrfjprog`. It also updates `segger-jlink` , which is a runtime dependency of the NRF tools.

This PR supersedes #178603 (`segger-jlink`update), which continues the stale / abandoned #121601 . Based on the work by @FlorianFranzen and @reardencode . Note that the udev rules for `segger-jlink` have to be applied via `services.udev.packages`, and the user has to be member of `dialout`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
