### PR TITLE
asciidoc: 9.1.0 -> 10.2.0

### DIFF
--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -47,6 +47,17 @@ stdenv.mkDerivation rec {
       url = "https://github.com/libjxl/libjxl/commit/204f87a5e4d684544b13900109abf040dc0b402b.patch";
       sha256 = "sha256-DoAaYWLmQ+R9GZbHMTYGe0gBL9ZesgtB+2WhmbARna8=";
     })
+
+    # fix build with asciidoc wrapped in shell script
+    (fetchpatch {
+      url = "https://github.com/libjxl/libjxl/commit/b8ec58c58c6281987f42ebec892f513824c0cc0e.patch";
+      hash = "sha256-g8U+YVhLfgSHJ+PWJgvVOI66+FElJSC8IgSRodNnsMw=";
+    })
+    (fetchpatch {
+      url = "https://github.com/libjxl/libjxl/commit/ca8e276aacf63a752346a6a44ba673b0af993237.patch";
+      excludes = [ "AUTHORS" ];
+      hash = "sha256-9VXy1LdJ0JhYbCGPNMySpnGLBxUrr8BYzE+oU3LnUGw=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -1,5 +1,6 @@
 { fetchurl, lib, stdenv, python3
 , fetchFromGitHub, autoreconfHook
+, installShellFiles
 , enableStandardFeatures ? false
 , sourceHighlight ? null
 , highlight ? null
@@ -17,8 +18,7 @@
 , docbook_xsl_ns ? null
 , docbook_xsl ? null
 , fop ? null
-# TODO: Package this:
-#, epubcheck ? null
+, epubcheck ? null
 , gnused ? null
 , coreutils ? null
 
@@ -61,8 +61,7 @@ assert enableStandardFeatures ->
   docbook_xsl_ns != null &&
   docbook_xsl != null &&
   (fop != null || !enableJava) &&
-# TODO: Package this:
-#  epubcheck != null &&
+  epubcheck != null &&
   gnused != null &&
   coreutils != null;
 
@@ -144,26 +143,24 @@ let
     sha256 = "08ya4bskygzqkfqwjllpg31qc5k08xp2k78z9b2480g8y57bfy10";
   };
 
-in
-
-stdenv.mkDerivation rec {
+in python3.pkgs.buildPythonApplication rec {
   pname = "asciidoc"
     + lib.optionalString enableStandardFeatures "-full"
     + lib.optionalString enableExtraPlugins "-with-plugins";
-  version = "9.1.0";
+  version = "10.2.0";
 
-  # Note: a substitution to improve reproducibility should be updated once 10.0.0 is
-  # released. See the comment in `patchPhase` for more information.
   src = fetchFromGitHub {
-    owner = "asciidoc";
-    repo = "asciidoc-py3";
+    owner = "asciidoc-py";
+    repo = "asciidoc-py";
     rev = version;
-    sha256 = "1clf1axkns23wfmh48xfspzsnw04pjh4mq1pshpzvj0cwxhz0yaq";
+    hash = "sha256-TqC0x9xB6e2d6Wc9bgnlqgZVOmYHmUUKfE/CKAiEtag=";
   };
 
-  strictDeps = true;
-  nativeBuildInputs = [ python3 unzip autoreconfHook ];
-  buildInputs = [ python3 ];
+  nativeBuildInputs = [
+    autoreconfHook
+    installShellFiles
+    unzip
+  ];
 
   # install filters early, so their shebangs are patched too
   postPatch = with lib; ''
@@ -230,22 +227,22 @@ stdenv.mkDerivation rec {
         -e "s|twopi|${graphviz}/bin/twopi|g" \
         -e "s|circo|${graphviz}/bin/circo|g" \
         -e "s|fdp|${graphviz}/bin/fdp|g" \
-        -i "filters/graphviz/graphviz2png.py"
+        -i "asciidoc/resources/filters/graphviz/graphviz2png.py"
 
     sed -e "s|run('latex|run('${texlive}/bin/latex|g" \
         -e "s|cmd = 'dvipng'|cmd = '${texlive}/bin/dvipng'|g" \
         -e "s|cmd = 'dvisvgm'|cmd = '${texlive}/bin/dvisvgm'|g" \
-        -i "filters/latex/latex2img.py"
+        -i "asciidoc/resources/filters/latex/latex2img.py"
 
     sed -e "s|run('abc2ly|run('${lilypond}/bin/abc2ly|g" \
         -e "s|run('lilypond|run('${lilypond}/bin/lilypond|g" \
         -e "s|run('convert|run('${imagemagick.out}/bin/convert|g" \
-        -i "filters/music/music2png.py"
+        -i "asciidoc/resources/filters/music/music2png.py"
 
     sed -e 's|filter="source-highlight|filter="${sourceHighlight}/bin/source-highlight|' \
         -e 's|filter="highlight|filter="${highlight}/bin/highlight|' \
         -e 's|filter="pygmentize|filter="${pygments}/bin/pygmentize|' \
-        -i "filters/source/source-highlight-filter.conf"
+        -i "asciidoc/resources/filters/source/source-highlight-filter.conf"
 
     # ENV is custom environment passed to programs that a2x invokes. Here we
     # use it to work around an impurity in the tetex package; tetex tools
@@ -260,55 +257,45 @@ stdenv.mkDerivation rec {
         -e "s|^W3M =.*|W3M = '${w3m}/bin/w3m'|" \
         -e "s|^LYNX =.*|LYNX = '${lynx}/bin/lynx'|" \
         -e "s|^XMLLINT =.*|XMLLINT = '${libxml2.bin}/bin/xmllint'|" \
-        -e "s|^EPUBCHECK =.*|EPUBCHECK = 'nixpkgs_is_missing_epubcheck'|" \
-        -i a2x.py
+        -e "s|^EPUBCHECK =.*|EPUBCHECK = '${epubcheck}/bin/epubcheck'|" \
+        -i asciidoc/a2x.py
   '' else ''
     sed -e "s|^ENV =.*|ENV = dict(XML_CATALOG_FILES='${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook_xsl_ns}/xml/xsl/docbook/catalog.xml ${docbook_xsl}/xml/xsl/docbook/catalog.xml')|" \
         -e "s|^XSLTPROC =.*|XSLTPROC = '${libxslt.bin}/bin/xsltproc'|" \
         -e "s|^XMLLINT =.*|XMLLINT = '${libxml2.bin}/bin/xmllint'|" \
-        -i a2x.py
+        -i asciidoc/a2x.py
   '') + ''
-    patchShebangs --host \
-      asciidoc.py \
-      a2x.py \
-      tests/testasciidoc.py \
-      filters/code/code-filter.py \
-      filters/latex/latex2img.py \
-      filters/music/music2png.py \
-      filters/unwraplatex.py \
-      filters/graphviz/graphviz2png.py
-
-    # Hardcode the path to its own asciidoc.
-    # This helps with cross-compilation.
-    substituteInPlace a2x.py \
-      --replace "find_executable(ASCIIDOC)" "'${placeholder "out"}/bin/asciidoc'"
-
-    # Note: this substitution will not work in the planned 10.0.0 release:
-    #
-    # https://github.com/asciidoc/asciidoc-py3/commit/dfffda23381014481cd13e8e9d8f131e1f93f08a
-    #
-    # Update this substitution to:
-    #
-    # --replace "python3 -m asciidoc.a2x" "python3 -m asciidoc.a2x -a revdate=01/01/1980"
-    substituteInPlace Makefile.in \
-      --replace "python3 a2x.py" "python3 a2x.py -a revdate=01/01/1980"
-
     # Fix tests
     for f in $(grep -R --files-with-matches "2002-11-25") ; do
-      substituteInPlace $f --replace "2002-11-25" "1970-01-01"
-      substituteInPlace $f --replace "00:37:42" "00:00:01"
+      substituteInPlace $f --replace "2002-11-25" "1980-01-02"
+      substituteInPlace $f --replace "00:37:42" "00:00:00"
     done
   '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
     # We want to use asciidoc from the build platform to build the documentation.
     substituteInPlace Makefile.in \
-      --replace "python3 a2x.py" "python3 ${buildPackages.asciidoc}/bin/a2x.py"
+      --replace "python3 -m asciidoc.a2x" "${buildPackages.asciidoc}/bin/a2x"
   '';
 
-  preInstall = "mkdir -p $out/etc/vim";
-  makeFlags = lib.optional stdenv.isCygwin "DESTDIR=/.";
+  postBuild = ''
+    make manpages
+  '';
 
-  checkInputs = [ sourceHighlight ];
-  doCheck = true;
+  postInstall = ''
+    installManPage doc/asciidoc.1 doc/a2x.1 doc/testasciidoc.1
+  '';
+
+  checkInputs = with python3.pkgs; [
+    pytest
+    pytest-mock
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    make test
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Text-based document generation system";
@@ -325,9 +312,10 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [
       fromSource
     ] ++ lib.optional _enableDitaaFilter binaryBytecode;
-    homepage = "http://www.methods.co.nz/asciidoc/";
+    homepage = "https://asciidoc-py.github.io/";
+    changelog = "https://github.com/asciidoc-py/asciidoc-py/blob/${src.rev}/CHANGELOG.adoc";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor dotlambda ];
   };
 }

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -2,38 +2,38 @@
 , fetchFromGitHub, autoreconfHook
 , installShellFiles
 , enableStandardFeatures ? false
-, sourceHighlight ? null
-, highlight ? null
-, pygments ? null
-, graphviz ? null
-, texlive ? null
-, dblatexFull ? null
-, libxslt ? null
-, w3m ? null
-, lynx ? null
-, imagemagick ? null
-, lilypond ? null
-, libxml2 ? null
-, docbook_xml_dtd_45 ? null
-, docbook_xsl_ns ? null
-, docbook_xsl ? null
-, fop ? null
-, epubcheck ? null
-, gnused ? null
-, coreutils ? null
+, sourceHighlight
+, highlight
+, pygments
+, graphviz
+, texlive
+, dblatexFull
+, libxslt
+, w3m
+, lynx
+, imagemagick
+, lilypond
+, libxml2
+, docbook_xml_dtd_45
+, docbook_xsl_ns
+, docbook_xsl
+, fop
+, epubcheck
+, gnused
+, coreutils
 
 # if true, enable all the below filters and backends
 , enableExtraPlugins ? false
 
 # unzip is needed to extract filter and backend plugins
-, unzip ? null
+, unzip
 # filters
-, enableDitaaFilter ? false, jre ? null
-, enableMscgenFilter ? false, mscgen ? null
-, enableDiagFilter ? false, blockdiag ? null, seqdiag ? null, actdiag ? null, nwdiag ? null
-, enableQrcodeFilter ? false, qrencode ? null
-, enableMatplotlibFilter ? false, matplotlib ? null, numpy ? null
-, enableAafigureFilter ? false, aafigure ? null, recursivePthLoader ? null
+, enableDitaaFilter ? false, jre
+, enableMscgenFilter ? false, mscgen
+, enableDiagFilter ? false, blockdiag, seqdiag, actdiag, nwdiag
+, enableQrcodeFilter ? false, qrencode
+, enableMatplotlibFilter ? false, matplotlib, numpy
+, enableAafigureFilter ? false, aafigure, recursivePthLoader
 # backends
 , enableDeckjsBackend ? false
 , enableOdfBackend ? false
@@ -43,37 +43,6 @@
 
 , buildPackages
 }:
-
-assert enableStandardFeatures ->
-  sourceHighlight != null &&
-  highlight != null &&
-  pygments != null &&
-  graphviz != null &&
-  texlive != null &&
-  dblatexFull != null &&
-  libxslt != null &&
-  w3m != null &&
-  lynx != null &&
-  imagemagick != null &&
-  lilypond != null &&
-  libxml2 != null &&
-  docbook_xml_dtd_45 != null &&
-  docbook_xsl_ns != null &&
-  docbook_xsl != null &&
-  (fop != null || !enableJava) &&
-  epubcheck != null &&
-  gnused != null &&
-  coreutils != null;
-
-# filters
-assert enableExtraPlugins || enableDitaaFilter || enableMscgenFilter || enableDiagFilter || enableQrcodeFilter || enableAafigureFilter -> unzip != null;
-assert (enableExtraPlugins && enableJava) || enableDitaaFilter -> jre != null;
-assert enableExtraPlugins || enableMscgenFilter -> mscgen != null;
-assert enableExtraPlugins || enableDiagFilter -> blockdiag != null && seqdiag != null && actdiag != null && nwdiag != null;
-assert enableExtraPlugins || enableMatplotlibFilter -> matplotlib != null && numpy != null;
-assert enableExtraPlugins || enableAafigureFilter -> aafigure != null && recursivePthLoader != null;
-# backends
-assert enableExtraPlugins || enableDeckjsBackend || enableOdfBackend -> unzip != null;
 
 let
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4470,21 +4470,17 @@ with pkgs;
   arpoison = callPackage ../tools/networking/arpoison { };
 
   asciidoc = callPackage ../tools/typesetting/asciidoc {
-    inherit (python3.pkgs) matplotlib numpy aafigure recursivePthLoader;
+    inherit (python3.pkgs) pygments matplotlib numpy aafigure recursivePthLoader;
+    texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
+    w3m = w3m-batch;
     enableStandardFeatures = false;
   };
 
   asciidoc-full = asciidoc.override {
-    inherit (python3.pkgs) pygments;
-    texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
-    w3m = w3m-batch;
     enableStandardFeatures = true;
   };
 
   asciidoc-full-with-plugins = asciidoc.override {
-    inherit (python3.pkgs) pygments;
-    texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
-    w3m = w3m-batch;
     enableStandardFeatures = true;
     enableExtraPlugins = true;
   };


### PR DESCRIPTION

###### Description of changes
https://github.com/asciidoc-py/asciidoc-py/blob/10.2.0/CHANGELOG.adoc

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
