### PR TITLE
autorandr: Fix distutils import warning

### DIFF
--- a/pkgs/tools/misc/autorandr/0001-don-t-use-sys.executable.patch
+++ b/pkgs/tools/misc/autorandr/0001-don-t-use-sys.executable.patch
@@ -1,0 +1,33 @@
+From fdcc2f01441ec25104456022e6f8d3120709cede Mon Sep 17 00:00:00 2001
+From: Romanos Skiadas <rom.skiad@gmail.com>
+Date: Tue, 28 Jun 2022 06:16:10 +0300
+Subject: [PATCH] don't use sys.executable
+
+This is required for forking self in a nixpkgs environment,
+where arandr might be wrapped. In that case, the actual arandr command
+will be a bash script, not python.
+There is no real reason to keep this around, nixpkgs properly sets the
+interpreter in the shebang anyway.
+---
+ autorandr.py | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git autorandr.py autorandr.py
+index 35c15f6..1e84a2f 100755
+--- a/autorandr.py
++++ b/autorandr.py
+@@ -1192,10 +1192,7 @@ def dispatch_call_to_sessions(argv):
+             os.chdir(pwent.pw_dir)
+             os.environ.clear()
+             os.environ.update(process_environ)
+-            if sys.executable != "" and sys.executable != None:
+-                os.execl(sys.executable, sys.executable, autorandr_binary, *argv[1:])
+-            else:
+-                os.execl(autorandr_binary, autorandr_binary, *argv[1:])
++            os.execl(autorandr_binary, autorandr_binary, *argv[1:])
+             sys.exit(1)
+         os.waitpid(child_pid, 0)
+ 
+-- 
+2.36.1
+

--- a/pkgs/tools/misc/autorandr/default.nix
+++ b/pkgs/tools/misc/autorandr/default.nix
@@ -1,24 +1,25 @@
-{ lib, stdenv
+{ lib
+, python3
 , python3Packages
 , fetchFromGitHub
 , systemd
 , xrandr
 , installShellFiles }:
 
-stdenv.mkDerivation rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "autorandr";
   version = "1.12.1";
 
-  buildInputs = [ python3Packages.python ];
-
   nativeBuildInputs = [ installShellFiles ];
+  propagatedBuildInputs = [ python3Packages.packaging ];
 
-  # no wrapper, as autorandr --batch does os.environ.clear()
   buildPhase = ''
     substituteInPlace autorandr.py \
       --replace 'os.popen("xrandr' 'os.popen("${xrandr}/bin/xrandr' \
       --replace '["xrandr"]' '["${xrandr}/bin/xrandr"]'
   '';
+
+  patches = [ ./0001-don-t-use-sys.executable.patch ];
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
Because autorandr still imports distutils, it produces a bunch of
deprecation warnings. we need to add packaging to propagatedBuildInputs,
but because this wasn't wrapped, the wrapper hood did not take care of
adjusting the system path.

The easiest way I could find to fix this was to actually wrap
autorandr. Then I also had to add a patch to disable autorandr
using sys.executable to fork itself in --batch mode. Otherwise it tries to use
python to run the bash wrapper, which doesn't work. This should be
fine in a nixpkgs environment, since nixpkgs sets the shebang explicitly.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
