### PR TITLE
ocamlPackages.pbkdf: 1.1.0 → 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/pbkdf/default.nix
+++ b/pkgs/development/ocaml-modules/pbkdf/default.nix
@@ -1,22 +1,23 @@
 { lib
 , buildDunePackage
-, fetchurl
+, fetchFromGitHub
+, cstruct
 , mirage-crypto
 , alcotest
 }:
 
 buildDunePackage rec {
   pname = "pbkdf";
-  version = "1.1.0";
+  version = "1.2.0";
 
-  useDune2 = true;
-
-  src = fetchurl {
-    url = "https://github.com/abeaumont/ocaml-pbkdf/releases/download/${version}/pbkdf-${version}.tbz";
-    sha256 = "e53ed1bd9abf490c858a341c10fb548bc9ad50d4479acdf95a9358a73d042264";
+  src = fetchFromGitHub {
+    owner = "abeaumont";
+    repo = "ocaml-pbkdf";
+    rev = version;
+    sha256 = "sha256-dGi4Vw+7VBpK/NpJ6zdpogm+E6G/oJovXCksJBSmqjI=";
   };
 
-  propagatedBuildInputs = [ mirage-crypto ];
+  propagatedBuildInputs = [ cstruct mirage-crypto ];
   checkInputs = [ alcotest ];
   doCheck = true;
 


### PR DESCRIPTION
###### Description of changes

Compatibility: https://github.com/abeaumont/ocaml-pbkdf/blob/1.2.0/CHANGES.md#120-2020-08-03

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
