### PR TITLE
mongodb: backport a fix to 5.0 in openssl detection.

### DIFF
--- a/pkgs/servers/nosql/mongodb/5.0.nix
+++ b/pkgs/servers/nosql/mongodb/5.0.nix
@@ -21,5 +21,6 @@ buildMongoDB {
   patches = [
     ./forget-build-dependencies-4-4.patch
     ./asio-no-experimental-string-view-4-4.patch
+    ./fix-gcc-Wno-exceptions-5.0.patch
   ];
 }

--- a/pkgs/servers/nosql/mongodb/fix-gcc-Wno-exceptions-5.0.patch
+++ b/pkgs/servers/nosql/mongodb/fix-gcc-Wno-exceptions-5.0.patch
@@ -1,0 +1,44 @@
+From e78b2bf6eaa0c43bd76dbb841add167b443d2bb0 Mon Sep 17 00:00:00 2001
+From: Mark Benvenuto <mark.benvenuto@mongodb.com>
+Date: Mon, 21 Jun 2021 11:36:56 -0400
+Subject: [PATCH] SERVER-57688 Fix debug gcc 11 and clang 12 builds on Fedora
+ 34
+
+---
+ SConstruct                              | 4 ----
+ src/mongo/db/query/plan_summary_stats.h | 4 +++-
+ src/mongo/util/shim_boost_assert.cpp    | 1 +
+ 3 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/SConstruct b/SConstruct
+index 25fd4a248d0c..23cff6f9da53 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -3108,10 +3108,6 @@ def doConfigure(myenv):
+         # harmful to capture unused variables we are suppressing for now with a plan to fix later.
+         AddToCCFLAGSIfSupported(myenv, "-Wno-unused-lambda-capture")
+ 
+-        # This warning was added in clang-5 and incorrectly flags our implementation of
+-        # exceptionToStatus(). See https://bugs.llvm.org/show_bug.cgi?id=34804
+-        AddToCCFLAGSIfSupported(myenv, "-Wno-exceptions")
+-
+         # Enable sized deallocation support.
+         AddToCXXFLAGSIfSupported(myenv, '-fsized-deallocation')
+ 
+diff --git a/src/mongo/db/query/plan_summary_stats.h b/src/mongo/db/query/plan_summary_stats.h
+index 58677ab20d25..cfaa2053d16f 100644
+--- a/src/mongo/db/query/plan_summary_stats.h
++++ b/src/mongo/db/query/plan_summary_stats.h
+@@ -29,9 +29,11 @@
+ 
+ #pragma once
+ 
+-#include "mongo/util/container_size_helper.h"
++#include <optional>
+ #include <string>
+ 
++#include "mongo/util/container_size_helper.h"
++
+ namespace mongo {
+ 
+ /**


### PR DESCRIPTION
###### Description of changes

might help with #171928
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I took a part of https://github.com/mongodb/mongo/commit/e78b2bf6eaa0c43bd76dbb841add167b443d2bb0.patch The last patch didn't match any file so I just ignored it. I don't know how to handle that with fetchpatch function so I copied.

It was added here https://github.com/mongodb/mongo/commit/107858d4d2ffd9f0690def5108898a8b4be70350 from GitHub UI it is added since 3.6 but before Werror was not enforced so it didn't cause issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (partially I needed space but the configure did pass)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
