### PR TITLE
htmldoc: fix darwin build

### DIFF
--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -14,8 +14,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ zlib libpng libjpeg ]
     ++ lib.optionals stdenv.isDarwin [ Foundation SystemConfiguration ];
 
+  # do not generate universal binary on Darwin
+  # because it is not supported by Nix's clang
+  postPatch = ''
+    substituteInPlace configure --replace "-arch x86_64 -arch arm64" ""
+  '';
+
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Converts HTML files to PostScript and PDF";
     homepage    = "https://michaelrsweet.github.io/htmldoc";
     changelog   = "https://github.com/michaelrsweet/htmldoc/releases/tag/v${version}";

--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, zlib, libpng, libjpeg, SystemConfiguration, Foundation, pkg-config }:
+{ lib, stdenv, testers, fetchFromGitHub, zlib, libpng, libjpeg, SystemConfiguration, Foundation, pkg-config, htmldoc }:
 
 stdenv.mkDerivation rec {
   pname = "htmldoc";
   version = "1.9.16";
   src = fetchFromGitHub {
     owner = "michaelrsweet";
-    repo = "htmldoc";
+    repo = pname;
     rev = "v${version}";
     sha256 = "117cj5sfzl18gan53ld8lxb0wycizcp9jcakcs3nsvnss99rw3a6";
   };
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace configure --replace "-arch x86_64 -arch arm64" ""
   '';
+
+  passthru.tests = testers.testVersion {
+    package = htmldoc;
+    command = "htmldoc --version";
+  };
 
   meta = with lib; {
     description = "Converts HTML files to PostScript and PDF";

--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.9.16";
   src = fetchFromGitHub {
     owner = "michaelrsweet";
-    repo = pname;
+    repo = "htmldoc";
     rev = "v${version}";
     sha256 = "117cj5sfzl18gan53ld8lxb0wycizcp9jcakcs3nsvnss99rw3a6";
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
