### PR TITLE
dterm: move to applications/terminal-emulators

### DIFF
--- a/pkgs/applications/terminal-emulators/dterm/default.nix
+++ b/pkgs/applications/terminal-emulators/dterm/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchurl, readline }:
+{ lib
+, stdenv
+, fetchurl
+, readline
+}:
 
 stdenv.mkDerivation rec {
   pname = "dterm";
@@ -6,20 +10,31 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.knossos.net.nz/downloads/dterm-${version}.tgz";
-    sha256 = "94533be79f1eec965e59886d5f00a35cb675c5db1d89419f253bb72f140abddb";
+    hash = "sha256-lFM7558e7JZeWYhtXwCjXLZ1xdsdiUGfJTu3LxQKvds=";
   };
 
   buildInputs = [ readline ];
+
   postPatch = ''
     substituteInPlace Makefile \
       --replace 'gcc' '${stdenv.cc.targetPrefix}cc'
   '';
+
   preInstall = "mkdir -p $out/bin";
+
   installFlags = [ "BIN=$(out)/bin/" ];
 
   meta = with lib; {
     homepage = "http://www.knossos.net.nz/resources/free-software/dterm/";
     description = "A simple terminal program";
+    longDescription = ''
+      dterm is a simple terminal emulator, which doesn’t actually emulate any
+      particular terminal. Mainly, it is designed for use with xterm and
+      friends, which already do a perfectly good emulation, and therefore don’t
+      need any special help; dterm simply provides a means by which keystrokes
+      are forwarded to the serial line, and data forwarded from the serial line
+      appears on the terminal.
+    '';
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ auchter ];
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1147,8 +1147,6 @@ with pkgs;
 
   cope = callPackage ../tools/misc/cope { };
 
-  dterm = callPackage ../tools/misc/dterm { };
-
   ejson2env = callPackage ../tools/admin/ejson2env { };
 
   davinci-resolve = callPackage ../applications/video/davinci-resolve { };
@@ -1582,6 +1580,8 @@ with pkgs;
   ctx = callPackage ../applications/terminal-emulators/ctx { };
 
   darktile = callPackage ../applications/terminal-emulators/darktile { };
+
+  dterm = callPackage ../applications/terminal-emulators/dterm { };
 
   eterm = callPackage ../applications/terminal-emulators/eterm { };
 


### PR DESCRIPTION
Also, add a `longDescription`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
