### PR TITLE
Fix broken seafile

### DIFF
--- a/pkgs/applications/networking/seahub/default.nix
+++ b/pkgs/applications/networking/seahub/default.nix
@@ -19,13 +19,13 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "seahub";
-  version = "8.0.8";
+  version = "9.0.6";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seahub";
-    rev = "c51346155b2f31e038c3a2a12e69dcc6665502e2"; # using a fixed revision because upstream may re-tag releases :/
-    sha256 = "0dagiifxllfk73xdzfw2g378jccpzplhdrmkwbaakbhgbvvkg92k";
+    rev = "876b7ba9b680fc668e89706aff535593772ae921"; # using a fixed revision because upstream may re-tag releases :/
+    sha256 = "sha256-GHvJlm5DVt3IVJnqJu8YobNNqbjdPd08s4DCdQQRQds=";
   };
 
   dontBuild = true;
@@ -52,6 +52,7 @@ python.pkgs.buildPythonApplication rec {
     openpyxl
     requests
     requests-oauthlib
+    chardet
     pyjwt
     pycryptodome
     qrcode

--- a/pkgs/applications/networking/seahub/default.nix
+++ b/pkgs/applications/networking/seahub/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , python3
 , makeWrapper
+, nixosTests
 }:
 let
   # Seahub 8.x.x does not support django-webpack-loader >=1.x.x
@@ -70,6 +71,9 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     inherit python;
     pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
+    tests = {
+      inherit (nixosTests) seafile;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/networking/seahub/default.nix
+++ b/pkgs/applications/networking/seahub/default.nix
@@ -70,7 +70,7 @@ python.pkgs.buildPythonApplication rec {
 
   passthru = {
     inherit python;
-    pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
+    pythonPath = python.pkgs.makePythonPath propagatedBuildInputs;
     tests = {
       inherit (nixosTests) seafile;
     };

--- a/pkgs/servers/seafile-server/default.nix
+++ b/pkgs/servers/seafile-server/default.nix
@@ -10,13 +10,13 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "seafile-server";
-  version = "8.0.8";
+  version = "9.0.6";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile-server";
-    rev = "807867afb7a86f526a6584278914ce9f3f51d1da";
-    sha256 = "1nq6dw4xzifbyhxn7yn5398q2sip1p1xwqz6xbis4nzgx4jldd4g";
+    rev = "881c270aa8d99ca6648e7aa1458fc283f38e6f31"; # using a fixed revision because upstream may re-tag releases :/
+    sha256 = "sha256-M1jIysirtl1KKyEvScOIshLvSa5vjxTdFEARgy8bLTc=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This addresses  #173825 by updating to seafile 9.0.6 (latest release).
Seahub was broken in 22.05 because of django version mismatch.

This should be backported to 22.05 since seahub is useless otherwise.

The service now supports major migration from 8.0.x to 9.0.x and nixos tests are now linked to seahub package as well (this should give visibility much sooner next time something is broken).

Update was tested by starting a container from nixos-21.11 and updating it from this branch.
<details>
<summary>container definition</summary>

```nix
{ pkgs, ... }: {
  services.seafile = {
    enable = true;
    ccnetSettings.General.SERVICE_URL = "http://10.233.2.2";
    adminEmail = "test@local.com";
    initialAdminPassword = "password";
  };
  services.nginx = {
    enable = true;
    virtualHosts."10.233.2.2" = {
      locations."/".proxyPass = "http://unix:/run/seahub/gunicorn.sock";
      locations."/seafdav".proxyPass = "http://127.0.0.1:6001/seafdav";
      locations."/seafhttp" = {
        proxyPass = "http://127.0.0.1:8082";
        extraConfig = ''
          rewrite ^/seafhttp(.*)$ $1 break;
          client_max_body_size 0;
          proxy_connect_timeout  36000s;
          proxy_read_timeout  36000s;
          proxy_send_timeout  36000s;
          send_timeout  36000s;
          proxy_http_version 1.1;
        '';
      };
    };
  };
  networking.firewall = { allowedTCPPorts = [ 80 ]; };
}
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
