### PR TITLE
ghc: Work around broken pyopenssl on aarch64-darwin

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20864,6 +20864,23 @@ with pkgs;
 
   sphinx = with python3Packages; toPythonApplication sphinx;
 
+  # A variation of sphinx that is only suitable for offline use as it excludes
+  # pyopenssl, which is broken on aarch64-darwin.
+  # https://github.com/NixOS/nixpkgs/issues/175875
+  sphinx_offline =
+    if !(stdenv.buildPlatform.isDarwin && stdenv.buildPlatform.isAarch64)
+    then sphinx
+    else
+      sphinx.override (o: {
+        requests = pkgsBuildTarget.python3Packages.requests.override (o: {
+          urllib3 = pkgsBuildTarget.python3Packages.urllib3.overrideAttrs (o: {
+            # urllib3 adds the optional pyopenssl to propagatedBuildInputs
+            # pkgs/development/python-modules/urllib3/default.nix
+            propagatedBuildInputs = [];
+          });
+        });
+      });
+
   sphinx-autobuild = with python3Packages; toPythonApplication sphinx-autobuild;
 
   sphinx-serve = with python3Packages; toPythonApplication sphinx-serve;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -47,6 +47,8 @@ let
   # Use this rather than `rec { ... }` below for sake of overlays.
   inherit (pkgs.haskell) compiler packages;
 
+  sphinx = buildPackages.sphinx_offline;
+
 in {
   lib = haskellLibUncomposable;
 
@@ -87,7 +89,7 @@ in {
           packages.ghc8102Binary
         else
           packages.ghc865Binary;
-      inherit (buildPackages.python3Packages) sphinx;
+      inherit sphinx;
       buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_7;
       llvmPackages = pkgs.llvmPackages_7;
     };
@@ -100,7 +102,7 @@ in {
           packages.ghc8107BinaryMinimal
         else
           packages.ghc8107Binary;
-      inherit (buildPackages.python3Packages) sphinx;
+      inherit sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and
       # https://github.com/xattr/xattr/issues/55 are solved.
@@ -116,7 +118,7 @@ in {
           packages.ghc8107BinaryMinimal
         else
           packages.ghc8107Binary;
-      inherit (buildPackages.python3Packages) sphinx;
+      inherit sphinx;
       inherit (buildPackages.darwin) autoSignDarwinBinariesHook xattr;
       buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
       llvmPackages = pkgs.llvmPackages_12;
@@ -128,7 +130,7 @@ in {
           packages.ghc8107BinaryMinimal
         else
           packages.ghc8107Binary;
-      inherit (buildPackages.python3Packages) sphinx;
+      inherit sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and
       # https://github.com/xattr/xattr/issues/55 are solved.
@@ -138,7 +140,7 @@ in {
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
       bootPkgs = packages.ghc8107Binary;
-      inherit (buildPackages.python3Packages) sphinx;
+      inherit sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and
       # https://github.com/xattr/xattr/issues/55 are solved.


### PR DESCRIPTION
###### Description of changes

Avoid https://github.com/NixOS/nixpkgs/issues/175875, build ghc on m1 again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Evaluated on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
