### PR TITLE
{jesec,rakshasa}-rtorrent: allow passthrough of dependency.

### DIFF
--- a/pkgs/applications/networking/p2p/jesec-rtorrent/default.nix
+++ b/pkgs/applications/networking/p2p/jesec-rtorrent/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-i7c1jSawHshj1kaXl8tdpelIKU24okeg9K5/+ht6t2k=";
   };
 
+  passthru = {
+    inherit libtorrent;
+  };
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/applications/networking/p2p/rakshasa-rtorrent/default.nix
+++ b/pkgs/applications/networking/p2p/rakshasa-rtorrent/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-HTwAs8dfZVXfLRNiT6QpjKGnuahHfoMfYWqdKkedUL0=";
   };
 
+  passthru = {
+    inherit libtorrent;
+  };
+
   nativeBuildInputs = [
     autoconf-archive
     autoreconfHook


### PR DESCRIPTION
###### Description of changes

Add a `passthru` attribute that exposes the `libtorrent` dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [-] (Package updates) Added a release notes entry if the change is major or breaking
  - [-] (Module updates) Added a release notes entry if the change is significant
  - [-] (Module addition) Added a release notes entry if adding a new NixOS module
  - [-] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [?] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


This is my first contribution here. If I've missed something from the contribution guidelines I'm happy to address that.
Wasn't sure if I was supposed to submit an issue as well as a PR, but I've submitted https://github.com/NixOS/nixpkgs/issues/178804 to describe the problem here.

The same issue exists with `rakshasa-rtorrent` as well, and I'm happy to submit a similar PR if this is accepted.