### PR TITLE
kinfocenter: add optional dependencies to path

### DIFF
--- a/pkgs/desktops/plasma-5/kinfocenter.nix
+++ b/pkgs/desktops/plasma-5/kinfocenter.nix
@@ -24,6 +24,11 @@
 , libraw1394
 , libGLU
 , pciutils
+, aha
+, glxinfo
+, vulkan-tools
+, wayland-utils
+, xdpyinfo
 }:
 
 mkDerivation {
@@ -53,10 +58,12 @@ mkDerivation {
     libGLU
     pciutils
   ];
-  preFixup = ''
-    # fix wrong symlink of infocenter pointing to a 'systemsettings5' binary in
-    # the same directory, while it is actually located in a completely different
-    # store path
-    ln -sf ${lib.getBin systemsettings}/bin/systemsettings5 $out/bin/kinfocenter
+  postFixup = ''
+    rm $out/bin/kinfocenter
+    # 'kinfocenter' simply opens 'systemsettings5', which checks
+    # the executable name to see in which mode it should open
+    makeWrapper ${lib.getBin systemsettings}/bin/systemsettings5 $out/bin/kinfocenter \
+      --argv0 $pname \
+      --prefix PATH : ${lib.makeBinPath [ aha glxinfo pciutils vulkan-tools wayland-utils xdpyinfo ]}
   '';
 }


### PR DESCRIPTION
###### Description of changes

`kinfocenter` requires some packages to show some types of information, and now the derivation adds these in `PATH`.
Fixes #168320.
Continuation of #175738.

One problem that I'm facing (the reason this is a draft) is that `kinfocenter` isn't a standalone application, but it's just a symbolic link to `systemsettings5`, [which check argv0 to see in which mode it needs to open](https://invent.kde.org/plasma/systemsettings/-/blob/master/app/main.cpp#L32).
However, I'm having trouble to do that, so if someone knows how to do it, it would be welcome.
I'm guessing that `.systemsettings5-wrapped` is interfering, but it's called with `exec -a "$0"`, so I don't understand...
Also, `pciutils` seemed to do nothing in `buildInputs`, so I removed it from there. I don't know if there are more that can be removed.
Finally, a weird thing, but if the symbolic link isn't removed (by `rm`), `makeWrapper` doesn't override the file already there, but it creates a new one on the symbolic link location. Is this normal?

EDIT: I noticed that `exec -a kinfocenter systemsettings` opens the regular settings, while `exec -a kinfocenter /nix/store/hash-systemsettings-5.25.2-bin/bin/.systemsettings-wrapped` opens kinfocenter correctly. Probably related to #150841.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
