### PR TITLE
Script to render changed NixOS options quickly

### DIFF
--- a/maintainers/scripts/changed-option-docs.nix
+++ b/maintainers/scripts/changed-option-docs.nix
@@ -1,0 +1,117 @@
+/*
+  Renders only changed NixOS options.
+
+  Caveats:
+
+    - Does not allow the testing of local links to the manual or other options.
+    - It may prioritize speed over correctness. If you want to a guaranteed
+      100% correct PR, you should always do a full build of the manual, but we
+      believe that a fast check has a right to exist. Any semi-structural
+      issues that do arise can be fixed.
+    - Only works for NixOS system options, not test options or Nixpkgs config options.
+
+  Example usage:
+
+    # since ref
+    nix-build ./maintainers/scripts/changed-option-docs.nix --argstr baseRef upstream/master
+
+    # open browser
+    xdg-open result/index.html
+
+    # since commit sha
+    nix-build ./maintainers/scripts/changed-option-docs.nix --argstr baseRef a509e0fcb5
+
+    # since last two commits
+    nix-build ./maintainers/scripts/changed-option-docs.nix --argstr baseRef $(git show HEAD~2 --format=%H)
+
+ */
+
+args@
+{ baseRef ? "upstream/master"
+, base ? builtins.fetchGit { url = toString ../..; ref = baseRef; }
+, system ? builtins.currentSystem
+, lib ? import ../../lib
+, pkgs ? import ../.. { inherit system; overlays = []; config = {}; }
+}:
+
+let
+  getOpts = nixpkgs:
+    let release = import (nixpkgs + "/nixos/release.nix") { hydraJob = drv: drv; };
+    in release.manual.${system}.optionsDoc.optionsNix;
+  currentOpts = getOpts ../..;
+  baseOpts = getOpts base;
+  isNew = name: newValue: !baseOpts?${name} || baseOpts.${name} != currentOpts.${name};
+  newOpts = lib.filterAttrs isNew currentOpts;
+
+  newOptionsDoc = pkgs.nixosOptionsDoc {
+    optionsNix = newOpts;
+    inherit lib pkgs;
+    options = throw "changed-option-docs: options should be unused";
+  };
+
+  # FIXME: copied from nixos/doc/manual/default.nix
+  toc = builtins.toFile "toc.xml"
+    ''
+      <toc role="chunk-toc">
+        <d:tocentry xmlns:d="http://docbook.org/ns/docbook" linkend="book-nixos-manual"><?dbhtml filename="index.html"?>
+          <d:tocentry linkend="ch-options"><?dbhtml filename="options.html"?></d:tocentry>
+          <d:tocentry linkend="ch-release-notes"><?dbhtml filename="release-notes.html"?></d:tocentry>
+        </d:tocentry>
+      </toc>
+    '';
+
+  # FIXME: copied from nixos/doc/manual/default.nix
+  manualXsltprocOptions = toString [
+    "--param section.autolabel 1"
+    "--param section.label.includes.component.label 1"
+    "--stringparam html.stylesheet 'style.css overrides.css highlightjs/mono-blue.css'"
+    "--stringparam html.script './highlightjs/highlight.pack.js ./highlightjs/loader.js'"
+    "--param xref.with.number.and.title 1"
+    "--param toc.section.depth 0"
+    "--param generate.consistent.ids 1"
+    "--stringparam admon.style ''"
+    "--stringparam callout.graphics.extension .svg"
+    "--stringparam current.docid manual"
+    "--param chunk.section.depth 0"
+    "--param chunk.first.sections 1"
+    "--param use.id.as.filename 1"
+    "--stringparam chunk.toc ${toc}"
+  ];
+
+  # TODO: refactor the NixOS documentation build so that the options part is
+  #       rendered in a separate derivation, that we can invoke here.
+  #       Such a split build will have to defer link checks until the manual
+  #       is combined.
+  docbookHtml = pkgs.runCommand "new-options" {
+    optionsDb = newOptionsDoc.optionsDocBook;
+    nativeBuildInputs = [ pkgs.libxslt.bin ];
+  } ''
+    dst=$out
+    mkdir -p $dst
+    # FIXME    --stringparam target.database.document "$olinkDB}/olinkdb.xml" \
+    xsltproc \
+        ${manualXsltprocOptions} \
+        --stringparam id.warnings "1" \
+        --stringparam target.database.document "olinkdb.xml" \
+        --nonet --output index.html.part \
+        ${pkgs.docbook_xsl_ns}/xml/xsl/docbook/xhtml/chunktoc.xsl \
+        $optionsDb
+
+    cp $optionsDb $dst/options-docbook.xml
+
+    # FIXME: copied from nixos/doc/manual/default.nix
+    cp ${../../doc/style.css} $dst/style.css
+    cp ${../../doc/overrides.css} $dst/overrides.css
+    cp -r ${pkgs.documentation-highlighter} $dst/highlightjs
+    { echo '<html><head><title>Added or Modified Options</title>'
+      echo '<link href="style.css" rel="stylesheet" type="text/css"/>'
+      echo '<link href="overrides.css" rel="stylesheet" type="text/css"/>'
+      echo '</head><body>'
+      cat index.html.part | sed -e 's/<?xml[^?]*?>//'
+      echo '</body></html>'
+    } >$dst/index.html
+  '';
+
+in
+  # newOptionsDoc.optionsDocBook
+  docbookHtml

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -182,6 +182,7 @@ in rec {
       nativeBuildInputs = [ buildPackages.libxml2.bin buildPackages.libxslt.bin ];
       meta.description = "The NixOS manual in HTML format";
       allowedReferences = ["out"];
+      passthru = { inherit optionsDoc; };
     }
     ''
       # Generate the HTML manual.

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -16,6 +16,7 @@
     }
 
 */
