### PR TITLE
ocamlPackages.mldoc: init at 1.3.9

### DIFF
--- a/pkgs/development/ocaml-modules/mldoc/default.nix
+++ b/pkgs/development/ocaml-modules/mldoc/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+, fetchpatch
+, angstrom
+, cmdliner
+, core
+, core_bench
+, js_of_ocaml
+, js_of_ocaml-ppx
+, ppx_deriving_yojson
+, uri
+, yojson
+, lwt
+, xmlm
+}:
+let
+  angstrom' = angstrom.overrideAttrs (attrs: {
+    patches = attrs.patches or [ ] ++ [
+      # mldoc requires Angstrom to expose `unsafe_lookahead`
+      (fetchpatch {
+        url = "https://github.com/logseq/angstrom/commit/bbe36c99c13678937d4c983a427e02a733d6cc24.patch";
+        sha256 = "sha256-RapY1QJ8U0HOqJ9TFDnCYB4tFLFuThESzdBZqjYuDUA=";
+      })
+    ];
+  });
+  uri' = uri.override { angstrom = angstrom'; };
+in
+buildDunePackage rec {
+  pname = "mldoc";
+  version = "1.3.9";
+
+  minimalOCamlVersion = "4.10";
+
+  src = fetchFromGitHub {
+    owner = "logseq";
+    repo = "mldoc";
+    rev = "v${version}";
+    sha256 = "sha256-C5SeG10EoZixCWeBxw7U+isAR8UWd1jzHLdmbp//gAs=";
+  };
+
+  buildInputs = [
+    cmdliner
+    core
+    core_bench
+    js_of_ocaml
+    js_of_ocaml-ppx
+    lwt
+  ];
+
+  propagatedBuildInputs = [
+    angstrom'
+    uri'
+    yojson
+    ppx_deriving_yojson
+    xmlm
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/logseq/mldoc";
+    description = "Another Emacs Org-mode and Markdown parser";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ marsam ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -899,6 +899,8 @@ let
 
     mirage-vnetif = callPackage ../development/ocaml-modules/mirage-vnetif { };
 
+    mldoc =  callPackage ../development/ocaml-modules/mldoc { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add https://github.com/logseq/mldoc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
