### PR TITLE
fcitx5 and its plugins: update

### DIFF
--- a/pkgs/development/libraries/libime/default.nix
+++ b/pkgs/development/libraries/libime/default.nix
@@ -26,13 +26,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libime";
-  version = "1.0.11";
+  version = "1.0.12";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
     rev = version;
-    sha256 = "sha256-0yo0D9Yxn7tx1HtEaQvWCDwpWxnRVa1rIGK/mC4G8CI=";
+    sha256 = "sha256-7zm0eQgOZk7PYCBqq6FmPGIz1ZaVlEaT9QM5clhovuQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -41,13 +41,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.0.16";
+  version = "5.0.17";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-aSuvYt9UjG6/uVpLRZueq+qFvMQHdIcnO3G/LIE+3pk=";
+    sha256 = "sha256-N98LhzfeCenjmHEva5PBeiLE/xNOdNT/6WA8Fe+O64c=";
   };
 
   prePatch = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -31,13 +31,13 @@ in
 
 mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.0.12";
+  version = "5.0.13";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-0+jKBA1IaeqV6epnJBgGwnDdAUxdMH6RyOKGmsw0M/o=";
+    sha256 = "sha256-umtt1xOgOEGVYVH0y/qRy3ihtKsVxYGvMGi4WFI9beY=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-gtk";
-  version = "5.0.14";
+  version = "5.0.15";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-sByITVBgOX3YYdJN6EzDYH0+N+FqZcoJlCp70SfkKpY=";
+    sha256 = "sha256-Vm2Un4PZugATjDz+mcEOnoapw3yyVf8Q55f5LO6juCU=";
   };
 
   cmakeFlags = [
@@ -60,11 +60,6 @@ stdenv.mkDerivation rec {
     at-spi2-core
     libXtst
   ] ++ lib.optional withGTK2 gtk2;
-
-  NIX_CFLAGS_COMPILE = lib.concatMapStringsSep " " (s: "-isystem ${s}") [
-    "${glib.dev}/include/gio-unix-2.0"
-    "${glib.dev}/include/glib-2.0"
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -13,13 +13,13 @@
 
 mkDerivation rec {
   pname = "fcitx5-qt";
-  version = "5.0.12";
+  version = "5.0.13";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-tK/sZa8PX+W8rZd5VH0a9nlxQ619w48//jQMTPytb+0=";
+    sha256 = "sha256-eX0tdNFGFiWrxBgghSGLHzKhK/eQ6DLLu7+ggNqTScg=";
   };
 
   preConfigure = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-unikey";
-  version = "5.0.9";
+  version = "5.0.10";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-unikey";
     rev = version;
-    sha256 = "sha256-lsWMQygIdHcEuHCEvi5d0PGI1jJ42C+9ji/w0L/eadM=";
+    sha256 = "sha256-gGKLv+IUcLOE3jHDzK7oX2R76cUT9VXaVFGEyNN0tV4=";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];


### PR DESCRIPTION
###### Description of changes

https://groups.google.com/g/fcitx/c/S_XPvcAbNyY
https://github.com/fcitx/libime/compare/1.0.11...1.0.12
https://github.com/fcitx/fcitx5/compare/5.0.16...5.0.17
https://github.com/fcitx/fcitx5-chinese-addons/compare/5.0.12...5.0.13
https://github.com/fcitx/fcitx5-gtk/compare/5.0.14...5.0.15
https://github.com/fcitx/fcitx5-qt/compare/5.0.12...5.0.13
https://github.com/fcitx/fcitx5-unikey/compare/5.0.9...5.0.10

###### Things done
fcitx5-rime is tested that can type Chinese.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwini
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

closes: #179099 #179068 #179065 due to duplication