### PR TITLE
teamspeak_server: 3.13.6 -> 3.13.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
@@ -4,13 +4,13 @@ let
   arch = if stdenv.is64bit then "amd64" else "x86";
 in stdenv.mkDerivation rec {
   pname = "teamspeak-server";
-  version = "3.13.6";
+  version = "3.13.7";
 
   src = fetchurl {
     url = "https://files.teamspeak-services.com/releases/server/${version}/teamspeak3-server_linux_${arch}-${version}.tar.bz2";
     sha256 = if stdenv.is64bit
-      then "sha256-U3BNJ4Jjhd39gD7iMsHT8CGtm/GFQDE2kYQa2btyK+w="
-      else "sha256-8UKiFedv6w5bmqNvo3AXwQnUROwbZnU0ZTh9V17zmxQ=";
+      then "sha256-d1pXMamAmAHkyPkGbNm8ViobNoVTE5wSSfKgdA1QBB4="
+      else "sha256-aMEDOnvBeKfzG8lDFhU8I5DYgG53IsCDBMV2MUyJi2g=";
   };
 
   buildInputs = [ stdenv.cc.cc postgresql.lib ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://community.teamspeak.com/t/teamspeak-server-3-13-7/35001

"This version updates the default license End Date from Nov 2022 to July 2027."

Before:

```
2022-06-23 07:07:05.275984|INFO    |Accounting    |   |Licensing Information
2022-06-23 07:07:05.276078|INFO    |Accounting    |   |licensed to       : Anonymous
2022-06-23 07:07:05.276161|INFO    |Accounting    |   |type              : No License
2022-06-23 07:07:05.276263|INFO    |Accounting    |   |starting date     : Thu Oct  1 00:00:00 2020
2022-06-23 07:07:05.276386|INFO    |Accounting    |   |ending date       : Tue Nov  1 00:00:00 2022
2022-06-23 07:07:05.276495|INFO    |Accounting    |   |max virtualservers: 1
2022-06-23 07:07:05.276595|INFO    |Accounting    |   |max slots         : 32
```

After:

```
2022-06-23 07:08:59.310516|INFO    |Accounting    |   |Licensing Information
2022-06-23 07:08:59.310653|INFO    |Accounting    |   |licensed to       : Anonymous
2022-06-23 07:08:59.310800|INFO    |Accounting    |   |type              : No License
2022-06-23 07:08:59.310892|INFO    |Accounting    |   |starting date     : Tue Feb  1 00:00:00 2022
2022-06-23 07:08:59.310982|INFO    |Accounting    |   |ending date       : Thu Jul  1 00:00:00 2027
2022-06-23 07:08:59.311098|INFO    |Accounting    |   |max virtualservers: 1
2022-06-23 07:08:59.311194|INFO    |Accounting    |   |max slots         : 32
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
