### PR TITLE
confclerk: 0.6.4 -> 0.7.1

### DIFF
--- a/pkgs/applications/misc/confclerk/default.nix
+++ b/pkgs/applications/misc/confclerk/default.nix
@@ -1,22 +1,20 @@
-{ lib, stdenv, fetchurl, qt4, qmake4Hook }:
+{ lib, mkDerivation, fetchurl, qtbase, qmake }:
 
-let version = "0.6.4"; in
-stdenv.mkDerivation {
+mkDerivation rec {
   pname = "confclerk";
-  inherit version;
+  version = "0.7.1";
 
   src = fetchurl {
     url = "https://www.toastfreeware.priv.at/tarballs/confclerk/confclerk-${version}.tar.gz";
-    sha256 = "10rhg44px4nvbkd3p341cmp2ds43jn8r4rvgladda9v8zmsgr2b3";
+    sha256 = "0l5i4d6lymh0k6gzihs41x4i8v1dz0mrwpga096af0vchpvlcarg";
   };
 
-  buildInputs = [ qt4 ];
+  buildInputs = [ qtbase ];
+  nativeBuildInputs = [ qmake ];
 
-  nativeBuildInputs = [ qmake4Hook ];
-
-  installPhase = ''
+  postInstall = ''
     mkdir -p $out/bin
-    cp src/bin/confclerk $out/bin
+    mv $out/confclerk $out/bin/
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25829,7 +25829,7 @@ with pkgs;
 
   complete-alias = callPackage ../tools/misc/complete-alias { };
 
-  confclerk = callPackage ../applications/misc/confclerk { };
+  confclerk = libsForQt5.callPackage ../applications/misc/confclerk { };
 
   copyq = libsForQt5.callPackage ../applications/misc/copyq { };
 


### PR DESCRIPTION
###### Description of changes
qt4 -> qt5

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).