### PR TITLE
[22.05] runitor: 0.9.2 -> 0.10.1

### DIFF
--- a/pkgs/tools/system/runitor/default.nix
+++ b/pkgs/tools/system/runitor/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, fetchpatch, testers, runitor }:
+{ lib, buildGoModule, fetchFromGitHub, testers, runitor }:
 
 buildGoModule rec {
   pname = "runitor";

--- a/pkgs/tools/system/runitor/default.nix
+++ b/pkgs/tools/system/runitor/default.nix
@@ -1,29 +1,20 @@
-{ lib, buildGoModule, fetchFromGitHub, testers, runitor }:
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch, testers, runitor }:
 
 buildGoModule rec {
   pname = "runitor";
-  version = "0.9.2";
+  version = "0.10.1";
   vendorSha256 = null;
 
   src = fetchFromGitHub {
     owner = "bdd";
     repo = "runitor";
     rev = "v${version}";
-    sha256 = "sha256-LuCxn4j0MlnJjSh3d18YNzNrtbqtMPxgkZttqKUGJd4";
+    sha256 = "sha256-qqfaA1WAHkuiyzyQbrSvnmwuRXElArErJ6PtLPOxzsg=";
   };
 
   ldflags = [
     "-s" "-w" "-X main.Version=v${version}"
   ];
-
-  # TODO(cole-h):
-  # End-to-end tests requiring localhost networking currently under
-  # OfBorg's Linux builders, while passing under Darwin.
-  #
-  # Ref: https://github.com/NixOS/nixpkgs/pull/170566#issuecomment-1114034891
-  #
-  # Temporarily disable tests.
-  doCheck = false;
 
   passthru.tests.version = testers.testVersion {
     package = runitor;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34552,7 +34552,7 @@ with pkgs;
 
   runit = callPackage ../tools/system/runit { };
 
-  runitor = callPackage ../tools/system/runitor { };
+  runitor = callPackage ../tools/system/runitor { buildGoModule = buildGo118Module; };
 
   refind = callPackage ../tools/bootloaders/refind { };
 


### PR DESCRIPTION
- New functionality
- No breaking changes
- Requires Go 1.18

0.9.2  -> 0.10.0
(cherry picked from commit ca0e288de3d4128f3af24da0e0d7b7b9127685c2)

0.10.0 -> 0.10.1
(cherry picked from commit 1f9c7f33930a657c0c7b0500a097f8c38d474832)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
