### PR TITLE
pam-reattach: init at 1.3

### DIFF
--- a/pkgs/os-specific/darwin/pam-reattach/default.nix
+++ b/pkgs/os-specific/darwin/pam-reattach/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitHub, cmake, openpam, darwin }:
+
+let
+  sdk =
+    if stdenv.isAarch64
+    then null
+    else darwin.apple_sdk.sdk;
+in
+
+stdenv.mkDerivation rec {
+  pname = "pam_reattach";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "fabianishere";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1k77kxqszdwgrb50w7algj22pb4fy5b9649cjb08zq9fqrzxcbz7";
+  };
+
+  cmakeFlags = [
+    "-DCMAKE_OSX_ARCHITECTURES=${
+      if stdenv.hostPlatform.system == "x86_64-darwin" then
+        "x86_64"
+      else
+        "arm64"
+    }"
+    "-DENABLE_CLI=ON"
+  ]
+  ++ lib.optional (sdk != null)
+    "-DCMAKE_LIBRARY_PATH=${sdk}/usr/lib";
+
+  buildInputs = [ openpam ]
+    ++ lib.optional (sdk != null) sdk;
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    homepage = "https://github.com/fabianishere/pam_reattach";
+    description = "Reattach to the user's GUI session on macOS during authentication (for Touch ID support in tmux)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lockejan ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2535,6 +2535,8 @@ with pkgs;
 
   plausible = callPackage ../servers/web-apps/plausible { };
 
+  pam-reattach = callPackage ../os-specific/darwin/pam-reattach {};
+
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace {};
 
   skhd = callPackage ../os-specific/darwin/skhd {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
