### PR TITLE
temporal-cli: 1.16.1 -> 1.16.2

### DIFF
--- a/pkgs/applications/networking/cluster/temporal-cli/default.nix
+++ b/pkgs/applications/networking/cluster/temporal-cli/default.nix
@@ -1,26 +1,17 @@
-{ lib, fetchFromGitHub, fetchpatch, buildGoModule, testers, temporal-cli }:
+{ lib, fetchFromGitHub, buildGoModule, testers, temporal-cli }:
 
 buildGoModule rec {
   pname = "temporal-cli";
-  version = "1.16.1";
+  version = "1.16.2";
 
   src = fetchFromGitHub {
     owner = "temporalio";
     repo = "tctl";
     rev = "v${version}";
-    sha256 = "sha256-WNdu/62/VmxTmzAvzx3zIlcAAlEmpN0yKzQOSUtrL8s=";
+    sha256 = "sha256-KLcCFQJlFeioIhqrbkhgoNPcbAYvy1ESG8x9Y/I7+nw=";
   };
 
-  patches = [
-    # Fix tests
-    (fetchpatch {
-      name = "fix-tests.patch";
-      url = "https://github.com/temporalio/tctl/pull/203/commits/2b113da137a3a925e8fbd7c18bdaaefc31397db4.patch";
-      sha256 = "sha256-HFPwbmLZ2uPHzaHvYoB4MTZvMVyzvUKggA76/bh50DQ=";
-    })
-  ];
-
-  vendorSha256 = "sha256-WF3T+HNisfR0JoKkHCC77kmHmsGZ9NfQ7UCwOmpCG/o=";
+  vendorSha256 = "sha256-kczmoP32/V0HHeC3Mr+giuMB+McVTNeC2F+t1ohY4/U=";
 
   ldflags = [ "-s" "-w" ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
