### PR TITLE
gdal: 3.4.2 -> 3.5.2

### DIFF
--- a/pkgs/development/libraries/brunsli/default.nix
+++ b/pkgs/development/libraries/brunsli/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     rm -r third_party
+  '' + lib.optionalString stdenv.isDarwin ''
+    rm -r build
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/brunsli/default.nix
+++ b/pkgs/development/libraries/brunsli/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, brotli
+}:
+
+stdenv.mkDerivation rec {
+  pname = "brunsli";
+  version = "0.1";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "brunsli";
+    rev = "v${version}";
+    hash = "sha256-ZcrRz2xSoRepgG8KZYY/JzgONerItW0e6mH1PYsko98=";
+  };
+
+  patches = [
+    # unvendor brotli
+    (fetchpatch {
+      url = "https://cgit.freebsd.org/ports/plain/graphics/brunsli/files/patch-CMakeLists.txt";
+      hash = "sha256-SqmkmL8r/KGvELq2em4ZLkCaKgZywZ/4fcC/enZ1nEI=";
+    })
+    (fetchpatch {
+      url = "https://cgit.freebsd.org/ports/plain/graphics/brunsli/files/patch-brunsli.cmake";
+      hash = "sha256-UmXK+NBd0+5AZX2oWnrpOnzHD7c3ghSO7oERWLOYjbA=";
+    })
+  ];
+
+  postPatch = ''
+    rm -r third_party
+  '';
+
+  patchFlags = [ "-p0" ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    brotli
+  ];
+
+  meta = {
+    description = "Lossless JPEG repacking library";
+    homepage = "https://github.com/google/brunsli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/libraries/brunsli/default.nix
+++ b/pkgs/development/libraries/brunsli/default.nix
@@ -23,19 +23,19 @@ stdenv.mkDerivation rec {
     # unvendor brotli
     (fetchpatch {
       url = "https://cgit.freebsd.org/ports/plain/graphics/brunsli/files/patch-CMakeLists.txt";
-      hash = "sha256-SqmkmL8r/KGvELq2em4ZLkCaKgZywZ/4fcC/enZ1nEI=";
+      extraPrefix = "";
+      hash = "sha256-/WPOG9OcEDj9ObBSXEM8Luq4Rix+PS2MvsYyHhK5mns=";
     })
     (fetchpatch {
       url = "https://cgit.freebsd.org/ports/plain/graphics/brunsli/files/patch-brunsli.cmake";
-      hash = "sha256-UmXK+NBd0+5AZX2oWnrpOnzHD7c3ghSO7oERWLOYjbA=";
+      extraPrefix = "";
+      hash = "sha256-+HXA9Tin+l2St7rRUEBM0AfhAjSoFxz8UX7hsg12aFg=";
     })
   ];
 
   postPatch = ''
     rm -r third_party
   '';
-
-  patchFlags = [ "-p0" ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -88,12 +88,14 @@ stdenv.mkDerivation rec {
     "-DGEOTIFF_LIBRARY_RELEASE=${lib.getLib libgeotiff}/lib/libgeotiff${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DMYSQL_INCLUDE_DIR=${lib.getDev libmysqlclient}/include/mysql"
     "-DMYSQL_LIBRARY=${lib.getLib libmysqlclient}/lib/mysql/libmysqlclient${stdenv.hostPlatform.extensions.sharedLibrary}"
+  ] ++ lib.optionals (!stdenv.isDarwin) [
     "-DCMAKE_SKIP_BUILD_RPATH=ON" # without, libgdal.so can't find libmariadb.so
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
   ];
 
   buildInputs = [
     armadillo
-    arrow-cpp
     c-blosc
     brunsli
     cfitsio
@@ -124,7 +126,6 @@ stdenv.mkDerivation rec {
     lz4
     libmysqlclient
     netcdf
-    openexr
     openjpeg
     openssl
     pcre2
@@ -138,11 +139,15 @@ stdenv.mkDerivation rec {
     libtiff
     tiledb
     libwebp
-    xercesc
     zlib
     zstd
     python3
     python3.pkgs.numpy
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    # tests for formats enabled by these packages fail on macos
+    arrow-cpp
+    openexr
+    xercesc
   ] ++ lib.optional stdenv.isDarwin libiconv;
 
   postInstall = ''

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -186,6 +186,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     # flaky on macos
     "test_rda_download_queue"
+  ] ++ lib.optionals (lib.versionOlder proj.version "8") [
+    "test_ogr_parquet_write_crs_without_id_in_datum_ensemble_members"
   ];
   postCheck = ''
     popd # ../autotest

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,84 +1,149 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, unzip, libjpeg, libtiff, zlib, postgresql
-, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl, libpng
-, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat, libiconv, libxml2
-, autoreconfHook, netcdfSupport ? true, netcdf, hdf5, curl, pkg-config }:
-
-with lib;
+{ lib
+, stdenv
+, fetchFromGitHub
+, bison
+, cmake
+, doxygen
+, graphviz
+, pkg-config
+, python3
+, swig
+, armadillo
+, arrow-cpp
+, c-blosc
+, brunsli
+, cfitsio
+, crunch
+, curl
+, cryptopp
+, libdeflate
+, expat
+, libgeotiff
+, geos
+, giflib
+, libheif
+, dav1d
+, libaom
+, libde265
+, rav1e
+, x265
+, hdf4
+, hdf5-cpp
+, libiconv
+, libjpeg
+, json_c
+, libjxl
+, libhwy
+, kea
+, lerc
+, xz
+, libxml2
+, lz4
+, libmysqlclient
+, netcdf
+, openexr
+, openjpeg
+, openssl
+, pcre2
+, libpng
+, poppler
+, postgresql
+, proj
+, qhull
+, libspatialite
+, sqlite
+, libtiff
+, tiledb
+, libwebp
+, xercesc
+, zlib
+, zstd
+}:
 
 stdenv.mkDerivation rec {
   pname = "gdal";
-  version = "3.4.2";
+  version = "3.5.2";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "gdal";
     rev = "v${version}";
-    sha256 = "sha256-bE55VV0SrG8nxCLdpODRalnuAkn+olRdMLUjduavj6M=";
+    sha256 = "sha256-jtAFI1J64ZaTqIljqQL1xOiTGC79AZWcIgidozWczMM=";
   };
 
-  sourceRoot = "source/gdal";
+  nativeBuildInputs = [
+    bison
+    cmake
+    doxygen
+    graphviz
+    pkg-config
+    python3.pkgs.setuptools
+    python3.pkgs.wrapPython
+    swig
+  ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config unzip ];
+  cmakeFlags = [
+    "-DGDAL_USE_INTERNAL_LIBS=OFF"
+    "-DGEOTIFF_INCLUDE_DIR=${lib.getDev libgeotiff}/include"
+    "-DGEOTIFF_LIBRARY_RELEASE=${lib.getLib libgeotiff}/lib/libgeotiff${stdenv.hostPlatform.extensions.sharedLibrary}"
+    "-DMYSQL_INCLUDE_DIR=${lib.getDev libmysqlclient}/include/mysql"
+    "-DMYSQL_LIBRARY=${lib.getLib libmysqlclient}/lib/mysql/libmysqlclient${stdenv.hostPlatform.extensions.sharedLibrary}"
+    "-DCMAKE_SKIP_BUILD_RPATH=ON" # without, libgdal.so can't find libmariadb.so
+  ];
 
   buildInputs = [
-    libjpeg
-    libtiff
-    libpng
-    proj
-    openssl
-    sqlite
-    libspatialite
-    libgeotiff
-    poppler
-    hdf4
-    qhull
-    giflib
+    armadillo
+    arrow-cpp
+    c-blosc
+    brunsli
+    cfitsio
+    crunch
+    curl
+    cryptopp
+    libdeflate
     expat
+    libgeotiff
+    geos
+    giflib
+    libheif
+    dav1d  # required by libheif
+    libaom  # required by libheif
+    libde265  # required by libheif
+    rav1e  # required by libheif
+    x265  # required by libheif
+    hdf4
+    hdf5-cpp
+    libjpeg
+    json_c
+    libjxl
+    libhwy  # required by libjxl
+    kea
+    lerc
+    xz
     libxml2
+    lz4
+    libmysqlclient
+    netcdf
+    openexr
+    openjpeg
+    openssl
+    pcre2
+    libpng
+    poppler
     postgresql
-  ] ++ (with pythonPackages; [ python setuptools numpy wrapPython ])
-    ++ lib.optional stdenv.isDarwin libiconv
-    ++ lib.optionals netcdfSupport [ netcdf hdf5 curl ];
-
-  configureFlags = [
-    "--with-expat=${expat.dev}"
-    "--with-jpeg=${libjpeg.dev}"
-    "--with-libtiff=${libtiff.dev}" # optional (without largetiff support)
-    "--with-png=${libpng.dev}" # optional
-    "--with-poppler=${poppler.dev}" # optional
-    "--with-libz=${zlib.dev}" # optional
-    "--with-pg=yes" # since gdal 3.0 doesn't use ${postgresql}/bin/pg_config
-    "--with-mysql=${getDev libmysqlclient}/bin/mysql_config"
-    "--with-geotiff=${libgeotiff}"
-    "--with-sqlite3=${sqlite.dev}"
-    "--with-spatialite=${libspatialite.dev}"
-    "--with-python" # optional
-    "--with-proj=${proj.dev}" # optional
-    "--with-geos=${geos}/bin/geos-config" # optional
-    "--with-hdf4=${hdf4.dev}" # optional
-    "--with-xml2=yes" # optional
-    (if netcdfSupport then "--with-netcdf=${netcdf}" else "")
-  ];
-
-  hardeningDisable = [ "format" ];
-
-  CXXFLAGS = lib.concatStringsSep " " [
-    "-fpermissive"
-    # poppler uses std::optional
-    "-std=c++17"
-  ];
-
-  # - Unset CC and CXX as they confuse libtool.
-  # - teach gdal that libdf is the legacy name for libhdf
-  preConfigure = ''
-    substituteInPlace configure \
-      --replace "-lmfhdf -ldf" "-lmfhdf -lhdf"
-  '';
-
-  preBuild = ''
-    substituteInPlace swig/python/GNUmakefile \
-      --replace "ifeq (\$(STD_UNIX_LAYOUT),\"TRUE\")" "ifeq (1,1)"
-  '';
+    proj
+    qhull
+    libspatialite
+    sqlite
+    libtiff
+    tiledb
+    libwebp
+    xercesc
+    zlib
+    zstd
+    python3
+    python3.pkgs.numpy
+  ] ++ lib.optional stdenv.isDarwin libiconv;
 
   postInstall = ''
     wrapPythonPrograms
@@ -91,13 +156,11 @@ stdenv.mkDerivation rec {
   # calls (coming from the python world)
   preCheck = ''
     pushd ../autotest
-    # something has made files here read-only by this point
-    chmod -R u+w .
 
     export HOME=$(mktemp -d)
-    export PYTHONPATH="$out/${pythonPackages.python.sitePackages}:$PYTHONPATH"
+    export PYTHONPATH="$out/${python3.sitePackages}:$PYTHONPATH"
   '';
-  installCheckInputs = with pythonPackages; [
+  installCheckInputs = with python3.pkgs; [
     pytestCheckHook
     pytest-env
     lxml
@@ -115,6 +178,8 @@ stdenv.mkDerivation rec {
     # https://github.com/OSGeo/gdal/issues/5523
     "test_transformer_dem_overrride_srs"
     "test_osr_ct_options_area_of_interest"
+    # ZIP does not support timestamps before 1980
+    " test_sentinel2_zipped"
   ] ++ lib.optionals (!stdenv.isx86_64) [
     # likely precision-related expecting x87 behaviour
     "test_jp2openjpeg_22"
@@ -129,8 +194,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Translator library for raster geospatial data formats";
     homepage = "https://www.gdal.org/";
+    changelog = "https://docs.unidata.ucar.edu/netcdf-c/${src.rev}/RELEASE_NOTES.html";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.marcweber ];
-    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [ marcweber dotlambda ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -34,7 +34,6 @@
 , json_c
 , libjxl
 , libhwy
-, kea
 , lerc
 , xz
 , libxml2
@@ -119,7 +118,6 @@ stdenv.mkDerivation rec {
     json_c
     libjxl
     libhwy  # required by libjxl
-    kea
     lerc
     xz
     libxml2

--- a/pkgs/development/libraries/lerc/default.nix
+++ b/pkgs/development/libraries/lerc/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lerc";
+  version = "3.0";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "esri";
+    repo = "lerc";
+    rev = "v${version}";
+    hash = "sha256-QO5+ouQy5nOcAgvxMeBDoSBP+G3ClDjXipnkuSIDcP0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "C++ library for Limited Error Raster Compression";
+    homepage = "https://github.com/esri/lerc";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/libraries/libgeotiff/default.nix
+++ b/pkgs/development/libraries/libgeotiff/default.nix
@@ -1,14 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, libtiff, libjpeg, proj, zlib, autoreconfHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libjpeg
+, libtiff
+, proj
+, zlib
+}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.1";
+  version = "1.7.1";
   pname = "libgeotiff";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "libgeotiff";
     rev = version;
-    sha256 = "081ag23pn2n5y4fkb2rnh4hmcnq92siqiqv0s20jmx0j3s2nvfxy";
+    hash = "sha256-bE6UAUKiorriTgYrqhxbMAN2NEtmV/8IIfF02RUghSI=";
   };
 
   outputs = [ "out" "dev" ];
@@ -20,15 +29,19 @@ stdenv.mkDerivation rec {
     "--with-zlib=${zlib.dev}"
   ];
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
   buildInputs = [ libtiff proj ];
 
-  hardeningDisable = [ "format" ];
+  #hardeningDisable = [ "format" ];
 
   meta = {
     description = "Library implementing attempt to create a tiff based interchange format for georeferenced raster imagery";
     homepage = "https://github.com/OSGeo/libgeotiff";
+    changelog = "https://github.com/OSGeo/libgeotiff/blob/${src.rev}/libgeotiff/NEWS";
     license = lib.licenses.mit;
     maintainers = [lib.maintainers.marcweber];
     platforms = with lib.platforms; linux ++ darwin;

--- a/pkgs/development/libraries/mapnik/catch2-src.patch
+++ b/pkgs/development/libraries/mapnik/catch2-src.patch
@@ -1,0 +1,14 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 0705ddce1..771291b88 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -7,8 +7,7 @@ include(FetchContent)
+ 
+ FetchContent_Declare(
+   Catch2
+-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+-  GIT_TAG        v2.13.7)
++  SOURCE_DIR @catch2_src@)
+ FetchContent_MakeAvailable(Catch2)
+ 
+ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19.0") 

--- a/pkgs/development/libraries/mapnik/cmake-harfbuzz.patch
+++ b/pkgs/development/libraries/mapnik/cmake-harfbuzz.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f2dc1f02d..739b8ae99 100644
+index d87a7052d..837867551 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -153,19 +153,8 @@ endif()
@@ -12,7 +12,7 @@ index f2dc1f02d..739b8ae99 100644
 -    message(STATUS "Found harfbuzz native cmake")
 -    list(APPEND MAPNIK_OPTIONAL_LIBS harfbuzz::harfbuzz)
 -else()
--    # Use pkg-config when harfbuzz is not found. 
+-    # Use pkg-config when harfbuzz is not found.
 -    # It might be possible that in future version harfbuzz could only be found via pkg-config.
 -    # harfbuzz related discussion: https://github.com/harfbuzz/harfbuzz/issues/2653
 -    message(STATUS "harfbuzz not found via cmake. Searching via pkg-config...")

--- a/pkgs/development/libraries/mapnik/cmake-harfbuzz.patch
+++ b/pkgs/development/libraries/mapnik/cmake-harfbuzz.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2dc1f02d..739b8ae99 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -153,19 +153,8 @@ endif()
+ 
+ mapnik_find_package(Freetype REQUIRED)
+ 
+-# try to find harfbuzz with the native configuration and fallback to our "own" FindHarfBuzz
+-mapnik_find_package(harfbuzz CONFIG QUIET)
+-if(harfbuzz_FOUND)
+-    message(STATUS "Found harfbuzz native cmake")
+-    list(APPEND MAPNIK_OPTIONAL_LIBS harfbuzz::harfbuzz)
+-else()
+-    # Use pkg-config when harfbuzz is not found. 
+-    # It might be possible that in future version harfbuzz could only be found via pkg-config.
+-    # harfbuzz related discussion: https://github.com/harfbuzz/harfbuzz/issues/2653
+-    message(STATUS "harfbuzz not found via cmake. Searching via pkg-config...")
+-    pkg_check_modules(harfbuzz REQUIRED IMPORTED_TARGET harfbuzz>=${HARFBUZZ_MIN_VERSION})
+-    list(APPEND MAPNIK_OPTIONAL_LIBS PkgConfig::harfbuzz)
+-endif()
++pkg_check_modules(harfbuzz REQUIRED IMPORTED_TARGET harfbuzz)
++list(APPEND MAPNIK_OPTIONAL_LIBS PkgConfig::harfbuzz)
+ 
+ if(USE_EXTERNAL_MAPBOX_GEOMETRY)
+     # this is used to provide a way to specify include dirs with CACHE VARIABLES

--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -1,111 +1,110 @@
-{ lib, stdenv, fetchzip
-, boost, cairo, freetype, gdal, harfbuzz, icu, libjpeg, libpng, libtiff
-, libwebp, libxml2, proj, python3, python ? python3, sqlite, zlib
-, sconsPackages
-
-# supply a postgresql package to enable the PostGIS input plugin
-, postgresql ? null
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPackages
+, cmake
+, pkg-config
+, substituteAll
+, boost
+, cairo
+, freetype
+, gdal
+, harfbuzz
+, icu
+, libjpeg
+, libpng
+, libtiff
+, libwebp
+, libxml2
+, proj
+, python3
+, sqlite
+, zlib
+, catch2
+, postgresql
 }:
 
-let
-  scons = sconsPackages.scons_3_0_1;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "mapnik";
-  version = "3.1.0";
+  version = "unstable-2022-04-14";
 
-  src = fetchzip {
-    # this one contains all git submodules and is cheaper than fetchgit
-    url = "https://github.com/mapnik/mapnik/releases/download/v${version}/mapnik-v${version}.tar.bz2";
-    sha256 = "sha256-qqPqN4vs3ZsqKgnx21yQhX8OzHca/0O+3mvQ/vnC5EY=";
+  src = fetchFromGitHub {
+    owner = "mapnik";
+    repo = "mapnik";
+    rev = "1ba1278b4227ccd887a95880d1c75aa6446132fc";
+    sha256 = "sha256-dtu+PKpK/crO5cZje0aj+vB9beG0eU6fyT9GNtvvtbM=";
+    fetchSubmodules = true;
   };
 
   postPatch = ''
     substituteInPlace configure \
-      --replace '$PYTHON scons/scons.py' ${scons}/bin/scons
+      --replace '$PYTHON scons/scons.py' ${buildPackages.scons}/bin/scons
     rm -r scons
   '';
 
   # a distinct dev output makes python-mapnik fail
   outputs = [ "out" ];
 
-  nativeBuildInputs = [ scons ];
+  patches = [
+    # The lib/cmake/harfbuzz/harfbuzz-config.cmake file in harfbuzz.dev is faulty,
+    # as it provides the wrong libdir. The workaround is to just rely on
+    # pkg-config to locate harfbuzz shared object files.
+    # Upstream HarfBuzz wants to drop CMake support anyway.
+    # See discussion: https://github.com/mapnik/mapnik/issues/4265
+    ./cmake-harfbuzz.patch
+    # prevent CMake from trying to get libraries on the Internet
+    (substituteAll {
+      src = ./catch2-src.patch;
+      catch2_src = catch2.src;
+    })
+    ./include.patch
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [
-    boost cairo freetype gdal harfbuzz icu libjpeg libpng libtiff
-    libwebp proj python sqlite zlib
-
-    # optional inputs
+    boost
+    cairo
+    freetype
+    gdal
+    harfbuzz
+    icu
+    libjpeg
+    libpng
+    libtiff
+    libwebp
+    proj
+    python3
+    sqlite
+    zlib
+    libxml2
     postgresql
   ];
 
-  propagatedBuildInputs = [ libxml2 ];
+  cmakeFlags = [
+    # Would require qt otherwise.
+    "-DBUILD_DEMO_VIEWER=OFF"
+  ];
 
-  prefixKey = "PREFIX=";
-
-  preConfigure = ''
-    patchShebangs ./configure
+  # mapnik-config is currently not build with CMake. So we use the SCons for
+  # this one. We can't add SCons to nativeBuildInputs though, as stdenv would
+  # then try to build everything with scons.
+  preBuild = ''
+    cd ..
+    ${buildPackages.scons}/bin/scons utils/mapnik-config
+    cd build
   '';
 
-  # NOTE: 2021-05-06:
-  # Add -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1 for backwards compatibility
-  # with major versions 6 and 7 of proj which are otherwise not compatible
-  # with mapnik 3.1.0. Note that:
-  #
-  # 1. Starting with proj version 8, this workaround will no longer be
-  #    supported by the upstream proj project.
-  #
-  # 2. Without the workaround, mapnik configures itself without proj support.
-  #
-  # 3. The master branch of mapnik (after 3.1.0) appears to add native support
-  #    for the proj 6 api, so this workaround is not likely to be needed in
-  #    subsequent mapnik releases. At that point, this block comment and the
-  #    NIX_CFLAGS_COMPILE expression can be removed.
-
-  NIX_CFLAGS_COMPILE =
-    if version != "3.1.0" && lib.versionAtLeast version "3.1.0"
-    then throw "The mapnik compatibility workaround for proj 6 may no longer be required. Remove workaround after checking."
-    else if lib.versionAtLeast (lib.getVersion proj) "8"
-    then throw ("mapnik currently requires a version of proj less than 8, but proj version is: " + (lib.getVersion proj))
-    else "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1";
-
-  configureFlags = [
-    "BOOST_INCLUDES=${boost.dev}/include"
-    "BOOST_LIBS=${boost.out}/lib"
-    "CAIRO_INCLUDES=${cairo.dev}/include"
-    "CAIRO_LIBS=${cairo.out}/lib"
-    "FREETYPE_INCLUDES=${freetype.dev}/include"
-    "FREETYPE_LIBS=${freetype.out}/lib"
-    "GDAL_CONFIG=${gdal}/bin/gdal-config"
-    "HB_INCLUDES=${harfbuzz.dev}/include"
-    "HB_LIBS=${harfbuzz.out}/lib"
-    "ICU_INCLUDES=${icu.dev}/include"
-    "ICU_LIBS=${icu.out}/lib"
-    "JPEG_INCLUDES=${libjpeg.dev}/include"
-    "JPEG_LIBS=${libjpeg.out}/lib"
-    "PNG_INCLUDES=${libpng.dev}/include"
-    "PNG_LIBS=${libpng.out}/lib"
-    "PROJ_INCLUDES=${proj.dev}/include"
-    "PROJ_LIBS=${proj.out}/lib"
-    "SQLITE_INCLUDES=${sqlite.dev}/include"
-    "SQLITE_LIBS=${sqlite.out}/lib"
-    "TIFF_INCLUDES=${libtiff.dev}/include"
-    "TIFF_LIBS=${libtiff.out}/lib"
-    "WEBP_INCLUDES=${libwebp}/include"
-    "WEBP_LIBS=${libwebp}/lib"
-    "XMLPARSER=libxml2"
-  ];
-
-  buildFlags = [
-    "JOBS=$(NIX_BUILD_CORES)"
-  ];
+  preInstall = ''
+    mkdir -p $out/bin
+    cp ../utils/mapnik-config/mapnik-config $out/bin/mapnik-config
+  '';
 
   meta = with lib; {
     description = "An open source toolkit for developing mapping applications";
     homepage = "https://mapnik.org";
     maintainers = with maintainers; [ hrdinka erictapen ];
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     platforms = platforms.all;
-    # https://github.com/mapnik/mapnik/issues/4232
-    broken = lib.versionAtLeast proj.version "8.0.0";
   };
 }

--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mapnik";
-  version = "unstable-2022-04-14";
+  version = "unstable-2022-10-18";
 
   src = fetchFromGitHub {
     owner = "mapnik";
     repo = "mapnik";
-    rev = "1ba1278b4227ccd887a95880d1c75aa6446132fc";
-    sha256 = "sha256-dtu+PKpK/crO5cZje0aj+vB9beG0eU6fyT9GNtvvtbM=";
+    rev = "05661e54392bcbb3367747f97a3ef6e468c105ba";
+    hash = "sha256-96AneLPH1gbh/u880Pdc9OdFq2MniSdaTJoKYqId7sw=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/libraries/mapnik/include.patch
+++ b/pkgs/development/libraries/mapnik/include.patch
@@ -1,0 +1,11 @@
+diff --git a/benchmark/src/test_png_encoding2.cpp b/benchmark/src/test_png_encoding2.cpp
+index 19897d180..5791b139c 100644
+--- a/benchmark/src/test_png_encoding2.cpp
++++ b/benchmark/src/test_png_encoding2.cpp
+@@ -1,5 +1,6 @@
+ #include "bench_framework.hpp"
+ #include "compare_images.hpp"
++#include <memory>
+ 
+ class test : public benchmark::test_case
+ {

--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -9,31 +9,19 @@
 , curl
 , gtest
 , nlohmann_json
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "proj";
-  version = "9.0.0";
+  version = "9.1.0";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "PROJ";
     rev = version;
-    sha256 = "sha256-zMP+WzC65BFz8g8mF5t7toqxmxCJePysd6WJuqpe8yg=";
+    hash = "sha256-Upsp72RorV+5PFPHOK3zCJgVTRZ6fSVVFRope8Bp8/M=";
   };
-
-  # https://github.com/OSGeo/PROJ/issues/3206
-  postPatch = ''
-    # NB will not apply once https://github.com/OSGeo/PROJ/pull/3150 is released
-    substituteInPlace cmake/ProjUtilities.cmake \
-      --replace '$\{exec_prefix\}/$'{PROJ_LIB_SUBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
-      --replace '$\{prefix\}/$'{PROJ_INCLUDE_SUBDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR} \
-      --replace '$\{prefix\}/$'{CMAKE_INSTALL_DATAROOTDIR} '$'{CMAKE_INSTALL_FULL_DATAROOTDIR}
-    substituteInPlace cmake/project-config.cmake.in \
-      --replace '$'{_ROOT}/@INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
-      --replace '$'{_ROOT}/@LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{_ROOT}/@BINDIR@ @CMAKE_INSTALL_FULL_BINDIR@
-  '';
 
   outputs = [ "out" "dev" ];
 
@@ -61,6 +49,10 @@ stdenv.mkDerivation rec {
       '';
 
   doCheck = true;
+
+  passthru.tests = {
+    python = python3.pkgs.pyproj;
+  };
 
   meta = with lib; {
     description = "Cartographic Projections Library";

--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , pkg-config
 , buildPackages
@@ -22,6 +23,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-Upsp72RorV+5PFPHOK3zCJgVTRZ6fSVVFRope8Bp8/M=";
   };
+
+  patches = [
+    # https://github.com/OSGeo/PROJ/pull/3252
+    (fetchpatch {
+      name = "only-add-find_dependencyCURL-for-static-builds.patch";
+      url = "https://github.com/OSGeo/PROJ/commit/11f4597bbb7069bd5d4391597808703bd96df849.patch";
+      hash = "sha256-4w5Cu2m5VJZr6E2dUVRyWJdED2TyS8cI8G20EwfQ4u0=";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/python-modules/basemap/default.nix
+++ b/pkgs/development/python-modules/basemap/default.nix
@@ -16,22 +16,16 @@
 
 buildPythonPackage rec {
   pname = "basemap";
-  version = "1.3.4";
+  version = "1.3.6";
 
   src = fetchFromGitHub {
     owner = "matplotlib";
     repo = "basemap";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-F/6xPmdXSJAuASyFaKOP+6Jz8U2JRZdqErEH7PFkr/w=";
+    hash = "sha256-BSWifzh+Y1f+x89oNYMBvttWY9qZ0IM5QYqSgyVb1fE=";
   };
 
   sourceRoot = "source/packages/basemap";
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "numpy >= 1.21, < 1.23" "numpy >= 1.21, < 1.24" \
-      --replace "pyshp >= 1.2, < 2.2" "pyshp >= 1.2, < 2.4"
-  '';
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/fiona/default.nix
+++ b/pkgs/development/python-modules/fiona/default.nix
@@ -2,6 +2,7 @@
 , attrs, click, cligj, click-plugins, six, munch, enum34
 , pytestCheckHook, boto3, mock, giflib, pytz
 , gdal, certifi
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -13,6 +14,14 @@ buildPythonPackage rec {
     inherit version;
     sha256 = "sha256-qCqZzps+eCV0AVfEXJ+yJZ1OkvCohqqsJfDbQP/h7qM=";
   };
+
+  patches = [
+    # https://github.com/Toblerity/Fiona/pull/1122
+    (fetchpatch {
+      url = "https://github.com/Toblerity/Fiona/commit/fa632130dcd9dfbb982ecaa4911b3fab3459168f.patch";
+      hash = "sha256-IuNHr3yBqS1jY9Swvcq8XPv6BpVlInDx0FVuzEMaYTY=";
+    })
+  ];
 
   CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 

--- a/pkgs/development/python-modules/pyproj/001.proj.patch
+++ b/pkgs/development/python-modules/pyproj/001.proj.patch
@@ -1,5 +1,5 @@
 diff --git a/pyproj/datadir.py b/pyproj/datadir.py
-index 9ca1d25..4198490 100644
+index df625fee..a2beb06c 100644
 --- a/pyproj/datadir.py
 +++ b/pyproj/datadir.py
 @@ -70,7 +70,7 @@ def get_data_dir() -> str:
@@ -8,23 +8,23 @@ index 9ca1d25..4198490 100644
          return _VALIDATED_PROJ_DATA
 -    internal_datadir = Path(__file__).absolute().parent / "proj_dir" / "share" / "proj"
 +    internal_datadir = Path("@proj@/share/proj")
-     proj_lib_dirs = os.environ.get("PROJ_LIB", "")
+     proj_lib_dirs = os.environ.get("PROJ_DATA", os.environ.get("PROJ_LIB", ""))
      prefix_datadir = Path(sys.prefix, "share", "proj")
- 
+     conda_windows_prefix_datadir = Path(sys.prefix, "Library", "share", "proj")
 diff --git a/setup.py b/setup.py
-index 6bb0c6c..b3d0321 100644
+index 71fb52cd..7984a68a 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -12,7 +12,7 @@ from setuptools import Extension, setup
- PROJ_MIN_VERSION = parse_version("7.2.0")
+@@ -13,7 +13,7 @@ from setuptools import Extension, setup
+ PROJ_MIN_VERSION = parse_version("8.2.0")
  CURRENT_FILE_PATH = Path(__file__).absolute().parent
  BASE_INTERNAL_PROJ_DIR = Path("proj_dir")
 -INTERNAL_PROJ_DIR = CURRENT_FILE_PATH / "pyproj" / BASE_INTERNAL_PROJ_DIR
 +INTERNAL_PROJ_DIR = Path("@proj@")
+ PROJ_VERSION_SEARCH = re.compile(r".*Rel\.\s+(?P<version>\d+\.\d+\.\d+).*")
  
  
- def get_proj_version(proj_dir: Path) -> str:
-@@ -155,7 +155,7 @@ def get_extension_modules():
+@@ -163,7 +163,7 @@ def get_extension_modules():
      # By default we'll try to get options PROJ_DIR or the local version of proj
      proj_dir = get_proj_dir()
      library_dirs = get_proj_libdirs(proj_dir)
@@ -34,7 +34,7 @@ index 6bb0c6c..b3d0321 100644
      proj_version = get_proj_version(proj_dir)
      check_proj_version(proj_version)
 diff --git a/test/test_cli.py b/test/test_cli.py
-index 7a696de..1b9b777 100644
+index 7a696de7..1b9b777b 100644
 --- a/test/test_cli.py
 +++ b/test/test_cli.py
 @@ -14,7 +14,7 @@ from pyproj.sync import _load_grid_geojson

--- a/pkgs/development/python-modules/pyproj/default.nix
+++ b/pkgs/development/python-modules/pyproj/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "pyproj";
-  version = "3.3.1";
+  version = "3.4.0";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pyproj4";
     repo = "pyproj";
     rev = "refs/tags/${version}";
-    hash = "sha256-QmpwnOnMjV29Tq+M6FCotDytq6zlhsp0Zgzw3V7nhNQ=";
+    hash = "sha256-EXPeDNGr6eAAsLXCkV9mmkNDO1KScjZYgmBPzt+A1OU=";
   };
 
   # force pyproj to use ${proj}
@@ -53,14 +53,13 @@ buildPythonPackage rec {
   ];
 
   preCheck = ''
-    # We need to build extensions locally to run tests
-    ${python.interpreter} setup.py build_ext --inplace
-    cd test
+    # import from $out
+    rm -r pyproj
   '';
 
   disabledTestPaths = [
-    "test_doctest_wrapper.py"
-    "test_datadir.py"
+    "test/test_doctest_wrapper.py"
+    "test/test_datadir.py"
   ];
 
   disabledTests = [
@@ -86,9 +85,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    description = "Python interface to PROJ.4 library";
+    description = "Python interface to PROJ library";
     homepage = "https://github.com/pyproj4/pyproj";
-    license = with lib.licenses; [ isc ];
-    maintainers = with lib.maintainers; [ lsix ];
+    changelog = "https://github.com/pyproj4/pyproj/blob/${src.rev}/docs/history.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lsix dotlambda ];
   };
 }

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
+, substituteAll
 , isPyPy
 , python
 , pillow
@@ -17,35 +19,43 @@
 , mapnik
 , proj
 , zlib
+, libxml2
+, sqlite
+, nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-mapnik";
-  version = "unstable-2020-02-24";
+  version = "unstable-2020-09-08";
 
   src = fetchFromGitHub {
     owner = "mapnik";
     repo = "python-mapnik";
-    rev = "7da019cf9eb12af8f8aa88b7d75789dfcd1e901b";
-    sha256 = "0snn7q7w1ab90311q8wgd1z64kw1svm5w831q0xd6glqhah86qc8";
+    rev = "a2c2a86eec954b42d7f00093da03807d0834b1b4";
+    hash = "sha256-GwDdrutJOHtW7pIWiUAiu1xucmRvp7YFYB3YSCrDsrY=";
+    # Only needed for test data
+    fetchSubmodules = true;
   };
 
-  disabled = isPyPy;
-  doCheck = false; # doesn't find needed test data files
-  preBuild = ''
-    export BOOST_PYTHON_LIB="boost_python${"${lib.versions.major python.version}${lib.versions.minor python.version}"}"
-    export BOOST_THREAD_LIB="boost_thread"
-    export BOOST_SYSTEM_LIB="boost_system"
-    export PYCAIRO=true
-  '';
+  patches = [
+    # https://github.com/mapnik/python-mapnik/issues/239
+    (fetchpatch {
+      url = "https://github.com/koordinates/python-mapnik/commit/318b1edac16f48a7f21902c192c1dd86f6210a44.patch";
+      sha256 = "sha256-cfU8ZqPPGCqoHEyGvJ8Xy/bGpbN2vSDct6A3N5+I8xM=";
+    })
+    ./find-pycairo-with-pkg-config.patch
+    # python-mapnik seems to depend on having the mapnik src directory
+    # structure available at build time. We just hardcode the paths.
+    (substituteAll {
+      src = ./find-libmapnik.patch;
+      libmapnik = "${mapnik}/lib";
+    })
+  ];
 
   nativeBuildInputs = [
     mapnik # for mapnik_config
     pkg-config
-  ];
-
-  patches = [
-    ./find-pycairo-with-pkg-config.patch
   ];
 
   buildInputs = [
@@ -60,9 +70,65 @@ buildPythonPackage rec {
     libwebp
     proj
     zlib
+    libxml2
+    sqlite
   ];
 
   propagatedBuildInputs = [ pillow pycairo ];
+
+  configureFlags = [
+    "XMLPARSER=libxml2"
+  ];
+
+  disabled = isPyPy;
+
+  preBuild = ''
+    export BOOST_PYTHON_LIB="boost_python${"${lib.versions.major python.version}${lib.versions.minor python.version}"}"
+    export BOOST_THREAD_LIB="boost_thread"
+    export BOOST_SYSTEM_LIB="boost_system"
+    export PYCAIRO=true
+    export XMLPARSER=libxml2
+  '';
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # import from $out
+    rm -r mapnik
+  '';
+
+  # https://github.com/mapnik/python-mapnik/issues/255
+  disabledTests = [
+    "test_adding_datasource_to_layer"
+    "test_compare_map"
+    "test_dataraster_coloring"
+    "test_dataraster_query_point"
+    "test_good_files"
+    "test_layer_init"
+    "test_load_save_map"
+    "test_loading_fontset_from_map"
+    "test_normalizing_definition"
+    "test_pdf_printing"
+    "test_proj_antimeridian_bbox"
+    "test_proj_transform_between_init_and_literal"
+    "test_pycairo_pdf_surface1"
+    "test_pycairo_svg_surface1"
+    "test_query_tolerance"
+    "test_raster_warping"
+    "test_raster_warping_does_not_overclip_source"
+    "test_render_points"
+    "test_render_with_scale_factor"
+    "test_style_level_image_filter"
+    "test_that_coordinates_do_not_overflow_and_polygon_is_rendered_csv"
+    "test_that_coordinates_do_not_overflow_and_polygon_is_rendered_memory"
+    "test_transparency_levels"
+    "test_visual_zoom_all_rendering1"
+    "test_visual_zoom_all_rendering2"
+    "test_wgs84_inverse_forward"
+  ];
 
   pythonImportsCheck = [ "mapnik" ];
 
@@ -70,6 +136,6 @@ buildPythonPackage rec {
     description = "Python bindings for Mapnik";
     maintainers = with maintainers; [ erictapen ];
     homepage = "https://mapnik.org";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
   };
 }

--- a/pkgs/development/python-modules/python-mapnik/find-libmapnik.patch
+++ b/pkgs/development/python-modules/python-mapnik/find-libmapnik.patch
@@ -1,0 +1,30 @@
+diff --git a/build.py b/build.py
+index 0f94826b6..3cceb4546 100644
+--- a/build.py
++++ b/build.py
+@@ -110,8 +110,8 @@ py_env.AppendUnique(LIBS='mapnik-wkt')
+ _mapnik = py_env.LoadableModule('mapnik/_mapnik', sources, LDMODULEPREFIX='', LDMODULESUFFIX='.so')
+ 
+ Depends(_mapnik, env.subst('../../src/%s' % env['MAPNIK_LIB_NAME']))
+-Depends(_mapnik, env.subst('../../src/json/libmapnik-json${LIBSUFFIX}'))
+-Depends(_mapnik, env.subst('../../src/wkt/libmapnik-wkt${LIBSUFFIX}'))
++Depends(_mapnik, env.subst('@libmapnik@/libmapnikjson${LIBSUFFIX}'))
++Depends(_mapnik, env.subst('@libmapnik@/libmapnikwkt${LIBSUFFIX}'))
+ 
+ if 'uninstall' not in COMMAND_LINE_TARGETS:
+     pymapniklib = env.Install(target_path,_mapnik)
+diff --git a/setup.py b/setup.py
+index 9985da5a2..5a03a1ec8 100755
+--- a/setup.py
++++ b/setup.py
+@@ -118,8 +118,8 @@ linkflags.extend(check_output([mapnik_config, '--libs']).split(' '))
+ linkflags.extend(check_output([mapnik_config, '--ldflags']).split(' '))
+ linkflags.extend(check_output([mapnik_config, '--dep-libs']).split(' '))
+ linkflags.extend([
+-'-lmapnik-wkt',
+-'-lmapnik-json',
++'-lmapnikwkt',
++'-lmapnikjson',
+ ] + ['-l%s' % i for i in get_boost_library_names()])
+ 
+ # Dynamically make the mapnik/paths.py file

--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./src/bin/keactrl/Makefile.am --replace '@sysconfdir@' "$out/etc"
+    # darwin special-casing just causes trouble
+    substituteInPlace ./m4macros/ax_crypto.m4 --replace 'apple-darwin' 'nope'
   '';
 
   outputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18150,6 +18150,8 @@ with pkgs;
 
   boxfort = callPackage ../development/libraries/boxfort { };
 
+  brunsli = callPackage ../development/libraries/brunsli { };
+
   buddy = callPackage ../development/libraries/buddy { };
 
   buildkit-nix = callPackage ../applications/virtualization/buildkit-nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18829,10 +18829,7 @@ with pkgs;
     libXpm = null;
   };
 
-  gdal = callPackage ../development/libraries/gdal {
-    pythonPackages = python3Packages;
-    autoreconfHook = buildPackages.autoreconfHook269;
-  };
+  gdal = callPackage ../development/libraries/gdal { };
 
   gdcm = callPackage ../development/libraries/gdcm {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Cocoa;
@@ -36794,10 +36791,8 @@ with pkgs;
 
   mysql-workbench = callPackage ../applications/misc/mysql-workbench (let mysql = mysql80; in {
     gdal = gdal.override {
-      libmysqlclient = mysql // {
-        lib = { dev = mysql; }
-      ;}
-    ;};
+      libmysqlclient = mysql;
+    };
     mysql = mysql;
     pcre = pcre-cpp;
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21066,7 +21066,6 @@ with pkgs;
     harfbuzz = harfbuzz.override {
       withIcu = true;
     };
-    boost = boost175;
   };
 
   manticoresearch = callPackage ../servers/search/manticoresearch { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36015,6 +36015,7 @@ with pkgs;
 
   gplates = libsForQt5.callPackage ../applications/science/misc/gplates {
     boost = boost175;
+    python3 = python39;
   };
 
   gravit = callPackage ../applications/science/astronomy/gravit { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21063,12 +21063,9 @@ with pkgs;
   opencl-clang = callPackage ../development/libraries/opencl-clang { };
 
   mapnik = callPackage ../development/libraries/mapnik {
-    gdal = gdal.override {
-      libgeotiff = libgeotiff.override { proj = proj_7; };
-      libspatialite = libspatialite.override { proj = proj_7; };
-      proj = proj_7;
+    harfbuzz = harfbuzz.override {
+      withIcu = true;
     };
-    proj = proj_7;
     boost = boost175;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19653,6 +19653,8 @@ with pkgs;
 
   leptonica = callPackage ../development/libraries/leptonica { };
 
+  lerc = callPackage ../development/libraries/lerc { };
+
   lib2geom = callPackage ../development/libraries/lib2geom { };
 
   lib3ds = callPackage ../development/libraries/lib3ds { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9000,7 +9000,7 @@ self: super: with self; {
 
   python-mapnik = callPackage ../development/python-modules/python-mapnik rec {
     inherit (pkgs) pkg-config cairo icu libjpeg libpng libtiff libwebp proj zlib;
-    boost = pkgs.boost175.override {
+    boost = pkgs.boost.override {
       enablePython = true;
       inherit python;
     };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3573,7 +3573,7 @@ self: super: with self; {
 
   gcsfs = callPackage ../development/python-modules/gcsfs { };
 
-  gdal = toPythonModule (pkgs.gdal.override { pythonPackages = self; });
+  gdal = toPythonModule (pkgs.gdal.override { python3 = python; });
 
   gdata = callPackage ../development/python-modules/gdata { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9007,7 +9007,7 @@ self: super: with self; {
     inherit (pkgs) pkg-config cairo harfbuzz icu libjpeg libpng libtiff libwebp proj zlib;
     inherit boost;
     mapnik = pkgs.mapnik.override {
-      inherit python boost;
+      inherit boost;
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8998,16 +8998,17 @@ self: super: with self; {
 
   python-manilaclient = callPackage ../development/python-modules/python-manilaclient { };
 
-  python-mapnik = let
+  python-mapnik = callPackage ../development/python-modules/python-mapnik rec {
+    inherit (pkgs) pkg-config cairo icu libjpeg libpng libtiff libwebp proj zlib;
     boost = pkgs.boost175.override {
       enablePython = true;
       inherit python;
     };
-  in callPackage ../development/python-modules/python-mapnik {
-    inherit (pkgs) pkg-config cairo harfbuzz icu libjpeg libpng libtiff libwebp proj zlib;
-    inherit boost;
+    harfbuzz = pkgs.harfbuzz.override {
+      withIcu = true;
+    };
     mapnik = pkgs.mapnik.override {
-      inherit boost;
+      inherit boost harfbuzz;
     };
   };
 


### PR DESCRIPTION
<!--
@jtojnar You "recently" touched mysql-workbench. Do you have a suggestion how to fix it?
```
$ nix-build -A mysql-workbench
error: attribute 'dev' missing

       at pkgs/development/libraries/gdal/default.nix:89:28:

           88|     "-DGEOTIFF_LIBRARY_RELEASE=${libgeotiff}/lib/libgeotiff${stdenv.hostPlatform.extensions.sharedLibrary}"
           89|     "-DMYSQL_INCLUDE_DIR=${libmysqlclient.dev}/include/mysql"
             |                            ^
           90|     "-DMYSQL_LIBRARY=${libmysqlclient}/lib/mysql/libmysqlclient${stdenv.hostPlatform.extensions.sharedLibrary}"
```
The relevant code is in `pkgs/top-level/all-packages.nix`:
```
mysql-workbench = callPackage ../applications/misc/mysql-workbench (let mysql = mysql57; in {
  gdal = gdal.override {
    libmysqlclient = mysql // {
      lib = { dev = mysql; }
    ;}
  ;};
  mysql = mysql;
  pcre = pcre-cpp;
  jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
});
```
-->
###### Description of changes
https://github.com/OSGeo/gdal/blob/v3.5.1/NEWS.md
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
