### PR TITLE
mongodb-4_0: fixed

### DIFF
--- a/pkgs/servers/nosql/mongodb/patches/mongodb-4.0-glibc-2.34.patch
+++ b/pkgs/servers/nosql/mongodb/patches/mongodb-4.0-glibc-2.34.patch
@@ -1,0 +1,14 @@
+--- a/src/mongo/stdx/thread.h
++++ b/src/mongo/stdx/thread.h
+@@ -103,10 +103,7 @@ private:
+     //   .                     N   Y :      4,344 |  13,048 |     7,352
+     //   .                     Y   Y :      4,424 |  13,672 |     8,392
+     //   ( https://jira.mongodb.org/secure/attachment/233569/233569_stacktrace-writeup.txt )
+-    static constexpr std::size_t kMongoMinSignalStackSize = std::size_t{64} << 10;
+-
+-    static constexpr std::size_t kStackSize =
+-        std::max(kMongoMinSignalStackSize, std::size_t{MINSIGSTKSZ});
++    static constexpr std::size_t kStackSize = std::size_t{64} << 10;
+     std::unique_ptr<char[]> _stackStorage = std::make_unique<char[]>(kStackSize);
+
+ #else   // !MONGO_HAS_SIGALTSTACK

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+{ stdenv, callPackage, fetchpatch, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
   buildMongoDB = callPackage ./mongodb.nix {
@@ -11,7 +11,15 @@ let
 in buildMongoDB {
   version = "4.0.27";
   sha256 = "sha256-ct33mnK4pszhYM4Is7j0GZQRyi8i8Qmy0wcklyq5LjM=";
-  patches =
-    [ ./forget-build-dependencies.patch ./mozjs-45_fix-3-byte-opcode.patch ]
+  patches = [
+    ./forget-build-dependencies.patch
+    ./mozjs-45_fix-3-byte-opcode.patch
+    ./patches/mongodb-4.0-glibc-2.34.patch # https://github.com/NixOS/nixpkgs/issues/171928
+    (fetchpatch {
+      name = "mongodb-4.4.1-gcc11.patch";
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/7168257cad6ea7c4856b01c5703d0ed5b764367c/dev-db/mongodb/files/mongodb-4.4.1-gcc11.patch";
+      sha256 = "sha256-RvfCP462RG+ZVjcb23DgCuxCdfPl2/UgH8N7FgCghGI=";
+    })
+  ]
     ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
 }

--- a/pkgs/servers/nosql/mongodb/v4_2.nix
+++ b/pkgs/servers/nosql/mongodb/v4_2.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+{ stdenv, callPackage, fetchpatch, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
   buildMongoDB = callPackage ./mongodb.nix {
@@ -11,7 +11,12 @@ let
 in buildMongoDB {
   version = "4.2.19";
   sha256 = "sha256-fngTHd+fSdHqiqQYOYS7o6P5eHybeZy3iNKkGzFmjTw=";
-  patches =
-    [ ./forget-build-dependencies-4-2.patch ]
-    ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-2.patch ];
+  patches = [
+    ./forget-build-dependencies-4-2.patch
+    (fetchpatch {
+      name = "mongodb-4.4.1-gcc11.patch";
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/7168257cad6ea7c4856b01c5703d0ed5b764367c/dev-db/mongodb/files/mongodb-4.4.1-gcc11.patch";
+      sha256 = "sha256-RvfCP462RG+ZVjcb23DgCuxCdfPl2/UgH8N7FgCghGI=";
+    })
+  ] ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-2.patch ];
 }


### PR DESCRIPTION
* mongodb-4_0: fixed
* mongodb-4_2: fixed

This PR is a breakdown of *currently* working parts of #171928 (stale PR)

Makes MongoDB 4_0 and 4_02 available while newer versions (4.4 & 5) are still broken.

I have refrained from doing further changes (like refactoring) in order to keep PR simple.

@bryanasdev000 Please review.