### PR TITLE
importCargoLock: Fix build failure caused by duplicate dependency in Cargo.toml

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -195,7 +195,10 @@ let
 
     for crate in ${toString depCrates}; do
       # Link the crate directory, removing the output path hash from the destination.
-      ln -s "$crate" $out/$(basename "$crate" | cut -c 34-)
+      # Check to make sure directory doesn't already exist when symlinking
+      if [ ! -L "$out/$(basename "$crate" | cut -c 34-)" ]; then
+        ln -s "$crate" "$out/$(basename "$crate" | cut -c 34-)"
+      fi
 
       if [ -e "$crate/.cargo-config" ]; then
         key=$(sed 's/\[source\."\(.*\)"\]/\1/; t; d' < "$crate/.cargo-config")


### PR DESCRIPTION
Fixes issue caused when a Cargo.toml contains the same dependency multiple times. In such a scenario the build would fail, since it couldn't link the file due to a permission issue.

###### Description of changes

```
if [ ! -L "$out/$(basename "$crate" | cut -c 34-)" ]; then
          ln -s "$crate" "$out/$(basename "$crate" | cut -c 34-)"
fi
 ```
