### PR TITLE
openldap: disable parallel build

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 
-# dependencies
+  # dependencies
 , cyrus_sasl
 , db
 , groff
@@ -29,7 +29,8 @@ stdenv.mkDerivation rec {
     "devdoc"
   ];
 
-  enableParallelBuilding = true;
+  # Fails to build with 48 cores because of ld not finding slapd-common.o
+  enableParallelBuilding = false;
 
   nativeBuildInputs = [
     groff
@@ -59,9 +60,9 @@ stdenv.mkDerivation rec {
     "ac_cv_func_memcmp_working=yes"
   ] ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
-  makeFlags= [
+  makeFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
-    "STRIP="  # Disable install stripping as it breaks cross-compiling. We strip binaries anyway in fixupPhase.
+    "STRIP=" # Disable install stripping as it breaks cross-compiling. We strip binaries anyway in fixupPhase.
     "prefix=${placeholder "out"}"
     "sysconfdir=${placeholder "out"}/etc"
     "systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
@@ -116,6 +117,6 @@ stdenv.mkDerivation rec {
     description = "An open source implementation of the Lightweight Directory Access Protocol";
     license = licenses.openldap;
     maintainers = with maintainers; [ ajs124 das_j hexa ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

The build failed on our 48-core machine, so it seems like it doesn't support it anymore.

```
libtool: link: cc -g -O2 -o .libs/ldif-filter ldif-filter.o slapd-common.o  ../../libraries/liblutil/liblutil.a ../../libraries/libldap/.libs/libldap.so /build/openldap-2.6.2/libraries/liblber/.libs/liblber.so ../../libraries/liblber/.libs/liblber.so /nix/store/zkw493raash35m4al6bhrzvvwm2f0bdi-cyrus-sasl-2.1.28/lib/libsasl2.so -lssl -lcrypto -lcrypt -Wl,-rpath -Wl,/nix/store/wj7pax447418mk0h0iv7kl8ybb8z1qsd-openldap-2.6.2/lib -Wl,-rpath -Wl,/nix/store/zkw493raash35m4al6bhrzvvwm2f0bdi-cyrus-sasl-2.1.28/lib
checking how to run the C preprocessor... gcc -E
/nix/store/cz52w8xf3i1d3xvzpzd9abf7rvpl9017-binutils-2.38/bin/ld: cannot find slapd-common.o: No such file or directory
...
collect2: error: ld returned 1 exit status
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
