### PR TITLE
CuteMarkEd-NG: init at unstable-2021-07-29

### DIFF
--- a/pkgs/applications/office/cutemarked-ng/0001-remove-dependency-on-vendored-library.patch
+++ b/pkgs/applications/office/cutemarked-ng/0001-remove-dependency-on-vendored-library.patch
@@ -1,0 +1,95 @@
+From b9bf46966dd7931f9f33c30ed608a21d0e71e923 Mon Sep 17 00:00:00 2001
+From: rewine <lhongxu@outlook.com>
+Date: Tue, 19 Jul 2022 13:19:10 +0800
+Subject: [PATCH 1/2] remove dependency on vendored library
+
+---
+ CuteMarkEd.pro                |  4 +---
+ app-static/app-static.pro     | 11 ++---------
+ app/app.pro                   |  2 --
+ app/cutemarkdownhighlighter.h |  2 +-
+ 4 files changed, 4 insertions(+), 15 deletions(-)
+
+diff --git a/CuteMarkEd.pro b/CuteMarkEd.pro
+index 4ee92e3..0d247a4 100644
+--- a/CuteMarkEd.pro
++++ b/CuteMarkEd.pro
+@@ -9,12 +9,10 @@ TEMPLATE = subdirs
+ CONFIG += c++14
+ 
+ SUBDIRS = \
+-    3rdparty \
+     libs \
+     app-static \
+     app \
+-    fontawesomeicon \
+-    test
++    fontawesomeicon
+ 
+ # build order: 3rdparty -> libs -> app-static -> app & test
+ #libs.depends = 3rdparty
+diff --git a/app-static/app-static.pro b/app-static/app-static.pro
+index cd3c292..560b4fc 100644
+--- a/app-static/app-static.pro
++++ b/app-static/app-static.pro
+@@ -13,7 +13,6 @@ CONFIG += c++11
+ 
+ INCLUDEPATH += $$PWD
+ # MD4C library
+-INCLUDEPATH += $$PWD/../3rdparty/md4c/src
+ 
+ SOURCES += \
+     snippets/jsonsnippettranslator.cpp \
+@@ -34,10 +33,7 @@ SOURCES += \
+     revealviewsynchronizer.cpp \
+     htmlpreviewcontroller.cpp \
+     htmlviewsynchronizer.cpp \
+-    yamlheaderchecker.cpp \
+-    $$PWD/../3rdparty/md4c/src/md4c.c \
+-    $$PWD/../3rdparty/md4c/src/entity.c \
+-    $$PWD/../3rdparty/md4c/src/md4c-html.c
++    yamlheaderchecker.cpp
+ 
+ HEADERS += \
+     snippets/snippet.h \
+@@ -64,10 +60,7 @@ HEADERS += \
+     revealviewsynchronizer.h \
+     htmlpreviewcontroller.h \
+     htmlviewsynchronizer.h \
+-    yamlheaderchecker.h \
+-    $$PWD/../3rdparty/md4c/src/md4c.h \
+-    $$PWD/../3rdparty/md4c/src/entity.h \
+-    $$PWD/../3rdparty/md4c/src/md4c-html.h
++    yamlheaderchecker.h
+ 
+ 
+ #unix:!symbian {
+diff --git a/app/app.pro b/app/app.pro
+index 4827673..ab961cf 100644
+--- a/app/app.pro
++++ b/app/app.pro
+@@ -40,8 +40,6 @@ macx {
+ }
+ 
+ #qmarkdowntextedit
+-include(../3rdparty/qmarkdowntextedit/qmarkdowntextedit.pri)
+-include(../3rdparty/hunspell/hunspell.pri)
+ INCLUDEPATH += $$PWD
+ 
+ SOURCES += \
+diff --git a/app/cutemarkdownhighlighter.h b/app/cutemarkdownhighlighter.h
+index c99ab56..78f2be6 100644
+--- a/app/cutemarkdownhighlighter.h
++++ b/app/cutemarkdownhighlighter.h
+@@ -19,7 +19,7 @@
+ 
+ #include <QSyntaxHighlighter>
+ 
+-#include "../3rdparty/qmarkdowntextedit/markdownhighlighter.h"
++#include <QMarkdownTextedit/markdownhighlighter.h>
+ 
+ namespace hunspell {
+ class SpellChecker;
+-- 
+2.36.1
+

--- a/pkgs/applications/office/cutemarked-ng/0002-use-pkgcofig-to-find-libraries.patch
+++ b/pkgs/applications/office/cutemarked-ng/0002-use-pkgcofig-to-find-libraries.patch
@@ -1,0 +1,25 @@
+From bdc66eace846edc8a7b435f7ca9f324427243ce4 Mon Sep 17 00:00:00 2001
+From: rewine <lhongxu@outlook.com>
+Date: Thu, 21 Jul 2022 17:30:22 +0800
+Subject: [PATCH 2/2] use pkgcofig to find libraries
+
+---
+ app/app.pro | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/app/app.pro b/app/app.pro
+index ab961cf..475487d 100644
+--- a/app/app.pro
++++ b/app/app.pro
+@@ -13,6 +13,8 @@ win32: QT += winextras
+ TARGET = cutemarked
+ TEMPLATE = app
+ CONFIG += c++11
++CONFIG += link_pkgconfig
++PKGCONFIG += QMarkdownTextedit hunspell md4c-html
+ 
+ unix:!macx {
+   CONFIG += link_pkgconfig
+-- 
+2.36.1
+

--- a/pkgs/applications/office/cutemarked-ng/default.nix
+++ b/pkgs/applications/office/cutemarked-ng/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qmake
+, pkg-config
+, qttools
+, qtbase
+, qtwebengine
+, wrapQtAppsHook
+, qmarkdowntextedit
+, md4c
+, hunspell
+}:
+
+stdenv.mkDerivation rec {
+  pname = "CuteMarkEd-NG";
+  version = "unstable-2021-07-29";
+
+  src = fetchFromGitHub {
+    owner = "Waqar144";
+    repo = pname;
+    rev = "9431ac603cef23d6f29e51e18f1eeee156f5bfb3";
+    sha256 = "sha256-w/D4C2ZYgI/7ZCDamTQlhrJ9vtvAMThgM/fopkdKWYc";
+  };
+
+  patches = [
+    ./0001-remove-dependency-on-vendored-library.patch
+    ./0002-use-pkgcofig-to-find-libraries.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace app/app.pro \
+      --replace '$$[QT_INSTALL_BINS]/lrelease' "lrelease"
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    md4c
+    qtwebengine
+    qmarkdowntextedit
+    hunspell.dev
+  ];
+
+  meta = with lib; {
+    description = "A Qt-based, free and open source markdown editor";
+    homepage = "https://github.com/Waqar144/CuteMarkEd-NG";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ rewine ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/qmarkdowntextedit/default.nix
+++ b/pkgs/development/libraries/qmarkdowntextedit/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, qmake
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qmarkdowntextedit";
+  version = "unstable-2022-06-30";
+
+  src = fetchFromGitHub {
+    owner = "pbek";
+    repo = pname;
+    rev = "3e52e20881d262c93b532641127c060267a500fe";
+    sha256 = "sha256-cvePq1X/Tq6ob762qjuYmoa8XNtVOiFTy/nbeXIih0w";
+  };
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  qmakeFlags = [
+    "qmarkdowntextedit-lib.pro"
+    "PREFIX=${placeholder "out"}"
+    "LIBDIR=${placeholder "out"}/lib"
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "install_trans_by_qmake";
+      url = "https://github.com/pbek/qmarkdowntextedit/commit/3e3992dcdc03a997dbb9b0634368c3feb7af0a17.patch";
+      sha256 = "sha256-6on53YnmUwoAAg48rwT64PCvvLo9ooU2Vlh9bOjvZzw";
+    })
+    (fetchpatch {
+      name = "Generate_pkgconfig_file_by_qmake";
+      url = "https://github.com/pbek/qmarkdowntextedit/commit/025153d3ab565ba071ffe79212d7befae3db2ba1.patch";
+      sha256 = "sha256-FfTmlQl1Hn8edtbaj8Gsu3hBRB4ebah6Z+YDZ0cwVac=";
+    })
+  ];
+
+  meta = with lib; {
+    description = "C++ Qt QPlainTextEdit widget with markdown highlighting and some other goodies";
+    homepage = "https://github.com/pbek/qmarkdowntextedit";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rewine ];
+  };
+}

