### PR TITLE
 buildRustPackage: fix overrideAttrs 

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -15,145 +15,149 @@
 , windows
 }:
 
-{ name ? "${args.pname}-${args.version}"
-
-  # Name for the vendored dependencies tarball
-, cargoDepsName ? name
-
-, src ? null
-, srcs ? null
-, unpackPhase ? null
-, cargoPatches ? []
-, patches ? []
-, sourceRoot ? null
-, logLevel ? ""
-, buildInputs ? []
-, nativeBuildInputs ? []
-, cargoUpdateHook ? ""
-, cargoDepsHook ? ""
-, buildType ? "release"
-, meta ? {}
-, cargoLock ? null
+{ cargoLock ? null
 , cargoVendorDir ? null
-, checkType ? buildType
-, buildNoDefaultFeatures ? false
-, checkNoDefaultFeatures ? buildNoDefaultFeatures
-, buildFeatures ? [ ]
-, checkFeatures ? buildFeatures
-, depsExtraArgs ? {}
 
-# Toggles whether a custom sysroot is created when the target is a .json file.
+  # Toggles whether a custom sysroot is created when the target is a .json file.
 , __internal_dontAddSysroot ? false
 
-# Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
-# contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
-# case for `rustfmt`/etc from the `rust-sources).
-# Otherwise, everything from the tarball would've been built/tested.
+  # Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
+  # contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
+  # case for `rustfmt`/etc from the `rust-sources).
+  # Otherwise, everything from the tarball would've been built/tested.
 , buildAndTestSubdir ? null
-, ... } @ args:
+, ...
+} @ args:
 
 assert cargoVendorDir == null && cargoLock == null -> !(args ? cargoSha256) && !(args ? cargoHash)
   -> throw "cargoSha256, cargoHash, cargoVendorDir, or cargoLock must be set";
-assert buildType == "release" || buildType == "debug";
 
-let
+# depsExtraArgs, cargoLock have to be removed otherwise 'cannot coerce a set to a string'
+# with structuredAttrs this won't be needed
+# also cargoUpdateHook to avoid changing hashes
+(stdenv.mkDerivation (removeAttrs args [ "depsExtraArgs" "cargoLock" "cargoUpdateHook" ])).overrideAttrs (finalAttrs: previousAttrs:
+  let
+    # If we have a cargoSha256 fixed-output derivation, validate it at build time
+    # against the src fixed-output derivation to check consistency.
+    # NOTE: this seems unused
+    #validateCargoDeps = finalAttrs ? cargoHash || finalAttrs ? cargoSha256;
 
-  cargoDeps =
-    if cargoVendorDir != null then null
-    else if cargoLock != null then importCargoLock cargoLock
-    else fetchCargoTarball ({
-      inherit src srcs sourceRoot unpackPhase cargoUpdateHook;
-      name = cargoDepsName;
-      patches = cargoPatches;
-    } // lib.optionalAttrs (args ? cargoHash) {
-      hash = args.cargoHash;
-    } // lib.optionalAttrs (args ? cargoSha256) {
-      sha256 = args.cargoSha256;
-    } // depsExtraArgs);
+    target = rust.toRustTargetSpec stdenv.hostPlatform;
+    targetIsJSON = lib.hasSuffix ".json" target;
+    useSysroot = targetIsJSON && !__internal_dontAddSysroot;
 
-  # If we have a cargoSha256 fixed-output derivation, validate it at build time
-  # against the src fixed-output derivation to check consistency.
-  validateCargoDeps = args ? cargoHash || args ? cargoSha256;
+    # see https://github.com/rust-lang/cargo/blob/964a16a28e234a3d397b2a7031d4ab4a428b1391/src/cargo/core/compiler/compile_kind.rs#L151-L168
+    # the "${}" is needed to transform the path into a /nix/store path before baseNameOf
+    shortTarget =
+      if targetIsJSON then
+        (lib.removeSuffix ".json" (builtins.baseNameOf "${target}"))
+      else target;
+    sysroot = callPackage ./sysroot { } {
+      inherit target shortTarget;
+      RUSTFLAGS = finalAttrs.RUSTFLAGS or "";
+      originalCargoToml = finalAttrs.src + /Cargo.toml; # profile info is later extracted
+    };
 
