### PR TITLE
Replace use of `testVersion` alias

### DIFF
--- a/pkgs/applications/blockchains/lndconnect/default.nix
+++ b/pkgs/applications/blockchains/lndconnect/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, testVersion, lndconnect }:
+{ lib, buildGoModule, fetchFromGitHub, lndconnect }:
 buildGoModule rec {
   pname = "lndconnect";
   version = "0.2.1";

--- a/pkgs/applications/graphics/mcomix/default.nix
+++ b/pkgs/applications/graphics/mcomix/default.nix
@@ -5,7 +5,7 @@
 , gtk3
 , mcomix
 , python3
-, testVersion
+, testers
 , wrapGAppsHook
 
 # Recommended Dependencies:
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication rec {
     )
   '';
 
-  passthru.tests.version = testVersion {
+  passthru.tests.version = testers.testVersion {
     package = mcomix;
   };
 

--- a/pkgs/applications/networking/cluster/roxctl/default.nix
+++ b/pkgs/applications/networking/cluster/roxctl/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testVersion, roxctl }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, roxctl }:
 
 buildGoModule rec {
   pname = "roxctl";
@@ -30,7 +30,7 @@ buildGoModule rec {
       --zsh <($out/bin/roxctl completion zsh)
   '';
 
-  passthru.tests.version = testVersion {
+  passthru.tests.version = testers.testVersion {
     package = roxctl;
     command = "roxctl version";
   };

--- a/pkgs/applications/version-management/git-and-tools/gfold/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gfold/default.nix
@@ -7,7 +7,7 @@
 , rustPlatform
 , Security
 , stdenv
-, testVersion
+, testers
 }:
 
 let
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage {
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  passthru.tests.version = testVersion {
+  passthru.tests.version = testers.testVersion {
     package = gfold;
     command = "gfold --version";
     inherit version;

--- a/pkgs/development/tools/jira-cli-go/default.nix
+++ b/pkgs/development/tools/jira-cli-go/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, less, more, installShellFiles, testVersion, jira-cli-go }:
+{ lib, buildGoModule, fetchFromGitHub, less, more, installShellFiles, testers, jira-cli-go }:
 
 buildGoModule rec {
   pname = "jira-cli-go";
@@ -22,7 +22,7 @@ buildGoModule rec {
 
   checkInputs = [ less more ]; # Tests expect a pager in $PATH
 
-  passthru.tests.version = testVersion {
+  passthru.tests.version = testers.testVersion {
     package = jira-cli-go;
     command = "jira version";
     inherit version;


### PR DESCRIPTION
- lndconnect: Drop unused input `testVersion`
- other packages: Import `testers` and use `testers.testVersion`

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
