### PR TITLE
kmscon: unstable-2018-09-07 -> 9.0.0

### DIFF
--- a/pkgs/os-specific/linux/kmscon/default.nix
+++ b/pkgs/os-specific/linux/kmscon/default.nix
@@ -1,31 +1,37 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, autoreconfHook
+, fetchpatch
+, meson
 , libtsm
 , systemd
 , libxkbcommon
 , libdrm
-, libGLU, libGL
+, libGLU
+, libGL
 , pango
 , pixman
 , pkg-config
 , docbook_xsl
 , libxslt
+, mesa
+, ninja
 }:
 
 stdenv.mkDerivation rec {
   pname = "kmscon";
-  version = "unstable-2018-09-07";
+  version = "9.0.0";
 
   src = fetchFromGitHub {
     owner = "Aetf";
     repo = "kmscon";
-    rev = "01dd0a231e2125a40ceba5f59fd945ff29bf2cdc";
-    sha256 = "0q62kjsvy2iwy8adfiygx2bfwlh83rphgxbis95ycspqidg9py87";
+    rev = "v${version}";
+    sha256 = "sha256-8owyyzCrZVbWXcCR+RA+m0MOrdzW+efI+rIMWEVEZ1o=";
   };
 
   buildInputs = [
-    libGLU libGL
+    libGLU
+    libGL
     libdrm
     libtsm
     libxkbcommon
@@ -33,13 +39,27 @@ stdenv.mkDerivation rec {
     pango
     pixman
     systemd
+    mesa
   ];
 
   nativeBuildInputs = [
-    autoreconfHook
+    meson
+    ninja
     docbook_xsl
     pkg-config
   ];
+
+  patches = [
+    (fetchpatch {
+      name = "0001-tests-fix-warnings.patch";
+      url = "https://github.com/Aetf/kmscon/commit/b65f4269b03de580923ab390bde795e7956b633f.patch";
+      sha256 = "sha256-ngflPwmNMM/2JzhV+hHiH3efQyoSULfqEywzWox9iAQ=";
+    })
+  ];
+
+  # _FORTIFY_SOURCE requires compiling with optimization (-O)
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-O"
+    + " -Wno-error=maybe-uninitialized"; # https://github.com/Aetf/kmscon/issues/49
 
   configureFlags = [
     "--enable-multi-seat"


### PR DESCRIPTION
###### Description of changes

This updates kmscon to the latest release tag on the repository, after 3 years(!) without an update in Nixpkgs.

NOTE: This PR depends on  #171069

Notifying maintainer; @omasanori 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
