### PR TITLE
clickable: init at 7.4.0

### DIFF
--- a/pkgs/development/tools/clickable/default.nix
+++ b/pkgs/development/tools/clickable/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitLab
+, buildPythonPackage
+, cookiecutter
+, requests
+, pyyaml
+, jsonschema
+, argcomplete
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "clickable";
+  version = "7.4.0";
+
+  src = fetchFromGitLab {
+    owner = "clickable";
+    repo = "clickable";
+    rev = "v${version}";
+    sha256 = "sha256-QS7vi0gUQbqqRYkZwD2B+zkt6DQ6AamQO7sihD8qWS0=";
+  };
+
+  propagatedBuildInputs = [
+    cookiecutter
+    requests
+    pyyaml
+    jsonschema
+    argcomplete
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+disabledTests = [
+  # Test require network connection
+  "test_cpp_plugin"
+  "test_html"
+  "test_python"
+  "test_qml_only"
+  "test_rust"
+];
+  meta = {
+    description = "A build system for Ubuntu Touch apps";
+    homepage = "https://clickable-ut.dev";
+    changelog = "https://clickable-ut.dev/en/latest/changelog.html";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ilyakooo0 ];
+  };
+}

--- a/pkgs/development/tools/clickable/default.nix
+++ b/pkgs/development/tools/clickable/default.nix
@@ -30,14 +30,15 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
 
-disabledTests = [
-  # Test require network connection
-  "test_cpp_plugin"
-  "test_html"
-  "test_python"
-  "test_qml_only"
-  "test_rust"
-];
+  disabledTests = [
+    # Test require network connection
+    "test_cpp_plugin"
+    "test_html"
+    "test_python"
+    "test_qml_only"
+    "test_rust"
+  ];
+
   meta = {
     description = "A build system for Ubuntu Touch apps";
     homepage = "https://clickable-ut.dev";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12345,6 +12345,8 @@ with pkgs;
 
   clean = callPackage ../development/compilers/clean { };
 
+  clickable = python3Packages.callPackage ../development/tools/clickable { };
+
   closurecompiler = callPackage ../development/compilers/closure { };
 
   cmdstan = callPackage ../development/compilers/cmdstan { };


### PR DESCRIPTION
###### Description of changes

Adds the clickable tool used to build and run Ubuntu Touch apps.

Homepage: https://clickable-ut.dev/en/latest/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
