### PR TITLE
Update perseus

### DIFF
--- a/pkgs/applications/science/math/perseus/default.nix
+++ b/pkgs/applications/science/math/perseus/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation {
   };
 
   sourceRoot = ".";
+  
   NIX_CFLAGS_COMPILE = [ "-std=c++14" ];  # Otherwise it does not compile 
+  
   buildPhase = ''
     g++ Pers.cpp -O3 -fpermissive -o perseus
   '';

--- a/pkgs/applications/science/math/perseus/default.nix
+++ b/pkgs/applications/science/math/perseus/default.nix
@@ -8,12 +8,12 @@ stdenv.mkDerivation {
   hardeningDisable = [ "stackprotector" ];
 
   src = fetchurl {
-    url = "http://www.sas.upenn.edu/~vnanda/source/perseus_4_beta.zip";
-    sha256 = "09brijnqabhgfjlj5wny0bqm5dwqcfkp1x5wif6yzdmqh080jybj";
+    url = "http://people.maths.ox.ac.uk/nanda/source/perseus_4_beta.zip";
+    sha256 = "sha256-cnkJEIC4tu+Ni7z0cKdjmLdS8QLe8iKpdA8uha2MeSU=";
   };
 
   sourceRoot = ".";
-
+  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];  # Otherwise it does not compile 
   buildPhase = ''
     g++ Pers.cpp -O3 -fpermissive -o perseus
   '';
@@ -32,9 +32,9 @@ stdenv.mkDerivation {
       around datasets arising from point samples, images, distance
       matrices and so forth.
     '';
-    homepage = "http://www.sas.upenn.edu/~vnanda/perseus/index.html";
+    homepage = "http://people.maths.ox.ac.uk/nanda/perseus/index.html";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ erikryb ];
+    maintainers = with lib.maintainers; [ erikryb mrbitt ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/science/math/perseus/default.nix
+++ b/pkgs/applications/science/math/perseus/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     '';
     homepage = "http://people.maths.ox.ac.uk/nanda/perseus/index.html";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ erikryb mrbitt ];
+    maintainers = with lib.maintainers; [ erikryb ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/science/math/perseus/default.nix
+++ b/pkgs/applications/science/math/perseus/default.nix
@@ -13,9 +13,7 @@ stdenv.mkDerivation {
   };
 
   sourceRoot = ".";
-  
-  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];  # Otherwise it does not compile 
-  
+  NIX_CFLAGS_COMPILE = [ "-std=c++14" ];
   buildPhase = ''
     g++ Pers.cpp -O3 -fpermissive -o perseus
   '';


### PR DESCRIPTION
new   url --> http://people.maths.ox.ac.uk/nanda/perseus/index.html
add   NIX_CFLAGS_COMPILE = [ "-std=c++14" ];  # Otherwise it does not compile

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
