### PR TITLE
python310Packages.mkdocstrings: init at 0.19.0

### DIFF
--- a/pkgs/development/python-modules/griffe/default.nix
+++ b/pkgs/development/python-modules/griffe/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, aiofiles
+, buildPythonApplication
+, cached-property
+, fetchFromGitHub
+, git
+, pdm-pep517
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonApplication rec {
+  pname = "griffe";
+  version = "0.21.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mkdocstrings";
+    repo = pname;
+    rev = version;
+    hash = "sha256-yhhEcPwh1AjMtDlPZVDR69WX/728wuKqdJdc+yv/o4c=";
+  };
+
+  nativeBuildInputs = [
+    pdm-pep517
+  ];
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
+    cached-property
+  ];
+
+  checkInputs = [
+    git
+    pytestCheckHook
+  ];
+
+  passthru.optional-dependencies = {
+    async = [
+      aiofiles
+    ];
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  pythonImportsCheck = [
+    "griffe"
+  ];
+
+  meta = with lib; {
+    description = "Signatures for entire Python programs";
+    homepage = "https://github.com/mkdocstrings/griffe";
+    license = licenses.isc;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocs-autorefs/default.nix
+++ b/pkgs/development/python-modules/mkdocs-autorefs/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, markdown
+, mkdocs
+, pytestCheckHook
+, pdm-pep517
+, pythonOlder
+}:
+
+buildPythonApplication rec {
+  pname = "mkdocs-autorefs";
+  version = "0.4.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mkdocstrings";
+    repo = "autorefs";
+    rev = version;
+    sha256 = "sha256-kiHb/XSFw6yaUbLJHBvHaQAOVUM6UfyFeomgniDZqgU=";
+  };
+
+  nativeBuildInputs = [
+    pdm-pep517
+  ];
+
+  propagatedBuildInputs = [
+    markdown
+    mkdocs
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  pythonImportsCheck = [
+    "mkdocs_autorefs"
+  ];
+
+  meta = with lib; {
+    description = "Automatically link across pages in MkDocs";
+    homepage = "https://github.com/mkdocstrings/autorefs/";
+    license = licenses.isc;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocstrings-python/default.nix
+++ b/pkgs/development/python-modules/mkdocstrings-python/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, griffe
+, mkdocs-material
+, mkdocstrings
+, pdm-pep517
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonApplication rec {
+  pname = "mkdocstrings-python";
+  version = "0.7.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mkdocstrings";
+    repo = "python";
+    rev = version;
+    hash = "sha256-cZk6Eu6Jp3tSPAb0HplR/I0pX2YIFhOaAsI3YRS0LVw=";
+  };
+
+  nativeBuildInputs = [
+    pdm-pep517
+  ];
+
+  propagatedBuildInputs = [
+    griffe
+    mkdocstrings
+  ];
+
+  checkInputs = [
+    mkdocs-material
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  pythonImportsCheck = [
+    "mkdocstrings_handlers"
+  ];
+
+  meta = with lib; {
+    description = "Python handler for mkdocstrings";
+    homepage = "https://github.com/mkdocstrings/python";
+    license = licenses.isc;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocstrings/default.nix
+++ b/pkgs/development/python-modules/mkdocstrings/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, jinja2
+, markdown
+, markupsafe
+, mkdocs
+, mkdocs-autorefs
+, pymdown-extensions
+, pytestCheckHook
+, pdm-pep517
+, pythonOlder
+}:
+
+buildPythonApplication rec {
+  pname = "mkdocstrings";
+  version = "0.19.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mkdocstrings";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-7OF1CrRnE4MYHuYD/pasnZpLe9lrbieGp4agnWAaKVo=";
+  };
+
+  nativeBuildInputs = [
+    pdm-pep517
+  ];
+
+  propagatedBuildInputs = [
+    jinja2
+    markdown
+    markupsafe
+    mkdocs
+    mkdocs-autorefs
+    pymdown-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  pythonImportsCheck = [
+    "mkdocstrings"
+  ];
+
+  disabledTestPaths = [
+    # Circular dependencies
+    "tests/test_extension.py"
+  ];
+
+  meta = with lib; {
+    description = "Automatic documentation from sources for MkDocs";
+    homepage = "https://github.com/mkdocstrings/mkdocstrings";
+    license = licenses.isc;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3787,6 +3787,8 @@ in {
 
   gridnet = callPackage ../development/python-modules/gridnet { };
 
+  griffe = callPackage ../development/python-modules/griffe { };
+
   grip = callPackage ../development/python-modules/grip { };
 
   groestlcoin_hash = callPackage ../development/python-modules/groestlcoin_hash { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5438,6 +5438,7 @@ in {
   mizani = callPackage ../development/python-modules/mizani { };
 
   mkdocs = callPackage ../development/python-modules/mkdocs { };
+  mkdocs-autorefs = callPackage ../development/python-modules/mkdocs-autorefs { };
   mkdocs-drawio-exporter = callPackage ../development/python-modules/mkdocs-drawio-exporter { };
   mkdocs-exclude = callPackage ../development/python-modules/mkdocs-exclude { };
   mkdocs-gitlab = callPackage ../development/python-modules/mkdocs-gitlab-plugin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5449,7 +5449,10 @@ in {
   mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };
   mkdocs-minify = callPackage ../development/python-modules/mkdocs-minify { };
   mkdocs-redirects = callPackage ../development/python-modules/mkdocs-redirects { };
+
   mkdocstrings = callPackage ../development/python-modules/mkdocstrings { };
+
+  mkdocstrings-python = callPackage ../development/python-modules/mkdocstrings-python { };
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5447,6 +5447,7 @@ in {
   mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };
   mkdocs-minify = callPackage ../development/python-modules/mkdocs-minify { };
   mkdocs-redirects = callPackage ../development/python-modules/mkdocs-redirects { };
+  mkdocstrings = callPackage ../development/python-modules/mkdocstrings { };
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 


### PR DESCRIPTION
###### Description of changes
Automatic documentation from sources for MkDocs

https://github.com/mkdocstrings/mkdocstrings
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
