### PR TITLE
python310Packages.pythran: 0.9.12 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/pythran/0001-hardcode-path-to-libgomp.patch
+++ b/pkgs/development/python-modules/pythran/0001-hardcode-path-to-libgomp.patch
@@ -1,64 +1,79 @@
-From 208fe98f10c580a5a2fb6a8cfdd56de109073925 Mon Sep 17 00:00:00 2001
-From: Frederik Rietdijk <fridh@fridh.nl>
-Date: Sat, 17 Jul 2021 18:36:27 +0200
-Subject: [PATCH] hardcode path to libgomp
-
----
- omp/__init__.py | 40 ++++------------------------------------
- 1 file changed, 4 insertions(+), 36 deletions(-)
-
 diff --git a/omp/__init__.py b/omp/__init__.py
-index bddae3063..9ba3678d8 100644
+index 3801d1c8c..a93a74d6f 100644
 --- a/omp/__init__.py
 +++ b/omp/__init__.py
-@@ -69,43 +69,11 @@ class OpenMP(object):
+@@ -48,72 +48,8 @@ class OpenMP(object):
+         return ['omp', 'gomp', 'iomp5']
  
      def init_not_msvc(self):
-         """ Find OpenMP library and try to load if using ctype interface. """
--        # find_library() does not search automatically LD_LIBRARY_PATH
--        paths = os.environ.get('LD_LIBRARY_PATH', '').split(':')
-+        libgomp_path = "@gomp@"
- 
--        for libomp_name in self.get_libomp_names():
--            if cxx is None or sys.platform == 'win32':
--                # Note: Clang supports -print-file-name, but not yet for
--                # clang-cl as of v12.0.0 (April '21)
--                continue
--
--            cmd = [cxx, '-print-file-name=' + libomp_name]
--            # the subprocess can fail in various ways in that case just give up
--            try:
--                path = os.path.dirname(check_output(cmd).decode().strip())
--                if path:
--                    paths.append(path)
--            except (OSError, CalledProcessError):
--                pass
--
--        # Try to load find libgomp shared library using loader search dirs
--        libgomp_path = find_library("gomp")
--
--        # Try to use custom paths if lookup failed
--        for path in paths:
--            if libgomp_path:
--                break
--            path = path.strip()
--            if os.path.isdir(path):
--                libgomp_path = find_library(os.path.join(str(path), "libgomp"))
--
--        if not libgomp_path:
--            raise ImportError("I can't find a shared library for libgomp,"
--                              " you may need to install it or adjust the "
--                              "LD_LIBRARY_PATH environment variable.")
+-        """ Find OpenMP library and try to load if using ctype interface. """
+-        # find_library() does not automatically search LD_LIBRARY_PATH
+-        # until Python 3.6+, so we explicitly add it.
+-        # LD_LIBRARY_PATH is used on Linux, while macOS uses DYLD_LIBRARY_PATH
+-        # and DYLD_FALLBACK_LIBRARY_PATH.
+-        env_vars = []
+-        if sys.platform == 'darwin':
+-            env_vars = ['DYLD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH']
 -        else:
--            # Load the library (shouldn't fail with an absolute path right?)
--            self.libomp = ctypes.CDLL(libgomp_path)
--            self.version = 45
-+        # Load the library (shouldn't fail with an absolute path right?)
-+        self.libomp = ctypes.CDLL(libgomp_path)
+-            env_vars = ['LD_LIBRARY_PATH']
+-
+-        paths = []
+-        for env_var in env_vars:
+-            env_paths = os.environ.get(env_var, '')
+-            if env_paths:
+-                paths.extend(env_paths.split(os.pathsep))
+-
+-
+-        libomp_names = self.get_libomp_names()
+-
+-        if cxx is not None:
+-            for libomp_name in libomp_names:
+-                cmd = [cxx,
+-                       '-print-file-name=lib{}{}'.format(
+-                           libomp_name,
+-                           get_shared_lib_extension())]
+-                # The subprocess can fail in various ways, including because it
+-                # doesn't support '-print-file-name'. In that case just give up.
+-                try:
+-                    output = check_output(cmd,
+-                                          stderr=DEVNULL)
+-                    path = os.path.dirname(output.decode().strip())
+-                    if path:
+-                        paths.append(path)
+-                except (OSError, CalledProcessError):
+-                    pass
+-
+-
+-        for libomp_name in libomp_names:
+-            # Try to load find libomp shared library using loader search dirs
+-            libomp_path = find_library(libomp_name)
+-
+-            # Try to use custom paths if lookup failed
+-            if not libomp_path:
+-                for path in paths:
+-                    candidate_path = os.path.join(
+-                        path,
+-                        'lib{}{}'.format(libomp_name,
+-                                         get_shared_lib_extension()))
+-                    if os.path.isfile(candidate_path):
+-                        libomp_path = candidate_path
+-                        break
+-
+-            # Load the library
+-            if libomp_path:
+-                try:
+-                    self.libomp = ctypes.CDLL(libomp_path)
+-                except OSError:
+-                    raise ImportError("found openMP library '{}' but couldn't load it. "
+-                                      "This may happen if you are cross-compiling.".format(libomp_path))
+-                self.version = 45
+-                return
+-
+-        raise ImportError("I can't find a shared library for libomp, you may need to install it "
+-                          "or adjust the {} environment variable.".format(env_vars[0]))
+-
++        self.libomp = ctypes.CDLL("@gomp@")
 +        self.version = 45
  
      def __getattr__(self, name):
          """
--- 
-2.32.0
-

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , openmp
-, pytest-runner
 , ply
 , networkx
 , decorator
@@ -11,8 +10,6 @@
 , six
 , numpy
 , beniget
-, pytestCheckHook
-, scipy
 , isPy3k
 , substituteAll
 }:
@@ -22,13 +19,13 @@ let
 
 in buildPythonPackage rec {
   pname = "pythran";
-  version = "0.9.12";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "serge-sans-paille";
     repo = "pythran";
     rev = version;
-    sha256 = "sha256-lQbVq4K/Q8RzlFhE+l3HPCmUGmauXawcKe31kfbUHsI=";
+    sha256 = "sha256-F9gUZOTSuiqvfGoN4yQqwUg9mnCeBntw5eHO7ZnjpzI=";
   };
 
   patches = [
@@ -37,10 +34,6 @@ in buildPythonPackage rec {
       src = ./0001-hardcode-path-to-libgomp.patch;
       gomp = "${if stdenv.cc.isClang then openmp else stdenv.cc.cc.lib}/lib/libgomp${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
-  ];
-
-  nativeBuildInputs = [
-    pytest-runner
   ];
 
   propagatedBuildInputs = [
@@ -62,14 +55,7 @@ in buildPythonPackage rec {
     "pythran.spec"
   ];
 
-  checkInputs = [
-    pytestCheckHook
-    numpy
-    scipy
-  ];
-
-  # Test suite is huge.
-  # Also, in the future scipy will rely on it resulting in a circular test dependency
+  # Test suite is huge and has a circular dependency on scipy.
   doCheck = false;
 
   disabled = !isPy3k;
@@ -79,5 +65,4 @@ in buildPythonPackage rec {
     homepage = "https://github.com/serge-sans-paille/pythran";
     license = lib.licenses.bsd3;
   };
-
 }


### PR DESCRIPTION
###### Description of changes

Unbreaks latest scipy.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
