### PR TITLE
blocky: 0.18 -> 0.19

### DIFF
--- a/pkgs/applications/networking/blocky/default.nix
+++ b/pkgs/applications/networking/blocky/default.nix
@@ -6,20 +6,20 @@
 
 buildGoModule rec {
   pname = "blocky";
-  version = "0.18";
+  version = "0.19";
 
   src = fetchFromGitHub {
     owner = "0xERR0R";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-rFHDoNrEmMSNEc3RLdSeRk9mF05drUYfJFQKHAk5alE=";
+    sha256 = "sha256-jOOakRuiNbdCGmbaQFuHcLsHhV26jaQY+1GgDj9ocs0=";
   };
 
   # needs network connection and fails at
   # https://github.com/0xERR0R/blocky/blob/development/resolver/upstream_resolver_test.go
   doCheck = false;
 
-  vendorSha256 = "sha256-rrqDjh5e3KX5+saYjnMPG0bhr5YEOPfz0QCRf6omNZI=";
+  vendorSha256 = "sha256-fsMBL9qyhIrV6eAsqpSaNniibMdYRVBnl2KCzStvMGQ=";
 
   meta = with lib; {
     description = "Fast and lightweight DNS proxy as ad-blocker for local network with many features.";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update blocky to latest version 0.19

Description: Fast and lightweight DNS proxy as ad-blocker for local network with many features.

Homepage: https://0xerr0r.github.io/blocky

[Release on GitHub](https://github.com/0xERR0R/blocky/releases/tag/v0.19)

[Compare changes on GitHub](https://github.com/0xERR0R/blocky/compare/v0.18..v0.19)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
