### PR TITLE
pngloss: init at unstable-2020-11-25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -97,6 +97,12 @@
     github = "1000teslas";
     githubId = 47207223;
   };
+  _2gn = {
+    name = "Hiram Tanner";
+    email = "101851090+2gn@users.noreply.github.com";
+    github = "2gn";
+    githubId = 101851090;
+  };
   _3699n = {
     email = "nicholas@nvk.pm";
     github = "3699n";

--- a/pkgs/tools/graphics/pngloss/default.nix
+++ b/pkgs/tools/graphics/pngloss/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, libpng, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "pngloss";
+  version = "unstable-2020-11-25";
+
+  src = fetchFromGitHub {
+    owner = "foobaz";
+    repo = pname;
+    rev = "559f09437e1c797a1eaf08dfdcddd9b082f0e09c";
+    sha256 = "sha256-dqrrzbLu4znyWOlTDIf56O3efxszetiP+CdFiy2PBd4=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    libpng
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ./src/pngloss $out/bin/pngloss
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Lossy compression of PNG images";
+    homepage = "https://github.com/foobaz/pngloss";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ _2gn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9370,6 +9370,8 @@ with pkgs;
 
   p0f = callPackage ../tools/security/p0f { };
 
+  pngloss = callPackage ../tools/graphics/pngloss { };
+
   pngout = callPackage ../tools/graphics/pngout { };
 
   patch = gnupatch;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
