### PR TITLE
plasma5Package.baloo: Unbreak kde-baloo.service startup

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/baloo.nix
+++ b/pkgs/development/libraries/kde-frameworks/baloo.nix
@@ -14,4 +14,12 @@ mkDerivation {
   ];
   outputs = [ "out" "dev" ];
   propagatedBuildInputs = [ kcoreaddons kfilemetadata qtbase ];
+
+  # kde-baloo.service uses `ExecCondition=@KDE_INSTALL_FULL_BINDIR@/kde-systemd-start-condition ...`
+  # which comes from the "plasma-workspace" derivation, but KDE_INSTALL_* all point at the "baloo" one
+  # (`${lib.getBin pkgs.plasma-workspace}` would cause infinite recursion)
+  postUnpack = ''
+    substituteInPlace "$sourceRoot"/src/file/kde-baloo.service.in \
+      --replace @KDE_INSTALL_FULL_BINDIR@ /run/current-system/sw/bin
+  '';
 }


### PR DESCRIPTION
https://invent.kde.org/frameworks/baloo/-/blob/048edc5d/src/file/kde-baloo.service.in#L9
expects the `kde-systemd-start-condition` executable to be in "baloo"s
installation directory, but unique nixpkgs derivations break this

```
$ journalctl --user -u kde-baloo -o cat
Starting Baloo File Indexer Daemon...
kde-baloo.service: Failed to locate executable /nix/store/74g3ahh0k0x6d5rj5rxs1lxhzx81vgdd-baloo-5.95.0/bin/kde-systemd-start-condition: No such file or directory
kde-baloo.service: Failed at step EXEC spawning /nix/store/74g3ahh0k0x6d5rj5rxs1lxhzx81vgdd-baloo-5.95.0/bin/kde-systemd-start-condition: No such file or directory
kde-baloo.service: Skipped due to 'exec-condition'.
Condition check resulted in Baloo File Indexer Daemon being skipped.
```
```
$ systemctl --user cat kde-baloo | grep kde-systemd-start-condition
ExecCondition=/nix/store/74g3ahh0k0x6d5rj5rxs1lxhzx81vgdd-baloo-5.95.0/bin/kde-systemd-start-condition --condition "baloofilerc:Basic Settings:Indexing-Enabled:true"
```
    
`kde-systemd-start-condition` is provided by the "plasma-workspace"
derivation which depends on "baloo".
    
Replace the CMake macro with the generic current system's path to fix
service startup and to avoid a recursive dependency.

@ttuegel @nyanloutre
