### PR TITLE
himitsu-keyring: init at 0.1.0

### DIFF
--- a/pkgs/tools/security/himitsu-keyring/default.nix
+++ b/pkgs/tools/security/himitsu-keyring/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, desktop-file-utils
+, glib
+, gobject-introspection
+, gtk3
+, gtk-layer-shell
+, libhandy
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "himitsu-keyring";
+  version = "0.1.0";
+
+  src = fetchFromSourcehut {
+    name = pname + "-src";
+    owner = "~martijnbraam";
+    repo = "keyring";
+    rev = "c4706fff5ccc72cd9e524b8cf51fd048f67ee415";
+    hash = "sha256-csNCfy2fPOO2RAOHHGiBfI+HuG2BsbLzbterE63TVqs=";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    glib
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gobject-introspection
+    gtk3
+    gtk-layer-shell
+    libhandy
+    (python3.withPackages (pp: with pp; [
+      pygobject3
+    ]))
+  ];
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~martijnbraam/keyring/";
+    description = "Himitsu keystore frontend";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ auchter ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2409,6 +2409,8 @@ with pkgs;
 
   himitsu-firefox = callPackage ../tools/security/himitsu-firefox { };
 
+  himitsu-keyring = callPackage ../tools/security/himitsu-keyring { };
+
   hinit = haskell.lib.compose.justStaticExecutables haskellPackages.hinit;
 
   hostctl = callPackage ../tools/system/hostctl { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add himitsu-keyring, a "graphical frontend for managing a Himitsu keystore"
https://git.sr.ht/~martijnbraam/keyring

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
