### PR TITLE
fetch-cargo-tarball: allow use index mirror

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -52,8 +52,9 @@
 , buildAndTestSubdir ? null
 , ... } @ args:
 
-assert cargoVendorDir == null && cargoLock == null -> !(args ? cargoSha256) && !(args ? cargoHash)
-  -> throw "cargoSha256, cargoHash, cargoVendorDir, or cargoLock must be set";
+assert cargoVendorDir == null && cargoLock == null
+    -> !(args ? cargoSha256 && args.cargoSha256 != null) && !(args ? cargoHash && args.cargoHash != null)
+    -> throw "cargoSha256, cargoHash, cargoVendorDir, or cargoLock must be set";
 assert buildType == "release" || buildType == "debug";
 
 let

--- a/pkgs/build-support/rust/fetch-cargo-tarball/cargo-vendor-normalise.py
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/cargo-vendor-normalise.py
@@ -13,7 +13,9 @@ def quote(s: str) -> str:
 def main() -> None:
     data = toml.load(sys.stdin)
 
-    assert list(data.keys()) == ["source"]
+    # There is no dependency to vendor in this project.
+    if not list(data.keys()) == ["source"]:
+        return
 
     # this value is non deterministic
     data["source"]["vendored-sources"]["directory"] = "@vendor@"

--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -58,9 +58,18 @@ in stdenv.mkDerivation ({
     export CARGO_HOME=$(mktemp -d cargo-home.XXX)
     CARGO_CONFIG=$(mktemp cargo-config.XXXX)
 
+    if [[ -n "$NIX_CRATES_INDEX" ]]; then
+    cat >$CARGO_HOME/config.toml <<EOF
+    [source.crates-io]
+    replace-with = 'mirror'
+    [source.mirror]
+    registry = "$NIX_CRATES_INDEX"
+    EOF
+    fi
+
     ${cargoUpdateHook}
 
-    cargo vendor $name | cargo-vendor-normalise > $CARGO_CONFIG
+    cargo vendor $name --respect-source-config | cargo-vendor-normalise > $CARGO_CONFIG
 
     # Add the Cargo.lock to allow hash invalidation
     cp Cargo.lock.orig $name/Cargo.lock
@@ -81,7 +90,7 @@ in stdenv.mkDerivation ({
 
   inherit (hash_) outputHashAlgo outputHash;
 
-  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_CRATES_INDEX" ];
 } // (builtins.removeAttrs args [
   "name" "sha256" "cargoUpdateHook" "nativeBuildInputs"
 ]))

--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -71,6 +71,8 @@ in stdenv.mkDerivation ({
 
     cargo vendor $name --respect-source-config | cargo-vendor-normalise > $CARGO_CONFIG
 
+    # Create an empty vendor directory when there is no dependency to vendor
+    mkdir -p $name
     # Add the Cargo.lock to allow hash invalidation
     cp Cargo.lock.orig $name/Cargo.lock
 

--- a/pkgs/tools/misc/elfcat/default.nix
+++ b/pkgs/tools/misc/elfcat/default.nix
@@ -11,8 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-NzFKNCCPWBj/fhaEJF34nyeyvLMeQwIcQgTlYc6mgYo=";
   };
 
-  # There is no dependency to vendor in this project.
-  cargoLock.lockFile = ./Cargo.lock;
+  cargoHash = "sha256-Dc+SuLwbLFcNSr9RiNSc7dgisBOvOUEIDR8dFAkC/O0=";
 
   meta = with lib; {
     description = "ELF visualizer, generates HTML files from ELF binaries.";


### PR DESCRIPTION
###### Description of changes

Allow to use a mirror when fetch the crates index. Since GitHub is blocked in mainland China this would be convenient.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
