### PR TITLE
nixos/doc: Instructions to add a new module test to nixosTests

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -21,6 +21,11 @@ import ./make-test-python.nix {
 }
 ```
 
+For the test to be actually used by NixOS' automatic testing framework, it has
+to be put into `nixos/tests/allTests.nix`. In doing so it is available for
+package testing in `nixosTests` as well (see:
+[Linking NixOS tests to package](#sec-linking-nixos-tests-to-packages)).
+
 The attribute `testScript` is a bit of Python code that executes the
 test (described below). During the test, it will start one or more
 virtual machines, the configuration of which is described by

--- a/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
+++ b/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
@@ -22,6 +22,15 @@ import ./make-test-python.nix {
 }
 </programlisting>
   <para>
+    For the test to be actually used by NixOS’ automatic testing
+    framework, it has to be put into
+    <literal>nixos/tests/allTests.nix</literal>. In doing so it is
+    available for package testing in <literal>nixosTests</literal> as
+    well (see:
+    <link linkend="sec-linking-nixos-tests-to-packages">Linking NixOS
+    tests to package</link>).
+  </para>
+  <para>
     The attribute <literal>testScript</literal> is a bit of Python code
     that executes the test (described below). During the test, it will
     start one or more virtual machines, the configuration of which is


### PR DESCRIPTION
Documented where a new module test has to be added to be useful.

Without adding a newly created module test to `nixosTests` it is not
actually used when running the automated tests for NixOS. Neither is it
available to be included into a package's test.

Rationale: While making PR #178431 I wanted to include a small test for my changes. Though [the basic procedure of writing a module test for NixOS](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests) seems well documented to me. What was missing was the link between the test and the actual testing done later on, when releasing NixOS or testing a package. Without any further hint from the manual, I assumed at first that any `*.nix` in `nixpkgs/nixos/tests` would be automatically included when NixOS is tested. This assumption was wrong as I figured out after some digging, when I was trying to [include the module test in a package](https://nixos.org/manual/nixpkgs/stable/#ssec-nixos-tests-linking) as proposed in the NixOS Manual. Only there I realized that my test was not automatically part of `nixosTests` and the testing framework, but had to be manually introduced.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] ran `nix-build nixos/release.nix -A manual.x86_64-linux` successfully and reviewed change in `result/`
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
