### PR TITLE
pykms: switch to maintained fork, fix PYTHONPATH, add test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -458,6 +458,7 @@ in {
   proxy = handleTest ./proxy.nix {};
   prowlarr = handleTest ./prowlarr.nix {};
   pt2-clone = handleTest ./pt2-clone.nix {};
+  pykms = handleTest ./pykms.nix {};
   public-inbox = handleTest ./public-inbox.nix {};
   pulseaudio = discoverTests (import ./pulseaudio.nix);
   qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};

--- a/nixos/tests/pykms.nix
+++ b/nixos/tests/pykms.nix
@@ -1,0 +1,14 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+  {
+    name = "pykms-test";
+    meta.maintainers = with pkgs.lib.maintainers; [ zopieux ];
+
+    nodes.machine = { config, lib, pkgs, ... }: {
+      services.pykms.enable = true;
+    };
+
+    testScript = ''
+      machine.wait_for_unit("pykms.service")
+      machine.succeed("${pkgs.pykms}/bin/client")
+    '';
+  })

--- a/pkgs/tools/networking/pykms/default.nix
+++ b/pkgs/tools/networking/pykms/default.nix
@@ -37,15 +37,15 @@ pypkgs.buildPythonApplication rec {
   version = "unstable-2021-01-25";
 
   src = fetchFromGitHub {
-    owner = "SystemRage";
+    owner = "Py-KMS-Organization";
     repo = "py-kms";
-    rev = "a3b0c85b5b90f63b33dfa5ae6085fcd52c6da2ff";
-    sha256 = "sha256-u0R0uJMQxHnJUDenxglhQkZza3/1DcyXCILcZVceygA=";
+    rev = "1435c86fe4f11aa7fd42d77fa61715ca3015eeab";
+    hash = "sha256-9KiMbS0uKTbWSZVIv5ziIeR9c8+EKfKd20yPmjCX7GQ=";
   };
 
   sourceRoot = "source/py-kms";
 
-  propagatedBuildInputs = with pypkgs; [ systemd pytz tzlocal ];
+  propagatedBuildInputs = with pypkgs; [ systemd pytz tzlocal dnspython ];
 
   postPatch = ''
     siteDir=$out/${python3.sitePackages}
@@ -64,11 +64,14 @@ pypkgs.buildPythonApplication rec {
 
     mkdir -p $siteDir
 
+    PYTHONPATH="$PYTHONPATH:$siteDir"
+
     mv * $siteDir
     for b in Client Server ; do
       makeWrapper ${python3.interpreter} $out/bin/''${b,,} \
         --argv0 pykms-''${b,,} \
-        --add-flags $siteDir/pykms_$b.py
+        --add-flags $siteDir/pykms_$b.py \
+        --set PYTHONPATH $PYTHONPATH
     done
 
     install -Dm755 ${dbScript} $out/libexec/create_pykms_db.sh
@@ -82,8 +85,8 @@ pypkgs.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Windows KMS (Key Management Service) server written in Python";
-    homepage = "https://github.com/SystemRage/py-kms";
+    homepage = "https://github.com/Py-KMS-Organization/py-kms";
     license = licenses.unlicense;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg zopieux ];
   };
 }


### PR DESCRIPTION
###### Description of changes

I have read the full diff[0] between the previous owner and the new maintained fork that I'm switching to, and could not find any suspicious code. The new fork includes fixes that are otherwise crashing as of Python 3.10.

This commit also fixes the PYTHONPATH which prevents the client from starting.

This commit also adds a test that the client can successfully query the server, testing the two components at once.

[0] https://github.com/SystemRage/py-kms/compare/master...Py-KMS-Organization:master

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).