### PR TITLE
python3Packages.plantuml: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14720,4 +14720,10 @@
     github = "dfithian";
     githubId = 8409320;
   };
+  nikstur = {
+    email = "nikstur@outlook.com";
+    name = "nikstur";
+    github = "nikstur";
+    githubId = 61635709;
+  };
 }

--- a/pkgs/development/python-modules/plantuml/default.nix
+++ b/pkgs/development/python-modules/plantuml/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+  # Runtime dependencies
+, httplib2
+, six
+}:
+
+buildPythonPackage {
+  pname = "plantuml";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "dougn";
+    repo = "python-plantuml";
+    rev = "93e1aac25b17d896b0d05d0a1aa352c7bd11dd31";
+    sha256 = "sha256-aPXPqoKlu8VLi0Jn84brG7v3qM9L18Ut4sabYYGb3qQ=";
+  };
+
+  propagatedBuildInputs = [
+    httplib2
+    six
+  ];
+
+  # Project does not contain a test suite
+  doCheck = false;
+
+  pythonImportsCheck = [ "plantuml" ];
+
+  meta = with lib; {
+    description = "Python interface to a plantuml web service instead of having to run java locally";
+    homepage = "https://github.com/dougn/python-plantuml";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ nikstur ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6755,6 +6755,8 @@ in {
 
   plaid-python = callPackage ../development/python-modules/plaid-python { };
 
+  plantuml = callPackage ../development/python-modules/plantuml { };
+
   plaster = callPackage ../development/python-modules/plaster { };
 
   plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy { };


### PR DESCRIPTION
###### Description of changes

New package:
python-plantuml is a Plantuml HTTP client.
https://github.com/dougn/python-plantuml

I need this package primarily as a dependency for [plantuml-markdown](https://github.com/mikitex70/plantuml-markdown/blob/master/setup.py). I plan to open a PR for plantuml-markdown after this package has been merged. 

Please let me know if declaring the actual plantuml application as `plantumlBinary` is the nix idiomatic way of doing things.

`plantuml/default.nix` has been formatted with nixpkgs-fmt and checked with statix

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
