### PR TITLE
ninja: disable line-clearing with TERM=dumb

### DIFF
--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -14,7 +14,7 @@ ninjaBuildPhase() {
     )
 
     echoCmd 'build flags' "${flagsArray[@]}"
-    ninja "${flagsArray[@]}" | cat
+    TERM=dumb ninja "${flagsArray[@]}"
 
     runHook postBuild
 }
@@ -33,7 +33,7 @@ ninjaInstallPhase() {
     )
 
     echoCmd 'install flags' "${flagsArray[@]}"
-    ninja "${flagsArray[@]}" | cat
+    TERM=dumb ninja "${flagsArray[@]}"
 
     runHook postInstall
 }
@@ -67,7 +67,7 @@ ninjaCheckPhase() {
         )
 
         echoCmd 'check flags' "${flagsArray[@]}"
-        ninja "${flagsArray[@]}" | cat
+        TERM=dumb ninja "${flagsArray[@]}"
     fi
 
     runHook postCheck


### PR DESCRIPTION
**Description of changes**

`TERM=dumb ninja` is 1% prettier than the current solution `ninja | cat`

`cat` shows up as a separate process in my process tree
`TERM=dumb` is less visible

based on https://github.com/NixOS/nixpkgs/pull/149810#issuecomment-1030599299

ping @pennae

**Background**

https://github.com/ninja-build/ninja/blob/master/src/line_printer.cc

```cc
  const char* term = getenv("TERM");
#ifndef _WIN32
  smart_terminal_ = isatty(1) && term && string(term) != "dumb";
```

```cc
  if (smart_terminal_) {
    printf("\r");  // Print over previous line, if any.
```

**Things done**

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
