### PR TITLE
pixelorama: init at 0.10.1

### DIFF
--- a/pkgs/applications/editors/pixelorama/default.nix
+++ b/pkgs/applications/editors/pixelorama/default.nix
@@ -1,0 +1,57 @@
+{ lib, stdenv, fetchFromGitHub, godot-headless, godot-export-templates }:
+
+let
+  preset =
+    if stdenv.isLinux then
+      if stdenv.is64bit then "Linux/X11 64-bit"
+      else "Linux/X11 32-bit"
+    else if stdenv.isDarwin then "Mac OSX"
+    else throw "unsupported platform";
+in stdenv.mkDerivation rec {
+  pname = "pixelorama";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "Orama-Interactive";
+    repo = "Pixelorama";
+    rev = "v${version}";
+    sha256 = "sha256-+Sfhv66skHawe6jzfzQyFxejN5TvTdmWunzl0/7yy4M=";
+  };
+
+  nativeBuildInputs = [
+    godot-headless
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+    mkdir -p $HOME/.local/share/godot/
+    ln -s "${godot-export-templates}/share/godot/templates" "$HOME/.local/share/godot/templates"
+    mkdir -p build
+    godot-headless -v --export "${preset}" ./build/pixelorama
+    godot-headless -v --export-pack "${preset}" ./build/pixelorama.pck
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 755 -t $out/libexec ./build/pixelorama
+    install -D -m 644 -t $out/libexec ./build/pixelorama.pck
+    install -D -m 644 -t $out/share/applications ./Misc/Linux/com.orama_interactive.Pixelorama.desktop
+    install -d -m 755 $out/bin
+    ln -s $out/libexec/pixelorama $out/bin/pixelorama
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://orama-interactive.itch.io/pixelorama";
+    description = "A free & open-source 2D sprite editor, made with the Godot Engine!";
+    license = licenses.mit;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27321,6 +27321,8 @@ with pkgs;
 
   pixelnuke = callPackage ../applications/graphics/pixelnuke { };
 
+  pixelorama = callPackage ../applications/editors/pixelorama { };
+
   pixeluvo = callPackage ../applications/graphics/pixeluvo { };
 
   pixinsight = libsForQt5.callPackage ../applications/graphics/pixinsight { };


### PR DESCRIPTION
###### Description of changes
Adds Pixelorama: A free & open-source 2D sprite editor, made with the Godot Engine!

Based on @jrobsonchase's [pixelorama derivation](https://github.com/jrobsonchase/nixos-config/blob/9c786901417c6aeee8690f9bf5a903fd2732c811/overlay/pixelorama.nix).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).