### PR TITLE
tidal-hifi: init at 4.0.0

### DIFF
--- a/pkgs/applications/audio/tidal-hifi/default.nix
+++ b/pkgs/applications/audio/tidal-hifi/default.nix
@@ -1,0 +1,119 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, makeWrapper
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, ffmpeg
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, libappindicator-gtk3
+, libdbusmenu
+, libdrm
+, libnotify
+, libpulseaudio
+, libsecret
+, libuuid
+, libxkbcommon
+, mesa
+, nss
+, pango
+, systemd
+, xdg-utils
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tidal-hifi";
+  version = "4.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/Mastermindzh/tidal-hifi/releases/download/${version}/tidal-hifi_${version}_amd64.deb";
+    sha256 = "19gx9x3v5ywlvg5vyqgj6pghzwinby0i8isavfrix798pfr98j5z";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    ffmpeg
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    pango
+    systemd
+    mesa # for libgbm
+    nss
+    libuuid
+    libdrm
+    libnotify
+    libsecret
+    libpulseaudio
+    libxkbcommon
+    libappindicator-gtk3
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libxshmfence
+    xorg.libXtst
+  ];
+
+  runtimeDependencies =
+    [ (lib.getLib systemd) libnotify libdbusmenu xdg-utils ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp -R "opt" "$out"
+    cp -R "usr/share" "$out/share"
+    chmod -R g-w "$out"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper $out/opt/tidal-hifi/tidal-hifi $out/bin/tidal-hifi \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  meta = with lib; {
+    description = "The web version of Tidal running in electron with hifi support thanks to widevine";
+    homepage = "https://github.com/Mastermindzh/tidal-hifi";
+    changelog = "https://github.com/Mastermindzh/tidal-hifi/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alternateved ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21030,6 +21030,8 @@ with pkgs;
 
   tidyp = callPackage ../development/libraries/tidyp { };
 
+  tidal-hifi = callPackage ../applications/audio/tidal-hifi { };
+
   tinycdb = callPackage ../development/libraries/tinycdb { };
 
   tinyxml = tinyxml2;


### PR DESCRIPTION
###### Description of changes

Tidal-hifi is a web version of Tidal running in electron with hifi support thanks to widevine. Since there is no official Linux client available at the moment, this is the only alternative to running [Tidal](https://tidal.com/) browser.

Link to the source: https://github.com/Mastermindzh/tidal-hifi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
