### PR TITLE
libsForQt5.phonon-backend-gstreamer: backport fix for https://bugs.kde.org/show_bug.cgi?id=445196

### DIFF
--- a/pkgs/development/libraries/phonon/backends/gstreamer.nix
+++ b/pkgs/development/libraries/phonon/backends/gstreamer.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, cmake, gst_all_1, phonon, pkg-config
+{ stdenv, lib, fetchurl, fetchpatch, cmake, gst_all_1, phonon, pkg-config
 , extra-cmake-modules, qttools, qtbase, qtx11extras
 , debug ? false
 }:
@@ -22,9 +22,17 @@ stdenv.mkDerivation rec {
     sha256 = "1wk1ip2w7fkh65zk6rilj314dna0hgsv2xhjmpr5w08xa8sii1y5";
   };
 
-  # Hardcode paths to useful plugins so the backend doesn't depend
-  # on system paths being set.
-  patches = [ ./gst-plugin-paths.patch ];
+  patches = [
+    # Hardcode paths to useful plugins so the backend doesn't depend
+    # on system paths being set.
+    ./gst-plugin-paths.patch
+
+    # Work around https://bugs.kde.org/show_bug.cgi?id=445196 until a new release.
+    (fetchpatch {
+      url = "https://invent.kde.org/libraries/phonon-gstreamer/-/commit/bbbb160f30a394655cff9398d17961142388b0f2.patch";
+      sha256 = "sha256-tNBqVt67LNb9SQogS9ol8/xYIZvVSoVUgXQahMfkFh8=";
+    })
+  ];
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
###### Description of changes

https://bugs.kde.org/show_bug.cgi?id=445196 has been fixed in phonon-backend-gstreamer since late 2021, but a release hasn't been tagged since 2019.

Backporting the patch makes the open/save dialog in Plasma Wayland actually usable.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
