### PR TITLE
ipcalc: add geoip support

### DIFF
--- a/pkgs/development/libraries/geoip/default.nix
+++ b/pkgs/development/libraries/geoip/default.nix
@@ -1,24 +1,29 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
 , drvName ? "geoip"
 
-# in geoipDatabase, you can insert a package defining
-# "${geoipDatabase}/share/GeoIP" e.g. geolite-legacy
+  # in geoipDatabase, you can insert a package defining
+  # "${geoipDatabase}/share/GeoIP" e.g. geolite-legacy
 , geoipDatabase ? "/var/lib/geoip-databases"
 }:
 
 let
-  dataDir = if lib.isDerivation geoipDatabase
+  dataDir =
+    if lib.isDerivation geoipDatabase
     then "${toString geoipDatabase}/share/GeoIP"
     else geoipDatabase;
+
 in
 stdenv.mkDerivation rec {
   pname = drvName;
   version = "1.6.12";
 
   src = fetchFromGitHub {
-    owner  = "maxmind";
-    repo   = "geoip-api-c";
-    rev    = "v${version}";
+    owner = "maxmind";
+    repo = "geoip-api-c";
+    rev = "v${version}";
     sha256 = "0ixyp3h51alnncr17hqp1p0rlqz9w69nlhm60rbzjjz3vjx52ajv";
   };
 
@@ -35,11 +40,13 @@ stdenv.mkDerivation rec {
     find . -name Makefile.in -exec sed -i -r 's#^pkgdatadir\s*=.+$#pkgdatadir = ${dataDir}#' {} \;
   '';
 
+  passthru = { inherit dataDir; };
+
   meta = with lib; {
     description = "An API for GeoIP/Geolocation databases";
     maintainers = with maintainers; [ thoughtpolice raskin ];
-    license     = licenses.lgpl21;
-    platforms   = platforms.unix;
-    homepage    = "https://www.maxmind.com";
+    license = licenses.lgpl21;
+    platforms = platforms.unix;
+    homepage = "https://www.maxmind.com";
   };
 }


### PR DESCRIPTION
###### Description of changes

- geoip: pass through the dataDir so consumers know where to look
- ipcalc: add geoip support

ipcalc previously used to "use" libmaxminddb but as it was set to link at runtime, it was in fact not working.

Instead use the legacy geoip databases that we carry in nixpkgs in order to enable geoip looking when running ipcalc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
