### PR TITLE
Revert "nixos/hedgedoc: Do not set StateDirectory to an absolute path"

### DIFF
--- a/nixos/modules/services/web-apps/hedgedoc.nix
+++ b/nixos/modules/services/web-apps/hedgedoc.nix
@@ -1031,8 +1031,7 @@ in
       '';
       serviceConfig = {
         WorkingDirectory = cfg.workDir;
-        StateDirectory = [ (builtins.replaceStrings [ "/var/lib/"  ] [ "" ] cfg.workDir) ];
-        ReadWritePaths = [ cfg.configuration.uploadsPath ];
+        StateDirectory = [ cfg.workDir cfg.configuration.uploadsPath ];
         ExecStart = "${cfg.package}/bin/hedgedoc";
         EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
         Environment = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#177536

I broke the hedgedoc service by having #177536 merged into master and release-22.05.

```
Jun 25 19:16:19 services systemd[1]: Starting HedgeDoc Service...
Jun 25 19:16:19 services systemd[1431]: hedgedoc.service: Failed to set up mount namespacing: /run/systemd/unit-root/var/lib/hedgedoc/uploads: No such file or directory
Jun 25 19:16:19 services systemd[1431]: hedgedoc.service: Failed at step NAMESPACE spawning /nix/store/zw6fbfhjdnmqkzxgdg0vqlh55ydn79s6-unit-script-hedgedoc-pre-start/bin/hedgedoc-pre-start: No such file or directory
Jun 25 19:16:19 services systemd[1]: hedgedoc.service: Control process exited, code=exited, status=226/NAMESPACE
Jun 25 19:16:19 services systemd[1]: hedgedoc.service: Failed with result 'exit-code'.
Jun 25 19:16:19 services systemd[1]: Failed to start HedgeDoc Service.
```

Resolves #179169