### PR TITLE
ocamlPackages.mirage-vnetif: 0.5.0 → 0.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-vnetif/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-vnetif/default.nix
@@ -1,28 +1,23 @@
 { lib, buildDunePackage, fetchurl
-, lwt, mirage-time, mirage-clock, mirage-net
+, lwt, mirage-net
 , cstruct, ipaddr, macaddr, mirage-profile
 , duration, logs
 }:
 
 buildDunePackage rec {
   pname = "mirage-vnetif";
-  version = "0.5.0";
+  version = "0.6.0";
 
-  minimumOCamlVersion = "4.06";
-
-  # due to cstruct
-  useDune2 = true;
+  minimalOCamlVersion = "4.06";
 
   src = fetchurl {
-    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "0cpqwf51v2cpz41dfqxabf3bsabwyl6a0h0v2ncrn33q58i60m5q";
+    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "sha256-fzRoNFqdnj4Ke+eNdo5crvbnKDx6/+dQyu+K3rD5dYw=";
   };
 
   propagatedBuildInputs = [
     lwt
     mirage-net
-    mirage-time
-    mirage-clock
     cstruct
     ipaddr
     macaddr


### PR DESCRIPTION
###### Description of changes

Compatibility with recent `cstruct`
https://github.com/mirage/mirage-vnetif/releases/tag/v0.6.0

cc maintainer @sternenseemann

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
