### PR TITLE
nordzy-icon-theme: unstable-2022-01-23 -> 1.5

### DIFF
--- a/pkgs/data/icons/nordzy-icon-theme/default.nix
+++ b/pkgs/data/icons/nordzy-icon-theme/default.nix
@@ -6,15 +6,15 @@
 , nordzy-themes ? [ "all" ] # Override this to only install selected themes
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation rec {
   pname = "nordzy-icon-theme";
-  version = "unstable-2022-01-23";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "alvatip";
     repo = "Nordzy-icon";
-    rev = "10b9ee80ef5c4cac1d1770d89a6d55046521ea36";
-    sha256 = "1b8abhs5gzr2qy407jq818pr67vjky8zn3pa3c8n552ayybblibk";
+    rev = version;
+    sha256 = "sha256-2uMbiee7wCyDxs6kYd5sL/keDVIVjIWxoci5/t2HF8s=";
   };
 
   # In the post patch phase we should first make sure to patch shebangs.


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [1.5](https://github.com/alvatip/Nordzy-icon/releases/tag/1.5)
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).