### PR TITLE
nixos/foliate: add ebook reader module

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -297,6 +297,27 @@ rec {
         merge = mergeEqualOption;
     };
 
+    # Specialized subdomains of float
+    floats = {
+      /* A float with a fixed range.
+       *
+       * Example:
+       *   (floats.between 0.0 100.0).check (-0.1)
+       *   => false
+       *   (floats.between 0.0 100.0).check (101.0)
+       *   => false
+       *   (floats.between 0.0 1.0).check 0.5
+       *   => true
+       */
+      between = lowest: highest:
+        assert lib.assertMsg (lowest <= highest)
+          "floats.between: lowest must be smaller than highest";
+        addCheck float (x: x >= lowest && x <= highest) // {
+          name = "floatBetween";
+          description = "float between ${toString lowest} and ${toString highest}";
+        };
+    };
+
     str = mkOptionType {
       name = "str";
       description = "string";

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -326,6 +326,14 @@
       </listitem>
       <listitem>
         <para>
+          There is a new module for the
+          <link xlink:href="https://johnfactotum.github.io/foliate/">Foliate</link>
+          eBook viewer under the <literal>programs.foliate</literal>
+          NixOS options.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           There is a new module for the <literal>thunar</literal>
           program (the Xfce file manager), which depends on the
           <literal>xfconf</literal> dbus service, and also has a dbus

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -121,6 +121,10 @@ Use `configure.packages` instead.
 
 - Add udev rules for the Teensy family of microcontrollers.
 
+- There is a new module
+for the [Foliate](https://johnfactotum.github.io/foliate/)
+eBook viewer under the `programs.foliate` NixOS options.
+
 - There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.
 
 - There is a new module for the `xfconf` program (the Xfce configuration storage system), which has a dbus service.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -157,6 +157,7 @@
   ./programs/fish.nix
   ./programs/flashrom.nix
   ./programs/flexoptix-app.nix
+  ./programs/foliate.nix
   ./programs/freetds.nix
   ./programs/fuse.nix
   ./programs/gamemode.nix

--- a/nixos/modules/programs/foliate.nix
+++ b/nixos/modules/programs/foliate.nix
@@ -1,0 +1,59 @@
+{ lib, pkgs, config, ... }:
+
+with lib; {
+  options.programs.foliate = {
+    enable = mkEnableOption "Foliate - A simple and modern eBook reader.";
+
+    extraConfig = mkOption {
+      description = "Additional options to put verbatim into Foliate's config file.";
+      type = types.lines;
+      default = ''
+        [com/github/johnfactotum/Foliate]
+      '';
+      example = ''
+        [com/github/johnfactotum/Foliate]
+        # Choose between: location, percentage, time-left-book, time-left-section, section-name
+        footer-left='location'
+        footer-right='section-name'
+
+        [com/github/johnfactotum/Foliate/view]
+        # Dark theme
+        bg-color='#000000'
+        fg-color='#FFFFFF'
+        link-color='#00FFFF'
+
+        # Choose between: auto, scrolled, continuous, single
+        layout='continuous'
+
+        # Any integer >= 0
+        margin=0
+
+        # Between 1.0 and 3.0
+        spacing=1.0
+
+        # Uncomment to set a custom font and font size:
+        # font='Fira Code 16'
+      '';
+    };
+  };
+  config = lib.mkIf config.programs.foliate.enable {
+    environment.systemPackages = [ pkgs.foliate ];
+
+    programs.dconf.enable = true;
+    programs.dconf.packages = [
+      (pkgs.writeTextFile {
+        name = "dconf-user-profile";
+        destination = "/etc/dconf/profile/user";
+        text = ''
+          user-db:user
+          system-db:site
+        '';
+      })
+      (pkgs.writeTextFile {
+        name = "dconf-foliate-settings";
+        destination = "/etc/dconf/db/site.d/00_foliate_settings";
+        text = config.programs.foliate.extraConfig;
+      })
+    ];
+  };
+}

--- a/nixos/tests/foliate.nix
+++ b/nixos/tests/foliate.nix
@@ -1,0 +1,42 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "foliate";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ kamadorueda ];
+  };
+
+  nodes.machine = { ... }: {
+    imports = [ ./common/x11.nix ];
+    config.programs.foliate = {
+      enable = true;
+      extraConfig = ''
+        [com/github/johnfactotum/Foliate]
+        footer-left='location'
+        footer-right='section-name'
+
+        [com/github/johnfactotum/Foliate/view]
+        bg-color='#000000'
+        fg-color='#FFFFFF'
+        link-color='#00FFFF'
+        layout='continuous'
+        margin=0
+        spacing=1.0
+      '';
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_x()
+    machine.succeed("foliate --version")
+
+    machine.copy_from_vm("/etc/dconf/profile/foliate")
+    with open(machine.out_dir / "foliate") as file:
+        content = file.read()
+        assert "user-db:user" in content
+
+    machine.copy_from_vm("/etc/dconf/db/foliate.d/00-nixos-settings")
+    with open(machine.out_dir / "00-nixos-settings") as file:
+        content = file.read()
+        assert "[com/github/johnfactotum/Foliate/view]" in content
+  '';
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
