### PR TITLE
hiprompt-gtk-py: init at unstable-2022-06-17

### DIFF
--- a/pkgs/tools/security/hiprompt-gtk-py/default.nix
+++ b/pkgs/tools/security/hiprompt-gtk-py/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, desktop-file-utils
+, glib
+, gobject-introspection
+, gtk3
+, gtk-layer-shell
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hiprompt-gtk-py";
+  version = "unstable-2022-06-17";
+
+  src = fetchFromSourcehut {
+    name = pname + "-src";
+    owner = "~sircmpwn";
+    repo = pname;
+    rev = "f74499302bdd6558d4644c25e15c9b5c482270ea";
+    hash = "sha256-/vYg7q4ZVakJ0BeULxJWXnBYb75tkgVVXbHYwnN6dZ4=";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    glib
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gobject-introspection
+    gtk3
+    gtk-layer-shell
+    (python3.withPackages (pp: with pp; [
+      pygobject3
+    ]))
+  ];
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~sircmpwn/hiprompt-gtk-py";
+    description = "A GTK+ Himitsu prompter for Wayland";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ auchter ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2411,6 +2411,8 @@ with pkgs;
 
   hinit = haskell.lib.compose.justStaticExecutables haskellPackages.hinit;
 
+  hiprompt-gtk-py = callPackage ../tools/security/hiprompt-gtk-py { };
+
   hostctl = callPackage ../tools/system/hostctl { };
 
   hp2p = callPackage ../tools/networking/hp2p { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [hiprompt-gtk-py](https://git.sr.ht/~sircmpwn/hiprompt-gtk-py), which is a GTK based prompter for [Himitsu](https://himitsustore.org/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
