### PR TITLE
darwin.iproute2mac: 1.2.1 -> 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6003,6 +6003,12 @@
     githubId = 2502736;
     name = "James Hillyerd";
   };
+  jiegec = {
+    name = "Jiajie Chen";
+    email = "c@jia.je";
+    github = "jiegec";
+    githubId = 6127678;
+  };
   jiehong = {
     email = "nixos@majiehong.com";
     github = "Jiehong";

--- a/pkgs/os-specific/darwin/iproute2mac/default.nix
+++ b/pkgs/os-specific/darwin/iproute2mac/default.nix
@@ -1,21 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, darwin, python2 }:
+{ lib, stdenv, fetchFromGitHub, darwin, python3 }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.1";
+  version = "1.4.0";
   pname = "iproute2mac";
 
   src = fetchFromGitHub {
     owner = "brona";
     repo = "iproute2mac";
     rev = "v${version}";
-    sha256 = "1n6la7blbxza2m79cpnywsavhzsdv4gzdxrkly4dppyidjg6jy1h";
+    sha256 = "sha256-xakCNjmZpdVY7MMxk38EZatrakgkEeDhvljhl+aMmGg=";
   };
 
-  buildInputs = [ python2 ];
+  buildInputs = [ python3 ];
 
   postPatch = ''
     substituteInPlace src/ip.py \
-      --replace /usr/bin/python ${python2}/bin/python \
       --replace /sbin/ifconfig ${darwin.network_cmds}/bin/ifconfig \
       --replace /sbin/route ${darwin.network_cmds}/bin/route \
       --replace /usr/sbin/netstat ${darwin.network_cmds}/bin/netstat \
@@ -32,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/brona/iproute2mac";
     description = "CLI wrapper for basic network utilites on Mac OS X inspired with iproute2 on Linux systems - ip command.";
     license = licenses.mit;
-    maintainers = with maintainers; [ flokli ];
+    maintainers = with maintainers; [ jiegec ];
     platforms = platforms.darwin;
   };
 }


### PR DESCRIPTION
https://github.com/brona/iproute2mac/releases/tag/v1.4.0

Related pr: https://github.com/NixOS/nixpkgs/pull/109003

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
