### PR TITLE
openiscsi: fix systemd service location

### DIFF
--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-DUSE_KMOD";
 
   preConfigure = ''
-    sed -i 's|/usr|/|' Makefile
-
     # Remove blanket -Werror. Fails for minor error on gcc-11.
     substituteInPlace usr/Makefile --replace ' -Werror ' ' '
   '';
@@ -32,11 +30,12 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "INSTALL=install"
     "SED=sed"
+    "prefix=/"
+    "manprefix=/share"
   ];
 
   installFlags = [
     "install"
-    "install_systemd"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Description of changes

With #177804 the location of the systemd services files was changed from `/lib/systemd/...` to `/usr/lib/systemd/...`, where they can not be found by the NIxOS systemd service builder.

This broke the `iscsi-root` and `iscsi-multipath-root` tests, which can be seen in the #177804 OfBorg checks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @trofi 