### PR TITLE
python3Packages.django-prometheus: fix 2.2.0 update

### DIFF
--- a/pkgs/development/python-modules/django-prometheus/default.nix
+++ b/pkgs/development/python-modules/django-prometheus/default.nix
@@ -16,8 +16,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "korfuri";
     repo = pname;
-    rev = version;
-    sha256 = "1y1cmycc545xrys41jk8kia36hwnkwhkw26mlpfdjgb63vq30x1d";
+    rev = "v${version}";
+    hash = "sha256-NE0zHnGGSrtkBLrSyBcQuyGrSfSQbdpevokg3YZhwDw=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/django-prometheus/drop-untestable-database-backends.patch
+++ b/pkgs/development/python-modules/django-prometheus/drop-untestable-database-backends.patch
@@ -1,5 +1,5 @@
 diff --git a/django_prometheus/tests/end2end/testapp/settings.py b/django_prometheus/tests/end2end/testapp/settings.py
-index 0630721..bd2190a 100644
+index cdd167f..5c6073b 100644
 --- a/django_prometheus/tests/end2end/testapp/settings.py
 +++ b/django_prometheus/tests/end2end/testapp/settings.py
 @@ -53,33 +53,6 @@ DATABASES = {
@@ -28,9 +28,9 @@ index 0630721..bd2190a 100644
 -    "mysql": {
 -        "ENGINE": "django_prometheus.db.backends.mysql",
 -        "NAME": "django_prometheus_1",
--        "USER": "travis",
+-        "USER": "root",
 -        "PASSWORD": "",
--        "HOST": "localhost",
+-        "HOST": "127.0.0.1",
 -        "PORT": "3306",
 -    },
      # The following databases are used by test_db.py only


### PR DESCRIPTION
###### Description of changes

Fixes the missing hash update in https://github.com/NixOS/nixpkgs/pull/151374

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
