### PR TITLE
yubikey-personalization-gui: fix pixmap installation

### DIFF
--- a/pkgs/tools/misc/yubikey-personalization-gui/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization-gui/default.nix
@@ -19,9 +19,9 @@ mkDerivation rec {
 
     # Desktop files
     install -D -m0644 resources/lin/yubikey-personalization-gui.desktop "$out/share/applications/yubikey-personalization-gui.desktop"
-    install -D -m0644 resources/lin/yubikey-personalization-gui.desktop "$out/share/pixmaps/yubikey-personalization-gui.xpm"
 
     # Icons
+    install -D -m0644 resources/lin/yubikey-personalization-gui.xpm "$out/share/pixmaps/yubikey-personalization-gui.xpm"
     install -D -m0644 resources/lin/yubikey-personalization-gui.png "$out/share/icons/hicolor/128x128/apps/yubikey-personalization-gui.png"
     for SIZE in 16 24 32 48 64 96; do
       # set modify/create for reproducible builds


### PR DESCRIPTION
###### Description of changes

The desktop file was copied over twice, once as desktop file, once as pixmap. Fix this and copy the actual pixmap.

###### Things done

```
❯ nix-build -A yubikey-personalization-gui
/nix/store/ha7dvyhn7sgzvpa4cfg1ap030hxikmvl-yubikey-personalization-gui-3.1.25

❯ file /nix/store/ha7dvyhn7sgzvpa4cfg1ap030hxikmvl-yubikey-personalization-gui-3.1.25/share/{applications,pixmaps}/*
/nix/store/ha7dvyhn7sgzvpa4cfg1ap030hxikmvl-yubikey-personalization-gui-3.1.25/share/applications/yubikey-personalization-gui.desktop: ASCII text
/nix/store/ha7dvyhn7sgzvpa4cfg1ap030hxikmvl-yubikey-personalization-gui-3.1.25/share/pixmaps/yubikey-personalization-gui.xpm:          X pixmap image, ASCII text
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).