### PR TITLE
mu: 1.6.11 -> 1.8.0

### DIFF
--- a/pkgs/tools/networking/mu/default.nix
+++ b/pkgs/tools/networking/mu/default.nix
@@ -1,53 +1,46 @@
-{ lib, stdenv, fetchFromGitHub, sqlite, pkg-config, autoreconfHook, pmccabe
-, xapian, glib, gmime3, texinfo, emacs, guile
-, gtk3, webkitgtk, libsoup, icu
-, makeWrapper
-, withMug ? false
-, batchSize ? null }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, coreutils
+, emacs
+, glib
+, gmime3
+, texinfo
+, xapian
+}:
 
 stdenv.mkDerivation rec {
   pname = "mu";
-  version = "1.6.11";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner  = "djcb";
     repo   = "mu";
-    rev    = version;
-    sha256 = "E/6+vEwYXk65/ZoAtUeTjvg56g6gz+Qtcaz0qwEru6c=";
+    rev    = "v${version}";
+    sha256 = "rb8R04eU/rG7PXx/horYk0+/3AgbxYYZtxy4ACILOZ8=";
   };
 
-  postPatch = lib.optionalString (batchSize != null) ''
-    sed -i lib/mu-store.cc --regexp-extended \
-      -e 's@(constexpr auto BatchSize).*@\1 = ${toString batchSize};@'
-  '';
+  postPatch = ''
+      # Fix mu4e-builddir (set it to $out)
+      substituteInPlace mu4e/mu4e-config.el.in \
+        --replace "@abs_top_builddir@" "$out"
+      substituteInPlace lib/utils/mu-utils.cc \
+        --replace "/bin/rm" "${coreutils}/bin/rm"
+    '';
 
-  buildInputs = [
-    sqlite xapian glib gmime3 texinfo emacs libsoup icu
-  ]
-    # Workaround for https://github.com/djcb/mu/issues/1641
-    ++ lib.optional (!stdenv.isDarwin) guile
-    ++ lib.optionals withMug [ gtk3 webkitgtk ];
+  buildInputs = [ emacs glib gmime3 texinfo xapian ];
 
-  nativeBuildInputs = [ pkg-config autoreconfHook pmccabe makeWrapper ];
+  mesonFlags = [
+    "-Dguile=disabled"
+    "-Dreadline=disabled"
+  ];
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
 
   enableParallelBuilding = true;
-
-  preBuild = ''
-    # Fix mu4e-builddir (set it to $out)
-    substituteInPlace mu4e/mu4e-meta.el.in \
-      --replace "@abs_top_builddir@" "$out"
-  '';
-
-  # Make sure included scripts can find their dependencies & optionally install mug
-  postInstall = ''
-    wrapProgram "$out/bin/mu" \
-      --prefix LD_LIBRARY_PATH : "$out/lib" \
-      --prefix GUILE_LOAD_PATH : "$out/share/guile/site/2.2"
-  '' + lib.optionalString withMug ''
-    for f in mug ; do
-      install -m755 toys/$f/$f $out/bin/$f
-    done
-  '';
 
   doCheck = true;
 
@@ -55,7 +48,7 @@ stdenv.mkDerivation rec {
     description = "A collection of utilties for indexing and searching Maildirs";
     license = licenses.gpl3Plus;
     homepage = "https://www.djcbsoftware.nl/code/mu/";
-    changelog = "https://github.com/djcb/mu/releases/tag/${version}";
+    changelog = "https://github.com/djcb/mu/releases/tag/v${version}";
     maintainers = with maintainers; [ antono chvp peterhoeg ];
     platforms = platforms.mesaPlatforms;
   };


### PR DESCRIPTION
https://github.com/djcb/mu/blob/release/1.8/NEWS.org

Also includes some cleanup of the dependencies. Guile support was deprecated, so
that is removed as well.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
