### PR TITLE
zrepl: add version to ldflags and strip binary

### DIFF
--- a/pkgs/tools/backup/zrepl/default.nix
+++ b/pkgs/tools/backup/zrepl/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
     makeWrapper
   ];
 
-  ldflags = [ "-X github.com/zrepl/zrepl/version.zreplVersion=${version}" ];
+  ldflags = [ "-s" "-w" "-X github.com/zrepl/zrepl/version.zreplVersion=${version}" ];
 
   postInstall = ''
     mkdir -p $out/lib/systemd/system

--- a/pkgs/tools/backup/zrepl/default.nix
+++ b/pkgs/tools/backup/zrepl/default.nix
@@ -24,6 +24,8 @@ buildGoModule rec {
     makeWrapper
   ];
 
+  ldflags = [ "-X github.com/zrepl/zrepl/version.zreplVersion=${version}" ];
+
   postInstall = ''
     mkdir -p $out/lib/systemd/system
     substitute dist/systemd/zrepl.service $out/lib/systemd/system/zrepl.service \


### PR DESCRIPTION
###### Description of changes

Whilst checking my nixos installation i noticed, that the zrepl binary build does not print out the version. A debian server which uses also zrepl does properly print the version information.

the output should look like this 

```
client: zrepl version=v0.5.0 go=go1.17.6 GOOS=linux GOARCH=amd64 Compiler=gc
server: zrepl version=v0.5.0 go=go1.17.6 GOOS=linux GOARCH=amd64 Compiler=gc
```

The version string is empty on nixos  and not showing 0.5.0.
When checking the upstream repo about hints what we may miss i noticed that they give a hint about [how the version is set](https://github.com/zrepl/zrepl/blob/66946df7560395aa6409340db1b77aafddaa7d36/README.md#additional-notes-to-distro-package-maintainers).
Its passed to the application by ldflags. The first commit adds ldflags to pass the version, which results in the above and expected output (for the zrepl version).


in addition i have added `-s -w` ldflags to strip ~2MB from the binary which i hopefully acceptable. if that's not the case please let me know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
