### PR TITLE
qemu-utils: remove qemu dependency

### DIFF
--- a/pkgs/applications/virtualization/qemu/utils.nix
+++ b/pkgs/applications/virtualization/qemu/utils.nix
@@ -6,6 +6,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ installShellFiles ];
   buildInputs = [ qemu ];
+  disallowedRequisites = [ qemu ];
   unpackPhase = "true";
 
   installPhase = ''

--- a/pkgs/applications/virtualization/qemu/utils.nix
+++ b/pkgs/applications/virtualization/qemu/utils.nix
@@ -1,4 +1,4 @@
-{ stdenv, installShellFiles, qemu }:
+{ stdenv, installShellFiles, qemu, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   pname = "qemu-utils";
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
     cp "${qemu}/bin/qemu-img" "$out/bin/qemu-img"
     cp "${qemu}/bin/qemu-io"  "$out/bin/qemu-io"
     cp "${qemu}/bin/qemu-nbd" "$out/bin/qemu-nbd"
+    ${removeReferencesTo}/bin/remove-references-to -t ${qemu} $out/bin/*
 
     installManPage ${qemu}/share/man/man1/qemu-img.1.gz
     installManPage ${qemu}/share/man/man8/qemu-nbd.8.gz


### PR DESCRIPTION
###### Description of changes

qemu-utils was pulling qemu which is a 900MB dependency. By removing
reference to it (unneeded), we're saving space on our deployments.
qemu-utils is a dependency of cloud-utils

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
