### PR TITLE
wine64Packages: fix mainProgram

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -269,6 +269,13 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>meta.mainProgram</literal> attribute of packages
+          in <literal>wineWowPackages</literal> now defaults to
+          <literal>&quot;wine64&quot;</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           (Neo)Vim can not be configured with
           <literal>configure.pathogen</literal> anymore to reduce
           maintainance burden. Use <literal>configure.packages</literal>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -104,6 +104,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   `python3.pkgs.influxgraph` packages, have been removed due to lack of upstream
   maintenance.
 
+- The `meta.mainProgram` attribute of packages in `wineWowPackages` now defaults to `"wine64"`.
+
 - (Neo)Vim can not be configured with `configure.pathogen` anymore to reduce maintainance burden.
 Use `configure.packages` instead.
 

--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -6,7 +6,7 @@
   patches,
   vkd3dArches,
   moltenvk,
-  buildScript ? null, configureFlags ? []
+  buildScript ? null, configureFlags ? [], mainProgram ? "wine"
 }:
 
 with import ./util.nix { inherit lib; };
@@ -198,6 +198,6 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
     description = if supportFlags.waylandSupport then "An Open Source implementation of the Windows API on top of OpenGL and Unix (with experimental Wayland support)" else "An Open Source implementation of the Windows API on top of X, OpenGL, and Unix";
     platforms = if supportFlags.waylandSupport then (lib.remove "x86_64-darwin" prevPlatforms) else prevPlatforms;
     maintainers = with lib.maintainers; [ avnik raskin bendlas jmc-figueira ];
-    mainProgram = "wine";
+    inherit mainProgram;
   };
 })

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -28,6 +28,7 @@ in with src; {
     monos =  [ mono ];
     configureFlags = [ "--enable-win64" ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    mainProgram = "wine64";
   };
   wineWow = callPackage ./base.nix {
     pname = "wine-wow";

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -41,5 +41,6 @@ in with src; {
     monos =  [ mono ];
     buildScript = ./builder-wow.sh;
     platforms = [ "x86_64-linux" ];
+    mainProgram = "wine64";
   };
 }


### PR DESCRIPTION
###### Description of changes

This patch fixes the `meta.mainProgram` of packages in `wine64Packages` by adding `mainProgram` as an input parameter of `base.nix` default to `"wine"`, and specified as `"wine64"` for packages mentioned above.

This change should be backward compatible and cause no rebuilds.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Cc package maintainers: @avnik @raskin @bendlas @jmc-figueira

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