+args@
 { pkgs
 , lib
 , options
@@ -34,6 +35,7 @@
 # instead of printing warnings for eg options with missing descriptions (which may be lost
 # by nix build unless -L is given), emit errors instead and fail the build
 , warningsAreErrors ? true
+, optionsNix ? null
 }:
 
 let
@@ -97,7 +99,7 @@ let
         '';
     in "<itemizedlist>${lib.concatStringsSep "\n" (map (p: describe (unpack p)) packages)}</itemizedlist>";
 
-  optionsNix = builtins.listToAttrs (map (o: { name = o.name; value = removeAttrs o ["name" "visible" "internal"]; }) optionsList);
+  optionsNix = args.optionsNix or (builtins.listToAttrs (map (o: { name = o.name; value = removeAttrs o ["name" "visible" "internal"]; }) optionsList));
 
 in rec {
   inherit optionsNix;

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -1,9 +1,12 @@
-with import ../lib;
+let lib = import ../lib;
+in
+with lib;
 
 { nixpkgs ? { outPath = cleanSource ./..; revCount = 130979; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" "aarch64-linux" ]
 , configuration ? {}
+, hydraJob ? lib.hydraJob
 }:
 
 with import ../pkgs/top-level/release-lib.nix { inherit supportedSystems; };


### PR DESCRIPTION
###### Description of changes

Expression that renders changed option docs quickly.

Good for quick review: renders in 9s with substituters enabled, or 3s with substituters disabled.
These are _interactive times_, as opposed to a full build of the manual + agony trying to find your options in an overburdened browser tab.

TODO
 - [ ] force `git diff --name-only` files into a `buildInSandbox = false` list
    - poc; replace cassandra by wiring a list all the way from release.nix. Does assume that all changes intersect with modules-list.nix, so no indirect imports. Maybe compute `genericClosure` on file-typed `imports` exclusively.
       ```diff
       --- a/nixos/modules/misc/documentation.nix
       +++ b/nixos/modules/misc/documentation.nix
       @@ -19,7 +19,8 @@ let
                && builtins.isPath m
                && isFunction f
                && instance ? options
       -        && instance.meta.buildDocsInSandbox or true;
       +        && instance.meta.buildDocsInSandbox or true
       +        && !(m == ../services/databases/cassandra.nix);
       ```
 - [ ] write convenience script around the expression, making common use cases easy (find PR branch-off commit automatically?)
 - [ ] refactor nixos/doc/manual to better support this. Nice to have. Adjacent to making the module system docs tooling properly reusable which is a project in itself
 - [ ] make this tool part of the review instructions
 - [ ] add a github action that renders an image and adds it to the pr description (nice to have)

***I'm way over my nixpkgs time budget so I won't work on this in the foreseeable future. I wrote this because I knew how to do it and if anyone finds it useful, I encourage them to make it mergeable.***

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