-  target = rust.toRustTargetSpec stdenv.hostPlatform;
-  targetIsJSON = lib.hasSuffix ".json" target;
-  useSysroot = targetIsJSON && !__internal_dontAddSysroot;
+    cargoDeps =
+      if cargoVendorDir != null then null
+      else if cargoLock != null then importCargoLock cargoLock
+      else
+        fetchCargoTarball ({
+          src = finalAttrs.src or "";
+          srcs = finalAttrs.srcs or null;
+          sourceRoot = finalAttrs.sourceRoot or null;
+          unpackPhase = finalAttrs.unpackPhase or null;
+          cargoUpdateHook = finalAttrs.cargoUpdateHook or args.cargoUpdateHook or "";
+          # Name for the vendored dependencies tarball
+          name = finalAttrs.cargoDepsName or finalAttrs.name or "${finalAttrs.pname}-${finalAttrs.version}";
+          # see comment below
+          #patches = finalAttrs.cargoPatches;
+          patches = finalAttrs.cargoPatches or [ ];
+        } // lib.optionalAttrs (finalAttrs ? cargoHash) {
+          hash = finalAttrs.cargoHash;
+        } // lib.optionalAttrs (finalAttrs ? cargoSha256) {
+          sha256 = finalAttrs.cargoSha256;
+        } // (args.depsExtraArgs or { }));
 
-  # see https://github.com/rust-lang/cargo/blob/964a16a28e234a3d397b2a7031d4ab4a428b1391/src/cargo/core/compiler/compile_kind.rs#L151-L168
-  # the "${}" is needed to transform the path into a /nix/store path before baseNameOf
-  shortTarget = if targetIsJSON then
-      (lib.removeSuffix ".json" (builtins.baseNameOf "${target}"))
-    else target;
+    maybeSetStr = x: lib.optionalString (previousAttrs ? ${x}) previousAttrs.${x};
+    maybeSetListFromPrevious = x: lib.optionals (previousAttrs ? ${x}) previousAttrs.${x};
 
-  sysroot = callPackage ./sysroot { } {
-    inherit target shortTarget;
-    RUSTFLAGS = args.RUSTFLAGS or "";
-    originalCargoToml = src + /Cargo.toml; # profile info is later extracted
-  };
+    # cargoBuildFeatures example:
+    # previous: use directly specified cargoBuildFeatures from the original derivation (the one in nixpkgs)
+    # final: use buildType from either the original derivation or one overriden with overrideAttrs
+    # default: use the default passed if none of the above are set
+    pickPreviousOrFinalOrDefault = previous: final: default: (previousAttrs.${previous} or finalAttrs.${final} or default);
 
-in
+  in
 
-# Tests don't currently work for `no_std`, and all custom sysroots are currently built without `std`.
-# See https://os.phil-opp.com/testing/ for more information.
-assert useSysroot -> !(args.doCheck or true);
+  # Tests don't currently work for `no_std`, and all custom sysroots are currently built without `std`.
+    # See https://os.phil-opp.com/testing/ for more information.
+  assert useSysroot -> !(finalAttrs.doCheck or true);
+  {
+    inherit buildAndTestSubdir cargoDeps;
 
-stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "cargoLock" ]) // lib.optionalAttrs useSysroot {
-  RUSTFLAGS = "--sysroot ${sysroot} " + (args.RUSTFLAGS or "");
-} // {
-  inherit buildAndTestSubdir cargoDeps;
+    # buildType is checked for 4 of the cargo built in types
+    # directly specifying cargoBuildType can be used as a escape-hatch
+    cargoBuildType = assert finalAttrs ? buildType -> lib.assertOneOf "buildType" finalAttrs.buildType [ "release" "debug" "test" "bench" ];
+      pickPreviousOrFinalOrDefault "cargoBuildType" "buildType" "release";
 
-  cargoBuildType = buildType;
+    cargoCheckType = pickPreviousOrFinalOrDefault "cargoCheckType" "checkType" finalAttrs.cargoBuildType;
 
-  cargoCheckType = checkType;
+    cargoBuildNoDefaultFeatures = pickPreviousOrFinalOrDefault "cargoBuildNoDefaultFeatures" "buildNoDefaultFeatures" false;
 
-  cargoBuildNoDefaultFeatures = buildNoDefaultFeatures;
+    cargoCheckNoDefaultFeatures = pickPreviousOrFinalOrDefault "cargoCheckNoDefaultFeatures" "checkNoDefaultFeatures"
+      finalAttrs.cargoBuildNoDefaultFeatures;
 
-  cargoCheckNoDefaultFeatures = checkNoDefaultFeatures;
+    cargoBuildFeatures = pickPreviousOrFinalOrDefault "cargoBuildFeatures" "buildFeatures" "";
 
-  cargoBuildFeatures = buildFeatures;
+    cargoCheckFeatures = pickPreviousOrFinalOrDefault "cargoCheckFeatures" "checkFeatures" finalAttrs.cargoBuildFeatures;
 
