### PR TITLE
ocamlPackages.shared-memory-ring: 3.1.0 → 3.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
+++ b/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
@@ -10,13 +10,11 @@
 
 buildDunePackage rec {
   pname = "shared-memory-ring";
-  version = "3.1.0";
-
-  useDune2 = true;
+  version = "3.1.1";
 
   src = fetchurl {
-    url = "https://github.com/mirage/shared-memory-ring/releases/download/v${version}/shared-memory-ring-v${version}.tbz";
-    sha256 = "06350ph3rdfvybi0cgs3h3rdkmjspk3c4375rxvbdg0kza1w22x1";
+    url = "https://github.com/mirage/shared-memory-ring/releases/download/v${version}/shared-memory-ring-${version}.tbz";
+    sha256 = "sha256-KW8grij/OAnFkdUdRRZF21X39DvqayzkTWeRKwF8uoU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/shared-memory-ring/lwt.nix
+++ b/pkgs/development/ocaml-modules/shared-memory-ring/lwt.nix
@@ -12,7 +12,7 @@
 buildDunePackage {
   pname = "shared-memory-ring-lwt";
 
-  inherit (shared-memory-ring) version src useDune2;
+  inherit (shared-memory-ring) version src;
 
   buildInputs = [
     ppx_cstruct


### PR DESCRIPTION
###### Description of changes

Compatibility with recent `cstruct`:
https://github.com/mirage/shared-memory-ring/blob/v3.1.1/CHANGES.md#v311-2022-04-13

cc maintainer @sternenseemann

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
