### PR TITLE
[DRAFT] speek: init at 1.6.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/speek/default.nix
+++ b/pkgs/applications/networking/instant-messengers/speek/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qmake
+, pkg-config
+, wrapQtAppsHook
+, protobuf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "speek";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Speek-App";
+    repo = "Speek";
+    rev = "v${version}-release";
+    sha256 = "sha256-j3PcWJEJgBuk1bYervdSi1iS+xT5pu/rfFw3QzI+VFs=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    protobuf
+  ];
+
+  sourceRoot = "source/src";
+
+  meta = with lib; {
+    description = ''
+      Privacy focused messenger that doesn't trust anyone with your identity,
+      your contact list, or your communications
+    '';
+    homepage = "https://github.com/Speek-App/Speek";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ onny ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10438,6 +10438,8 @@ with pkgs;
     jdk = jdk11;
   };
 
+  speek = libsForQt5.callPackage ../applications/networking/instant-messengers/speek { };
+
   spglib = callPackage ../development/libraries/spglib {
     inherit (llvmPackages) openmp;
   };


### PR DESCRIPTION
###### Description of changes

Fixes packaging request https://github.com/NixOS/nixpkgs/issues/178848

Adds a package for the P2P decentralized and anonymous messenger [speek](https://speek.network/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
