### PR TITLE
swayr: 0.16.1 -> 0.19.0

### DIFF
--- a/pkgs/tools/wayland/swayr/default.nix
+++ b/pkgs/tools/wayland/swayr/default.nix
@@ -2,20 +2,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "swayr";
-  version = "0.16.1";
+  version = "0.19.0";
 
   src = fetchFromSourcehut {
     owner = "~tsdh";
     repo = "swayr";
-    rev = "v${version}";
-    sha256 = "sha256-c/VHD5VceddhKanuId4rG1Tl+9Bg7zUmIqq4gMsy1e0=";
+    rev = "swayr-${version}";
+    sha256 = "sha256-ubindhU3G1iHqf/yiXIJk87uI3o5y2lfs22tbIfiqv4=";
   };
 
-  cargoSha256 = "sha256-0aGMWuU6DvBr9tvgDd1GZqhlY8bGCuPs8pSc5A03L3w=";
+  cargoSha256 = "sha256-X6BYLD7YmlHCO+3b3Ubai222tvsZUmZrwm3vS2PeqDY=";
 
   patches = [
     ./icon-paths.patch
   ];
+
+  # don't build swayrbar
+  buildAndTestSubdir = pname;
 
   preCheck = ''
     export HOME=$TMPDIR

--- a/pkgs/tools/wayland/swayr/icon-paths.patch
+++ b/pkgs/tools/wayland/swayr/icon-paths.patch
@@ -1,8 +1,8 @@
-diff --git a/src/config.rs b/src/config.rs
-index de7d04b..291114b 100644
---- a/src/config.rs
-+++ b/src/config.rs
-@@ -197,6 +197,12 @@ impl Default for Format {
+diff --git a/swayr/src/config.rs b/swayr/src/config.rs
+index bc6ec98..48cdc65 100644
+--- a/swayr/src/config.rs
++++ b/swayr/src/config.rs
+@@ -271,6 +271,12 @@ impl Default for Format {
              ),
              urgency_end: Some("</span>".to_string()),
              icon_dirs: Some(vec![
@@ -13,5 +13,5 @@ index de7d04b..291114b 100644
 +                "~/.nix-profile/share/icons/hicolor/48x48/apps".to_string(),
 +                "~/.nix-profile/share/pixmaps".to_string(),
                  "/usr/share/icons/hicolor/scalable/apps".to_string(),
+                 "/usr/share/icons/hicolor/64x64/apps".to_string(),
                  "/usr/share/icons/hicolor/48x48/apps".to_string(),
-                 "/usr/share/pixmaps".to_string(),


### PR DESCRIPTION
###### Description of changes

https://git.sr.ht/~tsdh/swayr/tree/swayr-0.19.0/item/swayr/NEWS.md

###### Things done

Update the patch and just build the swayr crate.

```
❯ nix-build -A swayr
/nix/store/by1m76qfclrki72nmm6x5gl2kbzywrlk-swayr-0.19.0

❯ ls -la /nix/store/by1m76qfclrki72nmm6x5gl2kbzywrlk-swayr-0.19.0/*/*
-r-xr-xr-x 2 root root  932224 Jan  1  1970 /nix/store/by1m76qfclrki72nmm6x5gl2kbzywrlk-swayr-0.19.0/bin/swayr
-r-xr-xr-x 2 root root 2911032 Jan  1  1970 /nix/store/by1m76qfclrki72nmm6x5gl2kbzywrlk-swayr-0.19.0/bin/swayrd

❯ /nix/store/by1m76qfclrki72nmm6x5gl2kbzywrlk-swayr-0.19.0/bin/swayr --version
swayr 0.19.0
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).