### PR TITLE
xcftools: patch CVE-2019-5086 and CVE-2019-5087

### DIFF
--- a/pkgs/tools/graphics/xcftools/default.nix
+++ b/pkgs/tools/graphics/xcftools/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, libpng, perl, gettext }:
+{lib, stdenv, fetchpatch, fetchurl, libpng, perl, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "xcftools";
@@ -11,7 +11,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpng perl gettext ];
 
-  patchPhase = ''
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-5086.CVE-2019-5087.patch";
+      url = "https://github.com/gladk/xcftools/commit/59c38e3e45b9112c2bcb4392bccf56e297854f8a.patch";
+      sha256 = "sha256-a1Biv6viXzTSaLDzinOyu0HdDTUPsKITsdKu9B9Y8GE=";
+    })
+  ];
+
+  postPatch = ''
     # Required if building with libpng-1.6, innocuous otherwise
     substituteInPlace xcf2png.c         \
       --replace png_voidp_NULL NULL     \


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #91020, after more than two years.

I notice that xcftools has no nixpkgs maintainer, and is largely unmaintained upstream as well; it can't properly read any XCF I can find on my system. I would suggest backporting this change to 22.05 to fix the vulnerabilities, and removing it from nixpkgs in a followup PR. ImageMagick is apparently a reasonable replacement: https://phabricator.wikimedia.org/T196054

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
