### PR TITLE
boulder: release-2022-05-31 -> release-2022-06-21

### DIFF
--- a/pkgs/tools/admin/boulder/default.nix
+++ b/pkgs/tools/admin/boulder/default.nix
@@ -1,18 +1,19 @@
-{ lib
+{ stdenv
+, lib
 , buildGoModule
 , fetchFromGitHub
 }:
 
 buildGoModule rec {
   pname = "boulder";
-  version = "release-2022-05-31";
-  rev = "99dcb9a5b31be576a55e33184581c942421bc172";
+  version = "2022-06-21";
+  rev = "09f87bb31a57f9a04932b7175fab1e3cabffd86f";
 
   src = fetchFromGitHub {
     owner = "letsencrypt";
     repo = "boulder";
-    rev = version;
-    sha256 = "sha256-x1Vf8agwVTgSkDVEdAnG3div+MzRsMi96jKJRc2s8Ks=";
+    rev = "release-${version}";
+    sha256 = "sha256-Q5fMM3UXMFqmpJks1xnINeKBA7dDam4bfczO3D43Yoo=";
   };
 
   vendorSha256 = null;
@@ -47,5 +48,6 @@ buildGoModule rec {
     '';
     license = licenses.mpl20;
     maintainers = with maintainers; [ azahi ];
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [release-2022-06-21](https://github.com/letsencrypt/boulder/releases/tag/release-2022-06-21).


###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).