### PR TITLE
tagainijisho: 1.0.3 -> 1.2.0

### DIFF
--- a/pkgs/applications/office/tagainijisho/default.nix
+++ b/pkgs/applications/office/tagainijisho/default.nix
@@ -1,16 +1,19 @@
-{ lib, stdenv, fetchurl, qt4, cmake, sqlite }:
-
-stdenv.mkDerivation rec {
+{ lib, mkDerivation, fetchzip, qtbase, qttools, cmake, sqlite }:
+mkDerivation rec {
   pname = "tagainijisho";
-  version = "1.0.3";
+  version = "1.2.0";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/Gnurou/tagainijisho/releases/download/${version}/tagainijisho-${version}.tar.gz";
-    sha256 = "0kmg1940yiqfm4vpifyj680283ids4nsij9s750nrshwxiwwbqvg";
+    hash = "sha256-fLq4Wfpa7Wr62KvHztgLiXE8eopCq+wipgabFm2bq6w=";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ qt4 sqlite ];
+  buildInputs = [ qtbase qttools sqlite ];
+
+  cmakeFlags = [
+    "-DEMBED_SQLITE=OFF"
+  ];
 
   meta = with lib; {
     description = "A free, open-source Japanese dictionary and kanji lookup tool";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30279,7 +30279,7 @@ with pkgs;
     inherit (haskell.packages.ghc8107) ghcWithPackages taffybar;
   };
 
-  tagainijisho = callPackage ../applications/office/tagainijisho {};
+  tagainijisho = libsForQt5.callPackage ../applications/office/tagainijisho {};
 
   tahoe-lafs = callPackage ../tools/networking/p2p/tahoe-lafs {};
 


### PR DESCRIPTION
###### Description of changes
qt4 -> qt5

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).