### PR TITLE
treewide: rename maintainer `earvstedt` -> `erikarvstedt`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3518,7 +3518,7 @@
     githubId = 424946;
     name = "James Earl Douglas";
   };
-  earvstedt = {
+  erikarvstedt = {
     email = "erik.arvstedt@gmail.com";
     matrix = "@erikarvstedt:matrix.org";
     github = "erikarvstedt";

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -83,7 +83,7 @@ let
   };
 in
 {
-  meta.maintainers = with maintainers; [ earvstedt Flakebi ];
+  meta.maintainers = with maintainers; [ erikarvstedt Flakebi ];
 
   imports = [
     (mkRenamedOptionModule [ "services" "paperless-ng" ] [ "services" "paperless" ])

--- a/nixos/tests/containers-custom-pkgs.nix
+++ b/nixos/tests/containers-custom-pkgs.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: let
 in {
   name = "containers-custom-pkgs";
   meta = {
-    maintainers = with lib.maintainers; [ adisbladis earvstedt ];
+    maintainers = with lib.maintainers; [ adisbladis erikarvstedt ];
   };
 
   nodes.machine = { config, ... }: {

--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ lib, ... }: {
   name = "paperless";
-  meta.maintainers = with lib.maintainers; [ earvstedt Flakebi ];
+  meta.maintainers = with lib.maintainers; [ erikarvstedt Flakebi ];
 
   nodes.machine = { pkgs, ... }: {
     environment.systemPackages = with pkgs; [ imagemagick jq ];

--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -26,7 +26,7 @@ buildDotnetModule rec {
   meta = with lib; {
     description = "Self-hosted, open-source cryptocurrency payment processor";
     homepage = "https://btcpayserver.org";
-    maintainers = with maintainers; [ kcalvinalvin earvstedt ];
+    maintainers = with maintainers; [ kcalvinalvin erikarvstedt ];
     license = licenses.mit;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/blockchains/nbxplorer/default.nix
+++ b/pkgs/applications/blockchains/nbxplorer/default.nix
@@ -22,7 +22,7 @@ buildDotnetModule rec {
 
   meta = with lib; {
     description = "Minimalist UTXO tracker for HD Cryptocurrency Wallets";
-    maintainers = with maintainers; [ kcalvinalvin earvstedt ];
+    maintainers = with maintainers; [ kcalvinalvin erikarvstedt ];
     license = licenses.mit;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/graphics/tesseract/tesseract3.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract3.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "OCR engine";
     homepage = "https://github.com/tesseract-ocr/tesseract";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ viric earvstedt ];
+    maintainers = with lib.maintainers; [ viric erikarvstedt ];
     platforms = with lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/graphics/tesseract/tesseract4.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract4.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     description = "OCR engine";
     homepage = "https://github.com/tesseract-ocr/tesseract";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ viric earvstedt ];
+    maintainers = with lib.maintainers; [ viric erikarvstedt ];
     platforms = with lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -196,6 +196,6 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     description = "A supercharged version of paperless: scan, index, and archive all of your physical documents";
     homepage = "https://paperless-ngx.readthedocs.io/en/latest/";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ lukegb gador earvstedt ];
+    maintainers = with maintainers; [ lukegb gador erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/djangoql/default.nix
+++ b/pkgs/development/python-modules/djangoql/default.nix
@@ -23,6 +23,6 @@ buildPythonPackage rec {
     description = "Advanced search language for Django";
     homepage = "https://github.com/ivelum/djangoql";
     license = licenses.mit;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/filemagic/default.nix
+++ b/pkgs/development/python-modules/filemagic/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage {
     description = "File type identification using libmagic";
     homepage = "https://github.com/aliles/filemagic";
     license = licenses.asl20;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -16,6 +16,6 @@ buildPythonPackage rec {
     description = "Fuzzy string matching for Python";
     homepage = "https://github.com/seatgeek/fuzzywuzzy";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/inotify-simple/default.nix
+++ b/pkgs/development/python-modules/inotify-simple/default.nix
@@ -19,6 +19,6 @@ buildPythonPackage rec {
     description = "A simple Python wrapper around inotify";
     homepage = "https://github.com/chrisjbillington/inotify_simple";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/langdetect/default.nix
+++ b/pkgs/development/python-modules/langdetect/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     description = "Python port of Google's language-detection library";
     homepage = "https://github.com/Mimino666/langdetect";
     license = licenses.asl20;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/pdftotext/default.nix
+++ b/pkgs/development/python-modules/pdftotext/default.nix
@@ -15,6 +15,6 @@ buildPythonPackage rec {
     description = "Simple PDF text extraction";
     homepage = "https://github.com/jalan/pdftotext";
     license = licenses.mit;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/pytest-env/default.nix
+++ b/pkgs/development/python-modules/pytest-env/default.nix
@@ -15,6 +15,6 @@ buildPythonPackage rec {
     description = "Pytest plugin used to set environment variables";
     homepage = "https://github.com/MobileDynasty/pytest-env";
     license = licenses.mit;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/development/python-modules/python-dotenv/default.nix
+++ b/pkgs/development/python-modules/python-dotenv/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Add .env support to your django/flask apps in development and deployments";
     homepage = "https://github.com/theskumar/python-dotenv";
     license = licenses.bsdOriginal;
-    maintainers = with maintainers; [ earvstedt ];
+    maintainers = with maintainers; [ erikarvstedt ];
   };
 }

--- a/pkgs/tools/backup/rsbep/default.nix
+++ b/pkgs/tools/backup/rsbep/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     description = "Create resilient backups with Reed-Solomon error correction and byte-spreading";
     homepage = "https://www.thanassis.space/rsbep.html";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.earvstedt ];
+    maintainers = [ maintainers.erikarvstedt ];
   };
 }

--- a/pkgs/tools/virtualization/extra-container/default.nix
+++ b/pkgs/tools/virtualization/extra-container/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/erikarvstedt/extra-container";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.earvstedt ];
+    maintainers = [ maintainers.erikarvstedt ];
   };
 }


### PR DESCRIPTION
#### Copy of commit msg
The maintainer name now matches the Github username, which simplifies maintainer notifications.

cc @Lassulus