### PR TITLE
python310Packages.cocotb: unbreak on Darwin

### DIFF
--- a/pkgs/development/python-modules/cocotb/0001-Patch-LDCXXSHARED-for-macOS-along-with-LDSHARED.patch
+++ b/pkgs/development/python-modules/cocotb/0001-Patch-LDCXXSHARED-for-macOS-along-with-LDSHARED.patch
@@ -1,0 +1,26 @@
+From 94c4768cd69b026e498d92133dd6c7d8589cf911 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sat, 25 Jun 2022 10:19:44 +0800
+Subject: [PATCH] Patch LDCXXSHARED for macOS along with LDSHARED
+
+In Nixpkgs, we patched distutils to respect LDCXXSHARED environment, so
+the replacement should be taken on LDCXXSHARED as well.
+---
+ cocotb_build_libs.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cocotb_build_libs.py b/cocotb_build_libs.py
+index 66097ec2..d5555b36 100755
+--- a/cocotb_build_libs.py
++++ b/cocotb_build_libs.py
+@@ -583,6 +583,7 @@ def get_ext():
+ 
+     if sys.platform == "darwin":
+         cfg_vars["LDSHARED"] = cfg_vars["LDSHARED"].replace("-bundle", "-dynamiclib")
++        cfg_vars["LDCXXSHARED"] = cfg_vars["LDCXXSHARED"].replace("-bundle", "-dynamiclib")
+ 
+     share_lib_dir = os.path.relpath(os.path.join(cocotb_share_dir, "lib"))
+     include_dir = os.path.relpath(os.path.join(cocotb_share_dir, "include"))
+-- 
+2.36.1
+

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -40,7 +40,16 @@ buildPythonPackage rec {
 
     # remove circular dependency cocotb-bus from setup.py
     substituteInPlace setup.py --replace "'cocotb-bus<1.0'" ""
+  '' + lib.optionalString stdenv.isDarwin ''
+    # disable lto on darwin
+    # https://github.com/NixOS/nixpkgs/issues/19098
+    substituteInPlace cocotb_build_libs.py --replace "-flto" ""
   '';
+
+  patches = [
+    # Fix "can't link with bundle (MH_BUNDLE) only dylibs (MH_DYLIB) file" error
+    ./0001-Patch-LDCXXSHARED-for-macOS-along-with-LDSHARED.patch
+  ];
 
   checkInputs = [ cocotb-bus pytestCheckHook swig verilog ];
 
@@ -53,6 +62,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/cocotb/cocotb";
     license = licenses.bsd3;
     maintainers = with maintainers; [ matthuszagh ];
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Disable lto, see issue #19098

- Replace `-bundle` in LDCXXSHARED env


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
