### PR TITLE
curl: run tests in passthru

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -156,6 +156,7 @@ in rec {
         (onSystems ["i686-linux"] "nixos.tests.zfs.installer")
         (onFullSupported "nixpkgs.emacs")
         (onFullSupported "nixpkgs.jdk")
+        (onFullSupported "nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck")
         ["nixpkgs.tarball"]
       ];
     };

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -120,6 +120,7 @@ in rec {
         "nixos.tests.proxy.x86_64-linux"
         "nixos.tests.simple.x86_64-linux"
         "nixpkgs.jdk.x86_64-linux"
+        "nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-linux"
         "nixpkgs.tarball"
       ];
   };

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -24,6 +24,14 @@ with pkgs;
 
   config = callPackage ./config.nix { };
 
+  # we can't add 'nixpkgs.curl.tests' to hydra jobs due to 'tests' (and 'passthru') being stripped
+  # TODO: add a function in lib-release.nix to get derivations and add `.x86_64-linux` to them
+  # then we can just point release files to nixpkgs.tests.packageTestsForChannelBlockers instead of
+  # nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck
+  packageTestsForChannelBlockers = recurseIntoAttrs {
+    curl = recurseIntoAttrs pkgs.curl.tests;
+  };
+
   haskell = callPackage ./haskell { };
 
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -61,14 +61,14 @@ assert wolfsslSupport -> wolfssl != null;
 assert zlibSupport -> zlib != null;
 assert zstdSupport -> zstd != null;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "curl";
   version = "7.83.1";
 
   src = fetchurl {
     urls = [
-      "https://curl.haxx.se/download/${pname}-${version}.tar.bz2"
-      "https://github.com/curl/curl/releases/download/${lib.replaceStrings ["."] ["_"] pname}-${version}/${pname}-${version}.tar.bz2"
+      "https://curl.haxx.se/download/curl-${finalAttrs.version}.tar.bz2"
+      "https://github.com/curl/curl/releases/download/curl-${finalAttrs.version}/curl-${finalAttrs.version}.tar.bz2"
     ];
     sha256 = "sha256-9Tmjb7RKgmDsXZd+Tg290u7intkPztqpvDyfeKETv/A=";
   };
@@ -177,16 +177,21 @@ stdenv.mkDerivation rec {
     ln $out/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libcurl-gnutls${stdenv.hostPlatform.extensions.sharedLibrary}.4.4.0
   '';
 
-  passthru = {
+  passthru = let
+    useThisCurl = attr: attr.override { curl = finalAttrs.finalPackage; };
+  in {
     inherit opensslSupport openssl;
     tests = {
-      inherit curlpp coeurl;
-      haskell-curl = haskellPackages.curl;
-      ocaml-curly = ocamlPackages.curly;
-      php-curl = phpExtensions.curl;
-      pycurl = python3.pkgs.pycurl;
+      curlpp = useThisCurl curlpp;
+      coeurl = useThisCurl coeurl;
+      haskell-curl = useThisCurl haskellPackages.curl;
+      ocaml-curly = useThisCurl ocamlPackages.curly;
+      pycurl = useThisCurl python3.pkgs.pycurl;
+      php-curl = useThisCurl phpExtensions.curl;
+      # error: attribute 'override' missing
       # Additional checking with support http3 protocol.
-      inherit (nixosTests) nginx-http3;
+      # nginx-http3 = useThisCurl nixosTests.nginx-http3;
+      nginx-http3 = nixosTests.nginx-http3;
     };
   };
 
@@ -199,4 +204,4 @@ stdenv.mkDerivation rec {
     # Fails to link against static brotli or gss
     broken = stdenv.hostPlatform.isStatic && (brotliSupport || gssSupport);
   };
-}
+})

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -33,6 +33,8 @@
 , ocamlPackages
 , phpExtensions
 , python3
+, tests
+, fetchpatch
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -152,7 +154,10 @@ stdenv.mkDerivation (finalAttrs: {
   CXX = "${stdenv.cc.targetPrefix}c++";
   CXXCPP = "${stdenv.cc.targetPrefix}c++ -E";
 
-  doCheck = true;
+  # takes 14 minutes on a 24 core and because many other packages depend on curl
+  # they cannot be run concurrently and are a bottleneck
+  # tests are available in passthru.tests.withCheck
+  doCheck = false;
   preCheck = ''
     patchShebangs tests/
   '' + lib.optionalString stdenv.isDarwin ''
@@ -182,6 +187,8 @@ stdenv.mkDerivation (finalAttrs: {
   in {
     inherit opensslSupport openssl;
     tests = {
+      withCheck = finalAttrs.finalPackage.overrideAttrs (_: { doCheck = true; });
+      fetchpatch = tests.fetchpatch.simple.override { fetchpatch = fetchpatch.override { fetchurl = useThisCurl fetchurl; }; };
       curlpp = useThisCurl curlpp;
       coeurl = useThisCurl coeurl;
       haskell-curl = useThisCurl haskellPackages.curl;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -66,8 +66,8 @@ lib.makeScope pkgs.newScope (self: with self; {
   #
   # Build inputs is used for extra deps that may be needed. And zendExtension
   # will mark the extension as a zend extension or not.
-  mkExtension =
-    { name
+  mkExtension = lib.makeOverridable
+    ({ name
     , configureFlags ? [ "--enable-${name}" ]
     , internalDeps ? [ ]
     , postPhpize ? ""
@@ -151,7 +151,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         description = "PHP upstream extension: ${name}";
         inherit (php.meta) maintainers homepage license;
       };
-    });
+    }));
 
   php = phpPackage;
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -97,6 +97,7 @@ let
               jobs.lib-tests
               jobs.pkgs-lib-tests
               jobs.stdenv.x86_64-linux
+              jobs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-linux
               jobs.cargo.x86_64-linux
               jobs.go.x86_64-linux
               jobs.linux.x86_64-linux
@@ -133,6 +134,7 @@ let
             ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools
             ++ lib.optionals supportDarwin.x86_64 [
               jobs.stdenv.x86_64-darwin
+              jobs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-darwin
               jobs.cargo.x86_64-darwin
               jobs.cachix.x86_64-darwin
               jobs.go.x86_64-darwin


### PR DESCRIPTION
curl is built many times during a stdenv rebuild

they are a bottleneck

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
