### PR TITLE
steamtinkerlaunch init at version 10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14392,4 +14392,10 @@
     github = "melias122";
     githubId = 1027766;
   };
+  Soupstraw = {
+    name = "Joosep Jääger";
+    email = "joosep.jaager@gmail.com";
+    github = "Soupstraw";
+    githubId = 6863341;
+  };
 }

--- a/pkgs/tools/games/steamtinkerlaunch/steamtinkerlaunch.nix
+++ b/pkgs/tools/games/steamtinkerlaunch/steamtinkerlaunch.nix
@@ -1,0 +1,29 @@
+{ stdenv, pkgs, xdotool, makeWrapper, xorg, unixtools, yad }:
+with pkgs;
+
+stdenv.mkDerivation {
+  name = "steamtinkerlaunch";
+  src = fetchFromGitHub {
+    owner = "frostworx";
+    repo = "steamtinkerlaunch";
+    rev = "39bacab0c2bf1a9338e7385b4035753c0a197907";
+    sha256 = "Fa7DXEIi9MIwj+48eGPE/sKfgy6aOZiWyJ0KrbHuhyQ=";
+  };
+
+  buildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    PREFIX="$out" make install
+    wrapProgram $out/bin/steamtinkerlaunch \
+      --prefix PATH : ${lib.makeBinPath [xdotool xorg.xwininfo unixtools.xxd yad]}
+  '';
+
+  meta = {
+    description = "Wrapper tool for use with the Steam client which allows customizing and start tools and options for games quickly on the fly";
+    homepage = "https://github.com/frostworx/steamtinkerlaunch";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ Soupstraw ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
