### PR TITLE
python310Packages.urllib3: remove pyopenssl as it is no longer recommended

### DIFF
--- a/pkgs/development/python-modules/selenium/default.nix
+++ b/pkgs/development/python-modules/selenium/default.nix
@@ -35,8 +35,7 @@ buildPythonPackage rec {
     trio
     trio-websocket
     urllib3
-  ] ++ urllib3.optional-dependencies.secure
-  ++ urllib3.optional-dependencies.socks;
+  ] ++ urllib3.optional-dependencies.socks;
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -2,14 +2,10 @@
 , brotli
 , brotlicffi
 , buildPythonPackage
-, certifi
-, cryptography
 , python-dateutil
 , fetchPypi
 , isPyPy
-, idna
 , mock
-, pyopenssl
 , pysocks
 , pytest-freezegun
 , pytest-timeout
@@ -65,7 +61,9 @@ buildPythonPackage rec {
 
   passthru.optional-dependencies = {
     brotli = if isPyPy then [ brotlicffi ] else [ brotli ];
-    secure = [ certifi cryptography idna pyopenssl ];
+    # we are removing secure dependencies as they are no longer relevant with py3:
+    # https://urllib3.readthedocs.io/en/stable/reference/contrib/pyopenssl.html
+    # secure = [ certifi cryptography idna pyopenssl ];
     socks = [ pysocks ];
   };
 


### PR DESCRIPTION
###### Description of changes

Fixes #178954

Commit 292269900315d5b952a99ec95aa4ccfc099952e0  introduced a bunch of [optional dependencies](https://github.com/urllib3/urllib3/blob/main/pyproject.toml#L40-L56) as mandatory. This had the side effect of breaking urllib3 on darwin-aarch64 as pyopenssl isn't supported on that platform (https://github.com/NixOS/nixpkgs/issues/175875)

This PR introduces a couple of arguments to allow toggling optional dependencies on and off defaulting them to `true` with the exception of `darwin-aarch64` which disables by default the broken optional dependencies.

Note: I am unsure if this is the right branch, I just tried to replicate what was done on the PR that introduced the change I linked above.

Note2: I think ideally we'd have as root packages:

- python310Packages.urllib3 (no optional deps, default installation, same as pip)
- python310Packages.urllib3-full (all optional deps enabled)

but didn't want to introduce "big" changes, just fix urllib3 on `darwin-aarch64`

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
