### PR TITLE
vim-utils: remove vim-addon-manager support

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -5,11 +5,9 @@ and additional libraries.
 
 Loading can be deferred; see examples.
 
-At the moment we support three different methods for managing plugins:
+At the moment we support two different methods for managing plugins:
 
 - Vim packages (*recommended*)
-- VAM (=vim-addon-manager)
-- Pathogen
 - vim-plug
 
 ## Custom configuration {#custom-configuration}
@@ -211,100 +209,6 @@ neovim.override {
     ];
   };
 }
-```
-
-## Managing plugins with VAM {#managing-plugins-with-vam}
-
-### Handling dependencies of Vim plugins {#handling-dependencies-of-vim-plugins}
-
-VAM introduced .json files supporting dependencies without versioning
-assuming that "using latest version" is ok most of the time.
-
-### Example {#example}
-
-First create a vim-scripts file having one plugin name per line. Example:
-
-```vim
-"tlib"
-{'name': 'vim-addon-sql'}
-{'filetype_regex': '\%(vim)$', 'names': ['reload', 'vim-dev-plugin']}
-```
-
-A discrete vim-scripts file can be read by VAM as well like this:
-
-```vim
-call vam#Scripts(expand('~/.vim-scripts'), {})
-```
-
-Create a default.nix file:
-
-```nix
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
-nixpkgs.vim_configurable.customize { name = "vim"; vimrcConfig.vam.pluginDictionaries = [ "vim-addon-vim2nix" ]; }
-```
-
-Create a generate.vim file:
-
-```vim
-ActivateAddons vim-addon-vim2nix
-let vim_scripts = "vim-scripts"
-call nix#ExportPluginsForNix({
-\  'path_to_nixpkgs': eval('{"'.substitute(substitute(substitute($NIX_PATH, ':', ',', 'g'), '=',':', 'g'), '\([:,]\)', '"\1"',"g").'"}')["nixpkgs"],
-\  'cache_file': '/tmp/vim2nix-cache',
-\  'try_catch': 0,
-\  'plugin_dictionaries': ["vim-addon-manager"]+map(readfile(vim_scripts), 'eval(v:val)')
-\ })
-```
-
-Then run
-
-```bash
-nix-shell -p vimUtils.vim_with_vim2nix --command "vim -c 'source generate.vim'"
-```
-
-You should get a Vim buffer with the nix derivations (output1) and vam.pluginDictionaries (output2).
-You can add your Vim to your system's configuration file like this and start it by "vim-my":
-
-```nix
-my-vim =
-  let plugins = let inherit (vimUtils) buildVimPluginFrom2Nix; in {
-    copy paste output1 here
-  }; in vim_configurable.customize {
-    name = "vim-my";
-
-    vimrcConfig.vam.knownPlugins = plugins; # optional
-    vimrcConfig.vam.pluginDictionaries = [
-       copy paste output2 here
-    ];
-
-  };
-```
-
-Sample output1:
-
-```nix
-"reload" = buildVimPluginFrom2Nix { # created by nix#NixDerivation
-  name = "reload";
-  src = fetchgit {
-    url = "https://github.com/xolox/vim-reload";
-    rev = "0a601a668727f5b675cb1ddc19f6861f3f7ab9e1";
-    sha256 = "0vb832l9yxj919f5hfg6qj6bn9ni57gnjd3bj7zpq7d4iv2s4wdh";
-  };
-  dependencies = ["nim-misc"];
-
-};
-[...]
-```
-
-Sample output2:
-
-```nix
-[
-  ''vim-addon-manager''
-  ''tlib''
-  { "name" = ''vim-addon-sql''; }
-  { "filetype_regex" = ''\%(vim)$$''; "names" = [ ''reload'' ''vim-dev-plugin'' ]; }
-]
 ```
 
 ## Adding new plugins to nixpkgs {#adding-new-plugins-to-nixpkgs}

--- a/pkgs/test/vim/default.nix
+++ b/pkgs/test/vim/default.nix
@@ -13,15 +13,6 @@ in
 
   ### vim tests
   ##################
-  vim_with_vim2nix = vim_configurable.customize {
-    name = "vim"; vimrcConfig.vam.pluginDictionaries = [ "vim2nix" ];
-  };
-
-  # test cases:
-  test_vim_with_vim_nix_using_vam = vim_configurable.customize {
-   name = "vim-with-vim-addon-nix-using-vam";
-    vimrcConfig.vam.pluginDictionaries = [{name = "vim-nix"; }];
-  };
 
   test_vim_with_vim_nix_using_plug = vim_configurable.customize {
     name = "vim-with-vim-addon-nix-using-plug";
@@ -31,28 +22,5 @@ in
   test_vim_with_vim_nix = vim_configurable.customize {
     name = "vim-with-vim-addon-nix";
     vimrcConfig.packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
-  };
-
-  # regression test for https://github.com/NixOS/nixpkgs/issues/53112
-  # The user may have specified their own plugins which may not be formatted
-  # exactly as the generated ones. In particular, they may not have the `pname`
-  # attribute.
-  test_vim_with_custom_plugin = vim_configurable.customize {
-    name = "vim_with_custom_plugin";
-    vimrcConfig.vam.knownPlugins =
-      vimPlugins // ({
-        vim-trailing-whitespace = buildVimPluginFrom2Nix {
-          name = "vim-trailing-whitespace";
-          src = fetchFromGitHub {
-            owner = "bronson";
-            repo = "vim-trailing-whitespace";
-            rev = "4c596548216b7c19971f8fc94e38ef1a2b55fee6";
-            sha256 = "0f1cpnp1nxb4i5hgymjn2yn3k1jwkqmlgw1g02sq270lavp2dzs9";
-          };
-          # make sure string dependencies are handled
-          dependencies = [ "vim-nix" ];
-        };
-      });
-    vimrcConfig.vam.pluginDictionaries = [ { names = [ "vim-trailing-whitespace" ]; } ];
   };
 })


### PR DESCRIPTION
###### Description of changes

It's hard to maintain this complex software and I dont see the advantages yet, now that vim supports "packages". Even if that were the case it could live somewhere else than nixpkgs, e.g., a vim-specific flake.
https://github.com/NixOS/nixpkgs/issues/56338

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
