### PR TITLE
Update cli11 and micromamba

### DIFF
--- a/pkgs/development/tools/misc/cli11/default.nix
+++ b/pkgs/development/tools/misc/cli11/default.nix
@@ -1,34 +1,29 @@
-{
-  lib, stdenv,
-  fetchFromGitHub,
-  cmake,
-  gtest,
-  python3,
-  boost
+{ lib
+, stdenv
+, fetchFromGitHub
+, boost
+, catch2
+, cmake
+, gtest
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "cli11";
-  version = "1.9.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "CLIUtils";
     repo = "CLI11";
     rev = "v${version}";
-    sha256 = "0hbch0vk8irgmiaxnfqlqys65v1770rxxdfn3d23m2vqyjh0j9l6";
+    sha256 = "sha256-emTIaoUyTINbAAn9tw1r3zLTQt58N8A1zoP+0y41yKo=";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  checkInputs = [ boost python3 ];
+  checkInputs = [ boost python3 catch2 ];
 
   doCheck = true;
-
-  preConfigure = ''
-    rm -rfv extern/googletest
-    ln -sfv ${gtest.src} extern/googletest
-    sed -i '/TrueFalseTest/d' tests/CMakeLists.txt
-  '';
 
   meta = with lib; {
     description = "Command line parser for C++11";

--- a/pkgs/tools/package-management/micromamba/default.nix
+++ b/pkgs/tools/package-management/micromamba/default.nix
@@ -1,5 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake
-, cli11, nlohmann_json, curl, libarchive, libyamlcpp, libsolv, reproc, spdlog, termcolor, ghc_filesystem
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cli11
+, cmake
+, curl
+, ghc_filesystem
+, libarchive
+, libsolv
+, libyamlcpp
+, nlohmann_json
+, python3
+, reproc
+, spdlog
+, termcolor
+, tl-expected
 }:
 
 let
@@ -9,7 +24,8 @@ let
     ];
 
     patches = [
-      # Patch added by the mamba team
+      # Apply the same patch as in the "official" boa-forge build:
+      # https://github.com/mamba-org/boa-forge/tree/master/libsolv
       (fetchpatch {
         url = "https://raw.githubusercontent.com/mamba-org/boa-forge/20530f80e2e15012078d058803b6e2c75ed54224/libsolv/conda_variant_priorization.patch";
         sha256 = "1iic0yx7h8s662hi2jqx68w5kpyrab4fr017vxd4wyxb6wyk35dd";
@@ -28,13 +44,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "micromamba";
-  version = "0.22.0";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "mamba-org";
     repo = "mamba";
     rev = "micromamba-" + version;
-    sha256 = "sha256-9/vkn8wks2nyzIn5hnK+zvX18Du2B8YZ3/ugrmEGVH8=";
+    sha256 = "sha256-CszDmt3SElHo1D2sNy2tPhZ43YD3pDjT8+fp2PVk+7Y=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -50,6 +66,8 @@ stdenv.mkDerivation rec {
     spdlog'
     termcolor
     ghc_filesystem
+    python3
+    tl-expected
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
This is my first PR to this project. Please let me know if more information is required!

###### Description of changes

##### Micromamba
Update of micromamba only contains bugfixes and improvements: https://github.com/mamba-org/mamba/blob/master/CHANGELOG.md

The build dependencies now include `python3`, `tl-expected` and `cli11>=2.2`. Furthermore, micromamba is now also build for `darwin` platforms (seems to have also been fixed in https://github.com/NixOS/nixpkgs/pull/178801 )

##### Cli11
Major release needed for the latest `micromamba` release. Breaking changes are few, though: https://github.com/CLIUtils/CLI11/blob/main/CHANGELOG.md

##### Ethminer
Ethminer seems to be the only other package depending on cli11. Unfortunately, I could not test-build it since I am stuck on MacOS at the moment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
