### PR TITLE
zrepl: add package option to module

### DIFF
--- a/nixos/modules/services/backup/zrepl.nix
+++ b/nixos/modules/services/backup/zrepl.nix
@@ -15,9 +15,9 @@ in
 
       package = mkOption {
         type = types.package;
-        description = "Which package to use for zrepl";
         default = pkgs.zrepl;
         defaultText = literalExpression "pkgs.zrepl";
+        description = "Which package to use for zrepl";
       };
 
       settings = mkOption {

--- a/nixos/modules/services/backup/zrepl.nix
+++ b/nixos/modules/services/backup/zrepl.nix
@@ -13,6 +13,13 @@ in
     services.zrepl = {
       enable = mkEnableOption "zrepl";
 
+      package = mkOption {
+        type = types.package;
+        description = "Which package to use for zrepl";
+        default = pkgs.zrepl;
+        defaultText = literalExpression "pkgs.zrepl";
+      };
+
       settings = mkOption {
         default = { };
         description = ''
@@ -30,14 +37,14 @@ in
   ### Implementation ###
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.zrepl ];
+    environment.systemPackages = [ cfg.package ];
 
     # zrepl looks for its config in this location by default. This
     # allows the use of e.g. `zrepl signal wakeup <job>` without having
     # to specify the storepath of the config.
     environment.etc."zrepl/zrepl.yml".source = configFile;
 
-    systemd.packages = [ pkgs.zrepl ];
+    systemd.packages = [ cfg.package ];
 
     # Note that pkgs.zrepl copies and adapts the upstream systemd unit, and
     # the fields defined here only override certain fields from that unit.


### PR DESCRIPTION
###### Description of changes

As zrepl relies on matching protocol versions under the hood its a better user experience to provide a option to specify the derivation to the nixos module.
i currently use this as a custom module in my flake, as i am mixing unstable and stable and want to ensure that the zrepl version match on both.

as the change is minimal and non breaking (default is the old behavior) i think adding a note to the release should be not needed. if i should add a note, please let me know.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