-  cargoCheckFeatures = checkFeatures;
+    patchRegistryDeps = ./patch-registry-deps;
 
-  patchRegistryDeps = ./patch-registry-deps;
+    nativeBuildInputs = maybeSetListFromPrevious "nativeBuildInputs" ++ [
+      cacert
+      git
+      cargoBuildHook
+      cargoCheckHook
+      cargoInstallHook
+      cargoSetupHook
+      rustc
+    ];
 
-  nativeBuildInputs = nativeBuildInputs ++ [
-    cacert
-    git
-    cargoBuildHook
-    cargoCheckHook
-    cargoInstallHook
-    cargoSetupHook
-    rustc
-  ];
-
-  buildInputs = buildInputs
+    buildInputs = maybeSetListFromPrevious "buildInputs"
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
     ++ lib.optionals stdenv.hostPlatform.isMinGW [ windows.pthreads ];
 
-  patches = cargoPatches ++ patches;
+    # commented for now to keep drv hash from changing
+    #cargoPatches = maybeSetListFromPrevious "cargoPatches";
+    #patches = finalAttrs.cargoPatches ++ maybeSetListFromPrevious "patches";
 
-  PKG_CONFIG_ALLOW_CROSS =
-    if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+    patches = (finalAttrs.cargoPatches or [ ]) ++ maybeSetListFromPrevious "patches";
 
-  postUnpack = ''
-    eval "$cargoDepsHook"
+    PKG_CONFIG_ALLOW_CROSS = previousAttrs.PKG_CONFIG_ALLOW_CROSS or
+      (if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0);
 
-    export RUST_LOG=${logLevel}
-  '' + (args.postUnpack or "");
+    postUnpack = ''
+      eval "$cargoDepsHook"
 
-  configurePhase = args.configurePhase or ''
-    runHook preConfigure
-    runHook postConfigure
-  '';
+      export RUST_LOG=${finalAttrs.logLevel or ""}
+    '' + maybeSetStr "postUnpack";
 
-  doCheck = args.doCheck or true;
+    configurePhase = previousAttrs.configurePhase or ''
+      runHook preConfigure
+      runHook postConfigure
+    '';
 
-  strictDeps = true;
+    doCheck = previousAttrs.doCheck or true;
 
-  passthru = { inherit cargoDeps; } // (args.passthru or {});
+    strictDeps = previousAttrs.strictDeps or true;
 
-  meta = {
-    # default to Rust's platforms
-    platforms = rustc.meta.platforms;
-  } // meta;
-})
+    passthru = { inherit cargoDeps; } // (previousAttrs.passthru or { });
+
+    meta = {
+      # default to Rust's platforms
+      platforms = rustc.meta.platforms;
+    } // previousAttrs.meta or { };
+
+  } // lib.optionalAttrs useSysroot
+    { RUSTFLAGS = "--sysroot ${sysroot} " + (previousAttrs.RUSTFLAGS or ""); })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -394,6 +394,24 @@ with pkgs;
 
   deadnix = callPackage ../development/tools/deadnix { };
 
+  deadnix1 = (deadnix.overrideAttrs (finalAttrs: previousAttrs: {
+    version = finalAttrs.src.rev;
+    src = fetchFromGitHub {
+      owner = "astro";
+      repo = "deadnix";
+      rev = "83c42cc64d190ecb72f5929eab0f64fe88e25dc4";
+      sha256 = "sha256-npyHYIJW7HyGIFpCZZK+t5JM/v2LsyFhAGJxX1DXO7E=";
+    };
+
+    cargoSha256 = "sha256-kZ4Bd0ba63QBHLAy7WwaR6KCZ3RwuPgp3h8+PKF9LQQ=";
+    # no longer necessary to override cargoDeps
+    #cargoDeps = previousAttrs.cargoDeps.overrideAttrs (lib.const {
+    #  name = "deadnix-vendor.tar.gz";
+    #  inherit (finalAttrs) src;
+    #  outputHash = "sha256-9U8cZ8+oa9n1kP3WgYSpk9deC3zBECH/YSTNA9e4jsc=";
+    #});
+  }));
+
   dsq = callPackage ../tools/misc/dsq { buildGoModule = buildGo118Module; };
 
   each = callPackage ../tools/text/each { };


### PR DESCRIPTION
this commit doesn't change any hashes yet

this fixes overriding cargoSha256 and other attrs

so no need to overriding cargoDeps anymore

will drop the first 2 commits before merge


Closes https://github.com/NixOS/nixpkgs/issues/107070

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
