### PR TITLE
coreutils: reintroduce patch disabling `SEEK_HOLE` in `cp` for darwin x86_64

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -39,6 +39,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-YaH0ENeLp+fzelpPUObRMgrKMzdUhKMlXt3xejhYBCM=";
   };
 
+  patches = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    # Workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51433
+    ./disable-seek-hole.patch
+  ];
+
   postPatch = ''
     # The test tends to fail on btrfs, f2fs and maybe other unusual filesystems.
     sed '2i echo Skipping dd sparse test && exit 77' -i ./tests/dd/sparse.sh

--- a/pkgs/tools/misc/coreutils/disable-seek-hole.patch
+++ b/pkgs/tools/misc/coreutils/disable-seek-hole.patch
@@ -1,0 +1,43 @@
+diff --git a/src/copy.c b/src/copy.c
+index cb9018f93..2a4ccc061 100644
+--- a/src/copy.c
++++ b/src/copy.c
+@@ -502,7 +502,7 @@ write_zeros (int fd, off_t n_bytes)
+   return true;
+ }
+
+-#ifdef SEEK_HOLE
++#if 0
+ /* Perform an efficient extent copy, if possible.  This avoids
+    the overhead of detecting holes in hole-introducing/preserving
+    copy, and thus makes copying sparse files much more efficient.
+@@ -1095,7 +1095,7 @@ infer_scantype (int fd, struct stat const *sb,
+          && ST_NBLOCKS (*sb) < sb->st_size / ST_NBLOCKSIZE))
+     return PLAIN_SCANTYPE;
+
+-#ifdef SEEK_HOLE
++#if 0
+   scan_inference->ext_start = lseek (fd, 0, SEEK_DATA);
+   if (0 <= scan_inference->ext_start)
+     return LSEEK_SCANTYPE;
+@@ -1377,7 +1377,7 @@ copy_reg (char const *src_name, char const *dst_name,
+       off_t n_read;
+       bool wrote_hole_at_eof = false;
+       if (! (
+-#ifdef SEEK_HOLE
++#if 0
+              scantype == LSEEK_SCANTYPE
+              ? lseek_copy (source_desc, dest_desc, buf, buf_size, hole_size,
+                            scan_inference.ext_start, src_open_sb.st_size,
+diff --git a/tests/seek-data-capable b/tests/seek-data-capable
+index cc6372214..6e7a9ec1e 100644
+--- a/tests/seek-data-capable
++++ b/tests/seek-data-capable
+@@ -1,5 +1,7 @@
+ import sys, os, errno, platform
+
++sys.exit(1)
++
+ # Pass an _empty_ file
+ if len(sys.argv) != 2:
+     sys.exit(1)


### PR DESCRIPTION
###### Description of changes

#169046 caused my macos 10.15 systems to start exhibiting the strange behaviour from https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51433 on some packages (reproducible case being `ffmpeg`) because it removed the patch disabling `SEEK_HOLE` for `cp`. Reinstating the patch fixes this.

Cheekily aiming this @ `staging-next` because it's blocking me testing on macos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