--- a/pkgs/development/libraries/qmarkdowntextedit/default.nix
+++ b/pkgs/development/libraries/qmarkdowntextedit/default.nix
@@ -1,20 +1,19 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , qmake
 , wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "qmarkdowntextedit";
-  version = "unstable-2022-06-30";
+  version = "unstable-2022-08-24";
 
   src = fetchFromGitHub {
     owner = "pbek";
     repo = pname;
-    rev = "3e52e20881d262c93b532641127c060267a500fe";
-    sha256 = "sha256-cvePq1X/Tq6ob762qjuYmoa8XNtVOiFTy/nbeXIih0w";
+    rev = "f7ddc0d520407405b9b132ca239f4a927e3025e6";
+    sha256 = "sha256-TEb2w48MZ8U1INVvUiS1XohdvnVLBCTba31AwATd/oE=";
   };
 
   nativeBuildInputs = [ qmake wrapQtAppsHook ];
@@ -23,19 +22,6 @@ stdenv.mkDerivation rec {
     "qmarkdowntextedit-lib.pro"
     "PREFIX=${placeholder "out"}"
     "LIBDIR=${placeholder "out"}/lib"
-  ];
-
-  patches = [
-    (fetchpatch {
-      name = "install_trans_by_qmake";
-      url = "https://github.com/pbek/qmarkdowntextedit/commit/3e3992dcdc03a997dbb9b0634368c3feb7af0a17.patch";
-      sha256 = "sha256-6on53YnmUwoAAg48rwT64PCvvLo9ooU2Vlh9bOjvZzw";
-    })
-    (fetchpatch {
-      name = "Generate_pkgconfig_file_by_qmake";
-      url = "https://github.com/pbek/qmarkdowntextedit/commit/025153d3ab565ba071ffe79212d7befae3db2ba1.patch";
-      sha256 = "sha256-FfTmlQl1Hn8edtbaj8Gsu3hBRB4ebah6Z+YDZ0cwVac=";
-    })
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10201,6 +10201,8 @@ with pkgs;
 
   qmk = callPackage ../tools/misc/qmk { };
 
+  qmarkdowntextedit = libsForQt5.callPackage  ../development/libraries/qmarkdowntextedit { };
+
   qodem = callPackage ../tools/networking/qodem { };
 
   qosmic = libsForQt5.callPackage ../applications/graphics/qosmic { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3483,6 +3483,8 @@ with pkgs;
 
   cucumber = callPackage ../development/tools/cucumber {};
 
+  cutemarked-ng = libsForQt5.callPackage ../applications/office/cutemarked-ng { };
+
   dabet = callPackage ../tools/misc/dabet { };
 
   dabtools = callPackage ../applications/radio/dabtools { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
