### PR TITLE
discord-development: init at {0.0.202,0.0.8759}

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -4,18 +4,15 @@ let
     stable = "0.0.18";
     ptb = "0.0.29";
     canary = "0.0.135";
+    development = "0.0.202";
   } else {
     stable = "0.0.264";
     ptb = "0.0.59";
     canary = "0.0.283";
+    development = "0.0.8759";
   };
   version = versions.${branch};
-  srcs = let
-    darwin-ptb = fetchurl {
-      url = "https://dl-ptb.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
-      sha256 = "sha256-LS7KExVXkOv8O/GrisPMbBxg/pwoDXIOo1dK9wk1yB8=";
-    };
-  in {
+  srcs = rec {
     x86_64-linux = {
       stable = fetchurl {
         url =
@@ -32,22 +29,42 @@ let
           "https://dl-canary.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";
         sha256 = "sha256-dmG+3BWS1BMHHQAv4fsXuObVeAJBeD+TqnyQz69AMac=";
       };
-    };
-    x86_64-darwin = {
-      stable = fetchurl {
-        url = "https://dl.discordapp.net/apps/osx/${version}/Discord.dmg";
-        sha256 = "1jvlxmbfqhslsr16prsgbki77kq7i3ipbkbn67pnwlnis40y9s7p";
+      development = fetchurl {
+        url =
+          "https://dl-development.discordapp.net/apps/linux/${version}/discord-development-${version}.tar.gz";
+        sha256 = "sha256-+OqIhjGr6y5xtFE5MpVlPM/Y7KCU66HH93/OIxgdq3k=";
       };
-      ptb = darwin-ptb;
+    };
+
+    aarch64-darwin = {
+      ptb = fetchurl {
+        url =
+          "https://dl-ptb.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
+        sha256 = "sha256-LS7KExVXkOv8O/GrisPMbBxg/pwoDXIOo1dK9wk1yB8=";
+      };
       canary = fetchurl {
         url =
           "https://dl-canary.discordapp.net/apps/osx/${version}/DiscordCanary.dmg";
         sha256 = "0mqpk1szp46mih95x42ld32rrspc6jx1j7qdaxf01whzb3d4pi9l";
       };
+      development = fetchurl {
+        url =
+          "https://dl-development.discordapp.net/apps/osx/${version}/DiscordDevelopment.dmg";
+        sha256 = "sha256-F/OR0l1Rh/YQaR5V/kmSLNQPwvFeWj/NfgY8fUYg9fA=";
+      };
     };
-    # Only PTB bundles a MachO Universal binary with ARM support.
-    aarch64-darwin = { ptb = darwin-ptb; };
+
+    # Stable does not (yet) provide aarch64-darwin support. PTB, Canary, and Development do.
+    x86_64-darwin = aarch64-darwin
+      // {
+        stable = fetchurl {
+          url =
+            "https://dl.discordapp.net/apps/osx/${version}/Discord.dmg";
+          sha256 = "1jvlxmbfqhslsr16prsgbki77kq7i3ipbkbn67pnwlnis40y9s7p";
+        };
+      };
   };
+
   src = srcs.${stdenv.hostPlatform.system}.${branch};
 
   meta = with lib; {
@@ -56,10 +73,11 @@ let
     downloadPage = "https://discordapp.com/download";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ ldesgoui MP2E devins2518 ];
+    maintainers = with maintainers; [ ldesgoui MP2E devins2518 ivar ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ]
-      ++ lib.optionals (branch == "ptb") [ "aarch64-darwin" ];
+      ++ lib.optionals (branch != "stable") [ "aarch64-darwin" ];
   };
+
   package = if stdenv.isLinux then ./linux.nix else ./darwin.nix;
 
   openasar = callPackage ./openasar.nix { };
@@ -72,20 +90,25 @@ let
       })
     )
     {
-      stable = rec {
+      stable = {
         pname = "discord";
         binaryName = "Discord";
         desktopName = "Discord";
       };
-      ptb = rec {
+      ptb = {
         pname = "discord-ptb";
         binaryName = "DiscordPTB";
         desktopName = "Discord PTB";
       };
-      canary = rec {
+      canary = {
         pname = "discord-canary";
         binaryName = "DiscordCanary";
         desktopName = "Discord Canary";
+      };
+      development = {
+        pname = "discord-development";
+        binaryName = "DiscordDevelopment";
+        desktopName = "Discord Development";
       };
     }
   );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35619,6 +35619,12 @@ with pkgs;
     branch = "canary";
   };
 
+  discord-development = import ../applications/networking/instant-messengers/discord {
+    inherit lib stdenv;
+    inherit (pkgs) callPackage fetchurl;
+    branch = "development";
+  };
+
   golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah {};
 
   linkchecker = callPackage ../tools/networking/linkchecker { };


### PR DESCRIPTION
###### Description of changes
This adds the development branch of discord, which wasn't packaged before. Note that I haven't tested the darwin version as I don't own a mac, I've just confirmed the hash is correct.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
