### PR TITLE
keepassxc: Avoid absolute path to fix autostart

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , qttools
 , darwin
@@ -57,6 +58,11 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
 
   patches = [
+    # pending "autostart: Linux: Exec= filename not absolute path"
+    (fetchpatch {
+      url = "https://github.com/keepassxreboot/keepassxc/pull/8191/commits/4e0a2cd39ddbdb30b9308494381e6fb494ca8481.patch";
+      sha256 = "sha256-E/Wp72lODu5Z32PPuyxwu4NwmjJTPJ4tJDvqepohdA0=";
+    })
     ./darwin.patch
   ];
 


### PR DESCRIPTION
```
Tools > Settings > General > Basic Settings > Startup
[x] Automatically launch KeePassXC at system startup
```

If set, this will create ~/.config/autostart/org.keepassxc.KeePassXC.desktop
```
[Desktop Entry]
Name=KeePassXC
GenericName=Password Manager
Exec=/nix/store/jn5pxhskvy08rnq4yfbcrsmzjpiwj09h-keepassxc-2.7.1/bin/.keepassxc-wrapped
TryExec=/nix/store/jn5pxhskvy08rnq4yfbcrsmzjpiwj09h-keepassxc-2.7.1/bin/.keepassxc-wrapped
Icon=keepassxc
StartupWMClass=keepassxc
StartupNotify=true
Terminal=false
Type=Application
Version=1.0
Categories=Utility;Security;Qt;
MimeType=application/x-keepass2;
X-GNOME-Autostart-enabled=true
X-GNOME-Autostart-Delay=2
X-KDE-autostart-after=panel
X-LXQt-Need-Tray=true
```

I noticed this by seeing `..keepassxc-wrapped-wrapped` in my process
list long after having fixed double wrapping, so grepping the home
directory turned up this persisted state.

Apply my upstream PR to effectively replace the absoloute path with the
program name.

To update the config file, unset above option, press OK, renavigate to
it, set it and press OK again.

@jonafato @turion
