### PR TITLE
crc: init at 2.4.1 with aarch64-darwin support

### DIFF
--- a/pkgs/applications/networking/cluster/crc/default.nix
+++ b/pkgs/applications/networking/cluster/crc/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, stdenv
+, testers
+, crc
+}:
+
+buildGoModule rec {
+  pname = "crc";
+  version = "2.4.1";
+
+  src = fetchFromGitHub {
+    owner = "code-ready";
+    repo = "crc";
+    rev = "v${version}";
+    sha256 = "sha256-4ckHvIswVwECAKsa/yN9rJSqZb04ZP1Zomq+1UdT1OY=";
+    # makefile calculates git commit and needs the git folder for it
+    leaveDotGit = true;
+  };
+
+  vendorSha256 = null;
+
+  nativeBuildInputs = [ git ];
+
+  buildPhase = ''
+    export HOME=$(mktemp -d)
+    runHook preBuild
+    make
+    runHook postBuild
+  '';
+
+  # tests are currently broken on aarch64-darwin
+  # https://github.com/code-ready/crc/issues/3237
+  doCheck = !(stdenv.isDarwin && stdenv.isAarch64);
+
+  checkPhase = ''
+    runHook preCheck
+    make test
+    runHook postCheck
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = crc;
+    command = "HOME=$(mktemp -d) crc version";
+  };
+
+  meta = with lib; {
+    description = "Manages a local OpenShift 4.x cluster or a Podman VM optimized for testing and development purposes";
+    homepage = "https://crc.dev";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ shikanime tricktron ];
+    mainProgram = "crc";
+  };
+}

--- a/pkgs/applications/networking/cluster/crc/default.nix
+++ b/pkgs/applications/networking/cluster/crc/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, testers
+, crc
+}:
+
+buildGoModule rec {
+  pname = "crc";
+  version = "2.3.0";
+  gitCommit = "502bf1d";
+
+  src = fetchFromGitHub {
+    owner = "code-ready";
+    repo = "crc";
+    rev = "v${version}";
+    sha256 = "HDIzCMwzqJj/L2wJf10MWRX9u4TbW+EjzBp2LtUqBLg=";
+  };
+
+  vendorSha256 = null;
+
+  buildPhase = ''
+    make SHELL=$SHELL COMMIT_SHA=${gitCommit}
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = crc;
+    command = "crc version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "Manages a local OpenShift 4.x cluster or a Podman VM optimized for testing and development purposes";
+    homepage = "https://crc.dev";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ shikanime ];
+    mainProgram = "crc";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -366,6 +366,8 @@ with pkgs;
 
   containerpilot = callPackage ../applications/networking/cluster/containerpilot { };
 
+  crc = callPackage ../applications/networking/cluster/crc { };
+
   coordgenlibs  = callPackage ../development/libraries/coordgenlibs { };
 
   cp437 = callPackage ../tools/misc/cp437 { };


### PR DESCRIPTION
###### Description of changes

Adds crc, a tool for local openshift cluster development.

@shikanime I used your 2.3.0 [pr](https://github.com/NixOS/nixpkgs/pull/173681) as a starting point and updated it to 2.4.1 which brings aarch64-darwin support. I created this new pr because I was not able to open a pull request to your repo and the changes were too many for a single review. I mainly tested it on aarch64-darwin, so it would be helpful if you could test/review it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
