### PR TITLE
ldtk: init at 1.1.3

### DIFF
--- a/pkgs/applications/editors/ldtk/default.nix
+++ b/pkgs/applications/editors/ldtk/default.nix
@@ -1,0 +1,58 @@
+{ lib, stdenv, fetchurl, makeWrapper, makeDesktopItem, copyDesktopItems, unzip
+, appimage-run }:
+
+stdenv.mkDerivation rec {
+  pname = "ldtk";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "https://github.com/deepnight/ldtk/releases/download/v${version}/ubuntu-distribution.zip";
+    sha256 = "sha256-qw7+4k4IH2+9DX4ny8EBbSlyXBrk/y91W04+zWPGupk=";
+  };
+
+  nativeBuildInputs = [ unzip makeWrapper copyDesktopItems appimage-run ];
+
+  buildInputs = [ appimage-run ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    unzip $src
+    appimage-run -x src 'LDtk ${version} installer.AppImage'
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 'LDtk ${version} installer.AppImage' $out/share/ldtk.AppImage
+    makeWrapper ${appimage-run}/bin/appimage-run $out/bin/ldtk \
+      --add-flags $out/share/ldtk.AppImage
+    install -Dm644 src/ldtk.png $out/share/icons/hicolor/1024x1024/apps/ldtk.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ldtk";
+      exec = "ldtk";
+      icon = "ldtk";
+      terminal = false;
+      desktopName = "LDtk";
+      comment = "2D level editor";
+      categories = [ "Utility" ];
+      mimeTypes = [ "application/json" ];
+    })
+  ];
+
+  meta = with lib; {
+    homepage = "https://ldtk.io/";
+    description = "Modern, lightweight and efficient 2D level editor";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ felschr ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3923,6 +3923,8 @@ with pkgs;
 
   languagetool = callPackage ../tools/text/languagetool {  };
 
+  ldtk = callPackage ../applications/editors/ldtk { };
+
   lepton = callPackage ../tools/graphics/lepton { };
 
   lepton-eda = callPackage ../applications/science/electronics/lepton-eda { };


### PR DESCRIPTION
###### Description of changes
Adds LDtk: A modern 2D level editor from the creator of Dead Cells, with a strong focus on user-friendliness.
Closes #168277

The AppImage is distributed within a zip file and I haven't found a way to use that with `appimageTools.wrapType2`, thus I'm using a wrapper which runs `appimage-run` instead.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).