### PR TITLE
fastly: init at 3.1.0

### DIFF
--- a/pkgs/misc/fastly/default.nix
+++ b/pkgs/misc/fastly/default.nix
@@ -1,0 +1,56 @@
+{ lib, fetchFromGitHub, installShellFiles, buildGoModule }:
+
+buildGoModule rec {
+  pname = "fastly";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "fastly";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "sha256-Su4ZwiuI+pMoLAGhc3dWcwgcfwe5cZGTg8kEnpM4JbA=";
+    # The git commit is part of the `fastly version` original output;
+    # leave that output the same in nixpkgs. Use the `.git` directory
+    # to retrieve the commit SHA, and remove the directory afterwards,
+    # since it is not needed after that.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  subPackages = [ "cmd/fastly" ];
+
+  vendorSha256 = "sha256-5MvJS10f7YLvO+wCmUJleU27hCJbsNrOIfUZnniGw+E=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Flags as provided by the build automation of the project:
+  #   https://github.com/fastly/cli/blob/7844f9f54d56f8326962112b5534e5c40e91bf09/.goreleaser.yml#L14-L18
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/fastly/cli/pkg/revision.AppVersion=v${version}"
+    "-X github.com/fastly/cli/pkg/revision.Environment=release"
+  ];
+  preBuild = ''
+    ldflags+=" -X github.com/fastly/cli/pkg/revision.GitCommit=$(cat COMMIT)"
+    ldflags+=" -X 'github.com/fastly/cli/pkg/revision.GoVersion=$(go version)'"
+  '';
+
+  postInstall = ''
+    export HOME="$(mktemp -d)"
+    installShellCompletion --cmd fastly \
+      --bash <($out/bin/fastly --completion-script-bash) \
+      --zsh <($out/bin/fastly --completion-script-zsh)
+  '';
+
+  meta = with lib; {
+    description = "Command line tool for interacting with the Fastly API";
+    license = licenses.asl20;
+    homepage = "https://github.com/fastly/cli";
+    maintainers = with maintainers; [ ereslibre shyim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3575,6 +3575,8 @@ with pkgs;
 
   extrude = callPackage ../tools/security/extrude { };
 
+  fastly = callPackage ../misc/fastly {};
+
   f2 = callPackage ../tools/misc/f2 {};
 
   f3 = callPackage ../tools/filesystems/f3 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supersedes https://github.com/NixOS/nixpkgs/pull/170077

I could not make the shell completions to work on all my environments. I managed to make it work for `x86_64-darwin` but not for `x86_64-linux` with weird errors about the `fastly` binary not being found.

I can look into that, but in the meantime we have a basic working `fastly` binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
