### PR TITLE
semgrep{,-core}: init at 0.103.0

### DIFF
--- a/pkgs/tools/security/semgrep/common.nix
+++ b/pkgs/tools/security/semgrep/common.nix
@@ -1,0 +1,55 @@
+{ lib, fetchFromGitHub, fetchzip }:
+
+rec {
+  version = "0.103.0";
+
+  src = fetchFromGitHub {
+    owner = "returntocorp";
+    repo = "semgrep";
+    rev = "v${version}";
+    sha256 = "sha256-vk6GBgLsXRLAVu60xW4WWWhhi4b1WLceTxh/TeISIUg=";
+  };
+
+  # submodule dependencies
+  # these are fetched so we:
+  #   1. don't fetch the many submodules we don't need
+  #   2. avoid fetchSubmodules since it's prone to impurities
+  langsSrc = fetchFromGitHub {
+    owner = "returntocorp";
+    repo = "semgrep-langs";
+    rev = "78e518dad1ce2a7c76854c944245434bd8426439";
+    sha256 = "sha256-t9F/OzzT6FI9G4Fxz0lUjz6TVrJlenusQNJnFpiKaQs=";
+  };
+
+  interfacesSrc = fetchFromGitHub {
+    owner = "returntocorp";
+    repo = "semgrep-interfaces";
+    rev = "a64a45034ea428ecbe9da6bd849a4f1cfd23cdd2";
+    sha256 = "sha256-eatuyA5xyfZVHCmHvZIzQK2c5eEWUEZd9LumJQtk8+s=";
+  };
+
+  # fetch pre-built semgrep-core since the ocaml build is complex and relies on
+  # the opam package manager at some point
+  coreRelease = fetchzip {
+    url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}-ubuntu-16.04.tgz";
+    sha256 = "sha256-L3NbiVYmgJim7H4W1cr75WOItSiHT1YIkUEefuaCYlY=";
+  };
+
+  meta = with lib; {
+    homepage = "https://semgrep.dev/";
+    downloadPage = "https://github.com/returntocorp/semgrep/";
+    changelog = "https://github.com/returntocorp/semgrep/blob/v${version}/CHANGELOG.md";
+    description = "Lightweight static analysis for many languages";
+    longDescription = ''
+      Semgrep is a fast, open-source, static analysis tool for finding bugs and
+      enforcing code standards at editor, commit, and CI time. Semgrep analyzes
+      code locally on your computer or in your build environment: code is never
+      uploaded. Its rules look like the code you already write; no abstract
+      syntax trees, regex wrestling, or painful DSLs.
+    '';
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ jk ambroisie ];
+    # limited by semgrep-core
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/security/semgrep/default.nix
+++ b/pkgs/tools/security/semgrep/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, fetchFromGitHub
+, callPackage
+, semgrep-core
+, buildPythonApplication
+, pythonPackages
+
+, pytestCheckHook
+, git
+}:
+
+let
+  common = callPackage ./common.nix { };
+in
+buildPythonApplication rec {
+  pname = "semgrep";
+  inherit (common) version;
+  src = "${common.src}/cli";
+
+  SEMGREP_CORE_BIN = "${semgrep-core}/bin/semgrep-core";
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "typing-extensions~=4.2" "typing-extensions" \
+      --replace "jsonschema~=3.2" "jsonschema" \
+      --replace "boltons~=21.0" "boltons"
+
+    # remove git submodule placeholders
+    rm -r ./src/semgrep/{lang,semgrep_interfaces}
+    # link submodule dependencies
+    ln -s ${common.langsSrc}/ ./src/semgrep/lang
+    ln -s ${common.interfacesSrc}/ ./src/semgrep/semgrep_interfaces
+  '';
+
+  doCheck = true;
+  checkInputs = [ git pytestCheckHook ] ++ (with pythonPackages; [
+    pytest-snapshot
+    pytest-mock
+    pytest-freezegun
+    types-freezegun
+  ]);
+  disabledTests = [
+    # requires networking
+    "tests/unit/test_metric_manager.py"
+  ];
+  preCheck = ''
+    # tests need a home directory
+    export HOME="$(mktemp -d)"
+
+    # disabledTestPaths doesn't manage to avoid the e2e tests
+    # remove them from pyproject.toml
+    # and remove need for pytest-split
+    substituteInPlace pyproject.toml \
+      --replace '"tests/e2e",' "" \
+      --replace 'addopts = "--splitting-algorithm=least_duration"' ""
+  '';
+
+  propagatedBuildInputs = with pythonPackages; [
+    attrs
+    boltons
+    colorama
+    click
+    click-option-group
+    glom
+    requests
+    ruamel-yaml
+    tqdm
+    packaging
+    jsonschema
+    wcmatch
+    peewee
+    defusedxml
+    urllib3
+    typing-extensions
+    python-lsp-jsonrpc
+  ];
+
+  meta = common.meta // {
+    description = common.meta.description + " - cli";
+  };
+}

--- a/pkgs/tools/security/semgrep/semgrep-core.nix
+++ b/pkgs/tools/security/semgrep/semgrep-core.nix
@@ -1,0 +1,22 @@
+{ lib, stdenvNoCC, callPackage }:
+
+let
+  common = callPackage ./common.nix { };
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "semgrep-core";
+  inherit (common) version;
+
+  src = common.coreRelease;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 -t $out/bin semgrep-core
+    runHook postInstall
+  '';
+
+  meta = common.meta // {
+    description = common.meta.description + " - core binary";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10437,6 +10437,9 @@ with pkgs;
 
   seexpr = callPackage ../development/compilers/seexpr { };
 
+  semgrep = python3.pkgs.callPackage ../tools/security/semgrep { };
+  semgrep-core = callPackage ../tools/security/semgrep/semgrep-core.nix { };
+
   setroot = callPackage  ../tools/X11/setroot { };
 
   setserial = callPackage ../tools/system/setserial { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package semgrep for nixpkgs

I tried building semgrep-core from source but it requires opam when building the pfff dependency and potentially others
In the future we could build semgrep-core from source but this will do for now

Writing an update script could also be done before merging

Metrics are enabled by default (to some extent) and turning it off by default is non-trivial and would need a small patch so I've left that as is for now too

Resolves #138018

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
