### PR TITLE
python3.pkgs.systemd: Fix compatibility with Python 3.10

### DIFF
--- a/pkgs/development/python-modules/systemd/default.nix
+++ b/pkgs/development/python-modules/systemd/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchFromGitHub
 , systemd
 , pkg-config
@@ -15,6 +16,15 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "1fakw7qln44mfd6pj4kqsgyrhkc6cyr653id34kv0rdnb1bvysrz";
   };
+
+  patches = [
+    # Fix runtime issues on Python 3.10
+    # https://github.com/systemd/python-systemd/issues/107
+    (fetchpatch {
+      url = "https://github.com/systemd/python-systemd/commit/c71bbac357f0ac722e1bcb2edfa925b68cca23c9.patch";
+      sha256 = "22s72Wa/BCwNNvwbxEUh58jhHlbA00SNwNVchVDovcc=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/python-modules/systemd/default.nix
+++ b/pkgs/development/python-modules/systemd/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildPythonPackage, fetchFromGitHub, systemd, pkg-config }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, systemd
+, pkg-config
+}:
 
 buildPythonPackage rec {
   pname = "systemd";
@@ -11,14 +16,27 @@ buildPythonPackage rec {
     sha256 = "1fakw7qln44mfd6pj4kqsgyrhkc6cyr653id34kv0rdnb1bvysrz";
   };
 
-  buildInputs = [ systemd ];
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
+  buildInputs = [
+    systemd
+  ];
+
+  # No module named 'systemd._journal
   doCheck = false;
+
+  pythonImportsCheck = [
+    "systemd.journal"
+    "systemd.id128"
+    "systemd.daemon"
+    "systemd.login"
+  ];
 
   meta = with lib; {
     description = "Python module for native access to the systemd facilities";
     homepage = "http://www.freedesktop.org/software/systemd/python-systemd/";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
   };
 }


### PR DESCRIPTION
###### Description of changes

Required for fail2ban to start correctly:

https://github.com/systemd/python-systemd/issues/107

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
