### PR TITLE
conmon: update git sha after upstream v2.1.2 retag

### DIFF
--- a/pkgs/applications/virtualization/conmon/default.nix
+++ b/pkgs/applications/virtualization/conmon/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-WxRMY43Z9OytY1kc91VVmqLn5cl0UC/0Zj8x3vpsaBQ=";
+    sha256 = "sha256-KDAm+Djk1AaA3zXhxywT6HknT0tVCEZLS27nO9j/WgM=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
###### Description of changes
Upstream retagged v2.1.2 onto a fixup that otherwise breaks with cri-o.
see: https://github.com/containers/conmon/commit/2bc95ee697e87d5f7b77063cf83fc32739addafe

This updates the sha in nixpkgs so we fetch the new "correct" v2.1.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

